### PR TITLE
chore(agent): bump bundled acp adapters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.25
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.26
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.26
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.27
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.25
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.26
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.26
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.27
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -271,7 +271,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.25",
+			SupportedRange:       ">=0.1.0-alpha.26",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{
@@ -312,7 +312,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Claude Code through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/claude-code-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.26",
+			SupportedRange:       ">=0.1.0-alpha.27",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.25" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.26" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {
@@ -41,7 +41,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
-	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.26" {
+	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.27" {
 		t.Fatalf("claude_code supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["claude_code"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary

- Bump bundled Codex ACP adapter to `v0.1.0-alpha.26`.
- Bump bundled Claude Code ACP adapter to `v0.1.0-alpha.27`.
- Update built-in adapter supported ranges and range assertions to match the Dockerfile pins.

## Validation

Adapter releases:
- `GOCACHE="$PWD/.gocache" make release-check` in `codex-acp-adapter`
- `GOCACHE="$PWD/.gocache" make release-check` in `claude-code-acp-adapter`
- Release workflows succeeded for `hecatehq/codex-acp-adapter@v0.1.0-alpha.26` and `hecatehq/claude-code-acp-adapter@v0.1.0-alpha.27`
- Verified both Linux amd64 tarballs against `checksums.txt` and confirmed the expected binary names are present

Hecate:
- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters`
- `GOCACHE="$PWD/.gocache" go vet ./internal/agentadapters`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run TestAgentAdapter -count=1`

Note: Docker is not reachable from this shell (`~/.docker/run/docker.sock` missing), so I could not run the Docker adapter-downloader stage directly. The manual checksum/download smoke covers the same published artifacts this Docker stage fetches.