### PR TITLE
test(acp): run full release smoke suite

### DIFF
--- a/just/smoke.just
+++ b/just/smoke.just
@@ -14,4 +14,4 @@ test-docker-smoke: _go-cache
 # them through Hecate's ACP boundary with fake vendor CLIs. Requires network.
 # Smoke test packaged Go ACP adapter release binaries.
 test-acp-release-smoke: _go-cache
-	{{go_env}} go test -tags acp_release -count=1 -run TestACPAdapterReleaseBinariesSmoke -timeout 5m ./internal/agentadapters
+	{{go_env}} go test -tags acp_release -count=1 -run TestACPAdapterReleaseBinaries -timeout 5m ./internal/agentadapters


### PR DESCRIPTION
## Summary
- update `just test-acp-release-smoke` to run the full `TestACPAdapterReleaseBinaries…` family
- include the prompt approval/grant release-binary smoke in the documented Hecate adapter packaging check

## Tests
- `just test-acp-release-smoke`
- `make real-cli-smoke` in `codex-acp-adapter`
- `make real-cli-smoke` in `claude-code-acp-adapter`