### PR TITLE
Route remaining project-work mutations through project authority

### DIFF
--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -753,14 +753,8 @@ func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	id := strings.TrimSpace(req.ID)
-	if id == "" {
-		id = newOpaqueTaskResourceID("art")
-	}
-	item, err := h.projectWork.CreateArtifact(r.Context(), projectwork.CollaborationArtifact{
-		ID:                     id,
-		ProjectID:              projectID,
-		WorkItemID:             workItemID,
+	item, err := h.projectWorkApplication().CreateArtifact(r.Context(), projectID, workItemID, projectworkapp.CreateArtifactCommand{
+		ID:                     req.ID,
 		AssignmentID:           req.AssignmentID,
 		Kind:                   req.Kind,
 		Title:                  req.Title,
@@ -923,7 +917,7 @@ func (h *Handler) HandleDeleteProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
-	if err := h.projectWork.DeleteHandoff(r.Context(), projectID, workItemID, handoffID); !writeProjectWorkError(w, err) {
+	if err := h.projectWorkApplication().DeleteHandoff(r.Context(), projectID, workItemID, handoffID); !writeProjectWorkError(w, err) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -142,6 +142,24 @@ type UpdateAssignmentCommand struct {
 	CompletedAt  *time.Time
 }
 
+type CreateArtifactCommand struct {
+	ID                     string
+	AssignmentID           string
+	Kind                   string
+	Title                  string
+	Body                   string
+	AuthorRoleID           string
+	EvidenceSourceKind     string
+	EvidenceURL            string
+	EvidenceExternalID     string
+	EvidenceProvider       string
+	EvidenceTrustLabel     string
+	ReviewedAssignmentID   string
+	ReviewVerdict          string
+	ReviewRisk             string
+	ReviewFollowUpRequired bool
+}
+
 type CreateHandoffCommand struct {
 	ID                    string
 	SourceAssignmentID    string
@@ -446,6 +464,35 @@ func (app *Application) DeleteAssignment(ctx context.Context, projectID, workIte
 	return app.store.DeleteAssignment(ctx, projectID, workItemID, assignmentID)
 }
 
+func (app *Application) CreateArtifact(ctx context.Context, projectID, workItemID string, cmd CreateArtifactCommand) (projectwork.CollaborationArtifact, error) {
+	if app == nil || app.store == nil {
+		return projectwork.CollaborationArtifact{}, ErrStoreNotConfigured
+	}
+	id := strings.TrimSpace(cmd.ID)
+	if id == "" {
+		id = app.idgen("art")
+	}
+	return app.store.CreateArtifact(ctx, projectwork.CollaborationArtifact{
+		ID:                     id,
+		ProjectID:              projectID,
+		WorkItemID:             workItemID,
+		AssignmentID:           cmd.AssignmentID,
+		Kind:                   cmd.Kind,
+		Title:                  cmd.Title,
+		Body:                   cmd.Body,
+		AuthorRoleID:           cmd.AuthorRoleID,
+		EvidenceSourceKind:     cmd.EvidenceSourceKind,
+		EvidenceURL:            cmd.EvidenceURL,
+		EvidenceExternalID:     cmd.EvidenceExternalID,
+		EvidenceProvider:       cmd.EvidenceProvider,
+		EvidenceTrustLabel:     cmd.EvidenceTrustLabel,
+		ReviewedAssignmentID:   cmd.ReviewedAssignmentID,
+		ReviewVerdict:          cmd.ReviewVerdict,
+		ReviewRisk:             cmd.ReviewRisk,
+		ReviewFollowUpRequired: cmd.ReviewFollowUpRequired,
+	})
+}
+
 func (app *Application) CreateHandoff(ctx context.Context, projectID, workItemID string, cmd CreateHandoffCommand) (projectwork.Handoff, error) {
 	if app == nil || app.store == nil {
 		return projectwork.Handoff{}, ErrStoreNotConfigured
@@ -535,6 +582,13 @@ func (app *Application) UpdateHandoff(ctx context.Context, projectID, workItemID
 			item.CreatedByRoleID = *cmd.CreatedByRoleID
 		}
 	})
+}
+
+func (app *Application) DeleteHandoff(ctx context.Context, projectID, workItemID, handoffID string) error {
+	if app == nil || app.store == nil {
+		return ErrStoreNotConfigured
+	}
+	return app.store.DeleteHandoff(ctx, projectID, workItemID, handoffID)
 }
 
 func (app *Application) StartTaskAssignment(ctx context.Context, cmd StartTaskAssignmentCommand) (*StartTaskAssignmentResult, error) {

--- a/internal/projectworkapp/application_test.go
+++ b/internal/projectworkapp/application_test.go
@@ -205,6 +205,44 @@ func TestApplication_UpdateAssignmentAppliesOptionalFields(t *testing.T) {
 	}
 }
 
+func TestApplication_CreateArtifactGeneratesIDAndPreservesReviewMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := projectwork.NewMemoryStore()
+	app := newTestApplication(store)
+	if _, err := app.CreateWorkItem(ctx, "proj_1", CreateWorkItemCommand{ID: "work_1", Title: "Build"}); err != nil {
+		t.Fatalf("CreateWorkItem() error = %v", err)
+	}
+	if _, err := app.CreateAssignment(ctx, "proj_1", "work_1", CreateAssignmentCommand{ID: "asgn_impl", RoleID: "software_developer"}); err != nil {
+		t.Fatalf("CreateAssignment(impl) error = %v", err)
+	}
+	if _, err := app.CreateAssignment(ctx, "proj_1", "work_1", CreateAssignmentCommand{ID: "asgn_review", RoleID: "reviewer_qa"}); err != nil {
+		t.Fatalf("CreateAssignment(review) error = %v", err)
+	}
+
+	artifact, err := app.CreateArtifact(ctx, "proj_1", "work_1", CreateArtifactCommand{
+		AssignmentID:           "asgn_review",
+		Kind:                   projectwork.ArtifactKindReview,
+		Title:                  "Review",
+		Body:                   "Changes requested.",
+		AuthorRoleID:           "reviewer_qa",
+		ReviewedAssignmentID:   "asgn_impl",
+		ReviewVerdict:          projectwork.ReviewVerdictChangesRequested,
+		ReviewRisk:             projectwork.ReviewRiskMedium,
+		ReviewFollowUpRequired: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateArtifact() error = %v", err)
+	}
+	if artifact.ID != "art_fixed" || artifact.ProjectID != "proj_1" || artifact.WorkItemID != "work_1" {
+		t.Fatalf("artifact = %+v, want generated id and scope", artifact)
+	}
+	if artifact.ReviewedAssignmentID != "asgn_impl" || artifact.ReviewVerdict != projectwork.ReviewVerdictChangesRequested || artifact.ReviewRisk != projectwork.ReviewRiskMedium || !artifact.ReviewFollowUpRequired {
+		t.Fatalf("artifact review metadata = %+v, want review follow-up metadata", artifact)
+	}
+}
+
 func TestApplication_CreateAndUpdateHandoffAppliesOptionalFields(t *testing.T) {
 	t.Parallel()
 
@@ -263,6 +301,16 @@ func TestApplication_CreateAndUpdateHandoffAppliesOptionalFields(t *testing.T) {
 	updateArtifacts[0] = "mutated"
 	if updated.LinkedArtifactIDs[0] != "artifact_2" {
 		t.Fatalf("updated handoff linked artifacts mutated through command: %+v", updated.LinkedArtifactIDs)
+	}
+	if err := app.DeleteHandoff(ctx, "proj_1", "work_1", handoff.ID); err != nil {
+		t.Fatalf("DeleteHandoff() error = %v", err)
+	}
+	handoffs, err := store.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: "proj_1", WorkItemID: "work_1"})
+	if err != nil {
+		t.Fatalf("ListHandoffs() error = %v", err)
+	}
+	if len(handoffs) != 0 {
+		t.Fatalf("handoffs after delete = %+v, want none", handoffs)
 	}
 }
 


### PR DESCRIPTION
## Overview

Routes the remaining project-work HTTP mutations through `projectworkapp` instead of writing directly to the project work store.

## Changes

- Add `CreateArtifactCommand` and `Application.CreateArtifact` for typed collaboration artifact creation.
- Add `Application.DeleteHandoff` so handoff deletion uses the same authority boundary as handoff create/update.
- Update the project-work HTTP handlers to call the application layer for artifact creation and handoff deletion.
- Add application-layer coverage for generated artifact IDs, review metadata, and handoff deletion through the app seam.

## Validation

- `go test ./internal/projectworkapp ./internal/api`
- `go vet ./internal/projectworkapp ./internal/api`
- `go test -race -timeout 10m ./...`
- `git diff --check`
- Production scan for remaining direct project-work create/update/delete calls in project-work routes
