### PR TITLE
feat(agentadapters): surface ACP capability contract

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -154,6 +154,30 @@ stream chunks delivered after a prompt has been cancelled.
 | Cursor Agent   | `cursor-agent acp`        | Operator-owned Cursor Agent auth visible to `cursor-agent` | `CURSOR_API_KEY`                                 |
 | Grok Build     | `grok agent ... stdio`    | Operator-owned Grok login visible to `grok`                | `XAI_API_KEY` or Hecate's `PROVIDER_XAI_API_KEY` |
 
+## Hecate ACP Capability Contract
+
+`GET /hecate/v1/agent-adapters` includes a `capabilities` array for each
+adapter. This is Hecate's contract for the surfaces it knows how to supervise;
+the explicit probe still decides which live ACP Initialize features are
+available from the installed adapter today.
+
+| Capability          | Catalog status                                                       | What Hecate does                                                                                                                                                           |
+| ------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prompt_session`    | `supported`                                                          | Starts, reuses, closes, and recovers ACP sessions while keeping the Hecate transcript durable.                                                                             |
+| `structured_stream` | `supported`                                                          | Converts ACP assistant messages, thoughts, tool calls/results, terminal rows, usage, and stop reasons into External Agent activity.                                        |
+| `cancel`            | `supported`                                                          | Sends operator stop/cancel through the ACP session boundary and ignores late stream chunks after cancellation.                                                             |
+| `permissions`       | `supported`                                                          | Turns ACP permission requests into External Agent approvals and durable grants.                                                                                            |
+| `mcp_servers`       | `supported`                                                          | Passes configured stdio/HTTP MCP servers to ACP `session/new` and `session/load`.                                                                                          |
+| `config_options`    | `adapter_dependent`                                                  | Renders and persists agent-owned model, effort, mode, and similar selectors when the adapter reports them.                                                                 |
+| `terminal_rpc`      | `operator_opt_in`                                                    | Enables ACP terminal callbacks only when the operator opts in with `HECATE_AGENT_ADAPTER_TERMINALS=1`; remote runtime also requires `HECATE_REMOTE_ALLOW_ACP_TERMINALS=1`. |
+| `authenticate`      | `supported` for Codex and Claude Code, otherwise `adapter_dependent` | Calls ACP `agent-login` only when the live adapter advertises that method.                                                                                                 |
+| `logout`            | `supported` for Codex and Claude Code, otherwise `adapter_dependent` | Calls ACP `auth.logout` only when the live adapter advertises logout.                                                                                                      |
+
+Connections renders this matrix as compact chips on each adapter row. If a
+probe succeeds, live ACP Initialize capabilities override the static login and
+logout expectation for that row so the UI does not show actions the installed
+adapter did not advertise.
+
 The Docker runtime image includes the supported agent CLIs and ACP adapters so
 local/self-host Docker deployments can use External Agents without installing
 those binaries into the container at runtime. Bare binary and desktop

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1002,11 +1002,28 @@ GET /hecate/v1/agent-adapters
       "status": "available",
       "path": "/Users/alice/.local/bin/codex-acp-adapter",
       "cost_mode": "external",
-      "supported_range": ">=0.1.0-alpha.28",
+      "supported_range": ">=0.1.0-alpha.29",
       "version_outside_range": false,
       "supports_authenticate": true,
       "supports_logout": true,
       "auth_status": "unknown",
+      "capabilities": [
+        {
+          "id": "prompt_session",
+          "name": "sessions",
+          "status": "supported"
+        },
+        {
+          "id": "permissions",
+          "name": "permissions",
+          "status": "supported"
+        },
+        {
+          "id": "terminal_rpc",
+          "name": "terminal RPC",
+          "status": "operator_opt_in"
+        }
+      ],
       "credential_modes": [
         {
           "id": "local_login",
@@ -1062,10 +1079,27 @@ GET /hecate/v1/agent-adapters
       "status": "missing",
       "error": "exec: \"claude-code-acp-adapter\": executable file not found in $PATH",
       "cost_mode": "external",
-      "supported_range": ">=0.1.0-alpha.29",
+      "supported_range": ">=0.1.0-alpha.30",
       "supports_authenticate": true,
       "supports_logout": true,
       "auth_status": "unknown",
+      "capabilities": [
+        {
+          "id": "prompt_session",
+          "name": "sessions",
+          "status": "supported"
+        },
+        {
+          "id": "permissions",
+          "name": "permissions",
+          "status": "supported"
+        },
+        {
+          "id": "terminal_rpc",
+          "name": "terminal RPC",
+          "status": "operator_opt_in"
+        }
+      ],
       "claude_code_cli": {
         "available": true,
         "command": "/Users/alice/.local/bin/claude",
@@ -1090,6 +1124,23 @@ billing classification.
 call ACP `authenticate` or `logout` for this adapter. UIs should use these
 catalog fields instead of hard-coding adapter IDs; the actions are currently
 enabled for the standalone Go Codex and Claude Code adapters.
+
+`capabilities` is Hecate's catalog-level ACP contract for the row. It describes
+the features Hecate knows how to supervise for that adapter family, such as
+sessions, structured activity, cancellation, permission approvals, MCP server
+handoff, config options, terminal callbacks, authenticate, and logout. Capability
+`status` is one of:
+
+| Status              | Meaning                                                                   |
+| ------------------- | ------------------------------------------------------------------------- |
+| `supported`         | Hecate supports the surface for this adapter family.                      |
+| `adapter_dependent` | Hecate will use the surface only when the live ACP adapter advertises it. |
+| `operator_opt_in`   | Hecate supports the surface only behind an explicit operator setting.     |
+| `not_supported`     | Hecate should not show or invoke this surface.                            |
+
+Probe results remain authoritative for live ACP Initialize features. For
+example, a probed adapter can turn `supports_authenticate` or `supports_logout`
+off even when the catalog expected them.
 
 `credential_modes` describes how the adapter can authenticate. `local_login`
 means operator-local CLI/browser login state and is not sufficient for remote

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -82,7 +82,34 @@ type Adapter struct {
 	SupportsAuthenticate bool
 	SupportsLogout       bool
 	CredentialModes      []CredentialMode
+	Capabilities         []Capability
 }
+
+type Capability struct {
+	ID          string
+	Name        string
+	Description string
+	Status      string
+}
+
+const (
+	CapabilityPromptSession    = "prompt_session"
+	CapabilityStructuredStream = "structured_stream"
+	CapabilityCancel           = "cancel"
+	CapabilityPermissions      = "permissions"
+	CapabilityMCPServers       = "mcp_servers"
+	CapabilityConfigOptions    = "config_options"
+	CapabilityTerminalRPC      = "terminal_rpc"
+	CapabilityAuthenticate     = "authenticate"
+	CapabilityLogout           = "logout"
+)
+
+const (
+	CapabilityStatusSupported        = "supported"
+	CapabilityStatusAdapterDependent = "adapter_dependent"
+	CapabilityStatusOperatorOptIn    = "operator_opt_in"
+	CapabilityStatusNotSupported     = "not_supported"
+)
 
 type CredentialMode struct {
 	ID            string
@@ -276,6 +303,10 @@ func BuiltIns() []Adapter {
 			SupportedRange:       ">=0.1.0-alpha.29",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
+			Capabilities: acpCapabilityMatrix(
+				CapabilityStatusSupported,
+				CapabilityStatusSupported,
+			),
 			CredentialModes: []CredentialMode{
 				{
 					ID:          CredentialModeLocalLogin,
@@ -317,6 +348,10 @@ func BuiltIns() []Adapter {
 			SupportedRange:       ">=0.1.0-alpha.30",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
+			Capabilities: acpCapabilityMatrix(
+				CapabilityStatusSupported,
+				CapabilityStatusSupported,
+			),
 			CredentialModes: []CredentialMode{
 				{
 					ID:          CredentialModeLocalLogin,
@@ -347,6 +382,10 @@ func BuiltIns() []Adapter {
 			CostMode:       "external",
 			DocsURL:        "https://cursor.com/cli",
 			SupportedRange: ">=0.1.0",
+			Capabilities: acpCapabilityMatrix(
+				CapabilityStatusAdapterDependent,
+				CapabilityStatusAdapterDependent,
+			),
 			CredentialModes: []CredentialMode{
 				{
 					ID:          CredentialModeLocalLogin,
@@ -377,6 +416,10 @@ func BuiltIns() []Adapter {
 			CostMode:       "external",
 			DocsURL:        "https://docs.x.ai/build/cli/headless-scripting#acp",
 			SupportedRange: ">=0.1.0",
+			Capabilities: acpCapabilityMatrix(
+				CapabilityStatusAdapterDependent,
+				CapabilityStatusAdapterDependent,
+			),
 			CredentialModes: []CredentialMode{
 				{
 					ID:          CredentialModeLocalLogin,
@@ -393,6 +436,65 @@ func BuiltIns() []Adapter {
 			},
 		},
 	})
+}
+
+func acpCapabilityMatrix(authenticateStatus, logoutStatus string) []Capability {
+	return []Capability{
+		{
+			ID:          CapabilityPromptSession,
+			Name:        "sessions",
+			Status:      CapabilityStatusSupported,
+			Description: "Prepare, reuse, and recover ACP sessions while keeping Hecate transcript continuity.",
+		},
+		{
+			ID:          CapabilityStructuredStream,
+			Name:        "activity",
+			Status:      CapabilityStatusSupported,
+			Description: "Render structured assistant, thought, tool, terminal, and usage updates in the transcript.",
+		},
+		{
+			ID:          CapabilityCancel,
+			Name:        "cancel",
+			Status:      CapabilityStatusSupported,
+			Description: "Stop active external-agent work and suppress late stream output after cancellation.",
+		},
+		{
+			ID:          CapabilityPermissions,
+			Name:        "permissions",
+			Status:      CapabilityStatusSupported,
+			Description: "Turn ACP permission requests into External Agent approvals and reusable grants.",
+		},
+		{
+			ID:          CapabilityMCPServers,
+			Name:        "MCP",
+			Status:      CapabilityStatusSupported,
+			Description: "Pass configured stdio or HTTP MCP servers into ACP sessions.",
+		},
+		{
+			ID:          CapabilityConfigOptions,
+			Name:        "config",
+			Status:      CapabilityStatusAdapterDependent,
+			Description: "Render and persist ACP session config options such as model, effort, or permission mode when the adapter advertises them.",
+		},
+		{
+			ID:          CapabilityTerminalRPC,
+			Name:        "terminal RPC",
+			Status:      CapabilityStatusOperatorOptIn,
+			Description: "Run ACP terminal callbacks only when explicitly enabled by the operator and approval policy.",
+		},
+		{
+			ID:          CapabilityAuthenticate,
+			Name:        "login",
+			Status:      authenticateStatus,
+			Description: "Call ACP agent-login when the adapter advertises a Hecate-compatible login action.",
+		},
+		{
+			ID:          CapabilityLogout,
+			Name:        "logout",
+			Status:      logoutStatus,
+			Description: "Call ACP auth logout when the adapter advertises a logout action.",
+		},
+	}
 }
 
 func adaptersForBuild(items []Adapter) []Adapter {

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -38,6 +38,17 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; !got.SupportsLogout {
 		t.Fatalf("codex supports logout = false, want true")
 	}
+	assertAdapterCapabilities(t, found["codex"], map[string]string{
+		CapabilityPromptSession:    CapabilityStatusSupported,
+		CapabilityStructuredStream: CapabilityStatusSupported,
+		CapabilityCancel:           CapabilityStatusSupported,
+		CapabilityPermissions:      CapabilityStatusSupported,
+		CapabilityMCPServers:       CapabilityStatusSupported,
+		CapabilityConfigOptions:    CapabilityStatusAdapterDependent,
+		CapabilityTerminalRPC:      CapabilityStatusOperatorOptIn,
+		CapabilityAuthenticate:     CapabilityStatusSupported,
+		CapabilityLogout:           CapabilityStatusSupported,
+	})
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
@@ -50,6 +61,17 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; !got.SupportsLogout {
 		t.Fatalf("claude_code supports logout = false, want true")
 	}
+	assertAdapterCapabilities(t, found["claude_code"], map[string]string{
+		CapabilityPromptSession:    CapabilityStatusSupported,
+		CapabilityStructuredStream: CapabilityStatusSupported,
+		CapabilityCancel:           CapabilityStatusSupported,
+		CapabilityPermissions:      CapabilityStatusSupported,
+		CapabilityMCPServers:       CapabilityStatusSupported,
+		CapabilityConfigOptions:    CapabilityStatusAdapterDependent,
+		CapabilityTerminalRPC:      CapabilityStatusOperatorOptIn,
+		CapabilityAuthenticate:     CapabilityStatusSupported,
+		CapabilityLogout:           CapabilityStatusSupported,
+	})
 	if got := found["cursor_agent"]; got.Command != "cursor-agent" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("cursor_agent adapter = %#v", got)
 	}
@@ -62,6 +84,17 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["cursor_agent"]; len(got.Args) != 1 || got.Args[0] != "acp" {
 		t.Fatalf("cursor_agent adapter = %#v", got)
 	}
+	assertAdapterCapabilities(t, found["cursor_agent"], map[string]string{
+		CapabilityPromptSession:    CapabilityStatusSupported,
+		CapabilityStructuredStream: CapabilityStatusSupported,
+		CapabilityCancel:           CapabilityStatusSupported,
+		CapabilityPermissions:      CapabilityStatusSupported,
+		CapabilityMCPServers:       CapabilityStatusSupported,
+		CapabilityConfigOptions:    CapabilityStatusAdapterDependent,
+		CapabilityTerminalRPC:      CapabilityStatusOperatorOptIn,
+		CapabilityAuthenticate:     CapabilityStatusAdapterDependent,
+		CapabilityLogout:           CapabilityStatusAdapterDependent,
+	})
 	if got := found["grok_build"]; got.Command != "grok" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("grok_build adapter = %#v", got)
 	}
@@ -80,6 +113,17 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["grok_build"]; len(got.LaunchOptions) != 0 {
 		t.Fatalf("grok_build launch options = %#v, want ACP-owned controls only", got.LaunchOptions)
 	}
+	assertAdapterCapabilities(t, found["grok_build"], map[string]string{
+		CapabilityPromptSession:    CapabilityStatusSupported,
+		CapabilityStructuredStream: CapabilityStatusSupported,
+		CapabilityCancel:           CapabilityStatusSupported,
+		CapabilityPermissions:      CapabilityStatusSupported,
+		CapabilityMCPServers:       CapabilityStatusSupported,
+		CapabilityConfigOptions:    CapabilityStatusAdapterDependent,
+		CapabilityTerminalRPC:      CapabilityStatusOperatorOptIn,
+		CapabilityAuthenticate:     CapabilityStatusAdapterDependent,
+		CapabilityLogout:           CapabilityStatusAdapterDependent,
+	})
 	for _, tc := range []struct {
 		id      string
 		envKeys []string
@@ -100,6 +144,35 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 		} else if !hasCredentialMode(adapter, CredentialModeLocalLogin, false) {
 			t.Fatalf("%s credential modes = %#v, want local login mode in default build", tc.id, adapter.CredentialModes)
 		}
+	}
+}
+
+func assertAdapterCapabilities(t *testing.T, adapter Adapter, want map[string]string) {
+	t.Helper()
+	got := make(map[string]Capability, len(adapter.Capabilities))
+	for _, cap := range adapter.Capabilities {
+		if cap.ID == "" {
+			t.Fatalf("%s has capability without id: %#v", adapter.ID, cap)
+		}
+		if cap.Name == "" || cap.Description == "" {
+			t.Fatalf("%s capability %q missing operator copy: %#v", adapter.ID, cap.ID, cap)
+		}
+		if _, exists := got[cap.ID]; exists {
+			t.Fatalf("%s capability %q duplicated: %#v", adapter.ID, cap.ID, adapter.Capabilities)
+		}
+		got[cap.ID] = cap
+	}
+	for id, status := range want {
+		cap, ok := got[id]
+		if !ok {
+			t.Fatalf("%s missing capability %q in %#v", adapter.ID, id, adapter.Capabilities)
+		}
+		if cap.Status != status {
+			t.Fatalf("%s capability %q status = %q, want %q", adapter.ID, id, cap.Status, status)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("%s capabilities = %#v, want ids %#v", adapter.ID, adapter.Capabilities, want)
 	}
 }
 

--- a/internal/api/handler_agent_adapters.go
+++ b/internal/api/handler_agent_adapters.go
@@ -147,6 +147,7 @@ func renderAgentAdapterItemWithOptions(ctx context.Context, item agentadapters.S
 		CredentialModes:      renderAgentAdapterCredentialModes(item.CredentialModes),
 		RemoteCredentialMode: item.RemoteCredentialMode,
 		RemoteCredentialHint: item.RemoteCredentialHint,
+		Capabilities:         renderAgentAdapterCapabilities(item.Capabilities),
 	}
 	if includeConfigOptions {
 		rendered.ConfigOptions = agentadapters.LaunchConfigOptions(ctx, item)
@@ -163,6 +164,25 @@ func renderAgentAdapterItemWithOptions(ctx context.Context, item agentadapters.S
 		}
 	}
 	return rendered
+}
+
+func renderAgentAdapterCapabilities(caps []agentadapters.Capability) []AgentAdapterCapabilityItem {
+	if len(caps) == 0 {
+		return nil
+	}
+	out := make([]AgentAdapterCapabilityItem, 0, len(caps))
+	for _, cap := range caps {
+		if strings.TrimSpace(cap.ID) == "" || strings.TrimSpace(cap.Status) == "" {
+			continue
+		}
+		out = append(out, AgentAdapterCapabilityItem{
+			ID:          cap.ID,
+			Name:        cap.Name,
+			Description: cap.Description,
+			Status:      cap.Status,
+		})
+	}
+	return out
 }
 
 func renderAgentAdapterCredentialModes(modes []agentadapters.CredentialMode) []AgentAdapterCredentialModeItem {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -846,8 +846,16 @@ type AgentAdapterResponseItem struct {
 	RemoteCredentialMode string                              `json:"remote_credential_mode,omitempty"`
 	RemoteCredentialOK   *bool                               `json:"remote_credential_ok,omitempty"`
 	RemoteCredentialHint string                              `json:"remote_credential_hint,omitempty"`
+	Capabilities         []AgentAdapterCapabilityItem        `json:"capabilities,omitempty"`
 	ConfigOptions        []agentcontrols.ConfigOption        `json:"config_options,omitempty"`
 	ClaudeCodeCLI        *AgentAdapterSetupCommandStatusItem `json:"claude_code_cli,omitempty"`
+}
+
+type AgentAdapterCapabilityItem struct {
+	ID          string `json:"id"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Status      string `json:"status"`
 }
 
 type AgentAdapterCredentialModeItem struct {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1149,6 +1149,13 @@ func TestAgentAdaptersReturnsBuiltIns(t *testing.T) {
 		if item.SupportedRange == "" {
 			t.Fatalf("adapter %q missing supported_range: %#v", item.ID, item)
 		}
+		if len(item.Capabilities) == 0 {
+			t.Fatalf("adapter %q missing capabilities: %#v", item.ID, item)
+		}
+		assertAgentAdapterResponseCapability(t, item, agentadapters.CapabilityPromptSession, agentadapters.CapabilityStatusSupported)
+		assertAgentAdapterResponseCapability(t, item, agentadapters.CapabilityCancel, agentadapters.CapabilityStatusSupported)
+		assertAgentAdapterResponseCapability(t, item, agentadapters.CapabilityPermissions, agentadapters.CapabilityStatusSupported)
+		assertAgentAdapterResponseCapability(t, item, agentadapters.CapabilityTerminalRPC, agentadapters.CapabilityStatusOperatorOptIn)
 	}
 	if !foundCodex {
 		t.Fatalf("missing codex adapter: %#v", response.Data)
@@ -1162,6 +1169,23 @@ func TestAgentAdaptersReturnsBuiltIns(t *testing.T) {
 	if !foundGrok {
 		t.Fatalf("missing grok_build adapter: %#v", response.Data)
 	}
+}
+
+func assertAgentAdapterResponseCapability(t *testing.T, item AgentAdapterResponseItem, id, status string) {
+	t.Helper()
+	for _, cap := range item.Capabilities {
+		if cap.ID != id {
+			continue
+		}
+		if cap.Status != status {
+			t.Fatalf("adapter %q capability %q status = %q, want %q", item.ID, id, cap.Status, status)
+		}
+		if cap.Name == "" || cap.Description == "" {
+			t.Fatalf("adapter %q capability %q missing copy: %#v", item.ID, id, cap)
+		}
+		return
+	}
+	t.Fatalf("adapter %q missing capability %q in %#v", item.ID, id, item.Capabilities)
 }
 
 func TestAgentAdaptersListDoesNotRunAdapterDiagnostics(t *testing.T) {

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -27,7 +27,11 @@ import {
   providerRepairActionLabel,
 } from "../../lib/provider-readiness";
 import { isRemoteRuntimeSession } from "../../lib/runtime-utils";
-import type { AgentAdapterHealthRecord, AgentAdapterRecord } from "../../types/agent-adapter";
+import type {
+  AgentAdapterCapability,
+  AgentAdapterHealthRecord,
+  AgentAdapterRecord,
+} from "../../types/agent-adapter";
 import type { ChatGrantRecord } from "../../types/chat";
 import type { ModelRecord } from "../../types/model";
 import type {
@@ -911,6 +915,7 @@ function AdapterStatusRow({
             </span>
           )}
         </div>
+        <AdapterCapabilitiesSummary adapter={adapter} health={health} />
         {showHealthDetail && health && detail && (
           <div
             data-testid={`external-agents-adapter-${adapter.id}-detail`}
@@ -1009,6 +1014,87 @@ function AdapterStatusRow({
       </div>
     </div>
   );
+}
+
+function AdapterCapabilitiesSummary({
+  adapter,
+  health,
+}: {
+  adapter: AgentAdapterRecord;
+  health: AgentAdapterHealthRecord | null;
+}) {
+  const capabilities = visibleAdapterCapabilities(adapter, health);
+  if (!capabilities.length) return null;
+  return (
+    <div
+      data-testid={`external-agents-adapter-${adapter.id}-capabilities`}
+      aria-label={`${adapter.name || adapter.id} ACP capabilities`}
+      style={{ display: "flex", flexWrap: "wrap", gap: 5, marginTop: 7 }}
+    >
+      {capabilities.map((capability) => {
+        const suffix = capabilityStatusSuffix(capability.status);
+        return (
+          <span
+            key={capability.id}
+            title={capability.description}
+            style={{
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              color: "var(--t2)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              lineHeight: 1.25,
+              padding: "3px 6px",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {capability.name || capability.id}
+            {suffix && <span style={{ color: "var(--t3)" }}> · {suffix}</span>}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function visibleAdapterCapabilities(
+  adapter: AgentAdapterRecord,
+  health: AgentAdapterHealthRecord | null,
+): AgentAdapterCapability[] {
+  return (adapter.capabilities ?? [])
+    .map((capability) => resolveLiveCapability(capability, health))
+    .filter((capability) => capability.status !== "not_supported");
+}
+
+function resolveLiveCapability(
+  capability: AgentAdapterCapability,
+  health: AgentAdapterHealthRecord | null,
+): AgentAdapterCapability {
+  if (!health?.capabilities_known) return capability;
+  if (capability.id === "authenticate") {
+    return {
+      ...capability,
+      status: health.supports_authenticate === true ? "supported" : "not_supported",
+    };
+  }
+  if (capability.id === "logout") {
+    return {
+      ...capability,
+      status: health.supports_logout === true ? "supported" : "not_supported",
+    };
+  }
+  return capability;
+}
+
+function capabilityStatusSuffix(status: string): string {
+  switch (status) {
+    case "adapter_dependent":
+      return "if advertised";
+    case "operator_opt_in":
+      return "opt-in";
+    default:
+      return "";
+  }
 }
 
 function adapterLogoutSupportedByHecate(

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -24,6 +24,15 @@ function setup(stateOverrides = {}, actionOverrides = {}) {
   return { state, actions, user };
 }
 
+function capability(id: string, name: string, status = "supported") {
+  return {
+    id,
+    name,
+    status,
+    description: `${name} support`,
+  };
+}
+
 beforeEach(() => {
   vi.mocked(getPlugins).mockReset();
   vi.mocked(getPlugins).mockResolvedValue({ object: "plugins", data: [] });
@@ -491,6 +500,57 @@ describe("Connections external-agent panel", () => {
     expect(screen.queryByRole("button", { name: "Sign in Codex" })).toBeNull();
     await user.click(await screen.findByRole("button", { name: "Sign in Cursor Agent" }));
     expect(authenticateAgentAdapter).toHaveBeenCalledWith("cursor_agent");
+  });
+
+  it("shows the ACP capability matrix and applies live auth capability overrides", async () => {
+    const { state, actions } = setup({
+      agentAdapters: [
+        {
+          id: "codex",
+          name: "Codex",
+          kind: "acp",
+          command: "codex-acp-adapter",
+          available: true,
+          status: "available",
+          auth_status: "ok",
+          supports_authenticate: true,
+          supports_logout: true,
+          capabilities: [
+            capability("prompt_session", "sessions"),
+            capability("cancel", "cancel"),
+            capability("permissions", "permissions"),
+            capability("config_options", "config", "adapter_dependent"),
+            capability("terminal_rpc", "terminal RPC", "operator_opt_in"),
+            capability("authenticate", "login"),
+            capability("logout", "logout"),
+          ],
+        },
+      ],
+      agentAdapterHealthByID: new Map([
+        [
+          "codex",
+          {
+            adapter_id: "codex",
+            status: "ready",
+            stage: "ready",
+            capabilities_known: true,
+            supports_authenticate: false,
+            supports_logout: false,
+            supports_load_session: true,
+            duration_ms: 42,
+          },
+        ],
+      ]),
+    });
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
+
+    const capabilities = await screen.findByTestId("external-agents-adapter-codex-capabilities");
+    expect(within(capabilities).getByText("sessions")).toBeTruthy();
+    expect(within(capabilities).getByText("permissions")).toBeTruthy();
+    expect(within(capabilities).getByText(/config/)).toHaveTextContent("if advertised");
+    expect(within(capabilities).getByText(/terminal RPC/)).toHaveTextContent("opt-in");
+    expect(within(capabilities).queryByText("login")).toBeNull();
+    expect(within(capabilities).queryByText("logout")).toBeNull();
   });
 
   it("revoke asks for inline confirmation before deleting the grant", async () => {

--- a/ui/src/types/agent-adapter.ts
+++ b/ui/src/types/agent-adapter.ts
@@ -26,7 +26,15 @@ export type AgentAdapterRecord = {
   remote_credential_ok?: boolean;
   remote_credential_hint?: string;
   config_options?: ChatConfigOptionRecord[];
+  capabilities?: AgentAdapterCapability[];
   claude_code_cli?: AgentAdapterSetupCommandStatus;
+};
+
+export type AgentAdapterCapability = {
+  id: string;
+  name?: string;
+  description?: string;
+  status: "supported" | "adapter_dependent" | "operator_opt_in" | "not_supported" | string;
 };
 
 export type AgentAdapterCredentialMode = {


### PR DESCRIPTION
## Summary

- add a catalog-level ACP capability matrix to built-in External Agent adapters
- expose the matrix through `/hecate/v1/agent-adapters` and render it in Connections
- keep live probe capabilities authoritative for login/logout visibility
- document the capability contract in External Agents and Runtime API docs

## Tests

- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters -run 'TestBuiltInsIncludeInitialExternalAgents|TestBuiltInGoAdaptersUseReleasedBinaries'`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestAgentAdaptersReturnsBuiltIns|TestAgentAdapterProbeAppliesLiveCapabilitiesToAdapterRow'`
- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go vet ./internal/agentadapters ./internal/api`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./internal/agentadapters ./internal/api`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test -- SettingsView.test.tsx`
- `cd ui && bun run test`
- `just docs-format-check`
- `just check-links`
- `git diff --check`
