### PR TITLE
fix(agentadapters): classify MCP approvals

### DIFF
--- a/docs/design/implemented/external-agent-approval-loop-v1.md
+++ b/docs/design/implemented/external-agent-approval-loop-v1.md
@@ -140,25 +140,38 @@ recorded as an `chat_approval` row with `status=approved/denied` and
 
 ### Tool-kind extraction
 
-ACP's `RequestPermissionRequest` doesn't carry a clean tool name. v1 derives
-`tool_kind` from the embedded `tool_call.tool_name` field (always present in
-the ACP shape we've observed across Codex / Claude Code / Cursor / Grok Build)
-and falls back to the option `kind` when the tool field is missing. The mapping:
+Hecate records a normalized `tool_kind` for grant matching and telemetry. The
+adapter's raw tool name stays on the approval row for display/audit, but grants
+use the stable kind so "allow this adapter's MCP tools" does not depend on a
+vendor-specific tool label.
+
+Extraction order:
+
+1. Use ACP `tool_call.kind` when it maps to Hecate's closed taxonomy.
+2. If the typed kind is missing or `other`, infer from the adapter title.
+3. Fall back to `other`.
+
+Current mapping:
 
 ```
-tool_call.tool_name → tool_kind
-─────────────────────────────────
-write_file, edit_file, str_replace, multi_edit  → file_write
-read_file, read_text_file                       → file_read
-shell, bash, run_command, execute               → shell_exec
-fetch, http_get, web_search                     → network
-*                                               → other
+ACP kind / title hint         → tool_kind
+────────────────────────────────────────
+edit / write / patch / apply  → file_write
+read / open / view            → file_read
+execute / run / shell / bash  → shell_exec
+fetch / http / request        → network
+move / rename                 → file_move
+delete / remove               → file_delete
+search / grep / find          → search
+think                         → think
+mcp                           → mcp
+*                             → other
 ```
 
-Adapters can emit tool names not in this list; the fallback is the literal
-adapter-supplied name, recorded as `tool_kind=<adapter>:<raw>`. Frontends
-render it as "unknown tool: …" so the operator sees what the adapter is
-actually asking for, not a sanitized lie.
+The title heuristic is intentionally lenient and only runs after the typed ACP
+kind. MCP titles such as `docs/search` still record `tool_kind=mcp` when the
+adapter supplies `kind=mcp`; without that typed signal, a title containing the
+word `MCP` also maps to `mcp`.
 
 ### Default behavior
 
@@ -390,12 +403,12 @@ These need resolution before this draft can become v1.0 stable.
    per-Hecate-chat.
    - Status: open
 
-2. **Tool-kind extraction reliability.** `tool_call.tool_name` isn't a
-   strict ACP-required field. If an adapter sends a `RequestPermission`
-   without it, all grants degrade to `tool_kind=other`, which makes the
-   `adapter_tool` scope coarser than operators expect. Should we require
-   adapters to emit `tool_name`? Push for an ACP spec change?
-   - Status: open
+2. **Tool-kind extraction reliability.** `tool_call.kind` is now the primary
+   signal and title matching is fallback-only. The Go adapters preserve MCP
+   permission requests as `kind=mcp`, and Hecate records them as `tool_kind=mcp`
+   for grant matching.
+   - Status: resolved for current Codex / Claude Code adapters; keep provider
+     fixtures for new adapters.
 
 3. **What happens to in-flight grants when an adapter is removed from
    `BuiltIns`?** Probably orphan and surface in Connections as "stale grants

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -158,8 +158,10 @@ partial action results and `failed_action_index`. Retrying the exact same
 proposal resumes at the next unapplied action. Retrying the same proposal id
 with a changed action set returns `409 conflict`, and retrying a fully applied
 proposal also returns `409 conflict`. Clients should show the landed action
-kinds and ids from `partial_result.actions`; an empty list means preflight
-blocked the proposal before anything landed.
+kinds and ids from `partial_result.actions`; `committed_action_count`,
+`failed_action_index`, `resume_action_index`, and `total_action_count` are the
+server-owned progress counters. An empty list and `committed_action_count: 0`
+mean preflight blocked the proposal before anything landed.
 
 Future versions may persist proposal ids server-side so reviewed actions,
 confirmation, and resumable progress survive process restarts. In v0 the
@@ -438,6 +440,9 @@ POST /hecate/v1/project-assistant/apply
   "data": {
     "proposal_id": "pa_...",
     "applied": true,
+    "total_action_count": 1,
+    "committed_action_count": 1,
+    "resume_action_index": 1,
     "actions": [
       {
         "kind": "create_project",
@@ -467,9 +472,16 @@ same field lists the landed action kinds and ids:
     "type": "not_found",
     "message": "project assistant apply failed at action 1: project assistant target not found: project \"proj_missing\"",
     "failed_action_index": 1,
+    "total_action_count": 2,
+    "committed_action_count": 1,
+    "resume_action_index": 1,
     "partial_result": {
       "proposal_id": "pa_...",
       "applied": false,
+      "total_action_count": 2,
+      "committed_action_count": 1,
+      "failed_action_index": 1,
+      "resume_action_index": 1,
       "actions": [
         {
           "kind": "create_project",

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3400,11 +3400,12 @@ stores, apply preflights the remaining typed actions against current project,
 work, handoff, memory-candidate, and chat targets, including explicit resources
 created earlier in the same proposal. Multi-action apply is sequential and
 resumable within the current process: on a failure the error includes
-`failed_action_index` and `partial_result`. An empty
-`partial_result.actions` list means preflight blocked the proposal before any
-new durable write; a non-empty list means those actions landed and the unchanged
-proposal id can resume after them. Changing the action set or reapplying a fully
-applied proposal returns `409 conflict`.
+`failed_action_index`, `total_action_count`, `committed_action_count`,
+`resume_action_index`, and `partial_result`. An empty
+`partial_result.actions` list with `committed_action_count: 0` means preflight
+blocked the proposal before any new durable write; a non-empty list means those
+actions landed and the unchanged proposal id can resume after them. Changing the
+action set or reapplying a fully applied proposal returns `409 conflict`.
 
 Endpoints:
 

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -1383,6 +1383,57 @@ func TestSessionManagerACPApprovalApproveCreatesGrantAndReusesSession(t *testing
 	assertApprovalPathForSession(t, store, sessionID, PathGrant, ApprovalStatusApproved)
 }
 
+func TestSessionManagerACPApprovalRecordsMCPToolKind(t *testing.T) {
+	installFakeACPExecutable(t, "codex-acp-adapter")
+	workspace := t.TempDir()
+
+	store := NewMemoryApprovalStore()
+	coord := NewApprovalCoordinator(CoordinatorOptions{
+		Mode:    ModePrompt,
+		Store:   store,
+		Timeout: 5 * time.Second,
+	})
+	manager := NewSessionManager()
+	manager.SetApprovalCoordinator(coord)
+	t.Cleanup(func() { _ = manager.Shutdown(context.Background()) })
+
+	const sessionID = "chat_permission_mcp"
+	done := make(chan runResultAndError, 1)
+	go func() {
+		run, err := manager.Run(context.Background(), RunRequest{
+			SessionID:      sessionID,
+			AdapterID:      "codex",
+			Workspace:      workspace,
+			Prompt:         "mcp permission prompt",
+			Timeout:        10 * time.Second,
+			MaxOutputBytes: 64 * 1024,
+		})
+		done <- runResultAndError{run: run, err: err}
+	}()
+
+	pending := waitForPendingACPApproval(t, store, sessionID)
+	if pending.ToolKind != ToolKindMCP || pending.ToolName != "docs/search" || pending.Workspace != canonicalTestPath(t, workspace) {
+		t.Fatalf("pending approval = %+v, want mcp docs/search in workspace %q", pending, canonicalTestPath(t, workspace))
+	}
+	if _, err := coord.Resolve(context.Background(), pending.ID, ResolveRequest{
+		Decision:       ApprovalDecisionApprove,
+		Scope:          ApprovalScopeOnce,
+		SelectedOption: "allow_once_id",
+		Note:           "safe MCP read",
+	}); err != nil {
+		t.Fatalf("Resolve approve: %v", err)
+	}
+
+	first := awaitRunResult(t, done)
+	if first.err != nil {
+		t.Fatalf("Run after MCP approval: %v", first.err)
+	}
+	if !strings.Contains(first.run.Output, "permission approved") {
+		t.Fatalf("Run output = %q, want permission approved", first.run.Output)
+	}
+	assertApprovalPathForSession(t, store, sessionID, PathOperator, ApprovalStatusApproved)
+}
+
 func TestSessionManagerACPApprovalRejectLeavesSessionReusable(t *testing.T) {
 	installFakeACPExecutable(t, "codex-acp-adapter")
 	workspace := t.TempDir()
@@ -2898,14 +2949,18 @@ func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (ac
 		}
 		return acp.PromptResponse{StopReason: acp.StopReasonMaxTokens}, nil
 	}
-	if strings.HasPrefix(prompt, "permission prompt") {
+	if strings.HasPrefix(prompt, "permission prompt") || strings.HasPrefix(prompt, "mcp permission prompt") {
 		if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{
 			SessionId: params.SessionId,
 			Update:    acp.UpdateAgentMessageText("waiting for permission"),
 		}); err != nil {
 			return acp.PromptResponse{}, err
 		}
-		resp, err := a.conn.RequestPermission(turnCtx, fakeACPRequestPermission())
+		req := fakeACPRequestPermission()
+		if strings.HasPrefix(prompt, "mcp permission prompt") {
+			req = fakeACPMCPRequestPermission()
+		}
+		resp, err := a.conn.RequestPermission(turnCtx, req)
 		if err != nil {
 			return acp.PromptResponse{}, err
 		}
@@ -3024,6 +3079,23 @@ func fakeACPRequestPermission() acp.RequestPermissionRequest {
 			Title:      &title,
 			Kind:       &kind,
 			RawInput:   map[string]any{"path": "README.md"},
+		},
+	}
+}
+
+func fakeACPMCPRequestPermission() acp.RequestPermissionRequest {
+	title := "docs/search"
+	kind := acp.ToolKind("mcp")
+	return acp.RequestPermissionRequest{
+		Options: []acp.PermissionOption{
+			{OptionId: "allow_once_id", Kind: acp.PermissionOptionKindAllowOnce, Name: "Allow once"},
+			{OptionId: "reject_once_id", Kind: acp.PermissionOptionKindRejectOnce, Name: "Reject once"},
+		},
+		ToolCall: acp.ToolCallUpdate{
+			ToolCallId: acp.ToolCallId("mcp-permission-call"),
+			Title:      &title,
+			Kind:       &kind,
+			RawInput:   map[string]any{"server": "docs", "tool": "search", "query": "permissions"},
 		},
 	}
 }

--- a/internal/agentadapters/toolkind.go
+++ b/internal/agentadapters/toolkind.go
@@ -23,6 +23,7 @@ const (
 	ToolKindFileDelete = "file_delete"
 	ToolKindSearch     = "search"
 	ToolKindThink      = "think"
+	ToolKindMCP        = "mcp"
 	ToolKindOther      = "other"
 )
 
@@ -89,6 +90,8 @@ func mapACPToolKind(k acp.ToolKind) string {
 		return ToolKindSearch
 	case acp.ToolKindThink:
 		return ToolKindThink
+	case acp.ToolKind("mcp"):
+		return ToolKindMCP
 	case acp.ToolKindOther, acp.ToolKindSwitchMode:
 		return ""
 	}
@@ -102,6 +105,8 @@ func mapACPToolKind(k acp.ToolKind) string {
 func mapTitleToToolKind(title string) string {
 	t := " " + strings.ToLower(title) + " "
 	switch {
+	case containsAny(t, " mcp "):
+		return ToolKindMCP
 	case containsAny(t, " delete ", " remove ", " rm "):
 		return ToolKindFileDelete
 	case containsAny(t, " move ", " rename "):

--- a/internal/agentadapters/toolkind_test.go
+++ b/internal/agentadapters/toolkind_test.go
@@ -22,6 +22,7 @@ func TestExtractToolKindACPKindPriority(t *testing.T) {
 		{"delete maps to file_delete", acp.ToolKindDelete, ToolKindFileDelete},
 		{"search maps to search", acp.ToolKindSearch, ToolKindSearch},
 		{"think maps to think", acp.ToolKindThink, ToolKindThink},
+		{"mcp maps to mcp", acp.ToolKind("mcp"), ToolKindMCP},
 	}
 	for _, tc := range tests {
 		tc := tc
@@ -52,6 +53,7 @@ func TestExtractToolKindFallsBackToTitle(t *testing.T) {
 		{"Execute shell", ToolKindShellExec},
 		{"Fetch https://...", ToolKindNetwork},
 		{"HTTP request", ToolKindNetwork},
+		{"MCP search docs", ToolKindMCP},
 		{"Search the docs", ToolKindSearch},
 		{"Delete file", ToolKindFileDelete},
 		{"Rename file", ToolKindFileMove},

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -203,8 +203,11 @@ func writeProjectAssistantApplyError(w http.ResponseWriter, err error) {
 	}
 	status, code := projectAssistantErrorStatusCode(err)
 	fields := map[string]any{
-		"failed_action_index": applyErr.FailedActionIndex,
-		"partial_result":      applyErr.Result,
+		"failed_action_index":    applyErr.FailedActionIndex,
+		"total_action_count":     applyErr.Result.TotalActionCount,
+		"committed_action_count": applyErr.Result.CommittedActionCount,
+		"resume_action_index":    applyErr.Result.ResumeActionIndex,
+		"partial_result":         applyErr.Result,
 	}
 	operatorAction := ""
 	var closeoutErr projectworkapp.WorkItemCloseoutBlockedError

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -36,10 +36,13 @@ type projectAssistantContextResponse struct {
 
 type projectAssistantErrorResponse struct {
 	Error struct {
-		Type              string                       `json:"type"`
-		Message           string                       `json:"message"`
-		FailedActionIndex int                          `json:"failed_action_index"`
-		PartialResult     projectassistant.ApplyResult `json:"partial_result"`
+		Type                 string                       `json:"type"`
+		Message              string                       `json:"message"`
+		FailedActionIndex    int                          `json:"failed_action_index"`
+		TotalActionCount     int                          `json:"total_action_count"`
+		CommittedActionCount int                          `json:"committed_action_count"`
+		ResumeActionIndex    int                          `json:"resume_action_index"`
+		PartialResult        projectassistant.ApplyResult `json:"partial_result"`
 	} `json:"error"`
 }
 
@@ -633,6 +636,9 @@ func TestProjectAssistantAPI_ProposeAndApplyCreateProject(t *testing.T) {
 	if applied.Object != "project_assistant.apply_result" || !applied.Data.Applied || applied.Data.ProposalID != "pa_api" {
 		t.Fatalf("apply response = %+v, want applied project assistant result", applied)
 	}
+	if applied.Data.TotalActionCount != 1 || applied.Data.CommittedActionCount != 1 || applied.Data.ResumeActionIndex != 1 || applied.Data.FailedActionIndex != nil {
+		t.Fatalf("apply progress = %+v, want applied counts for one action", applied.Data)
+	}
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_api", nil))
@@ -694,9 +700,15 @@ func TestProjectAssistantAPI_ApplyPreflightFailureIncludesEmptyProgress(t *testi
 	if payload.Error.Type != errCodeNotFound || payload.Error.FailedActionIndex != 1 {
 		t.Fatalf("error = %+v, want not_found at action index 1", payload.Error)
 	}
+	if payload.Error.TotalActionCount != 2 || payload.Error.CommittedActionCount != 0 || payload.Error.ResumeActionIndex != 0 {
+		t.Fatalf("error progress = %+v, want failed action 1 and resume action 0", payload.Error)
+	}
 	partial := payload.Error.PartialResult
 	if partial.ProposalID != "pa_preflight_api" || partial.Applied || len(partial.Actions) != 0 {
 		t.Fatalf("partial_result = %+v, want no action results before preflight failure", partial)
+	}
+	if partial.TotalActionCount != 2 || partial.CommittedActionCount != 0 || partial.ResumeActionIndex != 0 || partial.FailedActionIndex == nil || *partial.FailedActionIndex != 1 {
+		t.Fatalf("partial_result progress = %+v, want failed action 1 and resume action 0", partial)
 	}
 	if _, ok, err := handler.projects.Get(t.Context(), "proj_preflight_api"); err != nil || ok {
 		t.Fatalf("Get preflight-blocked project ok=%v err=%v, want no durable mutation", ok, err)
@@ -751,12 +763,15 @@ func TestProjectAssistantAPI_ApplyDoneReturnsCloseoutReadiness(t *testing.T) {
 	}
 	var payload struct {
 		Error struct {
-			Type              string                           `json:"type"`
-			Message           string                           `json:"message"`
-			OperatorAction    string                           `json:"operator_action"`
-			FailedActionIndex int                              `json:"failed_action_index"`
-			PartialResult     projectassistant.ApplyResult     `json:"partial_result"`
-			Readiness         ProjectWorkItemReadinessResponse `json:"readiness"`
+			Type                 string                           `json:"type"`
+			Message              string                           `json:"message"`
+			OperatorAction       string                           `json:"operator_action"`
+			FailedActionIndex    int                              `json:"failed_action_index"`
+			TotalActionCount     int                              `json:"total_action_count"`
+			CommittedActionCount int                              `json:"committed_action_count"`
+			ResumeActionIndex    int                              `json:"resume_action_index"`
+			PartialResult        projectassistant.ApplyResult     `json:"partial_result"`
+			Readiness            ProjectWorkItemReadinessResponse `json:"readiness"`
 		} `json:"error"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
@@ -765,8 +780,14 @@ func TestProjectAssistantAPI_ApplyDoneReturnsCloseoutReadiness(t *testing.T) {
 	if payload.Error.Type != errCodeConflict || payload.Error.FailedActionIndex != 0 || payload.Error.OperatorAction == "" {
 		t.Fatalf("assistant closeout error = %+v, want conflict at action 0 with operator action", payload.Error)
 	}
+	if payload.Error.TotalActionCount != 1 || payload.Error.CommittedActionCount != 0 || payload.Error.ResumeActionIndex != 0 {
+		t.Fatalf("assistant closeout progress = %+v, want failed action 0 and resume action 0", payload.Error)
+	}
 	if payload.Error.PartialResult.ProposalID != "pa_assistant_closeout" || payload.Error.PartialResult.Applied || len(payload.Error.PartialResult.Actions) != 0 {
 		t.Fatalf("partial_result = %+v, want no committed assistant actions", payload.Error.PartialResult)
+	}
+	if payload.Error.PartialResult.TotalActionCount != 1 || payload.Error.PartialResult.CommittedActionCount != 0 || payload.Error.PartialResult.ResumeActionIndex != 0 || payload.Error.PartialResult.FailedActionIndex == nil || *payload.Error.PartialResult.FailedActionIndex != 0 {
+		t.Fatalf("partial_result progress = %+v, want failed action 0 and resume action 0", payload.Error.PartialResult)
 	}
 	if payload.Error.Readiness.Ready || payload.Error.Readiness.Status != "blocked" ||
 		len(payload.Error.Readiness.MissingEvidenceAssignmentIDs) != 1 ||

--- a/internal/projectassistant/proposal_apply.go
+++ b/internal/projectassistant/proposal_apply.go
@@ -46,11 +46,7 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 		return ApplyResult{}, fmt.Errorf("%w: proposal %q action set changed after partial apply", ErrConflict, proposal.ID)
 	}
 	if failedActionIndex, err := s.preflightApply(ctx, proposal.Actions, len(progress.results)); err != nil {
-		partial := ApplyResult{
-			ProposalID: proposal.ID,
-			Applied:    false,
-			Actions:    cloneActionResults(progress.results),
-		}
+		partial := applyResult(proposal.ID, false, len(proposal.Actions), &failedActionIndex, progress.results)
 		return partial, &ApplyError{
 			ProposalID:        proposal.ID,
 			FailedActionIndex: failedActionIndex,
@@ -63,11 +59,7 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 		action := proposal.Actions[idx]
 		result, err := s.applyAction(ctx, action)
 		if err != nil {
-			partial := ApplyResult{
-				ProposalID: proposal.ID,
-				Applied:    false,
-				Actions:    cloneActionResults(progress.results),
-			}
+			partial := applyResult(proposal.ID, false, len(proposal.Actions), &idx, progress.results)
 			return partial, &ApplyError{
 				ProposalID:        proposal.ID,
 				FailedActionIndex: idx,
@@ -80,7 +72,7 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 
 	progress.complete = true
 
-	return ApplyResult{ProposalID: proposal.ID, Applied: true, Actions: cloneActionResults(progress.results)}, nil
+	return applyResult(proposal.ID, true, len(proposal.Actions), nil, progress.results), nil
 }
 
 type applyActionSpec struct {
@@ -139,4 +131,27 @@ func cloneActionResults(results []ActionResult) []ActionResult {
 		}
 	}
 	return cloned
+}
+
+func applyResult(proposalID string, applied bool, totalActionCount int, failedActionIndex *int, results []ActionResult) ApplyResult {
+	committedActionCount := len(results)
+	resumeActionIndex := committedActionCount
+	failed := cloneIntPtr(failedActionIndex)
+	return ApplyResult{
+		ProposalID:           proposalID,
+		Applied:              applied,
+		Actions:              cloneActionResults(results),
+		TotalActionCount:     totalActionCount,
+		CommittedActionCount: committedActionCount,
+		FailedActionIndex:    failed,
+		ResumeActionIndex:    resumeActionIndex,
+	}
+}
+
+func cloneIntPtr(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -116,9 +116,13 @@ type Action struct {
 }
 
 type ApplyResult struct {
-	ProposalID string         `json:"proposal_id"`
-	Applied    bool           `json:"applied"`
-	Actions    []ActionResult `json:"actions"`
+	ProposalID           string         `json:"proposal_id"`
+	Applied              bool           `json:"applied"`
+	Actions              []ActionResult `json:"actions"`
+	TotalActionCount     int            `json:"total_action_count"`
+	CommittedActionCount int            `json:"committed_action_count"`
+	FailedActionIndex    *int           `json:"failed_action_index,omitempty"`
+	ResumeActionIndex    int            `json:"resume_action_index"`
 }
 
 type ActionResult struct {

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -35,6 +35,15 @@ type assistantFixtureBuilder struct {
 	build func(t *testing.T) assistantFixture
 }
 
+type failingAssignmentWorkAuthority struct {
+	WorkAuthority
+	err error
+}
+
+func (authority failingAssignmentWorkAuthority) CreateAssignment(context.Context, string, string, WorkAssignmentCommand) (projectwork.Assignment, error) {
+	return projectwork.Assignment{}, authority.err
+}
+
 type fakeAssistantLLM struct {
 	response string
 	err      error
@@ -1603,7 +1612,7 @@ func TestService_ApplyCreatesProjectWorkRecords(t *testing.T) {
 			fixture := builder.build(t)
 			project := createTestProject(t, ctx, fixture.projects)
 
-			_, err := fixture.service.Apply(ctx, Proposal{
+			result, err := fixture.service.Apply(ctx, Proposal{
 				ID:                   "pa_project_work",
 				RequiresConfirmation: true,
 				Actions: []Action{
@@ -1643,6 +1652,9 @@ func TestService_ApplyCreatesProjectWorkRecords(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Apply project work: %v", err)
 			}
+			if !result.Applied || result.TotalActionCount != 3 || result.CommittedActionCount != 3 || result.ResumeActionIndex != 3 || result.FailedActionIndex != nil {
+				t.Fatalf("apply result = %+v, want applied progress counts for 3 actions", result)
+			}
 
 			item, ok, err := fixture.work.GetWorkItem(ctx, project.ID, "work_a")
 			if err != nil || !ok {
@@ -1664,6 +1676,81 @@ func TestService_ApplyCreatesProjectWorkRecords(t *testing.T) {
 			}
 			if len(handoffs) != 1 || handoffs[0].ID != "handoff_a" || handoffs[0].Status != projectwork.HandoffStatusPending {
 				t.Fatalf("handoffs = %+v, want pending handoff", handoffs)
+			}
+		})
+	}
+}
+
+func TestService_ApplyLoopFailureReportsCommittedProgressAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+			applyErr := fmt.Errorf("%w: injected assignment failure", ErrConflict)
+			fixture.service.workAuthority = failingAssignmentWorkAuthority{
+				WorkAuthority: storeWorkAuthority{store: fixture.work},
+				err:           applyErr,
+			}
+
+			proposal := Proposal{
+				ID:                   "pa_apply_loop_partial",
+				RequiresConfirmation: true,
+				Actions: []Action{
+					{
+						Kind: ActionCreateWorkItem,
+						Patch: rawPatch(t, map[string]any{
+							"id":         "work_loop_partial",
+							"project_id": project.ID,
+							"title":      "Apply loop partial",
+						}),
+					},
+					{
+						Kind: ActionCreateAssignment,
+						Patch: rawPatch(t, map[string]any{
+							"id":           "asgn_loop_partial",
+							"project_id":   project.ID,
+							"work_item_id": "work_loop_partial",
+							"role_id":      "software_developer",
+							"root_id":      project.Roots[0].ID,
+							"driver_kind":  projectwork.AssignmentDriverHecateTask,
+							"status":       projectwork.AssignmentStatusQueued,
+						}),
+					},
+				},
+			}
+
+			result, err := fixture.service.Apply(ctx, proposal, true)
+			if !errors.Is(err, ErrConflict) {
+				t.Fatalf("Apply err = %v, want ErrConflict", err)
+			}
+			var partial *ApplyError
+			if !errors.As(err, &partial) {
+				t.Fatalf("Apply err = %T %v, want ApplyError", err, err)
+			}
+			if partial.FailedActionIndex != 1 {
+				t.Fatalf("failed_action_index = %d, want 1", partial.FailedActionIndex)
+			}
+			if result.Applied || result.TotalActionCount != 2 || result.CommittedActionCount != 1 || result.ResumeActionIndex != 1 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
+				t.Fatalf("partial result progress = %+v, want one committed action and failed action 1", result)
+			}
+			if len(result.Actions) != 1 || result.Actions[0].Kind != ActionCreateWorkItem || result.Actions[0].ID != "work_loop_partial" {
+				t.Fatalf("partial actions = %+v, want committed work item action", result.Actions)
+			}
+			if partial.Result.CommittedActionCount != result.CommittedActionCount || len(partial.Result.Actions) != len(result.Actions) {
+				t.Fatalf("apply error result = %+v, want returned partial result %+v", partial.Result, result)
+			}
+			if _, ok, err := fixture.work.GetWorkItem(ctx, project.ID, "work_loop_partial"); err != nil || !ok {
+				t.Fatalf("GetWorkItem ok=%v err=%v, want committed work item", ok, err)
+			}
+			assignments, err := fixture.work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: project.ID, WorkItemID: "work_loop_partial"})
+			if err != nil {
+				t.Fatalf("ListAssignments: %v", err)
+			}
+			if len(assignments) != 0 {
+				t.Fatalf("assignments = %+v, want no assignment after injected apply failure", assignments)
 			}
 		})
 	}
@@ -1864,6 +1951,9 @@ func TestService_ApplyPreflightBlocksStaleTargetsBeforeMutatingAcrossStores(t *t
 			if applyErr.FailedActionIndex != 1 {
 				t.Fatalf("failed_action_index = %d, want 1", applyErr.FailedActionIndex)
 			}
+			if result.TotalActionCount != 2 || result.CommittedActionCount != 0 || result.ResumeActionIndex != 0 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
+				t.Fatalf("partial result progress = %+v, want failed action 1 and resume action 0", result)
+			}
 			if result.Applied || len(result.Actions) != 0 {
 				t.Fatalf("partial result = %+v, want no action results before preflight failure", result)
 			}
@@ -1963,6 +2053,9 @@ func TestService_ApplyPreflightBlocksCloseoutBeforeMutatingAcrossStores(t *testi
 			if applyErr.FailedActionIndex != 1 || len(applyErr.Result.Actions) != 0 {
 				t.Fatalf("apply error = %+v, want preflight failure at done action with no committed actions", applyErr)
 			}
+			if applyErr.Result.TotalActionCount != 2 || applyErr.Result.CommittedActionCount != 0 || applyErr.Result.ResumeActionIndex != 0 || applyErr.Result.FailedActionIndex == nil || *applyErr.Result.FailedActionIndex != 1 {
+				t.Fatalf("apply error progress = %+v, want failed action 1 and resume action 0", applyErr.Result)
+			}
 			handoffs, err := fixture.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: project.ID, WorkItemID: workItem.ID})
 			if err != nil {
 				t.Fatalf("ListHandoffs: %v", err)
@@ -2032,6 +2125,9 @@ func TestService_ApplyPreflightBlocksMissingHandoffTargetBeforeMutatingAcrossSto
 			}
 			if applyErr.FailedActionIndex != 1 {
 				t.Fatalf("failed_action_index = %d, want 1", applyErr.FailedActionIndex)
+			}
+			if result.TotalActionCount != 2 || result.CommittedActionCount != 0 || result.ResumeActionIndex != 0 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
+				t.Fatalf("result progress = %+v, want failed action 1 and resume action 0", result)
 			}
 			if result.Applied || len(result.Actions) != 0 {
 				t.Fatalf("result = %+v, want no partial action results", result)

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -437,6 +437,7 @@ function ProjectAssistantApplyResultPanel({
   setupFirst: boolean;
   workItemCount: number;
 }) {
+  const appliedCount = result.committed_action_count ?? result.actions.length;
   const resultActions = projectAssistantFollowUpActions({
     memoryCandidateCount,
     onCreateWork,
@@ -456,7 +457,7 @@ function ProjectAssistantApplyResultPanel({
         <span className="badge badge-green">applied</span>
         <div style={assistantResultCopyStyle}>
           <strong style={{ color: "var(--t1)" }}>
-            Applied {result.actions.length} action{result.actions.length === 1 ? "" : "s"}
+            Applied {appliedCount} action{appliedCount === 1 ? "" : "s"}
           </strong>
           <span style={subtleTextStyle}>Proposal {result.proposal_id} is applied.</span>
         </div>

--- a/ui/src/features/projects/useProjectAssistantController.test.ts
+++ b/ui/src/features/projects/useProjectAssistantController.test.ts
@@ -88,6 +88,10 @@ describe("Project Assistant controller helpers", () => {
           partial_result: {
             proposal_id: "pa_partial",
             applied: false,
+            total_action_count: 2,
+            committed_action_count: 1,
+            failed_action_index: 1,
+            resume_action_index: 1,
             actions: [{ kind: "create_assignment", id: "asgn_1" }],
           },
         },
@@ -97,5 +101,26 @@ describe("Project Assistant controller helpers", () => {
     expect(partial).toContain("applied 1 of 2 actions");
     expect(partial).toContain("create assignment asgn_1");
     expect(partial).toContain("failed at action 2 (create memory candidate)");
+
+    const serverCountedPartial = projectAssistantApplyErrorMessage(
+      new ApiError("partial", 409, "conflict", {
+        fields: {
+          failed_action_index: 1,
+          total_action_count: 3,
+          committed_action_count: 1,
+          resume_action_index: 1,
+          partial_result: {
+            proposal_id: "pa_partial",
+            applied: false,
+            total_action_count: 3,
+            committed_action_count: 1,
+            failed_action_index: 1,
+            resume_action_index: 1,
+            actions: [{ kind: "create_assignment", id: "asgn_1" }],
+          },
+        },
+      }),
+    );
+    expect(serverCountedPartial).toContain("applied 1 of 3 actions");
   });
 });

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -324,11 +324,20 @@ function projectAssistantPartialApplyErrorMessage(
   error: ApiError,
   proposal?: ProjectAssistantProposal,
 ): string {
-  const failedActionIndex = projectAssistantFailedActionIndex(error.fields.failed_action_index);
   const partialResult = projectAssistantPartialResult(error.fields.partial_result);
+  const failedActionIndex =
+    projectAssistantNonNegativeInteger(error.fields.failed_action_index) ??
+    (partialResult ? projectAssistantNonNegativeInteger(partialResult.failed_action_index) : null);
   if (failedActionIndex === null || !partialResult) return "";
-  const appliedCount = partialResult.actions.length;
-  const totalCount = proposal?.actions.length ?? Math.max(appliedCount, failedActionIndex + 1);
+  const appliedCount =
+    projectAssistantNonNegativeInteger(error.fields.committed_action_count) ??
+    projectAssistantNonNegativeInteger(partialResult.committed_action_count) ??
+    partialResult.actions.length;
+  const totalCount =
+    projectAssistantNonNegativeInteger(error.fields.total_action_count) ??
+    projectAssistantNonNegativeInteger(partialResult.total_action_count) ??
+    proposal?.actions.length ??
+    Math.max(appliedCount, failedActionIndex + 1);
   const landed = projectAssistantAppliedActionsSummary(partialResult.actions);
   const failed = projectAssistantFailedActionSummary(proposal, failedActionIndex);
   return `Project Assistant applied ${appliedCount} of ${totalCount} actions${landed}. It then failed at action ${failedActionIndex + 1}${failed}. Apply the same proposal again after fixing the target state to resume from the next unapplied action.`;
@@ -379,7 +388,7 @@ function projectAssistantActionKindLabel(kind: string) {
   return kind.replace(/_/g, " ");
 }
 
-function projectAssistantFailedActionIndex(value: unknown): number | null {
+function projectAssistantNonNegativeInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
@@ -397,6 +406,13 @@ function projectAssistantPartialResult(value: unknown): ProjectAssistantApplyRes
     proposal_id: result.proposal_id,
     applied: result.applied,
     actions: result.actions,
+    total_action_count: projectAssistantNonNegativeInteger(result.total_action_count) ?? undefined,
+    committed_action_count:
+      projectAssistantNonNegativeInteger(result.committed_action_count) ?? undefined,
+    failed_action_index:
+      projectAssistantNonNegativeInteger(result.failed_action_index) ?? undefined,
+    resume_action_index:
+      projectAssistantNonNegativeInteger(result.resume_action_index) ?? undefined,
   };
 }
 

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -1185,9 +1185,16 @@ describe("api client", () => {
               type: "conflict",
               message: "project assistant apply failed",
               failed_action_index: 1,
+              total_action_count: 2,
+              committed_action_count: 1,
+              resume_action_index: 1,
               partial_result: {
                 proposal_id: "pa_partial",
                 applied: false,
+                total_action_count: 2,
+                committed_action_count: 1,
+                failed_action_index: 1,
+                resume_action_index: 1,
                 actions: [{ kind: "create_assignment", id: "asgn_1" }],
               },
             },
@@ -1199,9 +1206,16 @@ describe("api client", () => {
       await expect(getUsageSummary("?scope=global")).rejects.toMatchObject({
         fields: {
           failed_action_index: 1,
+          total_action_count: 2,
+          committed_action_count: 1,
+          resume_action_index: 1,
           partial_result: {
             proposal_id: "pa_partial",
             applied: false,
+            total_action_count: 2,
+            committed_action_count: 1,
+            failed_action_index: 1,
+            resume_action_index: 1,
             actions: [{ kind: "create_assignment", id: "asgn_1" }],
           },
         },

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -82,6 +82,10 @@ export type ProjectAssistantApplyResult = {
   proposal_id: string;
   applied: boolean;
   actions: ProjectAssistantActionResult[];
+  total_action_count?: number;
+  committed_action_count?: number;
+  failed_action_index?: number;
+  resume_action_index?: number;
 };
 
 export type ProjectAssistantProposalResponse = {


### PR DESCRIPTION
## Summary
- add mcp to Hecate's normalized external-adapter approval tool-kind taxonomy
- record ACP permissions with kind=mcp as tool_kind=mcp for grant matching and telemetry
- add fake ACP session coverage for MCP approval recording
- update the implemented approval-loop design notes

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/agentadapters
- just docs-format-check