### PR TITLE
feat(agentadapters): show ACP terminal refs in tool output

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -234,8 +234,9 @@ is configured, require `HECATE_REMOTE_ALLOW_ACP_TERMINALS=1` in remote runtime
 mode, and route `terminal/create` through the External Agent approval
 coordinator before spawning anything. Terminal callback lifecycle should remain
 operator-visible through External Agent chat activities (`type="terminal"`):
-record command/cwd/status/exit output previews from the active ACP turn instead
-of adding an operator-facing embedded terminal API/UI.
+record command/cwd/status/exit output previews from the active ACP turn, and
+reuse retained terminal output for ACP tool-call terminal refs when available,
+instead of adding an operator-facing embedded terminal API/UI.
 
 Hecate owns the ACP process/session boundary, not provider-specific adapter
 implementation parity. Tests in this repository should use the repo-local fake

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -523,9 +523,11 @@ names are included in approval context; env values are not persisted in the
 approval payload. Terminal lifecycle callbacks are also projected into the
 chat activity timeline as `terminal` rows: Hecate records the command, working
 directory, running/completed/failed/cancelled status, exit code when available,
-and a bounded output preview after the process exits. This makes approved
-client-side commands visible after refresh even though Hecate does not expose
-an embedded operator terminal UI.
+and a bounded output preview after the process exits. When an ACP tool-call
+update references a terminal, Hecate also reuses the retained terminal output
+preview in the `tool_call` activity detail and artifact preview when available.
+This makes approved client-side commands visible after refresh even though
+Hecate does not expose an embedded operator terminal UI.
 
 On Hecate shutdown, active External Agent turns are cancelled first. Hecate waits
 briefly for the ACP turn to drain, closes any unreleased ACP terminals, asks the

--- a/internal/agentadapters/acp_chat_client.go
+++ b/internal/agentadapters/acp_chat_client.go
@@ -32,9 +32,13 @@ type acpChatClient struct {
 	terminalMu       sync.Mutex
 	terminalsEnabled bool
 	terminals        map[string]*acpTerminal
+	terminalPreviews map[string]string
 }
 
 func (c *acpChatClient) setTurn(turn *acpTurn) {
+	if turn != nil {
+		turn.setTerminalOutputLookup(c.terminalToolOutputPreview)
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.turn = turn

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -217,6 +217,22 @@ func TestSessionManagerRunsACPTerminalCallbackThroughAdapterProcess(t *testing.T
 	if !strings.Contains(completed.ArtifactPreview, "terminal ok") {
 		t.Fatalf("terminal activity preview = %q, want command output", completed.ArtifactPreview)
 	}
+	var terminalTool *Activity
+	for i := range activities {
+		if activities[i].ID == "tool:terminal_ref" {
+			terminalTool = &activities[i]
+			break
+		}
+	}
+	if terminalTool == nil {
+		t.Fatalf("Run activities = %+v, want terminal-ref tool activity", activities)
+	}
+	if !strings.Contains(terminalTool.Detail, "terminal output: terminal ok") {
+		t.Fatalf("terminal-ref tool detail = %q, want terminal output summary", terminalTool.Detail)
+	}
+	if !strings.Contains(terminalTool.ArtifactPreview, "terminal ok") {
+		t.Fatalf("terminal-ref tool preview = %q, want terminal output", terminalTool.ArtifactPreview)
+	}
 }
 
 type acpSessionActivityCapture struct {
@@ -2640,6 +2656,44 @@ func TestACPTurnSurfacesToolContentPreview(t *testing.T) {
 	}
 }
 
+func TestACPTurnSurfacesTerminalContentPreview(t *testing.T) {
+	var activities []Activity
+	turn := newACPTurn(64*1024, nil)
+	turn.setTerminalOutputLookup(func(terminalID string) (string, bool) {
+		if terminalID != "term_123" {
+			return "", false
+		}
+		return "go test ./...\nok", true
+	})
+	turn.setActivityCallback(func(activity Activity) {
+		activities = append(activities, activity)
+	})
+	status := acp.ToolCallStatusCompleted
+	turn.recordUpdate(acp.SessionNotification{
+		SessionId: acp.SessionId("session_1"),
+		Update: acp.SessionUpdate{
+			ToolCallUpdate: &acp.SessionToolCallUpdate{
+				ToolCallId: acp.ToolCallId("call_terminal"),
+				Status:     &status,
+				Kind:       acp.Ptr(acp.ToolKindExecute),
+				Content: []acp.ToolCallContent{
+					acp.ToolTerminalRef("term_123"),
+				},
+			},
+		},
+	})
+
+	if len(activities) != 1 {
+		t.Fatalf("activities = %#v, want 1", activities)
+	}
+	if got := activities[0].Detail; got != "execute · 1 terminal, terminal output: go test ./... ok" {
+		t.Fatalf("activity detail = %q", got)
+	}
+	if got := activities[0].ArtifactPreview; got != "go test ./...\nok" {
+		t.Fatalf("artifact preview = %q", got)
+	}
+}
+
 func TestACPTurnDecodesCommandBridgeToolActivityShape(t *testing.T) {
 	var activities []Activity
 	turn := newACPTurn(64*1024, nil)
@@ -3106,6 +3160,24 @@ func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (ac
 			TerminalId: terminal.TerminalId,
 		})
 		if err != nil {
+			return acp.PromptResponse{}, err
+		}
+		status := acp.ToolCallStatusCompleted
+		kind := acp.ToolKindExecute
+		if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{
+			SessionId: params.SessionId,
+			Update: acp.SessionUpdate{
+				ToolCallUpdate: &acp.SessionToolCallUpdate{
+					ToolCallId: acp.ToolCallId("terminal_ref"),
+					Status:     &status,
+					Kind:       &kind,
+					Title:      acp.Ptr("Terminal command"),
+					Content: []acp.ToolCallContent{
+						acp.ToolTerminalRef(terminal.TerminalId),
+					},
+				},
+			},
+		}); err != nil {
 			return acp.PromptResponse{}, err
 		}
 		if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{

--- a/internal/agentadapters/acp_terminal.go
+++ b/internal/agentadapters/acp_terminal.go
@@ -35,6 +35,7 @@ type acpTerminal struct {
 	done         chan struct{}
 	killed       atomic.Bool
 	exitReported atomic.Bool
+	onExit       func(*acpTerminal)
 	exitCode     *int
 	waitErr      error
 }
@@ -86,6 +87,7 @@ func (c *acpChatClient) CreateTerminal(ctx context.Context, params acp.CreateTer
 		term:        term,
 		output:      newACPTerminalOutputBuffer(limit),
 		done:        make(chan struct{}),
+		onExit:      c.emitTerminalExitActivity,
 	}
 	c.storeTerminal(item)
 	go item.watch()
@@ -143,6 +145,7 @@ func (c *acpChatClient) ReleaseTerminal(ctx context.Context, params acp.ReleaseT
 	if err := item.term.Close(ctx); err != nil {
 		return acp.ReleaseTerminalResponse{}, err
 	}
+	c.rememberTerminalPreview(item)
 	if doneBeforeClose {
 		c.emitTerminalExitActivity(item)
 	} else {
@@ -340,6 +343,43 @@ func terminalOutputPreview(item *acpTerminal) string {
 	return capToolOutputPreview(output)
 }
 
+func (c *acpChatClient) terminalToolOutputPreview(terminalID string) (string, bool) {
+	terminalID = strings.TrimSpace(terminalID)
+	if terminalID == "" {
+		return "", false
+	}
+	c.terminalMu.Lock()
+	item := c.terminals[terminalID]
+	preview := ""
+	if c.terminalPreviews != nil {
+		preview = c.terminalPreviews[terminalID]
+	}
+	c.terminalMu.Unlock()
+	if item != nil {
+		preview = terminalOutputPreview(item)
+	}
+	if strings.TrimSpace(preview) == "" {
+		return "", false
+	}
+	return preview, true
+}
+
+func (c *acpChatClient) rememberTerminalPreview(item *acpTerminal) {
+	if item == nil {
+		return
+	}
+	preview := terminalOutputPreview(item)
+	if strings.TrimSpace(preview) == "" {
+		return
+	}
+	c.terminalMu.Lock()
+	defer c.terminalMu.Unlock()
+	if c.terminalPreviews == nil {
+		c.terminalPreviews = make(map[string]string)
+	}
+	c.terminalPreviews[item.id] = preview
+}
+
 func terminalDone(item *acpTerminal) bool {
 	if item == nil {
 		return false
@@ -408,6 +448,9 @@ func (c *acpChatClient) storeTerminal(item *acpTerminal) {
 		c.terminals = make(map[string]*acpTerminal)
 	}
 	c.terminals[item.id] = item
+	if c.terminalPreviews != nil {
+		delete(c.terminalPreviews, item.id)
+	}
 }
 
 func (c *acpChatClient) lookupTerminal(id string) (*acpTerminal, error) {
@@ -470,6 +513,9 @@ func (t *acpTerminal) watch() {
 	code := result.ExitCode
 	t.exitCode = &code
 	t.waitErr = err
+	if t.onExit != nil {
+		t.onExit(t)
+	}
 	close(t.done)
 }
 

--- a/internal/agentadapters/acp_terminal_rpc_test.go
+++ b/internal/agentadapters/acp_terminal_rpc_test.go
@@ -120,6 +120,33 @@ func TestAcpChatClientTerminalRPCLifecycle(t *testing.T) {
 	}
 }
 
+func TestAcpChatClientTerminalToolOutputPreviewSurvivesRemoval(t *testing.T) {
+	t.Parallel()
+
+	client := &acpChatClient{}
+	item := &acpTerminal{
+		id:     "term_123",
+		output: newACPTerminalOutputBuffer(1024),
+	}
+	item.output.append("terminal output\n")
+	client.storeTerminal(item)
+
+	preview, ok := client.terminalToolOutputPreview("term_123")
+	if !ok || preview != "terminal output" {
+		t.Fatalf("terminalToolOutputPreview(active) = %q, %v; want retained active output", preview, ok)
+	}
+	removed, err := client.removeTerminal("term_123")
+	if err != nil {
+		t.Fatalf("removeTerminal: %v", err)
+	}
+	client.rememberTerminalPreview(removed)
+
+	preview, ok = client.terminalToolOutputPreview("term_123")
+	if !ok || preview != "terminal output" {
+		t.Fatalf("terminalToolOutputPreview(removed) = %q, %v; want retained removed output", preview, ok)
+	}
+}
+
 func TestAcpChatClientTerminalRPCOutputTruncatesFromBeginning(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix shell semantics")

--- a/internal/agentadapters/acp_turn.go
+++ b/internal/agentadapters/acp_turn.go
@@ -63,6 +63,8 @@ const toolOutputPreviewMaxBytes = 64 * 1024
 
 const toolOutputPreviewTruncatedSuffix = "\n… (tool output truncated)"
 
+type acpTerminalOutputLookup func(terminalID string) (string, bool)
+
 type acpTurn struct {
 	output         limitedBuffer
 	raw            limitedBuffer
@@ -102,6 +104,7 @@ type acpTurn struct {
 	postToolText   bool
 	onOutput       func(string)
 	onActivity     func(Activity)
+	terminalOutput acpTerminalOutputLookup
 
 	mu sync.Mutex
 }
@@ -120,6 +123,22 @@ func (t *acpTurn) setActivityCallback(onActivity func(Activity)) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.onActivity = onActivity
+}
+
+func (t *acpTurn) setTerminalOutputLookup(lookup acpTerminalOutputLookup) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.terminalOutput = lookup
+}
+
+func (t *acpTurn) lookupTerminalOutput(terminalID string) (string, bool) {
+	t.mu.Lock()
+	lookup := t.terminalOutput
+	t.mu.Unlock()
+	if lookup == nil {
+		return "", false
+	}
+	return lookup(terminalID)
 }
 
 func (t *acpTurn) recordUpdate(params acp.SessionNotification) {
@@ -314,14 +333,15 @@ func (t *acpTurn) recordToolCall(update *acp.SessionUpdateToolCall) {
 	t.markToolSeen()
 	status := acpToolStatus(string(update.Status))
 	t.rememberToolKind(string(update.ToolCallId), update.Kind)
+	terminalOutput := t.lookupTerminalOutput
 	t.emitActivity(Activity{
 		ID:              "tool:" + string(update.ToolCallId),
 		Type:            "tool_call",
 		Status:          status,
 		Kind:            string(update.Kind),
 		Title:           firstNonEmpty(update.Title, string(update.ToolCallId)),
-		Detail:          toolCallDetail(update.Kind, update.Locations, update.Content, update.RawInput),
-		ArtifactPreview: toolOutputPreview(update.Content, update.RawOutput),
+		Detail:          toolCallDetail(update.Kind, update.Locations, update.Content, update.RawInput, terminalOutput),
+		ArtifactPreview: toolOutputPreview(update.Content, update.RawOutput, terminalOutput),
 	})
 	t.emitFileChangeActivities(string(update.ToolCallId), update.Kind, status, update.Locations)
 }
@@ -368,14 +388,15 @@ func (t *acpTurn) recordToolCallUpdate(update *acp.SessionToolCallUpdate) {
 		kind = t.lookupToolKind(string(update.ToolCallId))
 	}
 	normalizedStatus := acpToolStatus(status)
+	terminalOutput := t.lookupTerminalOutput
 	t.emitActivity(Activity{
 		ID:              "tool:" + string(update.ToolCallId),
 		Type:            "tool_call",
 		Status:          normalizedStatus,
 		Kind:            string(kind),
 		Title:           title,
-		Detail:          toolCallDetail(kind, update.Locations, update.Content, update.RawInput),
-		ArtifactPreview: toolOutputPreview(update.Content, update.RawOutput),
+		Detail:          toolCallDetail(kind, update.Locations, update.Content, update.RawInput, terminalOutput),
+		ArtifactPreview: toolOutputPreview(update.Content, update.RawOutput, terminalOutput),
 	})
 	t.emitFileChangeActivities(string(update.ToolCallId), kind, normalizedStatus, update.Locations)
 }
@@ -603,7 +624,7 @@ func acpToolStatus(status string) string {
 	}
 }
 
-func toolCallDetail(kind acp.ToolKind, locations []acp.ToolCallLocation, content []acp.ToolCallContent, rawInput any) string {
+func toolCallDetail(kind acp.ToolKind, locations []acp.ToolCallLocation, content []acp.ToolCallContent, rawInput any, terminalOutput acpTerminalOutputLookup) string {
 	parts := make([]string, 0, 3)
 	if kind != "" {
 		parts = append(parts, string(kind))
@@ -615,7 +636,7 @@ func toolCallDetail(kind acp.ToolKind, locations []acp.ToolCallLocation, content
 		parts = append(parts, summarizeToolLocations(locations))
 	}
 	if len(content) > 0 {
-		if summary := summarizeToolContent(content); summary != "" {
+		if summary := summarizeToolContent(content, terminalOutput); summary != "" {
 			parts = append(parts, summary)
 		}
 	}
@@ -708,9 +729,10 @@ func summarizeToolLocations(locations []acp.ToolCallLocation) string {
 	return strings.Join(parts, ", ")
 }
 
-func summarizeToolContent(content []acp.ToolCallContent) string {
+func summarizeToolContent(content []acp.ToolCallContent, terminalOutput acpTerminalOutputLookup) string {
 	var diffs, terminals int
 	var textPreview string
+	var terminalPreview string
 	var textCount int
 	for _, item := range content {
 		switch {
@@ -718,6 +740,11 @@ func summarizeToolContent(content []acp.ToolCallContent) string {
 			diffs++
 		case item.Terminal != nil:
 			terminals++
+			if terminalPreview == "" && terminalOutput != nil {
+				if preview, ok := terminalOutput(item.Terminal.TerminalId); ok {
+					terminalPreview = preview
+				}
+			}
 		case item.Content != nil:
 			textCount++
 			if textPreview == "" {
@@ -731,6 +758,9 @@ func summarizeToolContent(content []acp.ToolCallContent) string {
 	}
 	if terminals > 0 {
 		parts = append(parts, pluralize(terminals, "terminal"))
+	}
+	if terminalPreview != "" {
+		parts = append(parts, fmt.Sprintf("terminal output: %s", trimToolSummary(terminalPreview)))
 	}
 	if textPreview != "" {
 		label := "output"
@@ -753,14 +783,20 @@ func trimToolSummary(value string) string {
 	return string(runes[:117]) + "..."
 }
 
-func toolOutputPreview(content []acp.ToolCallContent, rawOutput any) string {
+func toolOutputPreview(content []acp.ToolCallContent, rawOutput any, terminalOutput acpTerminalOutputLookup) string {
 	parts := make([]string, 0, len(content)+1)
 	for _, item := range content {
-		if item.Content == nil {
-			continue
-		}
-		if text := contentBlockText(item.Content.Content); strings.TrimSpace(text) != "" {
+		switch {
+		case item.Content != nil:
+			text := contentBlockText(item.Content.Content)
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
 			parts = append(parts, text)
+		case item.Terminal != nil && terminalOutput != nil:
+			if preview, ok := terminalOutput(item.Terminal.TerminalId); ok && strings.TrimSpace(preview) != "" {
+				parts = append(parts, preview)
+			}
 		}
 	}
 	if len(parts) == 0 {


### PR DESCRIPTION
## Summary
- enrich ACP tool-call activities that reference terminals with retained terminal output previews
- retain terminal output after release so later terminal-ref updates can still render useful output
- document the terminal-ref projection behavior in runtime docs and backend guidance

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -count=1 -timeout 10m ./internal/agentadapters
- just docs-format-check
- just agent-docs-check
- git diff --check HEAD