### PR TITLE
feat(agentadapters): surface ACP agent info in health

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -563,6 +563,11 @@ for display and audit. That means a broad `mcp` grant applies to MCP tool
 requests from that adapter within the chosen session/workspace/adapter scope,
 not only to one vendor-specific `server/tool` label.
 
+Adapter health probes also preserve ACP `initialize.agentInfo` in
+`/hecate/v1/agent-adapters/{id}/health` as `agent_info`. Connections renders
+that live self-reported agent name/version alongside the static binary version
+checks so operators can confirm which ACP implementation answered the handshake.
+
 ![Chats workspace with an external-agent file-write approval waiting for operator review](../screenshots/chat-agent-approval.png)
 
 ![Agent approval modal with ACP options, scope choices, and audit note](../screenshots/chat-agent-approval-modal.png)

--- a/internal/agentadapters/probe.go
+++ b/internal/agentadapters/probe.go
@@ -52,12 +52,22 @@ type ProbeResult struct {
 	Error                string            `json:"error,omitempty"`
 	Stderr               string            `json:"stderr,omitempty"`
 	Hint                 string            `json:"hint,omitempty"`
+	AgentInfo            *ProbeAgentInfo   `json:"agent_info,omitempty"`
 	CapabilitiesKnown    bool              `json:"capabilities_known,omitempty"`
 	SupportsAuthenticate bool              `json:"supports_authenticate"`
 	SupportsLogout       bool              `json:"supports_logout"`
 	SupportsLoadSession  bool              `json:"supports_load_session"`
 	AuthMethods          []ProbeAuthMethod `json:"auth_methods,omitempty"`
 	DurationMS           int64             `json:"duration_ms"`
+}
+
+// ProbeAgentInfo is the safe subset of ACP Initialize agentInfo that Hecate
+// can surface in health responses. It helps operators verify the process that
+// answered the ACP handshake without parsing stderr or shelling out again.
+type ProbeAgentInfo struct {
+	Name    string `json:"name,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // ProbeAuthMethod is the non-secret subset of ACP Initialize authMethods that
@@ -275,6 +285,7 @@ func applyInitializeCapabilities(res *ProbeResult, initResp acp.InitializeRespon
 		return
 	}
 	res.CapabilitiesKnown = true
+	res.AgentInfo = probeAgentInfo(initResp.AgentInfo)
 	res.SupportsLoadSession = initResp.AgentCapabilities.LoadSession
 	res.SupportsLogout = initResp.AgentCapabilities.Auth.Logout != nil
 	res.AuthMethods = probeAuthMethods(initResp.AuthMethods)
@@ -284,6 +295,23 @@ func applyInitializeCapabilities(res *ProbeResult, initResp acp.InitializeRespon
 			break
 		}
 	}
+}
+
+func probeAgentInfo(info *acp.Implementation) *ProbeAgentInfo {
+	if info == nil {
+		return nil
+	}
+	out := ProbeAgentInfo{
+		Name:    strings.TrimSpace(info.Name),
+		Version: strings.TrimSpace(info.Version),
+	}
+	if info.Title != nil {
+		out.Title = strings.TrimSpace(*info.Title)
+	}
+	if out.Name == "" && out.Title == "" && out.Version == "" {
+		return nil
+	}
+	return &out
 }
 
 func probeAuthMethods(methods []acp.AuthMethod) []ProbeAuthMethod {

--- a/internal/agentadapters/probe_test.go
+++ b/internal/agentadapters/probe_test.go
@@ -136,8 +136,14 @@ func TestApplyInitializeCapabilities(t *testing.T) {
 	t.Parallel()
 
 	description := "Run native login"
+	title := "Codex ACP Adapter"
 	res := ProbeResult{AdapterID: "codex"}
 	applyInitializeCapabilities(&res, acp.InitializeResponse{
+		AgentInfo: &acp.Implementation{
+			Name:    "codex-acp-adapter",
+			Title:   &title,
+			Version: "0.1.0-alpha.28",
+		},
 		AgentCapabilities: acp.AgentCapabilities{
 			Auth:        acp.AgentAuthCapabilities{Logout: &acp.LogoutCapabilities{}},
 			LoadSession: true,
@@ -171,6 +177,12 @@ func TestApplyInitializeCapabilities(t *testing.T) {
 	if !res.CapabilitiesKnown {
 		t.Fatalf("CapabilitiesKnown = false, want true")
 	}
+	if res.AgentInfo == nil ||
+		res.AgentInfo.Name != "codex-acp-adapter" ||
+		res.AgentInfo.Title != title ||
+		res.AgentInfo.Version != "0.1.0-alpha.28" {
+		t.Fatalf("AgentInfo = %#v, want initialize agent metadata", res.AgentInfo)
+	}
 	if !res.SupportsAuthenticate {
 		t.Fatalf("SupportsAuthenticate = false, want true for %s", ACPAuthMethodAgentLogin)
 	}
@@ -191,6 +203,27 @@ func TestApplyInitializeCapabilities(t *testing.T) {
 	}
 	if got := res.AuthMethods[2]; got.ID != "terminal-login" || got.Kind != "terminal" {
 		t.Fatalf("terminal auth method = %#v, want terminal summary", got)
+	}
+}
+
+func TestProbeAgentInfoTrimsAndOmitsEmptyValues(t *testing.T) {
+	t.Parallel()
+
+	if got := probeAgentInfo(nil); got != nil {
+		t.Fatalf("probeAgentInfo(nil) = %#v, want nil", got)
+	}
+	blankTitle := " "
+	if got := probeAgentInfo(&acp.Implementation{Name: " ", Title: &blankTitle, Version: " "}); got != nil {
+		t.Fatalf("probeAgentInfo(blank) = %#v, want nil", got)
+	}
+	title := " Claude Code "
+	got := probeAgentInfo(&acp.Implementation{
+		Name:    " claude-code-acp-adapter ",
+		Title:   &title,
+		Version: " 0.1.0-alpha.29 ",
+	})
+	if got == nil || got.Name != "claude-code-acp-adapter" || got.Title != "Claude Code" || got.Version != "0.1.0-alpha.29" {
+		t.Fatalf("probeAgentInfo() = %#v, want trimmed agent info", got)
 	}
 }
 

--- a/internal/api/handler_agent_adapter_health_test.go
+++ b/internal/api/handler_agent_adapter_health_test.go
@@ -33,6 +33,11 @@ func TestAgentAdapterHealthSurfacesProbeResult(t *testing.T) {
 				Status:    agentadapters.ProbeStatusReady,
 				Stage:     agentadapters.ProbeStageReady,
 				Path:      "/usr/local/bin/codex-acp-adapter",
+				AgentInfo: &agentadapters.ProbeAgentInfo{
+					Name:    "codex-acp-adapter",
+					Title:   "Codex ACP Adapter",
+					Version: "0.1.0-alpha.28",
+				},
 			},
 		},
 		{
@@ -100,6 +105,11 @@ func TestAgentAdapterHealthSurfacesProbeResult(t *testing.T) {
 			}
 			if resp.Data.AdapterID != "codex" {
 				t.Fatalf("AdapterID = %q, want codex", resp.Data.AdapterID)
+			}
+			if tc.name == "ready" {
+				if resp.Data.AgentInfo == nil || resp.Data.AgentInfo.Name != "codex-acp-adapter" || resp.Data.AgentInfo.Version != "0.1.0-alpha.28" {
+					t.Fatalf("AgentInfo = %#v, want initialized adapter metadata", resp.Data.AgentInfo)
+				}
 			}
 		})
 	}

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -799,6 +799,8 @@ function AdapterStatusRow({
   const showHealthCapabilities = Boolean(
     health?.capabilities_known && showHealthDebugMetadata && !showLocalAuthSetup,
   );
+  const agentInfoLabel = formatAgentInfoLabel(health?.agent_info);
+  const showAgentInfo = Boolean(agentInfoLabel && showHealthDebugMetadata && !showLocalAuthSetup);
   const showAuthenticateAction =
     !remoteRuntime &&
     adapter.available &&
@@ -894,6 +896,11 @@ function AdapterStatusRow({
           )}
           {showHealthDuration && health?.duration_ms !== undefined && (
             <span>{health.duration_ms} ms</span>
+          )}
+          {showAgentInfo && (
+            <span>
+              reports <span style={{ color: "var(--t1)" }}>{agentInfoLabel}</span>
+            </span>
           )}
           {showHealthCapabilities && health && (
             <span>
@@ -1222,6 +1229,13 @@ function remoteCredentialKeys(adapter: AgentAdapterRecord): string[] {
 
 function isDevOverridePath(path: string): boolean {
   return path.startsWith("dev-override://");
+}
+
+function formatAgentInfoLabel(info: AgentAdapterHealthRecord["agent_info"]): string {
+  const name = info?.title?.trim() || info?.name?.trim() || "";
+  const version = info?.version?.trim() || "";
+  if (!name) return version;
+  return version ? `${name} ${version}` : name;
 }
 
 type ChipTone = ExternalAgentReadinessTone;

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -852,6 +852,26 @@ describe("ProvidersView table renders", () => {
           supports_logout: true,
         },
       ],
+      agentAdapterHealthByID: new Map([
+        [
+          "codex",
+          {
+            adapter_id: "codex",
+            status: "ready",
+            stage: "ready",
+            capabilities_known: true,
+            supports_authenticate: true,
+            supports_logout: true,
+            supports_load_session: true,
+            agent_info: {
+              name: "codex-acp-adapter",
+              title: "Codex ACP Adapter",
+              version: "0.1.0-alpha.28",
+            },
+            duration_ms: 42,
+          },
+        ],
+      ]),
       chatGrants: [
         {
           id: "grant-1",
@@ -870,6 +890,7 @@ describe("ProvidersView table renders", () => {
     expect(screen.getByTestId("external-agents-adapter-codex")).toBeTruthy();
     expect(screen.getByTestId("external-agents-row-grant-1")).toBeTruthy();
     expect(screen.getByText("file write")).toBeTruthy();
+    expect(screen.getByText("Codex ACP Adapter 0.1.0-alpha.28")).toBeTruthy();
     expect(listChatGrants).toHaveBeenCalled();
   });
 

--- a/ui/src/types/agent-adapter.ts
+++ b/ui/src/types/agent-adapter.ts
@@ -60,12 +60,19 @@ export type AgentAdapterHealthRecord = {
   error?: string;
   stderr?: string;
   hint?: string;
+  agent_info?: AgentAdapterAgentInfoRecord;
   capabilities_known?: boolean;
   supports_authenticate?: boolean;
   supports_logout?: boolean;
   supports_load_session?: boolean;
   auth_methods?: AgentAdapterAuthMethodRecord[];
   duration_ms: number;
+};
+
+export type AgentAdapterAgentInfoRecord = {
+  name?: string;
+  title?: string;
+  version?: string;
 };
 
 export type AgentAdapterAuthMethodRecord = {


### PR DESCRIPTION
## Summary
- Preserve ACP `initialize.agentInfo` in adapter health probe results as `agent_info`.
- Surface the live self-reported adapter name/version in Connections alongside existing health debug metadata.
- Document the health field and add backend/UI tests for the new contract.

## Tests
- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters ./internal/api -run 'TestApplyInitializeCapabilities|TestProbeAgentInfo|TestAgentAdapterHealthSurfacesProbeResult|TestAgentAdapterProbeEndpointReturnsFreshAdapterAndHealth'`
- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go vet ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./internal/agentadapters ./internal/api`
- `cd ui && bun run test -- ProvidersView`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `just docs-format-check`
- `git diff --check`
