### PR TITLE
Report project delete cleanup

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2166,6 +2166,23 @@ chats and chats scoped to other projects stay untouched. Assignment links to
 task/chat IDs are metadata only; the linked tasks or unprojected chat sessions
 are not deleted through assignment cleanup.
 
+The response reports the scoped records Hecate cleaned up:
+
+```json
+{
+  "object": "project_delete",
+  "data": {
+    "project_id": "proj_...",
+    "project_name": "Launch operations",
+    "chat_sessions_deleted": 2,
+    "project_work_rows_deleted": 8,
+    "project_skills_deleted": 1,
+    "memory_entries_deleted": 3,
+    "memory_candidates_deleted": 4
+  }
+}
+```
+
 ### Project Memory
 
 Project memory is explicit operator-approved context. Hecate never writes these

--- a/internal/api/handler_project_memory_test.go
+++ b/internal/api/handler_project_memory_test.go
@@ -440,8 +440,15 @@ func TestProjectMemoryAPI_ProjectDeleteRemovesMemory(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID, nil))
-	if rec.Code != http.StatusNoContent {
-		t.Fatalf("delete project status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete project status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var deleted ProjectDeleteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &deleted); err != nil {
+		t.Fatalf("decode delete response: %v", err)
+	}
+	if deleted.Data.ProjectID != project.Data.ID || deleted.Data.MemoryEntriesDeleted != 1 {
+		t.Fatalf("delete response = %+v, want project id and 1 memory entry", deleted)
 	}
 	items, err := memoryStore.List(t.Context(), memory.Filter{ProjectID: project.Data.ID, IncludeDisabled: true})
 	if err != nil {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -731,8 +731,15 @@ func TestProjectWorkAPI_ProjectDeletionCleansRows(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID, nil))
-	if rec.Code != http.StatusNoContent {
-		t.Fatalf("delete project status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete project status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var deleted ProjectDeleteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &deleted); err != nil {
+		t.Fatalf("decode delete response: %v", err)
+	}
+	if deleted.Data.ProjectID != project.Data.ID || deleted.Data.ProjectWorkRowsDeleted != 4 {
+		t.Fatalf("delete response = %+v, want project id and 4 project work rows", deleted)
 	}
 	if items, err := handler.projectWork.ListWorkItems(ctx, project.Data.ID); err != nil || len(items) != 0 {
 		t.Fatalf("project work items after project delete = %+v err=%v, want none", items, err)

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -347,7 +347,7 @@ func (h *Handler) HandleDeleteProjectContextSource(w http.ResponseWriter, r *htt
 }
 
 func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
-	_, err := h.projectApplication().DeleteProject(r.Context(), r.PathValue("id"))
+	result, err := h.projectApplication().DeleteProject(r.Context(), r.PathValue("id"))
 	if errors.Is(err, projectapp.ErrProjectNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
@@ -360,7 +360,7 @@ func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	WriteJSON(w, http.StatusOK, ProjectDeleteResponse{Object: "project_delete", Data: renderProjectDeleteResult(result)})
 }
 
 func writeProjectRootMutationResponse(w http.ResponseWriter, status int, project projects.Project, err error) {
@@ -631,6 +631,18 @@ func renderProject(project projects.Project) ProjectResponseItem {
 		CreatedAt:                formatOptionalTime(project.CreatedAt),
 		UpdatedAt:                formatOptionalTime(project.UpdatedAt),
 		LastOpenedAt:             formatOptionalTime(project.LastOpenedAt),
+	}
+}
+
+func renderProjectDeleteResult(result projectapp.DeleteProjectResult) ProjectDeleteResponseItem {
+	return ProjectDeleteResponseItem{
+		ProjectID:               result.Project.ID,
+		ProjectName:             result.Project.Name,
+		ChatSessionsDeleted:     result.ChatSessionsDeleted,
+		ProjectWorkRowsDeleted:  result.ProjectWorkRowsDeleted,
+		ProjectSkillsDeleted:    result.ProjectSkillsDeleted,
+		MemoryEntriesDeleted:    result.MemoryEntriesDeleted,
+		MemoryCandidatesDeleted: result.MemoryCandidatesDeleted,
 	}
 }
 

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -106,8 +106,17 @@ func TestProjectsAPI_CRUD(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+created.Data.ID, nil))
-	if rec.Code != http.StatusNoContent {
-		t.Fatalf("delete status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var deleted ProjectDeleteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &deleted); err != nil {
+		t.Fatalf("decode delete response: %v", err)
+	}
+	if deleted.Object != "project_delete" ||
+		deleted.Data.ProjectID != created.Data.ID ||
+		deleted.Data.ProjectName != "Renamed" {
+		t.Fatalf("delete response = %+v, want project id/name", deleted)
 	}
 }
 
@@ -818,8 +827,18 @@ func TestProjectsAPI_DeleteProjectDeletesProjectChats(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+created.Data.ID, nil))
-	if rec.Code != http.StatusNoContent {
-		t.Fatalf("delete status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var deleted ProjectDeleteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &deleted); err != nil {
+		t.Fatalf("decode delete response: %v", err)
+	}
+	if deleted.Object != "project_delete" ||
+		deleted.Data.ProjectID != created.Data.ID ||
+		deleted.Data.ProjectName != "Hecate" ||
+		deleted.Data.ChatSessionsDeleted != 2 {
+		t.Fatalf("delete response = %+v, want project id/name and 2 deleted chats", deleted)
 	}
 
 	sessions, err := chatStore.List(ctx)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -274,6 +274,21 @@ type ProjectResponse struct {
 	Data   ProjectResponseItem `json:"data"`
 }
 
+type ProjectDeleteResponse struct {
+	Object string                    `json:"object"`
+	Data   ProjectDeleteResponseItem `json:"data"`
+}
+
+type ProjectDeleteResponseItem struct {
+	ProjectID               string `json:"project_id"`
+	ProjectName             string `json:"project_name,omitempty"`
+	ChatSessionsDeleted     int    `json:"chat_sessions_deleted"`
+	ProjectWorkRowsDeleted  int    `json:"project_work_rows_deleted"`
+	ProjectSkillsDeleted    int    `json:"project_skills_deleted"`
+	MemoryEntriesDeleted    int    `json:"memory_entries_deleted"`
+	MemoryCandidatesDeleted int    `json:"memory_candidates_deleted"`
+}
+
 type AgentProfileResponse struct {
 	Object string                   `json:"object"`
 	Data   AgentProfileResponseItem `json:"data"`

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -430,9 +430,42 @@ export async function mockGatewayAPIs(page: Page, opts: GatewayMockOptions = {})
     r.fulfill(ok({ object: "list", data: MOCK_FULL_PRESETS })),
   );
 
-  await page.route("/hecate/v1/projects*", (r) =>
-    r.fulfill(ok({ object: "projects", data: projects })),
-  );
+  await page.route("/hecate/v1/projects*", async (route) => {
+    const request = route.request();
+    const method = request.method();
+    const url = new URL(request.url());
+    const suffix = url.pathname.replace("/hecate/v1/projects", "").replace(/^\/+/, "");
+    const parts = suffix ? suffix.split("/").map((part) => decodeURIComponent(part)) : [];
+    const projectID = parts[0] || "";
+
+    if (parts.length === 1 && projectID && method === "DELETE") {
+      const index = projects.findIndex((project) => project.id === projectID);
+      const [project] = index >= 0 ? projects.splice(index, 1) : [];
+      const chatSessionsDeleted = chatSessions.filter(
+        (session) => session.project_id === projectID,
+      ).length;
+      for (let i = chatSessions.length - 1; i >= 0; i -= 1) {
+        if (chatSessions[i]?.project_id === projectID) chatSessions.splice(i, 1);
+      }
+      await route.fulfill(
+        ok({
+          object: "project_delete",
+          data: {
+            project_id: projectID,
+            project_name: project?.name || "",
+            chat_sessions_deleted: chatSessionsDeleted,
+            project_work_rows_deleted: 0,
+            project_skills_deleted: 0,
+            memory_entries_deleted: 0,
+            memory_candidates_deleted: 0,
+          },
+        }),
+      );
+      return;
+    }
+
+    await route.fulfill(ok({ object: "projects", data: projects }));
+  });
 
   await page.route("/hecate/v1/agent-adapters*", (r) =>
     r.fulfill(ok({ object: "agent_adapters", data: MOCK_AGENT_ADAPTERS })),

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -85,6 +85,16 @@ vi.mock("../lib/api", async (importOriginal) => {
   };
 });
 
+const projectDeleteResult = {
+  project_id: "proj_1",
+  project_name: "Hecate",
+  chat_sessions_deleted: 1,
+  project_work_rows_deleted: 2,
+  project_skills_deleted: 1,
+  memory_entries_deleted: 3,
+  memory_candidates_deleted: 4,
+};
+
 function emptyActivityData() {
   return {
     project_id: "",
@@ -1073,7 +1083,7 @@ describe("ConsoleShell navigation", () => {
   });
 
   it("confirms project deletion from the chat sidebar", async () => {
-    const deleteProject = vi.fn(async () => true);
+    const deleteProject = vi.fn(async () => projectDeleteResult);
     const state = createRuntimeConsoleFixture({
       projects: [
         {
@@ -1114,13 +1124,18 @@ describe("ConsoleShell navigation", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Delete project$/i }));
 
     expect(deleteProject).toHaveBeenCalledWith("proj_1");
+    expect(
+      await screen.findByText(
+        "Deleted Hecate. Cleaned up 1 chat, 2 work rows, 1 skill, 3 memory entries, 4 memory candidates.",
+      ),
+    ).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.queryByText("Project chat")).toBeNull();
     });
   });
 
   it("keeps project chats visible when project deletion fails", async () => {
-    const deleteProject = vi.fn(async () => false);
+    const deleteProject = vi.fn(async () => null);
     const state = createRuntimeConsoleFixture({
       projects: [
         {

--- a/ui/src/app/state/projects.test.tsx
+++ b/ui/src/app/state/projects.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ProjectsProvider, useProjects } from "./projects";
 import { createProject, deleteProject, getProjects, updateProject } from "../../lib/api";
-import type { ProjectRecord } from "../../types/project";
+import type { ProjectDeleteRecord, ProjectRecord } from "../../types/project";
 
 vi.mock("../../lib/api", () => ({
   createProject: vi.fn(),
@@ -28,6 +28,19 @@ const project: ProjectRecord = {
   ],
   created_at: "2026-05-21T10:00:00Z",
   updated_at: "2026-05-21T10:00:00Z",
+};
+
+const deleteResult = {
+  object: "project_delete",
+  data: {
+    project_id: project.id,
+    project_name: project.name,
+    chat_sessions_deleted: 1,
+    project_work_rows_deleted: 2,
+    project_skills_deleted: 1,
+    memory_entries_deleted: 3,
+    memory_candidates_deleted: 4,
+  },
 };
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -144,24 +157,26 @@ describe("ProjectsProvider", () => {
 
   it("deletes a project and clears the active project when needed", async () => {
     window.localStorage.setItem("hecate.project", project.id);
-    vi.mocked(deleteProject).mockResolvedValue();
+    vi.mocked(deleteProject).mockResolvedValue(deleteResult);
     const { result } = renderHook(() => useProjects(), {
       wrapper: ({ children }) => (
         <ProjectsProvider initialState={{ projects: [project] }}>{children}</ProjectsProvider>
       ),
     });
 
+    let deleted: ProjectDeleteRecord | null = null;
     await act(async () => {
-      await result.current.actions.deleteProject(project.id);
+      deleted = await result.current.actions.deleteProject(project.id);
     });
 
     expect(deleteProject).toHaveBeenCalledWith(project.id);
+    expect(deleted).toEqual(deleteResult.data);
     expect(result.current.state.projects).toEqual([]);
     expect(result.current.activeProjectID).toBe("");
     expect(window.localStorage.getItem("hecate.project")).toBeNull();
   });
 
-  it("returns false and keeps local state when project deletion fails", async () => {
+  it("returns null and keeps local state when project deletion fails", async () => {
     window.localStorage.setItem("hecate.project", project.id);
     vi.mocked(deleteProject).mockRejectedValue(new Error("delete failed"));
     const { result } = renderHook(() => useProjects(), {
@@ -170,12 +185,12 @@ describe("ProjectsProvider", () => {
       ),
     });
 
-    let deleted = true;
+    let deleted: ProjectDeleteRecord | null = deleteResult.data;
     await act(async () => {
       deleted = await result.current.actions.deleteProject(project.id);
     });
 
-    expect(deleted).toBe(false);
+    expect(deleted).toBeNull();
     expect(result.current.state.projects).toEqual([project]);
     expect(result.current.activeProjectID).toBe(project.id);
     expect(result.current.state.error).toBe("delete failed");

--- a/ui/src/app/state/projects.tsx
+++ b/ui/src/app/state/projects.tsx
@@ -13,7 +13,7 @@ import {
   updateProject as updateProjectRequest,
 } from "../../lib/api";
 import { parseStoredString, usePersistedState } from "../../lib/persistedState";
-import type { CreateProjectPayload, ProjectRecord } from "../../types/project";
+import type { CreateProjectPayload, ProjectDeleteRecord, ProjectRecord } from "../../types/project";
 
 const ACTIVE_PROJECT_STORAGE_KEY = "hecate.project";
 
@@ -34,7 +34,7 @@ export type ProjectsActions = {
   selectProject: (id: string) => Promise<void>;
   createProject: (payload: CreateProjectPayload) => Promise<ProjectRecord | null>;
   renameProject: (id: string, name: string) => Promise<void>;
-  deleteProject: (id: string) => Promise<boolean>;
+  deleteProject: (id: string) => Promise<ProjectDeleteRecord | null>;
 };
 
 type ProjectsContextValue = {
@@ -191,12 +191,12 @@ export function ProjectsProvider({
   }, []);
 
   const deleteProject = useCallback(
-    async (id: string): Promise<boolean> => {
+    async (id: string): Promise<ProjectDeleteRecord | null> => {
       const projectID = id.trim();
-      if (!projectID) return false;
+      if (!projectID) return null;
       dispatch({ type: "error/set", value: "" });
       try {
-        await deleteProjectRequest(projectID);
+        const payload = await deleteProjectRequest(projectID);
         dispatch({
           type: "projects/set",
           next: (current) => current.filter((project) => project.id !== projectID),
@@ -204,13 +204,13 @@ export function ProjectsProvider({
         if (activeProjectID === projectID) {
           setActiveProjectIDState("");
         }
-        return true;
+        return payload.data;
       } catch (error) {
         dispatch({
           type: "error/set",
           value: error instanceof Error ? error.message : "Failed to delete project.",
         });
-        return false;
+        return null;
       }
     },
     [activeProjectID, setActiveProjectIDState],

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -12,6 +12,7 @@ import type { AgentAdapterRecord } from "../../types/agent-adapter";
 import type { ChatSessionRecord } from "../../types/chat";
 import { ProjectScopePanel } from "../projects/ProjectScopePanel";
 import { BrandAvatar, ConfirmModal, Icon, Icons } from "../shared/ui";
+import { formatProjectDeleteSummary } from "../projects/projectDisplay";
 
 import { NewChatAgentButton, chatAgentOption, chatAgentOptionStatus } from "./ChatAgentControls";
 import type { ChatAgentOptionID } from "./ChatAgentControls";
@@ -145,7 +146,7 @@ export function ChatSidebar({
             </>
           )}
           onProjectSelected={(projectID) => selectProjectScope(projectID)}
-          onProjectDeleted={(projectID) => {
+          onProjectDeleted={(projectID, result) => {
             const activeDeletedSession = chat.state.chatSessions.some(
               (session) =>
                 session.id === chat.state.activeChatSessionID && session.project_id === projectID,
@@ -156,6 +157,7 @@ export function ChatSidebar({
             if (activeDeletedSession || chat.state.activeChatSession?.project_id === projectID) {
               chatActions.startNewChat();
             }
+            settingsActions.setNoticeMessage("success", formatProjectDeleteSummary(result));
           }}
         />
         <div

--- a/ui/src/features/projects/ProjectScopePanel.tsx
+++ b/ui/src/features/projects/ProjectScopePanel.tsx
@@ -3,7 +3,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { useProjects } from "../../app/state/projects";
 import { chooseWorkspaceDirectory } from "../../lib/api";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
-import type { ProjectRecord } from "../../types/project";
+import type { ProjectDeleteRecord, ProjectRecord } from "../../types/project";
 import { ConfirmModal, Icon, Icons } from "../shared/ui";
 import { CreateProjectModal } from "./CreateProjectModal";
 import { createProjectPayloadFromForm, type CreateProjectForm } from "./projectSettings";
@@ -12,7 +12,7 @@ type ProjectScopePanelProps = {
   noProjectDetail: string;
   emptyHint: string;
   deleteMessage: (project: ProjectRecord) => ReactNode;
-  onProjectDeleted?: (projectID: string) => void;
+  onProjectDeleted?: (projectID: string, result: ProjectDeleteRecord) => void;
   onProjectSelected?: (projectID: string, project: ProjectRecord | null) => void;
 };
 
@@ -193,7 +193,7 @@ export function ProjectScopePanel({
             const projectID = pendingDeleteProject.id;
             const deleted = await projects.actions.deleteProject(projectID);
             if (!deleted) return;
-            onProjectDeleted?.(projectID);
+            onProjectDeleted?.(projectID, deleted);
             setDeleteProjectID(null);
           }}
         />

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1765,11 +1765,20 @@ describe("ProjectsView index", () => {
   it("uses existing project actions for create, rename, and delete", async () => {
     resetProjectWorkMocks();
     const user = userEvent.setup();
+    const deleteResult = {
+      project_id: project.id,
+      project_name: project.name,
+      chat_sessions_deleted: 1,
+      project_work_rows_deleted: 2,
+      project_skills_deleted: 1,
+      memory_entries_deleted: 3,
+      memory_candidates_deleted: 4,
+    };
     const actions = {
       ...createRuntimeConsoleActions(),
       createProject: vi.fn(async () => project),
       renameProject: vi.fn(async () => undefined),
-      deleteProject: vi.fn(async () => true),
+      deleteProject: vi.fn(async () => deleteResult),
       selectProject: vi.fn(async () => undefined),
     };
     const state = createRuntimeConsoleFixture({

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -154,6 +154,7 @@ import {
   workItemUpdatePayloadFromForm,
 } from "./projectWorkForms";
 import {
+  formatProjectDeleteSummary,
   formatProjectRowRelativeTime,
   projectErrorMessage as errorMessage,
 } from "./projectDisplay";
@@ -688,6 +689,10 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
       const deleted = await projects.actions.deleteProject(pendingDeleteProject.id);
       if (deleted) {
         setDeleteProjectID("");
+        settings.actions.setNotice({
+          kind: "success",
+          message: formatProjectDeleteSummary(deleted),
+        });
         if (selectedProjectID === pendingDeleteProject.id) {
           clearSelectedProject();
         }

--- a/ui/src/features/projects/projectDisplay.ts
+++ b/ui/src/features/projects/projectDisplay.ts
@@ -1,7 +1,7 @@
 import { ApiError } from "../../lib/api";
 import { projectRootOptionLabel } from "./projectSettings";
 import { shortID } from "./projectUtils";
-import type { ProjectRecord } from "../../types/project";
+import type { ProjectDeleteRecord, ProjectRecord } from "../../types/project";
 
 export function formatProjectRowRelativeTime(iso: string): string {
   const parsed = Date.parse(iso);
@@ -70,4 +70,23 @@ export function projectRootTitle(project: ProjectRecord, rootID: string): string
   const root = project.roots.find((item) => item.id === rootID);
   if (!root) return rootID;
   return projectRootOptionLabel(root);
+}
+
+export function formatProjectDeleteSummary(result: ProjectDeleteRecord): string {
+  const projectName = result.project_name?.trim() || result.project_id;
+  const cleaned = [
+    countLabel(result.chat_sessions_deleted, "chat"),
+    countLabel(result.project_work_rows_deleted, "work row"),
+    countLabel(result.project_skills_deleted, "skill"),
+    countLabel(result.memory_entries_deleted, "memory entry", "memory entries"),
+    countLabel(result.memory_candidates_deleted, "memory candidate"),
+  ].filter(Boolean);
+  if (cleaned.length === 0) {
+    return `Deleted ${projectName}. No scoped project records needed cleanup.`;
+  }
+  return `Deleted ${projectName}. Cleaned up ${cleaned.join(", ")}.`;
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return count > 0 ? `${count} ${count === 1 ? singular : plural}` : "";
 }

--- a/ui/src/features/runs/TasksView.tsx
+++ b/ui/src/features/runs/TasksView.tsx
@@ -44,6 +44,7 @@ import { TaskList } from "./TaskList";
 import { TaskDetail } from "./TaskDetail";
 import { NewTaskSlideOver, type CreateTaskPayload } from "./NewTaskSlideOver";
 import { ProjectScopePanel } from "../projects/ProjectScopePanel";
+import { formatProjectDeleteSummary } from "../projects/projectDisplay";
 
 type StreamState = "idle" | "connecting" | "live" | "closed" | "error";
 type TaskFocusRequest = { taskID: string; runID?: string; nonce: number };
@@ -588,6 +589,9 @@ export function TasksView({
             )}
             onProjectSelected={(projectID) => {
               void loadTasks("", "", projectID);
+            }}
+            onProjectDeleted={(_, result) => {
+              setNotice({ tone: "success", message: formatProjectDeleteSummary(result) });
             }}
           />
         }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -92,6 +92,7 @@ import type {
   ProjectCollaborationArtifactResponse,
   ProjectCollaborationArtifactsResponse,
   ProjectContextSourcePayload,
+  ProjectDeleteResponse,
   ProjectHandoffResponse,
   ProjectHandoffsResponse,
   ProjectHealthResponse,
@@ -518,8 +519,8 @@ export async function createProjectWorktreeRoot(
   );
 }
 
-export async function deleteProject(id: string): Promise<void> {
-  return fetchJSON<void>(`${HECATE_API}/projects/${encodeURIComponent(id)}`, {
+export async function deleteProject(id: string): Promise<ProjectDeleteResponse> {
+  return fetchJSON<ProjectDeleteResponse>(`${HECATE_API}/projects/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });
 }

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -29,7 +29,7 @@ import type {
   ProviderPresetRecord,
   ProviderRecord,
 } from "../types/provider";
-import type { CreateProjectPayload, ProjectRecord } from "../types/project";
+import type { CreateProjectPayload, ProjectDeleteRecord, ProjectRecord } from "../types/project";
 import type { RetentionRunData } from "../types/retention";
 import type { HealthResponse, RuntimeHeaders, SessionResponse } from "../types/runtime";
 import type { UsageEventRecord, UsageSummaryResponse } from "../types/usage";
@@ -249,7 +249,7 @@ export type RuntimeConsoleFixtureActions = {
   selectProject: (id: string) => Promise<void>;
   createProject: (payload: CreateProjectPayload) => Promise<ProjectRecord | null>;
   renameProject: (id: string, name: string) => Promise<void>;
-  deleteProject: (id: string) => Promise<boolean>;
+  deleteProject: (id: string) => Promise<ProjectDeleteRecord | null>;
   getChatApproval: (sessionID: string, approvalID: string) => Promise<unknown>;
   listChatMessageFiles: (sessionID: string, messageID: string) => Promise<unknown[]>;
   getChatWorkspaceDiff: (sessionID: string) => Promise<unknown>;
@@ -328,7 +328,14 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
     selectProject: async () => undefined,
     createProject: async () => null,
     renameProject: async () => undefined,
-    deleteProject: async () => true,
+    deleteProject: async () => ({
+      project_id: "",
+      chat_sessions_deleted: 0,
+      project_work_rows_deleted: 0,
+      project_skills_deleted: 0,
+      memory_entries_deleted: 0,
+      memory_candidates_deleted: 0,
+    }),
     getChatApproval: async () => null,
     listChatMessageFiles: async () => [],
     getChatWorkspaceDiff: async () => ({

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -55,6 +55,21 @@ export type ProjectResponse = {
   data: ProjectRecord;
 };
 
+export type ProjectDeleteRecord = {
+  project_id: string;
+  project_name?: string;
+  chat_sessions_deleted: number;
+  project_work_rows_deleted: number;
+  project_skills_deleted: number;
+  memory_entries_deleted: number;
+  memory_candidates_deleted: number;
+};
+
+export type ProjectDeleteResponse = {
+  object: string;
+  data: ProjectDeleteRecord;
+};
+
 export type ProjectAssistantAction = {
   kind: string;
   target?: Record<string, string>;


### PR DESCRIPTION
## Summary

- Return a typed `project_delete` response from `DELETE /hecate/v1/projects/{id}` with scoped cleanup counts from `projectapp.DeleteProject`.
- Thread the result through project state and project-scope delete handlers so Chats, Projects, and Tasks show the same cleanup notice.
- Update API docs, backend tests, UI fixtures, and UI tests for the new contract.

## Validation

- `GOCACHE="$PWD/.gocache" go test ./internal/api`
- `just go-format-check`
- `just vet`
- `just docs-format-check`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- `bun run test -- src/app/state/projects.test.tsx src/app/AppShell.test.tsx src/features/projects/ProjectsView.test.tsx`
- `bun run test`
- `just test-race`
- `E2E_HECATE_BIN="$PWD/hecate" just test-e2e`
- `bun run test:e2e`
