### PR TITLE
chore: bump bundled ACP adapters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.31
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.32
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.32
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.33
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,8 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.31
-ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.32
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.32
+ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.33
 
 RUN apk add --no-cache ca-certificates curl tar \
     && set -eux; \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,16 +24,17 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.31` and `claude-code-acp-adapter` versions older than
-`v0.1.0-alpha.32` as outside the tested range because those older releases lack
+older than `v0.1.0-alpha.32` and `claude-code-acp-adapter` versions older than
+`v0.1.0-alpha.33` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
 external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
 failure/stop-reason classification, local-login environment contract,
 `session/close` cleanup behavior, structured tool output preservation, or
 permission-outcome, rejected-tool-result, post-cancel stream, and MCP
-permission-label hardening that is exercised by the real CLI smoke suite.
-The
-`v0.1.0-alpha.8` adapters added supported Codex and Claude Code JSON stream
+permission-label hardening that is exercised by the real CLI smoke suite, plus
+the real-provider stdio MCP smoke coverage and current prompt permission
+selectors.
+The `v0.1.0-alpha.8` adapters added supported Codex and Claude Code JSON stream
 translation into ACP assistant-message, thought, tool-call, tool-result, and
 usage updates, so Hecate can render External Agent activity without exposing raw
 JSONL output in the chat transcript. The `v0.1.0-alpha.9` adapters added
@@ -95,6 +96,9 @@ so hosts can discover the supported lifecycle surface without probing calls.
 Codex adapter `v0.1.0-alpha.31` adds GitHub artifact attestations for release
 archives and documents the stable-readiness parity gate that remains before a
 stable adapter tag.
+Codex adapter `v0.1.0-alpha.32` adds an ACP approval-policy config selector,
+including explicit bypass mode, and expands the opt-in real CLI smoke suite to
+verify a local stdio MCP echo tool call.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter
@@ -157,6 +161,10 @@ probing calls.
 Claude Code adapter `v0.1.0-alpha.32` adds GitHub artifact attestations for
 release archives and documents the stable-readiness parity gate that remains
 before a stable adapter tag.
+Claude Code adapter `v0.1.0-alpha.33` expands the opt-in real CLI smoke suite
+to verify a local stdio MCP echo tool call, delimits Claude's variadic
+`--mcp-config` option before prompt text, and preserves provider tool metadata
+on matching result updates.
 
 ## Supported External Agents
 

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -300,7 +300,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.31",
+			SupportedRange:       ">=0.1.0-alpha.32",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			Capabilities: acpCapabilityMatrix(
@@ -345,7 +345,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Claude Code through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/claude-code-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.32",
+			SupportedRange:       ">=0.1.0-alpha.33",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			Capabilities: acpCapabilityMatrix(

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.31" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.32" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {
@@ -52,7 +52,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["claude_code"]; got.Command != "claude-code-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("claude_code adapter = %#v", got)
 	}
-	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.32" {
+	if got := found["claude_code"]; got.SupportedRange != ">=0.1.0-alpha.33" {
 		t.Fatalf("claude_code supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["claude_code"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary
- bump bundled Codex ACP adapter to v0.1.0-alpha.32
- bump bundled Claude Code ACP adapter to v0.1.0-alpha.33
- raise Hecate supported ranges and document the new MCP real-smoke-covered adapter releases

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters
- just test-acp-release-smoke
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters ./internal/api