### PR TITLE
Route handoff mutations through project authority

### DIFF
--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -834,14 +834,8 @@ func (h *Handler) HandleCreateProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	id := strings.TrimSpace(req.ID)
-	if id == "" {
-		id = newOpaqueTaskResourceID("handoff")
-	}
-	item, err := h.projectWork.CreateHandoff(r.Context(), projectwork.Handoff{
-		ID:                    id,
-		ProjectID:             projectID,
-		WorkItemID:            workItemID,
+	item, err := h.projectWorkApplication().CreateHandoff(r.Context(), projectID, workItemID, projectworkapp.CreateHandoffCommand{
+		ID:                    req.ID,
 		SourceAssignmentID:    req.SourceAssignmentID,
 		SourceRunID:           req.SourceRunID,
 		SourceChatSessionID:   req.SourceChatSessionID,
@@ -877,8 +871,24 @@ func (h *Handler) HandleUpdateProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	item, err := h.projectWork.UpdateHandoff(r.Context(), projectID, workItemID, handoffID, func(item *projectwork.Handoff) {
-		applyProjectHandoffPatch(item, req)
+	item, err := h.projectWorkApplication().UpdateHandoff(r.Context(), projectID, workItemID, handoffID, projectworkapp.UpdateHandoffCommand{
+		SourceAssignmentID:    req.SourceAssignmentID,
+		SourceRunID:           req.SourceRunID,
+		SourceChatSessionID:   req.SourceChatSessionID,
+		SourceMessageID:       req.SourceMessageID,
+		TargetRoleID:          req.TargetRoleID,
+		TargetAssignmentID:    req.TargetAssignmentID,
+		TargetWorkItemID:      req.TargetWorkItemID,
+		Title:                 req.Title,
+		Summary:               req.Summary,
+		RecommendedNextAction: req.RecommendedNextAction,
+		LinkedArtifactIDs:     req.LinkedArtifactIDs,
+		LinkedMemoryIDs:       req.LinkedMemoryIDs,
+		ContextRefs:           req.ContextRefs,
+		Status:                req.Status,
+		ProvenanceKind:        req.ProvenanceKind,
+		TrustLabel:            req.TrustLabel,
+		CreatedByRoleID:       req.CreatedByRoleID,
 	})
 	if !writeProjectWorkError(w, err) {
 		return
@@ -897,8 +907,8 @@ func (h *Handler) HandleUpdateProjectHandoffStatus(w http.ResponseWriter, r *htt
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	item, err := h.projectWork.UpdateHandoff(r.Context(), projectID, workItemID, handoffID, func(item *projectwork.Handoff) {
-		item.Status = req.Status
+	item, err := h.projectWorkApplication().UpdateHandoff(r.Context(), projectID, workItemID, handoffID, projectworkapp.UpdateHandoffCommand{
+		Status: &req.Status,
 	})
 	if !writeProjectWorkError(w, err) {
 		return
@@ -917,60 +927,6 @@ func (h *Handler) HandleDeleteProjectHandoff(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func applyProjectHandoffPatch(item *projectwork.Handoff, req updateProjectHandoffRequest) {
-	if req.SourceAssignmentID != nil {
-		item.SourceAssignmentID = *req.SourceAssignmentID
-	}
-	if req.SourceRunID != nil {
-		item.SourceRunID = *req.SourceRunID
-	}
-	if req.SourceChatSessionID != nil {
-		item.SourceChatSessionID = *req.SourceChatSessionID
-	}
-	if req.SourceMessageID != nil {
-		item.SourceMessageID = *req.SourceMessageID
-	}
-	if req.TargetRoleID != nil {
-		item.TargetRoleID = *req.TargetRoleID
-	}
-	if req.TargetAssignmentID != nil {
-		item.TargetAssignmentID = *req.TargetAssignmentID
-	}
-	if req.TargetWorkItemID != nil {
-		item.TargetWorkItemID = *req.TargetWorkItemID
-	}
-	if req.Title != nil {
-		item.Title = *req.Title
-	}
-	if req.Summary != nil {
-		item.Summary = *req.Summary
-	}
-	if req.RecommendedNextAction != nil {
-		item.RecommendedNextAction = *req.RecommendedNextAction
-	}
-	if req.LinkedArtifactIDs != nil {
-		item.LinkedArtifactIDs = *req.LinkedArtifactIDs
-	}
-	if req.LinkedMemoryIDs != nil {
-		item.LinkedMemoryIDs = *req.LinkedMemoryIDs
-	}
-	if req.ContextRefs != nil {
-		item.ContextRefs = *req.ContextRefs
-	}
-	if req.Status != nil {
-		item.Status = *req.Status
-	}
-	if req.ProvenanceKind != nil {
-		item.ProvenanceKind = *req.ProvenanceKind
-	}
-	if req.TrustLabel != nil {
-		item.TrustLabel = *req.TrustLabel
-	}
-	if req.CreatedByRoleID != nil {
-		item.CreatedByRoleID = *req.CreatedByRoleID
-	}
 }
 
 func (h *Handler) requireProject(w http.ResponseWriter, r *http.Request, projectID string) bool {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -486,6 +486,51 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_CreateHandoffGeneratesOpaqueHandoffID(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectWorkTestServer()
+	project := createProjectForWorkTest(t, server)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items", bytes.NewReader([]byte(`{
+		"id":"work_generated_handoff",
+		"title":"Generated handoff"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create work item status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_generated_handoff/handoffs", bytes.NewReader([]byte(`{
+		"title":"Generated handoff",
+		"summary":"Ready for the next operator step.",
+		"recommended_next_action":"Review the generated handoff ID."
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create handoff status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectHandoffEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode handoff: %v", err)
+	}
+	if !strings.HasPrefix(created.Data.ID, "handoff_") {
+		t.Fatalf("generated handoff id = %q, want handoff_ prefix", created.Data.ID)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_generated_handoff/handoffs", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list handoffs status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var handoffs ProjectHandoffsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &handoffs); err != nil {
+		t.Fatalf("decode handoffs: %v", err)
+	}
+	if len(handoffs.Data) != 1 || handoffs.Data[0].ID != created.Data.ID {
+		t.Fatalf("handoffs = %+v, want generated handoff id %q", handoffs.Data, created.Data.ID)
+	}
+}
+
 func TestProjectWorkAPI_PatchDoneRequiresCloseoutReadiness(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()

--- a/internal/projectassistant/action_handlers.go
+++ b/internal/projectassistant/action_handlers.go
@@ -361,7 +361,7 @@ func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (Act
 }
 
 func (s *Service) applyCreateHandoff(ctx context.Context, action Action) (ActionResult, error) {
-	if s.work == nil {
+	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
 	var patch handoffPatch
@@ -379,10 +379,8 @@ func (s *Service) applyCreateHandoff(ctx context.Context, action Action) (Action
 	if id == "" {
 		id = s.idgen("handoff")
 	}
-	handoff, err := s.work.CreateHandoff(ctx, projectwork.Handoff{
+	handoff, err := s.workAuthority.CreateHandoff(ctx, projectID, patch.WorkItemID, WorkHandoffCommand{
 		ID:                    id,
-		ProjectID:             projectID,
-		WorkItemID:            patch.WorkItemID,
 		SourceAssignmentID:    patch.SourceAssignmentID,
 		SourceRunID:           patch.SourceRunID,
 		SourceChatSessionID:   patch.SourceChatSessionID,
@@ -408,7 +406,7 @@ func (s *Service) applyCreateHandoff(ctx context.Context, action Action) (Action
 }
 
 func (s *Service) applyUpdateHandoff(ctx context.Context, action Action) (ActionResult, error) {
-	if s.work == nil {
+	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
 	projectID := targetValue(action, "project_id")
@@ -427,16 +425,10 @@ func (s *Service) applyUpdateHandoff(ctx context.Context, action Action) (Action
 	if patch.TargetAssignmentID == nil && patch.TargetRoleID == nil && patch.Status == nil {
 		return ActionResult{}, fmt.Errorf("%w: update_handoff patch must set at least one mutable field", ErrInvalid)
 	}
-	handoff, err := s.work.UpdateHandoff(ctx, projectID, workItemID, handoffID, func(item *projectwork.Handoff) {
-		if patch.TargetAssignmentID != nil {
-			item.TargetAssignmentID = *patch.TargetAssignmentID
-		}
-		if patch.TargetRoleID != nil {
-			item.TargetRoleID = *patch.TargetRoleID
-		}
-		if patch.Status != nil {
-			item.Status = *patch.Status
-		}
+	handoff, err := s.workAuthority.UpdateHandoff(ctx, projectID, workItemID, handoffID, WorkHandoffUpdateCommand{
+		TargetAssignmentID: patch.TargetAssignmentID,
+		TargetRoleID:       patch.TargetRoleID,
+		Status:             patch.Status,
 	})
 	if err != nil {
 		return ActionResult{}, mapProjectWorkErr(err)

--- a/internal/projectassistant/work_authority.go
+++ b/internal/projectassistant/work_authority.go
@@ -12,6 +12,8 @@ type WorkAuthority interface {
 	CreateWorkItem(ctx context.Context, projectID string, cmd WorkItemCommand) (projectwork.WorkItem, error)
 	UpdateWorkItem(ctx context.Context, projectID, workItemID string, cmd WorkItemUpdateCommand) (projectwork.WorkItem, error)
 	CreateAssignment(ctx context.Context, projectID, workItemID string, cmd WorkAssignmentCommand) (projectwork.Assignment, error)
+	CreateHandoff(ctx context.Context, projectID, workItemID string, cmd WorkHandoffCommand) (projectwork.Handoff, error)
+	UpdateHandoff(ctx context.Context, projectID, workItemID, handoffID string, cmd WorkHandoffUpdateCommand) (projectwork.Handoff, error)
 }
 
 type WorkRoleCommand struct {
@@ -51,6 +53,33 @@ type WorkAssignmentCommand struct {
 	RootID     string
 	DriverKind string
 	Status     string
+}
+
+type WorkHandoffCommand struct {
+	ID                    string
+	SourceAssignmentID    string
+	SourceRunID           string
+	SourceChatSessionID   string
+	SourceMessageID       string
+	TargetRoleID          string
+	TargetAssignmentID    string
+	TargetWorkItemID      string
+	Title                 string
+	Summary               string
+	RecommendedNextAction string
+	LinkedArtifactIDs     []string
+	LinkedMemoryIDs       []string
+	ContextRefs           []string
+	Status                string
+	ProvenanceKind        string
+	TrustLabel            string
+	CreatedByRoleID       string
+}
+
+type WorkHandoffUpdateCommand struct {
+	TargetAssignmentID *string
+	TargetRoleID       *string
+	Status             *string
 }
 
 func workAuthorityForStores(stores Stores) WorkAuthority {
@@ -140,5 +169,44 @@ func (authority storeWorkAuthority) CreateAssignment(ctx context.Context, projec
 		RootID:     cmd.RootID,
 		DriverKind: driverKind,
 		Status:     cmd.Status,
+	})
+}
+
+func (authority storeWorkAuthority) CreateHandoff(ctx context.Context, projectID, workItemID string, cmd WorkHandoffCommand) (projectwork.Handoff, error) {
+	return authority.store.CreateHandoff(ctx, projectwork.Handoff{
+		ID:                    cmd.ID,
+		ProjectID:             projectID,
+		WorkItemID:            workItemID,
+		SourceAssignmentID:    cmd.SourceAssignmentID,
+		SourceRunID:           cmd.SourceRunID,
+		SourceChatSessionID:   cmd.SourceChatSessionID,
+		SourceMessageID:       cmd.SourceMessageID,
+		TargetRoleID:          cmd.TargetRoleID,
+		TargetAssignmentID:    cmd.TargetAssignmentID,
+		TargetWorkItemID:      cmd.TargetWorkItemID,
+		Title:                 cmd.Title,
+		Summary:               cmd.Summary,
+		RecommendedNextAction: cmd.RecommendedNextAction,
+		LinkedArtifactIDs:     append([]string(nil), cmd.LinkedArtifactIDs...),
+		LinkedMemoryIDs:       append([]string(nil), cmd.LinkedMemoryIDs...),
+		ContextRefs:           append([]string(nil), cmd.ContextRefs...),
+		Status:                cmd.Status,
+		ProvenanceKind:        cmd.ProvenanceKind,
+		TrustLabel:            cmd.TrustLabel,
+		CreatedByRoleID:       cmd.CreatedByRoleID,
+	})
+}
+
+func (authority storeWorkAuthority) UpdateHandoff(ctx context.Context, projectID, workItemID, handoffID string, cmd WorkHandoffUpdateCommand) (projectwork.Handoff, error) {
+	return authority.store.UpdateHandoff(ctx, projectID, workItemID, handoffID, func(item *projectwork.Handoff) {
+		if cmd.TargetAssignmentID != nil {
+			item.TargetAssignmentID = *cmd.TargetAssignmentID
+		}
+		if cmd.TargetRoleID != nil {
+			item.TargetRoleID = *cmd.TargetRoleID
+		}
+		if cmd.Status != nil {
+			item.Status = *cmd.Status
+		}
 	})
 }

--- a/internal/projectassistantapp/work_authority.go
+++ b/internal/projectassistantapp/work_authority.go
@@ -81,6 +81,45 @@ func (authority projectWorkAuthority) CreateAssignment(ctx context.Context, proj
 	return assignment, nil
 }
 
+func (authority projectWorkAuthority) CreateHandoff(ctx context.Context, projectID, workItemID string, cmd projectassistant.WorkHandoffCommand) (projectwork.Handoff, error) {
+	handoff, err := authority.app.CreateHandoff(ctx, projectID, workItemID, projectworkapp.CreateHandoffCommand{
+		ID:                    cmd.ID,
+		SourceAssignmentID:    cmd.SourceAssignmentID,
+		SourceRunID:           cmd.SourceRunID,
+		SourceChatSessionID:   cmd.SourceChatSessionID,
+		SourceMessageID:       cmd.SourceMessageID,
+		TargetRoleID:          cmd.TargetRoleID,
+		TargetAssignmentID:    cmd.TargetAssignmentID,
+		TargetWorkItemID:      cmd.TargetWorkItemID,
+		Title:                 cmd.Title,
+		Summary:               cmd.Summary,
+		RecommendedNextAction: cmd.RecommendedNextAction,
+		LinkedArtifactIDs:     append([]string(nil), cmd.LinkedArtifactIDs...),
+		LinkedMemoryIDs:       append([]string(nil), cmd.LinkedMemoryIDs...),
+		ContextRefs:           append([]string(nil), cmd.ContextRefs...),
+		Status:                cmd.Status,
+		ProvenanceKind:        cmd.ProvenanceKind,
+		TrustLabel:            cmd.TrustLabel,
+		CreatedByRoleID:       cmd.CreatedByRoleID,
+	})
+	if err != nil {
+		return projectwork.Handoff{}, mapProjectWorkApplicationErr(err)
+	}
+	return handoff, nil
+}
+
+func (authority projectWorkAuthority) UpdateHandoff(ctx context.Context, projectID, workItemID, handoffID string, cmd projectassistant.WorkHandoffUpdateCommand) (projectwork.Handoff, error) {
+	handoff, err := authority.app.UpdateHandoff(ctx, projectID, workItemID, handoffID, projectworkapp.UpdateHandoffCommand{
+		TargetAssignmentID: cmd.TargetAssignmentID,
+		TargetRoleID:       cmd.TargetRoleID,
+		Status:             cmd.Status,
+	})
+	if err != nil {
+		return projectwork.Handoff{}, mapProjectWorkApplicationErr(err)
+	}
+	return handoff, nil
+}
+
 func mapProjectWorkApplicationErr(err error) error {
 	if err == nil {
 		return nil

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -142,6 +142,47 @@ type UpdateAssignmentCommand struct {
 	CompletedAt  *time.Time
 }
 
+type CreateHandoffCommand struct {
+	ID                    string
+	SourceAssignmentID    string
+	SourceRunID           string
+	SourceChatSessionID   string
+	SourceMessageID       string
+	TargetRoleID          string
+	TargetAssignmentID    string
+	TargetWorkItemID      string
+	Title                 string
+	Summary               string
+	RecommendedNextAction string
+	LinkedArtifactIDs     []string
+	LinkedMemoryIDs       []string
+	ContextRefs           []string
+	Status                string
+	ProvenanceKind        string
+	TrustLabel            string
+	CreatedByRoleID       string
+}
+
+type UpdateHandoffCommand struct {
+	SourceAssignmentID    *string
+	SourceRunID           *string
+	SourceChatSessionID   *string
+	SourceMessageID       *string
+	TargetRoleID          *string
+	TargetAssignmentID    *string
+	TargetWorkItemID      *string
+	Title                 *string
+	Summary               *string
+	RecommendedNextAction *string
+	LinkedArtifactIDs     *[]string
+	LinkedMemoryIDs       *[]string
+	ContextRefs           *[]string
+	Status                *string
+	ProvenanceKind        *string
+	TrustLabel            *string
+	CreatedByRoleID       *string
+}
+
 type StartTaskAssignmentCommand struct {
 	ProjectID         string
 	WorkItemID        string
@@ -403,6 +444,97 @@ func (app *Application) DeleteAssignment(ctx context.Context, projectID, workIte
 		return ErrStoreNotConfigured
 	}
 	return app.store.DeleteAssignment(ctx, projectID, workItemID, assignmentID)
+}
+
+func (app *Application) CreateHandoff(ctx context.Context, projectID, workItemID string, cmd CreateHandoffCommand) (projectwork.Handoff, error) {
+	if app == nil || app.store == nil {
+		return projectwork.Handoff{}, ErrStoreNotConfigured
+	}
+	id := strings.TrimSpace(cmd.ID)
+	if id == "" {
+		id = app.idgen("handoff")
+	}
+	return app.store.CreateHandoff(ctx, projectwork.Handoff{
+		ID:                    id,
+		ProjectID:             projectID,
+		WorkItemID:            workItemID,
+		SourceAssignmentID:    cmd.SourceAssignmentID,
+		SourceRunID:           cmd.SourceRunID,
+		SourceChatSessionID:   cmd.SourceChatSessionID,
+		SourceMessageID:       cmd.SourceMessageID,
+		TargetRoleID:          cmd.TargetRoleID,
+		TargetAssignmentID:    cmd.TargetAssignmentID,
+		TargetWorkItemID:      cmd.TargetWorkItemID,
+		Title:                 cmd.Title,
+		Summary:               cmd.Summary,
+		RecommendedNextAction: cmd.RecommendedNextAction,
+		LinkedArtifactIDs:     append([]string(nil), cmd.LinkedArtifactIDs...),
+		LinkedMemoryIDs:       append([]string(nil), cmd.LinkedMemoryIDs...),
+		ContextRefs:           append([]string(nil), cmd.ContextRefs...),
+		Status:                cmd.Status,
+		ProvenanceKind:        cmd.ProvenanceKind,
+		TrustLabel:            cmd.TrustLabel,
+		CreatedByRoleID:       cmd.CreatedByRoleID,
+	})
+}
+
+func (app *Application) UpdateHandoff(ctx context.Context, projectID, workItemID, handoffID string, cmd UpdateHandoffCommand) (projectwork.Handoff, error) {
+	if app == nil || app.store == nil {
+		return projectwork.Handoff{}, ErrStoreNotConfigured
+	}
+	return app.store.UpdateHandoff(ctx, projectID, workItemID, handoffID, func(item *projectwork.Handoff) {
+		if cmd.SourceAssignmentID != nil {
+			item.SourceAssignmentID = *cmd.SourceAssignmentID
+		}
+		if cmd.SourceRunID != nil {
+			item.SourceRunID = *cmd.SourceRunID
+		}
+		if cmd.SourceChatSessionID != nil {
+			item.SourceChatSessionID = *cmd.SourceChatSessionID
+		}
+		if cmd.SourceMessageID != nil {
+			item.SourceMessageID = *cmd.SourceMessageID
+		}
+		if cmd.TargetRoleID != nil {
+			item.TargetRoleID = *cmd.TargetRoleID
+		}
+		if cmd.TargetAssignmentID != nil {
+			item.TargetAssignmentID = *cmd.TargetAssignmentID
+		}
+		if cmd.TargetWorkItemID != nil {
+			item.TargetWorkItemID = *cmd.TargetWorkItemID
+		}
+		if cmd.Title != nil {
+			item.Title = *cmd.Title
+		}
+		if cmd.Summary != nil {
+			item.Summary = *cmd.Summary
+		}
+		if cmd.RecommendedNextAction != nil {
+			item.RecommendedNextAction = *cmd.RecommendedNextAction
+		}
+		if cmd.LinkedArtifactIDs != nil {
+			item.LinkedArtifactIDs = append([]string(nil), *cmd.LinkedArtifactIDs...)
+		}
+		if cmd.LinkedMemoryIDs != nil {
+			item.LinkedMemoryIDs = append([]string(nil), *cmd.LinkedMemoryIDs...)
+		}
+		if cmd.ContextRefs != nil {
+			item.ContextRefs = append([]string(nil), *cmd.ContextRefs...)
+		}
+		if cmd.Status != nil {
+			item.Status = *cmd.Status
+		}
+		if cmd.ProvenanceKind != nil {
+			item.ProvenanceKind = *cmd.ProvenanceKind
+		}
+		if cmd.TrustLabel != nil {
+			item.TrustLabel = *cmd.TrustLabel
+		}
+		if cmd.CreatedByRoleID != nil {
+			item.CreatedByRoleID = *cmd.CreatedByRoleID
+		}
+	})
 }
 
 func (app *Application) StartTaskAssignment(ctx context.Context, cmd StartTaskAssignmentCommand) (*StartTaskAssignmentResult, error) {

--- a/internal/projectworkapp/application_test.go
+++ b/internal/projectworkapp/application_test.go
@@ -205,6 +205,67 @@ func TestApplication_UpdateAssignmentAppliesOptionalFields(t *testing.T) {
 	}
 }
 
+func TestApplication_CreateAndUpdateHandoffAppliesOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := projectwork.NewMemoryStore()
+	app := newTestApplication(store)
+	if _, err := app.CreateWorkItem(ctx, "proj_1", CreateWorkItemCommand{ID: "work_1", Title: "Build"}); err != nil {
+		t.Fatalf("CreateWorkItem() error = %v", err)
+	}
+	if _, err := app.CreateAssignment(ctx, "proj_1", "work_1", CreateAssignmentCommand{ID: "asgn_source", RoleID: "software_developer"}); err != nil {
+		t.Fatalf("CreateAssignment(source) error = %v", err)
+	}
+	if _, err := app.CreateAssignment(ctx, "proj_1", "work_1", CreateAssignmentCommand{ID: "asgn_target", RoleID: "reviewer_qa"}); err != nil {
+		t.Fatalf("CreateAssignment(target) error = %v", err)
+	}
+	linkedArtifacts := []string{"artifact_1", "artifact_1"}
+	contextRefs := []string{"ctx_1"}
+
+	handoff, err := app.CreateHandoff(ctx, "proj_1", "work_1", CreateHandoffCommand{
+		SourceAssignmentID:    "asgn_source",
+		TargetRoleID:          "reviewer_qa",
+		Title:                 "Review follow-up",
+		Summary:               "Review needs follow-up.",
+		RecommendedNextAction: "Queue the reviewer.",
+		LinkedArtifactIDs:     linkedArtifacts,
+		ContextRefs:           contextRefs,
+	})
+	if err != nil {
+		t.Fatalf("CreateHandoff() error = %v", err)
+	}
+	if handoff.ID != "handoff_fixed" || handoff.ProjectID != "proj_1" || handoff.WorkItemID != "work_1" || handoff.Status != projectwork.HandoffStatusPending {
+		t.Fatalf("handoff = %+v, want generated id, scope, and pending default", handoff)
+	}
+	linkedArtifacts[0] = "mutated"
+	contextRefs[0] = "mutated"
+	if handoff.LinkedArtifactIDs[0] != "artifact_1" || handoff.ContextRefs[0] != "ctx_1" {
+		t.Fatalf("handoff slices mutated through command: %+v/%+v", handoff.LinkedArtifactIDs, handoff.ContextRefs)
+	}
+
+	status := projectwork.HandoffStatusAccepted
+	action := "Start the target assignment."
+	targetAssignmentID := "asgn_target"
+	updateArtifacts := []string{"artifact_2"}
+	updated, err := app.UpdateHandoff(ctx, "proj_1", "work_1", handoff.ID, UpdateHandoffCommand{
+		TargetAssignmentID:    &targetAssignmentID,
+		RecommendedNextAction: &action,
+		LinkedArtifactIDs:     &updateArtifacts,
+		Status:                &status,
+	})
+	if err != nil {
+		t.Fatalf("UpdateHandoff() error = %v", err)
+	}
+	if updated.TargetAssignmentID != "asgn_target" || updated.RecommendedNextAction != action || updated.Status != projectwork.HandoffStatusAccepted {
+		t.Fatalf("updated handoff = %+v, want target assignment, action, accepted status", updated)
+	}
+	updateArtifacts[0] = "mutated"
+	if updated.LinkedArtifactIDs[0] != "artifact_2" {
+		t.Fatalf("updated handoff linked artifacts mutated through command: %+v", updated.LinkedArtifactIDs)
+	}
+}
+
 func TestApplication_ReconcileChatSessionAssignmentsUpdatesLinkedExternalAssignment(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Overview

Routes project handoff create/update mutations through the project-work application authority instead of writing them directly from HTTP handlers or Project Assistant apply handlers.

This follows the same boundary as the Project Assistant work-item authority: the Assistant still performs typed preflight and target checks, while durable project-work mutations are owned by `projectworkapp`.

## Changes

- Add `CreateHandoffCommand` and `UpdateHandoffCommand` to `projectworkapp.Application`.
- Route Project Assistant `create_handoff` and `update_handoff` through `WorkAuthority`.
- Add app-backed handoff methods to the Project Assistant application adapter.
- Route HTTP handoff create/update/status handlers through `projectWorkApplication()`.
- Add an app-level regression test for handoff ID generation, optional updates, and slice copying.

## Validation

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test ./internal/projectworkapp ./internal/projectassistant ./internal/projectassistantapp ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go vet ./internal/projectworkapp ./internal/projectassistant ./internal/projectassistantapp ./internal/api`
- `git diff --check`
- source-name scan: no matches
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.gocache go test -race -timeout 10m ./...`
