### PR TITLE
chore(agentadapters): bump bundled ACP adapter releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.28
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.29
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.29
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.30
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.28
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.29
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.29
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.30
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,14 +24,14 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.28` and `claude-code-acp-adapter` versions older than
-`v0.1.0-alpha.29` as outside the tested range because those older releases lack
+older than `v0.1.0-alpha.29` and `claude-code-acp-adapter` versions older than
+`v0.1.0-alpha.30` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
 external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
 failure/stop-reason classification, local-login environment contract,
 `session/close` cleanup behavior, structured tool output preservation, or
-permission-outcome and MCP permission-label hardening that is exercised by the
-real CLI smoke suite.
+permission-outcome, rejected-tool-result, post-cancel stream, and MCP
+permission-label hardening that is exercised by the real CLI smoke suite.
 The
 `v0.1.0-alpha.8` adapters added supported Codex and Claude Code JSON stream
 translation into ACP assistant-message, thought, tool-call, tool-result, and
@@ -85,6 +85,10 @@ options must match an adapter-offered option, and expands source-shaped
 permission-request parsing for option aliases and defaults.
 Codex adapter `v0.1.0-alpha.28` preserves MCP permission request labels as
 `server/tool` when the Codex stream includes MCP server and tool fields.
+Codex adapter `v0.1.0-alpha.29` marks denied, rejected, blocked, timed-out,
+interrupted, and aborted provider tool results as failed ACP tool updates, and
+uses the shared command bridge guard that drops stream chunks delivered after a
+prompt has been cancelled.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter
@@ -136,6 +140,10 @@ selected options must match an adapter-offered option, and expands
 source-shaped permission-request parsing for option aliases and defaults.
 Claude Code adapter `v0.1.0-alpha.29` preserves MCP permission request labels
 as `server/tool` and infers MCP permission kind from typed MCP payloads.
+Claude Code adapter `v0.1.0-alpha.30` marks denied, rejected, blocked,
+timed-out, interrupted, aborted, and non-zero-exit provider tool results as
+failed ACP tool updates, and uses the shared command bridge guard that drops
+stream chunks delivered after a prompt has been cancelled.
 
 ## Supported External Agents
 

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -273,7 +273,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.28",
+			SupportedRange:       ">=0.1.0-alpha.29",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{
@@ -314,7 +314,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Claude Code through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/claude-code-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.29",
+			SupportedRange:       ">=0.1.0-alpha.30",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			CredentialModes: []CredentialMode{

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.28" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.29" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {
@@ -41,7 +41,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
-	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.29" {
+	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.30" {
 		t.Fatalf("claude_code supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["claude_code"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary
- bump bundled Codex ACP adapter to v0.1.0-alpha.29
- bump bundled Claude Code ACP adapter to v0.1.0-alpha.30
- update supported ranges and external-agent docs for rejected tool-result and post-cancel stream hardening

## Adapter releases
- hecatehq/codex-acp-adapter v0.1.0-alpha.29 released successfully
- hecatehq/claude-code-acp-adapter v0.1.0-alpha.30 released successfully

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters -run 'Test(BuiltInAdapters|DockerfilesPinSameGoACPAdapterVersions|DockerfilesInstallGoACPAdapterReleaseBinaries)'
- just test-acp-release-smoke
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters -count=1
- just docs-format-check
- git diff --check

Note: an initial broad package test hit a non-reproducible ACP terminal callback assertion; the focused terminal test and a rerun of the full package passed.