### PR TITLE
fix(cli): keep root shell responsive

### DIFF
--- a/cmd/hecate/cli.go
+++ b/cmd/hecate/cli.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -25,12 +27,12 @@ func newRootCommand() *cobra.Command {
 		Short:         "Local AI runtime console",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if printVersion {
 				printVersionString(cmd.OutOrStdout())
-				return
+				return nil
 			}
-			runServe()
+			return runInteractiveShell(cmd.InOrStdin(), cmd.OutOrStdout())
 		},
 	}
 	root.CompletionOptions.DisableDefaultCmd = true
@@ -96,4 +98,34 @@ func newLegacyMCPServerCommand() *cobra.Command {
 
 func printVersionString(w io.Writer) {
 	fmt.Fprintln(w, version.Version)
+}
+
+func runInteractiveShell(in io.Reader, out io.Writer) error {
+	fmt.Fprintln(out, "Hecate operator shell")
+	fmt.Fprintln(out, "Type help for commands. Use `hecate serve` to start the runtime.")
+	fmt.Fprintln(out)
+
+	scanner := bufio.NewScanner(in)
+	for {
+		fmt.Fprint(out, "hecate> ")
+		if !scanner.Scan() {
+			fmt.Fprintln(out)
+			return scanner.Err()
+		}
+		switch strings.ToLower(strings.TrimSpace(scanner.Text())) {
+		case "", "status":
+			fmt.Fprintln(out, "Runtime status is available from the browser UI or `hecate serve` logs.")
+		case "help", "h", "?":
+			fmt.Fprintln(out, "Commands: status, serve, ui, help, quit")
+		case "serve":
+			fmt.Fprintln(out, "Start the runtime with: hecate serve")
+		case "ui":
+			fmt.Fprintln(out, "Start the runtime with `hecate serve`, then open http://127.0.0.1:8765")
+		case "quit", "exit", "q":
+			fmt.Fprintln(out, "bye")
+			return nil
+		default:
+			fmt.Fprintln(out, "Unknown command. Type help for commands.")
+		}
+	}
 }

--- a/cmd/hecate/cli_test.go
+++ b/cmd/hecate/cli_test.go
@@ -60,6 +60,39 @@ func TestCLI_HelpListsCommandTree(t *testing.T) {
 	}
 }
 
+func TestCLI_BareCommandRunsInteractiveShellUntilQuit(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := newRootCommand()
+	cmd.SetArgs(nil)
+	cmd.SetIn(strings.NewReader("help\nserve\nstatus\nq\n"))
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(bare): %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"Hecate operator shell",
+		"Commands: status, serve, ui, help, quit",
+		"Start the runtime with: hecate serve",
+		"Runtime status is available",
+		"bye",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("interactive output does not contain %q:\n%s", want, output)
+		}
+	}
+	if got := strings.Count(output, "hecate> "); got != 4 {
+		t.Fatalf("prompt count = %d, want 4; output:\n%s", got, output)
+	}
+	if strings.Contains(output, "hecate ·") {
+		t.Fatalf("interactive shell printed serve banner, likely started runtime:\n%s", output)
+	}
+}
+
 func TestCLI_MCPHelpListsServeOnly(t *testing.T) {
 	t.Parallel()
 

--- a/docs/design/proposals/cli-structure.md
+++ b/docs/design/proposals/cli-structure.md
@@ -2,7 +2,9 @@
 
 > **Status:** partially implemented.
 > **Current source of truth:** [`cmd/hecate/cli.go`](../../../cmd/hecate/cli.go), [`cmd/hecate/main.go`](../../../cmd/hecate/main.go), and [`docs/runtime/mcp.md`](../../runtime/mcp.md).
-> **Next action:** make bare `hecate` the terminal operator UI, then add `hecate ui`, `status`, `about`, and `doctor` in focused follow-up PRs.
+> **Next action:** grow bare `hecate` from the lightweight operator shell into
+> the terminal operator UI, then add `hecate ui`, `status`, `about`, and
+> `doctor` in focused follow-up PRs.
 
 ## Implementation status
 
@@ -11,10 +13,11 @@ The first command-tree slice is implemented with Cobra:
 - `hecate serve` starts the runtime / HTTP API / embedded UI server.
 - `hecate mcp serve` starts the stdio MCP server.
 - `hecate version`, `hecate --version`, and `hecate -v` print the version.
-- Bare `hecate` still starts the runtime as a temporary compatibility alias.
+- Bare `hecate` opens a lightweight operator shell. The shell keeps the process
+  interactive until `quit` / `exit` / `q`; it does not start the runtime.
 - `hecate mcp-server` still works as a hidden compatibility alias.
 
-Not implemented yet: the terminal operator UI for bare `hecate`, `hecate ui`,
+Not implemented yet: the full terminal operator UI for bare `hecate`, `hecate ui`,
 `status`, `about`, `doctor`, auth commands, ACP server commands, and
 `migrate`.
 

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -337,10 +337,11 @@ Hecate.
 Use this order when troubleshooting:
 
 1. **Discovery** — `GET /hecate/v1/agent-adapters` tells you whether Hecate can
-   find the adapter command and whether the installed version is inside
-   Hecate's tested range.
+   find the adapter command. This catalog path is intentionally cheap: it does
+   not spawn adapter CLIs for version, auth, or launch-control discovery.
 2. **Probe** — `POST /hecate/v1/agent-adapters/{id}/probe` actually starts the
-   agent bridge and opens a temporary ACP session. This is the best "will it run?"
+   agent bridge and opens a temporary ACP session. This refreshes version,
+   auth/capability, and launch-control details and is the best "will it run?"
    check.
 3. **Chat run** — send a real prompt only after discovery/probe are green. If
    the agent still fails, open the message's raw diagnostics disclosure; the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -982,8 +982,10 @@ use `reason`, `provider_status`, `provider_blocked_reason`, and
 
 External coding-agent catalog. This is the first discovery surface for
 External Agent chats: it reports the agent runtimes Hecate knows how to
-supervise, whether their command can be started, and any launch
-`config_options` that can be selected before a concrete chat session exists.
+supervise and whether their command can be found. This endpoint is deliberately
+cheap so the app can render startup state without spawning coding-agent CLIs.
+Use `POST /hecate/v1/agent-adapters/{id}/probe` for live version, auth,
+capability, and launch-control discovery.
 
 ```json
 GET /hecate/v1/agent-adapters
@@ -1000,13 +1002,11 @@ GET /hecate/v1/agent-adapters
       "status": "available",
       "path": "/Users/alice/.local/bin/codex-acp-adapter",
       "cost_mode": "external",
-      "adapter_version": "0.0.0-dev",
-      "agent_version": "0.48.0",
-      "supported_range": ">=0.0.0-dev",
+      "supported_range": ">=0.1.0-alpha.24",
       "version_outside_range": false,
       "supports_authenticate": true,
       "supports_logout": true,
-      "auth_status": "ok",
+      "auth_status": "unknown",
       "credential_modes": [
         {
           "id": "local_login",
@@ -1026,7 +1026,7 @@ GET /hecate/v1/agent-adapters
       "name": "Grok Build",
       "kind": "acp",
       "command": "grok",
-      "args": ["agent"],
+      "args": ["agent", "stdio"],
       "available": true,
       "status": "available",
       "path": "/Users/alice/.local/bin/grok",
@@ -1035,7 +1035,7 @@ GET /hecate/v1/agent-adapters
       "supported_range": ">=0.1.0",
       "supports_authenticate": false,
       "supports_logout": false,
-      "auth_status": "ok"
+      "auth_status": "unknown"
     },
     {
       "id": "cursor_agent",
@@ -1047,13 +1047,11 @@ GET /hecate/v1/agent-adapters
       "status": "available",
       "path": "/Users/alice/.local/bin/cursor-agent",
       "cost_mode": "external",
-      "agent_version": "0.0.9",
       "supported_range": ">=0.1.0",
-      "version_outside_range": true,
+      "version_outside_range": false,
       "supports_authenticate": false,
       "supports_logout": false,
-      "auth_status": "unauthenticated",
-      "auth_error": "Run cursor-agent login, or set CURSOR_API_KEY for the agent environment."
+      "auth_status": "unknown"
     },
     {
       "id": "claude_code",
@@ -1064,31 +1062,29 @@ GET /hecate/v1/agent-adapters
       "status": "missing",
       "error": "exec: \"claude-code-acp-adapter\": executable file not found in $PATH",
       "cost_mode": "external",
-      "supported_range": ">=0.0.0-dev",
+      "supported_range": ">=0.1.0-alpha.25",
       "supports_authenticate": true,
       "supports_logout": true,
       "auth_status": "unknown",
-      "auth_error": "Open Connections and test Claude Code. If it reports a sign-in error, run `claude /login` in Terminal."
+      "claude_code_cli": {
+        "available": true,
+        "command": "/Users/alice/.local/bin/claude",
+        "executable_path": "/Users/alice/.local/bin/claude"
+      }
     }
   ]
 }
 ```
 
-`adapter_version` is the ACP bridge version when Hecate uses a separate binary
-to speak ACP. The standalone Go Codex and Claude Code adapters report
-`0.0.0-dev` when installed directly with `go install`; Hecate container images
-bundle release-built adapter binaries so they report their stamped tag.
-`agent_version` is the underlying coding-agent CLI version, such as `codex`,
-`claude`, `cursor-agent`, or `grok`. Both fields are extracted from `--version`
-output and omitted when the command is missing or does not print a recognisable
-semver string. `version_outside_range` is `true` when the version subject to
-`supported_range` does not satisfy the constraint — the Connections UI shows an
-amber "outside tested range" chip in that case.
+`adapter_version` and `agent_version` are omitted from the catalog response.
+They are populated by the explicit probe response after Hecate starts the ACP
+adapter and runs the live diagnostics. `version_outside_range` remains `false`
+until a probed version is known to fall outside `supported_range`.
 
-`auth_status` is a lightweight dashboard hint, not a full login check. Values:
-`ok`, `unauthenticated`, `billing`, or `unknown`. It is derived from known env
-vars and login files without spawning the agent. Use `POST
-/hecate/v1/agent-adapters/{id}/probe` for the full ACP handshake.
+`auth_status` is `unknown` on the cheap catalog path unless a dev or remote
+runtime override can classify it without spawning a CLI. Use `POST
+/hecate/v1/agent-adapters/{id}/probe` for the full ACP handshake and login /
+billing classification.
 
 `supports_authenticate` and `supports_logout` tell clients whether Hecate can
 call ACP `authenticate` or `logout` for this adapter. UIs should use these
@@ -1112,17 +1108,15 @@ These are **external agents**, not model providers. They run ACP-compatible
 coding agents under Hecate supervision; cost is reported as `external`
 until an agent can supply structured usage.
 
-`config_options` on a catalog row are Hecate-managed launch controls. Clients
-can render them before creating an External Agent chat and pass the selected
-options to `POST /hecate/v1/chat/sessions`. Values prefixed with
-`__hecate_no_` are explicit "not selected" sentinels. Some options are optional;
-launch-model options can be required by the adapter definition and cause
-`400 chat.model_required` at session creation until a real value is selected.
-Agent-owned ACP model state appears on the prepared chat session instead of
-the catalog row and is updated with ACP `session/set_model`. When an agent
-uses CLI help or model-list commands to populate launch controls, the catalog
-endpoint reuses a short in-process cache instead of spawning the CLI on every
-refresh.
+`config_options` are omitted from the catalog response. Hecate returns
+launch-control options on explicit probe responses and prepared chat sessions,
+where it is acceptable to run the adapter's help/model discovery or consume the
+ACP session's own controls. Values prefixed with `__hecate_no_` are explicit
+"not selected" sentinels. Some options are optional; launch-model options can
+be required by the adapter definition and cause `400 chat.model_required` at
+session creation until a real value is selected. Agent-owned ACP model state
+appears on the prepared chat session and is updated with ACP
+`session/set_model`.
 
 ### `POST /hecate/v1/agent-adapters/{id}/probe`
 

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -528,6 +528,22 @@ func List(ctx context.Context) []Status {
 }
 
 func ListWithLookup(ctx context.Context, lookup LookupFunc) []Status {
+	return listWithLookup(ctx, lookup, statusDiagnosticsFull)
+}
+
+// ListCatalog returns the built-in adapter catalog using only cheap local
+// discovery. It intentionally avoids version/auth subprocess probes so app
+// startup and the Connections list can render immediately; explicit probe
+// endpoints refresh the expensive health details on demand.
+func ListCatalog(ctx context.Context) []Status {
+	return ListCatalogWithLookup(ctx, exec.LookPath)
+}
+
+func ListCatalogWithLookup(ctx context.Context, lookup LookupFunc) []Status {
+	return listWithLookup(ctx, lookup, statusDiagnosticsCatalog)
+}
+
+func listWithLookup(ctx context.Context, lookup LookupFunc, diagnostics statusDiagnosticsMode) []Status {
 	if lookup == nil {
 		lookup = exec.LookPath
 	}
@@ -535,7 +551,7 @@ func ListWithLookup(ctx context.Context, lookup LookupFunc) []Status {
 	items := BuiltIns()
 	out := make([]Status, 0, len(items))
 	for _, item := range items {
-		out = append(out, statusForAdapter(ctx, item, lookup))
+		out = append(out, statusForAdapterWithDiagnostics(ctx, item, lookup, diagnostics))
 	}
 	return out
 }
@@ -562,6 +578,17 @@ func statusForAdapterByID(ctx context.Context, id string, lookup LookupFunc) (St
 }
 
 func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc) Status {
+	return statusForAdapterWithDiagnostics(ctx, item, lookup, statusDiagnosticsFull)
+}
+
+type statusDiagnosticsMode int
+
+const (
+	statusDiagnosticsFull statusDiagnosticsMode = iota
+	statusDiagnosticsCatalog
+)
+
+func statusForAdapterWithDiagnostics(ctx context.Context, item Adapter, lookup LookupFunc, diagnostics statusDiagnosticsMode) Status {
 	status := Status{
 		Adapter:    item,
 		Status:     StatusMissing,
@@ -601,9 +628,11 @@ func statusForAdapter(ctx context.Context, item Adapter, lookup LookupFunc) Stat
 	status.Available = true
 	status.Status = StatusAvailable
 	status.Path = path
-	status.AdapterVersion, status.AgentVersion = detectAdapterAndAgentVersionsForStatus(ctx, item, path, lookup)
-	status.VersionOutsideRange = !satisfiesRange(firstNonEmptyVersion(status.AdapterVersion, status.AgentVersion), item.SupportedRange)
-	status.AuthStatus, status.AuthError = DetectAuthStatus(item)
+	if diagnostics == statusDiagnosticsFull {
+		status.AdapterVersion, status.AgentVersion = detectAdapterAndAgentVersionsForStatus(ctx, item, path, lookup)
+		status.VersionOutsideRange = !satisfiesRange(firstNonEmptyVersion(status.AdapterVersion, status.AgentVersion), item.SupportedRange)
+		status.AuthStatus, status.AuthError = DetectAuthStatus(item)
+	}
 	return status
 }
 

--- a/internal/api/handler_agent_adapters.go
+++ b/internal/api/handler_agent_adapters.go
@@ -9,10 +9,10 @@ import (
 )
 
 func (h *Handler) HandleAgentAdapters(w http.ResponseWriter, r *http.Request) {
-	items := agentadapters.List(r.Context())
+	items := agentadapters.ListCatalog(r.Context())
 	data := make([]AgentAdapterResponseItem, 0, len(items))
 	for _, item := range items {
-		data = append(data, renderAgentAdapterItem(r.Context(), item))
+		data = append(data, renderAgentAdapterCatalogItem(r.Context(), item))
 	}
 
 	WriteJSON(w, http.StatusOK, AgentAdapterResponse{
@@ -115,6 +115,14 @@ type AgentAdapterAuthenticateResponse struct {
 }
 
 func renderAgentAdapterItem(ctx context.Context, item agentadapters.Status) AgentAdapterResponseItem {
+	return renderAgentAdapterItemWithOptions(ctx, item, true)
+}
+
+func renderAgentAdapterCatalogItem(ctx context.Context, item agentadapters.Status) AgentAdapterResponseItem {
+	return renderAgentAdapterItemWithOptions(ctx, item, false)
+}
+
+func renderAgentAdapterItemWithOptions(ctx context.Context, item agentadapters.Status, includeConfigOptions bool) AgentAdapterResponseItem {
 	rendered := AgentAdapterResponseItem{
 		ID:                   item.ID,
 		Name:                 item.Name,
@@ -139,7 +147,9 @@ func renderAgentAdapterItem(ctx context.Context, item agentadapters.Status) Agen
 		CredentialModes:      renderAgentAdapterCredentialModes(item.CredentialModes),
 		RemoteCredentialMode: item.RemoteCredentialMode,
 		RemoteCredentialHint: item.RemoteCredentialHint,
-		ConfigOptions:        agentadapters.LaunchConfigOptions(ctx, item),
+	}
+	if includeConfigOptions {
+		rendered.ConfigOptions = agentadapters.LaunchConfigOptions(ctx, item)
 	}
 	if item.RemoteCredentialHint != "" || item.RemoteCredentialMode != "" {
 		remoteCredentialOK := item.RemoteCredentialOK

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1164,6 +1164,57 @@ func TestAgentAdaptersReturnsBuiltIns(t *testing.T) {
 	}
 }
 
+func TestAgentAdaptersListDoesNotRunAdapterDiagnostics(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("shell-script subprocess fixture is POSIX-only")
+	}
+	dir := t.TempDir()
+	countFile := filepath.Join(dir, "executed")
+	for _, name := range []string{
+		"codex-acp-adapter",
+		"codex",
+		"claude-code-acp-adapter",
+		"claude",
+		"cursor-agent",
+		"grok",
+	} {
+		path := filepath.Join(dir, name)
+		body := "#!/bin/sh\n" +
+			"echo \"$0 $@\" >> " + strconv.Quote(countFile) + "\n" +
+			"echo " + strconv.Quote(name+" 9.9.9") + "\n"
+		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+			t.Fatalf("write fake executable %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("HOME", t.TempDir())
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{}, logger, nil, nil, nil, nil))
+	client := newAPITestClient(t, handler)
+	response := mustRequestJSON[AgentAdapterResponse](client, http.MethodGet, "/hecate/v1/agent-adapters", "")
+
+	if len(response.Data) != 4 {
+		t.Fatalf("adapter count = %d, want 4", len(response.Data))
+	}
+	for _, item := range response.Data {
+		if item.AdapterVersion != "" || item.AgentVersion != "" {
+			t.Fatalf("adapter %q versions = %q/%q, want lazy empty versions", item.ID, item.AdapterVersion, item.AgentVersion)
+		}
+		if item.AuthStatus != agentadapters.AuthStatusUnknown {
+			t.Fatalf("adapter %q auth_status = %q, want lazy unknown", item.ID, item.AuthStatus)
+		}
+		if len(item.ConfigOptions) != 0 {
+			t.Fatalf("adapter %q config_options = %#v, want lazy empty options", item.ID, item.ConfigOptions)
+		}
+	}
+	if raw, err := os.ReadFile(countFile); err == nil {
+		t.Fatalf("adapter list executed diagnostics:\n%s", string(raw))
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("read diagnostics count file: %v", err)
+	}
+}
+
 func TestAgentAdaptersOmitsCatalogConfigOptionsForGrok(t *testing.T) {
 	t.Setenv("HECATE_AGENT_ADAPTER_DEV_OVERRIDES", "grok_build=ready")
 


### PR DESCRIPTION
## Summary

- make bare `hecate` open a lightweight operator shell instead of starting the full runtime path
- keep the shell interactive across `help`, `serve`, and `status`; only `quit` / `exit` / `q` exits
- make `GET /hecate/v1/agent-adapters` use a cheap catalog path that avoids adapter version/auth/config subprocess probes
- keep richer adapter diagnostics on explicit probe paths and update runtime docs

## Tests

- `GOCACHE="$PWD/.gocache" go test ./cmd/hecate`
- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run TestAgentAdapters`
- `just docs-format-check`
- `GOCACHE="$PWD/.gocache" go vet ./cmd/hecate ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go test ./cmd/hecate ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
