### PR TITLE
test(agentadapters): assert session approval option

### DIFF
--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -1342,14 +1342,17 @@ func TestSessionManagerACPApprovalApproveCreatesGrantAndReusesSession(t *testing
 	resolved, err := coord.Resolve(context.Background(), pending.ID, ResolveRequest{
 		Decision:       ApprovalDecisionApprove,
 		Scope:          ApprovalScopeSession,
-		SelectedOption: "allow_once_id",
+		SelectedOption: "allow_always_id",
 		Note:           "safe for this session",
 	})
 	if err != nil {
 		t.Fatalf("Resolve approve: %v", err)
 	}
-	if resolved.Status != ApprovalStatusApproved || resolved.Path != PathOperator {
-		t.Fatalf("resolved approval = %+v, want approved via operator", resolved)
+	if resolved.Status != ApprovalStatusApproved ||
+		resolved.Path != PathOperator ||
+		resolved.SelectedOption != "allow_always_id" ||
+		resolved.Scope != ApprovalScopeSession {
+		t.Fatalf("resolved approval = %+v, want session-scoped allow_always via operator", resolved)
 	}
 
 	first := awaitRunResult(t, firstDone)


### PR DESCRIPTION
## Summary

- tighten the fake ACP approval approve flow to select the session-scoped allow_always option
- assert the resolved approval records the selected option and session scope before the fake adapter continues

## Tests

- GOCACHE="$PWD/.gocache" go test ./internal/agentadapters -run 'TestSessionManagerACPApproval(ApproveCreatesGrantAndReusesSession|RejectLeavesSessionReusable|CancelLeavesSessionReusable)' -count=1\n- GOCACHE="$PWD/.gocache" go test ./internal/agentadapters\n- GOCACHE="$PWD/.gocache" go vet ./internal/agentadapters\n- GOCACHE="$PWD/.gocache" go test -race -timeout 5m ./internal/agentadapters