### PR TITLE
Isolate project delete cleanup authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ internal/
   chatcontext/          pure context-packet lookup/decode/normalize helpers and
                           canonical ref builders shared by API context endpoints
   projects/             durable project identity store (memory / sqlite / postgres)
+  projectapp/           project lifecycle application layer used by API handlers:
+                          project delete cascade boundaries and cleanup authority
   projectskills/        project-scoped SKILL.md metadata registry
                           (memory / sqlite / postgres; no body injection or execution)
   projectwork/          project roles, work items, assignments, handoffs, and

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hecatehq/hecate/internal/chatapp"
 	"github.com/hecatehq/hecate/internal/modelapp"
 	"github.com/hecatehq/hecate/internal/pluginregistryapp"
+	"github.com/hecatehq/hecate/internal/projectapp"
 	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
 	"github.com/hecatehq/hecate/internal/providerapp"
@@ -49,6 +50,21 @@ func (h *Handler) providerApplication() *providerapp.Application {
 		ControlPlane: h.controlPlane,
 		Runtime:      h.providerRuntime,
 		Config:       h.config,
+	})
+}
+
+func (h *Handler) projectApplication() *projectapp.Application {
+	if h == nil {
+		return projectapp.New(projectapp.Options{})
+	}
+	return projectapp.New(projectapp.Options{
+		Projects:         h.projects,
+		Chats:            h.agentChat,
+		DeleteChat:       h.deleteProjectChatSession,
+		ProjectWork:      h.projectWork,
+		ProjectSkills:    h.projectSkills,
+		Memory:           h.memory,
+		MemoryCandidates: h.memoryCandidates,
 	})
 }
 

--- a/internal/api/applications_test.go
+++ b/internal/api/applications_test.go
@@ -20,6 +20,9 @@ func TestHandlerApplicationHelpersAreNilSafe(t *testing.T) {
 	if handler.providerApplication() == nil {
 		t.Fatal("providerApplication() returned nil")
 	}
+	if handler.projectApplication() == nil {
+		t.Fatal("projectApplication() returned nil")
+	}
 	if handler.projectWorkApplication() == nil {
 		t.Fatal("projectWorkApplication() returned nil")
 	}

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/projectapp"
 	"github.com/hecatehq/hecate/internal/projects"
 )
 
@@ -273,49 +275,13 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	if _, ok, err := h.projects.Get(r.Context(), id); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	} else if !ok {
+	_, err := h.projectApplication().DeleteProject(r.Context(), r.PathValue("id"))
+	if errors.Is(err, projectapp.ErrProjectNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
 	}
-	if err := h.deleteProjectChats(r.Context(), id); err != nil {
-		if errors.Is(err, errChatSessionDeleteConflict) {
-			WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
-			return
-		}
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if h.projectWork != nil {
-		if _, err := h.projectWork.DeleteProject(r.Context(), id); err != nil {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-	}
-	if h.projectSkills != nil {
-		if _, err := h.projectSkills.DeleteProject(r.Context(), id); err != nil {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-	}
-	if h.memory != nil {
-		if _, err := h.memory.DeleteByProjectID(r.Context(), id); err != nil {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-	}
-	if h.memoryCandidates != nil {
-		if _, err := h.memoryCandidates.DeleteCandidatesByProjectID(r.Context(), id); err != nil {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-	}
-	err := h.projects.Delete(r.Context(), id)
-	if errors.Is(err, projects.ErrNotFound) {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+	if errors.Is(err, projectapp.ErrProjectDeleteConflict) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
 		return
 	}
 	if err != nil {
@@ -325,27 +291,12 @@ func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Handler) deleteProjectChats(ctx context.Context, projectID string) error {
-	if h.agentChat == nil {
-		return nil
+func (h *Handler) deleteProjectChatSession(ctx context.Context, session chat.Session) (bool, error) {
+	stopping, err := h.deleteExistingChatSession(ctx, session)
+	if errors.Is(err, errChatSessionDeleteConflict) {
+		return stopping, fmt.Errorf("%w: %v", projectapp.ErrProjectDeleteConflict, err)
 	}
-	sessions, err := h.agentChat.List(ctx)
-	if err != nil {
-		return err
-	}
-	for _, session := range sessions {
-		if session.ProjectID != projectID {
-			continue
-		}
-		stopping, err := h.deleteExistingChatSession(ctx, session)
-		if err != nil {
-			return err
-		}
-		if stopping {
-			return fmt.Errorf("%w: chat session %q is still stopping", errChatSessionDeleteConflict, session.ID)
-		}
-	}
-	return nil
+	return stopping, err
 }
 
 func projectFromCreateRequest(req createProjectRequest) (projects.Project, error) {

--- a/internal/projectapp/application.go
+++ b/internal/projectapp/application.go
@@ -1,0 +1,169 @@
+package projectapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+var (
+	ErrProjectStoreNotConfigured = errors.New("project store is not configured")
+	ErrProjectNotFound           = errors.New("project not found")
+	ErrProjectDeleteConflict     = errors.New("project delete conflicts with current state")
+	ErrChatDeleteNotConfigured   = errors.New("project chat delete authority is not configured")
+)
+
+type ProjectStore interface {
+	Get(ctx context.Context, id string) (projects.Project, bool, error)
+	Delete(ctx context.Context, id string) error
+}
+
+type ChatSessionStore interface {
+	List(ctx context.Context) ([]chat.Session, error)
+}
+
+type ChatDeleteFunc func(context.Context, chat.Session) (bool, error)
+
+type ProjectWorkStore interface {
+	DeleteProject(ctx context.Context, projectID string) (int, error)
+}
+
+type ProjectSkillStore interface {
+	DeleteProject(ctx context.Context, projectID string) (int, error)
+}
+
+type MemoryStore interface {
+	DeleteByProjectID(ctx context.Context, projectID string) (int, error)
+}
+
+type MemoryCandidateStore interface {
+	DeleteCandidatesByProjectID(ctx context.Context, projectID string) (int, error)
+}
+
+type Application struct {
+	projects         ProjectStore
+	chats            ChatSessionStore
+	deleteChat       ChatDeleteFunc
+	projectWork      ProjectWorkStore
+	projectSkills    ProjectSkillStore
+	memory           MemoryStore
+	memoryCandidates MemoryCandidateStore
+}
+
+type Options struct {
+	Projects         ProjectStore
+	Chats            ChatSessionStore
+	DeleteChat       ChatDeleteFunc
+	ProjectWork      ProjectWorkStore
+	ProjectSkills    ProjectSkillStore
+	Memory           MemoryStore
+	MemoryCandidates MemoryCandidateStore
+}
+
+type DeleteProjectResult struct {
+	Project                 projects.Project
+	ChatSessionsDeleted     int
+	ProjectWorkRowsDeleted  int
+	ProjectSkillsDeleted    int
+	MemoryEntriesDeleted    int
+	MemoryCandidatesDeleted int
+}
+
+func New(opts Options) *Application {
+	return &Application{
+		projects:         opts.Projects,
+		chats:            opts.Chats,
+		deleteChat:       opts.DeleteChat,
+		projectWork:      opts.ProjectWork,
+		projectSkills:    opts.ProjectSkills,
+		memory:           opts.Memory,
+		memoryCandidates: opts.MemoryCandidates,
+	}
+}
+
+func (app *Application) DeleteProject(ctx context.Context, id string) (DeleteProjectResult, error) {
+	if app == nil || app.projects == nil {
+		return DeleteProjectResult{}, ErrProjectStoreNotConfigured
+	}
+	projectID := strings.TrimSpace(id)
+	project, ok, err := app.projects.Get(ctx, projectID)
+	if err != nil {
+		return DeleteProjectResult{}, err
+	}
+	if !ok {
+		return DeleteProjectResult{}, ErrProjectNotFound
+	}
+
+	result := DeleteProjectResult{Project: project}
+	if err := app.deleteProjectChats(ctx, projectID, &result); err != nil {
+		return result, err
+	}
+	if app.projectWork != nil {
+		deleted, err := app.projectWork.DeleteProject(ctx, projectID)
+		if err != nil {
+			return result, err
+		}
+		result.ProjectWorkRowsDeleted = deleted
+	}
+	if app.projectSkills != nil {
+		deleted, err := app.projectSkills.DeleteProject(ctx, projectID)
+		if err != nil {
+			return result, err
+		}
+		result.ProjectSkillsDeleted = deleted
+	}
+	if app.memory != nil {
+		deleted, err := app.memory.DeleteByProjectID(ctx, projectID)
+		if err != nil {
+			return result, err
+		}
+		result.MemoryEntriesDeleted = deleted
+	}
+	if app.memoryCandidates != nil {
+		deleted, err := app.memoryCandidates.DeleteCandidatesByProjectID(ctx, projectID)
+		if err != nil {
+			return result, err
+		}
+		result.MemoryCandidatesDeleted = deleted
+	}
+	// Cross-store cleanup is retry-friendly rather than transactional: the
+	// project identity stays durable until every scoped cleanup step succeeds.
+	if err := app.projects.Delete(ctx, projectID); err != nil {
+		if errors.Is(err, projects.ErrNotFound) {
+			return result, ErrProjectNotFound
+		}
+		return result, err
+	}
+	return result, nil
+}
+
+func (app *Application) deleteProjectChats(ctx context.Context, projectID string, result *DeleteProjectResult) error {
+	if app.chats == nil {
+		return nil
+	}
+	sessions, err := app.chats.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, session := range sessions {
+		if strings.TrimSpace(session.ProjectID) != projectID {
+			continue
+		}
+		if app.deleteChat == nil {
+			return ErrChatDeleteNotConfigured
+		}
+		stopping, err := app.deleteChat(ctx, session)
+		if err != nil {
+			return err
+		}
+		if stopping {
+			return fmt.Errorf("%w: chat session %q is still stopping", ErrProjectDeleteConflict, session.ID)
+		}
+		result.ChatSessionsDeleted++
+	}
+	return nil
+}

--- a/internal/projectapp/application_test.go
+++ b/internal/projectapp/application_test.go
@@ -1,0 +1,287 @@
+package projectapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestApplication_DeleteProjectCleansProjectScopedStores(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	projectStore := projects.NewMemoryStore()
+	chatStore := chat.NewMemoryStore()
+	workStore := projectwork.NewMemoryStore()
+	skillStore := projectskills.NewMemoryStore()
+	memoryStore := memory.NewMemoryStore()
+	projectID := "proj_delete"
+	otherProjectID := "proj_other"
+
+	if _, err := projectStore.Create(ctx, projects.Project{ID: projectID, Name: "Delete me"}); err != nil {
+		t.Fatalf("Create(project): %v", err)
+	}
+	if _, err := projectStore.Create(ctx, projects.Project{ID: otherProjectID, Name: "Keep me"}); err != nil {
+		t.Fatalf("Create(other project): %v", err)
+	}
+	if _, err := chatStore.Create(ctx, chat.Session{ID: "chat_delete", ProjectID: projectID, AgentID: chat.DefaultAgentID}); err != nil {
+		t.Fatalf("Create(project chat): %v", err)
+	}
+	if _, err := chatStore.Create(ctx, chat.Session{ID: "chat_keep", ProjectID: otherProjectID, AgentID: chat.DefaultAgentID}); err != nil {
+		t.Fatalf("Create(other chat): %v", err)
+	}
+	if _, err := chatStore.Create(ctx, chat.Session{ID: "chat_no_project", AgentID: chat.DefaultAgentID}); err != nil {
+		t.Fatalf("Create(no-project chat): %v", err)
+	}
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{ID: "work_delete", ProjectID: projectID, Title: "Cleanup"}); err != nil {
+		t.Fatalf("CreateWorkItem(project): %v", err)
+	}
+	if _, err := workStore.CreateAssignment(ctx, projectwork.Assignment{ID: "asgn_delete", ProjectID: projectID, WorkItemID: "work_delete", RoleID: "software_developer"}); err != nil {
+		t.Fatalf("CreateAssignment(project): %v", err)
+	}
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{ID: "work_keep", ProjectID: otherProjectID, Title: "Keep"}); err != nil {
+		t.Fatalf("CreateWorkItem(other): %v", err)
+	}
+	if _, err := skillStore.UpsertDiscovered(ctx, projectID, []projectskills.Skill{{ID: "skill_delete", Title: "Delete", Path: "SKILL.md"}}); err != nil {
+		t.Fatalf("UpsertDiscovered(project): %v", err)
+	}
+	if _, err := skillStore.UpsertDiscovered(ctx, otherProjectID, []projectskills.Skill{{ID: "skill_keep", Title: "Keep", Path: "SKILL.md"}}); err != nil {
+		t.Fatalf("UpsertDiscovered(other): %v", err)
+	}
+	if _, err := memoryStore.Create(ctx, memory.Entry{ID: "mem_delete", Scope: memory.ScopeProject, ProjectID: projectID, Title: "Delete", Body: "Delete"}); err != nil {
+		t.Fatalf("Create(memory): %v", err)
+	}
+	if _, err := memoryStore.Create(ctx, memory.Entry{ID: "mem_keep", Scope: memory.ScopeProject, ProjectID: otherProjectID, Title: "Keep", Body: "Keep"}); err != nil {
+		t.Fatalf("Create(other memory): %v", err)
+	}
+	if _, err := memoryStore.CreateCandidate(ctx, memory.Candidate{ID: "cand_delete", ProjectID: projectID, Title: "Delete", Body: "Delete"}); err != nil {
+		t.Fatalf("CreateCandidate(project): %v", err)
+	}
+	if _, err := memoryStore.CreateCandidate(ctx, memory.Candidate{ID: "cand_keep", ProjectID: otherProjectID, Title: "Keep", Body: "Keep"}); err != nil {
+		t.Fatalf("CreateCandidate(other): %v", err)
+	}
+
+	deletedChats := make([]string, 0, 1)
+	app := New(Options{
+		Projects:         projectStore,
+		Chats:            chatStore,
+		DeleteChat:       deleteChatFromStore(chatStore, &deletedChats, false),
+		ProjectWork:      workStore,
+		ProjectSkills:    skillStore,
+		Memory:           memoryStore,
+		MemoryCandidates: memoryStore,
+	})
+	result, err := app.DeleteProject(ctx, projectID)
+	if err != nil {
+		t.Fatalf("DeleteProject() error = %v", err)
+	}
+	if result.Project.ID != projectID || result.ChatSessionsDeleted != 1 || result.ProjectWorkRowsDeleted != 2 ||
+		result.ProjectSkillsDeleted != 1 || result.MemoryEntriesDeleted != 1 || result.MemoryCandidatesDeleted != 1 {
+		t.Fatalf("DeleteProject() result = %+v, want project and scoped delete counts", result)
+	}
+	if len(deletedChats) != 1 || deletedChats[0] != "chat_delete" {
+		t.Fatalf("deleted chats = %#v, want only project chat", deletedChats)
+	}
+	if _, ok, err := projectStore.Get(ctx, projectID); err != nil || ok {
+		t.Fatalf("Get(deleted project) ok=%v err=%v, want missing", ok, err)
+	}
+	if _, ok, err := projectStore.Get(ctx, otherProjectID); err != nil || !ok {
+		t.Fatalf("Get(other project) ok=%v err=%v, want present", ok, err)
+	}
+	assertProjectAppListCount(t, "project work", func() (int, error) {
+		items, err := workStore.ListWorkItems(ctx, projectID)
+		return len(items), err
+	}, 0)
+	assertProjectAppListCount(t, "other project work", func() (int, error) {
+		items, err := workStore.ListWorkItems(ctx, otherProjectID)
+		return len(items), err
+	}, 1)
+	assertProjectAppListCount(t, "project skills", func() (int, error) {
+		items, err := skillStore.List(ctx, projectID)
+		return len(items), err
+	}, 0)
+	assertProjectAppListCount(t, "other project skills", func() (int, error) {
+		items, err := skillStore.List(ctx, otherProjectID)
+		return len(items), err
+	}, 1)
+	assertProjectAppListCount(t, "project memory", func() (int, error) {
+		items, err := memoryStore.List(ctx, memory.Filter{ProjectID: projectID, IncludeDisabled: true})
+		return len(items), err
+	}, 0)
+	assertProjectAppListCount(t, "other project memory", func() (int, error) {
+		items, err := memoryStore.List(ctx, memory.Filter{ProjectID: otherProjectID, IncludeDisabled: true})
+		return len(items), err
+	}, 1)
+	assertProjectAppListCount(t, "project memory candidates", func() (int, error) {
+		items, err := memoryStore.ListCandidates(ctx, memory.CandidateFilter{ProjectID: projectID})
+		return len(items), err
+	}, 0)
+	assertProjectAppListCount(t, "other project memory candidates", func() (int, error) {
+		items, err := memoryStore.ListCandidates(ctx, memory.CandidateFilter{ProjectID: otherProjectID})
+		return len(items), err
+	}, 1)
+	assertProjectAppListCount(t, "remaining chats", func() (int, error) {
+		items, err := chatStore.List(ctx)
+		return len(items), err
+	}, 2)
+}
+
+func TestApplication_DeleteProjectStopsBeforeCleanupWhenProjectChatIsStopping(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	projectStore := projects.NewMemoryStore()
+	chatStore := chat.NewMemoryStore()
+	workStore := projectwork.NewMemoryStore()
+	memoryStore := memory.NewMemoryStore()
+	projectID := "proj_stopping"
+	if _, err := projectStore.Create(ctx, projects.Project{ID: projectID, Name: "Stopping"}); err != nil {
+		t.Fatalf("Create(project): %v", err)
+	}
+	if _, err := chatStore.Create(ctx, chat.Session{ID: "chat_stopping", ProjectID: projectID, AgentID: chat.DefaultAgentID}); err != nil {
+		t.Fatalf("Create(chat): %v", err)
+	}
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{ID: "work_stopping", ProjectID: projectID, Title: "Cleanup"}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := memoryStore.Create(ctx, memory.Entry{ID: "mem_stopping", Scope: memory.ScopeProject, ProjectID: projectID, Title: "Keep", Body: "Keep"}); err != nil {
+		t.Fatalf("Create(memory): %v", err)
+	}
+
+	deletedChats := make([]string, 0, 1)
+	app := New(Options{
+		Projects:         projectStore,
+		Chats:            chatStore,
+		DeleteChat:       deleteChatFromStore(chatStore, &deletedChats, true),
+		ProjectWork:      workStore,
+		Memory:           memoryStore,
+		MemoryCandidates: memoryStore,
+	})
+	result, err := app.DeleteProject(ctx, projectID)
+	if !errors.Is(err, ErrProjectDeleteConflict) {
+		t.Fatalf("DeleteProject() error = %v, want ErrProjectDeleteConflict", err)
+	}
+	if result.Project.ID != projectID || result.ChatSessionsDeleted != 0 || result.ProjectWorkRowsDeleted != 0 ||
+		result.MemoryEntriesDeleted != 0 {
+		t.Fatalf("DeleteProject() result = %+v, want no cleanup counts after stopping chat", result)
+	}
+	if len(deletedChats) != 0 {
+		t.Fatalf("deleted chats = %#v, want none when chat is still stopping", deletedChats)
+	}
+	if _, ok, err := projectStore.Get(ctx, projectID); err != nil || !ok {
+		t.Fatalf("Get(project) ok=%v err=%v, want still present", ok, err)
+	}
+	assertProjectAppListCount(t, "project work", func() (int, error) {
+		items, err := workStore.ListWorkItems(ctx, projectID)
+		return len(items), err
+	}, 1)
+	assertProjectAppListCount(t, "project memory", func() (int, error) {
+		items, err := memoryStore.List(ctx, memory.Filter{ProjectID: projectID, IncludeDisabled: true})
+		return len(items), err
+	}, 1)
+	assertProjectAppListCount(t, "project chats", func() (int, error) {
+		items, err := chatStore.List(ctx)
+		return len(items), err
+	}, 1)
+}
+
+func TestApplication_DeleteProjectKeepsProjectWhenLaterCleanupFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	projectStore := projects.NewMemoryStore()
+	chatStore := chat.NewMemoryStore()
+	workStore := projectwork.NewMemoryStore()
+	memoryStore := memory.NewMemoryStore()
+	projectID := "proj_retry"
+	if _, err := projectStore.Create(ctx, projects.Project{ID: projectID, Name: "Retry"}); err != nil {
+		t.Fatalf("Create(project): %v", err)
+	}
+	if _, err := chatStore.Create(ctx, chat.Session{ID: "chat_retry", ProjectID: projectID, AgentID: chat.DefaultAgentID}); err != nil {
+		t.Fatalf("Create(chat): %v", err)
+	}
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{ID: "work_retry", ProjectID: projectID, Title: "Cleanup"}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := memoryStore.Create(ctx, memory.Entry{ID: "mem_retry", Scope: memory.ScopeProject, ProjectID: projectID, Title: "Retry", Body: "Retry"}); err != nil {
+		t.Fatalf("Create(memory): %v", err)
+	}
+
+	skillErr := errors.New("skill cleanup failed")
+	deletedChats := make([]string, 0, 1)
+	app := New(Options{
+		Projects:      projectStore,
+		Chats:         chatStore,
+		DeleteChat:    deleteChatFromStore(chatStore, &deletedChats, false),
+		ProjectWork:   workStore,
+		ProjectSkills: failingProjectSkillStore{err: skillErr},
+		Memory:        memoryStore,
+	})
+	result, err := app.DeleteProject(ctx, projectID)
+	if !errors.Is(err, skillErr) {
+		t.Fatalf("DeleteProject() error = %v, want skill cleanup failure", err)
+	}
+	if result.ChatSessionsDeleted != 1 || result.ProjectWorkRowsDeleted != 1 || result.MemoryEntriesDeleted != 0 {
+		t.Fatalf("DeleteProject() result = %+v, want committed counts before skill failure", result)
+	}
+	if _, ok, err := projectStore.Get(ctx, projectID); err != nil || !ok {
+		t.Fatalf("Get(project) ok=%v err=%v, want project retained for retry", ok, err)
+	}
+	assertProjectAppListCount(t, "project chats", func() (int, error) {
+		items, err := chatStore.List(ctx)
+		return len(items), err
+	}, 0)
+	assertProjectAppListCount(t, "project work", func() (int, error) {
+		items, err := workStore.ListWorkItems(ctx, projectID)
+		return len(items), err
+	}, 0)
+	assertProjectAppListCount(t, "project memory", func() (int, error) {
+		items, err := memoryStore.List(ctx, memory.Filter{ProjectID: projectID, IncludeDisabled: true})
+		return len(items), err
+	}, 1)
+}
+
+func TestApplication_DeleteProjectMapsMissingProject(t *testing.T) {
+	t.Parallel()
+
+	app := New(Options{Projects: projects.NewMemoryStore()})
+	_, err := app.DeleteProject(context.Background(), "proj_missing")
+	if !errors.Is(err, ErrProjectNotFound) {
+		t.Fatalf("DeleteProject() error = %v, want ErrProjectNotFound", err)
+	}
+}
+
+type failingProjectSkillStore struct {
+	err error
+}
+
+func (s failingProjectSkillStore) DeleteProject(context.Context, string) (int, error) {
+	return 0, s.err
+}
+
+func deleteChatFromStore(store *chat.MemoryStore, deleted *[]string, stopping bool) ChatDeleteFunc {
+	return func(ctx context.Context, session chat.Session) (bool, error) {
+		if stopping {
+			return true, nil
+		}
+		*deleted = append(*deleted, session.ID)
+		return false, store.Delete(ctx, session.ID)
+	}
+}
+
+func assertProjectAppListCount(t *testing.T, label string, list func() (int, error), want int) {
+	t.Helper()
+	got, err := list()
+	if err != nil {
+		t.Fatalf("%s list error = %v", label, err)
+	}
+	if got != want {
+		t.Fatalf("%s count = %d, want %d", label, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/projectapp` as the project lifecycle application boundary for project deletion cleanup.
- Route `DELETE /hecate/v1/projects/{id}` through the project app so chat, project work, project skills, memory, and memory candidate cleanup is no longer owned by the HTTP handler.
- Preserve existing API behavior while adding application-level tests for scoped cleanup, no-project preservation, and stopping-chat conflicts.
- Update the repo codebase map for the new application package.

## Validation

- `GOCACHE="$PWD/.gocache" go test ./internal/projectapp ./internal/api`
- `GOCACHE="$PWD/.gocache" go vet ./internal/projectapp ./internal/api`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
