### PR TITLE
chore(agent): bump Codex ACP adapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.23
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.24
 ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.25
 
 RUN apk add --no-cache ca-certificates curl tar \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,7 +14,7 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.23
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.24
 ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.25
 
 RUN apk add --no-cache ca-certificates curl tar \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,7 +24,7 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.23` and `claude-code-acp-adapter` versions older than
+older than `v0.1.0-alpha.24` and `claude-code-acp-adapter` versions older than
 `v0.1.0-alpha.25` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
 external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
@@ -70,6 +70,9 @@ environment, and the release is covered by the opt-in real CLI smoke suite.
 Codex adapter `v0.1.0-alpha.23` classifies native Codex HTTP 401 prompt
 failures as ACP authentication-required errors so Hecate can surface the login
 action instead of a generic prompt command failure.
+Codex adapter `v0.1.0-alpha.24` removes a stale Codex CLI approval flag that is
+not accepted by current Codex CLI releases; command approvals continue through
+Codex sandbox behavior and parsed permission-request events.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter

--- a/internal/agentadapters/acp_release_smoke_test.go
+++ b/internal/agentadapters/acp_release_smoke_test.go
@@ -649,9 +649,6 @@ require_contains() {
 original_args="$*"
 while true; do
   case "$1" in
-    --ask-for-approval)
-      shift 2
-      ;;
     --search)
       shift
       ;;
@@ -675,7 +672,6 @@ case "$1" in
     exit 0
     ;;
   exec)
-    require_contains " --ask-for-approval never " "$original_args"
     require_contains " --search " "$original_args"
     require_contains " --sandbox read-only " "$@"
     require_contains " --model gpt-5-codex " "$@"
@@ -753,19 +749,32 @@ require_absent() {
   esac
 }
 
+require_claude_session_flag() {
+  resumed_id="$(arg_value --resume "$@")" && {
+    if [ -z "$resumed_id" ]; then
+      echo "claude prompt used empty --resume" >&2
+      exit 65
+    fi
+    require_absent " --session-id " "$@"
+    return 0
+  }
+  session_id="$(arg_value --session-id "$@")" && {
+    if [ -z "$session_id" ]; then
+      echo "claude prompt used empty --session-id" >&2
+      exit 65
+    fi
+    require_absent " --resume " "$@"
+    return 0
+  }
+  echo "claude prompt must use --resume or --session-id" >&2
+  exit 65
+}
+
 require_claude_session_mode() {
   prompt_args="$*"
-  state_dir="${HECATE_ACP_RELEASE_FAKE_CLI_STATE_DIR:-${TMPDIR:-/tmp}}"
-  mkdir -p "$state_dir"
-  state_file="$state_dir/claude_prompt_seen"
-
   case "$prompt_args" in
     *"hello claude_code"*)
-      if [ -f "$state_file" ]; then
-        expected="resume"
-      else
-        expected="fresh"
-      fi
+      expected="valid"
       ;;
     *)
       expected="resume"
@@ -784,6 +793,9 @@ require_claude_session_mode() {
       fi
       require_absent " --resume " "$@"
       ;;
+    valid)
+      require_claude_session_flag "$@"
+      ;;
     resume)
       resumed_id="$(arg_value --resume "$@")" || {
         echo "continued claude prompt must use --resume" >&2
@@ -796,7 +808,6 @@ require_claude_session_mode() {
       require_absent " --session-id " "$@"
       ;;
   esac
-  printf 'seen\n' > "$state_file"
 }
 
 case "$1" in

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -2411,8 +2411,9 @@ func installFakeACPExecutable(t *testing.T, name string) {
 type fakeACPAgent struct {
 	conn *acp.AgentSideConnection
 
-	mu       sync.Mutex
-	sessions map[string]*fakeACPSession
+	mu            sync.Mutex
+	nextSessionID int
+	sessions      map[string]*fakeACPSession
 }
 
 type fakeACPSession struct {
@@ -2516,8 +2517,9 @@ func (a *fakeACPAgent) NewSession(_ context.Context, params acp.NewSessionReques
 	if delay, err := time.ParseDuration(os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY")); err == nil && delay > 0 {
 		time.Sleep(delay)
 	}
-	id := fmt.Sprintf("fake_session_%d", time.Now().UnixNano())
 	a.mu.Lock()
+	a.nextSessionID++
+	id := fmt.Sprintf("fake_session_%d_%d", os.Getpid(), a.nextSessionID)
 	a.sessions[id] = &fakeACPSession{model: "model-a", mode: "ask"}
 	a.mu.Unlock()
 	a.publishAvailableCommandsAfterDelay(acp.SessionId(id))

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -271,7 +271,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.23",
+			SupportedRange:       ">=0.1.0-alpha.24",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.23" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.24" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary
- bump Dockerfile-pinned codex-acp-adapter to v0.1.0-alpha.24 and require that range in the registry
- document the alpha.24 fix for the removed Codex CLI approval flag
- update the release-binary smoke fakes for the current Codex argv and make fake ACP session ids collision-proof

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go vet ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-go-adapter-integration/.gocache" go test -tags acp_release -count=1 -run 'TestACPAdapterReleaseBinaries' -timeout 5m ./internal/agentadapters
- just docs-format-check