### PR TITLE
Warn on project skill capability mismatches

### DIFF
--- a/docs/design/proposals/workspace-instructions-skills-and-profiles.md
+++ b/docs/design/proposals/workspace-instructions-skills-and-profiles.md
@@ -287,8 +287,14 @@ Implemented registry behavior:
 - Discovery ignores nested worktree containers such as `.worktrees` and
   `.claude/worktrees`; worktrees should be explicit project roots when the
   operator wants them represented.
-- Discovery parses bounded metadata only: frontmatter `name`/`title` and
-  `description`, then H1/title fallback and directory id.
+- Discovery parses bounded metadata only: frontmatter `name`/`title`,
+  `description`, `hecate.suggested_tools`, and
+  `hecate.required_permissions.{tools,writes,network}`, then H1/title fallback
+  and directory id. Suggested-tool lists are normalized, de-duplicated, capped,
+  and summarized in operator-facing text.
+- Assignment launch planning compares resolved project skills with the resolved
+  profile and surfaces suggested-tool / required-permission mismatches as
+  operator warnings. It does not grant or revoke capabilities.
 - Hecate does not return, store, inject, execute, install, or fetch skill
   bodies.
 - Duplicate ids become `conflict` records with warnings. Missing rediscovered

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -278,10 +278,12 @@ metadata from `.agents/skills`, `.hecate/skills`, and enabled `AGENTS.md` /
 `CLAUDE.md` context-source references. The refresh ignores nested worktree
 containers such as `.worktrees` and `.claude/worktrees`; linked worktrees should
 be explicit project roots, not inherited onboarding input. Bootstrap itself does
-not perform a second filesystem scan. It deduplicates against existing role ids
-and existing memory/candidate source refs. It does not treat host-specific
-guidance as Hecate policy authority, call a model, create durable memory, start
-tasks, or launch agents.
+not perform a second filesystem scan. Skill capability hints such as suggested
+tools and required tools/writes/network posture remain advisory metadata for
+launch-readiness warnings; they do not grant capabilities. Bootstrap deduplicates
+against existing role ids and existing memory/candidate source refs. It does
+not treat host-specific guidance as Hecate policy authority, call a model,
+create durable memory, start tasks, or launch agents.
 
 In the operator UI, **Set up project** is the project onboarding action, not a
 regular draft mode. It refreshes workspace guidance context sources, refreshes

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2684,6 +2684,12 @@ runtime instructions. Bodies are never returned.
       "path": ".hecate/skills/backend/SKILL.md",
       "root_id": "root_...",
       "format": "skill_md",
+      "suggested_tools": ["git.diff", "file.read"],
+      "required_permissions": {
+        "tools": true,
+        "writes": false,
+        "network": false
+      },
       "enabled": true,
       "status": "available",
       "trust_label": "workspace_skill",
@@ -2712,11 +2718,20 @@ Discovery ignores nested worktree containers such as `.worktrees` and
 worktree as its own project root when the operator wants it represented.
 
 Only safe metadata is parsed from bounded `SKILL.md` files: frontmatter
-`name`/`title` and `description`, then H1/title fallback and directory id.
-Duplicate ids become `status: "conflict"` records with warnings. Previously
-persisted skills not found in the latest discovery become `status: "missing"`.
-Operator edits to `enabled`, `title`, `description`, and `trust_label` are
-preserved across rediscovery.
+`name`/`title`, `description`, optional `hecate.suggested_tools`, optional
+`hecate.required_permissions.{tools,writes,network}`, then H1/title fallback and
+directory id. Suggested-tool lists are normalized, de-duplicated, capped before
+storage/API exposure, and summarized in operator-facing text. Duplicate ids
+become `status: "conflict"` records with warnings. Previously persisted skills
+not found in the latest discovery become `status: "missing"`. Operator edits to
+`enabled`, `title`, `description`, and `trust_label` are preserved across
+rediscovery.
+
+Skill capability metadata is advisory. Skills do not grant tools, writes,
+network access, approval bypasses, script execution, or memory writes. During
+assignment launch planning, Hecate compares resolved project skills with the
+resolved agent profile and surfaces mismatches as launch-readiness and
+context-inspector warnings for operator review.
 
 #### `PATCH /hecate/v1/projects/{id}/skills/{skill_id}`
 

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -921,7 +921,14 @@ func appendResolvedProjectSkills(packet *chat.ContextPacket, skills projectworka
 	if len(skills.Resolved) > 0 {
 		var resolved []string
 		for _, skill := range skills.Resolved {
-			resolved = append(resolved, fmt.Sprintf("%s (%s)", skill.ID, skill.Path))
+			detail := fmt.Sprintf("%s (%s)", skill.ID, skill.Path)
+			if toolsSummary := projectskills.SuggestedToolsSummary(skill.SuggestedTools); toolsSummary != "" {
+				detail += "; suggested tools: " + toolsSummary
+			}
+			if permissions := projectSkillRequiredPermissionsSummary(skill.RequiredPermissions); permissions != "" {
+				detail += "; required permissions: " + permissions
+			}
+			resolved = append(resolved, detail)
 		}
 		body = append(body, "Resolved enabled skills: "+strings.Join(resolved, ", "))
 	} else {
@@ -951,6 +958,24 @@ func appendResolvedProjectSkills(packet *chat.ContextPacket, skills projectworka
 		Included:        len(skills.Resolved) > 0,
 		InclusionReason: "Skill metadata resolved for this assignment; skill bodies are not injected",
 	})
+}
+
+func projectSkillRequiredPermissionsSummary(permissions projectskills.RequiredPermissions) string {
+	var parts []string
+	appendPermission := func(label string, value *bool) {
+		if value == nil {
+			return
+		}
+		state := "off"
+		if *value {
+			state = "on"
+		}
+		parts = append(parts, label+" "+state)
+	}
+	appendPermission("tools", permissions.Tools)
+	appendPermission("writes", permissions.Writes)
+	appendPermission("network", permissions.Network)
+	return strings.Join(parts, ", ")
 }
 
 func appendProjectAssignmentPromptContext(packet *chat.ContextPacket, promptContext projectworkapp.AssignmentPromptContext) {

--- a/internal/api/handler_project_assignment_launch_readiness_test.go
+++ b/internal/api/handler_project_assignment_launch_readiness_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
@@ -24,6 +25,26 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessReturnsNativePlanWithoutSideEff
 		project.DefaultModel = "gpt-4o-mini"
 	}); err != nil {
 		t.Fatalf("Update project defaults: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.SkillIDs = []string{"network"}
+	}); err != nil {
+		t.Fatalf("Update role skills: %v", err)
+	}
+	if _, err := handler.projectSkills.UpsertDiscovered(t.Context(), "proj_start", []projectskills.Skill{{
+		ID:         "network",
+		ProjectID:  "proj_start",
+		Title:      "Network",
+		Path:       ".hecate/skills/network/SKILL.md",
+		Format:     projectskills.FormatSkillMD,
+		Enabled:    true,
+		Status:     projectskills.StatusAvailable,
+		TrustLabel: projectskills.TrustWorkspaceSkill,
+		RequiredPermissions: projectskills.RequiredPermissions{
+			Network: boolForLaunchReadinessTest(true),
+		},
+	}}); err != nil {
+		t.Fatalf("UpsertDiscovered skills: %v", err)
 	}
 
 	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/launch-readiness", "")
@@ -45,6 +66,9 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessReturnsNativePlanWithoutSideEff
 	if readiness.Data.ModelReadiness == nil || !readiness.Data.ModelReadiness.Ready {
 		t.Fatalf("model_readiness = %+v, want ready", readiness.Data.ModelReadiness)
 	}
+	if !launchReadinessWarningContains(readiness.Data.Warnings, "Project skill Network (network) declares network enabled") {
+		t.Fatalf("warnings = %+v, want project skill network posture warning", readiness.Data.Warnings)
+	}
 	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
 	if err != nil {
 		t.Fatalf("ListTasks: %v", err)
@@ -52,6 +76,19 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessReturnsNativePlanWithoutSideEff
 	if len(tasks) != 0 {
 		t.Fatalf("tasks = %+v, want no task created by launch readiness", tasks)
 	}
+}
+
+func boolForLaunchReadinessTest(value bool) *bool {
+	return &value
+}
+
+func launchReadinessWarningContains(items []string, want string) bool {
+	for _, item := range items {
+		if len(item) >= len(want) && item[:len(want)] == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestProjectWorkAPI_AssignmentLaunchReadinessSurfacesBlockedModel(t *testing.T) {

--- a/internal/api/handler_project_skills.go
+++ b/internal/api/handler_project_skills.go
@@ -129,6 +129,8 @@ func renderProjectSkill(item projectskills.Skill) ProjectSkillResponseItem {
 		Path:                   item.Path,
 		RootID:                 item.RootID,
 		Format:                 item.Format,
+		SuggestedTools:         append([]string(nil), item.SuggestedTools...),
+		RequiredPermissions:    renderProjectSkillRequiredPermissions(item.RequiredPermissions),
 		Enabled:                item.Enabled,
 		Status:                 item.Status,
 		TrustLabel:             item.TrustLabel,
@@ -138,6 +140,25 @@ func renderProjectSkill(item projectskills.Skill) ProjectSkillResponseItem {
 		CreatedAt:              formatProjectSkillTime(item.CreatedAt),
 		UpdatedAt:              formatProjectSkillTime(item.UpdatedAt),
 	}
+}
+
+func renderProjectSkillRequiredPermissions(permissions projectskills.RequiredPermissions) *ProjectSkillRequiredPermissionsResponseItem {
+	if permissions.Empty() {
+		return nil
+	}
+	return &ProjectSkillRequiredPermissionsResponseItem{
+		Tools:   cloneBoolResponseValue(permissions.Tools),
+		Writes:  cloneBoolResponseValue(permissions.Writes),
+		Network: cloneBoolResponseValue(permissions.Network),
+	}
+}
+
+func cloneBoolResponseValue(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
 }
 
 func appendUniqueProjectSkillWarnings(items []string, values ...string) []string {

--- a/internal/api/handler_project_skills_test.go
+++ b/internal/api/handler_project_skills_test.go
@@ -19,7 +19,18 @@ func TestProjectSkillsAPI_DiscoverListAndPatch(t *testing.T) {
 	handler.SetProjectStore(projects.NewMemoryStore())
 	server := NewServer(quietLogger(), handler)
 	root := t.TempDir()
-	writeProjectSkillAPITestFile(t, root, ".hecate/skills/backend/SKILL.md", "---\nname: Backend\ndescription: Build backend changes.\n---\n")
+	writeProjectSkillAPITestFile(t, root, ".hecate/skills/backend/SKILL.md", `---
+name: Backend
+description: Build backend changes.
+hecate:
+  suggested_tools:
+    - git.diff
+  required_permissions:
+    tools: true
+    writes: true
+    network: false
+---
+`)
 	writeProjectSkillAPITestFile(t, root, ".agents/skills/qa/SKILL.md", "# QA\n")
 	if _, err := handler.projects.Create(t.Context(), projects.Project{
 		ID:   "proj_skills_api",
@@ -44,6 +55,13 @@ func TestProjectSkillsAPI_DiscoverListAndPatch(t *testing.T) {
 	}
 	if discovered.Object != "project_skills" || len(discovered.Data) != 2 {
 		t.Fatalf("discover response = %+v, want two project skills", discovered)
+	}
+	backend := projectSkillResponseFor(discovered.Data, "backend")
+	if backend == nil || len(backend.SuggestedTools) != 1 || backend.SuggestedTools[0] != "git.diff" {
+		t.Fatalf("backend suggested tools = %+v, want git.diff", backend)
+	}
+	if backend.RequiredPermissions == nil || backend.RequiredPermissions.Tools == nil || !*backend.RequiredPermissions.Tools || backend.RequiredPermissions.Writes == nil || !*backend.RequiredPermissions.Writes || backend.RequiredPermissions.Network == nil || *backend.RequiredPermissions.Network {
+		t.Fatalf("backend required permissions = %+v, want tools/writes on and network off", backend.RequiredPermissions)
 	}
 
 	patchRec := httptest.NewRecorder()
@@ -125,6 +143,15 @@ func projectSkillResponseHas(items []ProjectSkillResponseItem, id string, enable
 		}
 	}
 	return false
+}
+
+func projectSkillResponseFor(items []ProjectSkillResponseItem, id string) *ProjectSkillResponseItem {
+	for idx := range items {
+		if items[idx].ID == id {
+			return &items[idx]
+		}
+	}
+	return nil
 }
 
 func projectSkillAPITestJSONBody(t *testing.T, payload any) *bytes.Reader {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -402,21 +402,29 @@ type ProjectSkillResponse struct {
 }
 
 type ProjectSkillResponseItem struct {
-	ID                     string   `json:"id"`
-	ProjectID              string   `json:"project_id"`
-	Title                  string   `json:"title"`
-	Description            string   `json:"description,omitempty"`
-	Path                   string   `json:"path,omitempty"`
-	RootID                 string   `json:"root_id,omitempty"`
-	Format                 string   `json:"format"`
-	Enabled                bool     `json:"enabled"`
-	Status                 string   `json:"status"`
-	TrustLabel             string   `json:"trust_label"`
-	SourceContextSourceIDs []string `json:"source_context_source_ids,omitempty"`
-	Warnings               []string `json:"warnings,omitempty"`
-	DiscoveredAt           string   `json:"discovered_at,omitempty"`
-	CreatedAt              string   `json:"created_at"`
-	UpdatedAt              string   `json:"updated_at"`
+	ID                     string                                       `json:"id"`
+	ProjectID              string                                       `json:"project_id"`
+	Title                  string                                       `json:"title"`
+	Description            string                                       `json:"description,omitempty"`
+	Path                   string                                       `json:"path,omitempty"`
+	RootID                 string                                       `json:"root_id,omitempty"`
+	Format                 string                                       `json:"format"`
+	SuggestedTools         []string                                     `json:"suggested_tools,omitempty"`
+	RequiredPermissions    *ProjectSkillRequiredPermissionsResponseItem `json:"required_permissions,omitempty"`
+	Enabled                bool                                         `json:"enabled"`
+	Status                 string                                       `json:"status"`
+	TrustLabel             string                                       `json:"trust_label"`
+	SourceContextSourceIDs []string                                     `json:"source_context_source_ids,omitempty"`
+	Warnings               []string                                     `json:"warnings,omitempty"`
+	DiscoveredAt           string                                       `json:"discovered_at,omitempty"`
+	CreatedAt              string                                       `json:"created_at"`
+	UpdatedAt              string                                       `json:"updated_at"`
+}
+
+type ProjectSkillRequiredPermissionsResponseItem struct {
+	Tools   *bool `json:"tools,omitempty"`
+	Writes  *bool `json:"writes,omitempty"`
+	Network *bool `json:"network,omitempty"`
 }
 
 type PluginsResponse struct {

--- a/internal/projectassistant/context.go
+++ b/internal/projectassistant/context.go
@@ -113,20 +113,28 @@ type RoleContext struct {
 }
 
 type ProjectSkillContext struct {
-	ID                     string    `json:"id"`
-	Title                  string    `json:"title"`
-	Description            string    `json:"description,omitempty"`
-	Path                   string    `json:"path"`
-	RootID                 string    `json:"root_id,omitempty"`
-	Format                 string    `json:"format"`
-	Enabled                bool      `json:"enabled"`
-	Status                 string    `json:"status"`
-	TrustLabel             string    `json:"trust_label"`
-	SourceContextSourceIDs []string  `json:"source_context_source_ids,omitempty"`
-	Warnings               []string  `json:"warnings,omitempty"`
-	DiscoveredAt           time.Time `json:"discovered_at"`
-	CreatedAt              time.Time `json:"created_at"`
-	UpdatedAt              time.Time `json:"updated_at"`
+	ID                     string                                  `json:"id"`
+	Title                  string                                  `json:"title"`
+	Description            string                                  `json:"description,omitempty"`
+	Path                   string                                  `json:"path"`
+	RootID                 string                                  `json:"root_id,omitempty"`
+	Format                 string                                  `json:"format"`
+	SuggestedTools         []string                                `json:"suggested_tools,omitempty"`
+	RequiredPermissions    *ProjectSkillRequiredPermissionsContext `json:"required_permissions,omitempty"`
+	Enabled                bool                                    `json:"enabled"`
+	Status                 string                                  `json:"status"`
+	TrustLabel             string                                  `json:"trust_label"`
+	SourceContextSourceIDs []string                                `json:"source_context_source_ids,omitempty"`
+	Warnings               []string                                `json:"warnings,omitempty"`
+	DiscoveredAt           time.Time                               `json:"discovered_at"`
+	CreatedAt              time.Time                               `json:"created_at"`
+	UpdatedAt              time.Time                               `json:"updated_at"`
+}
+
+type ProjectSkillRequiredPermissionsContext struct {
+	Tools   *bool `json:"tools,omitempty"`
+	Writes  *bool `json:"writes,omitempty"`
+	Network *bool `json:"network,omitempty"`
 }
 
 type AssignmentContext struct {
@@ -532,6 +540,8 @@ func projectSkillContext(item projectskills.Skill) ProjectSkillContext {
 		Path:                   item.Path,
 		RootID:                 item.RootID,
 		Format:                 item.Format,
+		SuggestedTools:         append([]string(nil), item.SuggestedTools...),
+		RequiredPermissions:    projectSkillRequiredPermissionsContext(item.RequiredPermissions),
 		Enabled:                item.Enabled,
 		Status:                 item.Status,
 		TrustLabel:             item.TrustLabel,
@@ -541,6 +551,25 @@ func projectSkillContext(item projectskills.Skill) ProjectSkillContext {
 		CreatedAt:              item.CreatedAt,
 		UpdatedAt:              item.UpdatedAt,
 	}
+}
+
+func projectSkillRequiredPermissionsContext(permissions projectskills.RequiredPermissions) *ProjectSkillRequiredPermissionsContext {
+	if permissions.Empty() {
+		return nil
+	}
+	return &ProjectSkillRequiredPermissionsContext{
+		Tools:   cloneProjectSkillBool(permissions.Tools),
+		Writes:  cloneProjectSkillBool(permissions.Writes),
+		Network: cloneProjectSkillBool(permissions.Network),
+	}
+}
+
+func cloneProjectSkillBool(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
 }
 
 func assignmentContext(item projectwork.Assignment) AssignmentContext {

--- a/internal/projectskills/discovery.go
+++ b/internal/projectskills/discovery.go
@@ -173,70 +173,121 @@ func discoverInBaseDir(fsys *workspacefs.FS, rootID string, base skillBaseDir, w
 		if err != nil || info.IsDir() {
 			continue
 		}
-		title, description, skillWarnings, status := readSkillMetadata(fsys, skillID, skillPath, info.Size())
-		if status == StatusInvalid && warnings != nil {
-			*warnings = append(*warnings, skillWarnings...)
+		metadata := readSkillMetadata(fsys, skillID, skillPath, info.Size())
+		if metadata.Status == StatusInvalid && warnings != nil {
+			*warnings = append(*warnings, metadata.Warnings...)
 		}
 		out = append(out, Skill{
 			ID:                     skillID,
-			Title:                  title,
-			Description:            description,
+			Title:                  metadata.Title,
+			Description:            metadata.Description,
 			Path:                   skillPath,
 			RootID:                 rootID,
 			Format:                 FormatSkillMD,
+			SuggestedTools:         metadata.SuggestedTools,
+			RequiredPermissions:    metadata.RequiredPermissions,
 			Enabled:                true,
-			Status:                 status,
+			Status:                 metadata.Status,
 			TrustLabel:             TrustWorkspaceSkill,
 			SourceContextSourceIDs: base.SourceContextSourceIDs,
-			Warnings:               skillWarnings,
+			Warnings:               metadata.Warnings,
 		})
 	}
 	return out
 }
 
-func readSkillMetadata(fsys *workspacefs.FS, skillID, skillPath string, size int64) (string, string, []string, string) {
-	title := titleFromID(skillID)
-	var warnings []string
-	status := StatusAvailable
+type skillMetadata struct {
+	Title               string
+	Description         string
+	SuggestedTools      []string
+	RequiredPermissions RequiredPermissions
+	Warnings            []string
+	Status              string
+}
+
+func readSkillMetadata(fsys *workspacefs.FS, skillID, skillPath string, size int64) skillMetadata {
+	metadata := skillMetadata{
+		Title:  titleFromID(skillID),
+		Status: StatusAvailable,
+	}
 	if size > skillMaxBytes {
-		warnings = append(warnings, fmt.Sprintf("Skipped metadata parsing for %s because it is larger than %d bytes.", skillPath, skillMaxBytes))
-		return title, "", warnings, StatusInvalid
+		metadata.Warnings = append(metadata.Warnings, fmt.Sprintf("Skipped metadata parsing for %s because it is larger than %d bytes.", skillPath, skillMaxBytes))
+		metadata.Status = StatusInvalid
+		return metadata
 	}
 	file, _, err := fsys.Open(skillPath)
 	if err != nil {
-		warnings = append(warnings, fmt.Sprintf("Failed to read skill metadata from %s: %v.", skillPath, err))
-		return title, "", warnings, StatusInvalid
+		metadata.Warnings = append(metadata.Warnings, fmt.Sprintf("Failed to read skill metadata from %s: %v.", skillPath, err))
+		metadata.Status = StatusInvalid
+		return metadata
 	}
 	defer file.Close()
 	raw, err := io.ReadAll(io.LimitReader(file, skillMaxBytes+1))
 	if err != nil {
-		warnings = append(warnings, fmt.Sprintf("Failed to read skill metadata from %s: %v.", skillPath, err))
-		return title, "", warnings, StatusInvalid
+		metadata.Warnings = append(metadata.Warnings, fmt.Sprintf("Failed to read skill metadata from %s: %v.", skillPath, err))
+		metadata.Status = StatusInvalid
+		return metadata
 	}
 	body := string(raw)
-	if name, description := parseFrontmatterMetadata(body); name != "" || description != "" {
-		if name != "" {
-			title = name
-		}
-		return title, description, warnings, status
+	frontmatter := parseFrontmatterMetadata(body)
+	if frontmatter.Title != "" {
+		metadata.Title = frontmatter.Title
+	}
+	metadata.Description = frontmatter.Description
+	metadata.SuggestedTools = frontmatter.SuggestedTools
+	metadata.RequiredPermissions = frontmatter.RequiredPermissions
+	if frontmatter.HasMetadata() {
+		return metadata
 	}
 	if heading := firstMarkdownHeading(body); heading != "" {
-		title = heading
+		metadata.Title = heading
 	}
-	return title, "", warnings, status
+	return metadata
 }
 
-func parseFrontmatterMetadata(body string) (string, string) {
+type skillFrontmatterMetadata struct {
+	Title               string
+	Description         string
+	SuggestedTools      []string
+	RequiredPermissions RequiredPermissions
+}
+
+func (metadata skillFrontmatterMetadata) HasMetadata() bool {
+	return metadata.Title != "" ||
+		metadata.Description != "" ||
+		len(metadata.SuggestedTools) > 0 ||
+		!metadata.RequiredPermissions.Empty()
+}
+
+func parseFrontmatterMetadata(body string) skillFrontmatterMetadata {
 	body = strings.TrimPrefix(body, "\ufeff")
 	if !strings.HasPrefix(body, "---\n") && !strings.HasPrefix(body, "---\r\n") {
-		return "", ""
+		return skillFrontmatterMetadata{}
 	}
 	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
-	var name, description string
+	var metadata skillFrontmatterMetadata
+	activeList := ""
+	activeMap := ""
+	inHecate := false
+	hecateIndent := -1
 	for idx := 1; idx < len(lines); idx++ {
+		rawLine := lines[idx]
 		line := strings.TrimSpace(lines[idx])
 		if line == "---" {
 			break
+		}
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		indent := frontmatterIndent(rawLine)
+		if inHecate && indent <= hecateIndent {
+			inHecate = false
+			activeList = ""
+			activeMap = ""
+		}
+		if inHecate && activeList == "suggested_tools" && strings.HasPrefix(line, "- ") {
+			metadata.SuggestedTools = append(metadata.SuggestedTools, strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "- ")), `"'`))
+			continue
 		}
 		key, value, ok := strings.Cut(line, ":")
 		if !ok {
@@ -245,12 +296,111 @@ func parseFrontmatterMetadata(body string) (string, string) {
 		value = strings.Trim(strings.TrimSpace(value), `"'`)
 		switch strings.ToLower(strings.TrimSpace(key)) {
 		case "name", "title":
-			name = value
+			if indent == 0 {
+				metadata.Title = value
+			}
 		case "description":
-			description = value
+			if indent == 0 {
+				metadata.Description = value
+			}
+		case "hecate":
+			inHecate = value == ""
+			hecateIndent = indent
+			activeList = ""
+			activeMap = ""
+		case "suggested_tools":
+			if !inHecate || indent <= hecateIndent {
+				activeList = ""
+				activeMap = ""
+				continue
+			}
+			activeMap = ""
+			if value == "" {
+				activeList = "suggested_tools"
+			} else {
+				activeList = ""
+				metadata.SuggestedTools = append(metadata.SuggestedTools, parseFrontmatterListValue(value)...)
+			}
+		case "required_permissions":
+			if !inHecate || indent <= hecateIndent {
+				activeList = ""
+				activeMap = ""
+				continue
+			}
+			activeList = ""
+			activeMap = "required_permissions"
+		case "tools", "writes", "network":
+			if inHecate && activeMap == "required_permissions" && indent > hecateIndent {
+				setRequiredPermission(&metadata.RequiredPermissions, strings.ToLower(strings.TrimSpace(key)), value)
+			}
+		default:
+			activeList = ""
+			activeMap = ""
 		}
 	}
-	return name, description
+	metadata.SuggestedTools = normalizeStringSlice(metadata.SuggestedTools)
+	return metadata
+}
+
+func frontmatterIndent(line string) int {
+	indent := 0
+	for _, char := range line {
+		switch char {
+		case ' ':
+			indent++
+		case '\t':
+			indent += 2
+		default:
+			return indent
+		}
+	}
+	return indent
+}
+
+func parseFrontmatterListValue(value string) []string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "[")
+	value = strings.TrimSuffix(value, "]")
+	if value == "" {
+		return nil
+	}
+	if !strings.Contains(value, ",") {
+		return []string{strings.Trim(value, `"'`)}
+	}
+	var out []string
+	for _, item := range strings.Split(value, ",") {
+		item = strings.Trim(strings.TrimSpace(item), `"'`)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func setRequiredPermission(permissions *RequiredPermissions, key, value string) {
+	parsed, ok := parseFrontmatterBool(value)
+	if !ok {
+		return
+	}
+	switch key {
+	case "tools":
+		permissions.Tools = &parsed
+	case "writes":
+		permissions.Writes = &parsed
+	case "network":
+		permissions.Network = &parsed
+	}
+}
+
+func parseFrontmatterBool(value string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "yes", "on", "1":
+		return true, true
+	case "false", "no", "off", "0":
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 func firstMarkdownHeading(body string) string {

--- a/internal/projectskills/discovery_test.go
+++ b/internal/projectskills/discovery_test.go
@@ -167,6 +167,60 @@ func TestDiscoverMarksDuplicateSkillIDsAsConflict(t *testing.T) {
 	}
 }
 
+func TestDiscoverParsesHecateCapabilityHints(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeSkillFile(t, root, ".hecate/skills/review/SKILL.md", `---
+title: Review
+description: Review implementation output.
+suggested_tools:
+  - shell.exec
+required_permissions:
+  network: true
+hecate:
+  suggested_tools:
+    - git.diff
+    - file.read
+  required_permissions:
+    tools: true
+    writes: false
+    network: false
+---
+# Ignored
+`)
+
+	skills, warnings := Discover(context.Background(), projects.Project{
+		ID: "proj_capabilities",
+		Roots: []projects.Root{{
+			ID:     "root_a",
+			Path:   root,
+			Active: true,
+		}},
+	})
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %+v, want none", warnings)
+	}
+	review := findSkillForTest(skills, "review")
+	if review == nil {
+		t.Fatalf("skills = %+v, missing review", skills)
+	}
+	if review.Title != "Review" || review.Description != "Review implementation output." {
+		t.Fatalf("review metadata = %+v, want frontmatter title and description", review)
+	}
+	if strings.Join(review.SuggestedTools, ",") != "file.read,git.diff" {
+		t.Fatalf("suggested tools = %+v, want sorted frontmatter tools", review.SuggestedTools)
+	}
+	if review.RequiredPermissions.Tools == nil || !*review.RequiredPermissions.Tools {
+		t.Fatalf("required tools = %+v, want true", review.RequiredPermissions.Tools)
+	}
+	if review.RequiredPermissions.Writes == nil || *review.RequiredPermissions.Writes {
+		t.Fatalf("required writes = %+v, want false", review.RequiredPermissions.Writes)
+	}
+	if review.RequiredPermissions.Network == nil || *review.RequiredPermissions.Network {
+		t.Fatalf("required network = %+v, want false", review.RequiredPermissions.Network)
+	}
+}
+
 func TestDiscoverBoundsGuidanceAndSkillMetadata(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/projectskills/sqlite.go
+++ b/internal/projectskills/sqlite.go
@@ -54,6 +54,8 @@ CREATE TABLE IF NOT EXISTS `+s.table+` (
 	path TEXT NOT NULL DEFAULT '',
 	root_id TEXT NOT NULL DEFAULT '',
 	format TEXT NOT NULL DEFAULT 'skill_md',
+	suggested_tools TEXT NOT NULL DEFAULT '[]',
+	required_permissions TEXT NOT NULL DEFAULT '{}',
 	enabled INTEGER NOT NULL DEFAULT 1,
 	status TEXT NOT NULL DEFAULT 'available',
 	trust_label TEXT NOT NULL DEFAULT 'workspace_skill',
@@ -64,7 +66,16 @@ CREATE TABLE IF NOT EXISTS `+s.table+` (
 	updated_at `+timestampColumn+`,
 	PRIMARY KEY(project_id, id)
 )`)
-	return err
+	if err != nil {
+		return err
+	}
+	if err := s.ensureColumn(ctx, "suggested_tools", `TEXT NOT NULL DEFAULT '[]'`); err != nil {
+		return err
+	}
+	if err := s.ensureColumn(ctx, "required_permissions", `TEXT NOT NULL DEFAULT '{}'`); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *SQLiteStore) List(ctx context.Context, projectID string) ([]Skill, error) {
@@ -229,14 +240,17 @@ func (s *SQLiteStore) upsertWith(ctx context.Context, execer sqliteExecer, item 
 	_, err := execer.ExecContext(ctx, fmt.Sprintf(`
 INSERT INTO %s (
 	id, project_id, title, description, path, root_id, format, enabled, status,
-	trust_label, source_context_source_ids, warnings, discovered_at, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	suggested_tools, required_permissions, trust_label, source_context_source_ids, warnings,
+	discovered_at, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(project_id, id) DO UPDATE SET
 	title = excluded.title,
 	description = excluded.description,
 	path = excluded.path,
 	root_id = excluded.root_id,
 	format = excluded.format,
+	suggested_tools = excluded.suggested_tools,
+	required_permissions = excluded.required_permissions,
 	enabled = excluded.enabled,
 	status = excluded.status,
 	trust_label = excluded.trust_label,
@@ -253,6 +267,8 @@ ON CONFLICT(project_id, id) DO UPDATE SET
 		item.Format,
 		boolToDB(item.Enabled),
 		item.Status,
+		encodeStringSlice(item.SuggestedTools),
+		encodeRequiredPermissions(item.RequiredPermissions),
 		item.TrustLabel,
 		encodeStringSlice(item.SourceContextSourceIDs),
 		encodeStringSlice(item.Warnings),
@@ -270,7 +286,8 @@ type skillScanner interface {
 func selectProjectSkillSQL(table string) string {
 	return fmt.Sprintf(`
 SELECT id, project_id, title, description, path, root_id, format, enabled, status,
-	trust_label, source_context_source_ids, warnings, discovered_at, created_at, updated_at
+	suggested_tools, required_permissions, trust_label, source_context_source_ids, warnings,
+	discovered_at, created_at, updated_at
 FROM %s
 `, table)
 }
@@ -278,7 +295,7 @@ FROM %s
 func scanSkill(row skillScanner) (Skill, error) {
 	var item Skill
 	var enabled int
-	var sourceIDsRaw, warningsRaw string
+	var suggestedToolsRaw, permissionsRaw, sourceIDsRaw, warningsRaw string
 	var discoveredAt, createdAt, updatedAt string
 	if err := row.Scan(
 		&item.ID,
@@ -290,6 +307,8 @@ func scanSkill(row skillScanner) (Skill, error) {
 		&item.Format,
 		&enabled,
 		&item.Status,
+		&suggestedToolsRaw,
+		&permissionsRaw,
 		&item.TrustLabel,
 		&sourceIDsRaw,
 		&warningsRaw,
@@ -300,6 +319,8 @@ func scanSkill(row skillScanner) (Skill, error) {
 		return Skill{}, err
 	}
 	item.Enabled = enabled != 0
+	item.SuggestedTools = decodeStringSlice(suggestedToolsRaw)
+	item.RequiredPermissions = decodeRequiredPermissions(permissionsRaw)
 	item.SourceContextSourceIDs = decodeStringSlice(sourceIDsRaw)
 	item.Warnings = decodeStringSlice(warningsRaw)
 	var err error
@@ -313,6 +334,20 @@ func scanSkill(row skillScanner) (Skill, error) {
 		return Skill{}, err
 	}
 	return normalizeSkill(item, item.UpdatedAt), nil
+}
+
+func (s *SQLiteStore) ensureColumn(ctx context.Context, column, definition string) error {
+	exists, err := storage.ColumnExists(ctx, s.client, strings.Trim(s.table, `"`), column)
+	if err != nil {
+		return fmt.Errorf("inspect %s project skill columns: %w", s.backend, err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, s.table, column, definition)); err != nil {
+		return fmt.Errorf("migrate %s project skills %s: %w", s.backend, column, err)
+	}
+	return nil
 }
 
 func boolToDB(value bool) int {
@@ -336,6 +371,25 @@ func decodeStringSlice(raw string) []string {
 		return nil
 	}
 	return normalizeStringSlice(items)
+}
+
+func encodeRequiredPermissions(permissions RequiredPermissions) string {
+	if permissions.Empty() {
+		return "{}"
+	}
+	raw, err := json.Marshal(permissions)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func decodeRequiredPermissions(raw string) RequiredPermissions {
+	var permissions RequiredPermissions
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &permissions); err != nil {
+		return RequiredPermissions{}
+	}
+	return cloneRequiredPermissions(permissions)
 }
 
 func formatTime(value time.Time) string {

--- a/internal/projectskills/store.go
+++ b/internal/projectskills/store.go
@@ -3,6 +3,7 @@ package projectskills
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -11,6 +12,9 @@ import (
 
 const (
 	FormatSkillMD = "skill_md"
+
+	suggestedToolsMaxItems        = 16
+	suggestedToolsSummaryMaxItems = 8
 
 	StatusAvailable = "available"
 	StatusMissing   = "missing"
@@ -33,6 +37,8 @@ type Skill struct {
 	Path                   string
 	RootID                 string
 	Format                 string
+	SuggestedTools         []string
+	RequiredPermissions    RequiredPermissions
 	Enabled                bool
 	Status                 string
 	TrustLabel             string
@@ -41,6 +47,16 @@ type Skill struct {
 	DiscoveredAt           time.Time
 	CreatedAt              time.Time
 	UpdatedAt              time.Time
+}
+
+type RequiredPermissions struct {
+	Tools   *bool `json:"tools,omitempty"`
+	Writes  *bool `json:"writes,omitempty"`
+	Network *bool `json:"network,omitempty"`
+}
+
+func (permissions RequiredPermissions) Empty() bool {
+	return permissions.Tools == nil && permissions.Writes == nil && permissions.Network == nil
 }
 
 type Store interface {
@@ -203,6 +219,11 @@ func normalizeSkill(skill Skill, now time.Time) Skill {
 	skill.Format = strings.TrimSpace(skill.Format)
 	skill.Status = strings.TrimSpace(skill.Status)
 	skill.TrustLabel = strings.TrimSpace(skill.TrustLabel)
+	var omittedSuggestedTools int
+	skill.SuggestedTools, omittedSuggestedTools = normalizeSuggestedTools(skill.SuggestedTools)
+	if omittedSuggestedTools > 0 {
+		skill.Warnings = append(skill.Warnings, fmt.Sprintf("Suggested tools list was capped at %d entries (+%d more omitted).", suggestedToolsMaxItems, omittedSuggestedTools))
+	}
 	if skill.Format == "" {
 		skill.Format = FormatSkillMD
 	}
@@ -266,9 +287,27 @@ func skillsFromMap(items map[string]Skill) []Skill {
 }
 
 func cloneSkill(skill Skill) Skill {
+	skill.SuggestedTools = append([]string(nil), skill.SuggestedTools...)
+	skill.RequiredPermissions = cloneRequiredPermissions(skill.RequiredPermissions)
 	skill.SourceContextSourceIDs = append([]string(nil), skill.SourceContextSourceIDs...)
 	skill.Warnings = append([]string(nil), skill.Warnings...)
 	return skill
+}
+
+func cloneRequiredPermissions(permissions RequiredPermissions) RequiredPermissions {
+	return RequiredPermissions{
+		Tools:   cloneBoolPointer(permissions.Tools),
+		Writes:  cloneBoolPointer(permissions.Writes),
+		Network: cloneBoolPointer(permissions.Network),
+	}
+}
+
+func cloneBoolPointer(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
 }
 
 func sortSkills(items []Skill) {
@@ -320,6 +359,32 @@ func normalizeStringSlice(items []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func normalizeSuggestedTools(items []string) ([]string, int) {
+	items = normalizeStringSlice(items)
+	if len(items) <= suggestedToolsMaxItems {
+		return items, 0
+	}
+	omitted := len(items) - suggestedToolsMaxItems
+	return append([]string(nil), items[:suggestedToolsMaxItems]...), omitted
+}
+
+func SuggestedToolsSummary(items []string) string {
+	items = normalizeStringSlice(items)
+	if len(items) == 0 {
+		return ""
+	}
+	omitted := 0
+	if len(items) > suggestedToolsSummaryMaxItems {
+		omitted = len(items) - suggestedToolsSummaryMaxItems
+		items = items[:suggestedToolsSummaryMaxItems]
+	}
+	summary := strings.Join(items, ", ")
+	if omitted > 0 {
+		summary += fmt.Sprintf(", +%d more", omitted)
+	}
+	return summary
 }
 
 func appendUniqueStrings(items []string, values ...string) []string {

--- a/internal/projectskills/store_test.go
+++ b/internal/projectskills/store_test.go
@@ -3,6 +3,7 @@ package projectskills
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -32,9 +33,17 @@ func TestStoreConformance_ProjectSkillsLifecycle(t *testing.T) {
 					Path:        ".hecate/skills/backend/SKILL.md",
 					RootID:      "root_a",
 					Format:      FormatSkillMD,
-					Enabled:     true,
-					Status:      StatusAvailable,
-					TrustLabel:  TrustWorkspaceSkill,
+					SuggestedTools: []string{
+						"git.diff",
+						"file.read",
+					},
+					RequiredPermissions: RequiredPermissions{
+						Tools:  boolForSkillTest(true),
+						Writes: boolForSkillTest(false),
+					},
+					Enabled:    true,
+					Status:     StatusAvailable,
+					TrustLabel: TrustWorkspaceSkill,
 				},
 				{
 					ID:       "qa",
@@ -54,6 +63,9 @@ func TestStoreConformance_ProjectSkillsLifecycle(t *testing.T) {
 			}
 			if items[0].ProjectID != "proj_alpha" || !items[0].Enabled || items[0].Status != StatusAvailable {
 				t.Fatalf("backend skill = %+v, want normalized project skill", items[0])
+			}
+			if len(items[0].SuggestedTools) != 2 || items[0].RequiredPermissions.Tools == nil || !*items[0].RequiredPermissions.Tools || items[0].RequiredPermissions.Writes == nil || *items[0].RequiredPermissions.Writes {
+				t.Fatalf("backend capability metadata = %+v / %+v, want persisted tools and permissions", items[0].SuggestedTools, items[0].RequiredPermissions)
 			}
 
 			updated, err := store.Update(ctx, "proj_alpha", "backend", func(skill *Skill) {
@@ -113,6 +125,106 @@ func TestStoreConformance_ProjectSkillsLifecycle(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_AddsCapabilityColumnsToExistingTable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	client, err := storage.NewSQLiteClient(ctx, storage.SQLiteConfig{
+		Path:        filepath.Join(t.TempDir(), "hecate.db"),
+		TablePrefix: "test",
+	})
+	if err != nil {
+		t.Fatalf("new sqlite client: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("close sqlite client: %v", err)
+		}
+	})
+	table := client.QualifiedTable("project_skills")
+	timestampColumn := storage.TimestampColumnDefaultZero(client)
+	if _, err := client.DB().ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS `+table+` (
+	id TEXT NOT NULL,
+	project_id TEXT NOT NULL,
+	title TEXT NOT NULL DEFAULT '',
+	description TEXT NOT NULL DEFAULT '',
+	path TEXT NOT NULL DEFAULT '',
+	root_id TEXT NOT NULL DEFAULT '',
+	format TEXT NOT NULL DEFAULT 'skill_md',
+	enabled INTEGER NOT NULL DEFAULT 1,
+	status TEXT NOT NULL DEFAULT 'available',
+	trust_label TEXT NOT NULL DEFAULT 'workspace_skill',
+	source_context_source_ids TEXT NOT NULL DEFAULT '[]',
+	warnings TEXT NOT NULL DEFAULT '[]',
+	discovered_at `+timestampColumn+`,
+	created_at `+timestampColumn+`,
+	updated_at `+timestampColumn+`,
+	PRIMARY KEY(project_id, id)
+)`); err != nil {
+		t.Fatalf("create old project_skills table: %v", err)
+	}
+	store, err := NewSQLiteStore(ctx, client)
+	if err != nil {
+		t.Fatalf("new sqlite project skill store: %v", err)
+	}
+	items, err := store.UpsertDiscovered(ctx, "proj_old", []Skill{{
+		ID:         "review",
+		Title:      "Review",
+		Path:       ".hecate/skills/review/SKILL.md",
+		Format:     FormatSkillMD,
+		Enabled:    true,
+		Status:     StatusAvailable,
+		TrustLabel: TrustWorkspaceSkill,
+		SuggestedTools: []string{
+			"git.diff",
+		},
+		RequiredPermissions: RequiredPermissions{Writes: boolForSkillTest(false)},
+	}})
+	if err != nil {
+		t.Fatalf("UpsertDiscovered: %v", err)
+	}
+	review := findSkillForTest(items, "review")
+	if review == nil || len(review.SuggestedTools) != 1 || review.RequiredPermissions.Writes == nil || *review.RequiredPermissions.Writes {
+		t.Fatalf("review skill = %+v, want migrated capability metadata", review)
+	}
+}
+
+func TestStore_CapsSuggestedToolsAndSummarizesOverflow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewMemoryStore()
+	items, err := store.UpsertDiscovered(ctx, "proj_tools", []Skill{{
+		ID:         "review",
+		Title:      "Review",
+		Path:       ".hecate/skills/review/SKILL.md",
+		Format:     FormatSkillMD,
+		Enabled:    true,
+		Status:     StatusAvailable,
+		TrustLabel: TrustWorkspaceSkill,
+		SuggestedTools: append(
+			suggestedToolsForSkillTest(suggestedToolsMaxItems+2),
+			"tool.00",
+		),
+	}})
+	if err != nil {
+		t.Fatalf("UpsertDiscovered: %v", err)
+	}
+	review := findSkillForTest(items, "review")
+	if review == nil {
+		t.Fatalf("items = %+v, missing review skill", items)
+	}
+	if len(review.SuggestedTools) != suggestedToolsMaxItems {
+		t.Fatalf("suggested tools = %+v, want cap of %d", review.SuggestedTools, suggestedToolsMaxItems)
+	}
+	wantWarning := fmt.Sprintf("Suggested tools list was capped at %d entries (+2 more omitted).", suggestedToolsMaxItems)
+	if !containsStringForTest(review.Warnings, wantWarning) {
+		t.Fatalf("warnings = %+v, want suggested tools cap warning", review.Warnings)
+	}
+	if got, want := SuggestedToolsSummary(review.SuggestedTools), "tool.00, tool.01, tool.02, tool.03, tool.04, tool.05, tool.06, tool.07, +8 more"; got != want {
+		t.Fatalf("SuggestedToolsSummary() = %q, want %q", got, want)
+	}
+}
+
 func newSQLiteSkillTestStore(t *testing.T) Store {
 	t.Helper()
 	ctx := context.Background()
@@ -151,4 +263,16 @@ func containsStringForTest(items []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func boolForSkillTest(value bool) *bool {
+	return &value
+}
+
+func suggestedToolsForSkillTest(count int) []string {
+	out := make([]string, 0, count)
+	for idx := 0; idx < count; idx++ {
+		out = append(out, fmt.Sprintf("tool.%02d", idx))
+	}
+	return out
 }

--- a/internal/projectworkapp/launch_plan.go
+++ b/internal/projectworkapp/launch_plan.go
@@ -365,9 +365,37 @@ func (app *Application) ResolveAssignmentSkills(ctx context.Context, projectID s
 			result.Skipped = append(result.Skipped, ResolvedProjectSkillSkip{ID: id, Reason: item.Status, Status: item.Status})
 		default:
 			result.Resolved = append(result.Resolved, item)
+			result.Warnings = append(result.Warnings, projectSkillCapabilityWarnings(item, profile)...)
 		}
 	}
+	result.Warnings = normalizeStringList(result.Warnings)
 	return result
+}
+
+func projectSkillCapabilityWarnings(skill projectskills.Skill, profile ResolvedAgentProfile) []string {
+	var warnings []string
+	label := labelWithID(firstNonEmpty(skill.Title, skill.ID), skill.ID)
+	appendPermissionWarning := func(name string, required *bool, actual bool) {
+		if required == nil || *required == actual {
+			return
+		}
+		wanted := "disabled"
+		if *required {
+			wanted = "enabled"
+		}
+		got := "disabled"
+		if actual {
+			got = "enabled"
+		}
+		warnings = append(warnings, fmt.Sprintf("Project skill %s declares %s %s, but resolved profile %s has %s %s.", label, name, wanted, firstNonEmpty(profile.ID, "unknown"), name, got))
+	}
+	appendPermissionWarning("tools", skill.RequiredPermissions.Tools, profile.ToolsEnabled)
+	appendPermissionWarning("writes", skill.RequiredPermissions.Writes, profile.WritesAllowed)
+	appendPermissionWarning("network", skill.RequiredPermissions.Network, profile.NetworkAllowed)
+	if toolsSummary := projectskills.SuggestedToolsSummary(skill.SuggestedTools); toolsSummary != "" && skill.RequiredPermissions.Tools == nil && !profile.ToolsEnabled {
+		warnings = append(warnings, fmt.Sprintf("Project skill %s suggests tools (%s), but resolved profile %s has tools disabled.", label, toolsSummary, firstNonEmpty(profile.ID, "unknown")))
+	}
+	return warnings
 }
 
 func (app *Application) AssignmentPromptContext(ctx context.Context, project projects.Project, profile ResolvedAgentProfile, workingDirectory string) AssignmentPromptContext {

--- a/internal/projectworkapp/launch_plan_test.go
+++ b/internal/projectworkapp/launch_plan_test.go
@@ -133,6 +133,75 @@ func TestApplication_ResolveTaskAssignmentLaunchPlanRejectsMissingModel(t *testi
 	}
 }
 
+func TestApplication_ResolveAssignmentSkillsWarnsForProfileCapabilityMismatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	skills := projectskills.NewMemoryStore()
+	if _, err := skills.UpsertDiscovered(ctx, "proj_1", []projectskills.Skill{
+		{
+			ID:         "review",
+			Title:      "Review",
+			Path:       ".hecate/skills/review/SKILL.md",
+			Format:     projectskills.FormatSkillMD,
+			Enabled:    true,
+			Status:     projectskills.StatusAvailable,
+			TrustLabel: projectskills.TrustWorkspaceSkill,
+			RequiredPermissions: projectskills.RequiredPermissions{
+				Tools:   boolForLaunchPlanTest(true),
+				Writes:  boolForLaunchPlanTest(false),
+				Network: boolForLaunchPlanTest(false),
+			},
+		},
+		{
+			ID:         "research",
+			Title:      "Research",
+			Path:       ".hecate/skills/research/SKILL.md",
+			Format:     projectskills.FormatSkillMD,
+			Enabled:    true,
+			Status:     projectskills.StatusAvailable,
+			TrustLabel: projectskills.TrustWorkspaceSkill,
+			SuggestedTools: []string{
+				"tool.00",
+				"tool.01",
+				"tool.02",
+				"tool.03",
+				"tool.04",
+				"tool.05",
+				"tool.06",
+				"tool.07",
+				"tool.08",
+				"tool.09",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("UpsertDiscovered() error = %v", err)
+	}
+	app := New(Options{SkillStore: skills})
+
+	resolved := app.ResolveAssignmentSkills(ctx, "proj_1", projectwork.AgentRoleProfile{
+		SkillIDs: []string{"review", "research"},
+	}, ResolvedAgentProfile{
+		ID:             "safe_review",
+		ToolsEnabled:   false,
+		WritesAllowed:  false,
+		NetworkAllowed: true,
+	})
+
+	if len(resolved.Resolved) != 2 {
+		t.Fatalf("resolved skills = %+v, want both skills resolved", resolved.Resolved)
+	}
+	if !launchPlanWarningContains(resolved.Warnings, "Project skill Review (review) declares tools enabled") {
+		t.Fatalf("warnings = %+v, want tools mismatch", resolved.Warnings)
+	}
+	if !launchPlanWarningContains(resolved.Warnings, "Project skill Review (review) declares network disabled") {
+		t.Fatalf("warnings = %+v, want network mismatch", resolved.Warnings)
+	}
+	if !launchPlanWarningContains(resolved.Warnings, "Project skill Research (research) suggests tools (tool.00, tool.01, tool.02, tool.03, tool.04, tool.05, tool.06, tool.07, +2 more)") {
+		t.Fatalf("warnings = %+v, want suggested tools mismatch", resolved.Warnings)
+	}
+}
+
 func TestApplication_ResolveTaskAssignmentLaunchPlanUsesRuntimeDefaultModel(t *testing.T) {
 	t.Parallel()
 
@@ -342,4 +411,17 @@ func launchPlanTestAssignment() projectwork.Assignment {
 		Status:     projectwork.AssignmentStatusQueued,
 		DriverKind: projectwork.AssignmentDriverHecateTask,
 	}
+}
+
+func boolForLaunchPlanTest(value bool) *bool {
+	return &value
+}
+
+func launchPlanWarningContains(items []string, want string) bool {
+	for _, item := range items {
+		if strings.Contains(item, want) {
+			return true
+		}
+	}
+	return false
 }

--- a/ui/src/features/projects/ProjectSkillsPanel.test.tsx
+++ b/ui/src/features/projects/ProjectSkillsPanel.test.tsx
@@ -25,6 +25,8 @@ function skill(overrides: Partial<ProjectSkillRecord> = {}): ProjectSkillRecord 
     path: ".hecate/skills/backend/SKILL.md",
     root_id: "root_1",
     format: "skill_md",
+    suggested_tools: ["git.diff", "file.read"],
+    required_permissions: { tools: true, writes: false, network: false },
     enabled: true,
     status: "available",
     trust_label: "workspace_skill",
@@ -62,6 +64,11 @@ describe("ProjectSkillsPanel", () => {
     expect(screen.getByText(/\.hecate\/skills\/backend\/SKILL\.md/)).toBeTruthy();
     expect(screen.getByText(/root root_1/)).toBeTruthy();
     expect(screen.getByText(/sources ctx_agents/)).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Suggested tools: git.diff, file.read · Required posture: tools on, writes off, network off",
+      ),
+    ).toBeTruthy();
 
     await userEvent.click(screen.getByRole("button", { name: "Refresh project skills" }));
     await userEvent.click(screen.getByRole("button", { name: "Discover" }));
@@ -107,6 +114,43 @@ describe("ProjectSkillsPanel", () => {
     expect(
       screen.getByText(
         "Discover skills from AGENTS.md / CLAUDE.md references, .agents/skills, or .hecate/skills.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("caps long suggested tool summaries", () => {
+    render(
+      <ProjectSkillsPanel
+        discovering={false}
+        error=""
+        loading={false}
+        onDiscover={vi.fn()}
+        onRefresh={vi.fn()}
+        onUpdate={vi.fn()}
+        project={project()}
+        skills={[
+          skill({
+            suggested_tools: [
+              "tool.00",
+              "tool.01",
+              "tool.02",
+              "tool.03",
+              "tool.04",
+              "tool.05",
+              "tool.06",
+              "tool.07",
+              "tool.08",
+              "tool.09",
+            ],
+          }),
+        ]}
+        updatingSkillID=""
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Suggested tools: tool.00, tool.01, tool.02, tool.03, tool.04, tool.05, tool.06, tool.07, +2 more · Required posture: tools on, writes off, network off",
       ),
     ).toBeTruthy();
   });

--- a/ui/src/features/projects/ProjectSkillsPanel.tsx
+++ b/ui/src/features/projects/ProjectSkillsPanel.tsx
@@ -20,6 +20,8 @@ type ProjectSkillsPanelProps = {
   updatingSkillID: string;
 };
 
+const suggestedToolsSummaryLimit = 8;
+
 export function ProjectSkillsPanel({
   discovering,
   error,
@@ -119,6 +121,7 @@ function ProjectSkillRow({
     draft.description.trim() !== (skill.description ?? "") ||
     draft.trustLabel.trim() !== skill.trust_label;
   const statusClass = skill.status === "available" ? "badge badge-green" : "badge badge-amber";
+  const capabilitySummary = projectSkillCapabilitySummary(skill);
 
   return (
     <div style={memoryEntryStyle}>
@@ -194,6 +197,7 @@ function ProjectSkillRow({
               : ""}
             {skill.discovered_at ? ` · discovered ${formatAbsoluteTime(skill.discovered_at)}` : ""}
           </div>
+          {capabilitySummary && <div style={skillCapabilityStyle}>{capabilitySummary}</div>}
           {skill.warnings?.length ? (
             <div style={{ display: "grid", gap: 3 }}>
               {skill.warnings.map((warning) => (
@@ -231,6 +235,42 @@ function skillFormFromRecord(skill: ProjectSkillRecord): SkillForm {
   };
 }
 
+function projectSkillCapabilitySummary(skill: ProjectSkillRecord): string {
+  const parts: string[] = [];
+  const suggestedTools = projectSkillSuggestedToolsSummary(skill.suggested_tools);
+  if (suggestedTools) {
+    parts.push(`Suggested tools: ${suggestedTools}`);
+  }
+  const permissions = projectSkillRequiredPermissionsSummary(skill);
+  if (permissions) {
+    parts.push(`Required posture: ${permissions}`);
+  }
+  return parts.join(" · ");
+}
+
+function projectSkillSuggestedToolsSummary(tools: string[] | undefined): string {
+  if (!tools?.length) return "";
+  const shown = tools.slice(0, suggestedToolsSummaryLimit);
+  const omitted = tools.length - shown.length;
+  return `${shown.join(", ")}${omitted > 0 ? `, +${omitted} more` : ""}`;
+}
+
+function projectSkillRequiredPermissionsSummary(skill: ProjectSkillRecord): string {
+  const permissions = skill.required_permissions;
+  if (!permissions) return "";
+  const parts: string[] = [];
+  for (const [label, value] of [
+    ["tools", permissions.tools],
+    ["writes", permissions.writes],
+    ["network", permissions.network],
+  ] as const) {
+    if (typeof value === "boolean") {
+      parts.push(`${label} ${value ? "on" : "off"}`);
+    }
+  }
+  return parts.join(", ");
+}
+
 function EmptyBlock({ title, detail }: { title: string; detail: string }) {
   return (
     <div
@@ -256,6 +296,13 @@ const subtleTextStyle: CSSProperties = {
   color: "var(--t3)",
   fontSize: 12,
   lineHeight: 1.4,
+};
+
+const skillCapabilityStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  lineHeight: 1.5,
 };
 
 const fieldStyle: CSSProperties = {

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -174,6 +174,8 @@ export type ProjectAssistantContextSkill = {
   path: string;
   root_id?: string;
   format: string;
+  suggested_tools?: string[];
+  required_permissions?: ProjectSkillRequiredPermissionsRecord;
   enabled: boolean;
   status: string;
   trust_label: string;
@@ -481,6 +483,8 @@ export type ProjectSkillRecord = {
   path: string;
   root_id?: string;
   format: string;
+  suggested_tools?: string[];
+  required_permissions?: ProjectSkillRequiredPermissionsRecord;
   enabled: boolean;
   status: "available" | "missing" | "invalid" | "conflict" | (string & {});
   trust_label: string;
@@ -489,6 +493,12 @@ export type ProjectSkillRecord = {
   discovered_at: string;
   created_at: string;
   updated_at: string;
+};
+
+export type ProjectSkillRequiredPermissionsRecord = {
+  tools?: boolean;
+  writes?: boolean;
+  network?: boolean;
 };
 
 export type UpdateProjectSkillPayload = {


### PR DESCRIPTION
## Overview

Adds advisory capability metadata for project skills and surfaces launch-readiness warnings when a resolved assignment profile does not match those hints.

## Changes

- Parse and persist `hecate.suggested_tools` and `hecate.required_permissions.{tools,writes,network}` from bounded project `SKILL.md` frontmatter.
- Expose the metadata through project skill, chat context, and Project Assistant context payloads.
- Add assignment launch-readiness warnings for skill/profile posture mismatches without blocking launch or granting permissions.
- Render capability summaries in the Project Skills panel and document the advisory contract.

## Verification

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-skill-capability-warnings/.gocache go test ./internal/projectskills ./internal/projectworkapp ./internal/projectassistant ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-skill-capability-warnings/.gocache go vet ./internal/projectskills ./internal/projectworkapp ./internal/projectassistant ./internal/api`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test src/features/projects/ProjectSkillsPanel.test.tsx`
- `bun run test`
