### PR TITLE
Expose Project Assistant apply outcome status

### DIFF
--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -157,11 +157,14 @@ after earlier actions have already mutated durable stores, the API returns the
 partial action results and `failed_action_index`. Retrying the exact same
 proposal resumes at the next unapplied action. Retrying the same proposal id
 with a changed action set returns `409 conflict`, and retrying a fully applied
-proposal also returns `409 conflict`. Clients should show the landed action
-kinds and ids from `partial_result.actions`; `committed_action_count`,
-`failed_action_index`, `resume_action_index`, and `total_action_count` are the
-server-owned progress counters. An empty list and `committed_action_count: 0`
-mean preflight blocked the proposal before anything landed.
+proposal also returns `409 conflict`. Clients should show `status` first, then
+the landed action kinds and ids from `partial_result.actions`. The status is
+`applied` after a successful apply, `blocked_before_apply` when preflight
+stopped the current apply attempt before writing another action, or
+`partial_due_to_runtime_failure` when a post-preflight store/runtime failure
+happened after apply began. `committed_action_count`, `failed_action_index`,
+`resume_action_index`, and `total_action_count` are the server-owned progress
+counters.
 
 Future versions may persist proposal ids server-side so reviewed actions,
 confirmation, and resumable progress survive process restarts. In v0 the
@@ -441,6 +444,7 @@ POST /hecate/v1/project-assistant/apply
   "object": "project_assistant.apply_result",
   "data": {
     "proposal_id": "pa_...",
+    "status": "applied",
     "applied": true,
     "total_action_count": 1,
     "committed_action_count": 1,
@@ -463,22 +467,28 @@ Stale ids, missing projects, missing chats, missing work items, or missing
 memory candidates return `404 not_found` or `409 conflict` depending on the
 state transition.
 
-When a multi-action apply fails, the error includes progress metadata. If
-preflight caught the failure before mutation, `partial_result.actions` is empty.
-If a later store/race failure happens after earlier actions were committed, the
-same field lists the landed action kinds and ids:
+When a multi-action apply fails, the error includes progress metadata and
+`apply_status`, which matches `partial_result.status`. If preflight caught the
+failure before mutation, the status is `blocked_before_apply`; on a first attempt
+`partial_result.actions` is empty, and on a resumed proposal it lists the
+actions that had already landed before this attempt. If a later store/race
+failure happens after earlier actions were committed in the current attempt, the
+status is `partial_due_to_runtime_failure` and the same field lists the landed
+action kinds and ids:
 
 ```json
 {
   "error": {
     "type": "not_found",
     "message": "project assistant apply failed at action 1: project assistant target not found: project \"proj_missing\"",
+    "apply_status": "partial_due_to_runtime_failure",
     "failed_action_index": 1,
     "total_action_count": 2,
     "committed_action_count": 1,
     "resume_action_index": 1,
     "partial_result": {
       "proposal_id": "pa_...",
+      "status": "partial_due_to_runtime_failure",
       "applied": false,
       "total_action_count": 2,
       "committed_action_count": 1,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3666,12 +3666,15 @@ stores, apply preflights the remaining typed actions against current project,
 work, handoff, memory-candidate, and chat targets, including explicit resources
 created earlier in the same proposal. Multi-action apply is sequential and
 resumable within the current process: on a failure the error includes
-`failed_action_index`, `total_action_count`, `committed_action_count`,
-`resume_action_index`, and `partial_result`. An empty
-`partial_result.actions` list with `committed_action_count: 0` means preflight
-blocked the proposal before any new durable write; a non-empty list means those
-actions landed and the unchanged proposal id can resume after them. Changing the
-action set or reapplying a fully applied proposal returns `409 conflict`.
+`apply_status`, `failed_action_index`, `total_action_count`,
+`committed_action_count`, `resume_action_index`, and `partial_result`.
+`apply_status` matches `partial_result.status`: `blocked_before_apply` or
+`partial_due_to_runtime_failure`. Successful apply results use `status:
+applied`. A `blocked_before_apply` result means preflight blocked the current
+apply attempt before writing another action. A
+`partial_due_to_runtime_failure` result means the unchanged proposal id can
+resume after the committed actions. Changing the action set or reapplying a
+fully applied proposal returns `409 conflict`.
 
 Endpoints:
 

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -203,6 +203,7 @@ func writeProjectAssistantApplyError(w http.ResponseWriter, err error) {
 	}
 	status, code := projectAssistantErrorStatusCode(err)
 	fields := map[string]any{
+		"apply_status":           applyErr.Result.Status,
 		"failed_action_index":    applyErr.FailedActionIndex,
 		"total_action_count":     applyErr.Result.TotalActionCount,
 		"committed_action_count": applyErr.Result.CommittedActionCount,

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -38,6 +38,7 @@ type projectAssistantErrorResponse struct {
 	Error struct {
 		Type                 string                       `json:"type"`
 		Message              string                       `json:"message"`
+		ApplyStatus          string                       `json:"apply_status"`
 		FailedActionIndex    int                          `json:"failed_action_index"`
 		TotalActionCount     int                          `json:"total_action_count"`
 		CommittedActionCount int                          `json:"committed_action_count"`
@@ -633,7 +634,7 @@ func TestProjectAssistantAPI_ProposeAndApplyCreateProject(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &applied); err != nil {
 		t.Fatalf("decode apply response: %v", err)
 	}
-	if applied.Object != "project_assistant.apply_result" || !applied.Data.Applied || applied.Data.ProposalID != "pa_api" {
+	if applied.Object != "project_assistant.apply_result" || applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.ProposalID != "pa_api" {
 		t.Fatalf("apply response = %+v, want applied project assistant result", applied)
 	}
 	if applied.Data.TotalActionCount != 1 || applied.Data.CommittedActionCount != 1 || applied.Data.ResumeActionIndex != 1 || applied.Data.FailedActionIndex != nil {
@@ -697,8 +698,11 @@ func TestProjectAssistantAPI_ApplyPreflightFailureIncludesEmptyProgress(t *testi
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("decode preflight apply error: %v", err)
 	}
-	if payload.Error.Type != errCodeNotFound || payload.Error.FailedActionIndex != 1 {
+	if payload.Error.Type != errCodeNotFound || payload.Error.ApplyStatus != projectassistant.ApplyStatusBlockedBeforeApply || payload.Error.FailedActionIndex != 1 {
 		t.Fatalf("error = %+v, want not_found at action index 1", payload.Error)
+	}
+	if payload.Error.PartialResult.Status != projectassistant.ApplyStatusBlockedBeforeApply {
+		t.Fatalf("partial_result status = %q, want %q", payload.Error.PartialResult.Status, projectassistant.ApplyStatusBlockedBeforeApply)
 	}
 	if payload.Error.TotalActionCount != 2 || payload.Error.CommittedActionCount != 0 || payload.Error.ResumeActionIndex != 0 {
 		t.Fatalf("error progress = %+v, want failed action 1 and resume action 0", payload.Error)
@@ -766,6 +770,7 @@ func TestProjectAssistantAPI_ApplyDoneReturnsCloseoutReadiness(t *testing.T) {
 			Type                 string                           `json:"type"`
 			Message              string                           `json:"message"`
 			OperatorAction       string                           `json:"operator_action"`
+			ApplyStatus          string                           `json:"apply_status"`
 			FailedActionIndex    int                              `json:"failed_action_index"`
 			TotalActionCount     int                              `json:"total_action_count"`
 			CommittedActionCount int                              `json:"committed_action_count"`
@@ -777,7 +782,7 @@ func TestProjectAssistantAPI_ApplyDoneReturnsCloseoutReadiness(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("decode assistant closeout error: %v", err)
 	}
-	if payload.Error.Type != errCodeConflict || payload.Error.FailedActionIndex != 0 || payload.Error.OperatorAction == "" {
+	if payload.Error.Type != errCodeConflict || payload.Error.ApplyStatus != projectassistant.ApplyStatusBlockedBeforeApply || payload.Error.FailedActionIndex != 0 || payload.Error.OperatorAction == "" {
 		t.Fatalf("assistant closeout error = %+v, want conflict at action 0 with operator action", payload.Error)
 	}
 	if payload.Error.TotalActionCount != 1 || payload.Error.CommittedActionCount != 0 || payload.Error.ResumeActionIndex != 0 {

--- a/internal/projectassistant/proposal_apply.go
+++ b/internal/projectassistant/proposal_apply.go
@@ -46,7 +46,7 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 		return ApplyResult{}, fmt.Errorf("%w: proposal %q action set changed after partial apply", ErrConflict, proposal.ID)
 	}
 	if failedActionIndex, err := s.preflightApply(ctx, proposal.Actions, len(progress.results)); err != nil {
-		partial := applyResult(proposal.ID, false, len(proposal.Actions), &failedActionIndex, progress.results)
+		partial := applyResult(proposal.ID, ApplyStatusBlockedBeforeApply, false, len(proposal.Actions), &failedActionIndex, progress.results)
 		return partial, &ApplyError{
 			ProposalID:        proposal.ID,
 			FailedActionIndex: failedActionIndex,
@@ -59,7 +59,7 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 		action := proposal.Actions[idx]
 		result, err := s.applyAction(ctx, action)
 		if err != nil {
-			partial := applyResult(proposal.ID, false, len(proposal.Actions), &idx, progress.results)
+			partial := applyResult(proposal.ID, ApplyStatusPartialDueToRuntimeFailure, false, len(proposal.Actions), &idx, progress.results)
 			return partial, &ApplyError{
 				ProposalID:        proposal.ID,
 				FailedActionIndex: idx,
@@ -72,7 +72,7 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 
 	progress.complete = true
 
-	return applyResult(proposal.ID, true, len(proposal.Actions), nil, progress.results), nil
+	return applyResult(proposal.ID, ApplyStatusApplied, true, len(proposal.Actions), nil, progress.results), nil
 }
 
 type applyActionSpec struct {
@@ -133,12 +133,13 @@ func cloneActionResults(results []ActionResult) []ActionResult {
 	return cloned
 }
 
-func applyResult(proposalID string, applied bool, totalActionCount int, failedActionIndex *int, results []ActionResult) ApplyResult {
+func applyResult(proposalID, status string, applied bool, totalActionCount int, failedActionIndex *int, results []ActionResult) ApplyResult {
 	committedActionCount := len(results)
 	resumeActionIndex := committedActionCount
 	failed := cloneIntPtr(failedActionIndex)
 	return ApplyResult{
 		ProposalID:           proposalID,
+		Status:               status,
 		Applied:              applied,
 		Actions:              cloneActionResults(results),
 		TotalActionCount:     totalActionCount,

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -32,6 +32,12 @@ const (
 	ActionCreateMemoryCandidate = "create_memory_candidate"
 )
 
+const (
+	ApplyStatusApplied                    = "applied"
+	ApplyStatusBlockedBeforeApply         = "blocked_before_apply"
+	ApplyStatusPartialDueToRuntimeFailure = "partial_due_to_runtime_failure"
+)
+
 var (
 	ErrInvalid              = errors.New("invalid project assistant proposal")
 	ErrUnknownActionKind    = errors.New("unknown project assistant action kind")
@@ -117,6 +123,7 @@ type Action struct {
 
 type ApplyResult struct {
 	ProposalID           string         `json:"proposal_id"`
+	Status               string         `json:"status"`
 	Applied              bool           `json:"applied"`
 	Actions              []ActionResult `json:"actions"`
 	TotalActionCount     int            `json:"total_action_count"`

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -1251,7 +1251,7 @@ func TestService_ApplyCreateAndUpdateProjectAcrossStores(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Apply setup: %v", err)
 			}
-			if !result.Applied || len(result.Actions) != len(proposal.Actions) {
+			if result.Status != ApplyStatusApplied || !result.Applied || len(result.Actions) != len(proposal.Actions) {
 				t.Fatalf("result = %+v, want all actions applied", result)
 			}
 			project, ok, err := fixture.projects.Get(ctx, "proj_alpha")
@@ -1733,7 +1733,7 @@ func TestService_ApplyLoopFailureReportsCommittedProgressAcrossStores(t *testing
 			if partial.FailedActionIndex != 1 {
 				t.Fatalf("failed_action_index = %d, want 1", partial.FailedActionIndex)
 			}
-			if result.Applied || result.TotalActionCount != 2 || result.CommittedActionCount != 1 || result.ResumeActionIndex != 1 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
+			if result.Status != ApplyStatusPartialDueToRuntimeFailure || result.Applied || result.TotalActionCount != 2 || result.CommittedActionCount != 1 || result.ResumeActionIndex != 1 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
 				t.Fatalf("partial result progress = %+v, want one committed action and failed action 1", result)
 			}
 			if len(result.Actions) != 1 || result.Actions[0].Kind != ActionCreateWorkItem || result.Actions[0].ID != "work_loop_partial" {
@@ -1951,7 +1951,7 @@ func TestService_ApplyPreflightBlocksStaleTargetsBeforeMutatingAcrossStores(t *t
 			if applyErr.FailedActionIndex != 1 {
 				t.Fatalf("failed_action_index = %d, want 1", applyErr.FailedActionIndex)
 			}
-			if result.TotalActionCount != 2 || result.CommittedActionCount != 0 || result.ResumeActionIndex != 0 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
+			if result.Status != ApplyStatusBlockedBeforeApply || result.TotalActionCount != 2 || result.CommittedActionCount != 0 || result.ResumeActionIndex != 0 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
 				t.Fatalf("partial result progress = %+v, want failed action 1 and resume action 0", result)
 			}
 			if result.Applied || len(result.Actions) != 0 {
@@ -2053,7 +2053,7 @@ func TestService_ApplyPreflightBlocksCloseoutBeforeMutatingAcrossStores(t *testi
 			if applyErr.FailedActionIndex != 1 || len(applyErr.Result.Actions) != 0 {
 				t.Fatalf("apply error = %+v, want preflight failure at done action with no committed actions", applyErr)
 			}
-			if applyErr.Result.TotalActionCount != 2 || applyErr.Result.CommittedActionCount != 0 || applyErr.Result.ResumeActionIndex != 0 || applyErr.Result.FailedActionIndex == nil || *applyErr.Result.FailedActionIndex != 1 {
+			if applyErr.Result.Status != ApplyStatusBlockedBeforeApply || applyErr.Result.TotalActionCount != 2 || applyErr.Result.CommittedActionCount != 0 || applyErr.Result.ResumeActionIndex != 0 || applyErr.Result.FailedActionIndex == nil || *applyErr.Result.FailedActionIndex != 1 {
 				t.Fatalf("apply error progress = %+v, want failed action 1 and resume action 0", applyErr.Result)
 			}
 			handoffs, err := fixture.work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: project.ID, WorkItemID: workItem.ID})
@@ -2126,7 +2126,7 @@ func TestService_ApplyPreflightBlocksMissingHandoffTargetBeforeMutatingAcrossSto
 			if applyErr.FailedActionIndex != 1 {
 				t.Fatalf("failed_action_index = %d, want 1", applyErr.FailedActionIndex)
 			}
-			if result.TotalActionCount != 2 || result.CommittedActionCount != 0 || result.ResumeActionIndex != 0 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
+			if result.Status != ApplyStatusBlockedBeforeApply || result.TotalActionCount != 2 || result.CommittedActionCount != 0 || result.ResumeActionIndex != 0 || result.FailedActionIndex == nil || *result.FailedActionIndex != 1 {
 				t.Fatalf("result progress = %+v, want failed action 1 and resume action 0", result)
 			}
 			if result.Applied || len(result.Actions) != 0 {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2431,6 +2431,7 @@ describe("ProjectsView cockpit", () => {
           failed_action_index: 1,
           partial_result: {
             proposal_id: "pa_partial",
+            status: "partial_due_to_runtime_failure",
             applied: false,
             actions: [
               {

--- a/ui/src/features/projects/useProjectAssistantController.test.ts
+++ b/ui/src/features/projects/useProjectAssistantController.test.ts
@@ -87,6 +87,7 @@ describe("Project Assistant controller helpers", () => {
           failed_action_index: 1,
           partial_result: {
             proposal_id: "pa_partial",
+            status: "partial_due_to_runtime_failure",
             applied: false,
             total_action_count: 2,
             committed_action_count: 1,
@@ -101,6 +102,58 @@ describe("Project Assistant controller helpers", () => {
     expect(partial).toContain("applied 1 of 2 actions");
     expect(partial).toContain("create assignment asgn_1");
     expect(partial).toContain("failed at action 2 (create memory candidate)");
+
+    const blocked = projectAssistantApplyErrorMessage(
+      new ApiError("blocked", 404, "not_found", {
+        fields: {
+          apply_status: "blocked_before_apply",
+          failed_action_index: 1,
+          total_action_count: 2,
+          committed_action_count: 0,
+          resume_action_index: 0,
+          partial_result: {
+            proposal_id: "pa_blocked",
+            status: "blocked_before_apply",
+            applied: false,
+            total_action_count: 2,
+            committed_action_count: 0,
+            failed_action_index: 1,
+            resume_action_index: 0,
+            actions: [],
+          },
+        },
+      }),
+      proposal,
+    );
+    expect(blocked).toContain("blocked this proposal before applying any actions");
+    expect(blocked).toContain("failed at action 2 (create memory candidate)");
+    expect(blocked).not.toContain("applied 0 of 2 actions");
+
+    const blockedResume = projectAssistantApplyErrorMessage(
+      new ApiError("blocked", 404, "not_found", {
+        fields: {
+          apply_status: "blocked_before_apply",
+          failed_action_index: 1,
+          total_action_count: 2,
+          committed_action_count: 1,
+          resume_action_index: 1,
+          partial_result: {
+            proposal_id: "pa_blocked_resume",
+            status: "blocked_before_apply",
+            applied: false,
+            total_action_count: 2,
+            committed_action_count: 1,
+            failed_action_index: 1,
+            resume_action_index: 1,
+            actions: [{ kind: "create_assignment", id: "asgn_1" }],
+          },
+        },
+      }),
+      proposal,
+    );
+    expect(blockedResume).toContain("blocked this proposal before applying additional actions");
+    expect(blockedResume).toContain("1 of 2 actions was already committed");
+    expect(blockedResume).toContain("create assignment asgn_1");
 
     const serverCountedPartial = projectAssistantApplyErrorMessage(
       new ApiError("partial", 409, "conflict", {

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -340,6 +340,15 @@ function projectAssistantPartialApplyErrorMessage(
     Math.max(appliedCount, failedActionIndex + 1);
   const landed = projectAssistantAppliedActionsSummary(partialResult.actions);
   const failed = projectAssistantFailedActionSummary(proposal, failedActionIndex);
+  const status =
+    projectAssistantApplyStatus(error.fields.apply_status) ??
+    projectAssistantApplyStatus(partialResult.status);
+  if (status === "blocked_before_apply") {
+    if (appliedCount > 0) {
+      return `Project Assistant blocked this proposal before applying additional actions. ${appliedCount} of ${totalCount} action${totalCount === 1 ? "" : "s"} ${appliedCount === 1 ? "was" : "were"} already committed${landed}. It failed at action ${failedActionIndex + 1}${failed}. Fix the target state, then apply the same proposal again.`;
+    }
+    return `Project Assistant blocked this proposal before applying any actions. It failed at action ${failedActionIndex + 1}${failed}. Fix the target state, then apply the same proposal again.`;
+  }
   return `Project Assistant applied ${appliedCount} of ${totalCount} actions${landed}. It then failed at action ${failedActionIndex + 1}${failed}. Apply the same proposal again after fixing the target state to resume from the next unapplied action.`;
 }
 
@@ -392,6 +401,14 @@ function projectAssistantNonNegativeInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
+function projectAssistantApplyStatus(value: unknown): ProjectAssistantApplyResult["status"] {
+  return value === "applied" ||
+    value === "blocked_before_apply" ||
+    value === "partial_due_to_runtime_failure"
+    ? value
+    : undefined;
+}
+
 function projectAssistantPartialResult(value: unknown): ProjectAssistantApplyResult | null {
   if (!value || typeof value !== "object") return null;
   const result = value as Partial<ProjectAssistantApplyResult>;
@@ -404,6 +421,7 @@ function projectAssistantPartialResult(value: unknown): ProjectAssistantApplyRes
   }
   return {
     proposal_id: result.proposal_id,
+    status: projectAssistantApplyStatus(result.status),
     applied: result.applied,
     actions: result.actions,
     total_action_count: projectAssistantNonNegativeInteger(result.total_action_count) ?? undefined,

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -1302,12 +1302,14 @@ describe("api client", () => {
             error: {
               type: "conflict",
               message: "project assistant apply failed",
+              apply_status: "partial_due_to_runtime_failure",
               failed_action_index: 1,
               total_action_count: 2,
               committed_action_count: 1,
               resume_action_index: 1,
               partial_result: {
                 proposal_id: "pa_partial",
+                status: "partial_due_to_runtime_failure",
                 applied: false,
                 total_action_count: 2,
                 committed_action_count: 1,
@@ -1323,12 +1325,14 @@ describe("api client", () => {
 
       await expect(getUsageSummary("?scope=global")).rejects.toMatchObject({
         fields: {
+          apply_status: "partial_due_to_runtime_failure",
           failed_action_index: 1,
           total_action_count: 2,
           committed_action_count: 1,
           resume_action_index: 1,
           partial_result: {
             proposal_id: "pa_partial",
+            status: "partial_due_to_runtime_failure",
             applied: false,
             total_action_count: 2,
             committed_action_count: 1,

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -93,8 +93,14 @@ export type ProjectAssistantActionResult = {
   data?: Record<string, string>;
 };
 
+export type ProjectAssistantApplyStatus =
+  | "applied"
+  | "blocked_before_apply"
+  | "partial_due_to_runtime_failure";
+
 export type ProjectAssistantApplyResult = {
   proposal_id: string;
+  status?: ProjectAssistantApplyStatus;
   applied: boolean;
   actions: ProjectAssistantActionResult[];
   total_action_count?: number;


### PR DESCRIPTION
Summary

- Add an explicit Project Assistant apply outcome status for successful results and partial/error results.
- Surface `apply_status` in API error details so clients can distinguish preflight blocks from runtime partial failures.
- Update the Projects UI helper copy so preflight blocks do not read like "applied 0 actions".
- Document the apply status contract in the runtime docs.

Validation

- `GOCACHE="$PWD/.gocache" go test ./internal/projectassistant ./internal/api`
- `bun run test -- src/lib/api.test.ts src/features/projects/useProjectAssistantController.test.ts src/features/projects/ProjectsView.test.tsx`
- `bun run typecheck`
- `just go-format-check`
- `just vet`
- `bun run lint`
- `bun run format:check`
- `just docs-format-check`
- `just test-race`
- `bun run build`
- `bun run test`
- `go build -o hecate ./cmd/hecate`
- `bun run test:e2e`
- `E2E_HECATE_BIN="$PWD/hecate" just test-e2e`
- `just format-check`
- GitHub Actions on this PR: passing