### PR TITLE
feat(agentadapters): surface ACP terminal activity

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -232,8 +232,10 @@ ACP terminal callbacks are a command-execution surface. Keep
 `clientCapabilities.terminal` false unless `HECATE_AGENT_ADAPTER_TERMINALS=1`
 is configured, require `HECATE_REMOTE_ALLOW_ACP_TERMINALS=1` in remote runtime
 mode, and route `terminal/create` through the External Agent approval
-coordinator before spawning anything. Do not add an operator-facing embedded
-terminal API/UI while working on ACP terminal support.
+coordinator before spawning anything. Terminal callback lifecycle should remain
+operator-visible through External Agent chat activities (`type="terminal"`):
+record command/cwd/status/exit output previews from the active ACP turn instead
+of adding an operator-facing embedded terminal API/UI.
 
 Hecate owns the ACP process/session boundary, not provider-specific adapter
 implementation parity. Tests in this repository should use the repo-local fake

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -520,7 +520,12 @@ retains bounded merged stdout/stderr for `terminal/output`, supports
 `terminal/release`. Terminal output retention truncates from the beginning at a
 valid UTF-8 boundary when the agent supplies `outputByteLimit`. Env variable
 names are included in approval context; env values are not persisted in the
-approval payload.
+approval payload. Terminal lifecycle callbacks are also projected into the
+chat activity timeline as `terminal` rows: Hecate records the command, working
+directory, running/completed/failed/cancelled status, exit code when available,
+and a bounded output preview after the process exits. This makes approved
+client-side commands visible after refresh even though Hecate does not expose
+an embedded operator terminal UI.
 
 On Hecate shutdown, active External Agent turns are cancelled first. Hecate waits
 briefly for the ACP turn to drain, closes any unreleased ACP terminals, asks the

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -171,6 +171,7 @@ func TestSessionManagerRunsACPTerminalCallbackThroughAdapterProcess(t *testing.T
 		Store: store,
 	}))
 	t.Cleanup(func() { _ = manager.Shutdown(context.Background()) })
+	var activityCapture acpSessionActivityCapture
 
 	result, err := manager.Run(context.Background(), RunRequest{
 		SessionID:      "chat_terminal_callback",
@@ -179,6 +180,7 @@ func TestSessionManagerRunsACPTerminalCallbackThroughAdapterProcess(t *testing.T
 		Prompt:         "terminal command",
 		Timeout:        5 * time.Second,
 		MaxOutputBytes: 64 * 1024,
+		OnActivity:     activityCapture.record,
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -207,6 +209,42 @@ func TestSessionManagerRunsACPTerminalCallbackThroughAdapterProcess(t *testing.T
 	if rows[0].Status != ApprovalStatusApproved || rows[0].ToolKind != ToolKindShellExec {
 		t.Fatalf("approval = %+v, want approved shell_exec", rows[0])
 	}
+	activities := activityCapture.snapshot()
+	completed := findTerminalActivity(activities, firstTerminalActivityID(activities), "completed")
+	if completed == nil {
+		t.Fatalf("Run activities = %+v, want completed terminal activity", activities)
+	}
+	if !strings.Contains(completed.ArtifactPreview, "terminal ok") {
+		t.Fatalf("terminal activity preview = %q, want command output", completed.ArtifactPreview)
+	}
+}
+
+type acpSessionActivityCapture struct {
+	mu         sync.Mutex
+	activities []Activity
+}
+
+func (c *acpSessionActivityCapture) record(activity Activity) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.activities = append(c.activities, activity)
+}
+
+func (c *acpSessionActivityCapture) snapshot() []Activity {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Activity, len(c.activities))
+	copy(out, c.activities)
+	return out
+}
+
+func firstTerminalActivityID(activities []Activity) string {
+	for _, activity := range activities {
+		if strings.HasPrefix(activity.ID, "terminal:") {
+			return strings.TrimPrefix(activity.ID, "terminal:")
+		}
+	}
+	return ""
 }
 
 func TestSessionManagerPreservesACPStopReason(t *testing.T) {

--- a/internal/agentadapters/acp_terminal.go
+++ b/internal/agentadapters/acp_terminal.go
@@ -27,12 +27,16 @@ const (
 var nextACPTerminalApprovalID atomic.Uint64
 
 type acpTerminal struct {
-	id       string
-	term     workspace.Terminal
-	output   *acpTerminalOutputBuffer
-	done     chan struct{}
-	exitCode *int
-	waitErr  error
+	id           string
+	commandLine  string
+	cwd          string
+	term         workspace.Terminal
+	output       *acpTerminalOutputBuffer
+	done         chan struct{}
+	killed       atomic.Bool
+	exitReported atomic.Bool
+	exitCode     *int
+	waitErr      error
 }
 
 func (c *acpChatClient) CreateTerminal(ctx context.Context, params acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
@@ -55,6 +59,7 @@ func (c *acpChatClient) CreateTerminal(ctx context.Context, params acp.CreateTer
 	if params.OutputByteLimit != nil && *params.OutputByteLimit > 0 {
 		limit = *params.OutputByteLimit
 	}
+	commandLine := terminalCommandLine(command, params.Args)
 	if err := c.approveTerminalCreate(ctx, params, cwd, limit); err != nil {
 		return acp.CreateTerminalResponse{}, err
 	}
@@ -70,17 +75,21 @@ func (c *acpChatClient) CreateTerminal(ctx context.Context, params acp.CreateTer
 		Env: env,
 	})
 	if err != nil {
+		c.emitCurrentTurnActivity(terminalActivity("", commandLine, cwd, "failed", terminalFailureDetail(err), ""))
 		return acp.CreateTerminalResponse{}, err
 	}
 
 	item := &acpTerminal{
-		id:     term.ID(),
-		term:   term,
-		output: newACPTerminalOutputBuffer(limit),
-		done:   make(chan struct{}),
+		id:          term.ID(),
+		commandLine: commandLine,
+		cwd:         cwd,
+		term:        term,
+		output:      newACPTerminalOutputBuffer(limit),
+		done:        make(chan struct{}),
 	}
 	c.storeTerminal(item)
 	go item.watch()
+	c.emitTerminalActivity(item, "running", "", "")
 	return acp.CreateTerminalResponse{TerminalId: item.id}, nil
 }
 
@@ -92,9 +101,12 @@ func (c *acpChatClient) KillTerminal(ctx context.Context, params acp.KillTermina
 	if err != nil {
 		return acp.KillTerminalResponse{}, err
 	}
+	item.killed.Store(true)
 	if err := item.term.Kill(ctx); err != nil {
+		item.killed.Store(false)
 		return acp.KillTerminalResponse{}, err
 	}
+	c.emitTerminalActivity(item, "cancelled", "killed", "")
 	return acp.KillTerminalResponse{}, nil
 }
 
@@ -127,8 +139,15 @@ func (c *acpChatClient) ReleaseTerminal(ctx context.Context, params acp.ReleaseT
 	if err != nil {
 		return acp.ReleaseTerminalResponse{}, err
 	}
+	doneBeforeClose := terminalDone(item)
 	if err := item.term.Close(ctx); err != nil {
 		return acp.ReleaseTerminalResponse{}, err
+	}
+	if doneBeforeClose {
+		c.emitTerminalExitActivity(item)
+	} else {
+		item.killed.Store(true)
+		c.emitTerminalActivity(item, "cancelled", "released before exit", "")
 	}
 	return acp.ReleaseTerminalResponse{}, nil
 }
@@ -146,6 +165,7 @@ func (c *acpChatClient) WaitForTerminalExit(ctx context.Context, params acp.Wait
 	case <-ctx.Done():
 		return acp.WaitForTerminalExitResponse{}, ctx.Err()
 	}
+	c.emitTerminalExitActivity(item)
 	return acp.WaitForTerminalExitResponse{ExitCode: item.exitCode}, item.waitErr
 }
 
@@ -201,16 +221,135 @@ func (c *acpChatClient) approveTerminalCreate(ctx context.Context, params acp.Cr
 }
 
 func terminalCommandLine(command string, args []string) string {
-	parts := make([]string, 0, len(args)+1)
+	parts := make([]string, 0, len(args))
 	if command = strings.TrimSpace(command); command != "" {
-		parts = append(parts, command)
+		parts = append(parts, shellDisplayQuote(command))
 	}
 	for _, arg := range args {
-		if arg = strings.TrimSpace(arg); arg != "" {
-			parts = append(parts, arg)
-		}
+		parts = append(parts, shellDisplayQuote(arg))
 	}
 	return strings.Join(parts, " ")
+}
+
+func shellDisplayQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			strings.ContainsRune("_@%+=:,./-", r) {
+			continue
+		}
+		return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+	}
+	return value
+}
+
+func (c *acpChatClient) emitTerminalExitActivity(item *acpTerminal) {
+	if item == nil {
+		return
+	}
+	if !item.exitReported.CompareAndSwap(false, true) {
+		return
+	}
+	status := "completed"
+	extra := "exit code unavailable"
+	if item.exitCode != nil {
+		extra = fmt.Sprintf("exit code %d", *item.exitCode)
+		if *item.exitCode != 0 {
+			status = "failed"
+		}
+	}
+	if item.waitErr != nil {
+		status = "failed"
+		extra = item.waitErr.Error()
+	}
+	if item.killed.Load() {
+		status = "cancelled"
+		extra = "killed"
+	}
+	c.emitTerminalActivity(item, status, extra, terminalOutputPreview(item))
+}
+
+func (c *acpChatClient) emitTerminalActivity(item *acpTerminal, status, extra, preview string) {
+	if item == nil {
+		return
+	}
+	c.emitCurrentTurnActivity(terminalActivity(item.id, item.commandLine, item.cwd, status, extra, preview))
+}
+
+func (c *acpChatClient) emitCurrentTurnActivity(activity Activity) {
+	turn := c.currentTurn()
+	if turn == nil {
+		return
+	}
+	turn.emitActivity(activity)
+}
+
+func terminalActivity(terminalID, commandLine, cwd, status, extra, preview string) Activity {
+	id := ""
+	if terminalID = strings.TrimSpace(terminalID); terminalID != "" {
+		id = "terminal:" + terminalID
+	}
+	return Activity{
+		ID:              id,
+		Type:            "terminal",
+		Status:          strings.TrimSpace(status),
+		Kind:            "execute",
+		Title:           "Terminal command",
+		Detail:          terminalActivityDetail(commandLine, cwd, extra),
+		ArtifactPreview: preview,
+	}
+}
+
+func terminalActivityDetail(commandLine, cwd, extra string) string {
+	parts := make([]string, 0, 3)
+	if commandLine = strings.TrimSpace(commandLine); commandLine != "" {
+		parts = append(parts, commandLine)
+	}
+	if cwd = strings.TrimSpace(cwd); cwd != "" {
+		parts = append(parts, "cwd "+cwd)
+	}
+	if extra = strings.TrimSpace(extra); extra != "" {
+		parts = append(parts, extra)
+	}
+	return strings.Join(parts, " · ")
+}
+
+func terminalFailureDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func terminalOutputPreview(item *acpTerminal) string {
+	if item == nil || item.output == nil {
+		return ""
+	}
+	output, truncated := item.output.snapshot()
+	output = strings.TrimRight(output, "\r\n")
+	if output == "" {
+		return ""
+	}
+	if truncated {
+		output = "[terminal output truncated]\n" + output
+	}
+	return capToolOutputPreview(output)
+}
+
+func terminalDone(item *acpTerminal) bool {
+	if item == nil {
+		return false
+	}
+	select {
+	case <-item.done:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *acpChatClient) terminalWorkingDirectory(cwd *string) (string, error) {

--- a/internal/agentadapters/acp_terminal_rpc_test.go
+++ b/internal/agentadapters/acp_terminal_rpc_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +32,16 @@ func TestAcpChatClientTerminalRPCsDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestTerminalCommandLineQuotesDisplayArgs(t *testing.T) {
+	t.Parallel()
+
+	got := terminalCommandLine("my cmd", []string{"-c", "printf 'hello world'", ""})
+	want := `'my cmd' -c 'printf '\''hello world'\''' ''`
+	if got != want {
+		t.Fatalf("terminalCommandLine = %q, want %q", got, want)
+	}
+}
+
 func TestAcpChatClientTerminalRPCLifecycle(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix shell semantics")
@@ -39,6 +50,7 @@ func TestAcpChatClientTerminalRPCLifecycle(t *testing.T) {
 
 	workspace := t.TempDir()
 	client, _ := newTerminalTestClient(workspace, ModeAuto)
+	activities := attachTerminalActivityCapture(client)
 
 	ctx := context.Background()
 	resp, err := client.CreateTerminal(ctx, acp.CreateTerminalRequest{
@@ -77,8 +89,31 @@ func TestAcpChatClientTerminalRPCLifecycle(t *testing.T) {
 	if output.ExitStatus == nil || output.ExitStatus.ExitCode == nil || *output.ExitStatus.ExitCode != 0 {
 		t.Fatalf("TerminalOutput exit status = %+v, want exit code 0", output.ExitStatus)
 	}
+	running := findTerminalActivity(activities.snapshot(), resp.TerminalId, "running")
+	if running == nil {
+		t.Fatalf("terminal activities = %+v, want running activity", activities.snapshot())
+	}
+	if running.Type != "terminal" || running.Kind != "execute" || running.Title != "Terminal command" {
+		t.Fatalf("running terminal activity = %+v, want terminal execute title", *running)
+	}
+	if !strings.Contains(running.Detail, "cwd "+workspace) || !strings.Contains(running.Detail, "sh -c") {
+		t.Fatalf("running terminal detail = %q, want command and cwd", running.Detail)
+	}
+	completed := findTerminalActivity(activities.snapshot(), resp.TerminalId, "completed")
+	if completed == nil {
+		t.Fatalf("terminal activities = %+v, want completed activity", activities.snapshot())
+	}
+	if !strings.Contains(completed.Detail, "exit code 0") {
+		t.Fatalf("completed terminal detail = %q, want exit code", completed.Detail)
+	}
+	if !strings.Contains(completed.ArtifactPreview, "hello world") || !strings.Contains(completed.ArtifactPreview, "err") {
+		t.Fatalf("completed terminal preview = %q, want retained output", completed.ArtifactPreview)
+	}
 	if _, err := client.ReleaseTerminal(ctx, acp.ReleaseTerminalRequest{TerminalId: resp.TerminalId}); err != nil {
 		t.Fatalf("ReleaseTerminal: %v", err)
+	}
+	if got := countTerminalActivities(activities.snapshot(), resp.TerminalId, "completed"); got != 1 {
+		t.Fatalf("completed terminal activity count = %d, want 1 after wait+release", got)
 	}
 	if _, err := client.TerminalOutput(ctx, acp.TerminalOutputRequest{TerminalId: resp.TerminalId}); err == nil {
 		t.Fatal("TerminalOutput after release succeeded; want not found")
@@ -129,6 +164,7 @@ func TestAcpChatClientTerminalRPCKillKeepsTerminalReadable(t *testing.T) {
 
 	workspace := t.TempDir()
 	client, _ := newTerminalTestClient(workspace, ModeAuto)
+	activities := attachTerminalActivityCapture(client)
 	resp, err := client.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
 		Command: "sh",
 		Args:    []string{"-c", "printf 'started\n'; exec sleep 60"},
@@ -156,6 +192,62 @@ func TestAcpChatClientTerminalRPCKillKeepsTerminalReadable(t *testing.T) {
 	if !strings.Contains(output.Output, "started") {
 		t.Fatalf("TerminalOutput output = %q, want retained output after kill", output.Output)
 	}
+	cancelled := findTerminalActivity(activities.snapshot(), resp.TerminalId, "cancelled")
+	if cancelled == nil {
+		t.Fatalf("terminal activities = %+v, want cancelled activity", activities.snapshot())
+	}
+	if !strings.Contains(cancelled.Detail, "killed") {
+		t.Fatalf("cancelled terminal detail = %q, want kill reason", cancelled.Detail)
+	}
+}
+
+type terminalActivityCapture struct {
+	mu         sync.Mutex
+	activities []Activity
+}
+
+func attachTerminalActivityCapture(client *acpChatClient) *terminalActivityCapture {
+	capture := &terminalActivityCapture{}
+	turn := newACPTurn(64*1024, nil)
+	turn.setActivityCallback(capture.record)
+	client.setTurn(turn)
+	return capture
+}
+
+func (c *terminalActivityCapture) record(activity Activity) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.activities = append(c.activities, activity)
+}
+
+func (c *terminalActivityCapture) snapshot() []Activity {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Activity, len(c.activities))
+	copy(out, c.activities)
+	return out
+}
+
+func findTerminalActivity(activities []Activity, terminalID, status string) *Activity {
+	id := "terminal:" + terminalID
+	for i := len(activities) - 1; i >= 0; i-- {
+		activity := activities[i]
+		if activity.ID == id && activity.Status == status {
+			return &activity
+		}
+	}
+	return nil
+}
+
+func countTerminalActivities(activities []Activity, terminalID, status string) int {
+	id := "terminal:" + terminalID
+	var count int
+	for _, activity := range activities {
+		if activity.ID == id && activity.Status == status {
+			count++
+		}
+	}
+	return count
 }
 
 func waitForTerminalOutput(t *testing.T, client *acpChatClient, terminalID string, want string) {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.test.tsx
@@ -186,6 +186,25 @@ describe("TranscriptActivityTimeline", () => {
     expect(screen.getByText("src/index.ts")).toBeInTheDocument();
   });
 
+  it("renders terminal activities with a terminal summary and prefix", () => {
+    const activities: ChatActivityRecord[] = [
+      {
+        id: "terminal:term_123",
+        type: "terminal",
+        status: "completed",
+        kind: "execute",
+        title: "Terminal command",
+        detail: "sh -c 'go test ./...' · cwd /repo · exit code 0",
+      },
+      { type: "completed", title: "Final answer", status: "completed" },
+    ];
+    render(<TranscriptActivityTimeline activities={activities} />);
+    expect(screen.getByText(/completed · 1 terminal/)).toBeInTheDocument();
+    expect(screen.getByText("terminal")).toBeInTheDocument();
+    expect(screen.getByText("Terminal command")).toBeInTheDocument();
+    expect(screen.getByText("sh -c 'go test ./...' · cwd /repo · exit code 0")).toBeInTheDocument();
+  });
+
   it("removes duplicate tool details that repeat title and status", () => {
     const activities: ChatActivityRecord[] = [
       {

--- a/ui/src/features/transcript/TranscriptActivityTimeline.tsx
+++ b/ui/src/features/transcript/TranscriptActivityTimeline.tsx
@@ -130,6 +130,7 @@ export function TranscriptActivityTimeline({
 
   const plan = primaryRaw.filter((activity) => activity.type === "plan");
   const tools = primaryRaw.filter((activity) => activity.type === "tool_call");
+  const terminals = primaryRaw.filter((activity) => activity.type === "terminal");
   const proposals = primaryRaw.filter(isProjectAssistantProposalActivity);
   const failedTools = tools.filter(
     (activity) => activityEffectiveStatus(activity) === "failed",
@@ -146,6 +147,7 @@ export function TranscriptActivityTimeline({
           ? `${failedTools} failed tool${failedTools === 1 ? "" : "s"}`
           : `${tools.length} tool${tools.length === 1 ? "" : "s"}`
       : "",
+    terminals.length > 0 ? `${terminals.length} terminal${terminals.length === 1 ? "" : "s"}` : "",
     proposals.length > 0
       ? `${proposals.length} proposal${proposals.length === 1 ? "" : "s"} ready`
       : "",
@@ -369,6 +371,7 @@ function advancedSummaryLabel(activity: ChatActivityRecord): string {
     /\boutput(?:\s+captured)?\s*(?::|·)/i.test(activity.detail ?? "")
   )
     return "Output";
+  if (activity.type === "terminal" && activity.artifact_preview?.trim()) return "Output";
   return "Advanced";
 }
 

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -811,6 +811,31 @@ describe("TranscriptMessageRow", () => {
     expect(screen.getByText(/drwxr-xr-x@ 20 chicoxyzzy staff 640/)).toBeInTheDocument();
   });
 
+  it("shows terminal output from terminal activity previews", async () => {
+    const user = userEvent.setup();
+    const activities: ChatActivityRecord[] = [
+      {
+        id: "terminal:term_123",
+        type: "terminal",
+        status: "completed",
+        kind: "execute",
+        title: "Terminal command",
+        detail: "sh -c 'printf ok' · cwd /repo · exit code 0",
+        artifact_preview: "ok\nall good",
+      },
+    ];
+
+    render(<TranscriptMessageRow {...baseProps} activities={activities} />);
+
+    expect(screen.getByText(/1 terminal/)).toBeInTheDocument();
+    expect(screen.queryByText(/all good/)).toBeNull();
+
+    await user.click(screen.getByText("Output"));
+
+    expect(screen.getByText("Terminal output")).toBeInTheDocument();
+    expect(screen.getByText(/all good/)).toBeInTheDocument();
+  });
+
   it("renders a Project Assistant proposal activity action", async () => {
     const user = userEvent.setup();
     const onOpenProjectProposal = vi.fn();

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -449,7 +449,13 @@ function renderAgentActivityAdvanced(
   if (toolOutput) {
     return (
       <ToolOutputPreview
-        title={activity.kind === "read" ? "Read output" : "Tool output"}
+        title={
+          activity.type === "terminal"
+            ? "Terminal output"
+            : activity.kind === "read"
+              ? "Read output"
+              : "Tool output"
+        }
         output={toolOutput}
       />
     );

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -266,6 +266,12 @@ export function activityDisplay(activity: ChatActivityRecord): { title: string; 
   if (activity.type === "tool_group") {
     return { title: activity.title, detail: cleanActivityDetail(activity) };
   }
+  if (activity.type === "terminal") {
+    return {
+      title: activity.title || "Terminal command",
+      detail: cleanActivityDetail(activity),
+    };
+  }
   if (activity.type === "thinking" && isModelTurnActivity(activity)) {
     return { title: "Thinking", detail: modelTurnDetail(activity) };
   }
@@ -334,6 +340,8 @@ export function activityLinePrefix(activity: ChatActivityRecord): string | undef
       return "model";
     case "approval":
       return "approval";
+    case "terminal":
+      return "terminal";
     default:
       return undefined;
   }
@@ -417,11 +425,12 @@ function toolActivityDetail(
 }
 
 export function capturedToolOutput(activity: ChatActivityRecord): string | undefined {
-  if (activity.type !== "tool_call") return undefined;
+  if (activity.type !== "tool_call" && activity.type !== "terminal") return undefined;
   const preview = activity.artifact_preview;
   const hasPreview = typeof preview === "string" && preview.trim().length > 0;
   const detail = activity.detail?.trim();
-  const parsed = detail ? parseToolOutputDetail(detail)?.output : undefined;
+  const parsed =
+    activity.type === "tool_call" && detail ? parseToolOutputDetail(detail)?.output : undefined;
   if (hasPreview && parsed) return parsed.length > preview.length ? parsed : preview;
   return hasPreview ? preview : parsed;
 }
@@ -730,15 +739,16 @@ function activitySortPhase(activity: ChatActivityRecord): number {
   if (activity.type === "thinking" || activity.type === "model_turns") return 4;
   if (activity.type === "approval") return 5;
   if (activity.type === "tool_call") return 6;
-  if (activity.type === "files_changed") return 7;
+  if (activity.type === "terminal") return 7;
+  if (activity.type === "files_changed") return 8;
   if (
     activity.type === "failed" ||
     activity.type === "cancelled" ||
     activity.type === "completed" ||
     activity.type === "run_result"
   )
-    return 9;
-  return 8;
+    return 10;
+  return 9;
 }
 
 export function activityStatusColor(status?: string) {


### PR DESCRIPTION
## Summary

- project ACP terminal/create, wait, kill, and release lifecycle into External Agent chat activities
- persist command/cwd/status/exit code and bounded terminal output previews on terminal completion
- teach the shared transcript timeline to summarize terminal activity and reveal terminal output previews
- document the terminal activity projection in runtime docs and backend guidance

## Verification

- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters -run 'Test(TerminalCommandLine|AcpChatClientTerminal|SessionManagerRunsACPTerminalCallback)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./internal/agentadapters
- cd ui && bun run test -- TranscriptActivityTimeline TranscriptMessageRow
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just docs-format-check
- just agent-docs-check
- git diff --check