### PR TITLE
Route Project Assistant work through project authority

### DIFF
--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -82,6 +82,7 @@ func (h *Handler) projectAssistantApplication() *projectassistantapp.Application
 			Projects:         h.projects,
 			Chats:            h.agentChat,
 			Work:             h.projectWork,
+			WorkApplication:  h.projectWorkApplication(),
 			ProjectSkills:    h.projectSkills,
 			Memory:           h.memory,
 			MemoryCandidates: h.memoryCandidates,

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projectassistantapp"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -201,11 +202,19 @@ func writeProjectAssistantApplyError(w http.ResponseWriter, err error) {
 		return
 	}
 	status, code := projectAssistantErrorStatusCode(err)
+	fields := map[string]any{
+		"failed_action_index": applyErr.FailedActionIndex,
+		"partial_result":      applyErr.Result,
+	}
+	operatorAction := ""
+	var closeoutErr projectworkapp.WorkItemCloseoutBlockedError
+	if errors.As(err, &closeoutErr) {
+		operatorAction = "Resolve closeout readiness blockers, refresh the work item, then retry."
+		fields["readiness"] = renderProjectWorkItemReadiness(closeoutErr.Readiness)
+	}
 	WriteErrorDetails(w, status, code, err.Error(), ErrorDetails{
-		Fields: map[string]any{
-			"failed_action_index": applyErr.FailedActionIndex,
-			"partial_result":      applyErr.Result,
-		},
+		OperatorAction: operatorAction,
+		Fields:         fields,
 	})
 }
 

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -703,6 +703,85 @@ func TestProjectAssistantAPI_ApplyPreflightFailureIncludesEmptyProgress(t *testi
 	}
 }
 
+func TestProjectAssistantAPI_ApplyDoneReturnsCloseoutReadiness(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantTestHandler()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_assistant_closeout",
+		Name: "Assistant Closeout",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_assistant_closeout",
+		ProjectID: "proj_assistant_closeout",
+		Title:     "Guard assistant closeout",
+		Status:    projectwork.WorkItemStatusReview,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_assistant_closeout",
+		ProjectID:  "proj_assistant_closeout",
+		WorkItemID: "work_assistant_closeout",
+		RoleID:     "software_developer",
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_assistant_closeout",
+		Title:                "Mark done",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{{
+			Kind:   projectassistant.ActionUpdateWorkItem,
+			Target: map[string]string{"project_id": "proj_assistant_closeout", "work_item_id": "work_assistant_closeout"},
+			Patch:  json.RawMessage(`{"status":"done"}`),
+		}},
+	}
+	applyBody, err := json.Marshal(map[string]any{"proposal": proposal, "confirm": true})
+	if err != nil {
+		t.Fatalf("marshal apply body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("assistant closeout apply status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Error struct {
+			Type              string                           `json:"type"`
+			Message           string                           `json:"message"`
+			OperatorAction    string                           `json:"operator_action"`
+			FailedActionIndex int                              `json:"failed_action_index"`
+			PartialResult     projectassistant.ApplyResult     `json:"partial_result"`
+			Readiness         ProjectWorkItemReadinessResponse `json:"readiness"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode assistant closeout error: %v", err)
+	}
+	if payload.Error.Type != errCodeConflict || payload.Error.FailedActionIndex != 0 || payload.Error.OperatorAction == "" {
+		t.Fatalf("assistant closeout error = %+v, want conflict at action 0 with operator action", payload.Error)
+	}
+	if payload.Error.PartialResult.ProposalID != "pa_assistant_closeout" || payload.Error.PartialResult.Applied || len(payload.Error.PartialResult.Actions) != 0 {
+		t.Fatalf("partial_result = %+v, want no committed assistant actions", payload.Error.PartialResult)
+	}
+	if payload.Error.Readiness.Ready || payload.Error.Readiness.Status != "blocked" ||
+		len(payload.Error.Readiness.MissingEvidenceAssignmentIDs) != 1 ||
+		payload.Error.Readiness.MissingEvidenceAssignmentIDs[0] != "asgn_assistant_closeout" {
+		t.Fatalf("assistant closeout readiness = %+v, want missing evidence blocker", payload.Error.Readiness)
+	}
+	stored, ok, err := handler.projectWork.GetWorkItem(t.Context(), "proj_assistant_closeout", "work_assistant_closeout")
+	if err != nil || !ok {
+		t.Fatalf("GetWorkItem() ok=%v err=%v, want stored work item", ok, err)
+	}
+	if stored.Status == projectwork.WorkItemStatusDone {
+		t.Fatalf("stored status = %q, want closeout guard to keep item open", stored.Status)
+	}
+}
+
 func TestProjectAssistantAPI_RepeatedApplyConflicts(t *testing.T) {
 	t.Parallel()
 	server := newProjectAssistantTestServer()

--- a/internal/projectassistant/action_handlers.go
+++ b/internal/projectassistant/action_handlers.go
@@ -213,7 +213,7 @@ func (s *Service) applyMoveChatSession(ctx context.Context, action Action) (Acti
 }
 
 func (s *Service) applyCreateRole(ctx context.Context, action Action) (ActionResult, error) {
-	if s.work == nil {
+	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
 	var patch rolePatch
@@ -231,9 +231,8 @@ func (s *Service) applyCreateRole(ctx context.Context, action Action) (ActionRes
 	if id == "" {
 		id = s.idgen("role")
 	}
-	role, err := s.work.CreateRole(ctx, projectwork.AgentRoleProfile{
+	role, err := s.workAuthority.CreateRole(ctx, projectID, WorkRoleCommand{
 		ID:                  id,
-		ProjectID:           projectID,
 		Name:                patch.Name,
 		Description:         patch.Description,
 		Instructions:        patch.Instructions,
@@ -250,7 +249,7 @@ func (s *Service) applyCreateRole(ctx context.Context, action Action) (ActionRes
 }
 
 func (s *Service) applyCreateWorkItem(ctx context.Context, action Action) (ActionResult, error) {
-	if s.work == nil {
+	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
 	var patch workItemPatch
@@ -268,9 +267,8 @@ func (s *Service) applyCreateWorkItem(ctx context.Context, action Action) (Actio
 	if id == "" {
 		id = s.idgen("work")
 	}
-	item, err := s.work.CreateWorkItem(ctx, projectwork.WorkItem{
+	item, err := s.workAuthority.CreateWorkItem(ctx, projectID, WorkItemCommand{
 		ID:              id,
-		ProjectID:       projectID,
 		Title:           patch.Title,
 		Brief:           patch.Brief,
 		Status:          patch.Status,
@@ -285,7 +283,7 @@ func (s *Service) applyCreateWorkItem(ctx context.Context, action Action) (Actio
 }
 
 func (s *Service) applyUpdateWorkItem(ctx context.Context, action Action) (ActionResult, error) {
-	if s.work == nil {
+	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
 	projectID := targetValue(action, "project_id")
@@ -300,26 +298,18 @@ func (s *Service) applyUpdateWorkItem(ctx context.Context, action Action) (Actio
 	if err := decodePatch(action, &patch); err != nil {
 		return ActionResult{}, err
 	}
-	item, err := s.work.UpdateWorkItem(ctx, projectID, workItemID, func(item *projectwork.WorkItem) {
-		if patch.Title != nil {
-			item.Title = *patch.Title
-		}
-		if patch.Brief != nil {
-			item.Brief = *patch.Brief
-		}
-		if patch.Status != nil {
-			item.Status = *patch.Status
-		}
-		if patch.Priority != nil {
-			item.Priority = *patch.Priority
-		}
-		if patch.OwnerRoleID != nil {
-			item.OwnerRoleID = *patch.OwnerRoleID
-		}
-		if patch.ReviewerRoleIDs != nil {
-			item.ReviewerRoleIDs = append([]string(nil), patch.ReviewerRoleIDs...)
-		}
-	})
+	update := WorkItemUpdateCommand{
+		Title:       patch.Title,
+		Brief:       patch.Brief,
+		Status:      patch.Status,
+		Priority:    patch.Priority,
+		OwnerRoleID: patch.OwnerRoleID,
+	}
+	if patch.ReviewerRoleIDs != nil {
+		reviewerRoleIDs := append([]string(nil), patch.ReviewerRoleIDs...)
+		update.ReviewerRoleIDs = &reviewerRoleIDs
+	}
+	item, err := s.workAuthority.UpdateWorkItem(ctx, projectID, workItemID, update)
 	if err != nil {
 		return ActionResult{}, mapProjectWorkErr(err)
 	}
@@ -327,7 +317,7 @@ func (s *Service) applyUpdateWorkItem(ctx context.Context, action Action) (Actio
 }
 
 func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (ActionResult, error) {
-	if s.work == nil {
+	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
 	var patch assignmentPatch
@@ -357,10 +347,8 @@ func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (Act
 	if id == "" {
 		id = s.idgen("asgn")
 	}
-	assignment, err := s.work.CreateAssignment(ctx, projectwork.Assignment{
+	assignment, err := s.workAuthority.CreateAssignment(ctx, projectID, item.ID, WorkAssignmentCommand{
 		ID:         id,
-		ProjectID:  projectID,
-		WorkItemID: item.ID,
 		RoleID:     patch.RoleID,
 		RootID:     rootID,
 		DriverKind: patch.DriverKind,

--- a/internal/projectassistant/proposal_apply_preflight.go
+++ b/internal/projectassistant/proposal_apply_preflight.go
@@ -259,11 +259,32 @@ func (p *applyPreflight) updateWorkItem(ctx context.Context, action Action) erro
 	if err := decodePatch(action, &patch); err != nil {
 		return err
 	}
+	if patch.Status != nil && strings.TrimSpace(*patch.Status) == projectwork.WorkItemStatusDone {
+		readiness, err := p.workItemReadiness(ctx, item)
+		if err != nil {
+			return err
+		}
+		if readiness.Status != "done" && !readiness.Ready {
+			return fmt.Errorf("%w: %w", ErrConflict, projectwork.WorkItemCloseoutBlockedError{Readiness: readiness})
+		}
+	}
 	if patch.Title != nil {
 		item.Title = *patch.Title
 	}
+	if patch.Brief != nil {
+		item.Brief = *patch.Brief
+	}
 	if patch.Status != nil {
 		item.Status = *patch.Status
+	}
+	if patch.Priority != nil {
+		item.Priority = *patch.Priority
+	}
+	if patch.OwnerRoleID != nil {
+		item.OwnerRoleID = *patch.OwnerRoleID
+	}
+	if patch.ReviewerRoleIDs != nil {
+		item.ReviewerRoleIDs = append([]string(nil), patch.ReviewerRoleIDs...)
 	}
 	p.workItems[scopedKey(projectID, workItemID)] = item
 	return nil
@@ -293,15 +314,20 @@ func (p *applyPreflight) createAssignment(ctx context.Context, action Action) er
 		}
 	}
 	id := strings.TrimSpace(patch.ID)
-	if id == "" {
-		return nil
+	if id != "" {
+		if exists, err := p.assignmentExists(ctx, projectID, id); err != nil {
+			return err
+		} else if exists {
+			return fmt.Errorf("%w: assignment %q already exists", ErrConflict, id)
+		}
+	} else {
+		id = preflightSyntheticID("assignment", len(p.assignments))
 	}
-	if exists, err := p.assignmentExists(ctx, projectID, id); err != nil {
-		return err
-	} else if exists {
-		return fmt.Errorf("%w: assignment %q already exists", ErrConflict, id)
+	status := strings.TrimSpace(patch.Status)
+	if status == "" {
+		status = projectwork.AssignmentStatusQueued
 	}
-	p.assignments[scopedKey(projectID, id)] = projectwork.Assignment{ID: id, ProjectID: projectID, WorkItemID: item.ID, RoleID: patch.RoleID}
+	p.assignments[scopedKey(projectID, id)] = projectwork.Assignment{ID: id, ProjectID: projectID, WorkItemID: item.ID, RoleID: patch.RoleID, RootID: strings.TrimSpace(patch.RootID), DriverKind: strings.TrimSpace(patch.DriverKind), Status: status}
 	return nil
 }
 
@@ -338,15 +364,29 @@ func (p *applyPreflight) createHandoff(ctx context.Context, action Action) error
 		}
 	}
 	id := strings.TrimSpace(patch.ID)
-	if id == "" {
-		return nil
+	if id != "" {
+		if exists, err := p.handoffExists(ctx, projectID, id); err != nil {
+			return err
+		} else if exists {
+			return fmt.Errorf("%w: handoff %q already exists", ErrConflict, id)
+		}
+	} else {
+		id = preflightSyntheticID("handoff", len(p.handoffs))
 	}
-	if exists, err := p.handoffExists(ctx, projectID, id); err != nil {
-		return err
-	} else if exists {
-		return fmt.Errorf("%w: handoff %q already exists", ErrConflict, id)
+	status := strings.TrimSpace(patch.Status)
+	if status == "" {
+		status = projectwork.HandoffStatusPending
 	}
-	p.handoffs[scopedKey(projectID, id)] = projectwork.Handoff{ID: id, ProjectID: projectID, WorkItemID: item.ID, TargetWorkItemID: patch.TargetWorkItemID}
+	p.handoffs[scopedKey(projectID, id)] = projectwork.Handoff{
+		ID:                 id,
+		ProjectID:          projectID,
+		WorkItemID:         item.ID,
+		TargetRoleID:       strings.TrimSpace(patch.TargetRoleID),
+		TargetAssignmentID: strings.TrimSpace(patch.TargetAssignmentID),
+		TargetWorkItemID:   strings.TrimSpace(patch.TargetWorkItemID),
+		LinkedArtifactIDs:  append([]string(nil), patch.LinkedArtifactIDs...),
+		Status:             status,
+	}
 	return nil
 }
 
@@ -383,6 +423,19 @@ func (p *applyPreflight) updateHandoff(ctx context.Context, action Action) error
 			return fmt.Errorf("%w: target assignment %q", ErrNotFound, *patch.TargetAssignmentID)
 		}
 		handoff.TargetAssignmentID = strings.TrimSpace(*patch.TargetAssignmentID)
+	}
+	if patch.TargetAssignmentID != nil && strings.TrimSpace(*patch.TargetAssignmentID) == "" {
+		handoff.TargetAssignmentID = ""
+	}
+	if patch.TargetRoleID != nil {
+		handoff.TargetRoleID = strings.TrimSpace(*patch.TargetRoleID)
+	}
+	if patch.Status != nil {
+		status := strings.TrimSpace(*patch.Status)
+		if status == "" {
+			status = projectwork.HandoffStatusPending
+		}
+		handoff.Status = status
 	}
 	p.handoffs[scopedKey(projectID, handoffID)] = handoff
 	return nil
@@ -471,6 +524,68 @@ func (p *applyPreflight) requireWorkItem(ctx context.Context, projectID, workIte
 	}
 	p.workItems[key] = item
 	return item, nil
+}
+
+func (p *applyPreflight) workItemReadiness(ctx context.Context, item projectwork.WorkItem) (projectwork.WorkItemReadiness, error) {
+	assignments, err := p.assignmentsForWorkItem(ctx, item.ProjectID, item.ID)
+	if err != nil {
+		return projectwork.WorkItemReadiness{}, err
+	}
+	artifacts, err := p.service.work.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: item.ProjectID, WorkItemID: item.ID})
+	if err != nil {
+		return projectwork.WorkItemReadiness{}, err
+	}
+	handoffs, err := p.handoffsForWorkItem(ctx, item.ProjectID, item.ID)
+	if err != nil {
+		return projectwork.WorkItemReadiness{}, err
+	}
+	return projectwork.EvaluateWorkItemReadiness(item, assignments, artifacts, handoffs), nil
+}
+
+func (p *applyPreflight) assignmentsForWorkItem(ctx context.Context, projectID, workItemID string) ([]projectwork.Assignment, error) {
+	items, err := p.service.work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return nil, err
+	}
+	indexByID := make(map[string]int, len(items)+len(p.assignments))
+	for idx, assignment := range items {
+		indexByID[assignment.ID] = idx
+	}
+	for _, assignment := range p.assignments {
+		if assignment.ProjectID != projectID || assignment.WorkItemID != workItemID {
+			continue
+		}
+		if idx, ok := indexByID[assignment.ID]; ok {
+			items[idx] = assignment
+			continue
+		}
+		indexByID[assignment.ID] = len(items)
+		items = append(items, assignment)
+	}
+	return items, nil
+}
+
+func (p *applyPreflight) handoffsForWorkItem(ctx context.Context, projectID, workItemID string) ([]projectwork.Handoff, error) {
+	items, err := p.service.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return nil, err
+	}
+	indexByID := make(map[string]int, len(items)+len(p.handoffs))
+	for idx, handoff := range items {
+		indexByID[handoff.ID] = idx
+	}
+	for _, handoff := range p.handoffs {
+		if handoff.ProjectID != projectID || handoff.WorkItemID != workItemID {
+			continue
+		}
+		if idx, ok := indexByID[handoff.ID]; ok {
+			items[idx] = handoff
+			continue
+		}
+		indexByID[handoff.ID] = len(items)
+		items = append(items, handoff)
+	}
+	return items, nil
 }
 
 func (p *applyPreflight) workItemExists(ctx context.Context, projectID, workItemID string) (bool, error) {
@@ -654,4 +769,8 @@ func preflightRootFromPatch(patch rootPatch) projects.Root {
 
 func scopedKey(scope, id string) string {
 	return strings.TrimSpace(scope) + "\x00" + strings.TrimSpace(id)
+}
+
+func preflightSyntheticID(kind string, count int) string {
+	return fmt.Sprintf("__preflight_%s_%d", strings.TrimSpace(kind), count+1)
 }

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -48,6 +48,7 @@ type Service struct {
 	projects         projects.Store
 	chats            chat.Store
 	work             projectwork.Store
+	workAuthority    WorkAuthority
 	projectSkills    projectskills.Store
 	memory           memory.Store
 	memoryCandidates memory.CandidateStore
@@ -60,6 +61,7 @@ type Stores struct {
 	Projects         projects.Store
 	Chats            chat.Store
 	Work             projectwork.Store
+	WorkAuthority    WorkAuthority
 	ProjectSkills    projectskills.Store
 	Memory           memory.Store
 	MemoryCandidates memory.CandidateStore
@@ -174,6 +176,7 @@ func NewService(stores Stores, idgen IDGenerator) *Service {
 		projects:         stores.Projects,
 		chats:            stores.Chats,
 		work:             stores.Work,
+		workAuthority:    workAuthorityForStores(stores),
 		projectSkills:    stores.ProjectSkills,
 		memory:           stores.Memory,
 		memoryCandidates: stores.MemoryCandidates,

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -1912,6 +1912,75 @@ func TestService_ApplyPreflightBlocksStaleTargetsBeforeMutatingAcrossStores(t *t
 	}
 }
 
+func TestService_ApplyPreflightBlocksCloseoutBeforeMutatingAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+			workItem, err := fixture.work.CreateWorkItem(ctx, projectwork.WorkItem{
+				ID:        "work_closeout_preflight",
+				ProjectID: project.ID,
+				Title:     "Closeout preflight",
+				Status:    projectwork.WorkItemStatusReview,
+			})
+			if err != nil {
+				t.Fatalf("CreateWorkItem: %v", err)
+			}
+			proposal := Proposal{
+				ID:                   "pa_closeout_preflight",
+				RequiresConfirmation: true,
+				Actions: []Action{
+					{
+						Kind: ActionCreateHandoff,
+						Patch: rawPatch(t, map[string]any{
+							"id":                      "handoff_pending",
+							"project_id":              project.ID,
+							"work_item_id":            workItem.ID,
+							"title":                   "Pending follow-up",
+							"summary":                 "Follow-up should block closeout.",
+							"recommended_next_action": "Resolve before marking done.",
+						}),
+					},
+					{
+						Kind:   ActionUpdateWorkItem,
+						Target: map[string]string{"project_id": project.ID, "work_item_id": workItem.ID},
+						Patch:  rawPatch(t, map[string]string{"status": projectwork.WorkItemStatusDone}),
+					},
+				},
+			}
+
+			result, err := fixture.service.Apply(ctx, proposal, true)
+			if !errors.Is(err, ErrConflict) || !errors.Is(err, projectwork.ErrWorkItemCloseoutBlocked) {
+				t.Fatalf("Apply err = %v result=%+v, want closeout conflict", err, result)
+			}
+			var applyErr *ApplyError
+			if !errors.As(err, &applyErr) {
+				t.Fatalf("Apply err = %T %v, want ApplyError", err, err)
+			}
+			if applyErr.FailedActionIndex != 1 || len(applyErr.Result.Actions) != 0 {
+				t.Fatalf("apply error = %+v, want preflight failure at done action with no committed actions", applyErr)
+			}
+			handoffs, err := fixture.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: project.ID, WorkItemID: workItem.ID})
+			if err != nil {
+				t.Fatalf("ListHandoffs: %v", err)
+			}
+			if len(handoffs) != 0 {
+				t.Fatalf("handoffs = %+v, want no durable handoff after preflight closeout block", handoffs)
+			}
+			stored, ok, err := fixture.work.GetWorkItem(ctx, project.ID, workItem.ID)
+			if err != nil || !ok {
+				t.Fatalf("GetWorkItem ok=%v err=%v, want stored item", ok, err)
+			}
+			if stored.Status == projectwork.WorkItemStatusDone {
+				t.Fatalf("work item status = %q, want not done after preflight closeout block", stored.Status)
+			}
+		})
+	}
+}
+
 func TestService_ApplyPreflightBlocksMissingHandoffTargetBeforeMutatingAcrossStores(t *testing.T) {
 	t.Parallel()
 	for _, builder := range assistantFixtureBuilders() {

--- a/internal/projectassistant/work_authority.go
+++ b/internal/projectassistant/work_authority.go
@@ -1,0 +1,144 @@
+package projectassistant
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type WorkAuthority interface {
+	CreateRole(ctx context.Context, projectID string, cmd WorkRoleCommand) (projectwork.AgentRoleProfile, error)
+	CreateWorkItem(ctx context.Context, projectID string, cmd WorkItemCommand) (projectwork.WorkItem, error)
+	UpdateWorkItem(ctx context.Context, projectID, workItemID string, cmd WorkItemUpdateCommand) (projectwork.WorkItem, error)
+	CreateAssignment(ctx context.Context, projectID, workItemID string, cmd WorkAssignmentCommand) (projectwork.Assignment, error)
+}
+
+type WorkRoleCommand struct {
+	ID                  string
+	Name                string
+	Description         string
+	Instructions        string
+	DefaultDriverKind   string
+	DefaultProvider     string
+	DefaultModel        string
+	DefaultAgentProfile string
+	SkillIDs            []string
+}
+
+type WorkItemCommand struct {
+	ID              string
+	Title           string
+	Brief           string
+	Status          string
+	Priority        string
+	OwnerRoleID     string
+	ReviewerRoleIDs []string
+}
+
+type WorkItemUpdateCommand struct {
+	Title           *string
+	Brief           *string
+	Status          *string
+	Priority        *string
+	OwnerRoleID     *string
+	ReviewerRoleIDs *[]string
+}
+
+type WorkAssignmentCommand struct {
+	ID         string
+	RoleID     string
+	RootID     string
+	DriverKind string
+	Status     string
+}
+
+func workAuthorityForStores(stores Stores) WorkAuthority {
+	if stores.WorkAuthority != nil {
+		return stores.WorkAuthority
+	}
+	if stores.Work == nil {
+		return nil
+	}
+	return storeWorkAuthority{store: stores.Work}
+}
+
+type storeWorkAuthority struct {
+	store projectwork.Store
+}
+
+func (authority storeWorkAuthority) CreateRole(ctx context.Context, projectID string, cmd WorkRoleCommand) (projectwork.AgentRoleProfile, error) {
+	return authority.store.CreateRole(ctx, projectwork.AgentRoleProfile{
+		ID:                  cmd.ID,
+		ProjectID:           projectID,
+		Name:                cmd.Name,
+		Description:         cmd.Description,
+		Instructions:        cmd.Instructions,
+		DefaultDriverKind:   cmd.DefaultDriverKind,
+		DefaultProvider:     cmd.DefaultProvider,
+		DefaultModel:        cmd.DefaultModel,
+		DefaultAgentProfile: cmd.DefaultAgentProfile,
+		SkillIDs:            append([]string(nil), cmd.SkillIDs...),
+	})
+}
+
+func (authority storeWorkAuthority) CreateWorkItem(ctx context.Context, projectID string, cmd WorkItemCommand) (projectwork.WorkItem, error) {
+	return authority.store.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:              cmd.ID,
+		ProjectID:       projectID,
+		Title:           cmd.Title,
+		Brief:           cmd.Brief,
+		Status:          cmd.Status,
+		Priority:        cmd.Priority,
+		OwnerRoleID:     cmd.OwnerRoleID,
+		ReviewerRoleIDs: append([]string(nil), cmd.ReviewerRoleIDs...),
+	})
+}
+
+func (authority storeWorkAuthority) UpdateWorkItem(ctx context.Context, projectID, workItemID string, cmd WorkItemUpdateCommand) (projectwork.WorkItem, error) {
+	return authority.store.UpdateWorkItem(ctx, projectID, workItemID, func(item *projectwork.WorkItem) {
+		if cmd.Title != nil {
+			item.Title = *cmd.Title
+		}
+		if cmd.Brief != nil {
+			item.Brief = *cmd.Brief
+		}
+		if cmd.Status != nil {
+			item.Status = *cmd.Status
+		}
+		if cmd.Priority != nil {
+			item.Priority = *cmd.Priority
+		}
+		if cmd.OwnerRoleID != nil {
+			item.OwnerRoleID = *cmd.OwnerRoleID
+		}
+		if cmd.ReviewerRoleIDs != nil {
+			item.ReviewerRoleIDs = append([]string(nil), *cmd.ReviewerRoleIDs...)
+		}
+	})
+}
+
+func (authority storeWorkAuthority) CreateAssignment(ctx context.Context, projectID, workItemID string, cmd WorkAssignmentCommand) (projectwork.Assignment, error) {
+	driverKind := strings.TrimSpace(cmd.DriverKind)
+	if driverKind == "" {
+		if roles, err := authority.store.ListRoles(ctx, projectID); err != nil {
+			return projectwork.Assignment{}, err
+		} else {
+			for _, role := range roles {
+				if role.ID == strings.TrimSpace(cmd.RoleID) {
+					driverKind = role.DefaultDriverKind
+					break
+				}
+			}
+		}
+	}
+	return authority.store.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         cmd.ID,
+		ProjectID:  projectID,
+		WorkItemID: workItemID,
+		RoleID:     cmd.RoleID,
+		RootID:     cmd.RootID,
+		DriverKind: driverKind,
+		Status:     cmd.Status,
+	})
+}

--- a/internal/projectassistantapp/application.go
+++ b/internal/projectassistantapp/application.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 type Application struct {
@@ -19,6 +20,7 @@ type Options struct {
 	Projects         projects.Store
 	Chats            chat.Store
 	Work             projectwork.Store
+	WorkApplication  *projectworkapp.Application
 	ProjectSkills    projectskills.Store
 	Memory           memory.Store
 	MemoryCandidates memory.CandidateStore
@@ -62,11 +64,16 @@ type ApplyCommand struct {
 }
 
 func New(options Options) *Application {
+	var workAuthority projectassistant.WorkAuthority
+	if options.WorkApplication != nil {
+		workAuthority = projectWorkAuthority{app: options.WorkApplication}
+	}
 	return &Application{
 		service: projectassistant.NewService(projectassistant.Stores{
 			Projects:         options.Projects,
 			Chats:            options.Chats,
 			Work:             options.Work,
+			WorkAuthority:    workAuthority,
 			ProjectSkills:    options.ProjectSkills,
 			Memory:           options.Memory,
 			MemoryCandidates: options.MemoryCandidates,

--- a/internal/projectassistantapp/application_test.go
+++ b/internal/projectassistantapp/application_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 func TestApplication_ContextDelegatesToProjectAssistantService(t *testing.T) {
@@ -112,6 +113,61 @@ func TestApplication_ApplyKeepsProgressInCachedApplication(t *testing.T) {
 	}
 	if _, err := app.Apply(ctx, ApplyCommand{Proposal: proposal, Confirm: true}); !errors.Is(err, projectassistant.ErrConflict) {
 		t.Fatalf("Apply(repeated) error = %v, want ErrConflict", err)
+	}
+}
+
+func TestApplication_ApplyWorkItemDoneUsesProjectWorkAuthority(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	projectStore := projects.NewMemoryStore()
+	workStore := projectwork.NewMemoryStore()
+	if _, err := projectStore.Create(ctx, projects.Project{ID: "proj_closeout", Name: "Closeout"}); err != nil {
+		t.Fatalf("Create(project) error = %v", err)
+	}
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:        "work_closeout",
+		ProjectID: "proj_closeout",
+		Title:     "Closeout gated work",
+		Status:    projectwork.WorkItemStatusReview,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem() error = %v", err)
+	}
+	if _, err := workStore.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_closeout",
+		ProjectID:  "proj_closeout",
+		WorkItemID: "work_closeout",
+		RoleID:     "software_developer",
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("CreateAssignment() error = %v", err)
+	}
+	app := New(Options{
+		Projects:        projectStore,
+		Work:            workStore,
+		WorkApplication: projectworkapp.New(projectworkapp.Options{Store: workStore}),
+	})
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_closeout",
+		Title:                "Mark done",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{{
+			Kind:   projectassistant.ActionUpdateWorkItem,
+			Target: map[string]string{"project_id": "proj_closeout", "work_item_id": "work_closeout"},
+			Patch:  rawJSON(t, map[string]string{"status": projectwork.WorkItemStatusDone}),
+		}},
+	}
+
+	result, err := app.Apply(ctx, ApplyCommand{Proposal: proposal, Confirm: true})
+	if !errors.Is(err, projectassistant.ErrConflict) || !errors.Is(err, projectworkapp.ErrWorkItemCloseoutBlocked) {
+		t.Fatalf("Apply(done) result=%+v error=%v, want Project Assistant conflict wrapping closeout blocker", result, err)
+	}
+	stored, ok, err := workStore.GetWorkItem(ctx, "proj_closeout", "work_closeout")
+	if err != nil || !ok {
+		t.Fatalf("GetWorkItem() ok=%v err=%v, want stored work item", ok, err)
+	}
+	if stored.Status == projectwork.WorkItemStatusDone {
+		t.Fatalf("stored status = %q, want closeout guard to keep item open", stored.Status)
 	}
 }
 

--- a/internal/projectassistantapp/work_authority.go
+++ b/internal/projectassistantapp/work_authority.go
@@ -1,0 +1,92 @@
+package projectassistantapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
+)
+
+type projectWorkAuthority struct {
+	app *projectworkapp.Application
+}
+
+func (authority projectWorkAuthority) CreateRole(ctx context.Context, projectID string, cmd projectassistant.WorkRoleCommand) (projectwork.AgentRoleProfile, error) {
+	role, err := authority.app.CreateRole(ctx, projectID, projectworkapp.CreateRoleCommand{
+		ID:                  cmd.ID,
+		Name:                cmd.Name,
+		Description:         cmd.Description,
+		Instructions:        cmd.Instructions,
+		DefaultDriverKind:   cmd.DefaultDriverKind,
+		DefaultProvider:     cmd.DefaultProvider,
+		DefaultModel:        cmd.DefaultModel,
+		DefaultAgentProfile: cmd.DefaultAgentProfile,
+		SkillIDs:            append([]string(nil), cmd.SkillIDs...),
+	})
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, mapProjectWorkApplicationErr(err)
+	}
+	return role, nil
+}
+
+func (authority projectWorkAuthority) CreateWorkItem(ctx context.Context, projectID string, cmd projectassistant.WorkItemCommand) (projectwork.WorkItem, error) {
+	item, err := authority.app.CreateWorkItem(ctx, projectID, projectworkapp.CreateWorkItemCommand{
+		ID:              cmd.ID,
+		Title:           cmd.Title,
+		Brief:           cmd.Brief,
+		Status:          cmd.Status,
+		Priority:        cmd.Priority,
+		OwnerRoleID:     cmd.OwnerRoleID,
+		ReviewerRoleIDs: append([]string(nil), cmd.ReviewerRoleIDs...),
+	})
+	if err != nil {
+		return projectwork.WorkItem{}, mapProjectWorkApplicationErr(err)
+	}
+	return item, nil
+}
+
+func (authority projectWorkAuthority) UpdateWorkItem(ctx context.Context, projectID, workItemID string, cmd projectassistant.WorkItemUpdateCommand) (projectwork.WorkItem, error) {
+	appCmd := projectworkapp.UpdateWorkItemCommand{
+		Title:       cmd.Title,
+		Brief:       cmd.Brief,
+		Status:      cmd.Status,
+		Priority:    cmd.Priority,
+		OwnerRoleID: cmd.OwnerRoleID,
+	}
+	if cmd.ReviewerRoleIDs != nil {
+		reviewerRoleIDs := append([]string(nil), *cmd.ReviewerRoleIDs...)
+		appCmd.ReviewerRoleIDs = &reviewerRoleIDs
+	}
+	item, err := authority.app.UpdateWorkItem(ctx, projectID, workItemID, appCmd)
+	if err != nil {
+		return projectwork.WorkItem{}, mapProjectWorkApplicationErr(err)
+	}
+	return item, nil
+}
+
+func (authority projectWorkAuthority) CreateAssignment(ctx context.Context, projectID, workItemID string, cmd projectassistant.WorkAssignmentCommand) (projectwork.Assignment, error) {
+	assignment, err := authority.app.CreateAssignment(ctx, projectID, workItemID, projectworkapp.CreateAssignmentCommand{
+		ID:         cmd.ID,
+		RoleID:     cmd.RoleID,
+		RootID:     cmd.RootID,
+		DriverKind: cmd.DriverKind,
+		Status:     cmd.Status,
+	})
+	if err != nil {
+		return projectwork.Assignment{}, mapProjectWorkApplicationErr(err)
+	}
+	return assignment, nil
+}
+
+func mapProjectWorkApplicationErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, projectworkapp.ErrWorkItemCloseoutBlocked) {
+		return fmt.Errorf("%w: %w", projectassistant.ErrConflict, err)
+	}
+	return err
+}

--- a/internal/projectwork/closeout_readiness.go
+++ b/internal/projectwork/closeout_readiness.go
@@ -1,0 +1,312 @@
+package projectwork
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+var ErrWorkItemCloseoutBlocked = errors.New("project work item closeout blocked")
+
+type WorkItemReadiness struct {
+	ProjectID                    string
+	WorkItemID                   string
+	Ready                        bool
+	Status                       string
+	Title                        string
+	Detail                       string
+	Blockers                     []string
+	Warnings                     []string
+	AssignmentCount              int
+	CompletedAssignments         int
+	ReviewFollowUpCount          int
+	ReviewFollowUpArtifactIDs    []string
+	ReviewFollowUps              []ReviewFollowUpReadiness
+	MissingEvidenceAssignmentIDs []string
+}
+
+type ReviewFollowUpReadiness struct {
+	ArtifactID           string
+	Title                string
+	Status               string
+	Blocker              string
+	ReviewedAssignmentID string
+	ReviewVerdict        string
+	ReviewRisk           string
+}
+
+type WorkItemCloseoutBlockedError struct {
+	Readiness WorkItemReadiness
+}
+
+func (e WorkItemCloseoutBlockedError) Error() string {
+	return ErrWorkItemCloseoutBlocked.Error()
+}
+
+func (e WorkItemCloseoutBlockedError) Unwrap() error {
+	return ErrWorkItemCloseoutBlocked
+}
+
+func EvaluateWorkItemReadiness(workItem WorkItem, assignments []Assignment, artifacts []CollaborationArtifact, handoffs []Handoff) WorkItemReadiness {
+	statuses := make([]string, 0, len(assignments))
+	assignmentsByID := AssignmentsByID(assignments)
+	closed := WorkItemClosed(workItem.Status)
+	readiness := WorkItemReadiness{
+		ProjectID:            workItem.ProjectID,
+		WorkItemID:           workItem.ID,
+		Status:               "ready",
+		Title:                "Ready to mark done",
+		Detail:               "Assignments, evidence, handoffs, and review follow-up are clear. The operator can mark this work item done.",
+		AssignmentCount:      len(assignments),
+		CompletedAssignments: 0,
+	}
+
+	for _, assignment := range assignments {
+		status := AssignmentReadinessStatus(assignment)
+		statuses = append(statuses, status)
+		if status != AssignmentStatusCompleted {
+			continue
+		}
+		readiness.CompletedAssignments++
+		if !closed && !AssignmentHasCloseoutEvidence(assignment, artifacts) {
+			readiness.MissingEvidenceAssignmentIDs = append(readiness.MissingEvidenceAssignmentIDs, assignment.ID)
+		}
+	}
+	if closed {
+		readiness.Status = "done"
+		readiness.Title = "Work item is done"
+		readiness.Detail = "This work item has already been marked done by the operator."
+		return readiness
+	}
+
+	activeAssignments := readinessStatusCount(statuses, IsActiveAssignmentStatus)
+	failedAssignments := readinessStatusCount(statuses, func(status string) bool {
+		return status == AssignmentStatusFailed
+	})
+	cancelledAssignments := readinessStatusCount(statuses, func(status string) bool {
+		return status == AssignmentStatusCancelled
+	})
+	unresolvedAssignments := readinessStatusCount(statuses, IsUnresolvedAssignmentStatus)
+	pendingHandoffs := 0
+	for _, handoff := range handoffs {
+		if handoff.Status == HandoffStatusPending {
+			pendingHandoffs++
+		}
+	}
+	if activeAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(activeAssignments, "assignment is still active", "assignments are still active"))
+	}
+	if failedAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(failedAssignments, "assignment failed", "assignments failed"))
+	}
+	if cancelledAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(cancelledAssignments, "assignment was cancelled", "assignments were cancelled"))
+	}
+	if unresolvedAssignments > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(unresolvedAssignments, "assignment is not complete", "assignments are not complete"))
+	}
+	if pendingHandoffs > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(pendingHandoffs, "handoff is pending", "handoffs are pending"))
+	}
+	if len(readiness.MissingEvidenceAssignmentIDs) > 0 {
+		readiness.Blockers = append(readiness.Blockers, readinessPlural(len(readiness.MissingEvidenceAssignmentIDs), "completed assignment is missing evidence", "completed assignments are missing evidence"))
+	}
+	if len(assignments) == 0 {
+		readiness.Warnings = append(readiness.Warnings, "No assignments are linked to this work item; closeout is manual.")
+	}
+	for _, artifact := range artifacts {
+		if ReviewArtifactNeedsFollowUpPath(artifact, handoffs) {
+			blocker := ReviewFollowUpBlocker(artifact, handoffs, assignmentsByID)
+			readiness.ReviewFollowUpArtifactIDs = append(readiness.ReviewFollowUpArtifactIDs, artifact.ID)
+			readiness.ReviewFollowUps = append(readiness.ReviewFollowUps, renderReviewFollowUpReadiness(artifact, blocker))
+		}
+		if blocker := ReviewFollowUpBlocker(artifact, handoffs, assignmentsByID); blocker != "" {
+			readiness.Blockers = append(readiness.Blockers, blocker)
+		}
+	}
+	readiness.ReviewFollowUpCount = len(readiness.ReviewFollowUpArtifactIDs)
+	readiness.Blockers = UniqueReadinessStrings(readiness.Blockers)
+	readiness.Warnings = UniqueReadinessStrings(readiness.Warnings)
+	if len(readiness.Blockers) > 0 {
+		readiness.Status = "blocked"
+		readiness.Title = "Closeout is blocked"
+		readiness.Detail = "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done."
+	}
+	readiness.Ready = readiness.Status == "ready"
+	return readiness
+}
+
+func ReviewFollowUpArtifact(artifacts []CollaborationArtifact, handoffs []Handoff) *CollaborationArtifact {
+	items := append([]CollaborationArtifact(nil), artifacts...)
+	sort.SliceStable(items, func(i, j int) bool {
+		left, right := firstNonZeroReadinessTime(items[i].UpdatedAt, items[i].CreatedAt), firstNonZeroReadinessTime(items[j].UpdatedAt, items[j].CreatedAt)
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return items[i].ID < items[j].ID
+	})
+	for i := range items {
+		if ReviewArtifactNeedsFollowUpPath(items[i], handoffs) {
+			return &items[i]
+		}
+	}
+	return nil
+}
+
+func ReviewFollowUpBlocker(artifact CollaborationArtifact, handoffs []Handoff, assignmentsByID map[string]Assignment) string {
+	if !ReviewArtifactRequiresFollowUp(artifact) {
+		return ""
+	}
+	title := firstNonEmptyReadinessString(artifact.Title, artifact.ID)
+	linked := make([]Handoff, 0)
+	for _, handoff := range handoffs {
+		for _, artifactID := range handoff.LinkedArtifactIDs {
+			if strings.TrimSpace(artifactID) == artifact.ID {
+				linked = append(linked, handoff)
+				break
+			}
+		}
+	}
+	if len(linked) == 0 {
+		return fmt.Sprintf("Review follow-up %q is not triaged", title)
+	}
+	hasTargetAssignment := false
+	hasCompletedTarget := false
+	hasDismissedOrSuperseded := false
+	for _, handoff := range linked {
+		if handoff.Status == HandoffStatusPending {
+			return fmt.Sprintf("Review follow-up %q has a pending handoff", title)
+		}
+		if handoff.Status == HandoffStatusDismissed || handoff.Status == HandoffStatusSuperseded {
+			hasDismissedOrSuperseded = true
+		}
+		if strings.TrimSpace(handoff.TargetAssignmentID) == "" {
+			continue
+		}
+		hasTargetAssignment = true
+		if assignment, ok := assignmentsByID[handoff.TargetAssignmentID]; ok {
+			hasCompletedTarget = hasCompletedTarget || AssignmentReadinessStatus(assignment) == AssignmentStatusCompleted
+		}
+	}
+	if hasCompletedTarget {
+		return ""
+	}
+	if hasTargetAssignment {
+		return fmt.Sprintf("Review follow-up %q assignment is not completed", title)
+	}
+	if hasDismissedOrSuperseded {
+		return ""
+	}
+	return fmt.Sprintf("Review follow-up %q is not triaged", title)
+}
+
+func AssignmentReadinessStatus(assignment Assignment) string {
+	return firstNonEmptyReadinessString(assignment.ExecutionRef.Status, assignment.Status)
+}
+
+func IsActiveAssignmentStatus(status string) bool {
+	return status == AssignmentStatusQueued || status == AssignmentStatusRunning || status == AssignmentStatusAwaitingApproval
+}
+
+func IsUnresolvedAssignmentStatus(status string) bool {
+	return status != AssignmentStatusCompleted &&
+		status != AssignmentStatusFailed &&
+		status != AssignmentStatusCancelled &&
+		!IsActiveAssignmentStatus(status)
+}
+
+func AssignmentHasCloseoutEvidence(assignment Assignment, artifacts []CollaborationArtifact) bool {
+	for _, artifact := range artifacts {
+		if artifact.Kind != ArtifactKindEvidenceLink {
+			continue
+		}
+		if artifact.AssignmentID == "" || artifact.AssignmentID == assignment.ID {
+			return true
+		}
+	}
+	return false
+}
+
+func AssignmentsByID(assignments []Assignment) map[string]Assignment {
+	byID := make(map[string]Assignment, len(assignments))
+	for _, assignment := range assignments {
+		byID[assignment.ID] = assignment
+	}
+	return byID
+}
+
+func WorkItemClosed(status string) bool {
+	switch strings.TrimSpace(status) {
+	case WorkItemStatusDone, WorkItemStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func UniqueReadinessStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}
+
+func renderReviewFollowUpReadiness(artifact CollaborationArtifact, blocker string) ReviewFollowUpReadiness {
+	return ReviewFollowUpReadiness{
+		ArtifactID:           artifact.ID,
+		Title:                firstNonEmptyReadinessString(artifact.Title, artifact.ID),
+		Status:               "needs_path",
+		Blocker:              strings.TrimSpace(blocker),
+		ReviewedAssignmentID: artifact.ReviewedAssignmentID,
+		ReviewVerdict:        artifact.ReviewVerdict,
+		ReviewRisk:           artifact.ReviewRisk,
+	}
+}
+
+func readinessStatusCount(statuses []string, predicate func(string) bool) int {
+	count := 0
+	for _, status := range statuses {
+		if predicate(status) {
+			count++
+		}
+	}
+	return count
+}
+
+func readinessPlural(count int, singular, plural string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %s", count, plural)
+}
+
+func firstNonEmptyReadinessString(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNonZeroReadinessTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/projectworkapp/closeout_readiness.go
+++ b/internal/projectworkapp/closeout_readiness.go
@@ -2,54 +2,15 @@ package projectworkapp
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
-var ErrWorkItemCloseoutBlocked = errors.New("project work item closeout blocked")
+var ErrWorkItemCloseoutBlocked = projectwork.ErrWorkItemCloseoutBlocked
 
-type WorkItemReadiness struct {
-	ProjectID                    string
-	WorkItemID                   string
-	Ready                        bool
-	Status                       string
-	Title                        string
-	Detail                       string
-	Blockers                     []string
-	Warnings                     []string
-	AssignmentCount              int
-	CompletedAssignments         int
-	ReviewFollowUpCount          int
-	ReviewFollowUpArtifactIDs    []string
-	ReviewFollowUps              []ReviewFollowUpReadiness
-	MissingEvidenceAssignmentIDs []string
-}
-
-type ReviewFollowUpReadiness struct {
-	ArtifactID           string
-	Title                string
-	Status               string
-	Blocker              string
-	ReviewedAssignmentID string
-	ReviewVerdict        string
-	ReviewRisk           string
-}
-
-type WorkItemCloseoutBlockedError struct {
-	Readiness WorkItemReadiness
-}
-
-func (e WorkItemCloseoutBlockedError) Error() string {
-	return ErrWorkItemCloseoutBlocked.Error()
-}
-
-func (e WorkItemCloseoutBlockedError) Unwrap() error {
-	return ErrWorkItemCloseoutBlocked
-}
+type WorkItemReadiness = projectwork.WorkItemReadiness
+type ReviewFollowUpReadiness = projectwork.ReviewFollowUpReadiness
+type WorkItemCloseoutBlockedError = projectwork.WorkItemCloseoutBlockedError
 
 func (app *Application) WorkItemReadiness(ctx context.Context, projectID, workItemID string) (WorkItemReadiness, error) {
 	if app == nil || app.store == nil {
@@ -74,113 +35,15 @@ func (app *Application) WorkItemReadiness(ctx context.Context, projectID, workIt
 	if err != nil {
 		return WorkItemReadiness{}, err
 	}
-	return EvaluateWorkItemReadiness(workItem, assignments, artifacts, handoffs), nil
+	return projectwork.EvaluateWorkItemReadiness(workItem, assignments, artifacts, handoffs), nil
 }
 
 func EvaluateWorkItemReadiness(workItem projectwork.WorkItem, assignments []projectwork.Assignment, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) WorkItemReadiness {
-	statuses := make([]string, 0, len(assignments))
-	assignmentsByID := AssignmentsByID(assignments)
-	closed := WorkItemClosed(workItem.Status)
-	readiness := WorkItemReadiness{
-		ProjectID:            workItem.ProjectID,
-		WorkItemID:           workItem.ID,
-		Status:               "ready",
-		Title:                "Ready to mark done",
-		Detail:               "Assignments, evidence, handoffs, and review follow-up are clear. The operator can mark this work item done.",
-		AssignmentCount:      len(assignments),
-		CompletedAssignments: 0,
-	}
-
-	for _, assignment := range assignments {
-		status := AssignmentReadinessStatus(assignment)
-		statuses = append(statuses, status)
-		if status != projectwork.AssignmentStatusCompleted {
-			continue
-		}
-		readiness.CompletedAssignments++
-		if !closed && !AssignmentHasCloseoutEvidence(assignment, artifacts) {
-			readiness.MissingEvidenceAssignmentIDs = append(readiness.MissingEvidenceAssignmentIDs, assignment.ID)
-		}
-	}
-	if closed {
-		readiness.Status = "done"
-		readiness.Title = "Work item is done"
-		readiness.Detail = "This work item has already been marked done by the operator."
-		return readiness
-	}
-
-	activeAssignments := readinessStatusCount(statuses, IsActiveAssignmentStatus)
-	failedAssignments := readinessStatusCount(statuses, func(status string) bool {
-		return status == projectwork.AssignmentStatusFailed
-	})
-	cancelledAssignments := readinessStatusCount(statuses, func(status string) bool {
-		return status == projectwork.AssignmentStatusCancelled
-	})
-	unresolvedAssignments := readinessStatusCount(statuses, IsUnresolvedAssignmentStatus)
-	pendingHandoffs := 0
-	for _, handoff := range handoffs {
-		if handoff.Status == projectwork.HandoffStatusPending {
-			pendingHandoffs++
-		}
-	}
-	if activeAssignments > 0 {
-		readiness.Blockers = append(readiness.Blockers, readinessPlural(activeAssignments, "assignment is still active", "assignments are still active"))
-	}
-	if failedAssignments > 0 {
-		readiness.Blockers = append(readiness.Blockers, readinessPlural(failedAssignments, "assignment failed", "assignments failed"))
-	}
-	if cancelledAssignments > 0 {
-		readiness.Blockers = append(readiness.Blockers, readinessPlural(cancelledAssignments, "assignment was cancelled", "assignments were cancelled"))
-	}
-	if unresolvedAssignments > 0 {
-		readiness.Blockers = append(readiness.Blockers, readinessPlural(unresolvedAssignments, "assignment is not complete", "assignments are not complete"))
-	}
-	if pendingHandoffs > 0 {
-		readiness.Blockers = append(readiness.Blockers, readinessPlural(pendingHandoffs, "handoff is pending", "handoffs are pending"))
-	}
-	if len(readiness.MissingEvidenceAssignmentIDs) > 0 {
-		readiness.Blockers = append(readiness.Blockers, readinessPlural(len(readiness.MissingEvidenceAssignmentIDs), "completed assignment is missing evidence", "completed assignments are missing evidence"))
-	}
-	if len(assignments) == 0 {
-		readiness.Warnings = append(readiness.Warnings, "No assignments are linked to this work item; closeout is manual.")
-	}
-	for _, artifact := range artifacts {
-		if ReviewArtifactNeedsFollowUpPath(artifact, handoffs) {
-			blocker := ReviewFollowUpBlocker(artifact, handoffs, assignmentsByID)
-			readiness.ReviewFollowUpArtifactIDs = append(readiness.ReviewFollowUpArtifactIDs, artifact.ID)
-			readiness.ReviewFollowUps = append(readiness.ReviewFollowUps, renderReviewFollowUpReadiness(artifact, blocker))
-		}
-		if blocker := ReviewFollowUpBlocker(artifact, handoffs, assignmentsByID); blocker != "" {
-			readiness.Blockers = append(readiness.Blockers, blocker)
-		}
-	}
-	readiness.ReviewFollowUpCount = len(readiness.ReviewFollowUpArtifactIDs)
-	readiness.Blockers = UniqueReadinessStrings(readiness.Blockers)
-	readiness.Warnings = UniqueReadinessStrings(readiness.Warnings)
-	if len(readiness.Blockers) > 0 {
-		readiness.Status = "blocked"
-		readiness.Title = "Closeout is blocked"
-		readiness.Detail = "Resolve the listed assignment, evidence, handoff, or review follow-up items before marking this work done."
-	}
-	readiness.Ready = readiness.Status == "ready"
-	return readiness
+	return projectwork.EvaluateWorkItemReadiness(workItem, assignments, artifacts, handoffs)
 }
 
 func ReviewFollowUpArtifact(artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) *projectwork.CollaborationArtifact {
-	items := append([]projectwork.CollaborationArtifact(nil), artifacts...)
-	sort.SliceStable(items, func(i, j int) bool {
-		left, right := FirstNonZeroTime(items[i].UpdatedAt, items[i].CreatedAt), FirstNonZeroTime(items[j].UpdatedAt, items[j].CreatedAt)
-		if !left.Equal(right) {
-			return left.After(right)
-		}
-		return items[i].ID < items[j].ID
-	})
-	for i := range items {
-		if ReviewArtifactNeedsFollowUpPath(items[i], handoffs) {
-			return &items[i]
-		}
-	}
-	return nil
+	return projectwork.ReviewFollowUpArtifact(artifacts, handoffs)
 }
 
 func ReviewArtifactNeedsFollowUpPath(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) bool {
@@ -196,138 +59,33 @@ func ReviewArtifactHasLinkedFollowUpPath(artifactID string, handoffs []projectwo
 }
 
 func ReviewFollowUpBlocker(artifact projectwork.CollaborationArtifact, handoffs []projectwork.Handoff, assignmentsByID map[string]projectwork.Assignment) string {
-	if !ReviewArtifactRequiresFollowUp(artifact) {
-		return ""
-	}
-	title := firstNonEmpty(artifact.Title, artifact.ID)
-	linked := make([]projectwork.Handoff, 0)
-	for _, handoff := range handoffs {
-		for _, artifactID := range handoff.LinkedArtifactIDs {
-			if strings.TrimSpace(artifactID) == artifact.ID {
-				linked = append(linked, handoff)
-				break
-			}
-		}
-	}
-	if len(linked) == 0 {
-		return fmt.Sprintf("Review follow-up %q is not triaged", title)
-	}
-	hasTargetAssignment := false
-	hasCompletedTarget := false
-	hasDismissedOrSuperseded := false
-	for _, handoff := range linked {
-		if handoff.Status == projectwork.HandoffStatusPending {
-			return fmt.Sprintf("Review follow-up %q has a pending handoff", title)
-		}
-		if handoff.Status == projectwork.HandoffStatusDismissed || handoff.Status == projectwork.HandoffStatusSuperseded {
-			hasDismissedOrSuperseded = true
-		}
-		if strings.TrimSpace(handoff.TargetAssignmentID) == "" {
-			continue
-		}
-		hasTargetAssignment = true
-		if assignment, ok := assignmentsByID[handoff.TargetAssignmentID]; ok {
-			hasCompletedTarget = hasCompletedTarget || AssignmentReadinessStatus(assignment) == projectwork.AssignmentStatusCompleted
-		}
-	}
-	if hasCompletedTarget {
-		return ""
-	}
-	if hasTargetAssignment {
-		return fmt.Sprintf("Review follow-up %q assignment is not completed", title)
-	}
-	if hasDismissedOrSuperseded {
-		return ""
-	}
-	return fmt.Sprintf("Review follow-up %q is not triaged", title)
+	return projectwork.ReviewFollowUpBlocker(artifact, handoffs, assignmentsByID)
 }
 
 func AssignmentReadinessStatus(assignment projectwork.Assignment) string {
-	return firstNonEmpty(assignment.ExecutionRef.Status, assignment.Status)
+	return projectwork.AssignmentReadinessStatus(assignment)
 }
 
 func IsActiveAssignmentStatus(status string) bool {
-	return status == projectwork.AssignmentStatusQueued || status == projectwork.AssignmentStatusRunning || status == projectwork.AssignmentStatusAwaitingApproval
+	return projectwork.IsActiveAssignmentStatus(status)
 }
 
 func IsUnresolvedAssignmentStatus(status string) bool {
-	return status != projectwork.AssignmentStatusCompleted &&
-		status != projectwork.AssignmentStatusFailed &&
-		status != projectwork.AssignmentStatusCancelled &&
-		!IsActiveAssignmentStatus(status)
+	return projectwork.IsUnresolvedAssignmentStatus(status)
 }
 
 func AssignmentHasCloseoutEvidence(assignment projectwork.Assignment, artifacts []projectwork.CollaborationArtifact) bool {
-	for _, artifact := range artifacts {
-		if artifact.Kind != projectwork.ArtifactKindEvidenceLink {
-			continue
-		}
-		if artifact.AssignmentID == "" || artifact.AssignmentID == assignment.ID {
-			return true
-		}
-	}
-	return false
+	return projectwork.AssignmentHasCloseoutEvidence(assignment, artifacts)
 }
 
 func AssignmentsByID(assignments []projectwork.Assignment) map[string]projectwork.Assignment {
-	byID := make(map[string]projectwork.Assignment, len(assignments))
-	for _, assignment := range assignments {
-		byID[assignment.ID] = assignment
-	}
-	return byID
+	return projectwork.AssignmentsByID(assignments)
 }
 
 func WorkItemClosed(status string) bool {
-	switch strings.TrimSpace(status) {
-	case projectwork.WorkItemStatusDone, projectwork.WorkItemStatusCancelled:
-		return true
-	default:
-		return false
-	}
+	return projectwork.WorkItemClosed(status)
 }
 
 func UniqueReadinessStrings(values []string) []string {
-	seen := make(map[string]struct{}, len(values))
-	unique := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		unique = append(unique, value)
-	}
-	return unique
-}
-
-func renderReviewFollowUpReadiness(artifact projectwork.CollaborationArtifact, blocker string) ReviewFollowUpReadiness {
-	return ReviewFollowUpReadiness{
-		ArtifactID:           artifact.ID,
-		Title:                firstNonEmpty(artifact.Title, artifact.ID),
-		Status:               "needs_path",
-		Blocker:              strings.TrimSpace(blocker),
-		ReviewedAssignmentID: artifact.ReviewedAssignmentID,
-		ReviewVerdict:        artifact.ReviewVerdict,
-		ReviewRisk:           artifact.ReviewRisk,
-	}
-}
-
-func readinessStatusCount(statuses []string, predicate func(string) bool) int {
-	count := 0
-	for _, status := range statuses {
-		if predicate(status) {
-			count++
-		}
-	}
-	return count
-}
-
-func readinessPlural(count int, singular, plural string) string {
-	if count == 1 {
-		return fmt.Sprintf("1 %s", singular)
-	}
-	return fmt.Sprintf("%d %s", count, plural)
+	return projectwork.UniqueReadinessStrings(values)
 }


### PR DESCRIPTION
## Overview

Routes Project Assistant project-work mutations through the project-work application authority instead of writing those records directly from the Assistant service.

This keeps Project Assistant proposals typed and explicit while sharing the same closeout guard used by the Projects UI. If an Assistant proposal tries to mark a work item done before closeout readiness passes, apply now returns a conflict with the readiness payload. Preflight also evaluates closeout readiness against the shadowed proposal state, so deterministic closeout blockers are caught before any earlier proposal action is durably applied.

## Changes

- Add a narrow Project Assistant `WorkAuthority` interface for role, work item, and assignment mutations.
- Add a project-assistant app adapter that translates that interface into `projectworkapp` commands.
- Wire the API Project Assistant application to the project-work application authority.
- Move the pure closeout readiness evaluator to `projectwork` and keep `projectworkapp` as the application facade.
- Mirror the closeout check in Project Assistant apply preflight using store state plus shadowed assignments/handoffs.
- Preserve closeout readiness errors in the Assistant apply error chain and response details.
- Add app/API regression tests for Assistant-driven closeout blocking.
- Add a chained-proposal regression proving preflight blocks `create_handoff -> mark done` before durable mutation.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test ./internal/projectassistant ./internal/projectassistantapp ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go vet ./internal/projectassistant ./internal/projectassistantapp ./internal/api`
- `git diff --check`
- source-name scan: no matches
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test -race -timeout 10m ./...`
