### PR TITLE
chore(agent): bump ACP adapter fix releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.22
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.24
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.23
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.25
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.22
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.24
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.23
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.25
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,8 +24,8 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.22` and `claude-code-acp-adapter` versions older than
-`v0.1.0-alpha.24` as outside the tested range because those older releases lack
+older than `v0.1.0-alpha.23` and `claude-code-acp-adapter` versions older than
+`v0.1.0-alpha.25` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
 external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
 failure/stop-reason classification, or the local-login environment contract that
@@ -67,6 +67,9 @@ approvals instead of silently auto-continuing parsed permission events.
 Codex adapter `v0.1.0-alpha.22` keeps first-party CLI local-login detection
 visible to the spawned Codex process while retaining the sanitized adapter
 environment, and the release is covered by the opt-in real CLI smoke suite.
+Codex adapter `v0.1.0-alpha.23` classifies native Codex HTTP 401 prompt
+failures as ACP authentication-required errors so Hecate can surface the login
+action instead of a generic prompt command failure.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter
@@ -104,6 +107,10 @@ Claude Code adapter `v0.1.0-alpha.24` keeps first-party CLI local-login
 detection visible to the spawned Claude process while retaining the sanitized
 adapter environment, and the release is covered by the opt-in real CLI smoke
 suite.
+Claude Code adapter `v0.1.0-alpha.25` resumes established or host-adopted native
+Claude sessions with `claude --resume`, while keeping `claude --session-id` for
+fresh session creation, so follow-up turns continue the same Claude session
+without hitting native session locks.
 
 ## Supported External Agents
 

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -271,7 +271,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.22",
+			SupportedRange:       ">=0.1.0-alpha.23",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{
@@ -312,7 +312,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Claude Code through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/claude-code-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.24",
+			SupportedRange:       ">=0.1.0-alpha.25",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.22" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.23" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {
@@ -41,7 +41,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
-	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.24" {
+	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.25" {
 		t.Fatalf("claude_code supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["claude_code"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary
- bump bundled Codex ACP adapter to v0.1.0-alpha.23
- bump bundled Claude Code ACP adapter to v0.1.0-alpha.25
- update supported ranges and external-agent docs for Codex auth classification and Claude follow-up resume behavior

## Released adapters
- hecatehq/codex-acp-adapter v0.1.0-alpha.23
- hecatehq/claude-code-acp-adapter v0.1.0-alpha.25

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- release artifact sanity checked with gh release view for both adapter tags