### PR TITLE
fix(agentadapters): support filesystem callbacks during probes

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -248,7 +248,10 @@ native session reload/recovery, and run output. Do not import standalone adapter
 source modules or
 `acp-adapter-kit` into Hecate just to test Codex/Claude adapter behavior; that
 parity belongs in the adapter repositories, with optional release-binary smokes
-(`just test-acp-release-smoke`) when packaging drift needs coverage.
+(`just test-acp-release-smoke`) when packaging drift needs coverage. Keep probe
+clients honest: any ACP client capability the probe advertises should be
+implemented by the probe client against its temporary workspace rather than
+returning "not supported" during `session/new`.
 
 Chat session lifecycle orchestration starts in `internal/chatapp.Application`.
 Session create, external-agent prepare, native session metadata persistence,

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -2808,9 +2808,10 @@ func installFakeACPExecutable(t *testing.T, name string) {
 	}
 	exe := filepath.Join(bin, name)
 	script := fmt.Sprintf(
-		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q HECATE_FAKE_ACP_EXPECT_MCP_METHOD=%q HECATE_FAKE_ACP_EXPECT_MCP_JSON=%q HECATE_FAKE_ACP_AUTHENTICATE_FILE=%q HECATE_FAKE_ACP_AUTHENTICATE_ERROR=%q HECATE_FAKE_ACP_LOGOUT_FILE=%q HECATE_FAKE_ACP_LOGOUT_ERROR=%q HECATE_FAKE_ACP_AUTH_AGENT_LOGIN=%q HECATE_FAKE_ACP_AUTH_AGENT_OTHER=%q HECATE_FAKE_ACP_AUTH_ENV_VAR=%q HECATE_FAKE_ACP_AUTH_TERMINAL=%q HECATE_FAKE_ACP_SUPPORTS_LOGOUT=%q HECATE_FAKE_ACP_CLOSE_UNSUPPORTED=%q HECATE_FAKE_ACP_CLOSE_FILE=%q HECATE_FAKE_ACP_DELETE_UNSUPPORTED=%q HECATE_FAKE_ACP_DELETE_FILE=%q HECATE_FAKE_ACP_INIT_FILE=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_NEW_SESSION_FS=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q HECATE_FAKE_ACP_EXPECT_MCP_METHOD=%q HECATE_FAKE_ACP_EXPECT_MCP_JSON=%q HECATE_FAKE_ACP_AUTHENTICATE_FILE=%q HECATE_FAKE_ACP_AUTHENTICATE_ERROR=%q HECATE_FAKE_ACP_LOGOUT_FILE=%q HECATE_FAKE_ACP_LOGOUT_ERROR=%q HECATE_FAKE_ACP_AUTH_AGENT_LOGIN=%q HECATE_FAKE_ACP_AUTH_AGENT_OTHER=%q HECATE_FAKE_ACP_AUTH_ENV_VAR=%q HECATE_FAKE_ACP_AUTH_TERMINAL=%q HECATE_FAKE_ACP_SUPPORTS_LOGOUT=%q HECATE_FAKE_ACP_CLOSE_UNSUPPORTED=%q HECATE_FAKE_ACP_CLOSE_FILE=%q HECATE_FAKE_ACP_DELETE_UNSUPPORTED=%q HECATE_FAKE_ACP_DELETE_FILE=%q HECATE_FAKE_ACP_INIT_FILE=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
 		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
+		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_FS"),
 		os.Getenv("HECATE_FAKE_ACP_COMMANDS_DELAY"),
 		os.Getenv("HECATE_FAKE_ACP_MODELS"),
 		os.Getenv("HECATE_FAKE_ACP_CONFIG_OPTIONS"),
@@ -2965,6 +2966,21 @@ func (a *fakeACPAgent) NewSession(_ context.Context, params acp.NewSessionReques
 	}
 	if delay, err := time.ParseDuration(os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY")); err == nil && delay > 0 {
 		time.Sleep(delay)
+	}
+	if os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_FS") == "1" {
+		if _, err := a.conn.WriteTextFile(context.Background(), acp.WriteTextFileRequest{
+			Path:    "probe/fs.txt",
+			Content: "probe ok",
+		}); err != nil {
+			return acp.NewSessionResponse{}, fmt.Errorf("fake new_session write_text_file: %w", err)
+		}
+		read, err := a.conn.ReadTextFile(context.Background(), acp.ReadTextFileRequest{Path: "probe/fs.txt"})
+		if err != nil {
+			return acp.NewSessionResponse{}, fmt.Errorf("fake new_session read_text_file: %w", err)
+		}
+		if read.Content != "probe ok" {
+			return acp.NewSessionResponse{}, fmt.Errorf("fake new_session read_text_file = %q, want probe ok", read.Content)
+		}
 	}
 	a.mu.Lock()
 	a.nextSessionID++

--- a/internal/agentadapters/probe.go
+++ b/internal/agentadapters/probe.go
@@ -220,7 +220,7 @@ func Probe(ctx context.Context, adapterID string) (res ProbeResult) {
 
 	defer terminateProcess(cmd)
 
-	conn := acp.NewClientSideConnection(probeClient{}, stdin, stdout)
+	conn := acp.NewClientSideConnection(probeClient{workspace: workspace}, stdin, stdout)
 
 	res.Stage = ProbeStageInitialize
 	initCtx, initCancel := context.WithTimeout(probeCtx, 10*time.Second)
@@ -477,10 +477,13 @@ func elapsedMS(start time.Time) int64 {
 	return time.Since(start).Milliseconds()
 }
 
-// probeClient is a no-op ACP client. The probe never receives turns
-// or activity from the adapter — we just need to satisfy the
-// interface so the protocol handshake can complete.
-type probeClient struct{}
+// probeClient is the minimal ACP client used during health probes.
+// It implements the same filesystem callbacks advertised during
+// Initialize against the temporary probe workspace; everything else
+// either no-ops or fails closed because probes never drive turns.
+type probeClient struct {
+	workspace string
+}
 
 func (probeClient) SessionUpdate(context.Context, acp.SessionNotification) error {
 	return nil
@@ -496,12 +499,12 @@ func (probeClient) RequestPermission(context.Context, acp.RequestPermissionReque
 	}, nil
 }
 
-func (probeClient) ReadTextFile(context.Context, acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
-	return acp.ReadTextFileResponse{}, errors.New("probe: read_text_file not supported")
+func (c probeClient) ReadTextFile(ctx context.Context, params acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
+	return (&acpChatClient{workspace: c.workspace}).ReadTextFile(ctx, params)
 }
 
-func (probeClient) WriteTextFile(context.Context, acp.WriteTextFileRequest) (acp.WriteTextFileResponse, error) {
-	return acp.WriteTextFileResponse{}, errors.New("probe: write_text_file not supported")
+func (c probeClient) WriteTextFile(ctx context.Context, params acp.WriteTextFileRequest) (acp.WriteTextFileResponse, error) {
+	return (&acpChatClient{workspace: c.workspace}).WriteTextFile(ctx, params)
 }
 
 func (probeClient) CreateTerminal(context.Context, acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {

--- a/internal/agentadapters/probe_test.go
+++ b/internal/agentadapters/probe_test.go
@@ -306,6 +306,16 @@ func TestProbeCapturesInitializeCapabilities(t *testing.T) {
 	}
 }
 
+func TestProbeSupportsFilesystemCallbacksDuringNewSession(t *testing.T) {
+	t.Setenv("HECATE_FAKE_ACP_NEW_SESSION_FS", "1")
+	installFakeACPExecutable(t, "codex-acp-adapter")
+
+	res := Probe(context.Background(), "codex")
+	if res.Status != ProbeStatusReady {
+		t.Fatalf("Status = %q, want ready; stage=%q error=%q stderr=%q", res.Status, res.Stage, res.Error, res.Stderr)
+	}
+}
+
 func TestProbeHonorsDevOverrideMatrix(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
## Summary
- make the ACP health-probe client implement advertised read/write file callbacks against its temp workspace
- add a fake ACP peer regression that uses read/write during session/new
- document that probe clients must implement advertised capabilities

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters -run 'TestProbeSupportsFilesystemCallbacksDuringNewSession|TestProbeCapturesInitializeCapabilities' -count=1 -v
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -count=1 -timeout 10m ./internal/agentadapters
- just docs-format-check
- just agent-docs-check
- git diff --check