### PR TITLE
fix(agentadapters): give ACP login flows a longer timeout

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -224,12 +224,15 @@ that agent auth method should set `supports_authenticate=true`; other auth
 methods may be surfaced as non-secret health diagnostics without enabling the
 button. Keep action execution aligned with the same live capability contract:
 do not call ACP `authenticate` unless `agent-login` was advertised, and do not
-call ACP `logout` unless `agentCapabilities.auth.logout` was advertised. Remote
-runtime mode blocks local ACP `authenticate`; hosted runs authenticate adapters
-through declared remote-safe env-key credential modes. Probe/auth helper
-clients that advertise filesystem callbacks must pass their temporary
-workspace into the callback implementation; otherwise adapters can fail inside
-Initialize/auth/logout when they use a capability Hecate claimed to support.
+call ACP `logout` unless `agentCapabilities.auth.logout` was advertised.
+Keep probe timeouts short, but do not reuse the probe timeout for
+operator-triggered `authenticate`: native login flows may open browser or
+terminal UI and need a longer window. Remote runtime mode blocks local ACP
+`authenticate`; hosted runs authenticate adapters through declared remote-safe
+env-key credential modes. Probe/auth helper clients that advertise filesystem
+callbacks must pass their temporary workspace into the callback implementation;
+otherwise adapters can fail inside Initialize/auth/logout when they use a
+capability Hecate claimed to support.
 
 ACP terminal callbacks are a command-execution surface. Keep
 `clientCapabilities.terminal` false unless `HECATE_AGENT_ADAPTER_TERMINALS=1`

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -327,7 +327,10 @@ non-secret `auth_methods`). Hecate shows the local **Sign in** action only when
 the live agent advertises ACP auth method `agent-login`, which is the method the
 Hecate `/authenticate` endpoint calls. It shows **Sign out** only when the live
 agent advertises ACP `auth.logout`; direct API calls enforce the same Initialize
-capability checks before invoking ACP `authenticate` or `logout`.
+capability checks before invoking ACP `authenticate` or `logout`. Probes stay
+short so the UI can classify broken adapters quickly, while the managed local
+`authenticate` action allows a longer native sign-in flow because Codex and
+Claude Code may open a browser or terminal login.
 
 Codex and Claude Code use standalone Go ACP adapter binaries backed by the
 operator's local vendor CLI. Cursor and Grok ship ACP mode inside the vendor CLI

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -865,6 +865,40 @@ func TestAuthenticateCallsACPAuthenticate(t *testing.T) {
 	}
 }
 
+func TestAuthenticateActionTimeoutCanExceedProbeTimeout(t *testing.T) {
+	if acpAuthenticateActionTimeout <= probeTimeout {
+		t.Fatalf("acpAuthenticateActionTimeout = %s, want longer than probe timeout %s", acpAuthenticateActionTimeout, probeTimeout)
+	}
+}
+
+func TestAuthenticateAllowsSlowAgentLoginFlow(t *testing.T) {
+	restore := overrideACPAuthTimeouts(t, 500*time.Millisecond, acpLogoutActionTimeout, acpAuthInitializeTimeout)
+	defer restore()
+	t.Setenv("HECATE_FAKE_ACP_AUTHENTICATE_DELAY", "75ms")
+	t.Setenv("HECATE_FAKE_ACP_AUTH_AGENT_LOGIN", "1")
+	installFakeACPExecutable(t, "codex-acp-adapter")
+
+	if _, err := Authenticate(context.Background(), "codex"); err != nil {
+		t.Fatalf("Authenticate with delayed login flow: %v", err)
+	}
+}
+
+func TestAuthenticateActionTimeoutCancelsSlowAgentLoginFlow(t *testing.T) {
+	restore := overrideACPAuthTimeouts(t, 200*time.Millisecond, acpLogoutActionTimeout, acpAuthInitializeTimeout)
+	defer restore()
+	t.Setenv("HECATE_FAKE_ACP_AUTHENTICATE_DELAY", "1s")
+	t.Setenv("HECATE_FAKE_ACP_AUTH_AGENT_LOGIN", "1")
+	installFakeACPExecutable(t, "codex-acp-adapter")
+
+	_, err := Authenticate(context.Background(), "codex")
+	if err == nil {
+		t.Fatal("Authenticate error = nil, want timeout")
+	}
+	if got := err.Error(); !strings.Contains(got, `authenticate ACP adapter "codex"`) || !strings.Contains(got, "context deadline exceeded") {
+		t.Fatalf("Authenticate error = %q, want context deadline diagnostic", got)
+	}
+}
+
 func TestAuthenticateSupportsFilesystemCallbacks(t *testing.T) {
 	t.Setenv("HECATE_FAKE_ACP_AUTH_FS", "1")
 	t.Setenv("HECATE_FAKE_ACP_AUTH_AGENT_LOGIN", "1")
@@ -929,6 +963,21 @@ func TestLogoutRejectsUnknownAdapter(t *testing.T) {
 	_, err := Logout(context.Background(), "no_such_adapter")
 	if err == nil || !strings.Contains(err.Error(), `agent adapter "no_such_adapter" not found`) {
 		t.Fatalf("Logout error = %v, want unknown adapter", err)
+	}
+}
+
+func overrideACPAuthTimeouts(t *testing.T, authenticate, logout, initialize time.Duration) func() {
+	t.Helper()
+	oldAuthenticate := acpAuthenticateActionTimeout
+	oldLogout := acpLogoutActionTimeout
+	oldInitialize := acpAuthInitializeTimeout
+	acpAuthenticateActionTimeout = authenticate
+	acpLogoutActionTimeout = logout
+	acpAuthInitializeTimeout = initialize
+	return func() {
+		acpAuthenticateActionTimeout = oldAuthenticate
+		acpLogoutActionTimeout = oldLogout
+		acpAuthInitializeTimeout = oldInitialize
 	}
 }
 
@@ -2828,7 +2877,7 @@ func installFakeACPExecutable(t *testing.T, name string) {
 	}
 	exe := filepath.Join(bin, name)
 	script := fmt.Sprintf(
-		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_NEW_SESSION_FS=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q HECATE_FAKE_ACP_EXPECT_MCP_METHOD=%q HECATE_FAKE_ACP_EXPECT_MCP_JSON=%q HECATE_FAKE_ACP_AUTHENTICATE_FILE=%q HECATE_FAKE_ACP_AUTHENTICATE_ERROR=%q HECATE_FAKE_ACP_LOGOUT_FILE=%q HECATE_FAKE_ACP_LOGOUT_ERROR=%q HECATE_FAKE_ACP_AUTH_FS=%q HECATE_FAKE_ACP_AUTH_AGENT_LOGIN=%q HECATE_FAKE_ACP_AUTH_AGENT_OTHER=%q HECATE_FAKE_ACP_AUTH_ENV_VAR=%q HECATE_FAKE_ACP_AUTH_TERMINAL=%q HECATE_FAKE_ACP_SUPPORTS_LOGOUT=%q HECATE_FAKE_ACP_CLOSE_UNSUPPORTED=%q HECATE_FAKE_ACP_CLOSE_FILE=%q HECATE_FAKE_ACP_DELETE_UNSUPPORTED=%q HECATE_FAKE_ACP_DELETE_FILE=%q HECATE_FAKE_ACP_INIT_FILE=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
+		"#!/bin/sh\nHECATE_FAKE_ACP_AGENT=1 HECATE_FAKE_ACP_LOAD_SESSION_FAIL=%q HECATE_FAKE_ACP_NEW_SESSION_DELAY=%q HECATE_FAKE_ACP_NEW_SESSION_FS=%q HECATE_FAKE_ACP_COMMANDS_DELAY=%q HECATE_FAKE_ACP_MODELS=%q HECATE_FAKE_ACP_CONFIG_OPTIONS=%q HECATE_FAKE_ACP_SET_MODEL_ERROR=%q HECATE_FAKE_ACP_EXPECT_MCP_METHOD=%q HECATE_FAKE_ACP_EXPECT_MCP_JSON=%q HECATE_FAKE_ACP_AUTHENTICATE_FILE=%q HECATE_FAKE_ACP_AUTHENTICATE_ERROR=%q HECATE_FAKE_ACP_AUTHENTICATE_DELAY=%q HECATE_FAKE_ACP_LOGOUT_FILE=%q HECATE_FAKE_ACP_LOGOUT_ERROR=%q HECATE_FAKE_ACP_AUTH_FS=%q HECATE_FAKE_ACP_AUTH_AGENT_LOGIN=%q HECATE_FAKE_ACP_AUTH_AGENT_OTHER=%q HECATE_FAKE_ACP_AUTH_ENV_VAR=%q HECATE_FAKE_ACP_AUTH_TERMINAL=%q HECATE_FAKE_ACP_SUPPORTS_LOGOUT=%q HECATE_FAKE_ACP_CLOSE_UNSUPPORTED=%q HECATE_FAKE_ACP_CLOSE_FILE=%q HECATE_FAKE_ACP_DELETE_UNSUPPORTED=%q HECATE_FAKE_ACP_DELETE_FILE=%q HECATE_FAKE_ACP_INIT_FILE=%q exec %q -test.run '^TestFakeACPAgentProcess$'\n",
 		os.Getenv("HECATE_FAKE_ACP_LOAD_SESSION_FAIL"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_DELAY"),
 		os.Getenv("HECATE_FAKE_ACP_NEW_SESSION_FS"),
@@ -2840,6 +2889,7 @@ func installFakeACPExecutable(t *testing.T, name string) {
 		os.Getenv("HECATE_FAKE_ACP_EXPECT_MCP_JSON"),
 		os.Getenv("HECATE_FAKE_ACP_AUTHENTICATE_FILE"),
 		os.Getenv("HECATE_FAKE_ACP_AUTHENTICATE_ERROR"),
+		os.Getenv("HECATE_FAKE_ACP_AUTHENTICATE_DELAY"),
 		os.Getenv("HECATE_FAKE_ACP_LOGOUT_FILE"),
 		os.Getenv("HECATE_FAKE_ACP_LOGOUT_ERROR"),
 		os.Getenv("HECATE_FAKE_ACP_AUTH_FS"),
@@ -2884,6 +2934,15 @@ func newFakeACPAgent() *fakeACPAgent {
 func (a *fakeACPAgent) Authenticate(ctx context.Context, params acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
 	if message := strings.TrimSpace(os.Getenv("HECATE_FAKE_ACP_AUTHENTICATE_ERROR")); message != "" {
 		return acp.AuthenticateResponse{}, fmt.Errorf("%s", message)
+	}
+	if delay, err := time.ParseDuration(os.Getenv("HECATE_FAKE_ACP_AUTHENTICATE_DELAY")); err == nil && delay > 0 {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return acp.AuthenticateResponse{}, ctx.Err()
+		case <-timer.C:
+		}
 	}
 	if err := a.checkAuthFilesystemCallbacks(ctx, "authenticate"); err != nil {
 		return acp.AuthenticateResponse{}, err

--- a/internal/agentadapters/logout.go
+++ b/internal/agentadapters/logout.go
@@ -19,6 +19,12 @@ const (
 	ACPAuthMethodAgentLogin         = "agent-login"
 )
 
+var (
+	acpAuthenticateActionTimeout = 5 * time.Minute
+	acpLogoutActionTimeout       = 30 * time.Second
+	acpAuthInitializeTimeout     = 10 * time.Second
+)
+
 type LogoutResult struct {
 	AdapterID  string `json:"adapter_id"`
 	Status     string `json:"status"`
@@ -46,7 +52,7 @@ func Authenticate(ctx context.Context, adapterID string) (AuthenticateResult, er
 	if _, ok := remoteruntime.FromContext(ctx); ok {
 		return AuthenticateResult{AdapterID: strings.TrimSpace(adapterID), MethodID: ACPAuthMethodAgentLogin}, fmt.Errorf("ACP authenticate is local-only in remote runtime mode; configure a remote-safe credential environment variable instead")
 	}
-	action, err := runACPAuthAction(ctx, adapterID, "authenticate", "hecate-adapter-authenticate-*", "hecate-authenticate", func(ctx context.Context, conn *acp.ClientSideConnection, initResp acp.InitializeResponse) error {
+	action, err := runACPAuthAction(ctx, adapterID, "authenticate", "hecate-adapter-authenticate-*", "hecate-authenticate", acpAuthenticateActionTimeout, func(ctx context.Context, conn *acp.ClientSideConnection, initResp acp.InitializeResponse) error {
 		if !initializeSupportsHecateAuthenticate(initResp) {
 			return fmt.Errorf("adapter %q does not advertise ACP auth method %q", adapterID, ACPAuthMethodAgentLogin)
 		}
@@ -67,7 +73,7 @@ func Authenticate(ctx context.Context, adapterID string) (AuthenticateResult, er
 }
 
 func Logout(ctx context.Context, adapterID string) (LogoutResult, error) {
-	action, err := runACPAuthAction(ctx, adapterID, "logout", "hecate-adapter-logout-*", "hecate-logout", func(ctx context.Context, conn *acp.ClientSideConnection, initResp acp.InitializeResponse) error {
+	action, err := runACPAuthAction(ctx, adapterID, "logout", "hecate-adapter-logout-*", "hecate-logout", acpLogoutActionTimeout, func(ctx context.Context, conn *acp.ClientSideConnection, initResp acp.InitializeResponse) error {
 		if initResp.AgentCapabilities.Auth.Logout == nil {
 			return fmt.Errorf("adapter %q does not advertise ACP logout", adapterID)
 		}
@@ -86,7 +92,7 @@ func Logout(ctx context.Context, adapterID string) (LogoutResult, error) {
 	return res, nil
 }
 
-func runACPAuthAction(ctx context.Context, adapterID, operation, workspacePattern, clientName string, action acpAuthAction) (acpAuthActionResult, error) {
+func runACPAuthAction(ctx context.Context, adapterID, operation, workspacePattern, clientName string, actionTimeout time.Duration, action acpAuthAction) (acpAuthActionResult, error) {
 	start := time.Now()
 	adapter, ok := BuiltInByID(adapterID)
 	if !ok {
@@ -101,9 +107,9 @@ func runACPAuthAction(ctx context.Context, adapterID, operation, workspacePatter
 	}
 	res.Path = path
 
-	actionCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-	defer cancel()
-
+	if actionTimeout <= 0 {
+		actionTimeout = probeTimeout
+	}
 	workspace, err := os.MkdirTemp("", workspacePattern)
 	if err != nil {
 		res.DurationMS = elapsedMS(start)
@@ -154,7 +160,7 @@ func runACPAuthAction(ctx context.Context, adapterID, operation, workspacePatter
 	defer cleanupProcess()
 
 	conn := acp.NewClientSideConnection(probeClient{workspace: workspace}, stdin, stdout)
-	initCtx, initCancel := context.WithTimeout(actionCtx, 10*time.Second)
+	initCtx, initCancel := context.WithTimeout(ctx, acpAuthInitializeTimeout)
 	initResp, err := conn.Initialize(initCtx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
 		ClientInfo: &acp.Implementation{
@@ -176,7 +182,7 @@ func runACPAuthAction(ctx context.Context, adapterID, operation, workspacePatter
 		return res, fmt.Errorf("initialize ACP adapter %q: %w%s", adapter.ID, err, stderrSuffix(stderr.String()))
 	}
 
-	callCtx, callCancel := context.WithTimeout(actionCtx, 10*time.Second)
+	callCtx, callCancel := context.WithTimeout(ctx, actionTimeout)
 	err = action(callCtx, conn, initResp)
 	callCancel()
 	if err != nil {


### PR DESCRIPTION
## Summary
- split ACP auth action timeouts from the short health probe window
- keep Initialize bounded separately while allowing native login flows more time
- add fake-adapter delayed-auth tests for successful slow login and timeout cancellation
- document the probe-vs-login timeout distinction

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters -run 'TestAuthenticate(ActionTimeout|AllowsSlow|CallsACP|SupportsFilesystem)|TestLogout(CallsACP|SupportsFilesystem)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -count=1 -timeout 10m ./internal/agentadapters
- just agent-docs-check
- just docs-format-check
- just check-links
- git diff --check