### PR TITLE
fix(agent): gracefully cancel unsupported acp elicitations

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -502,6 +502,10 @@ destructive: Hecate asks the ACP peer to delete the native session with
 `session/delete` before removing the persisted Hecate transcript. If an adapter
 does not implement `session/delete`, Hecate falls back to `session/close` and
 still terminates the owned process group.
+Hecate does not advertise ACP elicitation UI support yet. If an experimental
+adapter still sends unstable `elicitation/create`, Hecate replies with the ACP
+`cancel` outcome instead of surfacing a JSON-RPC method-not-found error; unstable
+`elicitation/complete` notifications are ignored.
 
 Every prompt also gets OTel-shaped observability. The message response includes
 `request_id`, `trace_id`, and `span_id`, and `GET

--- a/internal/agentadapters/acp_chat_client.go
+++ b/internal/agentadapters/acp_chat_client.go
@@ -99,6 +99,17 @@ func (c *acpChatClient) RequestPermission(ctx context.Context, params acp.Reques
 	return acp.RequestPermissionResponse{Outcome: acp.RequestPermissionOutcome{Cancelled: &acp.RequestPermissionOutcomeCancelled{}}}, nil
 }
 
+func (c *acpChatClient) UnstableCreateElicitation(context.Context, acp.UnstableCreateElicitationRequest) (acp.UnstableCreateElicitationResponse, error) {
+	// Hecate does not advertise elicitation support yet. Return the ACP
+	// "cancel" outcome so experimental agents degrade gracefully instead of
+	// seeing JSON-RPC method-not-found.
+	return acp.NewUnstableCreateElicitationResponseCancel(), nil
+}
+
+func (c *acpChatClient) UnstableCompleteElicitation(context.Context, acp.UnstableCompleteElicitationNotification) error {
+	return nil
+}
+
 func (c *acpChatClient) ReadTextFile(_ context.Context, params acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
 	fsys, path, err := c.workspaceFS(params.Path)
 	if err != nil {

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -236,6 +236,30 @@ func TestACPChatClientCapturesConfigOptionsWithoutActiveTurn(t *testing.T) {
 	}
 }
 
+func TestACPChatClientCancelsUnsupportedElicitation(t *testing.T) {
+	client := &acpChatClient{}
+	resp, err := client.UnstableCreateElicitation(context.Background(), acp.NewUnstableCreateElicitationRequestUrl(
+		acp.UnstableElicitationId("oauth-1"),
+		"https://example.com/oauth",
+	))
+	if err != nil {
+		t.Fatalf("UnstableCreateElicitation: %v", err)
+	}
+	if resp.Cancel == nil || resp.Cancel.Action != "cancel" {
+		t.Fatalf("elicitation response = %#v, want cancel action", resp)
+	}
+}
+
+func TestACPChatClientIgnoresElicitationComplete(t *testing.T) {
+	client := &acpChatClient{}
+	err := client.UnstableCompleteElicitation(context.Background(), acp.UnstableCompleteElicitationNotification{
+		ElicitationId: acp.UnstableElicitationId("oauth-1"),
+	})
+	if err != nil {
+		t.Fatalf("UnstableCompleteElicitation: %v", err)
+	}
+}
+
 func TestACPSessionConfigOptionUpdatePreservesManagedLaunchOptions(t *testing.T) {
 	session := &acpSession{
 		managedConfig: map[string]struct{}{"sandbox": {}},


### PR DESCRIPTION
## Summary
- add no-UI fallback handlers for unstable ACP `elicitation/create` and `elicitation/complete` client methods
- return ACP `cancel` for unsolicited elicitations instead of JSON-RPC method-not-found
- document that Hecate does not advertise elicitation support yet, but degrades gracefully if an experimental adapter sends it

## Tests
- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters`
- `GOCACHE="$PWD/.gocache" go vet ./internal/agentadapters`
- `just docs-format-check`
- `git diff --check`