### PR TITLE
chore: bump codex acp adapter to alpha 33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN bun run build
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.32
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.33
 ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.33
 
 RUN apk add --no-cache ca-certificates curl tar \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,7 +14,7 @@ ARG NODE_IMAGE=node:24-trixie-slim
 FROM alpine:${ALPINE_VERSION} AS adapter-downloader
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.32
+ARG CODEX_ACP_ADAPTER_VERSION=v0.1.0-alpha.33
 ARG CLAUDE_CODE_ACP_ADAPTER_VERSION=v0.1.0-alpha.33
 
 RUN apk add --no-cache ca-certificates curl tar \

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -24,16 +24,16 @@ transcript prelude for multi-turn continuity. Claude Code adapter
 after an adapter process restart. Codex does not yet claim vendor-native
 durable history across adapter process restarts; if a load is stale, Hecate
 falls back to a fresh native session. Hecate treats `codex-acp-adapter` versions
-older than `v0.1.0-alpha.32` and `claude-code-acp-adapter` versions older than
+older than `v0.1.0-alpha.33` and `claude-code-acp-adapter` versions older than
 `v0.1.0-alpha.33` as outside the tested range because those older releases lack
 the current continuity, permission-control, structured stream, session metadata,
 external MCP handoff surface, ACP authenticate/logout mapping, and prompt auth
 failure/stop-reason classification, local-login environment contract,
 `session/close` cleanup behavior, structured tool output preservation, or
 permission-outcome, rejected-tool-result, post-cancel stream, and MCP
-permission-label hardening that is exercised by the real CLI smoke suite, plus
-the real-provider stdio MCP smoke coverage and current prompt permission
-selectors.
+permission-label hardening that is exercised by the real CLI smoke suite, sparse
+Codex tool-completion metadata carry-over, plus the real-provider stdio MCP
+smoke coverage and current prompt permission selectors.
 The `v0.1.0-alpha.8` adapters added supported Codex and Claude Code JSON stream
 translation into ACP assistant-message, thought, tool-call, tool-result, and
 usage updates, so Hecate can render External Agent activity without exposing raw
@@ -99,6 +99,10 @@ stable adapter tag.
 Codex adapter `v0.1.0-alpha.32` adds an ACP approval-policy config selector,
 including explicit bypass mode, and expands the opt-in real CLI smoke suite to
 verify a local stdio MCP echo tool call.
+Codex adapter `v0.1.0-alpha.33` carries tool title/kind metadata from start
+events onto sparse completion updates, so Hecate can keep rendering MCP and
+provider tool timeline entries with stable labels even when the completion event
+only carries the result payload.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
 Claude-native `--session-id` reload after adapter restarts. Claude Code adapter

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -300,7 +300,7 @@ func BuiltIns() []Adapter {
 			Description:          "Run Codex through the standalone Go ACP adapter as an external coding-agent session supervised by Hecate.",
 			CostMode:             "external",
 			DocsURL:              "https://github.com/hecatehq/codex-acp-adapter",
-			SupportedRange:       ">=0.1.0-alpha.32",
+			SupportedRange:       ">=0.1.0-alpha.33",
 			SupportsAuthenticate: true,
 			SupportsLogout:       true,
 			Capabilities: acpCapabilityMatrix(

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -29,7 +29,7 @@ func TestBuiltInsIncludeInitialExternalAgents(t *testing.T) {
 	if got := found["codex"]; got.Command != "codex-acp-adapter" || got.Kind != DriverKindACP || got.CostMode != "external" {
 		t.Fatalf("codex adapter = %#v", got)
 	}
-	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.32" {
+	if got := found["codex"]; got.SupportedRange != ">=0.1.0-alpha.33" {
 		t.Fatalf("codex supported range = %q, want current Go adapter alpha range", got.SupportedRange)
 	}
 	if got := found["codex"]; !got.SupportsAuthenticate {


### PR DESCRIPTION
## Summary
- bump the bundled Codex ACP adapter to v0.1.0-alpha.33
- raise Hecate's tested Codex adapter range to match
- document the sparse tool-completion metadata carry-over added in the adapter release

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/agentadapters
- just test-acp-release-smoke