### PR TITLE
fix(agent): tolerate unsupported ACP session close

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -484,7 +484,9 @@ On Hecate shutdown, active External Agent turns are cancelled first. Hecate wait
 briefly for the ACP turn to drain, asks the native ACP session to close, and
 then kills the owned agent process group if it is still alive. This keeps app
 quit / restart from leaving Codex, Claude Code, Cursor Agent, or Grok Build
-processes behind.
+processes behind. If an ACP peer does not implement `session/close`, Hecate
+treats that as an optional shutdown method and still terminates the owned
+process group.
 Operators can also close an External Agent chat session manually to release the external
 agent process while keeping the Hecate chat history. Deleting a chat performs
 the same release step and then removes the persisted history.

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -856,7 +856,11 @@ func (s *acpSession) Close(ctx context.Context) error {
 	if s.conn != nil && s.nativeID != "" {
 		closeCtx, cancel := context.WithTimeout(ctx, acpShutdownCloseTimeout)
 		if _, err := s.conn.CloseSession(closeCtx, acp.CloseSessionRequest{SessionId: acp.SessionId(s.nativeID)}); err != nil && s.logger != nil {
-			s.logger.Warn("close ACP session RPC failed", slog.String("native_session_id", s.nativeID), slog.Any("error", err))
+			if isACPMethodNotFound(err, acp.AgentMethodSessionClose) {
+				s.logger.Debug("ACP session close RPC unsupported", slog.String("native_session_id", s.nativeID))
+			} else {
+				s.logger.Warn("close ACP session RPC failed", slog.String("native_session_id", s.nativeID), slog.Any("error", err))
+			}
 		}
 		cancel()
 	}
@@ -871,6 +875,25 @@ func (s *acpSession) Close(ctx context.Context) error {
 		s.envCleanup = nil
 	}
 	return nil
+}
+
+func isACPMethodNotFound(err error, method string) bool {
+	if err == nil {
+		return false
+	}
+	var rpcErr *acp.RequestError
+	if !errors.As(err, &rpcErr) || rpcErr.Code != -32601 {
+		return false
+	}
+	if method == "" {
+		return true
+	}
+	if data, ok := rpcErr.Data.(map[string]any); ok {
+		if got, ok := data["method"].(string); ok {
+			return got == method
+		}
+	}
+	return strings.Contains(rpcErr.Error(), method)
 }
 
 func (s *acpSession) setActiveTurn(cancel context.CancelFunc, done chan struct{}) {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -1026,6 +1026,34 @@ func TestSessionManagerShutdownKillsStubbornACPProcess(t *testing.T) {
 	}
 }
 
+func TestSessionManagerCloseTreatsUnsupportedACPCloseAsOptional(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_CLOSE_UNSUPPORTED", "1")
+	installFakeACPExecutable(t, "cursor-agent")
+
+	manager := NewSessionManager()
+	sessionID := "chat_close_optional"
+	run, err := manager.Run(context.Background(), RunRequest{
+		SessionID:      sessionID,
+		AdapterID:      "cursor_agent",
+		Workspace:      t.TempDir(),
+		Prompt:         "close unsupported",
+		Timeout:        5 * time.Second,
+		MaxOutputBytes: 64 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(run.Output, "turn 1: close unsupported") {
+		t.Fatalf("Run output = %q, want fake ACP response", run.Output)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := manager.CloseSession(ctx, sessionID); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+}
+
 func TestSessionManagerACPApprovalApproveCreatesGrantAndReusesSession(t *testing.T) {
 	installFakeACPExecutable(t, "codex-acp-adapter")
 	workspace := t.TempDir()
@@ -2353,7 +2381,7 @@ func installFakeACPExecutable(t *testing.T, name string) {
 	}
 	exe := filepath.Join(bin, name)
 	script := fmt.Sprintf(
-		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q HECATE_FAKE_ACP_EXPECT_MCP_METHOD=%q HECATE_FAKE_ACP_EXPECT_MCP_JSON=%q HECATE_FAKE_ACP_AUTHENTICATE_FILE=%q HECATE_FAKE_ACP_AUTHENTICATE_ERROR=%q HECATE_FAKE_ACP_LOGOUT_FILE=%q HECATE_FAKE_ACP_LOGOUT_ERROR=%q HECATE_FAKE_ACP_AUTH_AGENT_LOGIN=%q HECATE_FAKE_ACP_AUTH_AGENT_OTHER=%q HECATE_FAKE_ACP_AUTH_ENV_VAR=%q HECATE_FAKE_ACP_AUTH_TERMINAL=%q HECATE_FAKE_ACP_SUPPORTS_LOGOUT=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q HECATE_FAKE_ACP_EXPECT_MCP_METHOD=%q HECATE_FAKE_ACP_EXPECT_MCP_JSON=%q HECATE_FAKE_ACP_AUTHENTICATE_FILE=%q HECATE_FAKE_ACP_AUTHENTICATE_ERROR=%q HECATE_FAKE_ACP_LOGOUT_FILE=%q HECATE_FAKE_ACP_LOGOUT_ERROR=%q HECATE_FAKE_ACP_AUTH_AGENT_LOGIN=%q HECATE_FAKE_ACP_AUTH_AGENT_OTHER=%q HECATE_FAKE_ACP_AUTH_ENV_VAR=%q HECATE_FAKE_ACP_AUTH_TERMINAL=%q HECATE_FAKE_ACP_SUPPORTS_LOGOUT=%q HECATE_FAKE_ACP_CLOSE_UNSUPPORTED=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
 		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
 		os.Getenv("HECATE_FAKE_ACP_COMMANDS_DELAY"),
@@ -2371,6 +2399,7 @@ func installFakeACPExecutable(t *testing.T, name string) {
 		os.Getenv("HECATE_FAKE_ACP_AUTH_ENV_VAR"),
 		os.Getenv("HECATE_FAKE_ACP_AUTH_TERMINAL"),
 		os.Getenv("HECATE_FAKE_ACP_SUPPORTS_LOGOUT"),
+		os.Getenv("HECATE_FAKE_ACP_CLOSE_UNSUPPORTED"),
 		os.Args[0],
 	)
 	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
@@ -2692,6 +2721,9 @@ func (a *fakeACPAgent) Cancel(_ context.Context, params acp.CancelNotification) 
 }
 
 func (a *fakeACPAgent) CloseSession(context.Context, acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+	if os.Getenv("HECATE_FAKE_ACP_CLOSE_UNSUPPORTED") == "1" {
+		return acp.CloseSessionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionClose)
+	}
 	return acp.CloseSessionResponse{}, nil
 }
 


### PR DESCRIPTION
## Summary
- treat ACP session/close method-not-found as optional during External Agent shutdown
- keep warning logs for other close RPC failures
- add fake ACP regression coverage and document optional close behavior

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go vet ./internal/agentadapters
- just docs-format-check