### PR TITLE
fix(agent): delete native ACP sessions on chat removal

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -496,9 +496,12 @@ quit / restart from leaving Codex, Claude Code, Cursor Agent, or Grok Build
 processes behind. If an ACP peer does not implement `session/close`, Hecate
 treats that as an optional shutdown method and still terminates the owned
 process group.
-Operators can also close an External Agent chat session manually to release the external
-agent process while keeping the Hecate chat history. Deleting a chat performs
-the same release step and then removes the persisted history.
+Operators can also close an External Agent chat session manually to release the
+external agent process while keeping the Hecate chat history. Deleting a chat is
+destructive: Hecate asks the ACP peer to delete the native session with
+`session/delete` before removing the persisted Hecate transcript. If an adapter
+does not implement `session/delete`, Hecate falls back to `session/close` and
+still terminates the owned process group.
 
 Every prompt also gets OTel-shaped observability. The message response includes
 `request_id`, `trace_id`, and `span_id`, and `GET

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -619,7 +619,7 @@ POST /hecate/v1/mcp/probe
 
 Tool names come back un-namespaced — the operator wants to see what the upstream itself calls them, not the gateway's runtime alias. MCP Apps metadata is preserved when present: `_meta` is the raw upstream object, `ui_resource_uri` and `ui_visibility` are derived convenience fields, and `model_visible: false` means the tool is app-only and will not be shown to the agent-loop model. Bounded by a 10-second deadline; a stuck upstream surfaces as a 400 with the diagnostic rather than wedging the request.
 
-`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, plugin registry records, agent profiles, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are closed before their rows disappear. When SQLite or Postgres is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only and blocked in remote runtime mode: non-loopback sockets and forwarded-client headers are rejected.
+`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, plugin registry records, agent profiles, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are asked to delete their native ACP session before their rows disappear. If an adapter does not support `session/delete`, Hecate falls back to `session/close` and still tears down the owned process. When SQLite or Postgres is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only and blocked in remote runtime mode: non-loopback sockets and forwarded-client headers are rejected.
 
 ```json
 → 200
@@ -1931,10 +1931,12 @@ POST /hecate/v1/projects/proj_.../context-sources/discover
 
 Deletes the project catalog entry, its roots, and chat sessions scoped to that
 project. It also deletes project memory entries, memory candidates, and project work-coordination
-rows for that project. This does not delete workspace files. Unprojected chats
-and chats scoped to other projects stay untouched. Assignment links to task/chat
-IDs are metadata only; the linked tasks or unprojected chat sessions are not
-deleted through assignment cleanup.
+rows for that project. Project-scoped External Agent chats are deleted through
+the normal chat-delete path, so Hecate asks the adapter to delete the native ACP
+session where supported. This does not delete workspace files. Unprojected
+chats and chats scoped to other projects stay untouched. Assignment links to
+task/chat IDs are metadata only; the linked tasks or unprojected chat sessions
+are not deleted through assignment cleanup.
 
 ### Project Memory
 
@@ -4468,13 +4470,16 @@ currently running, the endpoint returns `409 invalid_request`.
 
 Closes the native ACP agent session while keeping the Hecate chat history.
 If a turn is currently running, Hecate cancels and waits briefly before closing
-the external session.
+the external session. This uses ACP `session/close` and does not delete the
+provider-side native session from the adapter's session list.
 
 ### `DELETE /hecate/v1/chat/sessions/{id}`
 
 Deletes a chat session from the configured chat-session backend.
-If the session has an active native ACP agent process, Hecate closes the
-native session and terminates the owned process as part of deletion.
+If the session has an active native ACP agent process, Hecate asks the adapter
+to delete the native session with ACP `session/delete` and terminates the owned
+process as part of deletion. If the adapter does not support `session/delete`,
+Hecate falls back to `session/close` before tearing down the process.
 If the session is a task-backed Hecate Chat with a non-terminal backing run,
 Hecate cancels that run before removing the chat transcript. The backing Task
 record remains available from Tasks.

--- a/e2e/chat_session_lifecycle_test.go
+++ b/e2e/chat_session_lifecycle_test.go
@@ -4,7 +4,12 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -57,14 +62,112 @@ func TestChatSessionApplicationLayerLifecycleE2E(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestExternalAgentChatDeleteDeletesNativeACPSessionE2E(t *testing.T) {
+	fakeACP := buildFakeACPAgentTestBinary(t)
+	adapterDir := t.TempDir()
+	deleteFile := filepath.Join(t.TempDir(), "deleted-native-session.txt")
+	installFakeACPAdapterExecutable(t, adapterDir, "codex-acp-adapter", fakeACP, map[string]string{
+		"HECATE_FAKE_ACP_DELETE_FILE": deleteFile,
+	})
+
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HOME="+t.TempDir(),
+		"PATH="+adapterDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	workspace := t.TempDir()
+	created := postJSONDecode[e2eChatSessionResponse](t, baseURL+"/hecate/v1/chat/sessions", fmt.Sprintf(`{
+		"agent_id": "codex",
+		"workspace": %q,
+		"title": "external delete e2e"
+	}`, workspace))
+	if created.Data.NativeSessionID == "" {
+		t.Fatalf("created external session native id is empty: %+v", created.Data)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, baseURL+"/hecate/v1/chat/sessions/"+created.Data.ID, nil)
+	if err != nil {
+		t.Fatalf("NewRequest DELETE external chat session: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE external chat session: %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE external chat session status = %d, want 204; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
+
+	got, err := os.ReadFile(deleteFile)
+	if err != nil {
+		t.Fatalf("read fake ACP delete file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != created.Data.NativeSessionID {
+		t.Fatalf("native session deleted = %q, want %q", strings.TrimSpace(string(got)), created.Data.NativeSessionID)
+	}
+
+	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/hecate/v1/chat/sessions/"+created.Data.ID, nil)
+	if err != nil {
+		t.Fatalf("NewRequest GET deleted external chat session: %v", err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET deleted external chat session: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET deleted external chat session status = %d, want 404; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	resp.Body.Close()
+}
+
+func buildFakeACPAgentTestBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "fake-acp-agent.test")
+	cmd := exec.Command("go", "test", "-c", "-o", bin, "./internal/agentadapters")
+	cmd.Dir = moduleRootDir()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build fake ACP agent test binary: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func installFakeACPAdapterExecutable(t *testing.T, dir, name, testBinary string, env map[string]string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir fake adapter dir: %v", err)
+	}
+	exe := filepath.Join(dir, name)
+	var b strings.Builder
+	b.WriteString("#!/bin/sh\n")
+	b.WriteString("HECATE_FAKE_ACP_AGENT=1")
+	for key, value := range env {
+		b.WriteString(" ")
+		b.WriteString(key)
+		b.WriteString("=")
+		b.WriteString(shellQuote(value))
+	}
+	b.WriteString(" exec ")
+	b.WriteString(shellQuote(testBinary))
+	b.WriteString(" -test.run '^TestFakeACPAgentProcess$'\n")
+	if err := os.WriteFile(exe, []byte(b.String()), 0o755); err != nil {
+		t.Fatalf("write fake adapter executable: %v", err)
+	}
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
 type e2eChatSessionResponse struct {
 	Object string             `json:"object"`
 	Data   e2eChatSessionItem `json:"data"`
 }
 
 type e2eChatSessionItem struct {
-	ID      string `json:"id"`
-	Title   string `json:"title"`
-	AgentID string `json:"agent_id"`
-	Status  string `json:"status"`
+	ID              string `json:"id"`
+	Title           string `json:"title"`
+	AgentID         string `json:"agent_id"`
+	Status          string `json:"status"`
+	NativeSessionID string `json:"native_session_id"`
 }

--- a/internal/agentadapters/acp_session.go
+++ b/internal/agentadapters/acp_session.go
@@ -14,5 +14,6 @@ type Runner interface {
 	Run(context.Context, RunRequest) (RunResult, error)
 	SetSessionConfigOption(context.Context, SetSessionConfigOptionRequest) (SetSessionConfigOptionResult, error)
 	CloseSession(context.Context, string) error
+	DeleteSession(context.Context, string) error
 	Shutdown(context.Context) error
 }

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -24,6 +24,13 @@ const (
 	acpInitialCommandTimeout = 500 * time.Millisecond
 )
 
+type acpSessionShutdownMode string
+
+const (
+	acpSessionShutdownClose  acpSessionShutdownMode = "close"
+	acpSessionShutdownDelete acpSessionShutdownMode = "delete"
+)
+
 type acpSession struct {
 	sessionID           string
 	adapter             Adapter
@@ -835,6 +842,14 @@ func selectedConfigOptionValue(options []agentcontrols.ConfigOption, id string) 
 }
 
 func (s *acpSession) Close(ctx context.Context) error {
+	return s.shutdown(ctx, acpSessionShutdownClose)
+}
+
+func (s *acpSession) Delete(ctx context.Context) error {
+	return s.shutdown(ctx, acpSessionShutdownDelete)
+}
+
+func (s *acpSession) shutdown(ctx context.Context, mode acpSessionShutdownMode) error {
 	if s == nil {
 		return nil
 	}
@@ -843,7 +858,8 @@ func (s *acpSession) Close(ctx context.Context) error {
 		if s.cmd != nil && s.cmd.Process != nil {
 			pid = s.cmd.Process.Pid
 		}
-		s.logger.Info("closing ACP adapter session",
+		s.logger.Info("shutting down ACP adapter session",
+			slog.String("mode", string(mode)),
 			slog.String("native_session_id", s.nativeID),
 			slog.Int("pid", pid),
 		)
@@ -854,20 +870,22 @@ func (s *acpSession) Close(ctx context.Context) error {
 	}
 	cancel()
 	if s.conn != nil && s.nativeID != "" {
-		closeCtx, cancel := context.WithTimeout(ctx, acpShutdownCloseTimeout)
-		if _, err := s.conn.CloseSession(closeCtx, acp.CloseSessionRequest{SessionId: acp.SessionId(s.nativeID)}); err != nil && s.logger != nil {
-			if isACPMethodNotFound(err, acp.AgentMethodSessionClose) {
-				s.logger.Debug("ACP session close RPC unsupported", slog.String("native_session_id", s.nativeID))
-			} else {
-				s.logger.Warn("close ACP session RPC failed", slog.String("native_session_id", s.nativeID), slog.Any("error", err))
+		if mode == acpSessionShutdownDelete {
+			deleted := s.deleteNativeSession(ctx)
+			if !deleted {
+				s.closeNativeSession(ctx)
 			}
+		} else {
+			s.closeNativeSession(ctx)
 		}
-		cancel()
 	}
 	if s.cmd != nil {
 		terminateProcess(s.cmd)
 		if s.logger != nil {
-			s.logger.Info("ACP adapter process terminated", slog.String("native_session_id", s.nativeID))
+			s.logger.Info("ACP adapter process terminated",
+				slog.String("mode", string(mode)),
+				slog.String("native_session_id", s.nativeID),
+			)
 		}
 	}
 	if s.envCleanup != nil {
@@ -875,6 +893,34 @@ func (s *acpSession) Close(ctx context.Context) error {
 		s.envCleanup = nil
 	}
 	return nil
+}
+
+func (s *acpSession) closeNativeSession(ctx context.Context) {
+	closeCtx, cancel := context.WithTimeout(ctx, acpShutdownCloseTimeout)
+	defer cancel()
+	if _, err := s.conn.CloseSession(closeCtx, acp.CloseSessionRequest{SessionId: acp.SessionId(s.nativeID)}); err != nil && s.logger != nil {
+		if isACPMethodNotFound(err, acp.AgentMethodSessionClose) {
+			s.logger.Debug("ACP session close RPC unsupported", slog.String("native_session_id", s.nativeID))
+		} else {
+			s.logger.Warn("close ACP session RPC failed", slog.String("native_session_id", s.nativeID), slog.Any("error", err))
+		}
+	}
+}
+
+func (s *acpSession) deleteNativeSession(ctx context.Context) bool {
+	deleteCtx, cancel := context.WithTimeout(ctx, acpShutdownCloseTimeout)
+	defer cancel()
+	if _, err := s.conn.UnstableDeleteSession(deleteCtx, acp.UnstableDeleteSessionRequest{SessionId: acp.SessionId(s.nativeID)}); err != nil {
+		if s.logger != nil {
+			if isACPMethodNotFound(err, acp.AgentMethodSessionDelete) {
+				s.logger.Debug("ACP session delete RPC unsupported", slog.String("native_session_id", s.nativeID))
+			} else {
+				s.logger.Warn("delete ACP session RPC failed", slog.String("native_session_id", s.nativeID), slog.Any("error", err))
+			}
+		}
+		return false
+	}
+	return true
 }
 
 func isACPMethodNotFound(err error, method string) bool {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -1054,6 +1054,76 @@ func TestSessionManagerCloseTreatsUnsupportedACPCloseAsOptional(t *testing.T) {
 	}
 }
 
+func TestSessionManagerDeleteSendsACPDelete(t *testing.T) {
+	deleteFile := filepath.Join(t.TempDir(), "delete.txt")
+	t.Setenv("HECATE_FAKE_ACP_DELETE_FILE", deleteFile)
+	installFakeACPExecutable(t, "codex-acp-adapter")
+
+	manager := NewSessionManager()
+	sessionID := "chat_delete_native"
+	run, err := manager.Run(context.Background(), RunRequest{
+		SessionID:      sessionID,
+		AdapterID:      "codex",
+		Workspace:      t.TempDir(),
+		Prompt:         "delete me",
+		Timeout:        5 * time.Second,
+		MaxOutputBytes: 64 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.TrimSpace(run.NativeSessionID) == "" {
+		t.Fatalf("NativeSessionID is empty")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := manager.DeleteSession(ctx, sessionID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	got, err := os.ReadFile(deleteFile)
+	if err != nil {
+		t.Fatalf("read delete file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != run.NativeSessionID {
+		t.Fatalf("deleted native session = %q, want %q", strings.TrimSpace(string(got)), run.NativeSessionID)
+	}
+}
+
+func TestSessionManagerDeleteFallsBackToCloseWhenACPDeleteUnsupported(t *testing.T) {
+	closeFile := filepath.Join(t.TempDir(), "close.txt")
+	t.Setenv("HECATE_FAKE_ACP_DELETE_UNSUPPORTED", "1")
+	t.Setenv("HECATE_FAKE_ACP_CLOSE_FILE", closeFile)
+	installFakeACPExecutable(t, "codex-acp-adapter")
+
+	manager := NewSessionManager()
+	sessionID := "chat_delete_fallback_close"
+	run, err := manager.Run(context.Background(), RunRequest{
+		SessionID:      sessionID,
+		AdapterID:      "codex",
+		Workspace:      t.TempDir(),
+		Prompt:         "delete fallback",
+		Timeout:        5 * time.Second,
+		MaxOutputBytes: 64 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := manager.DeleteSession(ctx, sessionID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	got, err := os.ReadFile(closeFile)
+	if err != nil {
+		t.Fatalf("read close file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != run.NativeSessionID {
+		t.Fatalf("fallback closed native session = %q, want %q", strings.TrimSpace(string(got)), run.NativeSessionID)
+	}
+}
+
 func TestSessionManagerACPApprovalApproveCreatesGrantAndReusesSession(t *testing.T) {
 	installFakeACPExecutable(t, "codex-acp-adapter")
 	workspace := t.TempDir()
@@ -2381,7 +2451,7 @@ func installFakeACPExecutable(t *testing.T, name string) {
 	}
 	exe := filepath.Join(bin, name)
 	script := fmt.Sprintf(
-		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q HECATE_FAKE_ACP_EXPECT_MCP_METHOD=%q HECATE_FAKE_ACP_EXPECT_MCP_JSON=%q HECATE_FAKE_ACP_AUTHENTICATE_FILE=%q HECATE_FAKE_ACP_AUTHENTICATE_ERROR=%q HECATE_FAKE_ACP_LOGOUT_FILE=%q HECATE_FAKE_ACP_LOGOUT_ERROR=%q HECATE_FAKE_ACP_AUTH_AGENT_LOGIN=%q HECATE_FAKE_ACP_AUTH_AGENT_OTHER=%q HECATE_FAKE_ACP_AUTH_ENV_VAR=%q HECATE_FAKE_ACP_AUTH_TERMINAL=%q HECATE_FAKE_ACP_SUPPORTS_LOGOUT=%q HECATE_FAKE_ACP_CLOSE_UNSUPPORTED=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q HECATE_FAKE_ACP_EXPECT_MCP_METHOD=%q HECATE_FAKE_ACP_EXPECT_MCP_JSON=%q HECATE_FAKE_ACP_AUTHENTICATE_FILE=%q HECATE_FAKE_ACP_AUTHENTICATE_ERROR=%q HECATE_FAKE_ACP_LOGOUT_FILE=%q HECATE_FAKE_ACP_LOGOUT_ERROR=%q HECATE_FAKE_ACP_AUTH_AGENT_LOGIN=%q HECATE_FAKE_ACP_AUTH_AGENT_OTHER=%q HECATE_FAKE_ACP_AUTH_ENV_VAR=%q HECATE_FAKE_ACP_AUTH_TERMINAL=%q HECATE_FAKE_ACP_SUPPORTS_LOGOUT=%q HECATE_FAKE_ACP_CLOSE_UNSUPPORTED=%q HECATE_FAKE_ACP_CLOSE_FILE=%q HECATE_FAKE_ACP_DELETE_UNSUPPORTED=%q HECATE_FAKE_ACP_DELETE_FILE=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
 		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
 		os.Getenv("HECATE_FAKE_ACP_COMMANDS_DELAY"),
@@ -2400,6 +2470,9 @@ func installFakeACPExecutable(t *testing.T, name string) {
 		os.Getenv("HECATE_FAKE_ACP_AUTH_TERMINAL"),
 		os.Getenv("HECATE_FAKE_ACP_SUPPORTS_LOGOUT"),
 		os.Getenv("HECATE_FAKE_ACP_CLOSE_UNSUPPORTED"),
+		os.Getenv("HECATE_FAKE_ACP_CLOSE_FILE"),
+		os.Getenv("HECATE_FAKE_ACP_DELETE_UNSUPPORTED"),
+		os.Getenv("HECATE_FAKE_ACP_DELETE_FILE"),
 		os.Args[0],
 	)
 	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
@@ -2460,9 +2533,12 @@ func (a *fakeACPAgent) Initialize(context.Context, acp.InitializeRequest) (acp.I
 	return acp.InitializeResponse{
 		ProtocolVersion: acp.ProtocolVersionNumber,
 		AgentCapabilities: acp.AgentCapabilities{
-			Auth:                authCaps,
-			LoadSession:         true,
-			SessionCapabilities: acp.SessionCapabilities{Close: &acp.SessionCloseCapabilities{}},
+			Auth:        authCaps,
+			LoadSession: true,
+			SessionCapabilities: acp.SessionCapabilities{
+				Close:  &acp.SessionCloseCapabilities{},
+				Delete: &acp.SessionDeleteCapabilities{},
+			},
 		},
 		AuthMethods: authMethods,
 	}, nil
@@ -2722,11 +2798,28 @@ func (a *fakeACPAgent) Cancel(_ context.Context, params acp.CancelNotification) 
 	return nil
 }
 
-func (a *fakeACPAgent) CloseSession(context.Context, acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+func (a *fakeACPAgent) CloseSession(_ context.Context, params acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
 	if os.Getenv("HECATE_FAKE_ACP_CLOSE_UNSUPPORTED") == "1" {
 		return acp.CloseSessionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionClose)
 	}
+	if path := strings.TrimSpace(os.Getenv("HECATE_FAKE_ACP_CLOSE_FILE")); path != "" {
+		if err := os.WriteFile(path, []byte(string(params.SessionId)+"\n"), 0o644); err != nil {
+			return acp.CloseSessionResponse{}, err
+		}
+	}
 	return acp.CloseSessionResponse{}, nil
+}
+
+func (a *fakeACPAgent) UnstableDeleteSession(_ context.Context, params acp.UnstableDeleteSessionRequest) (acp.UnstableDeleteSessionResponse, error) {
+	if os.Getenv("HECATE_FAKE_ACP_DELETE_UNSUPPORTED") == "1" {
+		return acp.UnstableDeleteSessionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionDelete)
+	}
+	if path := strings.TrimSpace(os.Getenv("HECATE_FAKE_ACP_DELETE_FILE")); path != "" {
+		if err := os.WriteFile(path, []byte(string(params.SessionId)+"\n"), 0o644); err != nil {
+			return acp.UnstableDeleteSessionResponse{}, err
+		}
+	}
+	return acp.UnstableDeleteSessionResponse{}, nil
 }
 
 func (a *fakeACPAgent) ListSessions(context.Context, acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {

--- a/internal/agentadapters/session_manager.go
+++ b/internal/agentadapters/session_manager.go
@@ -304,14 +304,30 @@ func (m *SessionManager) CloseSession(ctx context.Context, sessionID string) err
 	if m == nil {
 		return nil
 	}
-	m.mu.Lock()
-	session := m.sessions[sessionID]
-	delete(m.sessions, sessionID)
-	m.mu.Unlock()
+	session := m.takeSession(sessionID)
 	if session == nil {
 		return nil
 	}
 	return session.Close(ctx)
+}
+
+func (m *SessionManager) DeleteSession(ctx context.Context, sessionID string) error {
+	if m == nil {
+		return nil
+	}
+	session := m.takeSession(sessionID)
+	if session == nil {
+		return nil
+	}
+	return session.Delete(ctx)
+}
+
+func (m *SessionManager) takeSession(sessionID string) *acpSession {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	session := m.sessions[sessionID]
+	delete(m.sessions, sessionID)
+	return session
 }
 
 func (m *SessionManager) Shutdown(ctx context.Context) error {

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -360,8 +360,8 @@ func (h *Handler) deleteExistingChatSession(ctx context.Context, session chat.Se
 		return true, nil
 	}
 	if err := h.chatApplication().DeleteSession(ctx, chatapp.DeleteSessionCommand{
-		Session:     session,
-		CloseNative: isExternalChatSession(session),
+		Session:      session,
+		DeleteNative: isExternalChatSession(session),
 	}); err != nil {
 		return false, err
 	}

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2015,8 +2015,11 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentConcurrentRequestsCreateOneC
 	if got := runner.prepareCount(); got != 2 {
 		t.Fatalf("prepare requests = %d, want both requests to reach prepare", got)
 	}
-	if got := runner.closedCount(); got != 1 {
-		t.Fatalf("closed sessions = %d, want losing prepared chat closed", got)
+	if got := runner.deletedCount(); got != 1 {
+		t.Fatalf("deleted sessions = %d, want losing prepared chat deleted", got)
+	}
+	if got := runner.closedCount(); got != 0 {
+		t.Fatalf("closed sessions = %d, want destructive rollback to use delete", got)
 	}
 }
 
@@ -3610,6 +3613,7 @@ type concurrentProjectExternalPrepareRunner struct {
 	releasePrepare  chan struct{}
 	prepareRequests []agentadapters.PrepareSessionRequest
 	closedSessions  []string
+	deletedSessions []string
 }
 
 func newConcurrentProjectExternalPrepareRunner() *concurrentProjectExternalPrepareRunner {
@@ -3652,6 +3656,13 @@ func (r *concurrentProjectExternalPrepareRunner) CloseSession(_ context.Context,
 	return nil
 }
 
+func (r *concurrentProjectExternalPrepareRunner) DeleteSession(_ context.Context, sessionID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deletedSessions = append(r.deletedSessions, sessionID)
+	return nil
+}
+
 func (r *concurrentProjectExternalPrepareRunner) Shutdown(context.Context) error {
 	return nil
 }
@@ -3666,6 +3677,12 @@ func (r *concurrentProjectExternalPrepareRunner) closedCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.closedSessions)
+}
+
+func (r *concurrentProjectExternalPrepareRunner) deletedCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.deletedSessions)
 }
 
 func findProjectActivityItemForTest(t *testing.T, items []ProjectActivityItemResponse, assignmentID string) ProjectActivityItemResponse {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -573,7 +573,10 @@ func TestProjectsAPI_DeleteProjectDeletesProjectChats(t *testing.T) {
 	if !ids["chat_other"] || !ids["chat_unprojected"] {
 		t.Fatalf("unrelated chats = %v, want other project and unprojected chats retained", ids)
 	}
-	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != "chat_project_external" {
-		t.Fatalf("closed sessions = %#v, want project external chat closed", runner.closedSessions)
+	if len(runner.deletedSessions) != 1 || runner.deletedSessions[0] != "chat_project_external" {
+		t.Fatalf("deleted sessions = %#v, want project external chat deleted", runner.deletedSessions)
+	}
+	if len(runner.closedSessions) != 0 {
+		t.Fatalf("closed sessions = %#v, want project delete not close", runner.closedSessions)
 	}
 }

--- a/internal/api/handler_shutdown_test.go
+++ b/internal/api/handler_shutdown_test.go
@@ -74,6 +74,10 @@ func (r failingShutdownAgentChatRunner) CloseSession(context.Context, string) er
 	return nil
 }
 
+func (r failingShutdownAgentChatRunner) DeleteSession(context.Context, string) error {
+	return nil
+}
+
 func (r failingShutdownAgentChatRunner) Shutdown(context.Context) error {
 	return r.err
 }

--- a/internal/api/handler_system_reset_test.go
+++ b/internal/api/handler_system_reset_test.go
@@ -141,8 +141,11 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	if reset.Data.ProjectsDeleted != 1 || reset.Data.ProjectWorkRowsDeleted != 2 || reset.Data.PluginsDeleted != 1 || reset.Data.AgentProfilesDeleted != 1 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
 		t.Fatalf("reset stats = %+v, want one project, one plugin, one profile, two project-work rows, one task, provider, rule and two chats", reset.Data)
 	}
-	if len(runner.closedSessions) != 2 {
-		t.Fatalf("closed sessions = %#v, want two external chats closed", runner.closedSessions)
+	if len(runner.deletedSessions) != 2 {
+		t.Fatalf("deleted sessions = %#v, want two external chats deleted", runner.deletedSessions)
+	}
+	if len(runner.closedSessions) != 0 {
+		t.Fatalf("closed sessions = %#v, want reset delete path not close", runner.closedSessions)
 	}
 
 	chats, err := chatStore.List(ctx)
@@ -362,8 +365,11 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if reset.Data.PluginsDeleted != 1 {
 		t.Fatalf("plugins deleted = %d, want 1", reset.Data.PluginsDeleted)
 	}
-	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != "chat_sqlite_external" {
-		t.Fatalf("closed sessions = %#v, want sqlite external chat closed", runner.closedSessions)
+	if len(runner.deletedSessions) != 1 || runner.deletedSessions[0] != "chat_sqlite_external" {
+		t.Fatalf("deleted sessions = %#v, want sqlite external chat deleted", runner.deletedSessions)
+	}
+	if len(runner.closedSessions) != 0 {
+		t.Fatalf("closed sessions = %#v, want reset delete path not close", runner.closedSessions)
 	}
 	assertSQLiteTableCount(t, client, client.QualifiedTable("memory_entries"), 0)
 	assertSQLiteTableCount(t, client, client.QualifiedTable("agent_profiles"), 0)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2800,11 +2800,11 @@ func TestAgentChatCreateExternalSessionCleansUpPreparedSessionOnPersistFailure(t
 	if !strings.Contains(rec.Body.String(), "update failed") {
 		t.Fatalf("response body = %s, want update error", rec.Body.String())
 	}
-	if len(runner.closedSessions) != 1 {
-		t.Fatalf("closed sessions = %#v, want one prepared session closed", runner.closedSessions)
+	if len(runner.deletedSessions) != 1 {
+		t.Fatalf("deleted sessions = %#v, want one prepared session deleted", runner.deletedSessions)
 	}
-	if len(store.deletedIDs) != 1 || store.deletedIDs[0] != runner.closedSessions[0] {
-		t.Fatalf("deleted ids = %#v, closed = %#v, want persisted session deleted after close", store.deletedIDs, runner.closedSessions)
+	if len(store.deletedIDs) != 1 || store.deletedIDs[0] != runner.deletedSessions[0] {
+		t.Fatalf("deleted ids = %#v, native deletes = %#v, want persisted session deleted after native delete", store.deletedIDs, runner.deletedSessions)
 	}
 	if _, ok, err := baseStore.Get(context.Background(), store.deletedIDs[0]); err != nil || ok {
 		t.Fatalf("base store Get after cleanup: ok=%v err=%v, want missing", ok, err)
@@ -2850,6 +2850,7 @@ type fakeAgentChatRunner struct {
 	prepareDeadline        time.Time
 	prepareHasDeadline     bool
 	closedSessions         []string
+	deletedSessions        []string
 	closeErr               error
 	configOptions          []agentcontrols.ConfigOption
 	availableCommands      []agentcontrols.Command
@@ -2994,6 +2995,11 @@ func (r *fakeAgentChatRunner) SetSessionConfigOption(_ context.Context, req agen
 func (r *fakeAgentChatRunner) CloseSession(_ context.Context, sessionID string) error {
 	r.closedSessions = append(r.closedSessions, sessionID)
 	return r.closeErr
+}
+
+func (r *fakeAgentChatRunner) DeleteSession(_ context.Context, sessionID string) error {
+	r.deletedSessions = append(r.deletedSessions, sessionID)
+	return nil
 }
 
 func (r *fakeAgentChatRunner) Shutdown(context.Context) error { return nil }
@@ -3654,8 +3660,11 @@ func TestAgentChatDeleteCancelsRunBeforeDeletingSession(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("delete status = %d, want 204, body=%s", resp.StatusCode, string(body))
 	}
-	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != created.Data.ID {
-		t.Fatalf("closed sessions = %#v, want %q", runner.closedSessions, created.Data.ID)
+	if len(runner.deletedSessions) != 1 || runner.deletedSessions[0] != created.Data.ID {
+		t.Fatalf("deleted sessions = %#v, want %q", runner.deletedSessions, created.Data.ID)
+	}
+	if len(runner.closedSessions) != 0 {
+		t.Fatalf("closed sessions = %#v, want delete path not close", runner.closedSessions)
 	}
 	select {
 	case updated := <-done:
@@ -3690,8 +3699,11 @@ func TestAgentChatDeleteClosesIdleExternalSession(t *testing.T) {
 	}
 
 	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/chat/sessions/"+created.Data.ID, "")
-	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != created.Data.ID {
-		t.Fatalf("closed sessions = %#v, want %q", runner.closedSessions, created.Data.ID)
+	if len(runner.deletedSessions) != 1 || runner.deletedSessions[0] != created.Data.ID {
+		t.Fatalf("deleted sessions = %#v, want %q", runner.deletedSessions, created.Data.ID)
+	}
+	if len(runner.closedSessions) != 0 {
+		t.Fatalf("closed sessions = %#v, want delete path not close", runner.closedSessions)
 	}
 	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/chat/sessions/"+created.Data.ID, "")
 }
@@ -3785,6 +3797,9 @@ func TestAgentChatCloseKeepsHistoryAndClosesNativeSession(t *testing.T) {
 	closed := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions/"+created.Data.ID+"/close", `{}`)
 	if len(runner.closedSessions) != 1 || runner.closedSessions[0] != created.Data.ID {
 		t.Fatalf("closed sessions = %#v, want %q", runner.closedSessions, created.Data.ID)
+	}
+	if len(runner.deletedSessions) != 0 {
+		t.Fatalf("deleted sessions = %#v, want close path not delete", runner.deletedSessions)
 	}
 	if len(closed.Data.Messages) != 2 {
 		t.Fatalf("closed session messages = %d, want preserved history", len(closed.Data.Messages))

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -57,6 +57,7 @@ type TaskStore interface {
 type AgentRunner interface {
 	PrepareSession(context.Context, agentadapters.PrepareSessionRequest) (agentadapters.PrepareSessionResult, error)
 	CloseSession(context.Context, string) error
+	DeleteSession(context.Context, string) error
 	SetSessionConfigOption(context.Context, agentadapters.SetSessionConfigOptionRequest) (agentadapters.SetSessionConfigOptionResult, error)
 }
 
@@ -86,8 +87,8 @@ type CreateSessionResult struct {
 }
 
 type DeleteSessionCommand struct {
-	Session     chat.Session
-	CloseNative bool
+	Session      chat.Session
+	DeleteNative bool
 }
 
 type CloseNativeSessionCommand struct {
@@ -378,8 +379,8 @@ func (app *Application) DeleteSession(ctx context.Context, cmd DeleteSessionComm
 	if app == nil || app.store == nil {
 		return ErrStoreNotConfigured
 	}
-	if cmd.CloseNative && app.runner != nil {
-		_ = app.runner.CloseSession(ctx, cmd.Session.ID)
+	if cmd.DeleteNative && app.runner != nil {
+		_ = app.runner.DeleteSession(ctx, cmd.Session.ID)
 	}
 	return app.store.Delete(ctx, cmd.Session.ID)
 }
@@ -582,7 +583,7 @@ func (app *Application) cleanupExternalSession(sessionID string) {
 	if app.prepareTimeout > 0 {
 		cleanupCtx, cancel = context.WithTimeout(cleanupCtx, app.prepareTimeout)
 	}
-	_ = app.runner.CloseSession(cleanupCtx, sessionID)
+	_ = app.runner.DeleteSession(cleanupCtx, sessionID)
 	cancel()
 	_ = app.store.Delete(context.Background(), sessionID)
 }

--- a/internal/chatapp/application_test.go
+++ b/internal/chatapp/application_test.go
@@ -14,15 +14,17 @@ import (
 )
 
 type recordingAgentRunner struct {
-	prepareCalls   int
-	closeCalls     int
-	prepareErr     error
-	setCalls       int
-	setErr         error
-	prepareReq     agentadapters.PrepareSessionRequest
-	setReq         agentadapters.SetSessionConfigOptionRequest
-	closedSessions []string
-	configOptions  []agentcontrols.ConfigOption
+	prepareCalls    int
+	closeCalls      int
+	deleteCalls     int
+	prepareErr      error
+	setCalls        int
+	setErr          error
+	prepareReq      agentadapters.PrepareSessionRequest
+	setReq          agentadapters.SetSessionConfigOptionRequest
+	closedSessions  []string
+	deletedSessions []string
+	configOptions   []agentcontrols.ConfigOption
 }
 
 func (r *recordingAgentRunner) PrepareSession(_ context.Context, req agentadapters.PrepareSessionRequest) (agentadapters.PrepareSessionResult, error) {
@@ -53,6 +55,12 @@ func (r *recordingAgentRunner) CloseSession(_ context.Context, sessionID string)
 	return nil
 }
 
+func (r *recordingAgentRunner) DeleteSession(_ context.Context, sessionID string) error {
+	r.deleteCalls++
+	r.deletedSessions = append(r.deletedSessions, sessionID)
+	return nil
+}
+
 func TestApplication_CreateSessionPersistsBuiltInSession(t *testing.T) {
 	t.Parallel()
 
@@ -75,8 +83,8 @@ func TestApplication_CreateSessionPersistsBuiltInSession(t *testing.T) {
 	if result.Session.ID != "chat_hecate" || result.Session.AgentID != chat.DefaultAgentID {
 		t.Fatalf("session = %+v, want persisted built-in session", result.Session)
 	}
-	if runner.prepareCalls != 0 || runner.closeCalls != 0 {
-		t.Fatalf("runner prepare/close = %d/%d, want unused", runner.prepareCalls, runner.closeCalls)
+	if runner.prepareCalls != 0 || runner.closeCalls != 0 || runner.deleteCalls != 0 {
+		t.Fatalf("runner prepare/close/delete = %d/%d/%d, want unused", runner.prepareCalls, runner.closeCalls, runner.deleteCalls)
 	}
 	if _, ok, err := store.Get(ctx, "chat_hecate"); err != nil || !ok {
 		t.Fatalf("Get(chat_hecate) ok=%v err=%v, want persisted session", ok, err)
@@ -299,8 +307,8 @@ func TestApplication_CreateSessionPrepareFailureDeletesSession(t *testing.T) {
 	if !errors.As(err, &prepareErr) || !errors.Is(prepareErr.Unwrap(), runner.prepareErr) {
 		t.Fatalf("CreateSession(prepare failure) error = %v, want ExternalPrepareError", err)
 	}
-	if runner.closeCalls != 0 {
-		t.Fatalf("closeCalls = %d, want no close after failed prepare", runner.closeCalls)
+	if runner.closeCalls != 0 || runner.deleteCalls != 0 {
+		t.Fatalf("close/delete calls = %d/%d, want no cleanup after failed prepare", runner.closeCalls, runner.deleteCalls)
 	}
 	if _, ok, err := store.Get(ctx, "chat_ext"); err != nil || ok {
 		t.Fatalf("Get(chat_ext) ok=%v err=%v, want deleted session", ok, err)
@@ -338,8 +346,11 @@ func TestApplication_CreateSessionUpdateFailureCleansPreparedSession(t *testing.
 	if err == nil || !errors.Is(err, store.err) {
 		t.Fatalf("CreateSession(update failure) error = %v, want update error", err)
 	}
-	if runner.closeCalls != 1 || len(runner.closedSessions) != 1 || runner.closedSessions[0] != "chat_ext" {
-		t.Fatalf("closed sessions = %+v closeCalls=%d, want chat_ext closed once", runner.closedSessions, runner.closeCalls)
+	if runner.deleteCalls != 1 || len(runner.deletedSessions) != 1 || runner.deletedSessions[0] != "chat_ext" {
+		t.Fatalf("deleted sessions = %+v deleteCalls=%d, want chat_ext deleted once", runner.deletedSessions, runner.deleteCalls)
+	}
+	if runner.closeCalls != 0 {
+		t.Fatalf("closeCalls = %d, want no non-destructive close during failed create cleanup", runner.closeCalls)
 	}
 	if len(store.deletedIDs) != 1 || store.deletedIDs[0] != "chat_ext" {
 		t.Fatalf("deleted ids = %+v, want chat_ext", store.deletedIDs)
@@ -367,7 +378,7 @@ func TestApplication_CreateSessionNilDependencies(t *testing.T) {
 	}
 }
 
-func TestApplication_DeleteSessionClosesNativeSessionWhenRequested(t *testing.T) {
+func TestApplication_DeleteSessionDeletesNativeSessionWhenRequested(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -384,11 +395,14 @@ func TestApplication_DeleteSessionClosesNativeSessionWhenRequested(t *testing.T)
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := app.DeleteSession(ctx, DeleteSessionCommand{Session: session, CloseNative: true}); err != nil {
+	if err := app.DeleteSession(ctx, DeleteSessionCommand{Session: session, DeleteNative: true}); err != nil {
 		t.Fatalf("DeleteSession() error = %v", err)
 	}
-	if runner.closeCalls != 1 || runner.closedSessions[0] != "chat_ext" {
-		t.Fatalf("closed sessions = %+v closeCalls=%d, want chat_ext closed once", runner.closedSessions, runner.closeCalls)
+	if runner.deleteCalls != 1 || runner.deletedSessions[0] != "chat_ext" {
+		t.Fatalf("deleted sessions = %+v deleteCalls=%d, want chat_ext deleted once", runner.deletedSessions, runner.deleteCalls)
+	}
+	if runner.closeCalls != 0 {
+		t.Fatalf("closeCalls = %d, want delete path not close", runner.closeCalls)
 	}
 	if _, ok, err := store.Get(ctx, "chat_ext"); err != nil || ok {
 		t.Fatalf("Get(chat_ext) ok=%v err=%v, want deleted session", ok, err)
@@ -406,7 +420,7 @@ func TestApplication_DeleteSessionWithoutRunnerStillDeletes(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := app.DeleteSession(ctx, DeleteSessionCommand{Session: session, CloseNative: true}); err != nil {
+	if err := app.DeleteSession(ctx, DeleteSessionCommand{Session: session, DeleteNative: true}); err != nil {
 		t.Fatalf("DeleteSession(no runner) error = %v", err)
 	}
 	if _, ok, err := store.Get(ctx, "chat_ext"); err != nil || ok {

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -38,6 +38,7 @@ type TaskRunner interface {
 type AgentRunner interface {
 	PrepareSession(context.Context, agentadapters.PrepareSessionRequest) (agentadapters.PrepareSessionResult, error)
 	CloseSession(context.Context, string) error
+	DeleteSession(context.Context, string) error
 }
 
 type ChatSessionStore interface {
@@ -617,7 +618,7 @@ func (app *Application) cleanupExternalSession(sessionID string) {
 	if app.prepareTimeout > 0 {
 		cleanupCtx, cancel = context.WithTimeout(cleanupCtx, app.prepareTimeout)
 	}
-	_ = app.agentRunner.CloseSession(cleanupCtx, sessionID)
+	_ = app.agentRunner.DeleteSession(cleanupCtx, sessionID)
 	cancel()
 	_ = app.chatStore.Delete(context.Background(), sessionID)
 }

--- a/internal/projectworkapp/application_test.go
+++ b/internal/projectworkapp/application_test.go
@@ -357,6 +357,7 @@ func TestApplication_StartTaskAssignmentRunnerFailureMarksFailed(t *testing.T) {
 type recordingAgentRunner struct {
 	prepareCalls int
 	closeCalls   int
+	deleteCalls  int
 	prepareErr   error
 	prepareReq   agentadapters.PrepareSessionRequest
 }
@@ -376,6 +377,11 @@ func (r *recordingAgentRunner) PrepareSession(_ context.Context, req agentadapte
 
 func (r *recordingAgentRunner) CloseSession(_ context.Context, _ string) error {
 	r.closeCalls++
+	return nil
+}
+
+func (r *recordingAgentRunner) DeleteSession(_ context.Context, _ string) error {
+	r.deleteCalls++
 	return nil
 }
 
@@ -438,8 +444,8 @@ func TestApplication_StartExternalAgentAssignmentPreparesAndLinksSession(t *test
 	if err != nil {
 		t.Fatalf("StartExternalAgentAssignment() error = %v", err)
 	}
-	if runner.prepareCalls != 1 || runner.closeCalls != 0 {
-		t.Fatalf("runner prepare/close = %d/%d, want 1/0", runner.prepareCalls, runner.closeCalls)
+	if runner.prepareCalls != 1 || runner.closeCalls != 0 || runner.deleteCalls != 0 {
+		t.Fatalf("runner prepare/close/delete = %d/%d/%d, want 1/0/0", runner.prepareCalls, runner.closeCalls, runner.deleteCalls)
 	}
 	if got := runner.prepareReq.MCPServers; len(got) != 1 || got[0].Name != "fs" || got[0].Args[0] != "server.js" {
 		t.Fatalf("prepare MCP servers = %+v, want fs server", got)
@@ -560,8 +566,11 @@ func TestApplication_StartExternalAgentAssignmentCleansPreparedSessionWhenClaimL
 	if result == nil || result.Assignment.ExecutionRef.ChatSessionID != "chat_winner" {
 		t.Fatalf("result = %+v, want winning assignment", result)
 	}
-	if runner.prepareCalls != 1 || runner.closeCalls != 1 {
-		t.Fatalf("runner prepare/close = %d/%d, want 1/1 cleanup", runner.prepareCalls, runner.closeCalls)
+	if runner.prepareCalls != 1 || runner.deleteCalls != 1 {
+		t.Fatalf("runner prepare/delete = %d/%d, want 1/1 cleanup", runner.prepareCalls, runner.deleteCalls)
+	}
+	if runner.closeCalls != 0 {
+		t.Fatalf("closeCalls = %d, want destructive cleanup to use delete", runner.closeCalls)
 	}
 	if _, ok, err := chatStore.Get(ctx, "chat_ext"); err != nil || ok {
 		t.Fatalf("Get(chat_ext) ok=%v err=%v, want cleaned session", ok, err)


### PR DESCRIPTION
## Summary

- add a destructive `DeleteSession` path for ACP-backed External Agent sessions
- send ACP `session/delete` before tearing down owned adapter processes, with `session/close` fallback when delete is unsupported
- route chat deletion, project/reset cascades, and prepared-session rollback through native delete while keeping explicit close/idle/shutdown non-destructive
- document the close-vs-delete lifecycle and add protocol/app/API/e2e coverage

## Verification

- `GOCACHE="$PWD/.gocache" go test ./internal/chatapp ./internal/projectworkapp ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go vet ./internal/chatapp ./internal/projectworkapp ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./internal/chatapp ./internal/projectworkapp ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go vet ./...`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
- `GOCACHE="$PWD/.gocache" go test -tags e2e -run TestExternalAgentChatDeleteDeletesNativeACPSessionE2E ./e2e`
- `just docs-format-check`
- `just check-links`
- `git diff --check`

Note: broad Go/API/e2e checks were run with loopback access because sandboxed `httptest` listeners fail with `bind: operation not permitted`.