### PR TITLE
Show assignment launch posture details

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3051,6 +3051,17 @@ The response envelope is:
     "provider": "",
     "model": "dogfood-model",
     "execution_profile": "implementation",
+    "profile_posture": {
+      "id": "implementation",
+      "name": "Implementation",
+      "source": "role_default",
+      "tools_enabled": true,
+      "writes_allowed": true,
+      "network_allowed": false,
+      "approval_policy": "require",
+      "project_memory_policy": "include",
+      "context_source_policy": "include_enabled"
+    },
     "model_readiness": {
       "ready": false,
       "status": "blocked",
@@ -3065,9 +3076,11 @@ The response envelope is:
 Native Hecate Task assignments may include `model_readiness`, using the same
 reason and repair vocabulary as `metadata.readiness` on `/v1/models`. External
 Agent assignments include `external_agent_id`, `external_agent`, and
-`session_title` when the adapter/options resolve. `ready=false` is the UI gate
-for `Start assignment`, `Prepare chat`, and `Start from handoff`; operators
-must still confirm the separate start mutation after reviewing preflight.
+`session_title` when the adapter/options resolve. Assignments with a resolved
+profile include `profile_posture`, a read-only summary of the selected profile's
+tools, writes, network, approval, memory, and context-source posture. `ready=false`
+is the UI gate for `Start assignment`, `Prepare chat`, and `Start from handoff`;
+operators must still confirm the separate start mutation after reviewing preflight.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/preflight`
 

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -33,27 +33,41 @@ type ProjectAssignmentLaunchReadinessEnvelope struct {
 }
 
 type ProjectAssignmentLaunchReadinessResponse struct {
-	ProjectID        string                      `json:"project_id"`
-	WorkItemID       string                      `json:"work_item_id"`
-	AssignmentID     string                      `json:"assignment_id"`
-	GeneratedAt      string                      `json:"generated_at"`
-	Ready            bool                        `json:"ready"`
-	Status           string                      `json:"status"`
-	Title            string                      `json:"title"`
-	Detail           string                      `json:"detail"`
-	Blockers         []string                    `json:"blockers"`
-	Warnings         []string                    `json:"warnings"`
-	DriverKind       string                      `json:"driver_kind"`
-	Workspace        string                      `json:"workspace,omitempty"`
-	RootID           string                      `json:"root_id,omitempty"`
-	RootPath         string                      `json:"root_path,omitempty"`
-	Provider         string                      `json:"provider,omitempty"`
-	Model            string                      `json:"model,omitempty"`
-	ExecutionProfile string                      `json:"execution_profile,omitempty"`
-	ExternalAgentID  string                      `json:"external_agent_id,omitempty"`
-	ExternalAgent    string                      `json:"external_agent,omitempty"`
-	SessionTitle     string                      `json:"session_title,omitempty"`
-	ModelReadiness   *ModelReadinessResponseItem `json:"model_readiness,omitempty"`
+	ProjectID        string                                             `json:"project_id"`
+	WorkItemID       string                                             `json:"work_item_id"`
+	AssignmentID     string                                             `json:"assignment_id"`
+	GeneratedAt      string                                             `json:"generated_at"`
+	Ready            bool                                               `json:"ready"`
+	Status           string                                             `json:"status"`
+	Title            string                                             `json:"title"`
+	Detail           string                                             `json:"detail"`
+	Blockers         []string                                           `json:"blockers"`
+	Warnings         []string                                           `json:"warnings"`
+	DriverKind       string                                             `json:"driver_kind"`
+	Workspace        string                                             `json:"workspace,omitempty"`
+	RootID           string                                             `json:"root_id,omitempty"`
+	RootPath         string                                             `json:"root_path,omitempty"`
+	Provider         string                                             `json:"provider,omitempty"`
+	Model            string                                             `json:"model,omitempty"`
+	ExecutionProfile string                                             `json:"execution_profile,omitempty"`
+	ProfilePosture   *ProjectAssignmentLaunchProfilePostureResponseItem `json:"profile_posture,omitempty"`
+	ExternalAgentID  string                                             `json:"external_agent_id,omitempty"`
+	ExternalAgent    string                                             `json:"external_agent,omitempty"`
+	SessionTitle     string                                             `json:"session_title,omitempty"`
+	ModelReadiness   *ModelReadinessResponseItem                        `json:"model_readiness,omitempty"`
+}
+
+type ProjectAssignmentLaunchProfilePostureResponseItem struct {
+	ID                  string `json:"id,omitempty"`
+	Name                string `json:"name,omitempty"`
+	Source              string `json:"source,omitempty"`
+	Missing             bool   `json:"missing,omitempty"`
+	ToolsEnabled        bool   `json:"tools_enabled"`
+	WritesAllowed       bool   `json:"writes_allowed"`
+	NetworkAllowed      bool   `json:"network_allowed"`
+	ApprovalPolicy      string `json:"approval_policy,omitempty"`
+	ProjectMemoryPolicy string `json:"project_memory_policy,omitempty"`
+	ContextSourcePolicy string `json:"context_source_policy,omitempty"`
 }
 
 func (h *Handler) HandleProjectWorkAssignmentLaunchReadiness(w http.ResponseWriter, r *http.Request) {
@@ -309,6 +323,7 @@ func (h *Handler) populateTaskAssignmentLaunchReadiness(ctx context.Context, pro
 	readiness.Provider = plan.RequestedProvider
 	readiness.Model = plan.RequestedModel
 	readiness.ExecutionProfile = plan.ExecutionProfile
+	readiness.ProfilePosture = renderProjectAssignmentLaunchProfilePosture(plan.Profile)
 	readiness.Warnings = append(readiness.Warnings, projectAssignmentLaunchPlanWarnings(plan.Profile, plan.ResolvedSkills)...)
 	if h.service == nil {
 		return nil
@@ -335,6 +350,7 @@ func (h *Handler) populateExternalAgentAssignmentLaunchReadiness(ctx context.Con
 	readiness.RootID = plan.Root.ID
 	readiness.RootPath = plan.Root.Path
 	readiness.ExecutionProfile = plan.ExecutionProfile
+	readiness.ProfilePosture = renderProjectAssignmentLaunchProfilePosture(plan.Profile)
 	readiness.ExternalAgentID = plan.AdapterID
 	readiness.ExternalAgent = firstNonEmptyString(plan.Adapter.Name, plan.AdapterID)
 	readiness.SessionTitle = plan.SessionTitle
@@ -342,6 +358,21 @@ func (h *Handler) populateExternalAgentAssignmentLaunchReadiness(ctx context.Con
 	readiness.Detail = "Launch checks are clear. Review the preflight context before preparing this supervised External Agent chat."
 	readiness.Warnings = append(readiness.Warnings, projectAssignmentLaunchPlanWarnings(plan.Profile, plan.ResolvedSkills)...)
 	return nil
+}
+
+func renderProjectAssignmentLaunchProfilePosture(profile projectworkapp.ResolvedAgentProfile) *ProjectAssignmentLaunchProfilePostureResponseItem {
+	return &ProjectAssignmentLaunchProfilePostureResponseItem{
+		ID:                  profile.ID,
+		Name:                profile.Name,
+		Source:              profile.Source,
+		Missing:             profile.Missing,
+		ToolsEnabled:        profile.ToolsEnabled,
+		WritesAllowed:       profile.WritesAllowed,
+		NetworkAllowed:      profile.NetworkAllowed,
+		ApprovalPolicy:      profile.ApprovalPolicy,
+		ProjectMemoryPolicy: profile.ProjectMemoryPolicy,
+		ContextSourcePolicy: profile.ContextSourcePolicy,
+	}
 }
 
 func projectAssignmentLaunchPlanBlocker(err error) string {

--- a/internal/api/handler_project_assignment_launch_readiness_test.go
+++ b/internal/api/handler_project_assignment_launch_readiness_test.go
@@ -63,6 +63,9 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessReturnsNativePlanWithoutSideEff
 	if readiness.Data.Provider != "anthropic" || readiness.Data.Model != "gpt-4o-mini" || readiness.Data.ExecutionProfile != "coding_agent" {
 		t.Fatalf("launch hints = provider/model/profile %q/%q/%q, want anthropic/gpt-4o-mini/coding_agent", readiness.Data.Provider, readiness.Data.Model, readiness.Data.ExecutionProfile)
 	}
+	if readiness.Data.ProfilePosture == nil || readiness.Data.ProfilePosture.ID != "project_assignment" || !readiness.Data.ProfilePosture.ToolsEnabled || !readiness.Data.ProfilePosture.WritesAllowed || readiness.Data.ProfilePosture.NetworkAllowed {
+		t.Fatalf("profile_posture = %+v, want project_assignment posture with tools/writes on and network off", readiness.Data.ProfilePosture)
+	}
 	if readiness.Data.ModelReadiness == nil || !readiness.Data.ModelReadiness.Ready {
 		t.Fatalf("model_readiness = %+v, want ready", readiness.Data.ModelReadiness)
 	}

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -213,6 +213,17 @@ function launchReadiness(
     provider: "openai",
     model: "gpt-5",
     execution_profile: "implementation",
+    profile_posture: {
+      id: "implementation",
+      name: "Implementation",
+      source: "role_default",
+      tools_enabled: true,
+      writes_allowed: true,
+      network_allowed: false,
+      approval_policy: "require",
+      project_memory_policy: "include",
+      context_source_policy: "include_enabled",
+    },
     model_readiness: {
       ready: true,
       status: "ok",
@@ -561,7 +572,36 @@ describe("ProjectWorkItemDetail", () => {
     expect(within(readiness).getByText("/workspace/hecate")).toBeTruthy();
     expect(within(readiness).getByText("openai / gpt-5")).toBeTruthy();
     expect(within(readiness).getByText("implementation")).toBeTruthy();
+    expect(within(readiness).getByText("tools on · writes on · network off")).toBeTruthy();
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("marks missing launch profiles in the posture preview", async () => {
+    getProjectAssignmentLaunchReadinessMock.mockResolvedValueOnce({
+      object: "project_assignment_launch_readiness",
+      data: launchReadiness({
+        execution_profile: "missing_profile",
+        profile_posture: {
+          id: "missing_profile",
+          name: "missing_profile",
+          source: "project_default",
+          missing: true,
+          tools_enabled: false,
+          writes_allowed: false,
+          network_allowed: false,
+        },
+        warnings: [
+          'Referenced agent profile "missing_profile" was not found; using stored profile id as execution_profile hint.',
+        ],
+      }),
+    });
+    renderDetail();
+
+    const readiness = screen.getByRole("region", { name: "Assignment launch readiness" });
+    await userEvent.click(within(readiness).getByRole("button", { name: "Check readiness" }));
+
+    expect(await within(readiness).findByText("missing_profile (profile missing)")).toBeTruthy();
+    expect(within(readiness).getByText("tools off · writes off · network off")).toBeTruthy();
   });
 
   it("shows External Agent launch posture before preparing chat", async () => {
@@ -574,6 +614,9 @@ describe("ProjectWorkItemDetail", () => {
         external_agent: "Codex",
         external_agent_id: "codex",
         session_title: "Implementation follow-up",
+        warnings: [
+          "Project skill Review (review) declares network enabled, but resolved profile implementation has network disabled.",
+        ],
       }),
     });
     renderDetail({
@@ -589,6 +632,11 @@ describe("ProjectWorkItemDetail", () => {
     expect(within(posture).getAllByText("External Agent").length).toBeGreaterThan(0);
     expect(within(posture).getByText("Codex (codex)")).toBeTruthy();
     expect(within(posture).getByText("Implementation follow-up")).toBeTruthy();
+    expect(within(posture).getByText("tools on · writes on · network off")).toBeTruthy();
+    expect(
+      within(preflight).getByRole("status", { name: "Launch readiness warnings" }),
+    ).toBeTruthy();
+    expect(within(preflight).getByText(/Project skill Review/)).toBeTruthy();
     expect(within(posture).queryByText("openai / gpt-5")).toBeNull();
   });
 

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -1304,6 +1304,7 @@ function AssignmentLaunchPreflightModal({
 }) {
   const ready = state.status === "ready";
   const readinessNotice = ready ? assignmentLaunchReadinessNotice(state.readiness) : null;
+  const readinessWarnings = ready ? (state.readiness.warnings ?? []) : [];
   const canConfirm = ready && !readinessNotice;
   const runRepairAction = useCallback(
     (action?: () => void) => {
@@ -1361,6 +1362,9 @@ function AssignmentLaunchPreflightModal({
                 repairActions={repairActions}
               />
             )}
+            {!readinessNotice && readinessWarnings.length > 0 && (
+              <AssignmentLaunchWarnings warnings={readinessWarnings} />
+            )}
             <AssignmentLaunchPosture readiness={state.readiness} />
             <ContextInspectorPanel
               packet={state.packet}
@@ -1370,6 +1374,22 @@ function AssignmentLaunchPreflightModal({
         ) : null}
       </div>
     </Modal>
+  );
+}
+
+function AssignmentLaunchWarnings({ warnings }: { warnings: string[] }) {
+  return (
+    <div aria-label="Launch readiness warnings" role="status" style={launchWarningNoticeStyle}>
+      <div style={launchWarningNoticeTitleStyle}>
+        <Icon d={Icons.warning} size={13} />
+        Launch warnings
+      </div>
+      <ul style={{ margin: "2px 0 0 18px", padding: 0 }}>
+        {warnings.map((warning) => (
+          <li key={warning}>{warning}</li>
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -1937,8 +1957,13 @@ function assignmentLaunchPostureRows(
       value: `${firstNonEmpty(readiness.provider, "auto")} / ${firstNonEmpty(readiness.model, "auto")}`,
     });
   }
-  if (readiness.execution_profile) {
-    rows.push({ label: "Profile", value: readiness.execution_profile });
+  const profile = assignmentLaunchProfilePosture(readiness);
+  if (profile) {
+    rows.push({ label: "Profile", value: profile });
+  }
+  const capabilities = assignmentLaunchCapabilityPosture(readiness);
+  if (capabilities) {
+    rows.push({ label: "Capabilities", value: capabilities });
   }
   if (
     readiness.driver_kind === "external_agent" ||
@@ -1968,6 +1993,28 @@ function assignmentLaunchDriverLabel(kind: string): string {
     default:
       return kind || "unknown";
   }
+}
+
+function assignmentLaunchProfilePosture(readiness: ProjectAssignmentLaunchReadinessRecord): string {
+  const posture = readiness.profile_posture;
+  const profile = firstNonEmpty(
+    readiness.execution_profile,
+    labelWithID(posture?.name, posture?.id ?? ""),
+  );
+  if (!profile) return "";
+  return posture?.missing ? `${profile} (profile missing)` : profile;
+}
+
+function assignmentLaunchCapabilityPosture(
+  readiness: ProjectAssignmentLaunchReadinessRecord,
+): string {
+  const posture = readiness.profile_posture;
+  if (!posture) return "";
+  return [
+    `tools ${posture.tools_enabled ? "on" : "off"}`,
+    `writes ${posture.writes_allowed ? "on" : "off"}`,
+    `network ${posture.network_allowed ? "on" : "off"}`,
+  ].join(" · ");
 }
 
 function assignmentLaunchReadinessNotice(
@@ -2319,6 +2366,26 @@ const launchReadinessBlockerStyle: CSSProperties = {
   fontSize: 12,
   lineHeight: 1.4,
   overflowWrap: "anywhere",
+};
+
+const launchWarningNoticeStyle: CSSProperties = {
+  background: "var(--amber-bg)",
+  border: "1px solid var(--amber-border)",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--amber-lo)",
+  display: "grid",
+  fontSize: 12,
+  gap: 6,
+  lineHeight: 1.45,
+  padding: "10px 12px",
+};
+
+const launchWarningNoticeTitleStyle: CSSProperties = {
+  alignItems: "center",
+  color: "var(--amber)",
+  display: "flex",
+  fontWeight: 600,
+  gap: 8,
 };
 
 const assignmentEvidenceStyle: CSSProperties = {

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -592,10 +592,24 @@ export type ProjectAssignmentLaunchReadinessRecord = {
   provider?: string;
   model?: string;
   execution_profile?: string;
+  profile_posture?: ProjectAssignmentLaunchProfilePostureRecord;
   external_agent_id?: string;
   external_agent?: string;
   session_title?: string;
   model_readiness?: ModelReadinessRecord;
+};
+
+export type ProjectAssignmentLaunchProfilePostureRecord = {
+  id?: string;
+  name?: string;
+  source?: string;
+  missing?: boolean;
+  tools_enabled: boolean;
+  writes_allowed: boolean;
+  network_allowed: boolean;
+  approval_policy?: string;
+  project_memory_policy?: string;
+  context_source_policy?: string;
 };
 
 export type ProjectAssignmentStatus =


### PR DESCRIPTION
## Overview

Adds resolved profile posture to assignment launch readiness and shows it in the Projects cockpit before an operator starts or prepares an assignment.

## Changes

- Add `profile_posture` to the launch-readiness API response with profile identity, source, tools/writes/network, and policy posture.
- Render the capability posture in the inline launch-readiness preview and preflight modal.
- Show non-blocking launch warnings in the preflight modal even when launch is otherwise ready.
- Document the new response field and cover the API/UI behavior with tests.

## Verification

- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-skill-capability-warnings/.gocache go test ./internal/api`
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/project-skill-capability-warnings/.gocache go vet ./internal/api`
- `bun run test src/features/projects/ProjectWorkItemDetail.test.tsx`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`