### PR TITLE
polish(ui): clarify external agent approval grants

### DIFF
--- a/docs/design/implemented/external-agent-approval-loop-v1.md
+++ b/docs/design/implemented/external-agent-approval-loop-v1.md
@@ -108,12 +108,12 @@ to land that yet.
 When the operator resolves an approval, they pick a **scope** alongside the
 decision. v1 supports four scopes, in increasing breadth:
 
-| Scope            | Re-prompts when…                                                                                     | ACP option this maps to                                      |
-| ---------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `once`           | every subsequent matching request                                                                    | explicitly selected `allow_once`-style option                |
-| `session`        | re-asked next session, but auto-applied within this one                                              | `allow_always` (when adapter scopes "always" to its session) |
-| `workspace_tool` | re-asked for the same `(adapter, tool_name)` in a different workspace                                | Hecate-side approval grant                                   |
-| `adapter_tool`   | re-asked for a different tool, but auto-applied for this `(adapter, tool_name)` pair across sessions | Hecate-side approval grant                                   |
+| Scope            | Re-prompts when…                                                                                          | ACP option this maps to                                      |
+| ---------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `once`           | every subsequent matching request                                                                         | explicitly selected `allow_once`-style option                |
+| `session`        | re-asked next session, but auto-applied within this one                                                   | `allow_always` (when adapter scopes "always" to its session) |
+| `workspace_tool` | re-asked for the same `(adapter, tool_kind)` in a different workspace                                     | Hecate-side approval grant                                   |
+| `adapter_tool`   | re-asked for a different tool kind, but auto-applied for this `(adapter, tool_kind)` pair across sessions | Hecate-side approval grant                                   |
 
 Decisions broader than `once` persist in a new `chat_approval_grants`
 table:

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -73,7 +73,11 @@ Approvals are safety gates, not a sandbox.
 - Durable external-agent grants can be reviewed and revoked from Connections.
 - Auto-approval modes are dangerous for interactive use because they let tool requests proceed without operator review.
 
-Review broad grants carefully, especially workspace-wide or adapter-wide grants for file writes, shell commands, Git commands, and network access.
+Review broad grants carefully, especially workspace-wide or adapter-wide grants
+for file writes, shell commands, Git commands, network access, and MCP tools.
+External-agent grants match Hecate's normalized `tool_kind`, not a vendor's
+raw tool label, so an `mcp` grant applies to matching MCP tool requests from
+that adapter within the selected scope.
 
 ## Secrets and local state
 

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -557,6 +557,11 @@ are listed from `GET /hecate/v1/chat/grants`; the operator can revoke them from
 Connections. Pending approvals from a dead process are not
 replayed as actionable prompts — startup reconcile marks them `timed_out` with
 `path=startup_reconcile` before Hecate accepts traffic.
+Grant matching uses Hecate's normalized `tool_kind` (`file_write`, `shell_exec`,
+`mcp`, and so on), while the adapter's raw tool name stays on the approval row
+for display and audit. That means a broad `mcp` grant applies to MCP tool
+requests from that adapter within the chosen session/workspace/adapter scope,
+not only to one vendor-specific `server/tool` label.
 
 ![Chats workspace with an external-agent file-write approval waiting for operator review](../screenshots/chat-agent-approval.png)
 

--- a/ui/src/features/chats/AgentApprovalBanner.test.tsx
+++ b/ui/src/features/chats/AgentApprovalBanner.test.tsx
@@ -63,6 +63,16 @@ describe("AgentApprovalsBanner", () => {
     expect(screen.queryByTestId("agent-approval-banner-more")).toBeNull();
   });
 
+  it("labels MCP approvals with the normalized tool kind and raw tool name", () => {
+    render(
+      <AgentApprovalsBanner
+        pending={[approval({ approval_id: "ap-mcp", tool_kind: "mcp", tool_name: "docs/search" })]}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/MCP tool · docs\/search/)).toBeTruthy();
+  });
+
   it("collapses to two visible rows + an overflow button when there are three or more", () => {
     render(
       <AgentApprovalsBanner

--- a/ui/src/features/chats/AgentApprovalBanner.tsx
+++ b/ui/src/features/chats/AgentApprovalBanner.tsx
@@ -1,4 +1,5 @@
 import type { PendingAgentApproval } from "../../types/chat";
+import { agentApprovalToolLabel } from "../../lib/agent-approval-labels";
 import { Icon, Icons } from "../shared/ui";
 import { ChatNoticeFrame, ChatNoticeHeader, ChatNoticeRow } from "./ChatNotice";
 
@@ -103,7 +104,7 @@ function PendingApprovalRow({
   row: PendingAgentApproval;
   onSelect: (approvalID: string) => void;
 }) {
-  const label = row.tool_name ? `${row.tool_kind} · ${row.tool_name}` : row.tool_kind;
+  const label = agentApprovalToolLabel(row);
   const expiresIn = formatExpiresIn(row.expires_at);
   return (
     <ChatNoticeRow

--- a/ui/src/features/chats/AgentApprovalModal.test.tsx
+++ b/ui/src/features/chats/AgentApprovalModal.test.tsx
@@ -133,9 +133,9 @@ describe("AgentApprovalModal", () => {
     // Pick the broad scope.
     await user.click(await screen.findByTestId("agent-approval-modal-scope-adapter_tool"));
     expect(screen.getByTestId("agent-approval-modal-broad-warning")).toBeTruthy();
-    expect(screen.getByText("agent tool")).toBeTruthy();
+    expect(screen.getByText("agent tool kind")).toBeTruthy();
     expect(screen.getByTestId("agent-approval-modal-scope-description").textContent).toContain(
-      "Every future call",
+      "Every future fs request",
     );
     expect(screen.queryByText("adapter_tool")).toBeNull();
 
@@ -150,6 +150,39 @@ describe("AgentApprovalModal", () => {
       "s",
       "ap-1",
       expect.objectContaining({ decision: "approve", scope: "adapter_tool" }),
+    );
+  });
+
+  it("renders MCP approvals and broad MCP scopes without raw tool-kind leakage", async () => {
+    const { fetchApproval, onResolve, onCancel, onClose } = setup(
+      approvalRecord({
+        tool_kind: "mcp",
+        tool_name: "docs/search",
+        scope_choices: ["once", "workspace_tool", "adapter_tool"],
+      }),
+    );
+    render(
+      <AgentApprovalModal
+        sessionID="s"
+        approvalID="ap-1"
+        onClose={onClose}
+        fetchApproval={fetchApproval}
+        onResolve={onResolve}
+        onCancel={onCancel}
+      />,
+    );
+    await waitFor(() => expect(fetchApproval).toHaveBeenCalled());
+    expect(await screen.findByText("MCP tool · docs/search")).toBeTruthy();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("agent-approval-modal-scope-adapter_tool"));
+
+    expect(screen.getByText("agent MCP tools")).toBeTruthy();
+    expect(screen.getByTestId("agent-approval-modal-scope-description").textContent).toContain(
+      "Every future MCP tool request",
+    );
+    expect(screen.getByTestId("agent-approval-modal-broad-warning").textContent).toContain(
+      "future MCP tool requests",
     );
   });
 

--- a/ui/src/features/chats/AgentApprovalModal.tsx
+++ b/ui/src/features/chats/AgentApprovalModal.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
 import type { ResolveChatApprovalPayload } from "../../lib/api";
+import {
+  agentApprovalScopeDescription,
+  agentApprovalScopeLabel,
+  agentApprovalToolKindLabel,
+  agentApprovalToolLabel,
+} from "../../lib/agent-approval-labels";
 import type { ChatApprovalOption, ChatApprovalRecord } from "../../types/chat";
 import { Icon, Icons, Modal } from "../shared/ui";
 
@@ -12,7 +18,7 @@ import { Icon, Icons, Modal } from "../shared/ui";
 //   - Full row is fetched on open (not held in the pending map) so the
 //     banner stays cheap. While the fetch is in flight we show a
 //     spinner; on failure we close.
-//   - The broad agent-tool scope requires an explicit
+//   - The broad agent tool-kind scope requires an explicit
 //     "Confirm" step before sending the resolve to avoid one-click
 //     blanket-allow mistakes.
 //   - There's no diff preview surface today — the `agentApprovalItem`
@@ -77,7 +83,7 @@ export function AgentApprovalModal({
   const buttonLabel = decision === "allow" ? "Allow" : "Deny";
   const submitLabel =
     isBroadScope && !confirmingBroadScope ? `${buttonLabel} (broad scope)` : buttonLabel;
-  const scopeDescription = approvalScopeDescription(scope);
+  const scopeDescription = agentApprovalScopeDescription(scope, row?.tool_kind);
 
   async function handleSubmit() {
     if (!row || busy) return;
@@ -192,7 +198,7 @@ export function AgentApprovalModal({
               {row.workspace ? ` · ${row.workspace}` : ""}
             </span>
             <span style={{ fontSize: 13, color: "var(--t0)", fontWeight: 500 }}>
-              {row.tool_name ? `${row.tool_kind} · ${row.tool_name}` : row.tool_kind}
+              {agentApprovalToolLabel(row)}
             </span>
           </div>
 
@@ -351,7 +357,7 @@ export function AgentApprovalModal({
                     key={s}
                     type="button"
                     onClick={() => setScope(s)}
-                    title={approvalScopeDescription(s)}
+                    title={agentApprovalScopeDescription(s, row.tool_kind)}
                     data-testid={`agent-approval-modal-scope-${s}`}
                     style={{
                       padding: "4px 10px",
@@ -364,7 +370,7 @@ export function AgentApprovalModal({
                       cursor: "pointer",
                     }}
                   >
-                    {approvalScopeLabel(s)}
+                    {agentApprovalScopeLabel(s, row.tool_kind)}
                   </button>
                 ))}
               </div>
@@ -395,8 +401,8 @@ export function AgentApprovalModal({
                   }}
                 >
                   <Icon d={Icons.warning} size={12} /> <strong>Broad scope:</strong> this creates a
-                  durable grant for every future call to this tool from this agent. Click{" "}
-                  {buttonLabel} once to arm, then again to confirm.
+                  durable grant for future {agentApprovalToolKindLabel(row.tool_kind)} requests from
+                  this agent. Click {buttonLabel} once to arm, then again to confirm.
                 </div>
               )}
             </div>
@@ -441,32 +447,6 @@ export function AgentApprovalModal({
       )}
     </Modal>
   );
-}
-
-function approvalScopeLabel(scope: string): string {
-  switch (scope) {
-    case "workspace_tool":
-      return "workspace tool";
-    case "adapter_tool":
-      return "agent tool";
-    default:
-      return scope.replaceAll("_", " ");
-  }
-}
-
-function approvalScopeDescription(scope: string): string {
-  switch (scope) {
-    case "once":
-      return "Only this pending request will use the selected ACP option.";
-    case "session":
-      return "Matching requests in this external-agent chat session can reuse this decision.";
-    case "workspace_tool":
-      return "Matching calls to this tool in this workspace can reuse this decision.";
-    case "adapter_tool":
-      return "Every future call to this tool from this agent can reuse this decision.";
-    default:
-      return "";
-  }
 }
 
 function approvalOptionKindLabel(kind: string): string {

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -14,6 +14,7 @@ import {
 import { useRuntime } from "../../app/state/runtime";
 import { useSettings } from "../../app/state/settings";
 import { formatLocaleDateTime } from "../../lib/format";
+import { agentApprovalToolKindLabel } from "../../lib/agent-approval-labels";
 import {
   humanizeProbeError,
   resolveExternalAgentReadiness,
@@ -1305,7 +1306,7 @@ function GrantRow({
             ·
           </span>
           <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--t1)" }}>
-            {grant.tool_kind}
+            {agentApprovalToolKindLabel(grant.tool_kind)}
           </span>
           <span
             style={{

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -869,6 +869,7 @@ describe("ProvidersView table renders", () => {
     expect(await screen.findByTestId("external-agents-adapters")).toBeTruthy();
     expect(screen.getByTestId("external-agents-adapter-codex")).toBeTruthy();
     expect(screen.getByTestId("external-agents-row-grant-1")).toBeTruthy();
+    expect(screen.getByText("file write")).toBeTruthy();
     expect(listChatGrants).toHaveBeenCalled();
   });
 

--- a/ui/src/lib/agent-approval-labels.test.ts
+++ b/ui/src/lib/agent-approval-labels.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agentApprovalScopeDescription,
+  agentApprovalScopeLabel,
+  agentApprovalToolKindLabel,
+  agentApprovalToolLabel,
+} from "./agent-approval-labels";
+
+describe("agent approval labels", () => {
+  it("humanizes known tool kinds and leaves unknown kinds readable", () => {
+    expect(agentApprovalToolKindLabel("file_write")).toBe("file write");
+    expect(agentApprovalToolKindLabel("shell_exec")).toBe("shell command");
+    expect(agentApprovalToolKindLabel("mcp")).toBe("MCP tool");
+    expect(agentApprovalToolKindLabel("custom_tool")).toBe("custom tool");
+  });
+
+  it("combines the normalized kind label with the adapter tool name", () => {
+    expect(agentApprovalToolLabel({ tool_kind: "mcp", tool_name: "docs/search" })).toBe(
+      "MCP tool · docs/search",
+    );
+    expect(agentApprovalToolLabel({ tool_kind: "file_write", tool_name: "apply_patch" })).toBe(
+      "file write · apply_patch",
+    );
+  });
+
+  it("names broad MCP scopes as MCP-wide grants", () => {
+    expect(agentApprovalScopeLabel("workspace_tool", "mcp")).toBe("workspace MCP tools");
+    expect(agentApprovalScopeLabel("adapter_tool", "mcp")).toBe("agent MCP tools");
+    expect(agentApprovalScopeDescription("adapter_tool", "mcp")).toContain(
+      "Every future MCP tool request",
+    );
+  });
+});

--- a/ui/src/lib/agent-approval-labels.ts
+++ b/ui/src/lib/agent-approval-labels.ts
@@ -1,0 +1,56 @@
+type ApprovalToolLike = {
+  tool_kind?: string;
+  tool_name?: string;
+};
+
+const TOOL_KIND_LABELS: Record<string, string> = {
+  file_write: "file write",
+  file_read: "file read",
+  shell_exec: "shell command",
+  network: "network request",
+  file_move: "file move",
+  file_delete: "file delete",
+  search: "search",
+  think: "thinking",
+  mcp: "MCP tool",
+  other: "other tool",
+};
+
+export function agentApprovalToolKindLabel(toolKind?: string): string {
+  const trimmed = (toolKind ?? "").trim();
+  if (!trimmed) return "tool";
+  return TOOL_KIND_LABELS[trimmed] ?? trimmed.replaceAll("_", " ");
+}
+
+export function agentApprovalToolLabel(item: ApprovalToolLike): string {
+  const kindLabel = agentApprovalToolKindLabel(item.tool_kind);
+  const toolName = item.tool_name?.trim();
+  return toolName ? `${kindLabel} · ${toolName}` : kindLabel;
+}
+
+export function agentApprovalScopeLabel(scope: string, toolKind?: string): string {
+  switch (scope) {
+    case "workspace_tool":
+      return toolKind === "mcp" ? "workspace MCP tools" : "workspace tool kind";
+    case "adapter_tool":
+      return toolKind === "mcp" ? "agent MCP tools" : "agent tool kind";
+    default:
+      return scope.replaceAll("_", " ");
+  }
+}
+
+export function agentApprovalScopeDescription(scope: string, toolKind?: string): string {
+  const requestKind = agentApprovalToolKindLabel(toolKind);
+  switch (scope) {
+    case "once":
+      return "Only this pending request will use the selected ACP option.";
+    case "session":
+      return `Matching ${requestKind} requests in this external-agent chat session can reuse this decision.`;
+    case "workspace_tool":
+      return `Matching ${requestKind} requests in this workspace can reuse this decision.`;
+    case "adapter_tool":
+      return `Every future ${requestKind} request from this agent can reuse this decision.`;
+    default:
+      return "";
+  }
+}


### PR DESCRIPTION
## Summary

- add shared UI helpers for external-agent approval tool-kind and scope labels
- use the helpers in chat approval banners/modals and Connections grant rows
- clarify docs that durable external-agent grants match normalized tool_kind, including broad MCP grants

## Tests

- cd ui && bun run test -- AgentApprovalBanner AgentApprovalModal agent-approval-labels ProvidersView
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just docs-format-check
- git diff --check