### PR TITLE
Preflight Project Assistant apply

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -147,15 +147,19 @@ permission model.
   model-callable tool; chat or agent integrations must route durable mutations
   through an explicit blocking operator confirmation first.
 
-Apply is sequential across existing stores. A proposal id plus its canonical
-action set is the in-process progress boundary. If action N fails after earlier
-actions have already mutated durable stores, the API returns the partial action
-results and `failed_action_index`. Retrying the exact same proposal resumes at
-the next unapplied action. Retrying the same proposal id with a changed action
-set returns `409 conflict`, and retrying a fully applied proposal also returns
-`409 conflict`. Clients should show the landed action kinds and ids from
-`partial_result.actions` so the operator can clean up, retry, or re-draft from
-the visible partial state.
+Apply first preflights the remaining actions against current project, work,
+handoff, memory-candidate, and chat targets, including explicit resources
+created earlier in the same proposal. Deterministic stale-target failures
+therefore return `failed_action_index` with no new durable writes. After
+preflight, apply remains sequential across existing stores. A proposal id plus
+its canonical action set is the in-process progress boundary. If action N fails
+after earlier actions have already mutated durable stores, the API returns the
+partial action results and `failed_action_index`. Retrying the exact same
+proposal resumes at the next unapplied action. Retrying the same proposal id
+with a changed action set returns `409 conflict`, and retrying a fully applied
+proposal also returns `409 conflict`. Clients should show the landed action
+kinds and ids from `partial_result.actions`; an empty list means preflight
+blocked the proposal before anything landed.
 
 Future versions may persist proposal ids server-side so reviewed actions,
 confirmation, and resumable progress survive process restarts. In v0 the
@@ -452,8 +456,10 @@ Stale ids, missing projects, missing chats, missing work items, or missing
 memory candidates return `404 not_found` or `409 conflict` depending on the
 state transition.
 
-When a multi-action apply fails after earlier actions were committed, the error
-includes progress metadata:
+When a multi-action apply fails, the error includes progress metadata. If
+preflight caught the failure before mutation, `partial_result.actions` is empty.
+If a later store/race failure happens after earlier actions were committed, the
+same field lists the landed action kinds and ids:
 
 ```json
 {

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3386,13 +3386,16 @@ explicitly apply the proposal. Apply revalidates current server state before
 mutating projects, chats, project work, or memory candidates.
 
 Apply is a human-gated operation. Do not wire it as a direct model-callable tool
-without an explicit blocking operator confirmation. Multi-action apply is
-sequential and resumable within the current process: on a mid-sequence failure
-the error includes `failed_action_index` and `partial_result`; retrying the
-unchanged proposal id resumes after the committed actions, while changing the
-action set or reapplying a fully applied proposal returns `409 conflict`.
-Clients should present the landed action kinds and ids from
-`partial_result.actions` so the operator can recover from visible partial state.
+without an explicit blocking operator confirmation. Before mutating durable
+stores, apply preflights the remaining typed actions against current project,
+work, handoff, memory-candidate, and chat targets, including explicit resources
+created earlier in the same proposal. Multi-action apply is sequential and
+resumable within the current process: on a failure the error includes
+`failed_action_index` and `partial_result`. An empty
+`partial_result.actions` list means preflight blocked the proposal before any
+new durable write; a non-empty list means those actions landed and the unchanged
+proposal id can resume after them. Changing the action set or reapplying a fully
+applied proposal returns `409 conflict`.
 
 Endpoints:
 

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -655,17 +655,17 @@ func TestProjectAssistantAPI_ProposeAndApplyCreateProject(t *testing.T) {
 	}
 }
 
-func TestProjectAssistantAPI_ApplyPartialFailureIncludesProgress(t *testing.T) {
+func TestProjectAssistantAPI_ApplyPreflightFailureIncludesEmptyProgress(t *testing.T) {
 	t.Parallel()
-	server := newProjectAssistantTestServer()
+	handler, server := newProjectAssistantTestHandler()
 	proposal := projectassistant.Proposal{
-		ID:                   "pa_partial_api",
-		Title:                "Partial apply",
+		ID:                   "pa_preflight_api",
+		Title:                "Preflight apply",
 		RequiresConfirmation: true,
 		Actions: []projectassistant.Action{
 			{
 				Kind:  projectassistant.ActionCreateProject,
-				Patch: json.RawMessage(`{"id":"proj_partial_api","name":"Partial API"}`),
+				Patch: json.RawMessage(`{"id":"proj_preflight_api","name":"Preflight API"}`),
 			},
 			{
 				Kind: projectassistant.ActionCreateWorkItem,
@@ -685,21 +685,21 @@ func TestProjectAssistantAPI_ApplyPartialFailureIncludesProgress(t *testing.T) {
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
 	if rec.Code != http.StatusNotFound {
-		t.Fatalf("partial apply status = %d body=%s, want 404", rec.Code, rec.Body.String())
+		t.Fatalf("preflight apply status = %d body=%s, want 404", rec.Code, rec.Body.String())
 	}
 	var payload projectAssistantErrorResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
-		t.Fatalf("decode partial apply error: %v", err)
+		t.Fatalf("decode preflight apply error: %v", err)
 	}
 	if payload.Error.Type != errCodeNotFound || payload.Error.FailedActionIndex != 1 {
 		t.Fatalf("error = %+v, want not_found at action index 1", payload.Error)
 	}
 	partial := payload.Error.PartialResult
-	if partial.ProposalID != "pa_partial_api" || partial.Applied || len(partial.Actions) != 1 {
-		t.Fatalf("partial_result = %+v, want one unapplied partial result", partial)
+	if partial.ProposalID != "pa_preflight_api" || partial.Applied || len(partial.Actions) != 0 {
+		t.Fatalf("partial_result = %+v, want no action results before preflight failure", partial)
 	}
-	if partial.Actions[0].Kind != projectassistant.ActionCreateProject || partial.Actions[0].ID != "proj_partial_api" {
-		t.Fatalf("partial action = %+v, want created project action", partial.Actions[0])
+	if _, ok, err := handler.projects.Get(t.Context(), "proj_preflight_api"); err != nil || ok {
+		t.Fatalf("Get preflight-blocked project ok=%v err=%v, want no durable mutation", ok, err)
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2574,23 +2574,30 @@ func TestProjectWorkAPI_StartAssignmentRepeatedReturnsCurrentAssignment(t *testi
 func TestProjectWorkAPI_StartAssignmentActiveConflictBeatsModelValidation(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
+	taskID := "task_active_start"
+	runID := "run_active_start"
 	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
 		Workspace: t.TempDir(),
 		Driver:    projectwork.AssignmentDriverHecateTask,
+		Status:    projectwork.AssignmentStatusQueued,
+		TaskID:    taskID,
+		RunID:     runID,
 	})
-
-	rec := httptest.NewRecorder()
-	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("first start status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	if _, err := handler.taskStore.CreateTask(t.Context(), types.Task{
+		ID:          taskID,
+		Title:       "Active assignment",
+		Status:      "running",
+		LatestRunID: runID,
+	}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
 	}
-	var first ProjectWorkAssignmentEnvelope
-	if err := json.Unmarshal(rec.Body.Bytes(), &first); err != nil {
-		t.Fatalf("decode first assignment: %v", err)
-	}
-	firstRef := assignmentExecutionRefForTest(t, first.Data)
-	if firstRef.TaskID == "" || firstRef.RunID == "" {
-		t.Fatalf("first assignment execution_ref = %+v, want task and run", firstRef)
+	if _, err := handler.taskStore.CreateRun(t.Context(), types.TaskRun{
+		ID:     runID,
+		TaskID: taskID,
+		Number: 1,
+		Status: "running",
+	}); err != nil {
+		t.Fatalf("CreateRun: %v", err)
 	}
 
 	handler.config.Router.DefaultModel = ""
@@ -2607,18 +2614,18 @@ func TestProjectWorkAPI_StartAssignmentActiveConflictBeatsModelValidation(t *tes
 		t.Fatalf("Update role defaults: %v", err)
 	}
 
-	rec = httptest.NewRecorder()
+	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
 	if rec.Code != http.StatusConflict {
-		t.Fatalf("second start status = %d body=%s, want 409 before model validation", rec.Code, rec.Body.String())
+		t.Fatalf("start status = %d body=%s, want 409 before model validation", rec.Code, rec.Body.String())
 	}
-	var second ProjectWorkAssignmentEnvelope
-	if err := json.Unmarshal(rec.Body.Bytes(), &second); err != nil {
-		t.Fatalf("decode second assignment: %v", err)
+	var response ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode assignment: %v", err)
 	}
-	secondRef := assignmentExecutionRefForTest(t, second.Data)
-	if secondRef.TaskID != firstRef.TaskID || secondRef.RunID != firstRef.RunID {
-		t.Fatalf("second assignment execution_ref = %+v, want existing %+v", secondRef, firstRef)
+	ref := assignmentExecutionRefForTest(t, response.Data)
+	if ref.TaskID != taskID || ref.RunID != runID {
+		t.Fatalf("assignment execution_ref = %+v, want existing task/run %s/%s", ref, taskID, runID)
 	}
 }
 

--- a/internal/projectassistant/proposal_apply.go
+++ b/internal/projectassistant/proposal_apply.go
@@ -45,6 +45,19 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 	if progress.fingerprint != fingerprint {
 		return ApplyResult{}, fmt.Errorf("%w: proposal %q action set changed after partial apply", ErrConflict, proposal.ID)
 	}
+	if failedActionIndex, err := s.preflightApply(ctx, proposal.Actions, len(progress.results)); err != nil {
+		partial := ApplyResult{
+			ProposalID: proposal.ID,
+			Applied:    false,
+			Actions:    cloneActionResults(progress.results),
+		}
+		return partial, &ApplyError{
+			ProposalID:        proposal.ID,
+			FailedActionIndex: failedActionIndex,
+			Result:            partial,
+			Err:               err,
+		}
+	}
 
 	for idx := len(progress.results); idx < len(proposal.Actions); idx++ {
 		action := proposal.Actions[idx]
@@ -70,37 +83,47 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 	return ApplyResult{ProposalID: proposal.ID, Applied: true, Actions: cloneActionResults(progress.results)}, nil
 }
 
+type applyActionSpec struct {
+	kind      string
+	preflight func(*applyPreflight, context.Context, Action) error
+	apply     func(*Service, context.Context, Action) (ActionResult, error)
+}
+
+// applyActionSpecs is the maintenance contract between preflight and durable
+// apply. Add new Project Assistant mutation kinds here so the stale-target
+// preflight and the store-writing handler stay visibly paired.
+var applyActionSpecs = []applyActionSpec{
+	{kind: ActionCreateProject, preflight: (*applyPreflight).createProject, apply: (*Service).applyCreateProject},
+	{kind: ActionUpdateProject, preflight: (*applyPreflight).updateProject, apply: (*Service).applyUpdateProject},
+	{kind: ActionAttachProjectRoot, preflight: (*applyPreflight).attachProjectRoot, apply: (*Service).applyAttachProjectRoot},
+	{kind: ActionRemoveProjectRoot, preflight: (*applyPreflight).removeProjectRoot, apply: (*Service).applyRemoveProjectRoot},
+	{kind: ActionSetProjectDefaults, preflight: (*applyPreflight).setProjectDefaults, apply: (*Service).applySetProjectDefaults},
+	{kind: ActionMoveChatSession, preflight: (*applyPreflight).moveChatSession, apply: (*Service).applyMoveChatSession},
+	{kind: ActionCreateRole, preflight: (*applyPreflight).createRole, apply: (*Service).applyCreateRole},
+	{kind: ActionCreateWorkItem, preflight: (*applyPreflight).createWorkItem, apply: (*Service).applyCreateWorkItem},
+	{kind: ActionUpdateWorkItem, preflight: (*applyPreflight).updateWorkItem, apply: (*Service).applyUpdateWorkItem},
+	{kind: ActionCreateAssignment, preflight: (*applyPreflight).createAssignment, apply: (*Service).applyCreateAssignment},
+	{kind: ActionCreateHandoff, preflight: (*applyPreflight).createHandoff, apply: (*Service).applyCreateHandoff},
+	{kind: ActionUpdateHandoff, preflight: (*applyPreflight).updateHandoff, apply: (*Service).applyUpdateHandoff},
+	{kind: ActionCreateMemoryCandidate, preflight: (*applyPreflight).createMemoryCandidate, apply: (*Service).applyCreateMemoryCandidate},
+}
+
+func lookupApplyActionSpec(kind string) (applyActionSpec, bool) {
+	kind = normalizeKind(kind)
+	for _, spec := range applyActionSpecs {
+		if spec.kind == kind {
+			return spec, true
+		}
+	}
+	return applyActionSpec{}, false
+}
+
 func (s *Service) applyAction(ctx context.Context, action Action) (ActionResult, error) {
-	switch normalizeKind(action.Kind) {
-	case ActionCreateProject:
-		return s.applyCreateProject(ctx, action)
-	case ActionUpdateProject:
-		return s.applyUpdateProject(ctx, action)
-	case ActionAttachProjectRoot:
-		return s.applyAttachProjectRoot(ctx, action)
-	case ActionRemoveProjectRoot:
-		return s.applyRemoveProjectRoot(ctx, action)
-	case ActionSetProjectDefaults:
-		return s.applySetProjectDefaults(ctx, action)
-	case ActionMoveChatSession:
-		return s.applyMoveChatSession(ctx, action)
-	case ActionCreateRole:
-		return s.applyCreateRole(ctx, action)
-	case ActionCreateWorkItem:
-		return s.applyCreateWorkItem(ctx, action)
-	case ActionUpdateWorkItem:
-		return s.applyUpdateWorkItem(ctx, action)
-	case ActionCreateAssignment:
-		return s.applyCreateAssignment(ctx, action)
-	case ActionCreateHandoff:
-		return s.applyCreateHandoff(ctx, action)
-	case ActionUpdateHandoff:
-		return s.applyUpdateHandoff(ctx, action)
-	case ActionCreateMemoryCandidate:
-		return s.applyCreateMemoryCandidate(ctx, action)
-	default:
+	spec, ok := lookupApplyActionSpec(action.Kind)
+	if !ok {
 		return ActionResult{}, fmt.Errorf("%w: %s", ErrUnknownActionKind, action.Kind)
 	}
+	return spec.apply(s, ctx, action)
 }
 
 func cloneActionResults(results []ActionResult) []ActionResult {

--- a/internal/projectassistant/proposal_apply_preflight.go
+++ b/internal/projectassistant/proposal_apply_preflight.go
@@ -1,0 +1,657 @@
+package projectassistant
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type applyPreflight struct {
+	service          *Service
+	projects         map[string]projects.Project
+	roles            map[string]projectwork.AgentRoleProfile
+	workItems        map[string]projectwork.WorkItem
+	assignments      map[string]projectwork.Assignment
+	handoffs         map[string]projectwork.Handoff
+	memoryCandidates map[string]memory.Candidate
+}
+
+func (s *Service) preflightApply(ctx context.Context, actions []Action, startIndex int) (int, error) {
+	preflight := &applyPreflight{
+		service:          s,
+		projects:         make(map[string]projects.Project),
+		roles:            make(map[string]projectwork.AgentRoleProfile),
+		workItems:        make(map[string]projectwork.WorkItem),
+		assignments:      make(map[string]projectwork.Assignment),
+		handoffs:         make(map[string]projectwork.Handoff),
+		memoryCandidates: make(map[string]memory.Candidate),
+	}
+	for idx := startIndex; idx < len(actions); idx++ {
+		if err := preflight.action(ctx, actions[idx]); err != nil {
+			return idx, err
+		}
+	}
+	return -1, nil
+}
+
+func (p *applyPreflight) action(ctx context.Context, action Action) error {
+	spec, ok := lookupApplyActionSpec(action.Kind)
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownActionKind, action.Kind)
+	}
+	return spec.preflight(p, ctx, action)
+}
+
+func (p *applyPreflight) createProject(ctx context.Context, action Action) error {
+	if p.service.projects == nil {
+		return ErrStoreNotConfigured
+	}
+	var patch projectPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	if _, err := preflightRootsForProjectPatch(patch); err != nil {
+		return err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		return nil
+	}
+	if exists, err := p.projectExists(ctx, id); err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("%w: project %q already exists", ErrConflict, id)
+	}
+	p.projects[id] = projects.Project{
+		ID:                       id,
+		Name:                     patch.Name,
+		Description:              patch.Description,
+		Roots:                    preflightRootsFromPatch(patch.Roots),
+		DefaultProvider:          patch.DefaultProvider,
+		DefaultModel:             patch.DefaultModel,
+		DefaultAgentProfile:      patch.DefaultAgentProfile,
+		DefaultToolsEnabled:      patch.DefaultToolsEnabled,
+		DefaultWorkspaceMode:     patch.DefaultWorkspaceMode,
+		DefaultSystemPrompt:      patch.DefaultSystemPrompt,
+		DefaultCompactToolOutput: patch.DefaultCompactToolOutput,
+	}
+	return nil
+}
+
+func (p *applyPreflight) updateProject(ctx context.Context, action Action) error {
+	projectID := targetValue(action, "project_id")
+	project, err := p.requireProject(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	var patch updateProjectPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	if patch.Name != nil {
+		project.Name = *patch.Name
+	}
+	if patch.Description != nil {
+		project.Description = *patch.Description
+	}
+	p.projects[project.ID] = project
+	return nil
+}
+
+func (p *applyPreflight) attachProjectRoot(ctx context.Context, action Action) error {
+	projectID := targetValue(action, "project_id")
+	project, err := p.requireProject(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	var patch rootPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	root := preflightRootFromPatch(patch)
+	if root.ID == "" {
+		return nil
+	}
+	if projectHasRoot(project, root.ID) {
+		return fmt.Errorf("%w: root %q already exists", ErrConflict, root.ID)
+	}
+	project.Roots = append(project.Roots, root)
+	p.projects[project.ID] = project
+	return nil
+}
+
+func (p *applyPreflight) removeProjectRoot(ctx context.Context, action Action) error {
+	projectID := targetValue(action, "project_id")
+	rootID := targetValue(action, "root_id")
+	if projectID == "" || rootID == "" {
+		return fmt.Errorf("%w: target.project_id and target.root_id are required", ErrInvalid)
+	}
+	project, err := p.requireProject(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	if !projectHasRoot(project, rootID) {
+		return fmt.Errorf("%w: root %q", ErrNotFound, rootID)
+	}
+	roots := project.Roots[:0]
+	for _, root := range project.Roots {
+		if root.ID != rootID {
+			roots = append(roots, root)
+		}
+	}
+	project.Roots = roots
+	if project.DefaultRootID == rootID {
+		project.DefaultRootID = ""
+	}
+	p.projects[project.ID] = project
+	return nil
+}
+
+func (p *applyPreflight) setProjectDefaults(ctx context.Context, action Action) error {
+	projectID := targetValue(action, "project_id")
+	project, err := p.requireProject(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	var patch defaultsPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	if patch.DefaultRootID != nil && *patch.DefaultRootID != "" && !projectHasRoot(project, *patch.DefaultRootID) {
+		return fmt.Errorf("%w: root %q", ErrNotFound, *patch.DefaultRootID)
+	}
+	if patch.DefaultRootID != nil {
+		project.DefaultRootID = *patch.DefaultRootID
+	}
+	p.projects[project.ID] = project
+	return nil
+}
+
+func (p *applyPreflight) moveChatSession(ctx context.Context, action Action) error {
+	if p.service.chats == nil {
+		return ErrStoreNotConfigured
+	}
+	sessionID := targetValue(action, "chat_session_id")
+	if sessionID == "" {
+		return fmt.Errorf("%w: target.chat_session_id is required", ErrInvalid)
+	}
+	var patch moveChatSessionPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	if strings.TrimSpace(patch.ProjectID) != "" {
+		if _, err := p.requireProject(ctx, patch.ProjectID); err != nil {
+			return err
+		}
+	}
+	if _, err := p.requireChatSession(ctx, sessionID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *applyPreflight) createRole(ctx context.Context, action Action) error {
+	if p.service.work == nil {
+		return ErrStoreNotConfigured
+	}
+	var patch rolePatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	projectID := firstNonEmpty(patch.ProjectID, targetValue(action, "project_id"))
+	if _, err := p.requireProject(ctx, projectID); err != nil {
+		return err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		return nil
+	}
+	if exists, err := p.roleExists(ctx, projectID, id); err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("%w: role %q already exists", ErrConflict, id)
+	}
+	p.roles[scopedKey(projectID, id)] = projectwork.AgentRoleProfile{ID: id, ProjectID: projectID}
+	return nil
+}
+
+func (p *applyPreflight) createWorkItem(ctx context.Context, action Action) error {
+	if p.service.work == nil {
+		return ErrStoreNotConfigured
+	}
+	var patch workItemPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	projectID := firstNonEmpty(patch.ProjectID, targetValue(action, "project_id"))
+	if _, err := p.requireProject(ctx, projectID); err != nil {
+		return err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		return nil
+	}
+	if exists, err := p.workItemExists(ctx, projectID, id); err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("%w: work item %q already exists", ErrConflict, id)
+	}
+	p.workItems[scopedKey(projectID, id)] = projectwork.WorkItem{ID: id, ProjectID: projectID, Title: patch.Title, Status: patch.Status}
+	return nil
+}
+
+func (p *applyPreflight) updateWorkItem(ctx context.Context, action Action) error {
+	if p.service.work == nil {
+		return ErrStoreNotConfigured
+	}
+	projectID := targetValue(action, "project_id")
+	workItemID := targetValue(action, "work_item_id")
+	item, err := p.requireWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return err
+	}
+	var patch updateWorkItemPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	if patch.Title != nil {
+		item.Title = *patch.Title
+	}
+	if patch.Status != nil {
+		item.Status = *patch.Status
+	}
+	p.workItems[scopedKey(projectID, workItemID)] = item
+	return nil
+}
+
+func (p *applyPreflight) createAssignment(ctx context.Context, action Action) error {
+	if p.service.work == nil {
+		return ErrStoreNotConfigured
+	}
+	var patch assignmentPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	projectID := firstNonEmpty(patch.ProjectID, targetValue(action, "project_id"))
+	item, err := p.requireWorkItem(ctx, projectID, patch.WorkItemID)
+	if err != nil {
+		return err
+	}
+	projectID = item.ProjectID
+	if rootID := strings.TrimSpace(patch.RootID); rootID != "" {
+		project, err := p.requireProject(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		if !projectHasRoot(project, rootID) {
+			return fmt.Errorf("%w: root %q", ErrNotFound, rootID)
+		}
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		return nil
+	}
+	if exists, err := p.assignmentExists(ctx, projectID, id); err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("%w: assignment %q already exists", ErrConflict, id)
+	}
+	p.assignments[scopedKey(projectID, id)] = projectwork.Assignment{ID: id, ProjectID: projectID, WorkItemID: item.ID, RoleID: patch.RoleID}
+	return nil
+}
+
+func (p *applyPreflight) createHandoff(ctx context.Context, action Action) error {
+	if p.service.work == nil {
+		return ErrStoreNotConfigured
+	}
+	var patch handoffPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	projectID := firstNonEmpty(patch.ProjectID, targetValue(action, "project_id"))
+	item, err := p.requireWorkItem(ctx, projectID, patch.WorkItemID)
+	if err != nil {
+		return err
+	}
+	projectID = item.ProjectID
+	if sourceAssignmentID := strings.TrimSpace(patch.SourceAssignmentID); sourceAssignmentID != "" {
+		assignment, err := p.requireAssignment(ctx, projectID, sourceAssignmentID)
+		if err != nil {
+			return err
+		}
+		if assignment.WorkItemID != item.ID {
+			return fmt.Errorf("%w: source assignment %q", ErrNotFound, sourceAssignmentID)
+		}
+	}
+	if targetAssignmentID := strings.TrimSpace(patch.TargetAssignmentID); targetAssignmentID != "" {
+		assignment, err := p.requireAssignment(ctx, projectID, targetAssignmentID)
+		if err != nil {
+			return err
+		}
+		if targetWorkItemID := strings.TrimSpace(patch.TargetWorkItemID); targetWorkItemID != "" && assignment.WorkItemID != targetWorkItemID {
+			return fmt.Errorf("%w: target assignment %q", ErrNotFound, targetAssignmentID)
+		}
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		return nil
+	}
+	if exists, err := p.handoffExists(ctx, projectID, id); err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("%w: handoff %q already exists", ErrConflict, id)
+	}
+	p.handoffs[scopedKey(projectID, id)] = projectwork.Handoff{ID: id, ProjectID: projectID, WorkItemID: item.ID, TargetWorkItemID: patch.TargetWorkItemID}
+	return nil
+}
+
+func (p *applyPreflight) updateHandoff(ctx context.Context, action Action) error {
+	if p.service.work == nil {
+		return ErrStoreNotConfigured
+	}
+	projectID := targetValue(action, "project_id")
+	workItemID := targetValue(action, "work_item_id")
+	handoffID := targetValue(action, "handoff_id")
+	if projectID == "" || workItemID == "" || handoffID == "" {
+		return fmt.Errorf("%w: target.project_id, target.work_item_id, and target.handoff_id are required", ErrInvalid)
+	}
+	if _, err := p.requireWorkItem(ctx, projectID, workItemID); err != nil {
+		return err
+	}
+	handoff, err := p.requireHandoff(ctx, projectID, workItemID, handoffID)
+	if err != nil {
+		return err
+	}
+	var patch updateHandoffPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	if patch.TargetAssignmentID == nil && patch.TargetRoleID == nil && patch.Status == nil {
+		return fmt.Errorf("%w: update_handoff patch must set at least one mutable field", ErrInvalid)
+	}
+	if patch.TargetAssignmentID != nil && strings.TrimSpace(*patch.TargetAssignmentID) != "" {
+		assignment, err := p.requireAssignment(ctx, projectID, *patch.TargetAssignmentID)
+		if err != nil {
+			return err
+		}
+		if handoff.TargetWorkItemID != "" && assignment.WorkItemID != handoff.TargetWorkItemID {
+			return fmt.Errorf("%w: target assignment %q", ErrNotFound, *patch.TargetAssignmentID)
+		}
+		handoff.TargetAssignmentID = strings.TrimSpace(*patch.TargetAssignmentID)
+	}
+	p.handoffs[scopedKey(projectID, handoffID)] = handoff
+	return nil
+}
+
+func (p *applyPreflight) createMemoryCandidate(ctx context.Context, action Action) error {
+	if p.service.memoryCandidates == nil {
+		return ErrStoreNotConfigured
+	}
+	var patch memoryCandidatePatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	projectID := firstNonEmpty(patch.ProjectID, targetValue(action, "project_id"))
+	if _, err := p.requireProject(ctx, projectID); err != nil {
+		return err
+	}
+	id := strings.TrimSpace(patch.ID)
+	if id == "" {
+		return nil
+	}
+	if exists, err := p.memoryCandidateExists(ctx, projectID, id); err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("%w: memory candidate %q already exists", ErrConflict, id)
+	}
+	p.memoryCandidates[scopedKey(projectID, id)] = memory.Candidate{ID: id, ProjectID: projectID}
+	return nil
+}
+
+func (p *applyPreflight) requireProject(ctx context.Context, projectID string) (projects.Project, error) {
+	if p.service.projects == nil {
+		return projects.Project{}, ErrStoreNotConfigured
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return projects.Project{}, fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	if project, ok := p.projects[projectID]; ok {
+		return project, nil
+	}
+	project, ok, err := p.service.projects.Get(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, err
+	}
+	if !ok {
+		return projects.Project{}, fmt.Errorf("%w: project %q", ErrNotFound, projectID)
+	}
+	p.projects[projectID] = project
+	return project, nil
+}
+
+func (p *applyPreflight) projectExists(ctx context.Context, projectID string) (bool, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return false, nil
+	}
+	if _, ok := p.projects[projectID]; ok {
+		return true, nil
+	}
+	_, ok, err := p.service.projects.Get(ctx, projectID)
+	return ok, err
+}
+
+func (p *applyPreflight) requireWorkItem(ctx context.Context, projectID, workItemID string) (projectwork.WorkItem, error) {
+	if p.service.work == nil {
+		return projectwork.WorkItem{}, ErrStoreNotConfigured
+	}
+	if _, err := p.requireProject(ctx, projectID); err != nil {
+		return projectwork.WorkItem{}, err
+	}
+	workItemID = strings.TrimSpace(workItemID)
+	if workItemID == "" {
+		return projectwork.WorkItem{}, fmt.Errorf("%w: work_item_id is required", ErrInvalid)
+	}
+	key := scopedKey(projectID, workItemID)
+	if item, ok := p.workItems[key]; ok {
+		return item, nil
+	}
+	item, ok, err := p.service.work.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return projectwork.WorkItem{}, err
+	}
+	if !ok {
+		return projectwork.WorkItem{}, fmt.Errorf("%w: work item %q", ErrNotFound, workItemID)
+	}
+	p.workItems[key] = item
+	return item, nil
+}
+
+func (p *applyPreflight) workItemExists(ctx context.Context, projectID, workItemID string) (bool, error) {
+	if workItemID == "" {
+		return false, nil
+	}
+	if _, ok := p.workItems[scopedKey(projectID, workItemID)]; ok {
+		return true, nil
+	}
+	_, ok, err := p.service.work.GetWorkItem(ctx, projectID, workItemID)
+	return ok, err
+}
+
+func (p *applyPreflight) roleExists(ctx context.Context, projectID, roleID string) (bool, error) {
+	if roleID == "" {
+		return false, nil
+	}
+	if _, ok := p.roles[scopedKey(projectID, roleID)]; ok {
+		return true, nil
+	}
+	roles, err := p.service.work.ListRoles(ctx, projectID)
+	if err != nil {
+		return false, err
+	}
+	for _, role := range roles {
+		if role.ID == roleID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (p *applyPreflight) requireAssignment(ctx context.Context, projectID, assignmentID string) (projectwork.Assignment, error) {
+	assignmentID = strings.TrimSpace(assignmentID)
+	if assignmentID == "" {
+		return projectwork.Assignment{}, fmt.Errorf("%w: assignment_id is required", ErrInvalid)
+	}
+	key := scopedKey(projectID, assignmentID)
+	if assignment, ok := p.assignments[key]; ok {
+		return assignment, nil
+	}
+	assignments, err := p.service.work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return projectwork.Assignment{}, err
+	}
+	for _, assignment := range assignments {
+		if assignment.ID == assignmentID {
+			p.assignments[key] = assignment
+			return assignment, nil
+		}
+	}
+	return projectwork.Assignment{}, fmt.Errorf("%w: assignment %q", ErrNotFound, assignmentID)
+}
+
+func (p *applyPreflight) assignmentExists(ctx context.Context, projectID, assignmentID string) (bool, error) {
+	if assignmentID == "" {
+		return false, nil
+	}
+	if _, ok := p.assignments[scopedKey(projectID, assignmentID)]; ok {
+		return true, nil
+	}
+	assignments, err := p.service.work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return false, err
+	}
+	for _, assignment := range assignments {
+		if assignment.ID == assignmentID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (p *applyPreflight) requireHandoff(ctx context.Context, projectID, workItemID, handoffID string) (projectwork.Handoff, error) {
+	handoffID = strings.TrimSpace(handoffID)
+	if handoffID == "" {
+		return projectwork.Handoff{}, fmt.Errorf("%w: handoff_id is required", ErrInvalid)
+	}
+	key := scopedKey(projectID, handoffID)
+	if handoff, ok := p.handoffs[key]; ok {
+		if handoff.WorkItemID == workItemID {
+			return handoff, nil
+		}
+		return projectwork.Handoff{}, fmt.Errorf("%w: handoff %q", ErrNotFound, handoffID)
+	}
+	handoffs, err := p.service.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return projectwork.Handoff{}, err
+	}
+	for _, handoff := range handoffs {
+		if handoff.ID == handoffID {
+			p.handoffs[key] = handoff
+			return handoff, nil
+		}
+	}
+	return projectwork.Handoff{}, fmt.Errorf("%w: handoff %q", ErrNotFound, handoffID)
+}
+
+func (p *applyPreflight) handoffExists(ctx context.Context, projectID, handoffID string) (bool, error) {
+	if handoffID == "" {
+		return false, nil
+	}
+	if _, ok := p.handoffs[scopedKey(projectID, handoffID)]; ok {
+		return true, nil
+	}
+	handoffs, err := p.service.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID})
+	if err != nil {
+		return false, err
+	}
+	for _, handoff := range handoffs {
+		if handoff.ID == handoffID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (p *applyPreflight) requireChatSession(ctx context.Context, sessionID string) (chat.Session, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return chat.Session{}, fmt.Errorf("%w: chat_session_id is required", ErrInvalid)
+	}
+	session, ok, err := p.service.chats.Get(ctx, sessionID)
+	if err != nil {
+		return chat.Session{}, err
+	}
+	if !ok {
+		return chat.Session{}, fmt.Errorf("%w: chat session %q", ErrNotFound, sessionID)
+	}
+	return session, nil
+}
+
+func (p *applyPreflight) memoryCandidateExists(ctx context.Context, projectID, candidateID string) (bool, error) {
+	if candidateID == "" {
+		return false, nil
+	}
+	if _, ok := p.memoryCandidates[scopedKey(projectID, candidateID)]; ok {
+		return true, nil
+	}
+	_, ok, err := p.service.memoryCandidates.GetCandidate(ctx, projectID, candidateID)
+	return ok, err
+}
+
+func preflightRootsForProjectPatch(patch projectPatch) ([]projects.Root, error) {
+	workspacePath := strings.TrimSpace(patch.WorkspacePath)
+	workspaceKind := strings.TrimSpace(patch.WorkspaceKind)
+	if workspacePath != "" && len(patch.Roots) > 0 {
+		return nil, fmt.Errorf("%w: workspace_path cannot be combined with roots", ErrInvalid)
+	}
+	if workspacePath == "" && workspaceKind != "" {
+		return nil, fmt.Errorf("%w: workspace_kind requires workspace_path", ErrInvalid)
+	}
+	return preflightRootsFromPatch(patch.Roots), nil
+}
+
+func preflightRootsFromPatch(patches []rootPatch) []projects.Root {
+	roots := make([]projects.Root, 0, len(patches))
+	for _, patch := range patches {
+		root := preflightRootFromPatch(patch)
+		if root.ID != "" {
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}
+
+func preflightRootFromPatch(patch rootPatch) projects.Root {
+	active := true
+	if patch.Active != nil {
+		active = *patch.Active
+	}
+	return projects.Root{
+		ID:        strings.TrimSpace(patch.ID),
+		Path:      patch.Path,
+		Kind:      patch.Kind,
+		GitRemote: patch.GitRemote,
+		GitBranch: patch.GitBranch,
+		Active:    active,
+	}
+}
+
+func scopedKey(scope, id string) string {
+	return strings.TrimSpace(scope) + "\x00" + strings.TrimSpace(id)
+}

--- a/internal/projectassistant/proposal_validation.go
+++ b/internal/projectassistant/proposal_validation.go
@@ -11,33 +11,27 @@ import (
 
 func validateActionShape(action Action) error {
 	kind := normalizeKind(action.Kind)
-	switch kind {
-	case ActionCreateProject, ActionUpdateProject, ActionAttachProjectRoot, ActionRemoveProjectRoot,
-		ActionSetProjectDefaults, ActionMoveChatSession, ActionCreateRole, ActionCreateWorkItem, ActionUpdateWorkItem,
-		ActionCreateAssignment, ActionCreateHandoff, ActionUpdateHandoff, ActionCreateMemoryCandidate:
-		if len(action.Patch) == 0 && kind != ActionRemoveProjectRoot {
-			return fmt.Errorf("%w: action %q patch is required", ErrInvalid, kind)
-		}
-		if kind == ActionCreateAssignment {
-			hasRuntimeLinks, err := assignmentPatchHasRuntimeLinks(action.Patch)
-			if err != nil {
-				return err
-			}
-			if hasRuntimeLinks {
-				return fmt.Errorf("%w: create_assignment proposals cannot bind chats, tasks, runs, messages, or snapshots", ErrInvalid)
-			}
-			var patch assignmentPatch
-			if err := decodePatch(action, &patch); err != nil {
-				return err
-			}
-			if err := validateAssignmentProposalBoundary(patch); err != nil {
-				return err
-			}
-		}
-		return nil
-	default:
+	if _, ok := lookupApplyActionSpec(kind); !ok {
 		return fmt.Errorf("%w: %s", ErrUnknownActionKind, action.Kind)
 	}
+	if len(action.Patch) == 0 && kind != ActionRemoveProjectRoot {
+		return fmt.Errorf("%w: action %q patch is required", ErrInvalid, kind)
+	}
+	if kind != ActionCreateAssignment {
+		return nil
+	}
+	hasRuntimeLinks, err := assignmentPatchHasRuntimeLinks(action.Patch)
+	if err != nil {
+		return err
+	}
+	if hasRuntimeLinks {
+		return fmt.Errorf("%w: create_assignment proposals cannot bind chats, tasks, runs, messages, or snapshots", ErrInvalid)
+	}
+	var patch assignmentPatch
+	if err := decodePatch(action, &patch); err != nil {
+		return err
+	}
+	return validateAssignmentProposalBoundary(patch)
 }
 
 func validateAssignmentProposalBoundary(patch assignmentPatch) error {

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -1156,6 +1156,30 @@ func TestService_ApplyRequiresConfirmation(t *testing.T) {
 	}
 }
 
+func TestApplyActionSpecsPairPreflightAndApplyHandlers(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, len(applyActionSpecs))
+	for _, spec := range applyActionSpecs {
+		if strings.TrimSpace(spec.kind) == "" {
+			t.Fatal("apply action spec has empty kind")
+		}
+		if spec.preflight == nil {
+			t.Fatalf("apply action spec %q has nil preflight handler", spec.kind)
+		}
+		if spec.apply == nil {
+			t.Fatalf("apply action spec %q has nil apply handler", spec.kind)
+		}
+		if _, ok := seen[spec.kind]; ok {
+			t.Fatalf("apply action spec %q is duplicated", spec.kind)
+		}
+		seen[spec.kind] = struct{}{}
+		lookup, ok := lookupApplyActionSpec(spec.kind)
+		if !ok || lookup.kind != spec.kind {
+			t.Fatalf("lookupApplyActionSpec(%q) = %+v/%v, want same spec kind", spec.kind, lookup, ok)
+		}
+	}
+}
+
 func TestService_ApplyCreateAndUpdateProjectAcrossStores(t *testing.T) {
 	t.Parallel()
 	for _, builder := range assistantFixtureBuilders() {
@@ -1803,7 +1827,7 @@ func TestService_ApplyRepeatedProposalConflicts(t *testing.T) {
 	}
 }
 
-func TestService_ApplyPartialFailureReturnsProgressAndResumesAcrossStores(t *testing.T) {
+func TestService_ApplyPreflightBlocksStaleTargetsBeforeMutatingAcrossStores(t *testing.T) {
 	t.Parallel()
 	for _, builder := range assistantFixtureBuilders() {
 		t.Run(builder.name, func(t *testing.T) {
@@ -1811,12 +1835,12 @@ func TestService_ApplyPartialFailureReturnsProgressAndResumesAcrossStores(t *tes
 			ctx := context.Background()
 			fixture := builder.build(t)
 			proposal := Proposal{
-				ID:                   "pa_partial_resume",
+				ID:                   "pa_preflight_resume",
 				RequiresConfirmation: true,
 				Actions: []Action{
 					{
 						Kind:  ActionCreateProject,
-						Patch: rawPatch(t, map[string]string{"id": "proj_partial", "name": "Partial"}),
+						Patch: rawPatch(t, map[string]string{"id": "proj_preflight", "name": "Preflight"}),
 					},
 					{
 						Kind: ActionCreateWorkItem,
@@ -1840,14 +1864,14 @@ func TestService_ApplyPartialFailureReturnsProgressAndResumesAcrossStores(t *tes
 			if applyErr.FailedActionIndex != 1 {
 				t.Fatalf("failed_action_index = %d, want 1", applyErr.FailedActionIndex)
 			}
-			if result.Applied || len(result.Actions) != 1 || result.Actions[0].ID != "proj_partial" {
-				t.Fatalf("partial result = %+v, want first action only", result)
+			if result.Applied || len(result.Actions) != 0 {
+				t.Fatalf("partial result = %+v, want no action results before preflight failure", result)
 			}
 			if applyErr.Result.ProposalID != result.ProposalID || len(applyErr.Result.Actions) != len(result.Actions) {
 				t.Fatalf("apply error result = %+v, want returned partial result %+v", applyErr.Result, result)
 			}
-			if _, ok, err := fixture.projects.Get(ctx, "proj_partial"); err != nil || !ok {
-				t.Fatalf("get partially-created project ok=%v err=%v", ok, err)
+			if _, ok, err := fixture.projects.Get(ctx, "proj_preflight"); err != nil || ok {
+				t.Fatalf("get preflight-blocked project ok=%v err=%v, want no durable mutation", ok, err)
 			}
 
 			if _, err := fixture.projects.Create(ctx, projects.Project{ID: "proj_after_retry", Name: "After retry"}); err != nil {
@@ -1859,6 +1883,9 @@ func TestService_ApplyPartialFailureReturnsProgressAndResumesAcrossStores(t *tes
 			}
 			if !result.Applied || len(result.Actions) != 2 {
 				t.Fatalf("retry result = %+v, want both actions applied", result)
+			}
+			if _, ok, err := fixture.projects.Get(ctx, "proj_preflight"); err != nil || !ok {
+				t.Fatalf("get project after retry ok=%v err=%v, want created project", ok, err)
 			}
 			item, ok, err := fixture.work.GetWorkItem(ctx, "proj_after_retry", "work_after_retry")
 			if err != nil || !ok {
@@ -1872,20 +1899,86 @@ func TestService_ApplyPartialFailureReturnsProgressAndResumesAcrossStores(t *tes
 			if err != nil {
 				t.Fatalf("list projects: %v", err)
 			}
-			var partialProjectCount int
+			var preflightProjectCount int
 			for _, project := range projectsAfterRetry {
-				if project.ID == "proj_partial" {
-					partialProjectCount++
+				if project.ID == "proj_preflight" {
+					preflightProjectCount++
 				}
 			}
-			if partialProjectCount != 1 {
-				t.Fatalf("proj_partial count = %d, want one non-duplicated project", partialProjectCount)
+			if preflightProjectCount != 1 {
+				t.Fatalf("proj_preflight count = %d, want one non-duplicated project", preflightProjectCount)
 			}
 		})
 	}
 }
 
-func TestService_ApplyChangedProposalAfterPartialFailureConflictsAcrossStores(t *testing.T) {
+func TestService_ApplyPreflightBlocksMissingHandoffTargetBeforeMutatingAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+			workItem, err := fixture.work.CreateWorkItem(ctx, projectwork.WorkItem{
+				ID:        "work_handoff_preflight",
+				ProjectID: project.ID,
+				Title:     "Handoff preflight",
+				Status:    projectwork.WorkItemStatusReview,
+			})
+			if err != nil {
+				t.Fatalf("CreateWorkItem: %v", err)
+			}
+
+			proposal := Proposal{
+				ID:                   "pa_handoff_preflight",
+				RequiresConfirmation: true,
+				Actions: []Action{
+					{
+						Kind: ActionCreateHandoff,
+						Patch: rawPatch(t, map[string]any{
+							"id":                      "handoff_preflight",
+							"project_id":              project.ID,
+							"work_item_id":            workItem.ID,
+							"title":                   "Needs follow-up",
+							"summary":                 "A follow-up is required.",
+							"recommended_next_action": "Create the missing assignment.",
+						}),
+					},
+					{
+						Kind:   ActionUpdateHandoff,
+						Target: map[string]string{"project_id": project.ID, "work_item_id": workItem.ID, "handoff_id": "handoff_preflight"},
+						Patch:  rawPatch(t, map[string]string{"target_assignment_id": "asgn_missing"}),
+					},
+				},
+			}
+
+			result, err := fixture.service.Apply(ctx, proposal, true)
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("Apply err = %v, want ErrNotFound", err)
+			}
+			var applyErr *ApplyError
+			if !errors.As(err, &applyErr) {
+				t.Fatalf("Apply err = %T %v, want ApplyError", err, err)
+			}
+			if applyErr.FailedActionIndex != 1 {
+				t.Fatalf("failed_action_index = %d, want 1", applyErr.FailedActionIndex)
+			}
+			if result.Applied || len(result.Actions) != 0 {
+				t.Fatalf("result = %+v, want no partial action results", result)
+			}
+			handoffs, err := fixture.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: project.ID, WorkItemID: workItem.ID})
+			if err != nil {
+				t.Fatalf("ListHandoffs: %v", err)
+			}
+			if len(handoffs) != 0 {
+				t.Fatalf("handoffs = %+v, want no durable handoff after preflight failure", handoffs)
+			}
+		})
+	}
+}
+
+func TestService_ApplyChangedProposalAfterPreflightFailureConflictsAcrossStores(t *testing.T) {
 	t.Parallel()
 	for _, builder := range assistantFixtureBuilders() {
 		t.Run(builder.name, func(t *testing.T) {
@@ -1893,12 +1986,12 @@ func TestService_ApplyChangedProposalAfterPartialFailureConflictsAcrossStores(t 
 			ctx := context.Background()
 			fixture := builder.build(t)
 			proposal := Proposal{
-				ID:                   "pa_partial_changed",
+				ID:                   "pa_preflight_changed",
 				RequiresConfirmation: true,
 				Actions: []Action{
 					{
 						Kind:  ActionCreateProject,
-						Patch: rawPatch(t, map[string]string{"id": "proj_partial_changed", "name": "Partial"}),
+						Patch: rawPatch(t, map[string]string{"id": "proj_preflight_changed", "name": "Preflight"}),
 					},
 					{
 						Kind: ActionCreateWorkItem,


### PR DESCRIPTION
## Overview

Adds a Project Assistant apply preflight pass before durable mutations. The preflight walks the remaining typed actions, validates current project/work/handoff/memory-candidate/chat targets, and tracks explicit resources created earlier in the same proposal so chained actions can be checked before anything is written.

This keeps Project Assistant proposal apply human-gated and sequential, but prevents deterministic stale-target failures from leaving partial durable state. Store or race failures after preflight still use the existing partial-result/resume contract.

## Details

- Adds `preflightApply` in `internal/projectassistant` and invokes it under the existing apply lock after proposal fingerprint/progress checks.
- Pairs each action kind with its preflight handler and durable apply handler in one action-spec table so dispatch and shape validation cannot drift into separate allowlists.
- Preserves `ApplyError`, `failed_action_index`, and `partial_result`; an empty `partial_result.actions` now means preflight blocked before new writes landed.
- Covers project, root/default, chat move, role, work item, assignment, handoff, and memory-candidate targets.
- Adds regression coverage for stale cross-store targets, chained handoff target failures, API error payloads, changed-proposal conflicts after preflight failure, and action-spec table integrity.
- Updates Project Assistant/runtime API docs with the new apply semantics.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test ./internal/projectassistant ./internal/projectassistantapp ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go vet ./internal/projectassistant ./internal/projectassistantapp ./internal/api`
- `git diff --check`
- Source-name exclusion scan for public docs/code
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test -race -timeout 10m ./...`

Note: an earlier broad race run hit three unrelated `internal/agentadapters` ACP approval wait timeouts. The failing slice passed on direct rerun, and later full race runs passed.
