### PR TITLE
Guard work item closeout on the server

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2203,15 +2203,15 @@ status is returned.
 The Projects UI also exposes an operator closeout action for selected work
 items. The read-only
 `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/readiness` contract is
-the shared closeout authority for Project Operations and selected-work detail:
-it derives blockers from assignments, completion evidence, handoffs, and review
-follow-up without mutating project state. The guided action still uses the
-normal work-item `PATCH` path with `status="done"` only after the operator
-clicks Mark done. Hecate does not auto-mutate stored work-item status from
-review verdicts, handoffs, or assignment rollups without an explicit operator
-update. The guided closeout action is disabled while blockers remain; operators
-can still make an intentional manual override through the normal work-item edit
-flow.
+the shared closeout authority for Project Operations, selected-work detail, and
+`PATCH` requests that set `status="done"`: it derives blockers from
+assignments, completion evidence, handoffs, and review follow-up without
+mutating project state. The guided action still uses the normal work-item
+`PATCH` path only after the operator clicks Mark done. Hecate does not
+auto-mutate stored work-item status from review verdicts, handoffs, or
+assignment rollups without an explicit operator update. Updates that do not mark
+the work item done continue to use the normal edit flow while closeout blockers
+remain.
 
 #### `GET /hecate/v1/projects/{id}/activity`
 
@@ -2906,6 +2906,11 @@ artifact-id consumers.
 
 Updates `title`, `brief`, `status`, `priority`, `owner_role_id`, `root_id`, or
 `reviewer_role_ids`. An empty `root_id` clears the work-item root override.
+When `status` is set to `done`, the server validates the same closeout readiness
+contract returned by
+`GET /hecate/v1/projects/{id}/work-items/{work_item_id}/readiness`. If blockers
+remain, the update returns `409 conflict` with a `readiness` object in the error
+body. Other work-item edits are not blocked by closeout readiness.
 
 #### `DELETE /hecate/v1/projects/{id}/work-items/{work_item_id}`
 

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -286,8 +286,8 @@ func (h *Handler) renderProjectAssignmentLaunchReadiness(ctx context.Context, pr
 		readiness.Blockers = append(readiness.Blockers, fmt.Sprintf("Assignment driver_kind %q is not supported.", driverKind))
 	}
 
-	readiness.Blockers = projectWorkReadinessUniqueStrings(readiness.Blockers)
-	readiness.Warnings = projectWorkReadinessUniqueStrings(readiness.Warnings)
+	readiness.Blockers = projectworkapp.UniqueReadinessStrings(readiness.Blockers)
+	readiness.Warnings = projectworkapp.UniqueReadinessStrings(readiness.Warnings)
 	readiness.Ready = len(readiness.Blockers) == 0
 	if !readiness.Ready {
 		readiness.Status = projectAssignmentLaunchReadinessStatusBlocked

--- a/internal/api/handler_project_health.go
+++ b/internal/api/handler_project_health.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 const (
@@ -226,7 +227,7 @@ func projectHealthSummary(project projects.Project, entries []memory.Entry, cand
 		if artifact.Kind != projectwork.ArtifactKindReview {
 			continue
 		}
-		if projectWorkReadinessReviewArtifactRequiresFollowUp(artifact) {
+		if projectworkapp.ReviewArtifactRequiresFollowUp(artifact) {
 			summary.ReviewFollowUpCount++
 		}
 		switch artifact.ReviewVerdict {
@@ -526,7 +527,7 @@ func projectHealthReviewFollowUpAttention(projectID string, workItems []projectw
 		return items[i].ID < items[j].ID
 	})
 	for _, artifact := range items {
-		if !projectWorkReadinessReviewArtifactNeedsPath(artifact, handoffsByWorkItem[artifact.WorkItemID]) {
+		if !projectworkapp.ReviewArtifactNeedsFollowUpPath(artifact, handoffsByWorkItem[artifact.WorkItemID]) {
 			continue
 		}
 		workItem := workByID[artifact.WorkItemID]
@@ -598,7 +599,7 @@ func projectHealthStaleAssignments(project projects.Project, activity ProjectAct
 		workByID[workItem.ID] = workItem
 	}
 	for _, assignment := range assignments {
-		status := projectWorkReadinessAssignmentStatus(assignment)
+		status := projectworkapp.AssignmentReadinessStatus(assignment)
 		if !projectHealthAssignmentIsStale(assignment, status, now) {
 			continue
 		}
@@ -625,7 +626,7 @@ func projectHealthProjectedStaleAssignment(project projects.Project, workItem pr
 		WorkItem:       renderProjectActivityWorkItem(renderProjectWorkItem(workItem)),
 		Assignment:     renderedAssignment,
 		Role:           ProjectWorkRoleResponse{ID: assignment.RoleID, ProjectID: project.ID, Name: assignment.RoleID},
-		Status:         projectWorkReadinessAssignmentStatus(assignment),
+		Status:         projectworkapp.AssignmentReadinessStatus(assignment),
 		BlockingSignal: "stale_unknown",
 		StatusSummary:  "active assignment has not changed recently",
 		LinkedTaskID:   taskID,
@@ -743,7 +744,7 @@ func projectHealthAssignmentExecutionMissing(item ProjectActivityItemResponse) b
 }
 
 func projectHealthAssignmentIsStale(assignment projectwork.Assignment, status string, now time.Time) bool {
-	if !projectWorkReadinessActiveAssignmentStatus(status) {
+	if !projectworkapp.IsActiveAssignmentStatus(status) {
 		return false
 	}
 	updated := projectworkTime(assignment.UpdatedAt, assignment.StartedAt)

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 const (
@@ -301,19 +302,19 @@ func handoffOperationItems(projectID string, handoffs []projectwork.Handoff) []P
 
 func selectedWorkFollowThroughOperationItems(projectID string, workItems []projectwork.WorkItem, assignments []projectwork.Assignment, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) []ProjectOperationsBriefItemResponse {
 	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
-	assignmentsByID := projectWorkReadinessAssignmentsByID(assignments)
+	assignmentsByID := projectworkapp.AssignmentsByID(assignments)
 	allArtifactsByWorkItem := projectOperationsArtifactsByWorkItem(artifacts)
 	handoffsByWorkItem := projectOperationsHandoffsByWorkItem(handoffs)
 	items := make([]ProjectOperationsBriefItemResponse, 0, len(workItems))
 	for _, workItem := range workItems {
-		if projectWorkItemClosed(workItem.Status) {
+		if projectworkapp.WorkItemClosed(workItem.Status) {
 			continue
 		}
 		workItemAssignments := assignmentsByWorkItem[workItem.ID]
 		workItemArtifacts := allArtifactsByWorkItem[workItem.ID]
 		workItemHandoffs := handoffsByWorkItem[workItem.ID]
-		readiness := renderProjectWorkItemReadiness(workItem, workItemAssignments, workItemArtifacts, workItemHandoffs)
-		if review := projectWorkReadinessReviewFollowUpArtifact(workItemArtifacts, workItemHandoffs); review != nil {
+		readiness := projectworkapp.EvaluateWorkItemReadiness(workItem, workItemAssignments, workItemArtifacts, workItemHandoffs)
+		if review := projectworkapp.ReviewFollowUpArtifact(workItemArtifacts, workItemHandoffs); review != nil {
 			items = append(items, reviewFollowUpOperationItem(projectID, workItem, *review))
 		}
 		for _, assignmentID := range readiness.MissingEvidenceAssignmentIDs {
@@ -454,7 +455,7 @@ func assignmentGapOperationItems(projectID string, workItems []projectwork.WorkI
 		return items
 	}
 	for _, workItem := range workItems {
-		if projectWorkItemClosed(workItem.Status) || len(assignmentsByWorkItem[workItem.ID]) > 0 {
+		if projectworkapp.WorkItemClosed(workItem.Status) || len(assignmentsByWorkItem[workItem.ID]) > 0 {
 			continue
 		}
 		rendered := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
@@ -632,15 +633,6 @@ func projectHasActiveRoot(project projects.Project) bool {
 		}
 	}
 	return false
-}
-
-func projectWorkItemClosed(status string) bool {
-	switch strings.TrimSpace(status) {
-	case projectwork.WorkItemStatusDone, projectwork.WorkItemStatusCancelled:
-		return true
-	default:
-		return false
-	}
 }
 
 func projectOperationsArtifactsByWorkItem(artifacts []projectwork.CollaborationArtifact) map[string][]projectwork.CollaborationArtifact {

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
@@ -509,10 +510,10 @@ func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 		Status:            projectwork.HandoffStatusAccepted,
 		LinkedArtifactIDs: []string{artifact.ID},
 	}}
-	if projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, acceptedWithoutTarget) {
+	if projectworkapp.ReviewArtifactHasLinkedFollowUpPath(artifact.ID, acceptedWithoutTarget) {
 		t.Fatal("accepted handoff without target assignment should not hide review follow-up operation")
 	}
-	if projectWorkReadinessReviewFollowUpBlocker(artifact, acceptedWithoutTarget, nil) == "" {
+	if projectworkapp.ReviewFollowUpBlocker(artifact, acceptedWithoutTarget, nil) == "" {
 		t.Fatal("accepted handoff without target assignment should still block closeout")
 	}
 
@@ -521,7 +522,7 @@ func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 		Status:            projectwork.HandoffStatusPending,
 		LinkedArtifactIDs: []string{artifact.ID},
 	}}
-	if !projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, pending) || projectWorkReadinessReviewFollowUpBlocker(artifact, pending, nil) == "" {
+	if !projectworkapp.ReviewArtifactHasLinkedFollowUpPath(artifact.ID, pending) || projectworkapp.ReviewFollowUpBlocker(artifact, pending, nil) == "" {
 		t.Fatal("pending handoff should route through handoff review and block closeout")
 	}
 
@@ -530,7 +531,7 @@ func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 		Status:            projectwork.HandoffStatusDismissed,
 		LinkedArtifactIDs: []string{artifact.ID},
 	}}
-	if !projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, dismissed) || projectWorkReadinessReviewFollowUpBlocker(artifact, dismissed, nil) != "" {
+	if !projectworkapp.ReviewArtifactHasLinkedFollowUpPath(artifact.ID, dismissed) || projectworkapp.ReviewFollowUpBlocker(artifact, dismissed, nil) != "" {
 		t.Fatal("dismissed handoff should clear review follow-up without blocking closeout")
 	}
 
@@ -543,7 +544,7 @@ func TestProjectOperationsReviewFollowUpPathAndBlockerSemantics(t *testing.T) {
 	assignmentsByID := map[string]projectwork.Assignment{
 		"asgn_followup": {ID: "asgn_followup", Status: projectwork.AssignmentStatusCompleted},
 	}
-	if !projectWorkReadinessArtifactHasLinkedFollowUpPath(artifact.ID, completedTarget) || projectWorkReadinessReviewFollowUpBlocker(artifact, completedTarget, assignmentsByID) != "" {
+	if !projectworkapp.ReviewArtifactHasLinkedFollowUpPath(artifact.ID, completedTarget) || projectworkapp.ReviewFollowUpBlocker(artifact, completedTarget, assignmentsByID) != "" {
 		t.Fatal("completed target assignment should clear review follow-up closeout blocker")
 	}
 }

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -1047,6 +1047,16 @@ func writeProjectWorkError(w http.ResponseWriter, err error) bool {
 	if err == nil {
 		return true
 	}
+	var closeoutErr projectworkapp.WorkItemCloseoutBlockedError
+	if errors.As(err, &closeoutErr) {
+		WriteErrorDetails(w, http.StatusConflict, errCodeConflict, err.Error(), ErrorDetails{
+			OperatorAction: "Resolve closeout readiness blockers, refresh the work item, then retry.",
+			Fields: map[string]any{
+				"readiness": renderProjectWorkItemReadiness(closeoutErr.Readiness),
+			},
+		})
+		return false
+	}
 	writeAppErrorWithFallback(w, err, projectWorkErrorMappings, http.StatusInternalServerError, errCodeGatewayError)
 	return false
 }

--- a/internal/api/handler_project_work_readiness.go
+++ b/internal/api/handler_project_work_readiness.go
@@ -3,13 +3,10 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
-	"sort"
-	"strings"
 
-	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 type ProjectWorkItemReadinessEnvelope struct {
@@ -51,7 +48,7 @@ func (h *Handler) HandleProjectWorkItemReadiness(w http.ResponseWriter, r *http.
 	}
 	readiness, err := h.renderProjectWorkItemReadiness(r.Context(), projectID, r.PathValue("work_item_id"))
 	if err != nil {
-		if errors.Is(err, projects.ErrNotFound) {
+		if errors.Is(err, projectwork.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
 			return
 		}
@@ -62,275 +59,47 @@ func (h *Handler) HandleProjectWorkItemReadiness(w http.ResponseWriter, r *http.
 }
 
 func (h *Handler) renderProjectWorkItemReadiness(ctx context.Context, projectID, workItemID string) (ProjectWorkItemReadinessResponse, error) {
-	if _, ok, err := h.projects.Get(ctx, projectID); err != nil {
-		return ProjectWorkItemReadinessResponse{}, err
-	} else if !ok {
-		return ProjectWorkItemReadinessResponse{}, projects.ErrNotFound
-	}
-	workItem, ok, err := h.projectWork.GetWorkItem(ctx, projectID, workItemID)
+	readiness, err := h.projectWorkApplication().WorkItemReadiness(ctx, projectID, workItemID)
 	if err != nil {
 		return ProjectWorkItemReadinessResponse{}, err
 	}
-	if !ok {
-		return ProjectWorkItemReadinessResponse{}, projects.ErrNotFound
-	}
-	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})
-	if err != nil {
-		return ProjectWorkItemReadinessResponse{}, err
-	}
-	artifacts, err := h.projectWork.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: workItemID})
-	if err != nil {
-		return ProjectWorkItemReadinessResponse{}, err
-	}
-	handoffs, err := h.projectWork.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID, WorkItemID: workItemID})
-	if err != nil {
-		return ProjectWorkItemReadinessResponse{}, err
-	}
-	return renderProjectWorkItemReadiness(workItem, assignments, artifacts, handoffs), nil
+	return renderProjectWorkItemReadiness(readiness), nil
 }
 
-func renderProjectWorkItemReadiness(workItem projectwork.WorkItem, assignments []projectwork.Assignment, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) ProjectWorkItemReadinessResponse {
-	statuses := make([]string, 0, len(assignments))
-	assignmentsByID := projectWorkReadinessAssignmentsByID(assignments)
-	closed := projectWorkItemClosed(workItem.Status)
-	readiness := ProjectWorkItemReadinessResponse{
-		ProjectID:            workItem.ProjectID,
-		WorkItemID:           workItem.ID,
-		Status:               "ready",
-		Title:                "Ready to mark done",
-		Detail:               "Assignments, evidence, handoffs, and review follow-up are clear. The operator can mark this work item done.",
-		AssignmentCount:      len(assignments),
-		CompletedAssignments: 0,
-	}
-
-	for _, assignment := range assignments {
-		status := projectWorkReadinessAssignmentStatus(assignment)
-		statuses = append(statuses, status)
-		if status != projectwork.AssignmentStatusCompleted {
-			continue
-		}
-		readiness.CompletedAssignments++
-		if !closed && !projectWorkReadinessAssignmentHasEvidence(assignment, artifacts) {
-			readiness.MissingEvidenceAssignmentIDs = append(readiness.MissingEvidenceAssignmentIDs, assignment.ID)
-		}
-	}
-	if closed {
-		readiness.Status = "done"
-		readiness.Title = "Work item is done"
-		readiness.Detail = "This work item has already been marked done by the operator."
-		return readiness
-	}
-
-	activeAssignments := projectWorkReadinessStatusCount(statuses, projectWorkReadinessActiveAssignmentStatus)
-	failedAssignments := projectWorkReadinessStatusCount(statuses, func(status string) bool {
-		return status == projectwork.AssignmentStatusFailed
-	})
-	cancelledAssignments := projectWorkReadinessStatusCount(statuses, func(status string) bool {
-		return status == projectwork.AssignmentStatusCancelled
-	})
-	unresolvedAssignments := projectWorkReadinessStatusCount(statuses, projectWorkReadinessUnresolvedAssignmentStatus)
-	pendingHandoffs := 0
-	for _, handoff := range handoffs {
-		if handoff.Status == projectwork.HandoffStatusPending {
-			pendingHandoffs++
-		}
-	}
-	if activeAssignments > 0 {
-		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(activeAssignments, "assignment is still active", "assignments are still active"))
-	}
-	if failedAssignments > 0 {
-		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(failedAssignments, "assignment failed", "assignments failed"))
-	}
-	if cancelledAssignments > 0 {
-		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(cancelledAssignments, "assignment was cancelled", "assignments were cancelled"))
-	}
-	if unresolvedAssignments > 0 {
-		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(unresolvedAssignments, "assignment is not complete", "assignments are not complete"))
-	}
-	if pendingHandoffs > 0 {
-		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(pendingHandoffs, "handoff is pending", "handoffs are pending"))
-	}
-	if len(readiness.MissingEvidenceAssignmentIDs) > 0 {
-		readiness.Blockers = append(readiness.Blockers, projectWorkReadinessPlural(len(readiness.MissingEvidenceAssignmentIDs), "completed assignment is missing evidence", "completed assignments are missing evidence"))
-	}
-	if len(assignments) == 0 {
-		readiness.Warnings = append(readiness.Warnings, "No assignments are linked to this work item; closeout is manual.")
-	}
-	for _, artifact := range artifacts {
-		if projectWorkReadinessReviewArtifactNeedsPath(artifact, handoffs) {
-			blocker := projectWorkReadinessReviewFollowUpBlocker(artifact, handoffs, assignmentsByID)
-			readiness.ReviewFollowUpArtifactIDs = append(readiness.ReviewFollowUpArtifactIDs, artifact.ID)
-			readiness.ReviewFollowUps = append(readiness.ReviewFollowUps, renderProjectWorkItemReviewFollowUp(artifact, blocker))
-		}
-		if blocker := projectWorkReadinessReviewFollowUpBlocker(artifact, handoffs, assignmentsByID); blocker != "" {
-			readiness.Blockers = append(readiness.Blockers, blocker)
-		}
-	}
-	readiness.ReviewFollowUpCount = len(readiness.ReviewFollowUpArtifactIDs)
-	readiness.Blockers = projectWorkReadinessUniqueStrings(readiness.Blockers)
-	readiness.Warnings = projectWorkReadinessUniqueStrings(readiness.Warnings)
-	if len(readiness.Blockers) > 0 {
-		readiness.Status = "blocked"
-		readiness.Title = "Closeout is blocked"
-		readiness.Detail = "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done."
-	}
-	readiness.Ready = readiness.Status == "ready"
-	return readiness
-}
-
-func renderProjectWorkItemReviewFollowUp(artifact projectwork.CollaborationArtifact, blocker string) ProjectWorkItemReviewFollowUpResponse {
-	return ProjectWorkItemReviewFollowUpResponse{
-		ArtifactID:           artifact.ID,
-		Title:                firstNonEmpty(artifact.Title, artifact.ID),
-		Status:               "needs_path",
-		Blocker:              strings.TrimSpace(blocker),
-		ReviewedAssignmentID: artifact.ReviewedAssignmentID,
-		ReviewVerdict:        artifact.ReviewVerdict,
-		ReviewRisk:           artifact.ReviewRisk,
+func renderProjectWorkItemReadiness(readiness projectworkapp.WorkItemReadiness) ProjectWorkItemReadinessResponse {
+	return ProjectWorkItemReadinessResponse{
+		ProjectID:                    readiness.ProjectID,
+		WorkItemID:                   readiness.WorkItemID,
+		Ready:                        readiness.Ready,
+		Status:                       readiness.Status,
+		Title:                        readiness.Title,
+		Detail:                       readiness.Detail,
+		Blockers:                     append([]string(nil), readiness.Blockers...),
+		Warnings:                     append([]string(nil), readiness.Warnings...),
+		AssignmentCount:              readiness.AssignmentCount,
+		CompletedAssignments:         readiness.CompletedAssignments,
+		ReviewFollowUpCount:          readiness.ReviewFollowUpCount,
+		ReviewFollowUpArtifactIDs:    append([]string(nil), readiness.ReviewFollowUpArtifactIDs...),
+		ReviewFollowUps:              renderProjectWorkItemReviewFollowUps(readiness.ReviewFollowUps),
+		MissingEvidenceAssignmentIDs: append([]string(nil), readiness.MissingEvidenceAssignmentIDs...),
 	}
 }
 
-func projectWorkReadinessReviewFollowUpArtifact(artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) *projectwork.CollaborationArtifact {
-	items := append([]projectwork.CollaborationArtifact(nil), artifacts...)
-	sort.SliceStable(items, func(i, j int) bool {
-		left, right := projectworkTime(items[i].UpdatedAt, items[i].CreatedAt), projectworkTime(items[j].UpdatedAt, items[j].CreatedAt)
-		if !left.Equal(right) {
-			return left.After(right)
-		}
-		return items[i].ID < items[j].ID
-	})
-	for i := range items {
-		if projectWorkReadinessReviewArtifactNeedsPath(items[i], handoffs) {
-			return &items[i]
-		}
+func renderProjectWorkItemReviewFollowUps(items []projectworkapp.ReviewFollowUpReadiness) []ProjectWorkItemReviewFollowUpResponse {
+	if len(items) == 0 {
+		return nil
 	}
-	return nil
-}
-
-func projectWorkReadinessReviewArtifactNeedsPath(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) bool {
-	return projectwork.ReviewArtifactNeedsFollowUpPath(artifact, handoffs)
-}
-
-func projectWorkReadinessReviewArtifactRequiresFollowUp(artifact projectwork.CollaborationArtifact) bool {
-	return projectwork.ReviewArtifactRequiresFollowUp(artifact)
-}
-
-func projectWorkReadinessArtifactHasLinkedFollowUpPath(artifactID string, handoffs []projectwork.Handoff) bool {
-	return projectwork.ReviewArtifactHasLinkedFollowUpPath(artifactID, handoffs)
-}
-
-func projectWorkReadinessReviewFollowUpBlocker(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, assignmentsByID map[string]projectwork.Assignment) string {
-	if !projectWorkReadinessReviewArtifactRequiresFollowUp(artifact) {
-		return ""
+	out := make([]ProjectWorkItemReviewFollowUpResponse, 0, len(items))
+	for _, item := range items {
+		out = append(out, ProjectWorkItemReviewFollowUpResponse{
+			ArtifactID:           item.ArtifactID,
+			Title:                item.Title,
+			Status:               item.Status,
+			Blocker:              item.Blocker,
+			ReviewedAssignmentID: item.ReviewedAssignmentID,
+			ReviewVerdict:        item.ReviewVerdict,
+			ReviewRisk:           item.ReviewRisk,
+		})
 	}
-	title := firstNonEmpty(artifact.Title, artifact.ID)
-	linked := make([]projectwork.Handoff, 0)
-	for _, handoff := range handoffs {
-		for _, artifactID := range handoff.LinkedArtifactIDs {
-			if strings.TrimSpace(artifactID) == artifact.ID {
-				linked = append(linked, handoff)
-				break
-			}
-		}
-	}
-	if len(linked) == 0 {
-		return fmt.Sprintf("Review follow-up %q is not triaged", title)
-	}
-	hasTargetAssignment := false
-	hasCompletedTarget := false
-	hasDismissedOrSuperseded := false
-	for _, handoff := range linked {
-		if handoff.Status == projectwork.HandoffStatusPending {
-			return fmt.Sprintf("Review follow-up %q has a pending handoff", title)
-		}
-		if handoff.Status == projectwork.HandoffStatusDismissed || handoff.Status == projectwork.HandoffStatusSuperseded {
-			hasDismissedOrSuperseded = true
-		}
-		if strings.TrimSpace(handoff.TargetAssignmentID) == "" {
-			continue
-		}
-		hasTargetAssignment = true
-		if assignment, ok := assignmentsByID[handoff.TargetAssignmentID]; ok {
-			hasCompletedTarget = hasCompletedTarget || projectWorkReadinessAssignmentStatus(assignment) == projectwork.AssignmentStatusCompleted
-		}
-	}
-	if hasCompletedTarget {
-		return ""
-	}
-	if hasTargetAssignment {
-		return fmt.Sprintf("Review follow-up %q assignment is not completed", title)
-	}
-	if hasDismissedOrSuperseded {
-		return ""
-	}
-	return fmt.Sprintf("Review follow-up %q is not triaged", title)
-}
-
-func projectWorkReadinessAssignmentStatus(assignment projectwork.Assignment) string {
-	return firstNonEmpty(assignment.ExecutionRef.Status, assignment.Status)
-}
-
-func projectWorkReadinessActiveAssignmentStatus(status string) bool {
-	return status == projectwork.AssignmentStatusQueued || status == projectwork.AssignmentStatusRunning || status == projectwork.AssignmentStatusAwaitingApproval
-}
-
-func projectWorkReadinessUnresolvedAssignmentStatus(status string) bool {
-	return status != projectwork.AssignmentStatusCompleted &&
-		status != projectwork.AssignmentStatusFailed &&
-		status != projectwork.AssignmentStatusCancelled &&
-		!projectWorkReadinessActiveAssignmentStatus(status)
-}
-
-func projectWorkReadinessAssignmentHasEvidence(assignment projectwork.Assignment, artifacts []projectwork.CollaborationArtifact) bool {
-	for _, artifact := range artifacts {
-		if artifact.Kind != projectwork.ArtifactKindEvidenceLink {
-			continue
-		}
-		if artifact.AssignmentID == "" || artifact.AssignmentID == assignment.ID {
-			return true
-		}
-	}
-	return false
-}
-
-func projectWorkReadinessStatusCount(statuses []string, predicate func(string) bool) int {
-	count := 0
-	for _, status := range statuses {
-		if predicate(status) {
-			count++
-		}
-	}
-	return count
-}
-
-func projectWorkReadinessAssignmentsByID(assignments []projectwork.Assignment) map[string]projectwork.Assignment {
-	byID := make(map[string]projectwork.Assignment, len(assignments))
-	for _, assignment := range assignments {
-		byID[assignment.ID] = assignment
-	}
-	return byID
-}
-
-func projectWorkReadinessPlural(count int, singular, plural string) string {
-	if count == 1 {
-		return fmt.Sprintf("1 %s", singular)
-	}
-	return fmt.Sprintf("%d %s", count, plural)
-}
-
-func projectWorkReadinessUniqueStrings(values []string) []string {
-	seen := make(map[string]struct{}, len(values))
-	unique := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		unique = append(unique, value)
-	}
-	return unique
+	return out
 }

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -486,6 +486,100 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_PatchDoneRequiresCloseoutReadiness(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServer()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_closeout_guard",
+		Name: "Closeout Guard",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_guard",
+		ProjectID: "proj_closeout_guard",
+		Title:     "Guard closeout",
+		Status:    projectwork.WorkItemStatusReview,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_guard",
+		ProjectID:  "proj_closeout_guard",
+		WorkItemID: "work_guard",
+		RoleID:     "software_developer",
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/proj_closeout_guard/work-items/work_guard", bytes.NewReader([]byte(`{"status":"done"}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("patch done status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	var blocked struct {
+		Error struct {
+			Type      string                           `json:"type"`
+			Message   string                           `json:"message"`
+			Readiness ProjectWorkItemReadinessResponse `json:"readiness"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &blocked); err != nil {
+		t.Fatalf("decode blocked closeout: %v", err)
+	}
+	if blocked.Error.Type != errCodeConflict || blocked.Error.Message != projectworkapp.ErrWorkItemCloseoutBlocked.Error() {
+		t.Fatalf("blocked error = %+v, want closeout conflict", blocked.Error)
+	}
+	if blocked.Error.Readiness.Ready || blocked.Error.Readiness.Status != "blocked" || len(blocked.Error.Readiness.MissingEvidenceAssignmentIDs) != 1 || blocked.Error.Readiness.MissingEvidenceAssignmentIDs[0] != "asgn_guard" {
+		t.Fatalf("blocked readiness = %+v, want missing evidence blocker", blocked.Error.Readiness)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/proj_closeout_guard/work-items/work_guard", bytes.NewReader([]byte(`{"priority":"high"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch priority status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var patched ProjectWorkItemEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &patched); err != nil {
+		t.Fatalf("decode patched work item: %v", err)
+	}
+	if patched.Data.Priority != "high" {
+		t.Fatalf("patched item = %+v, want priority update", patched.Data)
+	}
+	stored, ok, err := handler.projectWork.GetWorkItem(t.Context(), "proj_closeout_guard", "work_guard")
+	if err != nil || !ok {
+		t.Fatalf("GetWorkItem() ok=%v err=%v, want stored work item", ok, err)
+	}
+	if stored.Status == projectwork.WorkItemStatusDone {
+		t.Fatalf("stored status = %q, want not done after priority-only update", stored.Status)
+	}
+
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:           "artifact_guard_evidence",
+		ProjectID:    "proj_closeout_guard",
+		WorkItemID:   "work_guard",
+		AssignmentID: "asgn_guard",
+		Kind:         projectwork.ArtifactKindEvidenceLink,
+		Title:        "Evidence",
+		Body:         "Evidence recorded.",
+		EvidenceURL:  "https://example.com/evidence",
+	}); err != nil {
+		t.Fatalf("CreateArtifact(evidence): %v", err)
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/proj_closeout_guard/work-items/work_guard", bytes.NewReader([]byte(`{"status":"done"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch done with evidence status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &patched); err != nil {
+		t.Fatalf("decode closed work item: %v", err)
+	}
+	if patched.Data.Status != projectwork.WorkItemStatusDone {
+		t.Fatalf("closed item status = %q, want done", patched.Data.Status)
+	}
+}
+
 func TestProjectWorkAPI_WorkAndAssignmentRootIDs(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectWorkTestServer()

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -297,6 +297,15 @@ func (app *Application) UpdateWorkItem(ctx context.Context, projectID, workItemI
 	if app == nil || app.store == nil {
 		return projectwork.WorkItem{}, ErrStoreNotConfigured
 	}
+	if cmd.Status != nil && strings.TrimSpace(*cmd.Status) == projectwork.WorkItemStatusDone {
+		readiness, err := app.WorkItemReadiness(ctx, projectID, workItemID)
+		if err != nil {
+			return projectwork.WorkItem{}, err
+		}
+		if readiness.Status != "done" && !readiness.Ready {
+			return projectwork.WorkItem{}, WorkItemCloseoutBlockedError{Readiness: readiness}
+		}
+	}
 	return app.store.UpdateWorkItem(ctx, projectID, workItemID, func(item *projectwork.WorkItem) {
 		if cmd.Title != nil {
 			item.Title = *cmd.Title

--- a/internal/projectworkapp/application_test.go
+++ b/internal/projectworkapp/application_test.go
@@ -75,6 +75,103 @@ func TestApplication_CreateAssignmentUsesRoleDefaultDriver(t *testing.T) {
 	}
 }
 
+func TestApplication_UpdateWorkItemDoneRequiresCloseoutReadiness(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := projectwork.NewMemoryStore()
+	app := newTestApplication(store)
+	if _, err := app.CreateWorkItem(ctx, "proj_1", CreateWorkItemCommand{ID: "work_1", Title: "Build", Status: projectwork.WorkItemStatusReview}); err != nil {
+		t.Fatalf("CreateWorkItem() error = %v", err)
+	}
+	if _, err := app.CreateAssignment(ctx, "proj_1", "work_1", CreateAssignmentCommand{
+		ID:     "asgn_1",
+		RoleID: "software_developer",
+		Status: projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("CreateAssignment() error = %v", err)
+	}
+
+	statusDone := projectwork.WorkItemStatusDone
+	_, err := app.UpdateWorkItem(ctx, "proj_1", "work_1", UpdateWorkItemCommand{Status: &statusDone})
+	if !errors.Is(err, ErrWorkItemCloseoutBlocked) {
+		t.Fatalf("UpdateWorkItem(done) error = %v, want ErrWorkItemCloseoutBlocked", err)
+	}
+	var blocked WorkItemCloseoutBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("UpdateWorkItem(done) error = %T, want WorkItemCloseoutBlockedError", err)
+	}
+	if blocked.Readiness.Ready || len(blocked.Readiness.MissingEvidenceAssignmentIDs) != 1 || blocked.Readiness.MissingEvidenceAssignmentIDs[0] != "asgn_1" {
+		t.Fatalf("blocked readiness = %+v, want missing evidence blocker", blocked.Readiness)
+	}
+	stored, ok, err := store.GetWorkItem(ctx, "proj_1", "work_1")
+	if err != nil || !ok {
+		t.Fatalf("GetWorkItem() ok=%v err=%v, want stored work item", ok, err)
+	}
+	if stored.Status == projectwork.WorkItemStatusDone {
+		t.Fatalf("stored work item status = %q, want not done after blocked closeout", stored.Status)
+	}
+
+	priority := "high"
+	updated, err := app.UpdateWorkItem(ctx, "proj_1", "work_1", UpdateWorkItemCommand{Priority: &priority})
+	if err != nil {
+		t.Fatalf("UpdateWorkItem(priority) error = %v", err)
+	}
+	if updated.Priority != priority {
+		t.Fatalf("updated priority = %q, want %q", updated.Priority, priority)
+	}
+
+	if _, err := store.CreateArtifact(ctx, projectwork.CollaborationArtifact{
+		ID:           "artifact_evidence",
+		ProjectID:    "proj_1",
+		WorkItemID:   "work_1",
+		AssignmentID: "asgn_1",
+		Kind:         projectwork.ArtifactKindEvidenceLink,
+		Title:        "Evidence",
+		Body:         "Evidence recorded.",
+		EvidenceURL:  "https://example.com/evidence",
+	}); err != nil {
+		t.Fatalf("CreateArtifact(evidence) error = %v", err)
+	}
+	updated, err = app.UpdateWorkItem(ctx, "proj_1", "work_1", UpdateWorkItemCommand{Status: &statusDone})
+	if err != nil {
+		t.Fatalf("UpdateWorkItem(done with evidence) error = %v", err)
+	}
+	if updated.Status != projectwork.WorkItemStatusDone {
+		t.Fatalf("updated status = %q, want done", updated.Status)
+	}
+}
+
+func TestApplication_UpdateWorkItemDoneAllowsManualEmptyCloseoutAndAlreadyDone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := projectwork.NewMemoryStore()
+	app := newTestApplication(store)
+	statusDone := projectwork.WorkItemStatusDone
+	if _, err := app.CreateWorkItem(ctx, "proj_1", CreateWorkItemCommand{ID: "work_empty", Title: "Manual closeout", Status: projectwork.WorkItemStatusReady}); err != nil {
+		t.Fatalf("CreateWorkItem(empty) error = %v", err)
+	}
+	updated, err := app.UpdateWorkItem(ctx, "proj_1", "work_empty", UpdateWorkItemCommand{Status: &statusDone})
+	if err != nil {
+		t.Fatalf("UpdateWorkItem(empty done) error = %v", err)
+	}
+	if updated.Status != projectwork.WorkItemStatusDone {
+		t.Fatalf("empty closeout status = %q, want done", updated.Status)
+	}
+
+	if _, err := app.CreateWorkItem(ctx, "proj_1", CreateWorkItemCommand{ID: "work_done", Title: "Already done", Status: projectwork.WorkItemStatusDone}); err != nil {
+		t.Fatalf("CreateWorkItem(done) error = %v", err)
+	}
+	updated, err = app.UpdateWorkItem(ctx, "proj_1", "work_done", UpdateWorkItemCommand{Status: &statusDone})
+	if err != nil {
+		t.Fatalf("UpdateWorkItem(already done) error = %v", err)
+	}
+	if updated.Status != projectwork.WorkItemStatusDone {
+		t.Fatalf("already-done status = %q, want done", updated.Status)
+	}
+}
+
 func TestApplication_UpdateAssignmentAppliesOptionalFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/projectworkapp/closeout_readiness.go
+++ b/internal/projectworkapp/closeout_readiness.go
@@ -1,0 +1,333 @@
+package projectworkapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+var ErrWorkItemCloseoutBlocked = errors.New("project work item closeout blocked")
+
+type WorkItemReadiness struct {
+	ProjectID                    string
+	WorkItemID                   string
+	Ready                        bool
+	Status                       string
+	Title                        string
+	Detail                       string
+	Blockers                     []string
+	Warnings                     []string
+	AssignmentCount              int
+	CompletedAssignments         int
+	ReviewFollowUpCount          int
+	ReviewFollowUpArtifactIDs    []string
+	ReviewFollowUps              []ReviewFollowUpReadiness
+	MissingEvidenceAssignmentIDs []string
+}
+
+type ReviewFollowUpReadiness struct {
+	ArtifactID           string
+	Title                string
+	Status               string
+	Blocker              string
+	ReviewedAssignmentID string
+	ReviewVerdict        string
+	ReviewRisk           string
+}
+
+type WorkItemCloseoutBlockedError struct {
+	Readiness WorkItemReadiness
+}
+
+func (e WorkItemCloseoutBlockedError) Error() string {
+	return ErrWorkItemCloseoutBlocked.Error()
+}
+
+func (e WorkItemCloseoutBlockedError) Unwrap() error {
+	return ErrWorkItemCloseoutBlocked
+}
+
+func (app *Application) WorkItemReadiness(ctx context.Context, projectID, workItemID string) (WorkItemReadiness, error) {
+	if app == nil || app.store == nil {
+		return WorkItemReadiness{}, ErrStoreNotConfigured
+	}
+	workItem, ok, err := app.store.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return WorkItemReadiness{}, err
+	}
+	if !ok {
+		return WorkItemReadiness{}, projectwork.ErrNotFound
+	}
+	assignments, err := app.store.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return WorkItemReadiness{}, err
+	}
+	artifacts, err := app.store.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return WorkItemReadiness{}, err
+	}
+	handoffs, err := app.store.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return WorkItemReadiness{}, err
+	}
+	return EvaluateWorkItemReadiness(workItem, assignments, artifacts, handoffs), nil
+}
+
+func EvaluateWorkItemReadiness(workItem projectwork.WorkItem, assignments []projectwork.Assignment, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) WorkItemReadiness {
+	statuses := make([]string, 0, len(assignments))
+	assignmentsByID := AssignmentsByID(assignments)
+	closed := WorkItemClosed(workItem.Status)
+	readiness := WorkItemReadiness{
+		ProjectID:            workItem.ProjectID,
+		WorkItemID:           workItem.ID,
+		Status:               "ready",
+		Title:                "Ready to mark done",
+		Detail:               "Assignments, evidence, handoffs, and review follow-up are clear. The operator can mark this work item done.",
+		AssignmentCount:      len(assignments),
+		CompletedAssignments: 0,
+	}
+
+	for _, assignment := range assignments {
+		status := AssignmentReadinessStatus(assignment)
+		statuses = append(statuses, status)
+		if status != projectwork.AssignmentStatusCompleted {
+			continue
+		}
+		readiness.CompletedAssignments++
+		if !closed && !AssignmentHasCloseoutEvidence(assignment, artifacts) {
+			readiness.MissingEvidenceAssignmentIDs = append(readiness.MissingEvidenceAssignmentIDs, assignment.ID)
+		}
+	}
+	if closed {
+		readiness.Status = "done"
+		readiness.Title = "Work item is done"
+		readiness.Detail = "This work item has already been marked done by the operator."
+		return readiness
+	}
+
+	activeAssignments := readinessStatusCount(statuses, IsActiveAssignmentStatus)
+	failedAssignments := readinessStatusCount(statuses, func(status string) bool {
+		return status == projectwork.AssignmentStatusFailed
+	})
+	cancelledAssignments := readinessStatusCount(statuses, func(status string) bool {
+		return status == projectwork.AssignmentStatusCancelled
+	})
+	unresolvedAssignments := readinessStatusCount(statuses, IsUnresolvedAssignmentStatus)
+	pendingHandoffs := 0
+	for _, handoff := range handoffs {
+		if handoff.Status == projectwork.HandoffStatusPending {
+			pendingHandoffs++
+		}
+	}
+	if activeAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(activeAssignments, "assignment is still active", "assignments are still active"))
+	}
+	if failedAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(failedAssignments, "assignment failed", "assignments failed"))
+	}
+	if cancelledAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(cancelledAssignments, "assignment was cancelled", "assignments were cancelled"))
+	}
+	if unresolvedAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(unresolvedAssignments, "assignment is not complete", "assignments are not complete"))
+	}
+	if pendingHandoffs > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(pendingHandoffs, "handoff is pending", "handoffs are pending"))
+	}
+	if len(readiness.MissingEvidenceAssignmentIDs) > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(len(readiness.MissingEvidenceAssignmentIDs), "completed assignment is missing evidence", "completed assignments are missing evidence"))
+	}
+	if len(assignments) == 0 {
+		readiness.Warnings = append(readiness.Warnings, "No assignments are linked to this work item; closeout is manual.")
+	}
+	for _, artifact := range artifacts {
+		if ReviewArtifactNeedsFollowUpPath(artifact, handoffs) {
+			blocker := ReviewFollowUpBlocker(artifact, handoffs, assignmentsByID)
+			readiness.ReviewFollowUpArtifactIDs = append(readiness.ReviewFollowUpArtifactIDs, artifact.ID)
+			readiness.ReviewFollowUps = append(readiness.ReviewFollowUps, renderReviewFollowUpReadiness(artifact, blocker))
+		}
+		if blocker := ReviewFollowUpBlocker(artifact, handoffs, assignmentsByID); blocker != "" {
+			readiness.Blockers = append(readiness.Blockers, blocker)
+		}
+	}
+	readiness.ReviewFollowUpCount = len(readiness.ReviewFollowUpArtifactIDs)
+	readiness.Blockers = UniqueReadinessStrings(readiness.Blockers)
+	readiness.Warnings = UniqueReadinessStrings(readiness.Warnings)
+	if len(readiness.Blockers) > 0 {
+		readiness.Status = "blocked"
+		readiness.Title = "Closeout is blocked"
+		readiness.Detail = "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done."
+	}
+	readiness.Ready = readiness.Status == "ready"
+	return readiness
+}
+
+func ReviewFollowUpArtifact(artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) *projectwork.CollaborationArtifact {
+	items := append([]projectwork.CollaborationArtifact(nil), artifacts...)
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := FirstNonZeroTime(items[i].UpdatedAt, items[i].CreatedAt), FirstNonZeroTime(items[j].UpdatedAt, items[j].CreatedAt)
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return items[i].ID < items[j].ID
+	})
+	for i := range items {
+		if ReviewArtifactNeedsFollowUpPath(items[i], handoffs) {
+			return &items[i]
+		}
+	}
+	return nil
+}
+
+func ReviewArtifactNeedsFollowUpPath(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) bool {
+	return projectwork.ReviewArtifactNeedsFollowUpPath(artifact, handoffs)
+}
+
+func ReviewArtifactRequiresFollowUp(artifact projectwork.CollaborationArtifact) bool {
+	return projectwork.ReviewArtifactRequiresFollowUp(artifact)
+}
+
+func ReviewArtifactHasLinkedFollowUpPath(artifactID string, handoffs []projectwork.Handoff) bool {
+	return projectwork.ReviewArtifactHasLinkedFollowUpPath(artifactID, handoffs)
+}
+
+func ReviewFollowUpBlocker(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, assignmentsByID map[string]projectwork.Assignment) string {
+	if !ReviewArtifactRequiresFollowUp(artifact) {
+		return ""
+	}
+	title := firstNonEmpty(artifact.Title, artifact.ID)
+	linked := make([]projectwork.Handoff, 0)
+	for _, handoff := range handoffs {
+		for _, artifactID := range handoff.LinkedArtifactIDs {
+			if strings.TrimSpace(artifactID) == artifact.ID {
+				linked = append(linked, handoff)
+				break
+			}
+		}
+	}
+	if len(linked) == 0 {
+		return fmt.Sprintf("Review follow-up %q is not triaged", title)
+	}
+	hasTargetAssignment := false
+	hasCompletedTarget := false
+	hasDismissedOrSuperseded := false
+	for _, handoff := range linked {
+		if handoff.Status == projectwork.HandoffStatusPending {
+			return fmt.Sprintf("Review follow-up %q has a pending handoff", title)
+		}
+		if handoff.Status == projectwork.HandoffStatusDismissed || handoff.Status == projectwork.HandoffStatusSuperseded {
+			hasDismissedOrSuperseded = true
+		}
+		if strings.TrimSpace(handoff.TargetAssignmentID) == "" {
+			continue
+		}
+		hasTargetAssignment = true
+		if assignment, ok := assignmentsByID[handoff.TargetAssignmentID]; ok {
+			hasCompletedTarget = hasCompletedTarget || AssignmentReadinessStatus(assignment) == projectwork.AssignmentStatusCompleted
+		}
+	}
+	if hasCompletedTarget {
+		return ""
+	}
+	if hasTargetAssignment {
+		return fmt.Sprintf("Review follow-up %q assignment is not completed", title)
+	}
+	if hasDismissedOrSuperseded {
+		return ""
+	}
+	return fmt.Sprintf("Review follow-up %q is not triaged", title)
+}
+
+func AssignmentReadinessStatus(assignment projectwork.Assignment) string {
+	return firstNonEmpty(assignment.ExecutionRef.Status, assignment.Status)
+}
+
+func IsActiveAssignmentStatus(status string) bool {
+	return status == projectwork.AssignmentStatusQueued || status == projectwork.AssignmentStatusRunning || status == projectwork.AssignmentStatusAwaitingApproval
+}
+
+func IsUnresolvedAssignmentStatus(status string) bool {
+	return status != projectwork.AssignmentStatusCompleted &&
+		status != projectwork.AssignmentStatusFailed &&
+		status != projectwork.AssignmentStatusCancelled &&
+		!IsActiveAssignmentStatus(status)
+}
+
+func AssignmentHasCloseoutEvidence(assignment projectwork.Assignment, artifacts []projectwork.CollaborationArtifact) bool {
+	for _, artifact := range artifacts {
+		if artifact.Kind != projectwork.ArtifactKindEvidenceLink {
+			continue
+		}
+		if artifact.AssignmentID == "" || artifact.AssignmentID == assignment.ID {
+			return true
+		}
+	}
+	return false
+}
+
+func AssignmentsByID(assignments []projectwork.Assignment) map[string]projectwork.Assignment {
+	byID := make(map[string]projectwork.Assignment, len(assignments))
+	for _, assignment := range assignments {
+		byID[assignment.ID] = assignment
+	}
+	return byID
+}
+
+func WorkItemClosed(status string) bool {
+	switch strings.TrimSpace(status) {
+	case projectwork.WorkItemStatusDone, projectwork.WorkItemStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func UniqueReadinessStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}
+
+func renderReviewFollowUpReadiness(artifact projectwork.CollaborationArtifact, blocker string) ReviewFollowUpReadiness {
+	return ReviewFollowUpReadiness{
+		ArtifactID:           artifact.ID,
+		Title:                firstNonEmpty(artifact.Title, artifact.ID),
+		Status:               "needs_path",
+		Blocker:              strings.TrimSpace(blocker),
+		ReviewedAssignmentID: artifact.ReviewedAssignmentID,
+		ReviewVerdict:        artifact.ReviewVerdict,
+		ReviewRisk:           artifact.ReviewRisk,
+	}
+}
+
+func readinessStatusCount(statuses []string, predicate func(string) bool) int {
+	count := 0
+	for _, status := range statuses {
+		if predicate(status) {
+			count++
+		}
+	}
+	return count
+}
+
+func readinessPlural(count int, singular, plural string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %s", count, plural)
+}


### PR DESCRIPTION
## Overview

Moves project work item closeout readiness into `projectworkapp` and uses it as the server authority for `PATCH` requests that set `status="done"`.

## Behavior

- Reuses one app-layer closeout readiness evaluator for the readiness endpoint, Project Operations hints, Project Health helpers, and the mutation guard.
- Blocks `PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}` with `409 conflict` when `status="done"` is requested while readiness blockers remain.
- Includes the typed `readiness` payload in the conflict response so stale clients can explain the blocker.
- Leaves ordinary work-item edits unblocked by closeout readiness and keeps empty-work manual closeout valid.
- Updates runtime API docs for the server-validated closeout contract.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test ./internal/projectworkapp ./internal/api -run 'TestApplication_UpdateWorkItemDone|TestProjectWorkAPI_PatchDone|TestProjectWorkItemReadiness|TestProjectOperationsReviewFollowUpPathAndBlockerSemantics|TestProjectOperationsBrief_ReadOnlyProjectOperations|TestProjectWorkAPI_AssignmentLaunchReadiness'`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test ./internal/projectwork ./internal/projectworkapp ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go vet ./internal/projectwork ./internal/projectworkapp ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test -race -timeout 10m ./...`
