### PR TITLE
Require Project Assistant apply status in UI

### DIFF
--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -86,6 +86,7 @@ describe("ProjectAssistantPanel", () => {
     const handlers = renderAssistantPanel({
       applyResult: {
         proposal_id: "pa_setup",
+        status: "applied",
         applied: true,
         actions: [{ kind: "create_memory_candidate" }, { kind: "create_role" }],
       },
@@ -124,6 +125,7 @@ describe("ProjectAssistantPanel", () => {
     const handlers = renderAssistantPanel({
       applyResult: {
         proposal_id: "pa_assignment",
+        status: "applied",
         applied: true,
         actions: [{ kind: "create_assignment" }],
       },

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -395,6 +395,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
       object: "project_assistant.apply_result",
       data: {
         proposal_id: "pa_test",
+        status: "applied",
         applied: true,
         actions: [
           {
@@ -1056,6 +1057,7 @@ function resetProjectWorkMocks() {
     object: "project_assistant.apply_result",
     data: {
       proposal_id: "pa_test",
+      status: "applied",
       applied: true,
       actions: [
         {

--- a/ui/src/features/projects/useProjectAssistantController.test.ts
+++ b/ui/src/features/projects/useProjectAssistantController.test.ts
@@ -53,6 +53,7 @@ describe("Project Assistant controller helpers", () => {
     expect(
       projectAssistantResultWorkItemID({
         proposal_id: "pa_1",
+        status: "applied",
         applied: true,
         actions: [
           { kind: "create_role", id: "role_1", data: { project_id: "proj_1" } },
@@ -158,12 +159,14 @@ describe("Project Assistant controller helpers", () => {
     const serverCountedPartial = projectAssistantApplyErrorMessage(
       new ApiError("partial", 409, "conflict", {
         fields: {
+          apply_status: "partial_due_to_runtime_failure",
           failed_action_index: 1,
           total_action_count: 3,
           committed_action_count: 1,
           resume_action_index: 1,
           partial_result: {
             proposal_id: "pa_partial",
+            status: "partial_due_to_runtime_failure",
             applied: false,
             total_action_count: 3,
             committed_action_count: 1,

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -10,6 +10,7 @@ import {
 } from "../../lib/api";
 import type {
   ProjectAssistantApplyResult,
+  ProjectAssistantApplyStatus,
   ProjectAssistantContextPayload,
   ProjectAssistantContextRecord,
   ProjectAssistantDraftPayload,
@@ -401,7 +402,7 @@ function projectAssistantNonNegativeInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
-function projectAssistantApplyStatus(value: unknown): ProjectAssistantApplyResult["status"] {
+function projectAssistantApplyStatus(value: unknown): ProjectAssistantApplyStatus | undefined {
   return value === "applied" ||
     value === "blocked_before_apply" ||
     value === "partial_due_to_runtime_failure"
@@ -412,7 +413,9 @@ function projectAssistantApplyStatus(value: unknown): ProjectAssistantApplyResul
 function projectAssistantPartialResult(value: unknown): ProjectAssistantApplyResult | null {
   if (!value || typeof value !== "object") return null;
   const result = value as Partial<ProjectAssistantApplyResult>;
+  const status = projectAssistantApplyStatus(result.status);
   if (
+    !status ||
     typeof result.proposal_id !== "string" ||
     typeof result.applied !== "boolean" ||
     !Array.isArray(result.actions)
@@ -421,7 +424,7 @@ function projectAssistantPartialResult(value: unknown): ProjectAssistantApplyRes
   }
   return {
     proposal_id: result.proposal_id,
-    status: projectAssistantApplyStatus(result.status),
+    status,
     applied: result.applied,
     actions: result.actions,
     total_action_count: projectAssistantNonNegativeInteger(result.total_action_count) ?? undefined,

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -100,7 +100,7 @@ export type ProjectAssistantApplyStatus =
 
 export type ProjectAssistantApplyResult = {
   proposal_id: string;
-  status?: ProjectAssistantApplyStatus;
+  status: ProjectAssistantApplyStatus;
   applied: boolean;
   actions: ProjectAssistantActionResult[];
   total_action_count?: number;


### PR DESCRIPTION
Summary

- Make the Project Assistant apply result status required in the UI type contract.
- Reject malformed partial apply results that do not carry a recognized status.
- Update Project Assistant UI test fixtures to match the server-owned apply outcome contract.

Validation

- `bun run typecheck`
- `bun run test -- src/features/projects/useProjectAssistantController.test.ts src/features/projects/ProjectsView.test.tsx src/features/projects/ProjectAssistantPanel.test.tsx`
- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run build`
- `git diff --check`