### PR TITLE
test(agent): harden ACP release smoke

### DIFF
--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -143,7 +143,7 @@ Acceptance:
 - **Don't run snapshot from a clean checkout, then `git add -A`.** The snapshot writes ~50 MB of binaries into `./dist`; a sweeping `git add` will pick them up if `dist/` isn't gitignored.
 - **`ui/dist/.gitkeep` must be tracked.** The `//go:embed all:ui/dist` directive in `embed.go` fails at compile time if `ui/dist` is completely absent from the tree. `.gitignore` keeps `ui/dist/*` but un-ignores `.gitkeep` via negation — the negation only works if `/dist/` (not `dist/`) is the rule anchoring the goreleaser output directory. If `go build` fails with `pattern all:ui/dist: no matching files found`, check that `ui/dist/.gitkeep` is tracked (`git ls-files ui/dist/`) and that `.gitignore` anchors the root dist rule with a leading `/`.
 - **`Dockerfile.release` is what goreleaser uses, not `Dockerfile`.** `Dockerfile` is the source-build image used by `docker compose up --build`; `Dockerfile.release` copies the prebuilt binary into the published GHCR image. They are two build paths for the same runtime shape, so any runtime package, bundled External Agent CLI/adapter, `ENV` var, volume, or default must land in both.
-- **Bundled External Agent versions are deliberate.** The Dockerfiles pin the top-level npm package versions for the upstream Codex CLI, Claude Code CLI, and Grok Build CLI. The Codex and Claude Code ACP adapters are bundled as checksum-verified GitHub release binaries, not npm packages. Cursor Agent comes from Cursor's official installer; because that script has no version flag, the Dockerfiles pin the installer SHA-256 and fail the build when Cursor rotates it. Review the new script, confirm the hardcoded Cursor package it installs, then update both Dockerfiles together.
+- **Bundled External Agent versions are deliberate.** The Dockerfiles pin the top-level vendor CLI packages for Codex, Claude Code, and Grok Build. The Codex and Claude Code ACP adapters are bundled as checksum-verified GitHub release binaries. Cursor Agent comes from Cursor's official installer; because that script has no version flag, the Dockerfiles pin the installer SHA-256 and fail the build when Cursor rotates it. Review the new script, confirm the hardcoded Cursor package it installs, then update both Dockerfiles together.
 - **ACP adapter bumps are a three-file contract.** When cutting a new
   `codex-acp-adapter` or `claude-code-acp-adapter` release for Hecate, update
   both `Dockerfile` and `Dockerfile.release`, then update the matching
@@ -153,7 +153,8 @@ Acceptance:
   is available, or dispatch the manual **ACP adapter release smoke** workflow;
   that check downloads the pinned release binaries and exercises probe, auth,
   config selectors, MCP propagation, prompt execution, stream activity,
-  permission approvals, and grant reuse through Hecate.
+  permission approvals, grant reuse, repeated prompt continuation, auth-required
+  classification, and native session reload/recovery through Hecate.
 - **CI's `e2e-ollama` job runs under `-tags 'e2e ollama'`** — `just verify` only covers `-tags 'e2e docker'` locally, so an ollama-only regression sails through the local gate. The `v0.1.0-alpha.7` cut hit this with the env-PRECONFIGURED gate: `gateway_test.go` was patched but `ollama_test.go` was missed. Before tagging, also run `OLLAMA_BASE_URL=http://127.0.0.1:11434 OLLAMA_MODEL=smollm2:135m go test -tags 'e2e ollama' -count=1 ./e2e/...` if any e2e helper has changed.
 - **Lychee link-check runs only on master pushes**, not on tag pushes — a broken markdown link in `AGENTS.md` / `docs-ai/**` won't block a release, but it'll blink red on the next master push. Run `just check-links` (or grep for the suspected dangling target) before tagging when the change set is doc-heavy.
 

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -321,10 +321,12 @@ CLIs on `PATH`, and runs Hecate's probe/auth/logout/session/run path against
 the real adapter binaries, including session config selector changes and
 session-level MCP propagation, command-backed prompt execution, prompt
 auth-required mapping, structured activity mapping, prompt-mode permission
-approval, session-scoped grant reuse, and native session reload/recovery. It
-requires network access and is intentionally not part of the normal unit-test
-ladder. The same check is available from GitHub Actions as the manual **ACP
-adapter release smoke** workflow.
+approval, session-scoped grant reuse, repeated prompt continuation, and native
+session reload/recovery. Its fake CLIs are strict about auth-error wording and
+native continuation flags so packaging bumps catch drift before an operator hits
+it. It requires network access and is intentionally not part of the normal
+unit-test ladder. The same check is available from GitHub Actions as the manual
+**ACP adapter release smoke** workflow.
 
 There is also a narrower discovery-only fixture env var,
 `HECATE_AGENT_ADAPTER_DISCOVERY_OVERRIDES`, used by backend tests that only

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -319,8 +319,11 @@ Dockerfile-pinned Go adapter release binaries, verifies checksums, and smokes
 probe capability discovery, ACP authenticate/logout, session config selectors
 and selector changes, session-level MCP propagation, advertised slash commands,
 command-backed prompt execution, prompt auth-required mapping, prompt streaming,
-usage mapping, structured activity mapping, stop-reason mapping, and native
-session reload/recovery with fake `codex` and `claude` CLIs.
+usage mapping, structured activity mapping, stop-reason mapping, repeated
+prompt continuation, and native session reload/recovery with fake `codex` and
+`claude` CLIs. The fake CLIs intentionally use real-world failure shapes, such
+as Codex's 401 auth wording and Claude Code's first-prompt versus resume flags,
+so adapter bumps prove Hecate still sees the same operator-facing behavior.
 
 ## Setup checks
 

--- a/internal/agentadapters/acp_release_smoke_test.go
+++ b/internal/agentadapters/acp_release_smoke_test.go
@@ -623,6 +623,7 @@ func extractSingleBinary(t *testing.T, archive []byte, binary, dst string) {
 func installFakeVendorCLI(t *testing.T, name, body string) {
 	t.Helper()
 	bin := filepath.Join(t.TempDir(), "bin")
+	stateDir := t.TempDir()
 	if err := os.Mkdir(bin, 0o755); err != nil {
 		t.Fatalf("mkdir vendor bin: %v", err)
 	}
@@ -631,6 +632,7 @@ func installFakeVendorCLI(t *testing.T, name, body string) {
 	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake %s CLI: %v", name, err)
 	}
+	t.Setenv("HECATE_ACP_RELEASE_FAKE_CLI_STATE_DIR", stateDir)
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
@@ -680,7 +682,7 @@ case "$1" in
     require_contains " --config model_reasoning_effort=\"high\" " "$@"
     require_contains " --config mcp_servers.hecate_01_docs={url=\"https://docs.example.com/mcp\",http_headers={\"Authorization\"=\"Bearer token\"}} " "$@"
     case "$*" in
-      *"/auth-fail"*) echo "Authentication required: run codex login" >&2; exit 67;;
+      *"/auth-fail"*) echo "Error: 401 Unauthorized: Missing bearer or basic authentication" >&2; exit 1;;
       *"/init focus on repo guidance"*) message="go codex init";;
       *"reload codex"*) message="go codex reload";;
       *"hello codex"*) message="go codex answer";;
@@ -724,6 +726,79 @@ require_contains() {
   esac
 }
 
+arg_value() {
+  key="$1"
+  shift
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "$key" ]; then
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "missing value for claude argument: $key" >&2
+        exit 65
+      fi
+      printf '%s\n' "$1"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+
+require_absent() {
+  pattern="$1"
+  shift
+  case " $* " in
+    *"$pattern"*) echo "unexpected claude argument pattern: $pattern in $*" >&2; exit 65 ;;
+    *) ;;
+  esac
+}
+
+require_claude_session_mode() {
+  prompt_args="$*"
+  state_dir="${HECATE_ACP_RELEASE_FAKE_CLI_STATE_DIR:-${TMPDIR:-/tmp}}"
+  mkdir -p "$state_dir"
+  state_file="$state_dir/claude_prompt_seen"
+
+  case "$prompt_args" in
+    *"hello claude_code"*)
+      if [ -f "$state_file" ]; then
+        expected="resume"
+      else
+        expected="fresh"
+      fi
+      ;;
+    *)
+      expected="resume"
+      ;;
+  esac
+
+  case "$expected" in
+    fresh)
+      session_id="$(arg_value --session-id "$@")" || {
+        echo "first claude prompt must use --session-id" >&2
+        exit 65
+      }
+      if [ -z "$session_id" ]; then
+        echo "first claude prompt used empty --session-id" >&2
+        exit 65
+      fi
+      require_absent " --resume " "$@"
+      ;;
+    resume)
+      resumed_id="$(arg_value --resume "$@")" || {
+        echo "continued claude prompt must use --resume" >&2
+        exit 65
+      }
+      if [ -z "$resumed_id" ]; then
+        echo "continued claude prompt used empty --resume" >&2
+        exit 65
+      fi
+      require_absent " --session-id " "$@"
+      ;;
+  esac
+  printf 'seen\n' > "$state_file"
+}
+
 case "$1" in
   --version)
     printf 'claude 9.8.7\n'
@@ -745,6 +820,7 @@ case "$1" in
     require_contains " --effort high " "$@"
     require_contains " --strict-mcp-config " "$@"
     require_contains " --mcp-config {\"mcpServers\":{\"docs\":{\"headers\":{\"Authorization\":\"Bearer token\"},\"type\":\"http\",\"url\":\"https://docs.example.com/mcp\"}}} " "$@"
+    require_claude_session_mode "$@"
     case "$*" in
       *"/auth-fail"*) echo "Authentication required: run claude /login" >&2; exit 67;;
       *"/verify release smoke"*) message="go claude verify"; stop_reason="end_turn";;


### PR DESCRIPTION
## Summary
- make the Codex release-smoke fake CLI use the real 401 auth failure wording with a generic exit code
- make the Claude release-smoke fake CLI enforce first-prompt vs continuation flags across repeated prompts and reloads
- document that the ACP release smoke now protects continuation and auth-classification drift

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test -tags acp_release -count=1 -run TestACPAdapterReleaseBinariesSmoke -timeout 5m ./internal/agentadapters
- just docs-format-check