### PR TITLE
Add project assignment launch readiness

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -347,6 +347,12 @@ Queued assignment launches now show a launch preflight context packet before
 dispatch; confirming the preview starts the native task or prepares the External
 Agent chat, while preflight itself creates no task, run, chat session, artifact,
 memory entry, or assignment update.
+Assignment launch readiness is a separate server-owned projection at
+`GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/launch-readiness`.
+The Projects UI uses its typed `ready`, `blockers`, resolved workspace/profile
+hints, and provider/model readiness fields to gate explicit start/prepare
+confirmation, while the preflight context packet remains inspectable evidence
+rather than client-parsed authority.
 Project roots now model concrete checkouts for assignment execution: work items
 and assignments can select a root by `root_id`, and launch resolution uses
 assignment root, work-item root, project default root, then first active root.

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -37,8 +37,8 @@ creation opens with a draft title, brief, and owner role for operator review.
 For each work item:
 
 1. Draft the first assignment from the owner role, or create one manually.
-2. Inspect the launch context before starting work when defaults, roots, or
-   provider/model posture are uncertain.
+2. Inspect launch readiness and launch context before starting work when
+   defaults, roots, or provider/model posture are uncertain.
 3. Start a Hecate Task or External Agent assignment.
 4. Record evidence, reviews, and handoffs as the work moves between roles.
 5. Close the work item only after assignments and review follow-up are clear.
@@ -86,6 +86,12 @@ drilling into the full work queue. Review follow-up and closeout operations
 open selected-work detail. Closeout readiness is the server contract shared by
 Project Operations and selected-work detail; the operator still creates
 follow-up paths or marks work done explicitly from that surface.
+Assignment launch readiness is also server-backed. Before `Start assignment`,
+`Prepare chat`, or `Start from handoff`, the detail view loads
+`GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/launch-readiness`
+and uses its typed `ready`/`blockers` fields as the launch gate. The separate
+preflight context packet remains inspectable evidence for the operator; it is
+not parsed by the client as the readiness authority.
 
 For a new work item with no assignments or artifacts yet, the detail view starts
 with a guided prepare action. Hecate can draft the first assignment from the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2965,6 +2965,55 @@ without a stored packet or execution link, or older runs that predate snapshots 
 instructions, memory, project sources, work context, runtime refs, and skipped
 or inspect-only items without reopening the raw task or chat transcript.
 
+#### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/launch-readiness`
+
+Returns a typed, read-only assignment launch readiness projection. The endpoint
+does not create a Task, Run, Chat session, memory entry, artifact, or assignment
+update. Hecate verifies the same launch shape used by preflight/start: project,
+work item, assignment, and role identity; queued/startable status; stored driver
+support; active execution; workspace/root resolution; profile and skills
+resolution; native provider/model readiness; and External Agent adapter/options
+resolution.
+
+The response envelope is:
+
+```json
+{
+  "object": "project_assignment_launch_readiness",
+  "data": {
+    "project_id": "proj_123",
+    "work_item_id": "work_123",
+    "assignment_id": "asgn_123",
+    "ready": false,
+    "status": "blocked",
+    "title": "Launch is blocked",
+    "detail": "Resolve the listed launch blockers before starting or preparing this assignment.",
+    "blockers": ["No routable provider reports model \"dogfood-model\"."],
+    "warnings": [],
+    "driver_kind": "hecate_task",
+    "workspace": "/Users/alice/dev/hecate",
+    "root_id": "root_main",
+    "provider": "",
+    "model": "dogfood-model",
+    "execution_profile": "implementation",
+    "model_readiness": {
+      "ready": false,
+      "status": "blocked",
+      "reason": "model_not_discovered",
+      "message": "No routable provider reports model \"dogfood-model\".",
+      "operator_action": "Pick one of the discovered models."
+    }
+  }
+}
+```
+
+Native Hecate Task assignments may include `model_readiness`, using the same
+reason and repair vocabulary as `metadata.readiness` on `/v1/models`. External
+Agent assignments include `external_agent_id`, `external_agent`, and
+`session_title` when the adapter/options resolve. `ready=false` is the UI gate
+for `Start assignment`, `Prepare chat`, and `Start from handoff`; operators
+must still confirm the separate start mutation after reviewing preflight.
+
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/preflight`
 
 Returns a launch context packet for a queued assignment without creating or
@@ -2982,22 +3031,17 @@ The response is a normal `context_packet` envelope with assignment refs only;
 task, run, chat session, and message refs remain empty because preflight is
 inspect-only. The packet includes a `runtime` / `launch_preflight` item with
 `included=false` describing what will be created on confirm. For native Hecate
-task assignments, the packet also includes a `runtime` / `launch_readiness`
-item when the gateway is wired. That item snapshots the resolved provider/model
-readiness using the same reason and repair vocabulary as `metadata.readiness`
-on `/v1/models`: `Ready: false` means the selected model is not currently
-routable through the configured providers and should be repaired before start.
-Its body is human-readable, and `metadata` carries stable keys such as `ready`,
-`status`, `provider`, `model`, `matched_provider`, `reason`, `message`, and
-`operator_action` for clients that need to gate UI actions without parsing
-copy. It is operator evidence, not injected prompt content.
+task assignments, the packet can also include a `runtime` / `launch_readiness`
+item when the gateway is wired. That item is operator evidence, not the UI
+authority; clients should gate launch confirmation with the typed
+`/launch-readiness` projection rather than parsing context item copy.
 
 The Projects cockpit uses this endpoint before `Start assignment`, `Prepare
 chat`, and `Start from handoff` so the operator can review the effective launch
-context before dispatch. The UI disables native assignment confirmation when
-preflight reports blocked provider/model readiness and offers repair actions for
-Project Settings, Roles, Agent Profiles, and Connections. Project-local actions
-repair defaults that feed assignment resolution; Connections remains the
+context before dispatch. The UI disables confirmation when
+`/launch-readiness` reports blockers and offers repair actions for Project
+Settings, Roles, Agent Profiles, and Connections. Project-local actions repair
+defaults that feed assignment resolution; Connections remains the
 provider/model readiness surface. `POST /start` remains the authoritative
 mutation path and the task runner/gateway still performs the actual route
 checks during execution.

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -22,6 +22,89 @@ import (
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
+const (
+	projectAssignmentLaunchReadinessStatusReady   = "ready"
+	projectAssignmentLaunchReadinessStatusBlocked = "blocked"
+)
+
+type ProjectAssignmentLaunchReadinessEnvelope struct {
+	Object string                                   `json:"object"`
+	Data   ProjectAssignmentLaunchReadinessResponse `json:"data"`
+}
+
+type ProjectAssignmentLaunchReadinessResponse struct {
+	ProjectID        string                      `json:"project_id"`
+	WorkItemID       string                      `json:"work_item_id"`
+	AssignmentID     string                      `json:"assignment_id"`
+	GeneratedAt      string                      `json:"generated_at"`
+	Ready            bool                        `json:"ready"`
+	Status           string                      `json:"status"`
+	Title            string                      `json:"title"`
+	Detail           string                      `json:"detail"`
+	Blockers         []string                    `json:"blockers"`
+	Warnings         []string                    `json:"warnings"`
+	DriverKind       string                      `json:"driver_kind"`
+	Workspace        string                      `json:"workspace,omitempty"`
+	RootID           string                      `json:"root_id,omitempty"`
+	RootPath         string                      `json:"root_path,omitempty"`
+	Provider         string                      `json:"provider,omitempty"`
+	Model            string                      `json:"model,omitempty"`
+	ExecutionProfile string                      `json:"execution_profile,omitempty"`
+	ExternalAgentID  string                      `json:"external_agent_id,omitempty"`
+	ExternalAgent    string                      `json:"external_agent,omitempty"`
+	SessionTitle     string                      `json:"session_title,omitempty"`
+	ModelReadiness   *ModelReadinessResponseItem `json:"model_readiness,omitempty"`
+}
+
+func (h *Handler) HandleProjectWorkAssignmentLaunchReadiness(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	projectID := r.PathValue("id")
+	workItemID := r.PathValue("work_item_id")
+	assignmentID := r.PathValue("assignment_id")
+	if h.projects == nil || h.projectWork == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
+		return
+	}
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	workItem, ok, err := h.projectWork.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+		return
+	}
+	assignment, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment not found")
+		return
+	}
+	role, roleOK, err := h.loadProjectWorkRole(ctx, projectID, assignment.RoleID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	readiness, err := h.renderProjectAssignmentLaunchReadiness(ctx, project, workItem, assignment, role, roleOK)
+	if err != nil {
+		WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectAssignmentLaunchReadinessEnvelope{Object: "project_assignment_launch_readiness", Data: readiness})
+}
+
 func (h *Handler) HandleProjectWorkAssignmentPreflight(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	projectID := r.PathValue("id")
@@ -134,6 +217,163 @@ func projectAssignmentPreflightErrorCode(err error) string {
 		}
 	}
 	return errCodeGatewayError
+}
+
+func (h *Handler) renderProjectAssignmentLaunchReadiness(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, roleOK bool) (ProjectAssignmentLaunchReadinessResponse, error) {
+	driverKind := firstNonEmptyString(strings.TrimSpace(assignment.DriverKind), projectwork.AssignmentDriverHecateTask)
+	readiness := ProjectAssignmentLaunchReadinessResponse{
+		ProjectID:    project.ID,
+		WorkItemID:   workItem.ID,
+		AssignmentID: assignment.ID,
+		GeneratedAt:  formatOptionalTime(time.Now().UTC()),
+		Status:       projectAssignmentLaunchReadinessStatusReady,
+		Title:        "Ready to start assignment",
+		Detail:       "Launch checks are clear. Review the preflight context before starting this assignment.",
+		DriverKind:   driverKind,
+		Blockers:     []string{},
+		Warnings:     []string{},
+	}
+	if !roleOK {
+		role = projectwork.AgentRoleProfile{ID: strings.TrimSpace(assignment.RoleID)}
+		readiness.Blockers = append(readiness.Blockers, "Assignment role not found.")
+	}
+	if status := strings.TrimSpace(assignment.Status); status != "" && status != projectwork.AssignmentStatusQueued {
+		if projectWorkAssignmentIsTerminal(status) {
+			readiness.Blockers = append(readiness.Blockers, "Terminal assignments cannot be started.")
+		} else {
+			readiness.Blockers = append(readiness.Blockers, "Only queued assignments can be started.")
+		}
+	}
+
+	switch driverKind {
+	case projectwork.AssignmentDriverHecateTask:
+		if h.taskStore == nil {
+			readiness.Blockers = append(readiness.Blockers, "Task store is not configured.")
+		}
+		if h.taskRunner == nil {
+			readiness.Blockers = append(readiness.Blockers, "Task runner is not configured.")
+		}
+		if h.taskStore != nil {
+			active, err := projectWorkAssignmentHasActiveExecution(ctx, h.taskStore, assignment)
+			if err != nil {
+				return ProjectAssignmentLaunchReadinessResponse{}, err
+			}
+			if active {
+				readiness.Blockers = append(readiness.Blockers, "Assignment already has active execution.")
+			}
+		}
+		if len(readiness.Blockers) == 0 {
+			if err := h.populateTaskAssignmentLaunchReadiness(ctx, project, workItem, assignment, role, &readiness); err != nil {
+				return ProjectAssignmentLaunchReadinessResponse{}, err
+			}
+		}
+	case projectwork.AssignmentDriverExternalAgent:
+		if h.agentChat == nil {
+			readiness.Blockers = append(readiness.Blockers, "Agent chat store is not configured.")
+		}
+		if h.agentChatRunner == nil {
+			readiness.Blockers = append(readiness.Blockers, "Agent chat runner is not configured.")
+		}
+		if strings.TrimSpace(assignment.ExecutionRef.ChatSessionID) != "" {
+			readiness.Blockers = append(readiness.Blockers, "External Agent assignment already has a prepared chat session.")
+		}
+		if len(readiness.Blockers) == 0 {
+			if err := h.populateExternalAgentAssignmentLaunchReadiness(ctx, project, workItem, assignment, role, &readiness); err != nil {
+				return ProjectAssignmentLaunchReadinessResponse{}, err
+			}
+		}
+	default:
+		readiness.Blockers = append(readiness.Blockers, fmt.Sprintf("Assignment driver_kind %q is not supported.", driverKind))
+	}
+
+	readiness.Blockers = projectWorkReadinessUniqueStrings(readiness.Blockers)
+	readiness.Warnings = projectWorkReadinessUniqueStrings(readiness.Warnings)
+	readiness.Ready = len(readiness.Blockers) == 0
+	if !readiness.Ready {
+		readiness.Status = projectAssignmentLaunchReadinessStatusBlocked
+		readiness.Title = "Launch is blocked"
+		readiness.Detail = "Resolve the listed launch blockers before starting or preparing this assignment."
+	}
+	return readiness, nil
+}
+
+func (h *Handler) populateTaskAssignmentLaunchReadiness(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, readiness *ProjectAssignmentLaunchReadinessResponse) error {
+	plan, err := h.projectWorkApplication().ResolveTaskAssignmentLaunchPlan(ctx, project, workItem, assignment, role)
+	if err != nil {
+		readiness.Blockers = append(readiness.Blockers, projectAssignmentLaunchPlanBlocker(err))
+		return nil
+	}
+	readiness.Workspace = plan.WorkingDirectory
+	readiness.RootID = plan.Root.ID
+	readiness.RootPath = plan.Root.Path
+	readiness.Provider = plan.RequestedProvider
+	readiness.Model = plan.RequestedModel
+	readiness.ExecutionProfile = plan.ExecutionProfile
+	readiness.Warnings = append(readiness.Warnings, projectAssignmentLaunchPlanWarnings(plan.Profile, plan.ResolvedSkills)...)
+	if h.service == nil {
+		return nil
+	}
+	result, err := h.service.ProviderModelReadiness(ctx, plan.RequestedProvider, plan.RequestedModel)
+	if err != nil {
+		return err
+	}
+	modelReadiness := renderModelReadiness(result.Readiness.ToModelReadiness())
+	readiness.ModelReadiness = &modelReadiness
+	if !modelReadiness.Ready {
+		readiness.Blockers = append(readiness.Blockers, projectAssignmentModelReadinessBlocker(modelReadiness))
+	}
+	return nil
+}
+
+func (h *Handler) populateExternalAgentAssignmentLaunchReadiness(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, readiness *ProjectAssignmentLaunchReadinessResponse) error {
+	plan, err := h.projectWorkApplication().ResolveExternalAgentAssignmentLaunchPlan(ctx, project, workItem, assignment, role)
+	if err != nil {
+		readiness.Blockers = append(readiness.Blockers, projectAssignmentLaunchPlanBlocker(err))
+		return nil
+	}
+	readiness.Workspace = plan.Workspace
+	readiness.RootID = plan.Root.ID
+	readiness.RootPath = plan.Root.Path
+	readiness.ExecutionProfile = plan.ExecutionProfile
+	readiness.ExternalAgentID = plan.AdapterID
+	readiness.ExternalAgent = firstNonEmptyString(plan.Adapter.Name, plan.AdapterID)
+	readiness.SessionTitle = plan.SessionTitle
+	readiness.Title = "Ready to prepare External Agent chat"
+	readiness.Detail = "Launch checks are clear. Review the preflight context before preparing this supervised External Agent chat."
+	readiness.Warnings = append(readiness.Warnings, projectAssignmentLaunchPlanWarnings(plan.Profile, plan.ResolvedSkills)...)
+	return nil
+}
+
+func projectAssignmentLaunchPlanBlocker(err error) string {
+	var launchErr projectworkapp.LaunchPlanError
+	if errors.As(err, &launchErr) && strings.TrimSpace(launchErr.Message) != "" {
+		return launchErr.Message
+	}
+	if strings.TrimSpace(err.Error()) != "" {
+		return err.Error()
+	}
+	return "Launch plan could not be resolved."
+}
+
+func projectAssignmentLaunchPlanWarnings(profile projectworkapp.ResolvedAgentProfile, skills projectworkapp.ResolvedProjectSkills) []string {
+	warnings := append([]string(nil), profile.Warnings...)
+	warnings = append(warnings, skills.Warnings...)
+	for _, skipped := range skills.Skipped {
+		if skipped.ID == "" {
+			continue
+		}
+		warnings = append(warnings, "Project skill "+skipped.ID+" was not included: "+firstNonEmptyString(skipped.Reason, "unavailable"))
+	}
+	return warnings
+}
+
+func projectAssignmentModelReadinessBlocker(readiness ModelReadinessResponseItem) string {
+	return firstNonEmptyString(
+		strings.TrimSpace(readiness.Message),
+		strings.TrimSpace(readiness.OperatorAction),
+		strings.TrimSpace(readiness.Reason),
+		"The selected provider/model cannot be routed for this assignment.",
+	)
 }
 
 func (h *Handler) projectAssignmentPreflightContext(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile) (chat.ContextPacket, error) {

--- a/internal/api/handler_project_assignment_launch_readiness_test.go
+++ b/internal/api/handler_project_assignment_launch_readiness_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessReturnsNativePlanWithoutSideEffects(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServerWithProviders(&fakeProvider{
+		name: "anthropic",
+	})
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultProvider = "anthropic"
+		project.DefaultModel = "gpt-4o-mini"
+	}); err != nil {
+		t.Fatalf("Update project defaults: %v", err)
+	}
+
+	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/launch-readiness", "")
+	if readiness.Object != "project_assignment_launch_readiness" {
+		t.Fatalf("object = %q, want project_assignment_launch_readiness", readiness.Object)
+	}
+	if !readiness.Data.Ready || readiness.Data.Status != projectAssignmentLaunchReadinessStatusReady {
+		t.Fatalf("readiness = %+v, want ready", readiness.Data)
+	}
+	if readiness.Data.ProjectID != "proj_start" || readiness.Data.WorkItemID != "work_start" || readiness.Data.AssignmentID != "asgn_start" {
+		t.Fatalf("refs = %+v, want project/work/assignment refs", readiness.Data)
+	}
+	if readiness.Data.DriverKind != projectwork.AssignmentDriverHecateTask || readiness.Data.Workspace != workspace || readiness.Data.RootID != "root_start" {
+		t.Fatalf("launch target = %+v, want native workspace/root", readiness.Data)
+	}
+	if readiness.Data.Provider != "anthropic" || readiness.Data.Model != "gpt-4o-mini" || readiness.Data.ExecutionProfile != "coding_agent" {
+		t.Fatalf("launch hints = provider/model/profile %q/%q/%q, want anthropic/gpt-4o-mini/coding_agent", readiness.Data.Provider, readiness.Data.Model, readiness.Data.ExecutionProfile)
+	}
+	if readiness.Data.ModelReadiness == nil || !readiness.Data.ModelReadiness.Ready {
+		t.Fatalf("model_readiness = %+v, want ready", readiness.Data.ModelReadiness)
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want no task created by launch readiness", tasks)
+	}
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessSurfacesBlockedModel(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServerWithProviders(&fakeProvider{
+		name:         "openai",
+		defaultModel: "gpt-4o-mini",
+	})
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           t.TempDir(),
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultProvider = ""
+		project.DefaultModel = "dogfood-model"
+	}); err != nil {
+		t.Fatalf("Update project defaults: %v", err)
+	}
+
+	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/launch-readiness", "")
+	if readiness.Data.Ready || readiness.Data.Status != projectAssignmentLaunchReadinessStatusBlocked {
+		t.Fatalf("readiness = %+v, want blocked", readiness.Data)
+	}
+	if readiness.Data.ModelReadiness == nil || readiness.Data.ModelReadiness.Ready || readiness.Data.ModelReadiness.Reason != "model_not_discovered" {
+		t.Fatalf("model_readiness = %+v, want blocked model_not_discovered", readiness.Data.ModelReadiness)
+	}
+	if len(readiness.Data.Blockers) == 0 || readiness.Data.Blockers[0] == "" {
+		t.Fatalf("blockers = %+v, want blocked model explanation", readiness.Data.Blockers)
+	}
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessReportsMissingRole(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServerWithProviders(&fakeProvider{})
+	workspace := t.TempDir()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_missing_role",
+		Name:            "Missing Role",
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-4o-mini",
+		DefaultRootID:   "root_missing_role",
+		Roots: []projects.Root{{
+			ID:     "root_missing_role",
+			Path:   workspace,
+			Kind:   "git",
+			Active: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_missing_role",
+		ProjectID: "proj_missing_role",
+		Title:     "Launch missing role",
+		Status:    projectwork.WorkItemStatusReady,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_missing_role",
+		ProjectID:  "proj_missing_role",
+		WorkItemID: "work_missing_role",
+		RoleID:     "role_missing",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusQueued,
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+
+	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_missing_role/work-items/work_missing_role/assignments/asgn_missing_role/launch-readiness", "")
+	if readiness.Data.Ready {
+		t.Fatalf("readiness = %+v, want missing role blocker", readiness.Data)
+	}
+	if len(readiness.Data.Blockers) != 1 || readiness.Data.Blockers[0] != "Assignment role not found." {
+		t.Fatalf("blockers = %+v, want missing role blocker", readiness.Data.Blockers)
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want no task created by launch readiness", tasks)
+	}
+}

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -75,6 +75,7 @@ var remoteRuntimeAllowedRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/assignments"},
 	{method: http.MethodPatch, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}"},
 	{method: http.MethodDelete, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/launch-readiness"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/preflight"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/context"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -112,6 +112,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments", handler.HandleCreateProjectWorkAssignment)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}", handler.HandleUpdateProjectWorkAssignment)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}", handler.HandleDeleteProjectWorkAssignment)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/launch-readiness", handler.HandleProjectWorkAssignmentLaunchReadiness)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/preflight", handler.HandleProjectWorkAssignmentPreflight)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/start", handler.HandleStartProjectWorkAssignment)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/context", handler.HandleProjectWorkAssignmentContext)

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -2,6 +2,7 @@ import type { Page, Route } from "@playwright/test";
 import { expect, mockGatewayAPIs, MOCK_SETTINGS_CONFIG_WITH_PROVIDERS, test } from "./fixtures";
 import type {
   ProjectActivityData,
+  ProjectAssignmentLaunchReadinessRecord,
   ProjectAssignmentRecord,
   ProjectCollaborationArtifactRecord,
   ProjectContextSourceRecord,
@@ -63,7 +64,7 @@ test("Projects journey: setup, first work, assignment, evidence, closeout", asyn
   await expect(page.getByRole("button", { name: "Start" })).toBeVisible();
   await page.getByRole("button", { name: "Start" }).click();
   await expect(page.getByRole("dialog", { name: /launch preflight/i })).toBeVisible();
-  await expect(page.getByText("Launch readiness")).toBeVisible();
+  await expect(page.getByText("Launch readiness", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Start assignment" }).click();
 
   await expect(page.getByText("completed", { exact: true })).toBeVisible();
@@ -444,6 +445,15 @@ async function handleWorkItemRoute(
       return;
     }
     const assignment = state.assignments.find((candidate) => candidate.id === assignmentID);
+    if (parts[5] === "launch-readiness" && method === "GET") {
+      await route.fulfill(
+        ok({
+          object: "project_assignment_launch_readiness",
+          data: assignmentLaunchReadiness(projectID, workItemID, assignmentID),
+        }),
+      );
+      return;
+    }
     if (parts[5] === "preflight") {
       await route.fulfill(
         ok({
@@ -651,6 +661,29 @@ function assignmentPreflight(projectID: string, workItemID: string, assignmentID
         included: true,
       },
     ],
+  };
+}
+
+function assignmentLaunchReadiness(
+  projectID: string,
+  workItemID: string,
+  assignmentID: string,
+): ProjectAssignmentLaunchReadinessRecord {
+  return {
+    project_id: projectID,
+    work_item_id: workItemID,
+    assignment_id: assignmentID,
+    generated_at: NOW,
+    ready: true,
+    status: "ready",
+    title: "Ready to start",
+    detail: "Assignment can start after operator confirmation.",
+    blockers: [],
+    warnings: [],
+    driver_kind: "hecate_task",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    execution_profile: "implementation",
   };
 }
 

--- a/ui/src/features/projects/ProjectHealthPanel.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.tsx
@@ -10,6 +10,7 @@ import { Badge, Icon, Icons } from "../shared/ui";
 import { useFloatingMenu } from "../shared/useFloatingMenu";
 import { routeProjectHealthAttention, type ProjectActionRoute } from "./projectActionRouting";
 import { activitySignalLabel } from "./projectInsights";
+import { projectVisibilityDetail } from "./projectVisibilityDetail";
 
 export type ProjectHealthPanelProps = {
   attentionItems: ProjectHealthAttention[];
@@ -57,6 +58,14 @@ export function ProjectHealthPanel({
   const totalAttentionCount =
     summary?.available_attention_count ?? attentionCount + omittedAttentionCount;
   const hiddenAttentionCount = Math.max(0, totalAttentionCount - attentionCount);
+  const hiddenAttentionDetail = projectVisibilityDetail({
+    shownCount: attentionCount,
+    totalCount: totalAttentionCount,
+    itemLabelSingular: "attention item",
+    itemLabelPlural: "attention items",
+    hiddenLabelSingular: "item",
+    hiddenLabelPlural: "items",
+  });
   const attentionLabel =
     totalAttentionCount > 0
       ? `Project attention: ${attentionCount}${hiddenAttentionCount > 0 ? `, ${hiddenAttentionCount} hidden` : ""}`
@@ -157,13 +166,7 @@ export function ProjectHealthPanel({
               ))}
             </div>
           )}
-          {hiddenAttentionCount > 0 && (
-            <div style={subtleTextStyle}>
-              Showing {attentionCount} of {totalAttentionCount} attention{" "}
-              {totalAttentionCount === 1 ? "item" : "items"}; {hiddenAttentionCount} lower-priority{" "}
-              {hiddenAttentionCount === 1 ? "item is" : "items are"} hidden.
-            </div>
-          )}
+          {hiddenAttentionDetail && <div style={subtleTextStyle}>{hiddenAttentionDetail}</div>}
           {attentionItems.length === 0 ? (
             <div style={subtleTextStyle}>No project attention items detected.</div>
           ) : (

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ContextPacketRecord } from "../../types/context";
 import type {
+  ProjectAssignmentLaunchReadinessRecord,
   ProjectAssignmentRecord,
   ProjectCollaborationArtifactRecord,
   ProjectHandoffRecord,
@@ -13,17 +14,19 @@ import type {
   ProjectWorkRoleRecord,
 } from "../../types/project";
 import { ProjectWorkItemDetail, type ProjectWorkItemDetailProps } from "./ProjectWorkItemDetail";
-import { getProjectAssignmentPreflight } from "../../lib/api";
+import { getProjectAssignmentLaunchReadiness, getProjectAssignmentPreflight } from "../../lib/api";
 
 vi.mock("../../lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/api")>();
   return {
     ...actual,
     getProjectAssignmentContext: vi.fn(),
+    getProjectAssignmentLaunchReadiness: vi.fn(),
     getProjectAssignmentPreflight: vi.fn(),
   };
 });
 
+const getProjectAssignmentLaunchReadinessMock = vi.mocked(getProjectAssignmentLaunchReadiness);
 const getProjectAssignmentPreflightMock = vi.mocked(getProjectAssignmentPreflight);
 
 function project(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
@@ -179,14 +182,44 @@ function preflightPacket(): ContextPacketRecord {
     id: "ctx_preflight",
     items: [
       {
-        kind: "launch_readiness",
-        title: "Ready",
+        kind: "launch_preflight",
+        title: "Launch preflight",
         trust_level: "runtime",
-        origin: "hecate",
-        included: true,
-        metadata: { ready: "true" },
+        origin: "project_assignment.preflight",
+        included: false,
+        body: "Preview only: no task, run, chat session, memory entry, artifact, or assignment update has been created.",
       },
     ],
+  };
+}
+
+function launchReadiness(
+  overrides: Partial<ProjectAssignmentLaunchReadinessRecord> = {},
+): ProjectAssignmentLaunchReadinessRecord {
+  return {
+    project_id: "proj_1",
+    work_item_id: "work_1",
+    assignment_id: "assign_1",
+    generated_at: "2026-06-20T12:00:00Z",
+    ready: true,
+    status: "ready",
+    title: "Ready to start assignment",
+    detail: "Launch checks are clear.",
+    blockers: [],
+    warnings: [],
+    driver_kind: "hecate_task",
+    workspace: "/workspace/hecate",
+    root_id: "root_main",
+    provider: "openai",
+    model: "gpt-5",
+    execution_profile: "implementation",
+    model_readiness: {
+      ready: true,
+      status: "ok",
+      provider: "openai",
+      model: "gpt-5",
+    },
+    ...overrides,
   };
 }
 
@@ -255,6 +288,10 @@ function renderDetail(overrides: Partial<ProjectWorkItemDetailProps> = {}) {
 describe("ProjectWorkItemDetail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getProjectAssignmentLaunchReadinessMock.mockResolvedValue({
+      object: "project_assignment_launch_readiness",
+      data: launchReadiness(),
+    });
     getProjectAssignmentPreflightMock.mockResolvedValue({
       object: "context_packet",
       data: preflightPacket(),
@@ -481,6 +518,11 @@ describe("ProjectWorkItemDetail", () => {
     const { handlers } = renderDetail();
 
     await userEvent.click(screen.getByRole("button", { name: "Start" }));
+    expect(getProjectAssignmentLaunchReadinessMock).toHaveBeenCalledWith(
+      "proj_1",
+      "work_1",
+      "assign_1",
+    );
     expect(getProjectAssignmentPreflightMock).toHaveBeenCalledWith("proj_1", "work_1", "assign_1");
 
     await userEvent.click(await screen.findByRole("button", { name: "Start assignment" }));
@@ -507,7 +549,48 @@ describe("ProjectWorkItemDetail", () => {
       "work_1",
       "assign_prepared",
     );
+    expect(getProjectAssignmentLaunchReadinessMock).toHaveBeenCalledWith(
+      "proj_1",
+      "work_1",
+      "assign_prepared",
+    );
     expect(handlers.onPreparedAssignmentPreflightOpened).toHaveBeenCalledWith("assign_prepared");
+    expect(handlers.onStartAssignment).not.toHaveBeenCalled();
+  });
+
+  it("blocks assignment launch confirmation from typed readiness", async () => {
+    getProjectAssignmentLaunchReadinessMock.mockResolvedValueOnce({
+      object: "project_assignment_launch_readiness",
+      data: launchReadiness({
+        ready: false,
+        status: "blocked",
+        title: "Launch is blocked",
+        detail: "Resolve launch blockers before starting this assignment.",
+        blockers: ['No routable provider reports model "dogfood-model".'],
+        model: "dogfood-model",
+        model_readiness: {
+          ready: false,
+          status: "blocked",
+          provider: "auto",
+          model: "dogfood-model",
+          reason: "model_not_discovered",
+          message: 'No routable provider reports model "dogfood-model".',
+          operator_action: "Pick one of the discovered models.",
+        },
+      }),
+    });
+    const { handlers } = renderDetail();
+
+    await userEvent.click(screen.getByRole("button", { name: "Start" }));
+    const preflight = await screen.findByRole("dialog", {
+      name: "Assignment assign_1 launch preflight",
+    });
+
+    expect(within(preflight).getByText("Provider/model not ready")).toBeTruthy();
+    expect(within(preflight).getByRole("status").textContent).toContain(
+      'No routable provider reports model "dogfood-model"',
+    );
+    expect(within(preflight).getByRole("button", { name: "Start assignment" })).toBeDisabled();
     expect(handlers.onStartAssignment).not.toHaveBeenCalled();
   });
 

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -525,11 +525,50 @@ describe("ProjectWorkItemDetail", () => {
     );
     expect(getProjectAssignmentPreflightMock).toHaveBeenCalledWith("proj_1", "work_1", "assign_1");
 
-    await userEvent.click(await screen.findByRole("button", { name: "Start assignment" }));
+    const preflight = await screen.findByRole("dialog", {
+      name: "Assignment assign_1 launch preflight",
+    });
+    const posture = within(preflight).getByRole("region", { name: "Resolved launch posture" });
+    expect(within(posture).getByText("Launch posture")).toBeTruthy();
+    expect(within(posture).getByText("Hecate task")).toBeTruthy();
+    expect(within(posture).getByText("/workspace/hecate")).toBeTruthy();
+    expect(within(posture).getByText("root_main")).toBeTruthy();
+    expect(within(posture).getByText("openai / gpt-5")).toBeTruthy();
+    expect(within(posture).getByText("implementation")).toBeTruthy();
+
+    await userEvent.click(within(preflight).getByRole("button", { name: "Start assignment" }));
 
     expect(handlers.onStartAssignment).toHaveBeenCalledWith(
       expect.objectContaining({ id: "assign_1" }),
     );
+  });
+
+  it("shows External Agent launch posture before preparing chat", async () => {
+    getProjectAssignmentLaunchReadinessMock.mockResolvedValueOnce({
+      object: "project_assignment_launch_readiness",
+      data: launchReadiness({
+        driver_kind: "external_agent",
+        provider: "",
+        model: "",
+        external_agent: "Codex",
+        external_agent_id: "codex",
+        session_title: "Implementation follow-up",
+      }),
+    });
+    renderDetail({
+      assignments: [assignment({ driver_kind: "external_agent", execution_ref: { kind: "none" } })],
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Prepare chat" }));
+    const preflight = await screen.findByRole("dialog", {
+      name: "Assignment assign_1 launch preflight",
+    });
+    const posture = within(preflight).getByRole("region", { name: "Resolved launch posture" });
+
+    expect(within(posture).getAllByText("External Agent").length).toBeGreaterThan(0);
+    expect(within(posture).getByText("Codex (codex)")).toBeTruthy();
+    expect(within(posture).getByText("Implementation follow-up")).toBeTruthy();
+    expect(within(posture).queryByText("openai / gpt-5")).toBeNull();
   });
 
   it("opens launch preflight when a prepared assignment becomes visible", async () => {
@@ -587,6 +626,7 @@ describe("ProjectWorkItemDetail", () => {
     });
 
     expect(within(preflight).getByText("Provider/model not ready")).toBeTruthy();
+    expect(within(preflight).getByRole("region", { name: "Resolved launch posture" })).toBeTruthy();
     expect(within(preflight).getByRole("status").textContent).toContain(
       'No routable provider reports model "dogfood-model"',
     );

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -1263,6 +1263,7 @@ function AssignmentLaunchPreflightModal({
                 repairActions={repairActions}
               />
             )}
+            <AssignmentLaunchPosture readiness={state.readiness} />
             <ContextInspectorPanel
               packet={state.packet}
               emptyDetail="No launch context metadata returned."
@@ -1271,6 +1272,34 @@ function AssignmentLaunchPreflightModal({
         ) : null}
       </div>
     </Modal>
+  );
+}
+
+function AssignmentLaunchPosture({
+  readiness,
+}: {
+  readiness: ProjectAssignmentLaunchReadinessRecord;
+}) {
+  const rows = assignmentLaunchPostureRows(readiness);
+  return (
+    <section aria-label="Resolved launch posture" style={launchPosturePanelStyle}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+        <div style={sectionLabelStyle}>Launch posture</div>
+        <span className={readiness.ready ? "badge badge-green" : "badge badge-amber"}>
+          {readiness.status || (readiness.ready ? "ready" : "blocked")}
+        </span>
+      </div>
+      <div style={launchPostureGridStyle}>
+        {rows.map((row) => (
+          <div key={row.label} style={launchPostureItemStyle}>
+            <div style={launchPostureLabelStyle}>{row.label}</div>
+            <div style={launchPostureValueStyle} title={row.value}>
+              {row.value}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -1795,6 +1824,54 @@ function formatLaunchContextBullet(label: string, value: string): string {
   return continuation ? `- ${label}: ${firstLine}\n${continuation}` : `- ${label}: ${firstLine}`;
 }
 
+function assignmentLaunchPostureRows(
+  readiness: ProjectAssignmentLaunchReadinessRecord,
+): Array<{ label: string; value: string }> {
+  const rows = [
+    { label: "Driver", value: assignmentLaunchDriverLabel(readiness.driver_kind) },
+    { label: "Workspace", value: firstNonEmpty(readiness.workspace, "No workspace resolved") },
+  ];
+  const root = labelWithID(readiness.root_path, readiness.root_id ?? "");
+  if (root) rows.push({ label: "Root", value: root });
+  if (readiness.provider || readiness.model) {
+    rows.push({
+      label: "Provider/model",
+      value: `${firstNonEmpty(readiness.provider, "auto")} / ${firstNonEmpty(readiness.model, "auto")}`,
+    });
+  }
+  if (readiness.execution_profile) {
+    rows.push({ label: "Profile", value: readiness.execution_profile });
+  }
+  if (
+    readiness.driver_kind === "external_agent" ||
+    readiness.external_agent ||
+    readiness.external_agent_id
+  ) {
+    rows.push({
+      label: "External Agent",
+      value: firstNonEmpty(
+        labelWithID(readiness.external_agent, readiness.external_agent_id ?? ""),
+        "Unresolved External Agent",
+      ),
+    });
+  }
+  if (readiness.session_title) {
+    rows.push({ label: "Session", value: readiness.session_title });
+  }
+  return rows;
+}
+
+function assignmentLaunchDriverLabel(kind: string): string {
+  switch (kind) {
+    case "hecate_task":
+      return "Hecate task";
+    case "external_agent":
+      return "External Agent";
+    default:
+      return kind || "unknown";
+  }
+}
+
 function assignmentLaunchReadinessNotice(
   readiness: ProjectAssignmentLaunchReadinessRecord,
 ): AssignmentLaunchReadinessNoticeRecord | null {
@@ -1840,6 +1917,41 @@ const subtleTextStyle: CSSProperties = {
   color: "var(--t3)",
   fontSize: 12,
   lineHeight: 1.4,
+};
+
+const launchPosturePanelStyle: CSSProperties = {
+  background: "var(--bg2)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 10,
+  padding: "10px 12px",
+};
+
+const launchPostureGridStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+};
+
+const launchPostureItemStyle: CSSProperties = {
+  display: "grid",
+  gap: 3,
+  minWidth: 0,
+};
+
+const launchPostureLabelStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  textTransform: "uppercase",
+};
+
+const launchPostureValueStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 12,
+  lineHeight: 1.35,
+  overflowWrap: "anywhere",
 };
 
 const metaLineStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useState, type CSSProperties } from "react";
 
-import { getProjectAssignmentContext, getProjectAssignmentPreflight } from "../../lib/api";
+import {
+  getProjectAssignmentContext,
+  getProjectAssignmentLaunchReadiness,
+  getProjectAssignmentPreflight,
+} from "../../lib/api";
 import { formatAbsoluteTime } from "../../lib/format";
 import type { ContextPacketRecord } from "../../types/context";
 import type {
   ProjectActivityItemRecord,
   ProjectAssignmentRecord,
+  ProjectAssignmentLaunchReadinessRecord,
   ProjectCollaborationArtifactRecord,
   ProjectHandoffRecord,
   ProjectRecord,
@@ -49,11 +54,18 @@ export type ProjectAssignmentChatLaunchRequest = {
 
 type AssignmentPreflightState =
   | { status: "idle" | "loading" }
-  | { status: "ready"; packet: ContextPacketRecord }
+  | {
+      status: "ready";
+      packet: ContextPacketRecord;
+      readiness: ProjectAssignmentLaunchReadinessRecord;
+    }
   | { status: "error"; detail: string };
 
 type AssignmentLaunchReadinessNoticeRecord = {
+  title: string;
   detail: string;
+  blockers: string[];
+  warnings: string[];
 };
 
 type AssignmentLaunchRepairActions = {
@@ -391,6 +403,18 @@ export function ProjectWorkItemDetail({
                               ).data
                           : null
                       }
+                      loadReadiness={
+                        project
+                          ? async () =>
+                              (
+                                await getProjectAssignmentLaunchReadiness(
+                                  project.id,
+                                  workItem.id,
+                                  assignment.id,
+                                )
+                              ).data
+                          : null
+                      }
                     />
                   );
                 })}
@@ -518,6 +542,18 @@ export function ProjectWorkItemDetail({
                           ? async () =>
                               (
                                 await getProjectAssignmentPreflight(
+                                  project.id,
+                                  workItem.id,
+                                  targetAssignment.id,
+                                )
+                              ).data
+                          : null
+                      }
+                      loadReadiness={
+                        project && targetAssignment
+                          ? async () =>
+                              (
+                                await getProjectAssignmentLaunchReadiness(
                                   project.id,
                                   workItem.id,
                                   targetAssignment.id,
@@ -848,6 +884,7 @@ function AssignmentRow({
   error,
   loadContext,
   loadPreflight,
+  loadReadiness,
   onCreateHandoff,
   onCreateReviewHandoff,
   onCreateReviewArtifact,
@@ -869,6 +906,7 @@ function AssignmentRow({
   error: string;
   loadContext?: (() => Promise<ContextPacketRecord>) | null;
   loadPreflight?: (() => Promise<ContextPacketRecord>) | null;
+  loadReadiness?: (() => Promise<ProjectAssignmentLaunchReadinessRecord>) | null;
   onCreateHandoff: () => void;
   onCreateReviewHandoff?: () => void;
   onCreateReviewArtifact?: () => void;
@@ -909,33 +947,34 @@ function AssignmentRow({
   const finishedAt = activityView?.finishedAt || execution?.finished_at || assignment.completed_at;
 
   const openPreflight = useCallback(async () => {
-    if (!loadPreflight) {
+    if (!loadPreflight || !loadReadiness) {
       onStart();
       return;
     }
     setPreflightOpen(true);
     setPreflightState({ status: "loading" });
     try {
-      const packet = await loadPreflight();
-      setPreflightState({ status: "ready", packet });
+      const [readiness, packet] = await Promise.all([loadReadiness(), loadPreflight()]);
+      setPreflightState({ status: "ready", packet, readiness });
     } catch (error) {
       setPreflightState({
         status: "error",
-        detail: projectErrorMessage(error, "Failed to load assignment launch preflight."),
+        detail: projectErrorMessage(error, "Failed to load assignment launch checks."),
       });
     }
-  }, [loadPreflight, onStart]);
+  }, [loadPreflight, loadReadiness, onStart]);
 
   useEffect(() => {
     if (!autoOpenPreflight) return;
     onAutoOpenPreflightHandled?.(assignment.id);
     if (!startable) return;
-    if (!loadPreflight) return;
+    if (!loadPreflight || !loadReadiness) return;
     void openPreflight();
   }, [
     assignment.id,
     autoOpenPreflight,
     loadPreflight,
+    loadReadiness,
     onAutoOpenPreflightHandled,
     openPreflight,
     startable,
@@ -1166,7 +1205,7 @@ function AssignmentLaunchPreflightModal({
   state: AssignmentPreflightState;
 }) {
   const ready = state.status === "ready";
-  const readinessNotice = ready ? assignmentLaunchReadinessNotice(state.packet) : null;
+  const readinessNotice = ready ? assignmentLaunchReadinessNotice(state.readiness) : null;
   const canConfirm = ready && !readinessNotice;
   const runRepairAction = useCallback(
     (action?: () => void) => {
@@ -1195,7 +1234,7 @@ function AssignmentLaunchPreflightModal({
             disabled={!canConfirm || pending}
             title={
               readinessNotice
-                ? "Fix the provider/model readiness issue before starting this assignment."
+                ? "Resolve the launch readiness blockers before starting this assignment."
                 : undefined
             }
           >
@@ -1276,11 +1315,23 @@ function AssignmentLaunchReadinessNotice({
           }}
         >
           <Icon d={Icons.warning} size={13} />
-          Provider/model not ready
+          {notice.title}
         </div>
         <div style={{ color: "var(--amber-lo)", fontSize: 12, lineHeight: 1.45 }}>
           {notice.detail}
         </div>
+        {notice.blockers.length > 0 && (
+          <ul style={{ margin: "2px 0 0 18px", padding: 0 }}>
+            {notice.blockers.map((blocker) => (
+              <li key={blocker}>{blocker}</li>
+            ))}
+          </ul>
+        )}
+        {notice.warnings.length > 0 && (
+          <div style={{ color: "var(--amber-lo)", fontSize: 12, lineHeight: 1.45 }}>
+            {notice.warnings.join(" ")}
+          </div>
+        )}
       </div>
       {actions.length > 0 && (
         <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 2 }}>
@@ -1305,6 +1356,7 @@ function ProjectHandoffRow({
   assignment,
   handoff,
   loadPreflight,
+  loadReadiness,
   onCreateAssignment,
   onDelete,
   onEdit,
@@ -1318,6 +1370,7 @@ function ProjectHandoffRow({
   assignment?: ProjectAssignmentRecord;
   handoff: ProjectHandoffRecord;
   loadPreflight?: (() => Promise<ContextPacketRecord>) | null;
+  loadReadiness?: (() => Promise<ProjectAssignmentLaunchReadinessRecord>) | null;
   onCreateAssignment: () => void;
   onDelete: () => void;
   onEdit: () => void;
@@ -1341,19 +1394,19 @@ function ProjectHandoffRow({
   const sourceRefs = handoffSourceRefs(handoff);
 
   async function openPreflight() {
-    if (!loadPreflight) {
+    if (!loadPreflight || !loadReadiness) {
       onStart();
       return;
     }
     setPreflightOpen(true);
     setPreflightState({ status: "loading" });
     try {
-      const packet = await loadPreflight();
-      setPreflightState({ status: "ready", packet });
+      const [readiness, packet] = await Promise.all([loadReadiness(), loadPreflight()]);
+      setPreflightState({ status: "ready", packet, readiness });
     } catch (error) {
       setPreflightState({
         status: "error",
-        detail: projectErrorMessage(error, "Failed to load assignment launch preflight."),
+        detail: projectErrorMessage(error, "Failed to load assignment launch checks."),
       });
     }
   }
@@ -1743,29 +1796,27 @@ function formatLaunchContextBullet(label: string, value: string): string {
 }
 
 function assignmentLaunchReadinessNotice(
-  packet: ContextPacketRecord,
+  readiness: ProjectAssignmentLaunchReadinessRecord,
 ): AssignmentLaunchReadinessNoticeRecord | null {
-  const item = packet.items?.find((candidate) => candidate.kind === "launch_readiness");
-  if (!item) return null;
-  const ready = (item.metadata?.ready || contextBodyField(item.body || "", "Ready")).toLowerCase();
-  if (ready !== "false") return null;
-  const message = item.metadata?.message || contextBodyField(item.body || "", "Message");
-  const action =
-    item.metadata?.operator_action || contextBodyField(item.body || "", "Operator action");
-  const reason = item.metadata?.reason || contextBodyField(item.body || "", "Reason");
-  const detail = [message, action].filter(Boolean).join(" ");
+  if (readiness.ready) return null;
+  const modelReadiness = readiness.model_readiness;
+  const title =
+    modelReadiness?.ready === false
+      ? "Provider/model not ready"
+      : readiness.title || "Launch is blocked";
+  const modelDetail = [modelReadiness?.message, modelReadiness?.operator_action]
+    .filter(Boolean)
+    .join(" ");
   return {
-    detail: detail || reason || "The selected provider/model cannot be routed for this assignment.",
+    title,
+    detail:
+      modelDetail ||
+      readiness.detail ||
+      modelReadiness?.reason ||
+      "Resolve launch readiness blockers before starting this assignment.",
+    blockers: readiness.blockers ?? [],
+    warnings: readiness.warnings ?? [],
   };
-}
-
-function contextBodyField(body: string, label: string): string {
-  const prefix = `${label}:`;
-  for (const rawLine of body.split("\n")) {
-    const line = rawLine.trim();
-    if (line.startsWith(prefix)) return line.slice(prefix.length).trim();
-  }
-  return "";
 }
 
 const sectionLabelStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -34,6 +34,7 @@ import {
 import { toProjectAssignmentExecutionViewModel } from "./projectAssignmentViewModels";
 import { formatProjectRowRelativeTime, workStatusLabel } from "./projectDisplay";
 import { projectActivityWorkItemToWorkItem } from "./projectInsights";
+import { projectVisibilityDetail } from "./projectVisibilityDetail";
 import { useProjectAssistantController } from "./useProjectAssistantController";
 
 export type WorkItemSummary = {
@@ -750,12 +751,15 @@ function projectOperationsLimitDetail(
     brief.summary.omitted_item_count ?? availableItemCount - returnedItemCount,
     0,
   );
-  const hiddenItemCount = Math.max(availableItemCount - shownItemCount, 0);
-  if (hiddenItemCount === 0) return "";
-  const operationLabel = availableItemCount === 1 ? "operation" : "operations";
-  const hiddenLabel = hiddenItemCount === 1 ? "operation is" : "operations are";
-  const capDetail = omittedItemCount > 0 ? ` (${omittedItemCount} capped by the server)` : "";
-  return `Showing ${shownItemCount} of ${availableItemCount} ${operationLabel}; ${hiddenItemCount} lower-priority ${hiddenLabel} hidden${capDetail}.`;
+  return projectVisibilityDetail({
+    shownCount: shownItemCount,
+    totalCount: availableItemCount,
+    itemLabelSingular: "operation",
+    itemLabelPlural: "operations",
+    hiddenLabelSingular: "operation",
+    hiddenLabelPlural: "operations",
+    serverOmittedCount: omittedItemCount,
+  });
 }
 
 function projectOperationBadge(item: ProjectOperationsBriefItem): string {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -31,6 +31,7 @@ import {
   getProjectOperationsBrief,
   getAgentProfiles,
   getProjectAssignmentContext,
+  getProjectAssignmentLaunchReadiness,
   getProjectAssignmentPreflight,
   getProjectAssignments,
   getProjectAssistantContext,
@@ -69,6 +70,7 @@ import {
 import launchContextContractRaw from "../../test/fixtures/launch-context-v1-contract.json";
 import { withRuntimeConsole } from "../../test/runtime-console-render";
 import type {
+  ProjectAssignmentLaunchReadinessRecord,
   ProjectAssignmentRecord,
   ProjectActivityData,
   ProjectHealthAttention,
@@ -244,6 +246,22 @@ vi.mock("../../lib/api", async (importOriginal) => {
     })),
     getProjectAssignments: vi.fn(async () => ({ object: "project_assignments", data: [] })),
     getProjectAssignmentContext: vi.fn(async () => ({ object: "context_packet", data: null })),
+    getProjectAssignmentLaunchReadiness: vi.fn(async () => ({
+      object: "project_assignment_launch_readiness",
+      data: {
+        project_id: "proj_1",
+        work_item_id: "work_1",
+        assignment_id: "asgn_1",
+        generated_at: "2026-06-20T12:00:00Z",
+        ready: true,
+        status: "ready",
+        title: "Ready to start assignment",
+        detail: "Launch checks are clear.",
+        blockers: [],
+        warnings: [],
+        driver_kind: "hecate_task",
+      },
+    })),
     getProjectAssignmentPreflight: vi.fn(async () => ({
       object: "context_packet",
       data: null,
@@ -474,6 +492,36 @@ function workItemReadiness(overrides = {}) {
     assignment_count: 1,
     completed_assignments: 0,
     review_follow_up_count: 0,
+    ...overrides,
+  };
+}
+
+function assignmentLaunchReadiness(
+  overrides: Partial<ProjectAssignmentLaunchReadinessRecord> = {},
+): ProjectAssignmentLaunchReadinessRecord {
+  return {
+    project_id: project.id,
+    work_item_id: workItem.id,
+    assignment_id: hecateAssignment.id,
+    generated_at: "2026-06-20T12:00:00Z",
+    ready: true,
+    status: "ready",
+    title: "Ready to start assignment",
+    detail: "Launch checks are clear.",
+    blockers: [],
+    warnings: [],
+    driver_kind: "hecate_task",
+    workspace: "/tmp/hecate-project",
+    root_id: "root_1",
+    provider: "ollama",
+    model: "qwen2.5-coder",
+    execution_profile: "implementation",
+    model_readiness: {
+      ready: true,
+      status: "ok",
+      provider: "ollama",
+      model: "qwen2.5-coder",
+    },
     ...overrides,
   };
 }
@@ -718,6 +766,10 @@ function resetProjectWorkMocks() {
         },
       ],
     },
+  });
+  vi.mocked(getProjectAssignmentLaunchReadiness).mockResolvedValue({
+    object: "project_assignment_launch_readiness",
+    data: assignmentLaunchReadiness(),
   });
   vi.mocked(getProjectAssignmentPreflight).mockResolvedValue({
     object: "context_packet",
@@ -1180,6 +1232,7 @@ afterEach(() => {
   vi.mocked(getProjectWorkItemReadiness).mockReset();
   vi.mocked(getProjectAssignments).mockReset();
   vi.mocked(getProjectAssignmentContext).mockReset();
+  vi.mocked(getProjectAssignmentLaunchReadiness).mockReset();
   vi.mocked(getProjectAssignmentPreflight).mockReset();
   vi.mocked(getProjectAssistantContext).mockReset();
   vi.mocked(getProjectCollaborationArtifacts).mockReset();
@@ -6393,6 +6446,27 @@ describe("ProjectsView cockpit", () => {
       object: "project_assignments",
       data: [queuedAssignment],
     });
+    vi.mocked(getProjectAssignmentLaunchReadiness).mockResolvedValueOnce({
+      object: "project_assignment_launch_readiness",
+      data: assignmentLaunchReadiness({
+        ready: false,
+        status: "blocked",
+        title: "Launch is blocked",
+        detail: "Resolve launch blockers before starting this assignment.",
+        blockers: ['No routable provider reports model "dogfood-model".'],
+        provider: "",
+        model: "dogfood-model",
+        model_readiness: {
+          ready: false,
+          status: "blocked",
+          provider: "auto",
+          model: "dogfood-model",
+          reason: "model_not_discovered",
+          message: 'No routable provider reports model "dogfood-model".',
+          operator_action: "Pick one of the discovered models.",
+        },
+      }),
+    });
     vi.mocked(getProjectAssignmentPreflight).mockResolvedValueOnce({
       object: "context_packet",
       data: {
@@ -6409,32 +6483,6 @@ describe("ProjectsView cockpit", () => {
           role_id: role.id,
         },
         items: [
-          {
-            section: "runtime",
-            kind: "launch_readiness",
-            trust_level: "runtime_state",
-            origin: "project_assignment.launch_readiness",
-            title: "Launch readiness",
-            body: [
-              "Ready: false",
-              "Status: blocked",
-              "Provider: auto",
-              "Model: dogfood-model",
-              "Reason: model_not_discovered",
-              'Message: No routable provider reports model "dogfood-model".',
-              "Operator action: Pick one of the discovered models.",
-            ].join("\n"),
-            included: false,
-            metadata: {
-              ready: "false",
-              status: "blocked",
-              provider: "auto",
-              model: "dogfood-model",
-              reason: "model_not_discovered",
-              message: 'No routable provider reports model "dogfood-model".',
-              operator_action: "Pick one of the discovered models.",
-            },
-          },
           {
             section: "runtime",
             kind: "launch_preflight",
@@ -6461,6 +6509,11 @@ describe("ProjectsView cockpit", () => {
     );
 
     await userEvent.click(await screen.findByRole("button", { name: "Start" }));
+    expect(getProjectAssignmentLaunchReadiness).toHaveBeenCalledWith(
+      project.id,
+      workItem.id,
+      queuedAssignment.id,
+    );
     const preflight = await screen.findByRole("dialog", {
       name: "Assignment asgn_1 launch preflight",
     });

--- a/ui/src/features/projects/projectVisibilityDetail.test.ts
+++ b/ui/src/features/projects/projectVisibilityDetail.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { projectVisibilityDetail } from "./projectVisibilityDetail";
+
+describe("projectVisibilityDetail", () => {
+  it("reconciles shown, total, and server-capped operation counts", () => {
+    expect(
+      projectVisibilityDetail({
+        shownCount: 4,
+        totalCount: 9,
+        itemLabelSingular: "operation",
+        itemLabelPlural: "operations",
+        hiddenLabelSingular: "operation",
+        hiddenLabelPlural: "operations",
+        serverOmittedCount: 1,
+      }),
+    ).toBe(
+      "Showing 4 of 9 operations; 5 lower-priority operations are hidden (1 capped by the server).",
+    );
+  });
+
+  it("formats attention item copy without server-cap wording", () => {
+    expect(
+      projectVisibilityDetail({
+        shownCount: 5,
+        totalCount: 7,
+        itemLabelSingular: "attention item",
+        itemLabelPlural: "attention items",
+        hiddenLabelSingular: "item",
+        hiddenLabelPlural: "items",
+      }),
+    ).toBe("Showing 5 of 7 attention items; 2 lower-priority items are hidden.");
+  });
+
+  it("returns an empty detail when nothing is hidden", () => {
+    expect(
+      projectVisibilityDetail({
+        shownCount: 3,
+        totalCount: 3,
+        itemLabelSingular: "operation",
+        itemLabelPlural: "operations",
+        hiddenLabelSingular: "operation",
+        hiddenLabelPlural: "operations",
+      }),
+    ).toBe("");
+  });
+});

--- a/ui/src/features/projects/projectVisibilityDetail.ts
+++ b/ui/src/features/projects/projectVisibilityDetail.ts
@@ -1,0 +1,30 @@
+export type ProjectVisibilityDetailOptions = {
+  shownCount: number;
+  totalCount: number;
+  itemLabelSingular: string;
+  itemLabelPlural: string;
+  hiddenLabelSingular: string;
+  hiddenLabelPlural: string;
+  serverOmittedCount?: number;
+};
+
+export function projectVisibilityDetail({
+  shownCount,
+  totalCount,
+  itemLabelSingular,
+  itemLabelPlural,
+  hiddenLabelSingular,
+  hiddenLabelPlural,
+  serverOmittedCount = 0,
+}: ProjectVisibilityDetailOptions): string {
+  const shown = Math.max(0, shownCount);
+  const total = Math.max(shown, totalCount);
+  const hidden = Math.max(0, total - shown);
+  if (hidden === 0) return "";
+  const totalLabel = total === 1 ? itemLabelSingular : itemLabelPlural;
+  const hiddenLabel = hidden === 1 ? hiddenLabelSingular : hiddenLabelPlural;
+  const hiddenVerb = hidden === 1 ? "is" : "are";
+  const capped = Math.max(0, serverOmittedCount);
+  const capDetail = capped > 0 ? ` (${capped} capped by the server)` : "";
+  return `Showing ${shown} of ${total} ${totalLabel}; ${hidden} lower-priority ${hiddenLabel} ${hiddenVerb} hidden${capDetail}.`;
+}

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -30,6 +30,7 @@ import {
   getChatWorkspaceFiles,
   getChatApproval,
   getProjectAssignmentContext,
+  getProjectAssignmentLaunchReadiness,
   getProjectAssignmentPreflight,
   getProjectAssignments,
   getProjectActivity,
@@ -652,6 +653,29 @@ describe("api client", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(result.data.id).toBe("ctx_preflight");
+  });
+
+  it("fetches project assignment launch readiness", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        object: "project_assignment_launch_readiness",
+        data: {
+          project_id: "proj/1",
+          work_item_id: "work/1",
+          assignment_id: "asgn/1",
+          ready: true,
+          status: "ready",
+        },
+      }),
+    );
+
+    const result = await getProjectAssignmentLaunchReadiness("proj/1", "work/1", "asgn/1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/proj%2F1/work-items/work%2F1/assignments/asgn%2F1/launch-readiness",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(result.data.ready).toBe(true);
   });
 
   it("creates project work items and assignments", async () => {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -85,6 +85,7 @@ import type {
   ProjectAssistantDraftPayload,
   ProjectAssistantProposalResponse,
   ProjectAssistantProposePayload,
+  ProjectAssignmentLaunchReadinessResponse,
   ProjectAssignmentResponse,
   ProjectAssignmentsResponse,
   ProjectActivityResponse,
@@ -798,6 +799,16 @@ export async function getProjectAssignmentPreflight(
 ): Promise<ContextPacketResponse> {
   return fetchJSON<ContextPacketResponse>(
     `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments/${encodeURIComponent(assignmentID)}/preflight`,
+  );
+}
+
+export async function getProjectAssignmentLaunchReadiness(
+  projectID: string,
+  workItemID: string,
+  assignmentID: string,
+): Promise<ProjectAssignmentLaunchReadinessResponse> {
+  return fetchJSON<ProjectAssignmentLaunchReadinessResponse>(
+    `${HECATE_API}/projects/${encodeURIComponent(projectID)}/work-items/${encodeURIComponent(workItemID)}/assignments/${encodeURIComponent(assignmentID)}/launch-readiness`,
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -1,3 +1,5 @@
+import type { ModelReadinessRecord } from "./model";
+
 export type ProjectRootRecord = {
   id: string;
   path: string;
@@ -542,6 +544,30 @@ export type ProjectWorkItemReadinessRecord = {
   missing_evidence_assignment_ids?: string[];
 };
 
+export type ProjectAssignmentLaunchReadinessRecord = {
+  project_id: string;
+  work_item_id: string;
+  assignment_id: string;
+  generated_at: string;
+  ready: boolean;
+  status: "blocked" | "ready" | (string & {});
+  title: string;
+  detail: string;
+  blockers: string[];
+  warnings: string[];
+  driver_kind: ProjectAssignmentDriverKind | string;
+  workspace?: string;
+  root_id?: string;
+  root_path?: string;
+  provider?: string;
+  model?: string;
+  execution_profile?: string;
+  external_agent_id?: string;
+  external_agent?: string;
+  session_title?: string;
+  model_readiness?: ModelReadinessRecord;
+};
+
 export type ProjectAssignmentStatus =
   | "queued"
   | "running"
@@ -1029,6 +1055,11 @@ export type ProjectWorkItemResponse = {
 export type ProjectWorkItemReadinessResponse = {
   object: string;
   data: ProjectWorkItemReadinessRecord;
+};
+
+export type ProjectAssignmentLaunchReadinessResponse = {
+  object: string;
+  data: ProjectAssignmentLaunchReadinessRecord;
 };
 
 export type ProjectAssignmentsResponse = {


### PR DESCRIPTION
## Summary
This PR makes assignment launch readiness a server-owned contract for Projects.

- Adds a read-only launch-readiness endpoint for project work assignments.
- Uses typed readiness to enable or block Start/Prepare in the assignment modal.
- Keeps preflight context as inspectable evidence, not the UI authority.
- Shares hidden-count copy for Project Operations and Needs Attention.

## Validation
- `go test ./internal/api -run 'TestProjectWorkAPI_AssignmentLaunchReadiness|TestProjectWorkAPI_Preflight|TestRemoteRuntimeRouteCoverage'`
- `go test ./internal/api ./internal/projectworkapp`
- `go test ./...`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run test`
- `bun run test:e2e e2e/projects.spec.ts`
- GitHub CI passing on PR #481
