### PR TITLE
fix(agentadapters): retain ACP terminal output on session cleanup

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -236,7 +236,9 @@ coordinator before spawning anything. Terminal callback lifecycle should remain
 operator-visible through External Agent chat activities (`type="terminal"`):
 record command/cwd/status/exit output previews from the active ACP turn, and
 reuse retained terminal output for ACP tool-call terminal refs when available,
-instead of adding an operator-facing embedded terminal API/UI.
+instead of adding an operator-facing embedded terminal API/UI. Session shutdown
+cleanup should mark unreleased ACP terminals as cancelled and retain their
+bounded output preview before removing them from the client terminal map.
 
 Hecate owns the ACP process/session boundary, not provider-specific adapter
 implementation parity. Tests in this repository should use the repo-local fake

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -532,10 +532,12 @@ Hecate does not expose an embedded operator terminal UI.
 On Hecate shutdown, active External Agent turns are cancelled first. Hecate waits
 briefly for the ACP turn to drain, closes any unreleased ACP terminals, asks the
 native ACP session to close, and then kills the owned agent process group if it
-is still alive. This keeps app quit / restart from leaving Codex, Claude Code,
-Cursor Agent, or Grok Build processes behind. If an ACP peer does not implement
-`session/close`, Hecate treats that as an optional shutdown method and still
-terminates the owned process group.
+is still alive. Closing unreleased terminals marks them cancelled in the active
+chat activity timeline and retains their bounded output preview when available.
+This keeps app quit / restart from leaving Codex, Claude Code, Cursor Agent, or
+Grok Build processes behind. If an ACP peer does not implement `session/close`,
+Hecate treats that as an optional shutdown method and still terminates the owned
+process group.
 Operators can also close an External Agent chat session manually to release the
 external agent process while keeping the Hecate chat history. Deleting a chat is
 destructive: Hecate asks the ACP peer to delete the native session with

--- a/internal/agentadapters/acp_terminal.go
+++ b/internal/agentadapters/acp_terminal.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unicode/utf8"
 
 	acp "github.com/coder/acp-go-sdk"
@@ -493,11 +494,30 @@ func (c *acpChatClient) closeTerminals(ctx context.Context) error {
 
 	var firstErr error
 	for _, item := range items {
+		item.killed.Store(true)
 		if err := item.term.Close(ctx); err != nil && firstErr == nil {
 			firstErr = err
 		}
+		waitForACPTerminalDone(ctx, item)
+		c.rememberTerminalPreview(item)
+		c.emitTerminalExitActivity(item)
 	}
 	return firstErr
+}
+
+func waitForACPTerminalDone(ctx context.Context, item *acpTerminal) {
+	if item == nil {
+		return
+	}
+	if terminalDone(item) {
+		return
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	select {
+	case <-item.done:
+	case <-waitCtx.Done():
+	}
 }
 
 func (t *acpTerminal) watch() {

--- a/internal/agentadapters/acp_terminal_rpc_test.go
+++ b/internal/agentadapters/acp_terminal_rpc_test.go
@@ -317,19 +317,35 @@ func TestAcpChatClientCloseTerminalsReleasesRunningChildren(t *testing.T) {
 
 	workspace := t.TempDir()
 	client, _ := newTerminalTestClient(workspace, ModeAuto)
+	activities := attachTerminalActivityCapture(client)
 	resp, err := client.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
-		Command: "sleep",
-		Args:    []string{"60"},
+		Command: "sh",
+		Args:    []string{"-c", "printf 'started\n'; exec sleep 60"},
 		Cwd:     &workspace,
 	})
 	if err != nil {
 		t.Fatalf("CreateTerminal: %v", err)
 	}
+	waitForTerminalOutput(t, client, resp.TerminalId, "started")
 	if err := client.closeTerminals(context.Background()); err != nil {
 		t.Fatalf("closeTerminals: %v", err)
 	}
 	if _, err := client.TerminalOutput(context.Background(), acp.TerminalOutputRequest{TerminalId: resp.TerminalId}); err == nil {
 		t.Fatal("TerminalOutput after closeTerminals succeeded; want not found")
+	}
+	cancelled := findTerminalActivity(activities.snapshot(), resp.TerminalId, "cancelled")
+	if cancelled == nil {
+		t.Fatalf("terminal activities = %+v, want cancelled activity", activities.snapshot())
+	}
+	if !strings.Contains(cancelled.Detail, "killed") {
+		t.Fatalf("cancelled terminal detail = %q, want killed reason", cancelled.Detail)
+	}
+	if !strings.Contains(cancelled.ArtifactPreview, "started") {
+		t.Fatalf("cancelled terminal preview = %q, want retained output", cancelled.ArtifactPreview)
+	}
+	preview, ok := client.terminalToolOutputPreview(resp.TerminalId)
+	if !ok || !strings.Contains(preview, "started") {
+		t.Fatalf("terminalToolOutputPreview after closeTerminals = %q, %v; want retained output", preview, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary
- mark unreleased ACP terminals as cancelled during session cleanup
- wait for the ACP terminal wrapper to finish enough to emit/retain bounded output previews
- document shutdown cleanup visibility for terminal activities

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -count=1 -timeout 10m ./internal/agentadapters
- just docs-format-check
- just agent-docs-check
- git diff --check