### PR TITLE
Unify project action routing

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -370,10 +370,12 @@ project defaults, roots, profile/skill refs, handoffs, review artifacts,
 assignment execution links, memory candidates, and memory/context metadata so
 operators can separate actionable setup gaps, blocked or stale assignments,
 pending handoffs, memory review work, and context readiness without adding a
-separate persisted health model. The Project Operations brief now exposes the
-top bounded operator actions from those same records with typed `action`
-routing back into existing Project Settings, Work Coordination, Memory/Context,
-preflight, selected-work follow-through, or Project Assistant proposal flows.
+separate persisted health model. Needs Attention and Project Operations share a
+typed `action` routing contract for follow-through into existing Project
+Settings, Work Coordination, Memory/Context, preflight, selected-work
+follow-through, task, activity bucket, or Project Assistant proposal flows.
+Projection-specific fields remain display metadata and should not become a
+second client routing authority.
 Review follow-up, missing completion evidence, and closeout-ready work items
 open the existing selected-work detail surface; the brief does not persist a
 plan, mark work done, or start work.

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -54,7 +54,9 @@ memory/context posture, and pending memory candidates. The menu also shows the
 server summary counts for setup, memory, context, and work follow-up so the
 operator can see why the project needs attention before opening a specific
 item. The menu opens existing surfaces only; it does not create records, launch
-agents, or write memory.
+agents, or write memory. Like Project Operations, Needs Attention rows use a
+typed server-provided `action` object for follow-through; compact row fields are
+display metadata, not a second routing authority.
 
 The Work Coordination tab starts with Project Operations when the server finds
 actionable project state: missing launch defaults, pending approvals, blocked

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2447,17 +2447,26 @@ show when lower-priority attention rows are hidden.
     "attention": [
       {
         "id": "proj_...:defaults",
+        "project_id": "proj_...",
         "title": "Provider/model defaults missing",
         "detail": "Native project starts and assignment chats need a default provider and model.",
         "status": "awaiting_approval",
-        "action": "settings"
+        "action": {
+          "type": "open_project_settings",
+          "project_id": "proj_..."
+        }
       },
       {
         "id": "memcand_...:memory-candidate",
+        "project_id": "proj_...",
         "title": "Memory candidate pending review",
         "detail": "Remember project convention - generated_summary",
         "status": "awaiting_approval",
-        "action": "memory",
+        "action": {
+          "type": "review_memory_candidate",
+          "project_id": "proj_...",
+          "candidate_id": "memcand_..."
+        },
         "candidate_id": "memcand_..."
       }
     ]
@@ -2465,12 +2474,15 @@ show when lower-priority attention rows are hidden.
 }
 ```
 
-Attention rows route to existing surfaces. `action` is used for project-wide
-targets (`settings`, `memory`, `profiles`, `roles`, `skills`); `work_item_id`,
-`task_id`, `run_id`, `chat_id`, `candidate_id`, and `bucket` point the operator
-to existing work, task, chat, memory-review, or activity surfaces. Clients
-should not mutate project state directly from a row; they open the referenced
-surface and use that surface's explicit typed mutation.
+Attention rows route to existing surfaces through a typed `action` object.
+Supported action types are shared with Project Operations where they overlap:
+`open_project_settings`, `open_memory_review`, `open_profiles`, `open_roles`,
+`open_skills`, `open_work_item`, `open_task`, `open_activity_bucket`, and
+`review_memory_candidate`. The top-level `work_item_id`, `task_id`, `run_id`,
+`chat_id`, `candidate_id`, and `bucket` fields remain row metadata for compact
+buttons and labels; clients should use `action` as the authority for row
+activation. Clients should not mutate project state directly from a row; they
+open the referenced surface and use that surface's explicit typed mutation.
 
 #### `GET /hecate/v1/projects/{id}/setup-readiness`
 

--- a/internal/api/handler_project_actions.go
+++ b/internal/api/handler_project_actions.go
@@ -1,0 +1,108 @@
+package api
+
+import "strings"
+
+const (
+	projectActionDraftProjectProposal    = "draft_project_proposal"
+	projectActionOpenActivityBucket      = "open_activity_bucket"
+	projectActionOpenAssignmentPreflight = "open_assignment_preflight"
+	projectActionOpenMemoryReview        = "open_memory_review"
+	projectActionOpenProfiles            = "open_profiles"
+	projectActionOpenProjectSettings     = "open_project_settings"
+	projectActionOpenRoles               = "open_roles"
+	projectActionOpenSkills              = "open_skills"
+	projectActionOpenTask                = "open_task"
+	projectActionOpenWorkItem            = "open_work_item"
+	projectActionReviewMemoryCandidate   = "review_memory_candidate"
+)
+
+type ProjectActionResponse struct {
+	Type           string `json:"type"`
+	ProjectID      string `json:"project_id"`
+	WorkItemID     string `json:"work_item_id,omitempty"`
+	AssignmentID   string `json:"assignment_id,omitempty"`
+	HandoffID      string `json:"handoff_id,omitempty"`
+	ActivityBucket string `json:"activity_bucket,omitempty"`
+	TaskID         string `json:"task_id,omitempty"`
+	RunID          string `json:"run_id,omitempty"`
+	ChatID         string `json:"chat_id,omitempty"`
+	CandidateID    string `json:"candidate_id,omitempty"`
+	Request        string `json:"request,omitempty"`
+}
+
+type ProjectOperationsBriefActionResponse = ProjectActionResponse
+
+func newProjectActionDraftProposal(projectID, workItemID, request string) ProjectActionResponse {
+	return ProjectActionResponse{
+		Type:       projectActionDraftProjectProposal,
+		ProjectID:  strings.TrimSpace(projectID),
+		WorkItemID: strings.TrimSpace(workItemID),
+		Request:    strings.TrimSpace(request),
+	}
+}
+
+func newProjectActionOpenAssignmentPreflight(projectID, workItemID, assignmentID, bucket string) ProjectActionResponse {
+	return ProjectActionResponse{
+		Type:           projectActionOpenAssignmentPreflight,
+		ProjectID:      strings.TrimSpace(projectID),
+		WorkItemID:     strings.TrimSpace(workItemID),
+		AssignmentID:   strings.TrimSpace(assignmentID),
+		ActivityBucket: strings.TrimSpace(bucket),
+	}
+}
+
+func newProjectActionOpenMemoryReview(projectID string) ProjectActionResponse {
+	return ProjectActionResponse{Type: projectActionOpenMemoryReview, ProjectID: strings.TrimSpace(projectID)}
+}
+
+func newProjectActionOpenProfiles(projectID string) ProjectActionResponse {
+	return ProjectActionResponse{Type: projectActionOpenProfiles, ProjectID: strings.TrimSpace(projectID)}
+}
+
+func newProjectActionOpenProjectSettings(projectID string) ProjectActionResponse {
+	return ProjectActionResponse{Type: projectActionOpenProjectSettings, ProjectID: strings.TrimSpace(projectID)}
+}
+
+func newProjectActionOpenRoles(projectID string) ProjectActionResponse {
+	return ProjectActionResponse{Type: projectActionOpenRoles, ProjectID: strings.TrimSpace(projectID)}
+}
+
+func newProjectActionOpenSkills(projectID string) ProjectActionResponse {
+	return ProjectActionResponse{Type: projectActionOpenSkills, ProjectID: strings.TrimSpace(projectID)}
+}
+
+func newProjectActionOpenTask(projectID, taskID, runID string) ProjectActionResponse {
+	return ProjectActionResponse{
+		Type:      projectActionOpenTask,
+		ProjectID: strings.TrimSpace(projectID),
+		TaskID:    strings.TrimSpace(taskID),
+		RunID:     strings.TrimSpace(runID),
+	}
+}
+
+func newProjectActionOpenWorkItem(projectID, workItemID, assignmentID, handoffID, bucket string) ProjectActionResponse {
+	return ProjectActionResponse{
+		Type:           projectActionOpenWorkItem,
+		ProjectID:      strings.TrimSpace(projectID),
+		WorkItemID:     strings.TrimSpace(workItemID),
+		AssignmentID:   strings.TrimSpace(assignmentID),
+		HandoffID:      strings.TrimSpace(handoffID),
+		ActivityBucket: strings.TrimSpace(bucket),
+	}
+}
+
+func newProjectActionOpenActivityBucket(projectID, bucket string) ProjectActionResponse {
+	return ProjectActionResponse{
+		Type:           projectActionOpenActivityBucket,
+		ProjectID:      strings.TrimSpace(projectID),
+		ActivityBucket: strings.TrimSpace(bucket),
+	}
+}
+
+func newProjectActionReviewMemoryCandidate(projectID, candidateID string) ProjectActionResponse {
+	return ProjectActionResponse{
+		Type:        projectActionReviewMemoryCandidate,
+		ProjectID:   strings.TrimSpace(projectID),
+		CandidateID: strings.TrimSpace(candidateID),
+	}
+}

--- a/internal/api/handler_project_health.go
+++ b/internal/api/handler_project_health.go
@@ -17,11 +17,6 @@ import (
 
 const (
 	projectHealthAttentionLimit = 5
-
-	projectHealthActionMemory   = "memory"
-	projectHealthActionProfiles = "profiles"
-	projectHealthActionSettings = "settings"
-	projectHealthActionSkills   = "skills"
 )
 
 type ProjectHealthEnvelope struct {
@@ -60,18 +55,19 @@ type ProjectHealthSummaryResponse struct {
 }
 
 type ProjectHealthAttentionItem struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Detail      string `json:"detail"`
-	Status      string `json:"status"`
-	Action      string `json:"action,omitempty"`
-	Bucket      string `json:"bucket,omitempty"`
-	WorkItemID  string `json:"work_item_id,omitempty"`
-	TaskID      string `json:"task_id,omitempty"`
-	RunID       string `json:"run_id,omitempty"`
-	ChatID      string `json:"chat_id,omitempty"`
-	CandidateID string `json:"candidate_id,omitempty"`
-	ActionLabel string `json:"action_label,omitempty"`
+	ID          string                `json:"id"`
+	ProjectID   string                `json:"project_id"`
+	Title       string                `json:"title"`
+	Detail      string                `json:"detail"`
+	Status      string                `json:"status"`
+	Action      ProjectActionResponse `json:"action"`
+	Bucket      string                `json:"bucket,omitempty"`
+	WorkItemID  string                `json:"work_item_id,omitempty"`
+	TaskID      string                `json:"task_id,omitempty"`
+	RunID       string                `json:"run_id,omitempty"`
+	ChatID      string                `json:"chat_id,omitempty"`
+	CandidateID string                `json:"candidate_id,omitempty"`
+	ActionLabel string                `json:"action_label,omitempty"`
 }
 
 func (h *Handler) HandleProjectHealth(w http.ResponseWriter, r *http.Request) {
@@ -247,28 +243,30 @@ func projectHealthAttentionItems(project projects.Project, activity ProjectActiv
 	items := make([]ProjectHealthAttentionItem, 0, projectHealthAttentionLimit+4)
 	if !projectHasActiveRoot(project) {
 		items = append(items, ProjectHealthAttentionItem{
-			ID:     projectHealthItemID(project.ID, "root"),
-			Title:  "No project root configured",
-			Detail: "Assignment starts need an active local workspace root for files, tools, and guidance discovery.",
-			Status: "stale_unknown",
-			Action: projectHealthActionSettings,
+			ID:        projectHealthItemID(project.ID, "root"),
+			ProjectID: project.ID,
+			Title:     "No project root configured",
+			Detail:    "Assignment starts need an active local workspace root for files, tools, and guidance discovery.",
+			Status:    "stale_unknown",
+			Action:    newProjectActionOpenProjectSettings(project.ID),
 		})
 	}
 	if projectHealthMissingDefaults(project) {
 		items = append(items, ProjectHealthAttentionItem{
-			ID:     projectHealthItemID(project.ID, "defaults"),
-			Title:  "Provider/model defaults missing",
-			Detail: "Native project starts and assignment chats need a default provider and model.",
-			Status: "awaiting_approval",
-			Action: projectHealthActionSettings,
+			ID:        projectHealthItemID(project.ID, "defaults"),
+			ProjectID: project.ID,
+			Title:     "Provider/model defaults missing",
+			Detail:    "Native project starts and assignment chats need a default provider and model.",
+			Status:    "awaiting_approval",
+			Action:    newProjectActionOpenProjectSettings(project.ID),
 		})
 	}
 	items = append(items, projectHealthProfileAttentionItems(project, roles, agentProfiles)...)
 	items = append(items, projectHealthSkillAttentionItems(project, roles, agentProfiles, skills)...)
-	if item := projectHealthPendingHandoffAttention(activity, workItems, handoffs); item != nil {
+	if item := projectHealthPendingHandoffAttention(project.ID, activity, workItems, handoffs); item != nil {
 		items = append(items, *item)
 	}
-	if item := projectHealthReviewFollowUpAttention(workItems, artifacts, handoffs); item != nil {
+	if item := projectHealthReviewFollowUpAttention(project.ID, workItems, artifacts, handoffs); item != nil {
 		items = append(items, *item)
 	}
 	if len(staleAssignments) > 0 {
@@ -279,20 +277,22 @@ func projectHealthAttentionItems(project projects.Project, activity ProjectActiv
 	}
 	if projectHealthEnabledMemoryCount(memoryEntries) == 0 && projectHealthEnabledContextSourceCount(project) == 0 {
 		items = append(items, ProjectHealthAttentionItem{
-			ID:     projectHealthItemID(project.ID, "context"),
-			Title:  "No project memory or context sources enabled",
-			Detail: "Project-scoped context is empty for new chats and linked context packets.",
-			Status: "stale_unknown",
-			Action: projectHealthActionMemory,
+			ID:        projectHealthItemID(project.ID, "context"),
+			ProjectID: project.ID,
+			Title:     "No project memory or context sources enabled",
+			Detail:    "Project-scoped context is empty for new chats and linked context packets.",
+			Status:    "stale_unknown",
+			Action:    newProjectActionOpenMemoryReview(project.ID),
 		})
 	}
 	if candidate := firstPendingProjectHealthMemoryCandidate(memoryCandidates); candidate != nil {
 		items = append(items, ProjectHealthAttentionItem{
 			ID:          projectHealthItemID(candidate.ID, "memory-candidate"),
+			ProjectID:   project.ID,
 			Title:       "Memory candidate pending review",
 			Detail:      strings.Join(projectHealthNonEmpty(candidate.Title, candidate.SuggestedTrustLabel), " - "),
 			Status:      "awaiting_approval",
-			Action:      projectHealthActionMemory,
+			Action:      newProjectActionReviewMemoryCandidate(project.ID, candidate.ID),
 			CandidateID: candidate.ID,
 		})
 	}
@@ -333,11 +333,12 @@ func projectHealthProfileAttentionItems(project projects.Project, roles []projec
 		return nil
 	}
 	return []ProjectHealthAttentionItem{{
-		ID:     projectHealthItemID(project.ID, "profiles", "missing"),
-		Title:  "Agent profile reference missing",
-		Detail: "Project or role defaults reference " + projectHealthSummarizeIDs(missing) + ".",
-		Status: "stale_unknown",
-		Action: projectHealthActionProfiles,
+		ID:        projectHealthItemID(project.ID, "profiles", "missing"),
+		ProjectID: project.ID,
+		Title:     "Agent profile reference missing",
+		Detail:    "Project or role defaults reference " + projectHealthSummarizeIDs(missing) + ".",
+		Status:    "stale_unknown",
+		Action:    newProjectActionOpenProfiles(project.ID),
 	}}
 }
 
@@ -390,11 +391,12 @@ func projectHealthSkillAttentionItems(project projects.Project, roles []projectw
 		status = "awaiting_approval"
 	}
 	return []ProjectHealthAttentionItem{{
-		ID:     projectHealthItemID(project.ID, "skills"),
-		Title:  "Project skills need review",
-		Detail: strings.Join(details, "; ") + ".",
-		Status: status,
-		Action: projectHealthActionSkills,
+		ID:        projectHealthItemID(project.ID, "skills"),
+		ProjectID: project.ID,
+		Title:     "Project skills need review",
+		Detail:    strings.Join(details, "; ") + ".",
+		Status:    status,
+		Action:    newProjectActionOpenSkills(project.ID),
 	}}
 }
 
@@ -435,7 +437,7 @@ func referencedProjectHealthSkillIDs(project projects.Project, roles []projectwo
 	return referenced
 }
 
-func projectHealthPendingHandoffAttention(activity ProjectActivityDataResponse, workItems []projectwork.WorkItem, handoffs []projectwork.Handoff) *ProjectHealthAttentionItem {
+func projectHealthPendingHandoffAttention(projectID string, activity ProjectActivityDataResponse, workItems []projectwork.WorkItem, handoffs []projectwork.Handoff) *ProjectHealthAttentionItem {
 	for _, item := range projectHealthUniqueActivityItems(activity) {
 		if !projectHealthHasPendingHandoff(item) {
 			continue
@@ -457,9 +459,11 @@ func projectHealthPendingHandoffAttention(activity ProjectActivityDataResponse, 
 		), " - ")
 		return &ProjectHealthAttentionItem{
 			ID:          projectHealthItemID(item.ID, "handoff"),
+			ProjectID:   projectID,
 			Title:       "Pending handoff: " + firstNonEmpty(item.WorkItem.Title, item.WorkItem.ID),
 			Detail:      detail,
 			Status:      "awaiting_approval",
+			Action:      newProjectActionOpenWorkItem(projectID, item.WorkItem.ID, item.Assignment.ID, "", "recent"),
 			Bucket:      "recent",
 			WorkItemID:  item.WorkItem.ID,
 			ActionLabel: "View recent",
@@ -491,9 +495,11 @@ func projectHealthPendingHandoffAttention(activity ProjectActivityDataResponse, 
 		), " - ")
 		return &ProjectHealthAttentionItem{
 			ID:          projectHealthItemID(handoff.ID, "handoff"),
+			ProjectID:   projectID,
 			Title:       "Pending handoff: " + firstNonEmpty(workItem.Title, handoff.Title, handoff.ID),
 			Detail:      detail,
 			Status:      "awaiting_approval",
+			Action:      newProjectActionOpenWorkItem(projectID, handoff.WorkItemID, firstNonEmpty(handoff.TargetAssignmentID, handoff.SourceAssignmentID), handoff.ID, ""),
 			WorkItemID:  handoff.WorkItemID,
 			ActionLabel: "Open handoff",
 		}
@@ -501,7 +507,7 @@ func projectHealthPendingHandoffAttention(activity ProjectActivityDataResponse, 
 	return nil
 }
 
-func projectHealthReviewFollowUpAttention(workItems []projectwork.WorkItem, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) *ProjectHealthAttentionItem {
+func projectHealthReviewFollowUpAttention(projectID string, workItems []projectwork.WorkItem, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) *ProjectHealthAttentionItem {
 	workByID := make(map[string]projectwork.WorkItem, len(workItems))
 	for _, workItem := range workItems {
 		workByID[workItem.ID] = workItem
@@ -536,9 +542,11 @@ func projectHealthReviewFollowUpAttention(workItems []projectwork.WorkItem, arti
 		}
 		return &ProjectHealthAttentionItem{
 			ID:          projectHealthItemID(artifact.ID, "review-follow-up"),
+			ProjectID:   projectID,
 			Title:       "Review follow-up: " + firstNonEmpty(workItem.Title, artifact.Title, artifact.ID),
 			Detail:      detail,
 			Status:      status,
+			Action:      newProjectActionOpenWorkItem(projectID, artifact.WorkItemID, "", "", ""),
 			WorkItemID:  artifact.WorkItemID,
 			ActionLabel: "Open review",
 		}
@@ -564,9 +572,11 @@ func projectHealthActivityAttention(item ProjectActivityItemResponse, title, act
 	taskID, runID, chatID := projectHealthExecutionRefs(item)
 	return ProjectHealthAttentionItem{
 		ID:          item.ID,
+		ProjectID:   item.ProjectID,
 		Title:       title + ": " + firstNonEmpty(item.WorkItem.Title, item.Assignment.ID),
 		Detail:      strings.Join(projectHealthNonEmpty(item.StatusSummary, firstNonEmpty(item.Role.Name, item.Assignment.RoleID), projectHealthUpdatedAtDetail(item.UpdatedAt)), " - "),
 		Status:      firstNonEmpty(item.BlockingSignal, item.Status),
+		Action:      newProjectActionOpenWorkItem(item.ProjectID, item.WorkItem.ID, item.Assignment.ID, "", bucket),
 		Bucket:      bucket,
 		WorkItemID:  item.WorkItem.ID,
 		TaskID:      taskID,

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -111,23 +111,31 @@ func TestProjectHealth_ReadOnlyAttention(t *testing.T) {
 		t.Fatalf("health summary = %+v, want candidate/handoff/review counts", response.Data.Summary)
 	}
 	defaults := findProjectHealthAttentionForTest(t, response.Data.Attention, "Provider/model defaults missing")
-	if defaults.Action != projectHealthActionSettings || defaults.Status != "awaiting_approval" {
-		t.Fatalf("defaults attention = %+v, want settings action", defaults)
+	assertProjectHealthActionForTest(t, defaults, projectActionOpenProjectSettings, "proj_health")
+	if defaults.Status != "awaiting_approval" {
+		t.Fatalf("defaults attention = %+v, want awaiting approval status", defaults)
 	}
 	handoff := findProjectHealthAttentionForTest(t, response.Data.Attention, "Pending handoff: Review server attention")
 	if handoff.WorkItemID != "work_review" || handoff.Bucket != "recent" || handoff.ActionLabel != "View recent" {
 		t.Fatalf("handoff attention = %+v, want recent work target", handoff)
 	}
+	assertProjectHealthActionForTest(t, handoff, projectActionOpenWorkItem, "proj_health")
+	if handoff.Action.WorkItemID != "work_review" || handoff.Action.AssignmentID != "asgn_review" || handoff.Action.ActivityBucket != "recent" {
+		t.Fatalf("handoff action = %+v, want recent work item target", handoff.Action)
+	}
 	review := findProjectHealthAttentionForTest(t, response.Data.Attention, "Review follow-up: Review server attention")
 	if review.WorkItemID != "work_review" || review.ActionLabel != "Open review" {
 		t.Fatalf("review attention = %+v, want review work target", review)
 	}
-	context := findProjectHealthAttentionForTest(t, response.Data.Attention, "No project memory or context sources enabled")
-	if context.Action != projectHealthActionMemory {
-		t.Fatalf("context attention = %+v, want memory action", context)
+	assertProjectHealthActionForTest(t, review, projectActionOpenWorkItem, "proj_health")
+	if review.Action.WorkItemID != "work_review" {
+		t.Fatalf("review action = %+v, want work item target", review.Action)
 	}
+	context := findProjectHealthAttentionForTest(t, response.Data.Attention, "No project memory or context sources enabled")
+	assertProjectHealthActionForTest(t, context, projectActionOpenMemoryReview, "proj_health")
 	candidate := findProjectHealthAttentionForTest(t, response.Data.Attention, "Memory candidate pending review")
-	if candidate.CandidateID != "memcand_health" || candidate.Action != projectHealthActionMemory {
+	assertProjectHealthActionForTest(t, candidate, projectActionReviewMemoryCandidate, "proj_health")
+	if candidate.CandidateID != "memcand_health" || candidate.Action.CandidateID != "memcand_health" {
 		t.Fatalf("candidate attention = %+v, want memory candidate target", candidate)
 	}
 
@@ -193,11 +201,13 @@ func TestProjectHealth_ProfileAndSkillReferences(t *testing.T) {
 		t.Fatalf("decode health: %v", err)
 	}
 	profiles := findProjectHealthAttentionForTest(t, response.Data.Attention, "Agent profile reference missing")
-	if profiles.Action != projectHealthActionProfiles || !strings.Contains(profiles.Detail, "missing_profile") {
+	assertProjectHealthActionForTest(t, profiles, projectActionOpenProfiles, "proj_refs")
+	if !strings.Contains(profiles.Detail, "missing_profile") {
 		t.Fatalf("profile attention = %+v, want missing profile detail", profiles)
 	}
 	skills := findProjectHealthAttentionForTest(t, response.Data.Attention, "Project skills need review")
-	if skills.Action != projectHealthActionSkills || !strings.Contains(skills.Detail, "unresolved: review") || !strings.Contains(skills.Detail, "disabled: backend") {
+	assertProjectHealthActionForTest(t, skills, projectActionOpenSkills, "proj_refs")
+	if !strings.Contains(skills.Detail, "unresolved: review") || !strings.Contains(skills.Detail, "disabled: backend") {
 		t.Fatalf("skill attention = %+v, want unresolved and disabled skill detail", skills)
 	}
 }
@@ -259,6 +269,10 @@ func TestProjectHealth_StandalonePendingHandoffAttention(t *testing.T) {
 	if handoff.WorkItemID != "work_standalone_handoff" || handoff.ActionLabel != "Open handoff" || handoff.Bucket != "" {
 		t.Fatalf("handoff attention = %+v, want standalone work target", handoff)
 	}
+	assertProjectHealthActionForTest(t, handoff, projectActionOpenWorkItem, "proj_standalone_handoff")
+	if handoff.Action.WorkItemID != "work_standalone_handoff" || handoff.Action.HandoffID != "handoff_standalone" {
+		t.Fatalf("handoff action = %+v, want standalone handoff work target", handoff.Action)
+	}
 }
 
 func TestProjectHealth_AttentionCapReportsOmittedItems(t *testing.T) {
@@ -315,4 +329,14 @@ func findProjectHealthAttentionForTest(t *testing.T, items []ProjectHealthAttent
 	}
 	t.Fatalf("project health attention %q not found in %+v", title, items)
 	return ProjectHealthAttentionItem{}
+}
+
+func assertProjectHealthActionForTest(t *testing.T, item ProjectHealthAttentionItem, actionType, projectID string) {
+	t.Helper()
+	if item.ProjectID != projectID {
+		t.Fatalf("attention item project_id = %q, want %q in %+v", item.ProjectID, projectID, item)
+	}
+	if item.Action.Type != actionType || item.Action.ProjectID != projectID {
+		t.Fatalf("attention action = %+v, want type %q for project %q", item.Action, actionType, projectID)
+	}
 }

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -104,6 +104,7 @@ func TestProjectHealth_ReadOnlyAttention(t *testing.T) {
 	if response.Object != "project_health" || response.Data.ProjectID != "proj_health" {
 		t.Fatalf("health envelope = %+v, want project_health for project", response)
 	}
+	assertProjectHealthItemsHaveActions(t, response.Data.Attention, "proj_health")
 	if response.Data.Summary.AttentionLimit != projectHealthAttentionLimit || response.Data.Summary.AttentionCount != 5 || response.Data.Summary.OmittedAttentionCount != 0 {
 		t.Fatalf("health summary = %+v, want bounded attention counts", response.Data.Summary)
 	}
@@ -200,6 +201,7 @@ func TestProjectHealth_ProfileAndSkillReferences(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode health: %v", err)
 	}
+	assertProjectHealthItemsHaveActions(t, response.Data.Attention, "proj_refs")
 	profiles := findProjectHealthAttentionForTest(t, response.Data.Attention, "Agent profile reference missing")
 	assertProjectHealthActionForTest(t, profiles, projectActionOpenProfiles, "proj_refs")
 	if !strings.Contains(profiles.Detail, "missing_profile") {
@@ -265,6 +267,7 @@ func TestProjectHealth_StandalonePendingHandoffAttention(t *testing.T) {
 	if response.Data.Summary.PendingHandoffCount != 1 {
 		t.Fatalf("PendingHandoffCount = %d, want 1", response.Data.Summary.PendingHandoffCount)
 	}
+	assertProjectHealthItemsHaveActions(t, response.Data.Attention, "proj_standalone_handoff")
 	handoff := findProjectHealthAttentionForTest(t, response.Data.Attention, "Pending handoff: Review standalone handoff")
 	if handoff.WorkItemID != "work_standalone_handoff" || handoff.ActionLabel != "Open handoff" || handoff.Bucket != "" {
 		t.Fatalf("handoff attention = %+v, want standalone work target", handoff)
@@ -312,6 +315,7 @@ func TestProjectHealth_AttentionCapReportsOmittedItems(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode health: %v", err)
 	}
+	assertProjectHealthItemsHaveActions(t, response.Data.Attention, "proj_cap_health")
 	if response.Data.Summary.AttentionCount != projectHealthAttentionLimit || response.Data.Summary.AvailableAttentionCount <= projectHealthAttentionLimit || response.Data.Summary.OmittedAttentionCount == 0 {
 		t.Fatalf("health summary = %+v, want omitted attention count", response.Data.Summary)
 	}
@@ -329,6 +333,27 @@ func findProjectHealthAttentionForTest(t *testing.T, items []ProjectHealthAttent
 	}
 	t.Fatalf("project health attention %q not found in %+v", title, items)
 	return ProjectHealthAttentionItem{}
+}
+
+func assertProjectHealthItemsHaveActions(t *testing.T, items []ProjectHealthAttentionItem, projectID string) {
+	t.Helper()
+	for _, item := range items {
+		if strings.TrimSpace(item.ProjectID) == "" {
+			t.Fatalf("attention item %q has empty project_id: %+v", item.ID, item)
+		}
+		if item.ProjectID != projectID {
+			t.Fatalf("attention item %q project_id = %q, want %q", item.ID, item.ProjectID, projectID)
+		}
+		if strings.TrimSpace(item.Action.Type) == "" {
+			t.Fatalf("attention item %q has empty action type: %+v", item.ID, item.Action)
+		}
+		if strings.TrimSpace(item.Action.ProjectID) == "" {
+			t.Fatalf("attention item %q has empty action project_id: %+v", item.ID, item.Action)
+		}
+		if item.Action.ProjectID != item.ProjectID {
+			t.Fatalf("attention item %q action project_id = %q, want item project_id %q", item.ID, item.Action.ProjectID, item.ProjectID)
+		}
+	}
 }
 
 func assertProjectHealthActionForTest(t *testing.T, item ProjectHealthAttentionItem, actionType, projectID string) {

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -20,11 +20,11 @@ const (
 
 	projectOperationsBriefItemLimit = 8
 
-	projectOperationsActionDraftProjectProposal    = "draft_project_proposal"
-	projectOperationsActionOpenAssignmentPreflight = "open_assignment_preflight"
-	projectOperationsActionOpenMemoryReview        = "open_memory_review"
-	projectOperationsActionOpenProjectSettings     = "open_project_settings"
-	projectOperationsActionOpenWorkItem            = "open_work_item"
+	projectOperationsActionDraftProjectProposal    = projectActionDraftProjectProposal
+	projectOperationsActionOpenAssignmentPreflight = projectActionOpenAssignmentPreflight
+	projectOperationsActionOpenMemoryReview        = projectActionOpenMemoryReview
+	projectOperationsActionOpenProjectSettings     = projectActionOpenProjectSettings
+	projectOperationsActionOpenWorkItem            = projectActionOpenWorkItem
 )
 
 type ProjectOperationsBriefEnvelope struct {
@@ -75,16 +75,6 @@ type ProjectOperationsBriefTargetResponse struct {
 	AssignmentID   string `json:"assignment_id,omitempty"`
 	HandoffID      string `json:"handoff_id,omitempty"`
 	ActivityBucket string `json:"activity_bucket,omitempty"`
-}
-
-type ProjectOperationsBriefActionResponse struct {
-	Type           string `json:"type"`
-	ProjectID      string `json:"project_id"`
-	WorkItemID     string `json:"work_item_id,omitempty"`
-	AssignmentID   string `json:"assignment_id,omitempty"`
-	HandoffID      string `json:"handoff_id,omitempty"`
-	ActivityBucket string `json:"activity_bucket,omitempty"`
-	Request        string `json:"request,omitempty"`
 }
 
 func (h *Handler) HandleProjectOperationsBrief(w http.ResponseWriter, r *http.Request) {
@@ -604,47 +594,23 @@ func boundedProjectOperationsItems(items []ProjectOperationsBriefItemResponse, l
 }
 
 func projectOperationsDraftProjectProposalAction(projectID, workItemID, request string) ProjectOperationsBriefActionResponse {
-	return ProjectOperationsBriefActionResponse{
-		Type:       projectOperationsActionDraftProjectProposal,
-		ProjectID:  projectID,
-		WorkItemID: strings.TrimSpace(workItemID),
-		Request:    strings.TrimSpace(request),
-	}
+	return newProjectActionDraftProposal(projectID, workItemID, request)
 }
 
 func projectOperationsOpenAssignmentPreflightAction(projectID, workItemID, assignmentID, bucket string) ProjectOperationsBriefActionResponse {
-	return ProjectOperationsBriefActionResponse{
-		Type:           projectOperationsActionOpenAssignmentPreflight,
-		ProjectID:      projectID,
-		WorkItemID:     workItemID,
-		AssignmentID:   assignmentID,
-		ActivityBucket: bucket,
-	}
+	return newProjectActionOpenAssignmentPreflight(projectID, workItemID, assignmentID, bucket)
 }
 
 func projectOperationsOpenMemoryReviewAction(projectID string) ProjectOperationsBriefActionResponse {
-	return ProjectOperationsBriefActionResponse{
-		Type:      projectOperationsActionOpenMemoryReview,
-		ProjectID: projectID,
-	}
+	return newProjectActionOpenMemoryReview(projectID)
 }
 
 func projectOperationsOpenProjectSettingsAction(projectID string) ProjectOperationsBriefActionResponse {
-	return ProjectOperationsBriefActionResponse{
-		Type:      projectOperationsActionOpenProjectSettings,
-		ProjectID: projectID,
-	}
+	return newProjectActionOpenProjectSettings(projectID)
 }
 
 func projectOperationsOpenWorkItemAction(projectID, workItemID, assignmentID, handoffID, bucket string) ProjectOperationsBriefActionResponse {
-	return ProjectOperationsBriefActionResponse{
-		Type:           projectOperationsActionOpenWorkItem,
-		ProjectID:      projectID,
-		WorkItemID:     workItemID,
-		AssignmentID:   assignmentID,
-		HandoffID:      handoffID,
-		ActivityBucket: bucket,
-	}
+	return newProjectActionOpenWorkItem(projectID, workItemID, assignmentID, handoffID, bucket)
 }
 
 func projectOperationsItemID(kind string, parts ...string) string {

--- a/ui/src/features/projects/ProjectHealthPanel.test.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import type {
+  ProjectAction,
   ProjectHealthAttention,
   ProjectHealthSummary,
   ProjectMemoryCandidateRecord,
@@ -50,47 +51,62 @@ function healthSummary(overrides: Partial<ProjectHealthSummary> = {}) {
   } satisfies ProjectHealthSummary;
 }
 
+function projectAction(
+  type: ProjectAction["type"],
+  overrides: Partial<ProjectAction> = {},
+): ProjectAction {
+  return { type, project_id: "proj_1", ...overrides };
+}
+
 function renderPanel(overrides: Partial<Parameters<typeof ProjectHealthPanel>[0]> = {}) {
   const candidate = memoryCandidate();
   const attentionItems: ProjectHealthAttention[] = [
     {
       id: "proj_1:defaults",
+      project_id: "proj_1",
       title: "Provider/model defaults missing",
       detail: "Set defaults before starting assignments.",
       status: "awaiting_approval",
-      action: "settings",
+      action: projectAction("open_project_settings"),
     },
     {
       id: "assign_1:blocked",
+      project_id: "proj_1",
       title: "Blocked assignment",
       detail: "One assignment needs review.",
       status: "failed",
       bucket: "blocked",
+      action: projectAction("open_activity_bucket", { activity_bucket: "blocked" }),
       action_label: "View blocked",
     },
     {
       id: "work_1:item",
+      project_id: "proj_1",
       title: "Work item needs attention",
       detail: "Open the work item.",
       status: "running",
+      action: projectAction("open_work_item", { work_item_id: "work_1" }),
       work_item_id: "work_1",
       action_label: "Open review",
     },
     {
       id: "task_1:item",
+      project_id: "proj_1",
       title: "Task needs attention",
       detail: "Open the linked task.",
       status: "running",
+      action: projectAction("open_task", { run_id: "run_1", task_id: "task_1" }),
       task_id: "task_1",
       run_id: "run_1",
     },
     {
       id: "memcand_1:memory-candidate",
+      project_id: "proj_1",
       title: "Memory candidate pending review",
       detail: "Review generated memory.",
       status: "awaiting_approval",
+      action: projectAction("review_memory_candidate", { candidate_id: candidate.id }),
       candidate_id: candidate.id,
-      action: "memory",
     },
   ];
   const handlers = {
@@ -175,7 +191,7 @@ describe("ProjectHealthPanel", () => {
           title: "Provider/model defaults missing",
           detail: "Set defaults before starting assignments.",
           status: "awaiting_approval",
-          action: "settings",
+          action: { type: "open_project_settings", project_id: "proj_other" },
         },
       ],
       selectedProjectID: "proj_1",
@@ -190,6 +206,36 @@ describe("ProjectHealthPanel", () => {
       "Project attention target changed. Refresh project work and try again.",
     );
     expect(handlers.onAttentionDefaults).not.toHaveBeenCalled();
+  });
+
+  it("applies the stale-project guard to compact attention controls", async () => {
+    const { handlers } = renderPanel({
+      attentionItems: [
+        {
+          id: "proj_other:blocked",
+          project_id: "proj_other",
+          title: "Blocked assignment",
+          detail: "One assignment needs review.",
+          status: "failed",
+          action: {
+            type: "open_activity_bucket",
+            project_id: "proj_other",
+            activity_bucket: "blocked",
+          },
+          bucket: "blocked",
+          action_label: "View blocked",
+        },
+      ],
+      selectedProjectID: "proj_1",
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Project attention: 1" }));
+    await userEvent.click(screen.getByRole("button", { name: "View blocked" }));
+
+    expect(handlers.onAttentionError).toHaveBeenCalledWith(
+      "Project attention target changed. Refresh project work and try again.",
+    );
+    expect(handlers.onAttentionBucket).not.toHaveBeenCalled();
   });
 
   it("shows when lower-priority attention items are hidden", async () => {

--- a/ui/src/features/projects/ProjectHealthPanel.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.tsx
@@ -8,7 +8,12 @@ import type {
 } from "../../types/project";
 import { Badge, Icon, Icons } from "../shared/ui";
 import { useFloatingMenu } from "../shared/useFloatingMenu";
-import { routeProjectHealthAttention, type ProjectActionRoute } from "./projectActionRouting";
+import {
+  PROJECT_ATTENTION_STALE_MESSAGE,
+  projectActivityBucket,
+  routeProjectHealthAttention,
+  type ProjectActionRoute,
+} from "./projectActionRouting";
 import { activitySignalLabel } from "./projectInsights";
 import { projectVisibilityDetail } from "./projectVisibilityDetail";
 
@@ -74,7 +79,8 @@ export function ProjectHealthPanel({
   const postureRows = projectHealthPostureRows(summary);
   const closeMenu = () => attentionMenu.close();
   const handleAttentionAction = (item: ProjectHealthAttention) => {
-    const candidate = memoryCandidates.find((candidate) => candidate.id === item.candidate_id);
+    const candidateID = projectHealthAttentionCandidateID(item);
+    const candidate = memoryCandidates.find((candidate) => candidate.id === candidateID);
     handleAttentionRoute(
       routeProjectHealthAttention(item, {
         hasMemoryCandidate: Boolean(candidate),
@@ -124,6 +130,15 @@ export function ProjectHealthPanel({
       default:
         return;
     }
+  };
+  const handleAttentionMetadataAction = (item: ProjectHealthAttention, run: () => void) => {
+    if (!projectHealthAttentionTargetCurrent(item, selectedProjectID)) {
+      onAttentionError?.(PROJECT_ATTENTION_STALE_MESSAGE);
+      closeMenu();
+      return;
+    }
+    run();
+    closeMenu();
   };
   return (
     <div ref={attentionMenu.wrapRef} style={projectAttentionMenuStyle}>
@@ -177,23 +192,21 @@ export function ProjectHealthPanel({
                   item={item}
                   onActivate={() => handleAttentionAction(item)}
                   onBucketChange={(bucket) => {
-                    onAttentionBucket(bucket);
-                    closeMenu();
+                    handleAttentionMetadataAction(item, () => onAttentionBucket(bucket));
                   }}
                   onOpenTask={(taskID, runID) => {
-                    onAttentionTask?.(taskID, runID);
-                    closeMenu();
+                    handleAttentionMetadataAction(item, () => onAttentionTask?.(taskID, runID));
                   }}
                   onReviewCandidate={(candidate) => {
-                    onAttentionReviewCandidate(candidate);
-                    closeMenu();
+                    handleAttentionMetadataAction(item, () =>
+                      onAttentionReviewCandidate(candidate),
+                    );
                   }}
                   onSelectWorkItem={(workItemID) => {
-                    onAttentionWorkItem(workItemID);
-                    closeMenu();
+                    handleAttentionMetadataAction(item, () => onAttentionWorkItem(workItemID));
                   }}
                   reviewCandidate={memoryCandidates.find(
-                    (candidate) => candidate.id === item.candidate_id,
+                    (candidate) => candidate.id === projectHealthAttentionCandidateID(item),
                   )}
                 />
               ))}
@@ -222,6 +235,9 @@ function ProjectHealthAttentionRow({
   onSelectWorkItem: (workItemID: string) => void;
   reviewCandidate?: ProjectMemoryCandidateRecord;
 }) {
+  const bucketTarget = projectHealthAttentionBucket(item);
+  const workItemID = projectHealthAttentionWorkItemID(item);
+  const taskTarget = projectHealthAttentionTaskTarget(item);
   return (
     <div
       className="project-attention-item"
@@ -242,19 +258,19 @@ function ProjectHealthAttentionRow({
         <span aria-hidden="true" className="project-attention-item-chevron">
           <Icon d={Icons.chevR} size={12} />
         </span>
-        {item.bucket && (
+        {bucketTarget && (
           <button
             className="btn btn-ghost btn-sm project-attention-item-action"
             type="button"
             onClick={(event) => {
               event.stopPropagation();
-              onBucketChange(item.bucket!);
+              onBucketChange(bucketTarget);
             }}
           >
             {item.action_label ?? "Inbox"}
           </button>
         )}
-        {item.work_item_id && (
+        {workItemID && (
           <button
             className="btn btn-ghost btn-sm project-attention-item-action"
             type="button"
@@ -265,20 +281,20 @@ function ProjectHealthAttentionRow({
             }
             onClick={(event) => {
               event.stopPropagation();
-              onSelectWorkItem(item.work_item_id!);
+              onSelectWorkItem(workItemID);
             }}
           >
-            {item.bucket ? "Details" : (item.action_label ?? "Details")}
+            {bucketTarget ? "Details" : (item.action_label ?? "Details")}
           </button>
         )}
-        {item.task_id && (
+        {taskTarget && (
           <button
             className="btn btn-ghost btn-sm project-attention-item-action"
             type="button"
             aria-label="Open attention task"
             onClick={(event) => {
               event.stopPropagation();
-              onOpenTask?.(item.task_id!, item.run_id);
+              onOpenTask?.(taskTarget.taskID, taskTarget.runID);
             }}
             disabled={!onOpenTask}
           >
@@ -303,6 +319,41 @@ function ProjectHealthAttentionRow({
       <div style={subtleTextStyle}>{item.detail}</div>
     </div>
   );
+}
+
+function projectHealthAttentionTargetCurrent(
+  item: ProjectHealthAttention,
+  selectedProjectID?: string,
+): boolean {
+  const projectID = item.action?.project_id;
+  return !projectID || !selectedProjectID || projectID === selectedProjectID;
+}
+
+function projectHealthAttentionBucket(
+  item: ProjectHealthAttention,
+): ProjectActivityBucketKey | undefined {
+  switch (item.action?.type) {
+    case "open_activity_bucket":
+    case "open_work_item":
+      return projectActivityBucket(item.action.activity_bucket);
+    default:
+      return undefined;
+  }
+}
+
+function projectHealthAttentionWorkItemID(item: ProjectHealthAttention): string | undefined {
+  return item.action?.type === "open_work_item" ? item.action.work_item_id : undefined;
+}
+
+function projectHealthAttentionTaskTarget(
+  item: ProjectHealthAttention,
+): { taskID: string; runID?: string } | undefined {
+  if (item.action?.type !== "open_task" || !item.action.task_id) return undefined;
+  return { taskID: item.action.task_id, runID: item.action.run_id };
+}
+
+function projectHealthAttentionCandidateID(item: ProjectHealthAttention): string | undefined {
+  return item.action?.type === "review_memory_candidate" ? item.action.candidate_id : undefined;
 }
 
 type ProjectHealthPostureRow = {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -177,6 +177,14 @@ function projectHealthData(
   };
 }
 
+function projectHealthAction(
+  projectID: string,
+  type: ProjectHealthAttention["action"]["type"],
+  overrides: Partial<ProjectHealthAttention["action"]> = {},
+): ProjectHealthAttention["action"] {
+  return { type, project_id: projectID, ...overrides };
+}
+
 function projectSetupReadinessData(
   projectID: string,
   overrides: Partial<ProjectSetupReadiness> = {},
@@ -4226,9 +4234,14 @@ describe("ProjectsView cockpit", () => {
       data: projectHealthData(project.id, [
         {
           id: staleAssignment.id,
+          project_id: project.id,
           title: "Stale or unknown assignment: Build cockpit UI",
           detail: "linked run missing",
           status: "stale_unknown",
+          action: projectHealthAction(project.id, "open_work_item", {
+            activity_bucket: "blocked",
+            work_item_id: workItem.id,
+          }),
           bucket: "blocked",
           work_item_id: workItem.id,
           task_id: "task_1",
@@ -4414,19 +4427,27 @@ describe("ProjectsView cockpit", () => {
         [
           {
             id: "asgn_1:handoff",
+            project_id: project.id,
             title: "Pending handoff: Build cockpit UI",
             detail: "QA handoff - Reviewer QA - updated 2026-06-04T10:00:00Z",
             status: "awaiting_approval",
+            action: projectHealthAction(project.id, "open_work_item", {
+              activity_bucket: "recent",
+              work_item_id: workItem.id,
+            }),
             bucket: "recent",
             work_item_id: workItem.id,
             action_label: "View recent",
           },
           {
             id: `${memoryCandidate.id}:memory-candidate`,
+            project_id: project.id,
             title: "Memory candidate pending review",
             detail: `${memoryCandidate.title} - ${memoryCandidate.suggested_trust_label}`,
             status: "awaiting_approval",
-            action: "memory",
+            action: projectHealthAction(project.id, "review_memory_candidate", {
+              candidate_id: memoryCandidate.id,
+            }),
             candidate_id: memoryCandidate.id,
           },
         ],
@@ -4558,17 +4579,19 @@ describe("ProjectsView cockpit", () => {
       data: projectHealthData(projectWithoutDefaults.id, [
         {
           id: `${projectWithoutDefaults.id}:defaults`,
+          project_id: projectWithoutDefaults.id,
           title: "Provider/model defaults missing",
           detail: "Native project starts and assignment chats need a default provider and model.",
           status: "awaiting_approval",
-          action: "settings",
+          action: projectHealthAction(projectWithoutDefaults.id, "open_project_settings"),
         },
         {
           id: `${projectWithoutDefaults.id}:context`,
+          project_id: projectWithoutDefaults.id,
           title: "No project memory or context sources enabled",
           detail: "Project-scoped context is empty for new chats and linked context packets.",
           status: "stale_unknown",
-          action: "memory",
+          action: projectHealthAction(projectWithoutDefaults.id, "open_memory_review"),
         },
       ]),
     });
@@ -4613,10 +4636,11 @@ describe("ProjectsView cockpit", () => {
       data: projectHealthData(project.id, [
         {
           id: `${project.id}:skills`,
+          project_id: project.id,
           title: "Project skills need review",
           detail: "disabled: backend.",
           status: "awaiting_approval",
-          action: "skills",
+          action: projectHealthAction(project.id, "open_skills"),
         },
       ]),
     });
@@ -4717,9 +4741,14 @@ describe("ProjectsView cockpit", () => {
       data: projectHealthData(project.id, [
         {
           id: staleAssignment.id,
+          project_id: project.id,
           title: "Stale or unknown assignment: Build cockpit UI",
           detail: "linked run missing",
           status: "stale_unknown",
+          action: projectHealthAction(project.id, "open_work_item", {
+            activity_bucket: "blocked",
+            work_item_id: workItem.id,
+          }),
           bucket: "blocked",
           work_item_id: workItem.id,
           task_id: "task_1",

--- a/ui/src/features/projects/projectActionRouting.test.ts
+++ b/ui/src/features/projects/projectActionRouting.test.ts
@@ -136,42 +136,103 @@ describe("projectActionRouting", () => {
   it("routes project health attention items to existing cockpit surfaces", () => {
     const attention = (overrides: Partial<ProjectHealthAttention>): ProjectHealthAttention => ({
       id: "attn_1",
+      project_id: "proj_1",
       title: "Needs attention",
       detail: "Open the right surface.",
       status: "blocked",
+      action: { type: "open_project_settings", project_id: "proj_1" },
       ...overrides,
     });
 
-    expect(routeProjectHealthAttention(attention({ action: "settings" }))).toEqual({
+    expect(
+      routeProjectHealthAttention(
+        attention({ action: { type: "open_project_settings", project_id: "proj_1" } }),
+      ),
+    ).toEqual({
       kind: "open_project_settings",
     });
     expect(
-      routeProjectHealthAttention(attention({ action: "settings", project_id: "other" }), {
-        selectedProjectID: "proj_1",
-      }),
+      routeProjectHealthAttention(
+        attention({
+          action: { type: "open_project_settings", project_id: "other" },
+          project_id: "other",
+        }),
+        {
+          selectedProjectID: "proj_1",
+        },
+      ),
     ).toEqual({
       kind: "error",
       message: "Project attention target changed. Refresh project work and try again.",
     });
-    expect(routeProjectHealthAttention(attention({ action: "skills" }))).toEqual({
+    expect(
+      routeProjectHealthAttention(
+        attention({ action: { type: "open_skills", project_id: "proj_1" } }),
+      ),
+    ).toEqual({
       kind: "open_skills",
     });
-    expect(routeProjectHealthAttention(attention({ candidate_id: "cand_1" }))).toEqual({
+    expect(
+      routeProjectHealthAttention(
+        attention({
+          action: {
+            type: "review_memory_candidate",
+            project_id: "proj_1",
+            candidate_id: "cand_1",
+          },
+          candidate_id: "cand_1",
+        }),
+      ),
+    ).toEqual({
       kind: "open_memory_review",
     });
     expect(
-      routeProjectHealthAttention(attention({ candidate_id: "cand_1" }), {
-        hasMemoryCandidate: true,
-      }),
+      routeProjectHealthAttention(
+        attention({
+          action: {
+            type: "review_memory_candidate",
+            project_id: "proj_1",
+            candidate_id: "cand_1",
+          },
+          candidate_id: "cand_1",
+        }),
+        {
+          hasMemoryCandidate: true,
+        },
+      ),
     ).toEqual({ kind: "review_memory_candidate", candidateID: "cand_1" });
     expect(
-      routeProjectHealthAttention(attention({ work_item_id: "work_1", bucket: "blocked" })),
+      routeProjectHealthAttention(
+        attention({
+          action: {
+            type: "open_work_item",
+            project_id: "proj_1",
+            work_item_id: "work_1",
+            activity_bucket: "blocked",
+          },
+          bucket: "blocked",
+          work_item_id: "work_1",
+        }),
+      ),
     ).toEqual({
       kind: "open_work_item",
       workItemID: "work_1",
       bucket: "blocked",
     });
-    expect(routeProjectHealthAttention(attention({ task_id: "task_1", run_id: "run_1" }))).toEqual({
+    expect(
+      routeProjectHealthAttention(
+        attention({
+          action: {
+            type: "open_task",
+            project_id: "proj_1",
+            task_id: "task_1",
+            run_id: "run_1",
+          },
+          run_id: "run_1",
+          task_id: "task_1",
+        }),
+      ),
+    ).toEqual({
       kind: "open_task",
       taskID: "task_1",
       runID: "run_1",

--- a/ui/src/features/projects/projectActionRouting.ts
+++ b/ui/src/features/projects/projectActionRouting.ts
@@ -1,10 +1,13 @@
 import type {
   ProjectActivityBucketKey,
+  ProjectAction,
   ProjectHealthAttention,
-  ProjectOperationsBriefAction,
   ProjectOperationsBriefItem,
   ProjectSetupReadinessAction,
 } from "../../types/project";
+
+export const PROJECT_ATTENTION_STALE_MESSAGE =
+  "Project attention target changed. Refresh project work and try again.";
 
 export type ProjectActionRoute =
   | { kind: "bootstrap_project" }
@@ -32,17 +35,44 @@ export function routeProjectOperationAction(
   item: ProjectOperationsBriefItem,
   selectedProjectID: string,
 ): ProjectActionRoute {
-  const action = item.action;
+  return routeProjectAction(item.action, {
+    missingMessage: "Project operation is missing an action. Refresh project work and try again.",
+    selectedProjectID,
+    source: "Project operation",
+    staleMessage: "Project operation target changed. Refresh project work and try again.",
+    unsupportedMessage:
+      "Project operation action is not supported. Refresh project work and try again.",
+  });
+}
+
+export function routeProjectAction(
+  action: ProjectAction | undefined,
+  {
+    hasMemoryCandidate,
+    missingMessage,
+    selectedProjectID,
+    source,
+    staleMessage,
+    unsupportedMessage,
+  }: {
+    hasMemoryCandidate?: boolean;
+    missingMessage: string;
+    selectedProjectID?: string;
+    source: string;
+    staleMessage: string;
+    unsupportedMessage: string;
+  },
+): ProjectActionRoute {
   if (!action?.type) {
     return {
       kind: "error",
-      message: "Project operation is missing an action. Refresh project work and try again.",
+      message: missingMessage,
     };
   }
   if (action.project_id && selectedProjectID && action.project_id !== selectedProjectID) {
     return {
       kind: "error",
-      message: "Project operation target changed. Refresh project work and try again.",
+      message: staleMessage,
     };
   }
   if (action.type === "draft_project_proposal") {
@@ -50,7 +80,7 @@ export function routeProjectOperationAction(
     if (!request) {
       return {
         kind: "error",
-        message: "Project operation is missing a Project Assistant draft request.",
+        message: `${source} is missing a Project Assistant draft request.`,
       };
     }
     return { kind: "draft_project_proposal", request, workItemID: action.work_item_id };
@@ -60,14 +90,26 @@ export function routeProjectOperationAction(
       return { kind: "open_project_settings" };
     case "open_memory_review":
       return { kind: "open_memory_review" };
+    case "open_profiles":
+      return { kind: "open_profiles" };
+    case "open_roles":
+      return { kind: "open_roles" };
+    case "open_skills":
+      return { kind: "open_skills" };
     case "open_assignment_preflight":
-      return routeProjectAssignmentPreflight(action);
+      return routeProjectAssignmentPreflight(action, source);
     case "open_work_item":
-      return routeProjectWorkTarget(action);
+      return routeProjectWorkTarget(action, source);
+    case "open_task":
+      return routeProjectTaskTarget(action, source);
+    case "open_activity_bucket":
+      return routeProjectActivityBucket(action, source);
+    case "review_memory_candidate":
+      return routeProjectMemoryCandidate(action, hasMemoryCandidate, source);
     default:
       return {
         kind: "error",
-        message: "Project operation action is not supported. Refresh project work and try again.",
+        message: unsupportedMessage,
       };
   }
 }
@@ -101,50 +143,26 @@ export function routeProjectHealthAttention(
   item: ProjectHealthAttention,
   options: { hasMemoryCandidate?: boolean; selectedProjectID?: string } = {},
 ): ProjectActionRoute {
-  if (
-    item.project_id &&
-    options.selectedProjectID &&
-    item.project_id !== options.selectedProjectID
-  ) {
-    return {
-      kind: "error",
-      message: "Project attention target changed. Refresh project work and try again.",
-    };
-  }
-  if (item.action === "settings" || item.id.endsWith(":defaults")) {
-    return { kind: "open_project_settings" };
-  }
-  if (item.action === "skills") return { kind: "open_skills" };
-  if (item.action === "profiles") return { kind: "open_profiles" };
-  if (item.action === "roles") return { kind: "open_roles" };
-  if (item.candidate_id) {
-    return options.hasMemoryCandidate
-      ? { kind: "review_memory_candidate", candidateID: item.candidate_id }
-      : { kind: "open_memory_review" };
-  }
-  if (item.work_item_id) {
-    return {
-      kind: "open_work_item",
-      workItemID: item.work_item_id,
-      bucket: projectActivityBucket(item.bucket),
-    };
-  }
-  if (item.task_id) {
-    return { kind: "open_task", taskID: item.task_id, runID: item.run_id };
-  }
-  const bucket = projectActivityBucket(item.bucket);
-  if (bucket) return { kind: "open_activity_bucket", bucket };
-  if (item.action === "memory" || item.id.endsWith(":context")) {
-    return { kind: "open_memory_review" };
-  }
-  return { kind: "none" };
+  return routeProjectAction(item.action, {
+    hasMemoryCandidate: options.hasMemoryCandidate,
+    missingMessage:
+      "Project attention item is missing an action. Refresh project work and try again.",
+    selectedProjectID: options.selectedProjectID,
+    source: "Project attention item",
+    staleMessage: PROJECT_ATTENTION_STALE_MESSAGE,
+    unsupportedMessage:
+      "Project attention action is not supported. Refresh project work and try again.",
+  });
 }
 
-function routeProjectAssignmentPreflight(action: ProjectOperationsBriefAction): ProjectActionRoute {
+function routeProjectAssignmentPreflight(
+  action: ProjectAction,
+  source: string,
+): ProjectActionRoute {
   if (!action.assignment_id) {
     return {
       kind: "error",
-      message: "Project operation is missing an assignment preflight target.",
+      message: `${source} is missing an assignment preflight target.`,
     };
   }
   return {
@@ -155,11 +173,11 @@ function routeProjectAssignmentPreflight(action: ProjectOperationsBriefAction): 
   };
 }
 
-function routeProjectWorkTarget(action: ProjectOperationsBriefAction): ProjectActionRoute {
+function routeProjectWorkTarget(action: ProjectAction, source: string): ProjectActionRoute {
   if (!action.work_item_id) {
     return {
       kind: "error",
-      message: "Project operation is missing a work item target.",
+      message: `${source} is missing a work item target.`,
     };
   }
   return {
@@ -167,6 +185,43 @@ function routeProjectWorkTarget(action: ProjectOperationsBriefAction): ProjectAc
     bucket: projectActivityBucket(action.activity_bucket),
     workItemID: action.work_item_id,
   };
+}
+
+function routeProjectTaskTarget(action: ProjectAction, source: string): ProjectActionRoute {
+  if (!action.task_id) {
+    return {
+      kind: "error",
+      message: `${source} is missing a task target.`,
+    };
+  }
+  return { kind: "open_task", taskID: action.task_id, runID: action.run_id };
+}
+
+function routeProjectActivityBucket(action: ProjectAction, source: string): ProjectActionRoute {
+  const bucket = projectActivityBucket(action.activity_bucket);
+  if (!bucket) {
+    return {
+      kind: "error",
+      message: `${source} is missing an activity bucket target.`,
+    };
+  }
+  return { kind: "open_activity_bucket", bucket };
+}
+
+function routeProjectMemoryCandidate(
+  action: ProjectAction,
+  hasMemoryCandidate: boolean | undefined,
+  source: string,
+): ProjectActionRoute {
+  if (!action.candidate_id) {
+    return {
+      kind: "error",
+      message: `${source} is missing a memory candidate target.`,
+    };
+  }
+  return hasMemoryCandidate
+    ? { kind: "review_memory_candidate", candidateID: action.candidate_id }
+    : { kind: "open_memory_review" };
 }
 
 export function projectActivityBucket(value?: string): ProjectActivityBucketKey | undefined {

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -842,21 +842,41 @@ export type ProjectActivityResponse = {
 
 export type ProjectActivityBucketKey = "all" | "active" | "blocked" | "completed" | "recent";
 
-export type ProjectHealthAttentionAction =
-  | "memory"
-  | "profiles"
-  | "roles"
-  | "settings"
-  | "skills"
+export type ProjectActionType =
+  | "draft_project_proposal"
+  | "open_activity_bucket"
+  | "open_assignment_preflight"
+  | "open_memory_review"
+  | "open_profiles"
+  | "open_project_settings"
+  | "open_roles"
+  | "open_skills"
+  | "open_task"
+  | "open_work_item"
+  | "review_memory_candidate"
   | (string & {});
+
+export type ProjectAction = {
+  type: ProjectActionType;
+  project_id: string;
+  work_item_id?: string;
+  assignment_id?: string;
+  handoff_id?: string;
+  activity_bucket?: "all" | "active" | "blocked" | "completed" | "recent" | (string & {});
+  task_id?: string;
+  run_id?: string;
+  chat_id?: string;
+  candidate_id?: string;
+  request?: string;
+};
 
 export type ProjectHealthAttention = {
   id: string;
-  project_id?: string;
+  project_id: string;
   title: string;
   detail: string;
   status: string;
-  action?: ProjectHealthAttentionAction;
+  action: ProjectAction;
   bucket?: ProjectActivityBucketKey;
   work_item_id?: string;
   task_id?: string;
@@ -954,14 +974,6 @@ export type ProjectSetupReadinessResponse = {
 
 export type ProjectOperationsBriefPriority = "high" | "medium" | "low" | (string & {});
 
-export type ProjectOperationsBriefActionType =
-  | "draft_project_proposal"
-  | "open_assignment_preflight"
-  | "open_memory_review"
-  | "open_project_settings"
-  | "open_work_item"
-  | (string & {});
-
 export type ProjectOperationsBriefTarget = {
   surface: "project_settings" | "work" | "memory" | string;
   project_id: string;
@@ -971,15 +983,7 @@ export type ProjectOperationsBriefTarget = {
   activity_bucket?: "all" | "active" | "blocked" | "completed" | "recent" | (string & {});
 };
 
-export type ProjectOperationsBriefAction = {
-  type: ProjectOperationsBriefActionType;
-  project_id: string;
-  work_item_id?: string;
-  assignment_id?: string;
-  handoff_id?: string;
-  activity_bucket?: "all" | "active" | "blocked" | "completed" | "recent" | (string & {});
-  request?: string;
-};
+export type ProjectOperationsBriefAction = ProjectAction;
 
 export type ProjectOperationsBriefItem = {
   id: string;


### PR DESCRIPTION
## Summary

- add a shared typed Project action response contract for Project Operations and Needs Attention
- emit typed actions from Project Health attention rows, including project ids for stale-target checks
- route Project Operations and Project Health through one client action router
- make compact Needs Attention controls derive targets from typed actions and share the stale-project guard
- document typed attention actions and the display-metadata boundary

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api -run 'TestProjectHealth|TestProjectOperationsBrief|TestProjectOperationItemFromActivity'`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./internal/api ./internal/projectworkapp`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test ./...`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test src/features/projects/projectActionRouting.test.ts src/features/projects/ProjectHealthPanel.test.tsx src/features/projects/ProjectsView.test.tsx`
- `bun run test`
- `git diff --check`

## Notes

The first broad `go test ./internal/api ./internal/projectworkapp` attempt was sandbox-blocked by a local `httptest` TCP listener; the same command passed with normal local permissions.