### PR TITLE
Persist Project Assistant proposal ledger

### DIFF
--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/pluginregistry"
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -214,6 +215,7 @@ func runServe() {
 	memoryStore := buildMemoryStore(cfg, logger, sqliteClient, postgresClient)
 	projectWorkStore := buildProjectWorkStore(cfg, logger, sqliteClient, postgresClient)
 	projectSkillStore := buildProjectSkillStore(cfg, logger, sqliteClient, postgresClient)
+	projectAssistantProposalStore := buildProjectAssistantProposalStore(cfg, logger, sqliteClient, postgresClient)
 	pluginRegistryStore := buildPluginRegistryStore(cfg, logger, sqliteClient, postgresClient)
 	agentProfileStore := buildAgentProfileStore(cfg, logger, sqliteClient, postgresClient)
 	// Approval state follows HECATE_BACKEND so chat transcripts, grants,
@@ -287,6 +289,7 @@ func runServe() {
 	handler.SetMemoryStore(memoryStore)
 	handler.SetProjectWorkStore(projectWorkStore)
 	handler.SetProjectSkillStore(projectSkillStore)
+	handler.SetProjectAssistantProposalStore(projectAssistantProposalStore)
 	handler.SetPluginRegistryStore(pluginRegistryStore)
 	handler.SetAgentProfileStore(agentProfileStore)
 	handler.SetAgentApprovalStore(approvalStore)
@@ -894,6 +897,27 @@ func buildProjectSkillStore(cfg config.Config, logger *slog.Logger, sqliteClient
 		return store
 	default:
 		return projectskills.NewMemoryStore()
+	}
+}
+
+func buildProjectAssistantProposalStore(cfg config.Config, logger *slog.Logger, sqliteClient *storage.SQLiteClient, postgresClient *storage.PostgresClient) projectassistant.ProposalStore {
+	switch cfg.Projects.Backend {
+	case "sqlite":
+		store, err := projectassistant.NewSQLiteProposalStore(context.Background(), sqliteClient)
+		if err != nil {
+			logger.Error("project assistant proposal store init failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return store
+	case "postgres":
+		store, err := projectassistant.NewPostgresProposalStore(context.Background(), postgresClient)
+		if err != nil {
+			logger.Error("project assistant proposal store init failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return store
+	default:
+		return projectassistant.NewMemoryProposalStore()
 	}
 }
 

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -152,26 +152,32 @@ handoff, memory-candidate, and chat targets, including explicit resources
 created earlier in the same proposal. Deterministic stale-target failures
 therefore return `failed_action_index` with no new durable writes. After
 preflight, apply remains sequential across existing stores. A proposal id plus
-its canonical action set is the in-process progress boundary. If action N fails
-after earlier actions have already mutated durable stores, the API returns the
-partial action results and `failed_action_index`. Retrying the exact same
-proposal resumes at the next unapplied action. Retrying the same proposal id
-with a changed action set returns `409 conflict`, and retrying a fully applied
-proposal also returns `409 conflict`. Clients should show `status` first, then
-the landed action kinds and ids from `partial_result.actions`. The status is
-`applied` after a successful apply, `blocked_before_apply` when preflight
-stopped the current apply attempt before writing another action, or
+its canonical action set is the durable progress boundary. The proposal ledger
+is stored with the project operations backend (`memory`, `sqlite`, or
+`postgres`) and records the typed proposal, source metadata, latest apply
+result, and apply attempts. If action N fails after earlier actions have
+already mutated durable stores, the API returns the partial action results and
+`failed_action_index`, then records the failed attempt. Retrying the exact same
+proposal resumes at the next unapplied action, including after a runtime
+restart when the same durable backend is still available. Retrying the same
+proposal id with a changed action set returns `409 conflict`, and retrying a
+fully applied proposal also returns `409 conflict`. Clients should show
+`status` first, then the landed action kinds and ids from
+`partial_result.actions` or the proposal record's `latest_result.actions`.
+The status is `applied` after a successful apply, `blocked_before_apply` when
+preflight stopped the current apply attempt before writing another action, or
 `partial_due_to_runtime_failure` when a post-preflight store/runtime failure
 happened after apply began. `committed_action_count`, `failed_action_index`,
 `resume_action_index`, and `total_action_count` are the server-owned progress
 counters.
 
-Future versions may persist proposal ids server-side so reviewed actions,
-confirmation, and resumable progress survive process restarts. In v0 the
-progress map is process-local; a runtime restart between a partial apply and a
-retry loses that resume point, so clients should refresh the proposal before
-retrying after restart. The v0 API keeps the persisted shape possible without
-requiring it.
+The ledger is an audit and recovery surface, not an auto-apply queue. It does
+not grant agents authority, does not start assignments, and does not promote
+memory candidates. Durable project mutations still require the typed proposal
+body plus explicit operator confirmation through `/project-assistant/apply`.
+Project deletion removes scoped proposal records before deleting the project
+row; "No project" proposals remain valid and are not deleted by a project
+cascade.
 
 ## Endpoints
 
@@ -420,6 +426,58 @@ POST /hecate/v1/project-assistant/propose
 ```
 
 Unknown action kinds return `400 invalid_request`.
+
+### `GET /hecate/v1/project-assistant/proposals/{id}`
+
+Returns the durable proposal record for reload and recovery flows.
+
+```json
+GET /hecate/v1/project-assistant/proposals/pa_...
+→ 200
+{
+  "object": "project_assistant.proposal_record",
+  "data": {
+    "id": "pa_...",
+    "project_id": "proj_hecate",
+    "source": "draft",
+    "source_id": "deterministic",
+    "proposal": {
+      "id": "pa_...",
+      "title": "Create project work item",
+      "summary": "Create a ready work item from the current assistant draft.",
+      "actions": [],
+      "requires_confirmation": true
+    },
+    "status": "partial_due_to_runtime_failure",
+    "latest_result": {
+      "proposal_id": "pa_...",
+      "status": "partial_due_to_runtime_failure",
+      "applied": false,
+      "total_action_count": 2,
+      "committed_action_count": 1,
+      "failed_action_index": 1,
+      "resume_action_index": 1,
+      "actions": [
+        {
+          "kind": "create_work_item",
+          "id": "work_...",
+          "data": {
+            "project_id": "proj_hecate",
+            "work_item_id": "work_..."
+          }
+        }
+      ]
+    },
+    "apply_attempts": [],
+    "created_at": "2026-06-22T10:00:00Z",
+    "updated_at": "2026-06-22T10:01:00Z"
+  }
+}
+```
+
+Missing proposal ids return `404 not_found`. The endpoint is read-only; clients
+must still call `POST /hecate/v1/project-assistant/apply` with `confirm: true`
+to mutate durable project state.
 
 ### `POST /hecate/v1/project-assistant/apply`
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3682,6 +3682,7 @@ Endpoints:
 - `POST /hecate/v1/project-assistant/draft`
 - `POST /hecate/v1/project-assistant/propose`
 - `POST /hecate/v1/project-assistant/apply`
+- `GET /hecate/v1/project-assistant/proposals/{id}`
 - `POST /hecate/v1/chat/sessions/{id}/project-assistant/draft`
 
 `context` returns the v0 item-limited and body-budgeted project packet plus the
@@ -3713,6 +3714,13 @@ safety model.
 requires `review_artifact_id` and returns a proposal to create a follow-up
 handoff, create a queued assignment, and link the handoff to that assignment.
 It does not start the assignment or mutate project work before apply.
+
+`GET /hecate/v1/project-assistant/proposals/{id}` returns the durable proposal
+record for reload/recovery flows: typed proposal, project/source metadata,
+latest apply result, and apply attempts. Proposal records follow the project
+operations backend and are read-only through this endpoint. Applying still
+requires `POST /hecate/v1/project-assistant/apply` with `confirm: true`; the
+record endpoint does not grant model-callable mutation authority.
 
 `POST /hecate/v1/chat/sessions/{id}/project-assistant/draft` is the Chat
 handoff variant for project-linked Hecate Chat sessions. The request body

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -58,13 +58,14 @@ func (h *Handler) projectApplication() *projectapp.Application {
 		return projectapp.New(projectapp.Options{})
 	}
 	return projectapp.New(projectapp.Options{
-		Projects:         h.projects,
-		Chats:            h.agentChat,
-		DeleteChat:       h.deleteProjectChatSession,
-		ProjectWork:      h.projectWork,
-		ProjectSkills:    h.projectSkills,
-		Memory:           h.memory,
-		MemoryCandidates: h.memoryCandidates,
+		Projects:                  h.projects,
+		Chats:                     h.agentChat,
+		DeleteChat:                h.deleteProjectChatSession,
+		ProjectWork:               h.projectWork,
+		ProjectSkills:             h.projectSkills,
+		ProjectAssistantProposals: h.projectAssistantProposals,
+		Memory:                    h.memory,
+		MemoryCandidates:          h.memoryCandidates,
 	})
 }
 
@@ -102,6 +103,7 @@ func (h *Handler) projectAssistantApplication() *projectassistantapp.Application
 			ProjectSkills:    h.projectSkills,
 			Memory:           h.memory,
 			MemoryCandidates: h.memoryCandidates,
+			Proposals:        h.projectAssistantProposals,
 			LLM:              gatewayAgentLLMClient{service: h.service},
 			IDGenerator:      newOpaqueTaskResourceID,
 		})

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/pluginregistry"
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
@@ -39,28 +40,29 @@ import (
 )
 
 type Handler struct {
-	config                   config.Config
-	logger                   *slog.Logger
-	service                  *gateway.Service
-	controlPlane             controlplane.Store
-	providerRuntime          ProviderRuntime
-	taskStore                taskstate.Store
-	taskRunner               *orchestrator.Runner
-	tracer                   profiler.Tracer
-	agentChat                chat.Store
-	projects                 projects.Store
-	memory                   memory.Store
-	memoryCandidates         memory.CandidateStore
-	projectWork              projectwork.Store
-	projectSkills            projectskills.Store
-	pluginRegistry           pluginregistry.Store
-	projectAssistantMu       sync.Mutex
-	projectAssistant         *projectassistantapp.Application
-	agentProfiles            agentprofiles.Store
-	agentChatRunner          agentadapters.Runner
-	agentChatLive            *agentChatLive
-	agentChatIdleSweepCancel context.CancelFunc
-	rateLimiter              *ratelimit.Store
+	config                    config.Config
+	logger                    *slog.Logger
+	service                   *gateway.Service
+	controlPlane              controlplane.Store
+	providerRuntime           ProviderRuntime
+	taskStore                 taskstate.Store
+	taskRunner                *orchestrator.Runner
+	tracer                    profiler.Tracer
+	agentChat                 chat.Store
+	projects                  projects.Store
+	memory                    memory.Store
+	memoryCandidates          memory.CandidateStore
+	projectWork               projectwork.Store
+	projectSkills             projectskills.Store
+	projectAssistantProposals projectassistant.ProposalStore
+	pluginRegistry            pluginregistry.Store
+	projectAssistantMu        sync.Mutex
+	projectAssistant          *projectassistantapp.Application
+	agentProfiles             agentprofiles.Store
+	agentChatRunner           agentadapters.Runner
+	agentChatLive             *agentChatLive
+	agentChatIdleSweepCancel  context.CancelFunc
+	rateLimiter               *ratelimit.Store
 	// secretCipher encrypts literal MCP server env values at task-creation
 	// time and wires the matching decrypting factory into the runner. nil
 	// when no settings key is configured — values are stored as-is
@@ -311,28 +313,29 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 
 	memoryStore := memory.NewMemoryStore()
 	h := &Handler{
-		config:              cfg,
-		logger:              logger,
-		service:             service,
-		controlPlane:        cpStore,
-		providerRuntime:     providerRuntime,
-		taskStore:           taskStore,
-		taskRunner:          runner,
-		tracer:              tracer,
-		rateLimiter:         rl,
-		agentChat:           chat.NewMemoryStore(),
-		projects:            projects.NewMemoryStore(),
-		memory:              memoryStore,
-		memoryCandidates:    memoryStore,
-		projectWork:         projectwork.NewMemoryStore(),
-		projectSkills:       projectskills.NewMemoryStore(),
-		pluginRegistry:      pluginregistry.NewMemoryStore(),
-		agentProfiles:       agentprofiles.NewMemoryStore(),
-		agentChatRunner:     agentChatRunner,
-		agentChatLive:       agentChatLive,
-		orchestratorMetrics: orchestratorMetrics,
-		agentChatMetrics:    agentChatMetrics,
-		approvalConfig:      approvalCfg,
+		config:                    cfg,
+		logger:                    logger,
+		service:                   service,
+		controlPlane:              cpStore,
+		providerRuntime:           providerRuntime,
+		taskStore:                 taskStore,
+		taskRunner:                runner,
+		tracer:                    tracer,
+		rateLimiter:               rl,
+		agentChat:                 chat.NewMemoryStore(),
+		projects:                  projects.NewMemoryStore(),
+		memory:                    memoryStore,
+		memoryCandidates:          memoryStore,
+		projectWork:               projectwork.NewMemoryStore(),
+		projectSkills:             projectskills.NewMemoryStore(),
+		projectAssistantProposals: projectassistant.NewMemoryProposalStore(),
+		pluginRegistry:            pluginregistry.NewMemoryStore(),
+		agentProfiles:             agentprofiles.NewMemoryStore(),
+		agentChatRunner:           agentChatRunner,
+		agentChatLive:             agentChatLive,
+		orchestratorMetrics:       orchestratorMetrics,
+		agentChatMetrics:          agentChatMetrics,
+		approvalConfig:            approvalCfg,
 	}
 	h.wireAgentChatRunnerHooks(agentChatRunner)
 	runner.SetProjectAssistantDraftTool(h)
@@ -438,6 +441,16 @@ func (h *Handler) SetProjectSkillStore(store projectskills.Store) {
 		return
 	}
 	h.projectSkills = store
+	h.projectAssistantMu.Lock()
+	h.projectAssistant = nil
+	h.projectAssistantMu.Unlock()
+}
+
+func (h *Handler) SetProjectAssistantProposalStore(store projectassistant.ProposalStore) {
+	if store == nil {
+		return
+	}
+	h.projectAssistantProposals = store
 	h.projectAssistantMu.Lock()
 	h.projectAssistant = nil
 	h.projectAssistantMu.Unlock()

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -175,6 +175,22 @@ func (h *Handler) HandleProjectAssistantPropose(w http.ResponseWriter, r *http.R
 	})
 }
 
+func (h *Handler) HandleProjectAssistantProposal(w http.ResponseWriter, r *http.Request) {
+	record, ok, err := h.projectAssistantApplication().Proposal(r.Context(), r.PathValue("id"))
+	if err != nil {
+		writeProjectAssistantError(w, err)
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project assistant proposal not found")
+		return
+	}
+	WriteJSON(w, http.StatusOK, map[string]any{
+		"object": "project_assistant.proposal_record",
+		"data":   record,
+	})
+}
+
 func (h *Handler) HandleProjectAssistantApply(w http.ResponseWriter, r *http.Request) {
 	var req projectAssistantApplyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -24,6 +24,11 @@ type projectAssistantProposalResponse struct {
 	Data   projectassistant.Proposal `json:"data"`
 }
 
+type projectAssistantProposalRecordResponse struct {
+	Object string                          `json:"object"`
+	Data   projectassistant.ProposalRecord `json:"data"`
+}
+
 type projectAssistantApplyResponse struct {
 	Object string                       `json:"object"`
 	Data   projectassistant.ApplyResult `json:"data"`
@@ -611,6 +616,22 @@ func TestProjectAssistantAPI_ProposeAndApplyCreateProject(t *testing.T) {
 		t.Fatalf("proposal actions = %+v, want create_project action", proposed.Data.Actions)
 	}
 
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/project-assistant/proposals/pa_api", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get proposal status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposalRecord projectAssistantProposalRecordResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposalRecord); err != nil {
+		t.Fatalf("decode proposal record response: %v", err)
+	}
+	if proposalRecord.Object != "project_assistant.proposal_record" || proposalRecord.Data.ID != "pa_api" || proposalRecord.Data.Status != projectassistant.ProposalStatusProposed {
+		t.Fatalf("proposal record = %+v, want proposed record", proposalRecord)
+	}
+	if proposalRecord.Data.ProjectID != "proj_api" || proposalRecord.Data.Source != projectassistant.ProposalSourceAPI {
+		t.Fatalf("proposal record project/source = %q/%q, want proj_api/api", proposalRecord.Data.ProjectID, proposalRecord.Data.Source)
+	}
+
 	applyBody, err := json.Marshal(map[string]any{"proposal": proposed.Data})
 	if err != nil {
 		t.Fatalf("marshal apply body: %v", err)
@@ -639,6 +660,18 @@ func TestProjectAssistantAPI_ProposeAndApplyCreateProject(t *testing.T) {
 	}
 	if applied.Data.TotalActionCount != 1 || applied.Data.CommittedActionCount != 1 || applied.Data.ResumeActionIndex != 1 || applied.Data.FailedActionIndex != nil {
 		t.Fatalf("apply progress = %+v, want applied counts for one action", applied.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/project-assistant/proposals/pa_api", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get applied proposal status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposalRecord); err != nil {
+		t.Fatalf("decode applied proposal record response: %v", err)
+	}
+	if proposalRecord.Data.Status != projectassistant.ApplyStatusApplied || proposalRecord.Data.LatestResult == nil || !proposalRecord.Data.LatestResult.Applied || len(proposalRecord.Data.ApplyAttempts) != 1 {
+		t.Fatalf("applied proposal record = %+v, want applied latest result with one attempt", proposalRecord.Data)
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -636,13 +636,14 @@ func renderProject(project projects.Project) ProjectResponseItem {
 
 func renderProjectDeleteResult(result projectapp.DeleteProjectResult) ProjectDeleteResponseItem {
 	return ProjectDeleteResponseItem{
-		ProjectID:               result.Project.ID,
-		ProjectName:             result.Project.Name,
-		ChatSessionsDeleted:     result.ChatSessionsDeleted,
-		ProjectWorkRowsDeleted:  result.ProjectWorkRowsDeleted,
-		ProjectSkillsDeleted:    result.ProjectSkillsDeleted,
-		MemoryEntriesDeleted:    result.MemoryEntriesDeleted,
-		MemoryCandidatesDeleted: result.MemoryCandidatesDeleted,
+		ProjectID:                        result.Project.ID,
+		ProjectName:                      result.Project.Name,
+		ChatSessionsDeleted:              result.ChatSessionsDeleted,
+		ProjectWorkRowsDeleted:           result.ProjectWorkRowsDeleted,
+		ProjectSkillsDeleted:             result.ProjectSkillsDeleted,
+		ProjectAssistantProposalsDeleted: result.ProjectAssistantProposalsDeleted,
+		MemoryEntriesDeleted:             result.MemoryEntriesDeleted,
+		MemoryCandidatesDeleted:          result.MemoryCandidatesDeleted,
 	}
 }
 

--- a/internal/api/handler_system_reset.go
+++ b/internal/api/handler_system_reset.go
@@ -60,6 +60,12 @@ func (h *Handler) resetSystemData(ctx context.Context) (SystemResetDataResponseI
 	}
 	stats.ProjectSkillsDeleted = projectSkillsDeleted
 
+	projectAssistantProposalsDeleted, err := h.resetProjectAssistantProposals(ctx)
+	if err != nil {
+		return stats, err
+	}
+	stats.ProjectAssistantProposalsDeleted = projectAssistantProposalsDeleted
+
 	pluginsDeleted, err := h.resetPlugins(ctx)
 	if err != nil {
 		return stats, err
@@ -165,6 +171,13 @@ func (h *Handler) resetProjectSkills(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 	return h.projectSkills.Clear(ctx)
+}
+
+func (h *Handler) resetProjectAssistantProposals(ctx context.Context) (int, error) {
+	if h.projectAssistantProposals == nil {
+		return 0, nil
+	}
+	return h.projectAssistantProposals.Clear(ctx)
 }
 
 func (h *Handler) resetPlugins(ctx context.Context) (int, error) {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -280,13 +280,14 @@ type ProjectDeleteResponse struct {
 }
 
 type ProjectDeleteResponseItem struct {
-	ProjectID               string `json:"project_id"`
-	ProjectName             string `json:"project_name,omitempty"`
-	ChatSessionsDeleted     int    `json:"chat_sessions_deleted"`
-	ProjectWorkRowsDeleted  int    `json:"project_work_rows_deleted"`
-	ProjectSkillsDeleted    int    `json:"project_skills_deleted"`
-	MemoryEntriesDeleted    int    `json:"memory_entries_deleted"`
-	MemoryCandidatesDeleted int    `json:"memory_candidates_deleted"`
+	ProjectID                        string `json:"project_id"`
+	ProjectName                      string `json:"project_name,omitempty"`
+	ChatSessionsDeleted              int    `json:"chat_sessions_deleted"`
+	ProjectWorkRowsDeleted           int    `json:"project_work_rows_deleted"`
+	ProjectSkillsDeleted             int    `json:"project_skills_deleted"`
+	ProjectAssistantProposalsDeleted int    `json:"project_assistant_proposals_deleted"`
+	MemoryEntriesDeleted             int    `json:"memory_entries_deleted"`
+	MemoryCandidatesDeleted          int    `json:"memory_candidates_deleted"`
 }
 
 type AgentProfileResponse struct {
@@ -1378,17 +1379,18 @@ type SystemResetDataResponse struct {
 }
 
 type SystemResetDataResponseItem struct {
-	ProjectsDeleted            int `json:"projects_deleted"`
-	ProjectSkillsDeleted       int `json:"project_skills_deleted"`
-	ProjectWorkRowsDeleted     int `json:"project_work_rows_deleted"`
-	PluginsDeleted             int `json:"plugins_deleted"`
-	AgentProfilesDeleted       int `json:"agent_profiles_deleted"`
-	ChatSessionsDeleted        int `json:"chat_sessions_deleted"`
-	TasksDeleted               int `json:"tasks_deleted"`
-	ProvidersDeleted           int `json:"providers_deleted"`
-	PolicyRulesDeleted         int `json:"policy_rules_deleted"`
-	AgentApprovalGrantsDeleted int `json:"agent_approval_grants_deleted"`
-	DatabaseRowsDeleted        int `json:"database_rows_deleted"`
+	ProjectsDeleted                  int `json:"projects_deleted"`
+	ProjectSkillsDeleted             int `json:"project_skills_deleted"`
+	ProjectWorkRowsDeleted           int `json:"project_work_rows_deleted"`
+	ProjectAssistantProposalsDeleted int `json:"project_assistant_proposals_deleted"`
+	PluginsDeleted                   int `json:"plugins_deleted"`
+	AgentProfilesDeleted             int `json:"agent_profiles_deleted"`
+	ChatSessionsDeleted              int `json:"chat_sessions_deleted"`
+	TasksDeleted                     int `json:"tasks_deleted"`
+	ProvidersDeleted                 int `json:"providers_deleted"`
+	PolicyRulesDeleted               int `json:"policy_rules_deleted"`
+	AgentApprovalGrantsDeleted       int `json:"agent_approval_grants_deleted"`
+	DatabaseRowsDeleted              int `json:"database_rows_deleted"`
 }
 
 type UsageSummaryResponseItem struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -40,6 +40,7 @@ var remoteRuntimeAllowedRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/project-assistant/draft"},
 	{method: http.MethodPost, path: "/hecate/v1/project-assistant/propose"},
 	{method: http.MethodPost, path: "/hecate/v1/project-assistant/apply"},
+	{method: http.MethodGet, path: "/hecate/v1/project-assistant/proposals/{id}"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}"},
 	{method: http.MethodPatch, path: "/hecate/v1/projects/{id}"},
 	{method: http.MethodDelete, path: "/hecate/v1/projects/{id}"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -77,6 +77,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/project-assistant/draft", handler.HandleProjectAssistantDraft)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/propose", handler.HandleProjectAssistantPropose)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/apply", handler.HandleProjectAssistantApply)
+	mux.HandleFunc("GET /hecate/v1/project-assistant/proposals/{id}", handler.HandleProjectAssistantProposal)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)

--- a/internal/projectapp/application.go
+++ b/internal/projectapp/application.go
@@ -49,44 +49,52 @@ type MemoryCandidateStore interface {
 	DeleteCandidatesByProjectID(ctx context.Context, projectID string) (int, error)
 }
 
+type ProjectAssistantProposalStore interface {
+	DeleteProject(ctx context.Context, projectID string) (int, error)
+}
+
 type Application struct {
-	projects         ProjectStore
-	chats            ChatSessionStore
-	deleteChat       ChatDeleteFunc
-	projectWork      ProjectWorkStore
-	projectSkills    ProjectSkillStore
-	memory           MemoryStore
-	memoryCandidates MemoryCandidateStore
+	projects                  ProjectStore
+	chats                     ChatSessionStore
+	deleteChat                ChatDeleteFunc
+	projectWork               ProjectWorkStore
+	projectSkills             ProjectSkillStore
+	projectAssistantProposals ProjectAssistantProposalStore
+	memory                    MemoryStore
+	memoryCandidates          MemoryCandidateStore
 }
 
 type Options struct {
-	Projects         ProjectStore
-	Chats            ChatSessionStore
-	DeleteChat       ChatDeleteFunc
-	ProjectWork      ProjectWorkStore
-	ProjectSkills    ProjectSkillStore
-	Memory           MemoryStore
-	MemoryCandidates MemoryCandidateStore
+	Projects                  ProjectStore
+	Chats                     ChatSessionStore
+	DeleteChat                ChatDeleteFunc
+	ProjectWork               ProjectWorkStore
+	ProjectSkills             ProjectSkillStore
+	ProjectAssistantProposals ProjectAssistantProposalStore
+	Memory                    MemoryStore
+	MemoryCandidates          MemoryCandidateStore
 }
 
 type DeleteProjectResult struct {
-	Project                 projects.Project
-	ChatSessionsDeleted     int
-	ProjectWorkRowsDeleted  int
-	ProjectSkillsDeleted    int
-	MemoryEntriesDeleted    int
-	MemoryCandidatesDeleted int
+	Project                          projects.Project
+	ChatSessionsDeleted              int
+	ProjectWorkRowsDeleted           int
+	ProjectSkillsDeleted             int
+	ProjectAssistantProposalsDeleted int
+	MemoryEntriesDeleted             int
+	MemoryCandidatesDeleted          int
 }
 
 func New(opts Options) *Application {
 	return &Application{
-		projects:         opts.Projects,
-		chats:            opts.Chats,
-		deleteChat:       opts.DeleteChat,
-		projectWork:      opts.ProjectWork,
-		projectSkills:    opts.ProjectSkills,
-		memory:           opts.Memory,
-		memoryCandidates: opts.MemoryCandidates,
+		projects:                  opts.Projects,
+		chats:                     opts.Chats,
+		deleteChat:                opts.DeleteChat,
+		projectWork:               opts.ProjectWork,
+		projectSkills:             opts.ProjectSkills,
+		projectAssistantProposals: opts.ProjectAssistantProposals,
+		memory:                    opts.Memory,
+		memoryCandidates:          opts.MemoryCandidates,
 	}
 }
 
@@ -335,6 +343,13 @@ func (app *Application) DeleteProject(ctx context.Context, id string) (DeletePro
 			return result, err
 		}
 		result.ProjectSkillsDeleted = deleted
+	}
+	if app.projectAssistantProposals != nil {
+		deleted, err := app.projectAssistantProposals.DeleteProject(ctx, projectID)
+		if err != nil {
+			return result, err
+		}
+		result.ProjectAssistantProposalsDeleted = deleted
 	}
 	if app.memory != nil {
 		deleted, err := app.memory.DeleteByProjectID(ctx, projectID)

--- a/internal/projectapp/application_test.go
+++ b/internal/projectapp/application_test.go
@@ -2,11 +2,13 @@ package projectapp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -20,6 +22,7 @@ func TestApplication_DeleteProjectCleansProjectScopedStores(t *testing.T) {
 	chatStore := chat.NewMemoryStore()
 	workStore := projectwork.NewMemoryStore()
 	skillStore := projectskills.NewMemoryStore()
+	proposalStore := projectassistant.NewMemoryProposalStore()
 	memoryStore := memory.NewMemoryStore()
 	projectID := "proj_delete"
 	otherProjectID := "proj_other"
@@ -66,23 +69,56 @@ func TestApplication_DeleteProjectCleansProjectScopedStores(t *testing.T) {
 	if _, err := memoryStore.CreateCandidate(ctx, memory.Candidate{ID: "cand_keep", ProjectID: otherProjectID, Title: "Keep", Body: "Keep"}); err != nil {
 		t.Fatalf("CreateCandidate(other): %v", err)
 	}
+	if _, err := proposalStore.UpsertProposal(ctx, projectassistant.ProposalRecord{
+		ID:        "pa_delete",
+		ProjectID: projectID,
+		Source:    projectassistant.ProposalSourceAPI,
+		Proposal: projectassistant.Proposal{
+			ID:                   "pa_delete",
+			Title:                "Delete scoped proposal",
+			RequiresConfirmation: true,
+			Actions: []projectassistant.Action{{
+				Kind:  projectassistant.ActionCreateMemoryCandidate,
+				Patch: jsonRaw(t, map[string]string{"project_id": projectID, "title": "Candidate"}),
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("UpsertProposal(project): %v", err)
+	}
+	if _, err := proposalStore.UpsertProposal(ctx, projectassistant.ProposalRecord{
+		ID:        "pa_keep",
+		ProjectID: otherProjectID,
+		Source:    projectassistant.ProposalSourceAPI,
+		Proposal: projectassistant.Proposal{
+			ID:                   "pa_keep",
+			Title:                "Keep proposal",
+			RequiresConfirmation: true,
+			Actions: []projectassistant.Action{{
+				Kind:  projectassistant.ActionCreateMemoryCandidate,
+				Patch: jsonRaw(t, map[string]string{"project_id": otherProjectID, "title": "Candidate"}),
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("UpsertProposal(other): %v", err)
+	}
 
 	deletedChats := make([]string, 0, 1)
 	app := New(Options{
-		Projects:         projectStore,
-		Chats:            chatStore,
-		DeleteChat:       deleteChatFromStore(chatStore, &deletedChats, false),
-		ProjectWork:      workStore,
-		ProjectSkills:    skillStore,
-		Memory:           memoryStore,
-		MemoryCandidates: memoryStore,
+		Projects:                  projectStore,
+		Chats:                     chatStore,
+		DeleteChat:                deleteChatFromStore(chatStore, &deletedChats, false),
+		ProjectWork:               workStore,
+		ProjectSkills:             skillStore,
+		ProjectAssistantProposals: proposalStore,
+		Memory:                    memoryStore,
+		MemoryCandidates:          memoryStore,
 	})
 	result, err := app.DeleteProject(ctx, projectID)
 	if err != nil {
 		t.Fatalf("DeleteProject() error = %v", err)
 	}
 	if result.Project.ID != projectID || result.ChatSessionsDeleted != 1 || result.ProjectWorkRowsDeleted != 2 ||
-		result.ProjectSkillsDeleted != 1 || result.MemoryEntriesDeleted != 1 || result.MemoryCandidatesDeleted != 1 {
+		result.ProjectSkillsDeleted != 1 || result.ProjectAssistantProposalsDeleted != 1 || result.MemoryEntriesDeleted != 1 || result.MemoryCandidatesDeleted != 1 {
 		t.Fatalf("DeleteProject() result = %+v, want project and scoped delete counts", result)
 	}
 	if len(deletedChats) != 1 || deletedChats[0] != "chat_delete" {
@@ -110,6 +146,12 @@ func TestApplication_DeleteProjectCleansProjectScopedStores(t *testing.T) {
 		items, err := skillStore.List(ctx, otherProjectID)
 		return len(items), err
 	}, 1)
+	if _, ok, err := proposalStore.GetProposal(ctx, "pa_delete"); err != nil || ok {
+		t.Fatalf("GetProposal(deleted) ok=%v err=%v, want missing", ok, err)
+	}
+	if _, ok, err := proposalStore.GetProposal(ctx, "pa_keep"); err != nil || !ok {
+		t.Fatalf("GetProposal(other) ok=%v err=%v, want present", ok, err)
+	}
 	assertProjectAppListCount(t, "project memory", func() (int, error) {
 		items, err := memoryStore.List(ctx, memory.Filter{ProjectID: projectID, IncludeDisabled: true})
 		return len(items), err
@@ -493,4 +535,13 @@ func assertProjectAppListCount(t *testing.T, label string, list func() (int, err
 	if got != want {
 		t.Fatalf("%s count = %d, want %d", label, got, want)
 	}
+}
+
+func jsonRaw(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal(%#v): %v", value, err)
+	}
+	return raw
 }

--- a/internal/projectassistant/bootstrap.go
+++ b/internal/projectassistant/bootstrap.go
@@ -30,15 +30,18 @@ func (s *Service) draftBootstrap(ctx context.Context, input DraftInput, draftCon
 	}
 
 	proposal, err := s.Propose(ctx, ProposalInput{
-		Title:   fmt.Sprintf("Set up %s guidance", firstNonEmpty(draftContext.Project.Name, projectID)),
-		Summary: "Create reviewable memory candidates from discovered guidance metadata and suggest project roles from local skill files.",
-		Actions: actions,
-		TraceID: strings.TrimSpace(input.TraceID),
+		ProjectID: projectID,
+		Source:    ProposalSourceBootstrap,
+		SourceID:  DraftModeBootstrap,
+		Title:     fmt.Sprintf("Set up %s guidance", firstNonEmpty(draftContext.Project.Name, projectID)),
+		Summary:   "Create reviewable memory candidates from discovered guidance metadata and suggest project roles from local skill files.",
+		Actions:   actions,
+		Warnings:  warnings,
+		TraceID:   strings.TrimSpace(input.TraceID),
 	})
 	if err != nil {
 		return Proposal{}, err
 	}
-	proposal.Warnings = warnings
 	return proposal, nil
 }
 

--- a/internal/projectassistant/model_draft.go
+++ b/internal/projectassistant/model_draft.go
@@ -65,10 +65,13 @@ func (s *Service) draftWithModel(ctx context.Context, input DraftInput, draftCon
 		return Proposal{}, err
 	}
 	return s.Propose(ctx, ProposalInput{
-		Title:   draft.Title,
-		Summary: draft.Summary,
-		Actions: draft.Actions,
-		TraceID: strings.TrimSpace(input.TraceID),
+		ProjectID: draftContext.Project.ID,
+		Source:    ProposalSourceModelDraft,
+		SourceID:  strings.TrimSpace(firstNonEmpty(provider, model)),
+		Title:     draft.Title,
+		Summary:   draft.Summary,
+		Actions:   draft.Actions,
+		TraceID:   strings.TrimSpace(input.TraceID),
 	})
 }
 

--- a/internal/projectassistant/proposal_apply.go
+++ b/internal/projectassistant/proposal_apply.go
@@ -28,25 +28,28 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 	}
 
 	// Hold the apply lock through the mutation sequence so a proposal ID cannot
-	// race itself into duplicate durable writes. Progress is intentionally
-	// in-process for v0; retrying the exact same action set resumes after the
-	// last committed action instead of replaying earlier mutations.
+	// race itself into duplicate durable writes. The proposal ledger records the
+	// latest committed action count so retrying the same action set resumes after
+	// the last ledgered mutation instead of replaying earlier actions.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	progress, ok := s.applyProgress[proposal.ID]
-	if !ok {
-		progress = &applyProgress{fingerprint: fingerprint}
-		s.applyProgress[proposal.ID] = progress
+	record, err := s.ensureApplyProposalRecord(ctx, proposal, fingerprint)
+	if err != nil {
+		return ApplyResult{}, err
 	}
-	if progress.complete {
+	if record.LatestResult != nil && record.LatestResult.Applied {
 		return ApplyResult{}, fmt.Errorf("%w: proposal %q was already applied", ErrConflict, proposal.ID)
 	}
-	if progress.fingerprint != fingerprint {
-		return ApplyResult{}, fmt.Errorf("%w: proposal %q action set changed after partial apply", ErrConflict, proposal.ID)
+	if record.Status == ApplyStatusApplied {
+		return ApplyResult{}, fmt.Errorf("%w: proposal %q was already applied", ErrConflict, proposal.ID)
 	}
-	if failedActionIndex, err := s.preflightApply(ctx, proposal.Actions, len(progress.results)); err != nil {
-		partial := applyResult(proposal.ID, ApplyStatusBlockedBeforeApply, false, len(proposal.Actions), &failedActionIndex, progress.results)
+	results := applyRecordResults(record)
+	if failedActionIndex, err := s.preflightApply(ctx, proposal.Actions, len(results)); err != nil {
+		partial := applyResult(proposal.ID, ApplyStatusBlockedBeforeApply, false, len(proposal.Actions), &failedActionIndex, results)
+		if _, ledgerErr := s.proposals.RecordApplyAttempt(ctx, applyAttemptForResult(s.idgen("paatt"), confirmed, partial, err)); ledgerErr != nil {
+			err = fmt.Errorf("%v; record apply attempt: %w", err, ledgerErr)
+		}
 		return partial, &ApplyError{
 			ProposalID:        proposal.ID,
 			FailedActionIndex: failedActionIndex,
@@ -55,11 +58,14 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 		}
 	}
 
-	for idx := len(progress.results); idx < len(proposal.Actions); idx++ {
+	for idx := len(results); idx < len(proposal.Actions); idx++ {
 		action := proposal.Actions[idx]
 		result, err := s.applyAction(ctx, action)
 		if err != nil {
-			partial := applyResult(proposal.ID, ApplyStatusPartialDueToRuntimeFailure, false, len(proposal.Actions), &idx, progress.results)
+			partial := applyResult(proposal.ID, ApplyStatusPartialDueToRuntimeFailure, false, len(proposal.Actions), &idx, results)
+			if _, ledgerErr := s.proposals.RecordApplyAttempt(ctx, applyAttemptForResult(s.idgen("paatt"), confirmed, partial, err)); ledgerErr != nil {
+				err = fmt.Errorf("%v; record apply attempt: %w", err, ledgerErr)
+			}
 			return partial, &ApplyError{
 				ProposalID:        proposal.ID,
 				FailedActionIndex: idx,
@@ -67,12 +73,48 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 				Err:               err,
 			}
 		}
-		progress.results = append(progress.results, result)
+		results = append(results, result)
+		progress := applyResult(proposal.ID, ProposalStatusApplying, false, len(proposal.Actions), nil, results)
+		if _, err := s.proposals.UpdateProposalApplyState(ctx, proposal.ID, progress); err != nil {
+			partial := applyResult(proposal.ID, ApplyStatusPartialDueToRuntimeFailure, false, len(proposal.Actions), &idx, results)
+			return partial, &ApplyError{
+				ProposalID:        proposal.ID,
+				FailedActionIndex: idx,
+				Result:            partial,
+				Err:               err,
+			}
+		}
 	}
 
-	progress.complete = true
+	applied := applyResult(proposal.ID, ApplyStatusApplied, true, len(proposal.Actions), nil, results)
+	if _, err := s.proposals.RecordApplyAttempt(ctx, applyAttemptForResult(s.idgen("paatt"), confirmed, applied, nil)); err != nil {
+		return applied, err
+	}
+	return applied, nil
+}
 
-	return applyResult(proposal.ID, ApplyStatusApplied, true, len(proposal.Actions), nil, progress.results), nil
+func (s *Service) ensureApplyProposalRecord(ctx context.Context, proposal Proposal, fingerprint string) (ProposalRecord, error) {
+	if s == nil || s.proposals == nil {
+		return ProposalRecord{}, ErrStoreNotConfigured
+	}
+	record, ok, err := s.proposals.GetProposal(ctx, proposal.ID)
+	if err != nil {
+		return ProposalRecord{}, err
+	}
+	if ok {
+		if strings.TrimSpace(record.Fingerprint) != fingerprint {
+			return ProposalRecord{}, fmt.Errorf("%w: proposal %q action set changed after partial apply", ErrConflict, proposal.ID)
+		}
+		return record, nil
+	}
+	return s.storeProposal(ctx, proposal, proposalProjectID(proposal), ProposalSourceApplyRequest, "")
+}
+
+func applyRecordResults(record ProposalRecord) []ActionResult {
+	if record.LatestResult == nil {
+		return nil
+	}
+	return cloneActionResults(record.LatestResult.Actions)
 }
 
 type applyActionSpec struct {

--- a/internal/projectassistant/proposal_store.go
+++ b/internal/projectassistant/proposal_store.go
@@ -1,0 +1,461 @@
+package projectassistant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	ProposalStatusProposed = "proposed"
+	ProposalStatusApplying = "applying"
+
+	ProposalSourceAPI            = "api"
+	ProposalSourceApplyRequest   = "apply_request"
+	ProposalSourceBootstrap      = "bootstrap"
+	ProposalSourceDraft          = "draft"
+	ProposalSourceModelDraft     = "model_draft"
+	ProposalSourceReviewFollowUp = "review_follow_up"
+)
+
+type ProposalStore interface {
+	Backend() string
+	UpsertProposal(ctx context.Context, record ProposalRecord) (ProposalRecord, error)
+	GetProposal(ctx context.Context, id string) (ProposalRecord, bool, error)
+	UpdateProposalApplyState(ctx context.Context, proposalID string, result ApplyResult) (ProposalRecord, error)
+	RecordApplyAttempt(ctx context.Context, attempt ApplyAttempt) (ProposalRecord, error)
+	DeleteProject(ctx context.Context, projectID string) (int, error)
+	Clear(ctx context.Context) (int, error)
+}
+
+type ProposalRecord struct {
+	ID            string         `json:"id"`
+	ProjectID     string         `json:"project_id,omitempty"`
+	Source        string         `json:"source,omitempty"`
+	SourceID      string         `json:"source_id,omitempty"`
+	Proposal      Proposal       `json:"proposal"`
+	Status        string         `json:"status"`
+	LatestResult  *ApplyResult   `json:"latest_result,omitempty"`
+	ApplyAttempts []ApplyAttempt `json:"apply_attempts,omitempty"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	AppliedAt     *time.Time     `json:"applied_at,omitempty"`
+
+	Fingerprint string `json:"-"`
+}
+
+type ApplyAttempt struct {
+	ID           string      `json:"id"`
+	ProposalID   string      `json:"proposal_id"`
+	Status       string      `json:"status"`
+	Confirmed    bool        `json:"confirmed"`
+	Result       ApplyResult `json:"result"`
+	ErrorType    string      `json:"error_type,omitempty"`
+	ErrorMessage string      `json:"error_message,omitempty"`
+	CreatedAt    time.Time   `json:"created_at"`
+}
+
+type MemoryProposalStore struct {
+	mu        sync.Mutex
+	proposals map[string]ProposalRecord
+	attempts  map[string][]ApplyAttempt
+}
+
+func NewMemoryProposalStore() *MemoryProposalStore {
+	return &MemoryProposalStore{
+		proposals: make(map[string]ProposalRecord),
+		attempts:  make(map[string][]ApplyAttempt),
+	}
+}
+
+func (s *MemoryProposalStore) Backend() string { return "memory" }
+
+func (s *MemoryProposalStore) UpsertProposal(_ context.Context, record ProposalRecord) (ProposalRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	if existing, ok := s.proposals[strings.TrimSpace(record.ID)]; ok && !existing.CreatedAt.IsZero() {
+		record.CreatedAt = existing.CreatedAt
+		if record.LatestResult == nil {
+			record.LatestResult = cloneApplyResultPtr(existing.LatestResult)
+		}
+		if record.AppliedAt == nil {
+			record.AppliedAt = cloneTimePtr(existing.AppliedAt)
+		}
+		if strings.TrimSpace(record.Status) == "" {
+			record.Status = existing.Status
+		}
+	}
+	record = normalizeProposalRecord(record, now)
+	if err := validateProposalRecord(record); err != nil {
+		return ProposalRecord{}, err
+	}
+	s.proposals[record.ID] = cloneProposalRecord(record)
+	return s.proposalWithAttemptsLocked(record.ID), nil
+}
+
+func (s *MemoryProposalStore) GetProposal(_ context.Context, id string) (ProposalRecord, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id = strings.TrimSpace(id)
+	if _, ok := s.proposals[id]; !ok {
+		return ProposalRecord{}, false, nil
+	}
+	return s.proposalWithAttemptsLocked(id), true, nil
+}
+
+func (s *MemoryProposalStore) UpdateProposalApplyState(_ context.Context, proposalID string, result ApplyResult) (ProposalRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	proposalID = strings.TrimSpace(proposalID)
+	record, ok := s.proposals[proposalID]
+	if !ok {
+		return ProposalRecord{}, ErrNotFound
+	}
+	record = applyResultToProposalRecord(record, result, time.Now().UTC())
+	s.proposals[proposalID] = cloneProposalRecord(record)
+	return s.proposalWithAttemptsLocked(proposalID), nil
+}
+
+func (s *MemoryProposalStore) RecordApplyAttempt(_ context.Context, attempt ApplyAttempt) (ProposalRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	proposalID := strings.TrimSpace(attempt.ProposalID)
+	record, ok := s.proposals[proposalID]
+	if !ok {
+		return ProposalRecord{}, ErrNotFound
+	}
+	now := time.Now().UTC()
+	attempt = normalizeApplyAttempt(attempt, now)
+	if err := validateApplyAttempt(attempt); err != nil {
+		return ProposalRecord{}, err
+	}
+	record = applyResultToProposalRecord(record, attempt.Result, now)
+	s.proposals[proposalID] = cloneProposalRecord(record)
+	s.attempts[proposalID] = append(s.attempts[proposalID], cloneApplyAttempt(attempt))
+	return s.proposalWithAttemptsLocked(proposalID), nil
+}
+
+func (s *MemoryProposalStore) DeleteProject(_ context.Context, projectID string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	projectID = strings.TrimSpace(projectID)
+	deleted := 0
+	for id, record := range s.proposals {
+		if strings.TrimSpace(record.ProjectID) != projectID {
+			continue
+		}
+		delete(s.proposals, id)
+		delete(s.attempts, id)
+		deleted++
+	}
+	return deleted, nil
+}
+
+func (s *MemoryProposalStore) Clear(_ context.Context) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	count := len(s.proposals)
+	s.proposals = make(map[string]ProposalRecord)
+	s.attempts = make(map[string][]ApplyAttempt)
+	return count, nil
+}
+
+func (s *MemoryProposalStore) proposalWithAttemptsLocked(id string) ProposalRecord {
+	record := cloneProposalRecord(s.proposals[id])
+	record.ApplyAttempts = cloneApplyAttempts(s.attempts[id])
+	return record
+}
+
+func normalizeProposalRecord(record ProposalRecord, now time.Time) ProposalRecord {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	record.ID = strings.TrimSpace(firstNonEmpty(record.ID, record.Proposal.ID))
+	record.ProjectID = strings.TrimSpace(firstNonEmpty(record.ProjectID, proposalProjectID(record.Proposal)))
+	record.Source = strings.TrimSpace(record.Source)
+	record.SourceID = strings.TrimSpace(record.SourceID)
+	record.Status = strings.TrimSpace(record.Status)
+	if record.Status == "" {
+		record.Status = ProposalStatusProposed
+	}
+	record.Proposal = cloneProposal(record.Proposal)
+	record.Proposal.ID = record.ID
+	if record.Proposal.RequiresConfirmation == false {
+		record.Proposal.RequiresConfirmation = true
+	}
+	if record.CreatedAt.IsZero() {
+		record.CreatedAt = now
+	}
+	if record.UpdatedAt.IsZero() || !record.UpdatedAt.After(record.CreatedAt) {
+		record.UpdatedAt = now
+	}
+	if record.LatestResult != nil {
+		record.LatestResult = cloneApplyResultPtr(record.LatestResult)
+		if record.LatestResult.ProposalID == "" {
+			record.LatestResult.ProposalID = record.ID
+		}
+		if record.LatestResult.TotalActionCount == 0 {
+			record.LatestResult.TotalActionCount = len(record.Proposal.Actions)
+		}
+		record.Status = strings.TrimSpace(firstNonEmpty(record.Status, record.LatestResult.Status))
+	}
+	record.AppliedAt = cloneTimePtr(record.AppliedAt)
+	record.ApplyAttempts = cloneApplyAttempts(record.ApplyAttempts)
+	record.Fingerprint = strings.TrimSpace(record.Fingerprint)
+	if record.Fingerprint == "" {
+		fingerprint, err := actionSetFingerprint(record.Proposal.Actions)
+		if err == nil {
+			record.Fingerprint = fingerprint
+		}
+	}
+	return record
+}
+
+func validateProposalRecord(record ProposalRecord) error {
+	if record.ID == "" {
+		return fmt.Errorf("%w: proposal id is required", ErrInvalid)
+	}
+	if record.Proposal.ID != record.ID {
+		return fmt.Errorf("%w: proposal record id mismatch", ErrInvalid)
+	}
+	if len(record.Proposal.Actions) == 0 {
+		return fmt.Errorf("%w: actions are required", ErrInvalid)
+	}
+	for _, action := range record.Proposal.Actions {
+		if err := validateActionShape(action); err != nil {
+			return err
+		}
+	}
+	if record.Fingerprint == "" {
+		return fmt.Errorf("%w: proposal fingerprint is required", ErrInvalid)
+	}
+	return nil
+}
+
+func normalizeApplyAttempt(attempt ApplyAttempt, now time.Time) ApplyAttempt {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	attempt.ID = strings.TrimSpace(attempt.ID)
+	attempt.ProposalID = strings.TrimSpace(firstNonEmpty(attempt.ProposalID, attempt.Result.ProposalID))
+	attempt.Status = strings.TrimSpace(firstNonEmpty(attempt.Status, attempt.Result.Status))
+	attempt.ErrorType = strings.TrimSpace(attempt.ErrorType)
+	attempt.ErrorMessage = strings.TrimSpace(attempt.ErrorMessage)
+	if attempt.Result.ProposalID == "" {
+		attempt.Result.ProposalID = attempt.ProposalID
+	}
+	if attempt.Result.Status == "" {
+		attempt.Result.Status = attempt.Status
+	}
+	if attempt.CreatedAt.IsZero() {
+		attempt.CreatedAt = now
+	}
+	return cloneApplyAttempt(attempt)
+}
+
+func validateApplyAttempt(attempt ApplyAttempt) error {
+	if attempt.ID == "" {
+		return fmt.Errorf("%w: apply attempt id is required", ErrInvalid)
+	}
+	if attempt.ProposalID == "" {
+		return fmt.Errorf("%w: apply attempt proposal_id is required", ErrInvalid)
+	}
+	if attempt.Status == "" {
+		return fmt.Errorf("%w: apply attempt status is required", ErrInvalid)
+	}
+	return nil
+}
+
+func applyResultToProposalRecord(record ProposalRecord, result ApplyResult, now time.Time) ProposalRecord {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	result = cloneApplyResult(result)
+	if result.ProposalID == "" {
+		result.ProposalID = record.ID
+	}
+	if result.TotalActionCount == 0 {
+		result.TotalActionCount = len(record.Proposal.Actions)
+	}
+	record.LatestResult = &result
+	record.Status = firstNonEmpty(result.Status, record.Status, ProposalStatusProposed)
+	record.UpdatedAt = now
+	if result.Applied || result.Status == ApplyStatusApplied {
+		appliedAt := now
+		record.AppliedAt = &appliedAt
+	}
+	return cloneProposalRecord(record)
+}
+
+func cloneProposalRecord(record ProposalRecord) ProposalRecord {
+	record.Proposal = cloneProposal(record.Proposal)
+	record.LatestResult = cloneApplyResultPtr(record.LatestResult)
+	record.ApplyAttempts = cloneApplyAttempts(record.ApplyAttempts)
+	record.AppliedAt = cloneTimePtr(record.AppliedAt)
+	return record
+}
+
+func cloneProposal(proposal Proposal) Proposal {
+	return Proposal{
+		ID:                   proposal.ID,
+		Title:                proposal.Title,
+		Summary:              proposal.Summary,
+		Actions:              cloneActions(proposal.Actions),
+		Warnings:             append([]string(nil), proposal.Warnings...),
+		RequiresConfirmation: proposal.RequiresConfirmation,
+		TraceID:              proposal.TraceID,
+	}
+}
+
+func cloneApplyResult(result ApplyResult) ApplyResult {
+	result.Actions = cloneActionResults(result.Actions)
+	result.FailedActionIndex = cloneIntPtr(result.FailedActionIndex)
+	return result
+}
+
+func cloneApplyResultPtr(result *ApplyResult) *ApplyResult {
+	if result == nil {
+		return nil
+	}
+	cloned := cloneApplyResult(*result)
+	return &cloned
+}
+
+func cloneApplyAttempt(attempt ApplyAttempt) ApplyAttempt {
+	attempt.Result = cloneApplyResult(attempt.Result)
+	return attempt
+}
+
+func cloneApplyAttempts(attempts []ApplyAttempt) []ApplyAttempt {
+	if attempts == nil {
+		return nil
+	}
+	out := make([]ApplyAttempt, len(attempts))
+	for idx, attempt := range attempts {
+		out[idx] = cloneApplyAttempt(attempt)
+	}
+	return out
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := value.UTC()
+	return &cloned
+}
+
+func proposalProjectID(proposal Proposal) string {
+	for _, action := range proposal.Actions {
+		if projectID := actionProjectID(action); projectID != "" {
+			return projectID
+		}
+	}
+	return ""
+}
+
+func actionProjectID(action Action) string {
+	if projectID := targetValue(action, "project_id"); projectID != "" {
+		return projectID
+	}
+	switch normalizeKind(action.Kind) {
+	case ActionCreateProject:
+		var patch projectPatch
+		if err := decodePatch(action, &patch); err == nil {
+			return strings.TrimSpace(patch.ID)
+		}
+	case ActionMoveChatSession:
+		var patch moveChatSessionPatch
+		if err := decodePatch(action, &patch); err == nil {
+			return strings.TrimSpace(patch.ProjectID)
+		}
+	case ActionCreateRole:
+		var patch rolePatch
+		if err := decodePatch(action, &patch); err == nil {
+			return strings.TrimSpace(patch.ProjectID)
+		}
+	case ActionCreateWorkItem:
+		var patch workItemPatch
+		if err := decodePatch(action, &patch); err == nil {
+			return strings.TrimSpace(patch.ProjectID)
+		}
+	case ActionCreateAssignment:
+		var patch assignmentPatch
+		if err := decodePatch(action, &patch); err == nil {
+			return strings.TrimSpace(patch.ProjectID)
+		}
+	case ActionCreateHandoff:
+		var patch handoffPatch
+		if err := decodePatch(action, &patch); err == nil {
+			return strings.TrimSpace(patch.ProjectID)
+		}
+	case ActionCreateMemoryCandidate:
+		var patch memoryCandidatePatch
+		if err := decodePatch(action, &patch); err == nil {
+			return strings.TrimSpace(patch.ProjectID)
+		}
+	}
+	return ""
+}
+
+func applyAttemptForResult(id string, confirmed bool, result ApplyResult, err error) ApplyAttempt {
+	attempt := ApplyAttempt{
+		ID:         strings.TrimSpace(id),
+		ProposalID: strings.TrimSpace(result.ProposalID),
+		Status:     strings.TrimSpace(result.Status),
+		Confirmed:  confirmed,
+		Result:     cloneApplyResult(result),
+		CreatedAt:  time.Now().UTC(),
+	}
+	if err != nil {
+		attempt.ErrorType = applyAttemptErrorType(err)
+		attempt.ErrorMessage = err.Error()
+	}
+	return attempt
+}
+
+func applyAttemptErrorType(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, ErrInvalid):
+		return "invalid"
+	case errors.Is(err, ErrNotFound):
+		return "not_found"
+	case errors.Is(err, ErrConflict):
+		return "conflict"
+	case errors.Is(err, ErrConfirmationRequired):
+		return "confirmation_required"
+	case errors.Is(err, ErrStoreNotConfigured):
+		return "store_not_configured"
+	default:
+		return "error"
+	}
+}
+
+func encodeProposalJSON(proposal Proposal) ([]byte, error) {
+	raw, err := json.Marshal(cloneProposal(proposal))
+	if err != nil {
+		return nil, fmt.Errorf("%w: encode proposal: %v", ErrInvalid, err)
+	}
+	return raw, nil
+}
+
+func encodeApplyResultJSON(result ApplyResult) ([]byte, error) {
+	raw, err := json.Marshal(cloneApplyResult(result))
+	if err != nil {
+		return nil, fmt.Errorf("%w: encode apply result: %v", ErrInvalid, err)
+	}
+	return raw, nil
+}

--- a/internal/projectassistant/proposal_store_sql.go
+++ b/internal/projectassistant/proposal_store_sql.go
@@ -1,0 +1,480 @@
+package projectassistant
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/storage"
+)
+
+type SQLProposalStore struct {
+	client    storage.SQLClient
+	backend   string
+	proposals string
+	attempts  string
+}
+
+func NewSQLiteProposalStore(ctx context.Context, client *storage.SQLiteClient) (*SQLProposalStore, error) {
+	return newSQLProposalStore(ctx, client)
+}
+
+func NewPostgresProposalStore(ctx context.Context, client *storage.PostgresClient) (*SQLProposalStore, error) {
+	return newSQLProposalStore(ctx, client)
+}
+
+func newSQLProposalStore(ctx context.Context, client storage.SQLClient) (*SQLProposalStore, error) {
+	if client == nil || client.DB() == nil {
+		return nil, errors.New("sql client is required")
+	}
+	store := &SQLProposalStore{
+		client:    client,
+		backend:   client.Backend(),
+		proposals: client.QualifiedTable("project_assistant_proposals"),
+		attempts:  client.QualifiedTable("project_assistant_apply_attempts"),
+	}
+	if err := store.migrate(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *SQLProposalStore) Backend() string { return s.backend }
+
+func (s *SQLProposalStore) migrate(ctx context.Context) error {
+	if _, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	id TEXT PRIMARY KEY,
+	project_id TEXT NOT NULL DEFAULT '',
+	source TEXT NOT NULL DEFAULT '',
+	source_id TEXT NOT NULL DEFAULT '',
+	proposal TEXT NOT NULL,
+	fingerprint TEXT NOT NULL,
+	status TEXT NOT NULL DEFAULT 'proposed',
+	latest_result TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	applied_at TEXT NOT NULL DEFAULT ''
+)`, s.proposals)); err != nil {
+		return fmt.Errorf("create project assistant proposals table: %w", err)
+	}
+	if _, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	id TEXT PRIMARY KEY,
+	proposal_id TEXT NOT NULL,
+	status TEXT NOT NULL,
+	confirmed INTEGER NOT NULL DEFAULT 0,
+	result TEXT NOT NULL DEFAULT '{}',
+	error_type TEXT NOT NULL DEFAULT '',
+	error_message TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL
+)`, s.attempts)); err != nil {
+		return fmt.Errorf("create project assistant apply attempts table: %w", err)
+	}
+	if _, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "%s" ON %s (project_id)`, strings.Trim(s.proposals, `"`)+"_project_idx", s.proposals)); err != nil {
+		return fmt.Errorf("create project assistant proposals project index: %w", err)
+	}
+	if _, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS "%s" ON %s (proposal_id, created_at, id)`, strings.Trim(s.attempts, `"`)+"_proposal_idx", s.attempts)); err != nil {
+		return fmt.Errorf("create project assistant attempts proposal index: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLProposalStore) UpsertProposal(ctx context.Context, record ProposalRecord) (ProposalRecord, error) {
+	now := time.Now().UTC()
+	if existing, ok, err := s.getProposalOnly(ctx, strings.TrimSpace(record.ID)); err != nil {
+		return ProposalRecord{}, err
+	} else if ok {
+		record.CreatedAt = existing.CreatedAt
+		if record.LatestResult == nil {
+			record.LatestResult = cloneApplyResultPtr(existing.LatestResult)
+		}
+		if record.AppliedAt == nil {
+			record.AppliedAt = cloneTimePtr(existing.AppliedAt)
+		}
+		if strings.TrimSpace(record.Status) == "" {
+			record.Status = existing.Status
+		}
+	}
+	record = normalizeProposalRecord(record, now)
+	if err := validateProposalRecord(record); err != nil {
+		return ProposalRecord{}, err
+	}
+	if err := s.upsertProposal(ctx, s.client.DB(), record); err != nil {
+		return ProposalRecord{}, err
+	}
+	loaded, _, err := s.GetProposal(ctx, record.ID)
+	return loaded, err
+}
+
+func (s *SQLProposalStore) GetProposal(ctx context.Context, id string) (ProposalRecord, bool, error) {
+	record, ok, err := s.getProposalOnly(ctx, strings.TrimSpace(id))
+	if err != nil || !ok {
+		return ProposalRecord{}, ok, err
+	}
+	attempts, err := s.listAttempts(ctx, record.ID)
+	if err != nil {
+		return ProposalRecord{}, false, err
+	}
+	record.ApplyAttempts = attempts
+	return cloneProposalRecord(record), true, nil
+}
+
+func (s *SQLProposalStore) UpdateProposalApplyState(ctx context.Context, proposalID string, result ApplyResult) (ProposalRecord, error) {
+	proposalID = strings.TrimSpace(proposalID)
+	record, ok, err := s.getProposalOnly(ctx, proposalID)
+	if err != nil {
+		return ProposalRecord{}, err
+	}
+	if !ok {
+		return ProposalRecord{}, ErrNotFound
+	}
+	record = applyResultToProposalRecord(record, result, time.Now().UTC())
+	if err := s.upsertProposal(ctx, s.client.DB(), record); err != nil {
+		return ProposalRecord{}, err
+	}
+	loaded, _, err := s.GetProposal(ctx, proposalID)
+	return loaded, err
+}
+
+func (s *SQLProposalStore) RecordApplyAttempt(ctx context.Context, attempt ApplyAttempt) (ProposalRecord, error) {
+	proposalID := strings.TrimSpace(attempt.ProposalID)
+	tx, err := s.client.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return ProposalRecord{}, err
+	}
+	record, ok, err := s.getProposalOnlyWith(ctx, tx, proposalID)
+	if err != nil {
+		_ = tx.Rollback()
+		return ProposalRecord{}, err
+	}
+	if !ok {
+		_ = tx.Rollback()
+		return ProposalRecord{}, ErrNotFound
+	}
+	now := time.Now().UTC()
+	attempt = normalizeApplyAttempt(attempt, now)
+	if err := validateApplyAttempt(attempt); err != nil {
+		_ = tx.Rollback()
+		return ProposalRecord{}, err
+	}
+	record = applyResultToProposalRecord(record, attempt.Result, now)
+	if err := s.upsertProposal(ctx, tx, record); err != nil {
+		_ = tx.Rollback()
+		return ProposalRecord{}, err
+	}
+	if err := s.insertAttempt(ctx, tx, attempt); err != nil {
+		_ = tx.Rollback()
+		return ProposalRecord{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ProposalRecord{}, err
+	}
+	loaded, _, err := s.GetProposal(ctx, proposalID)
+	return loaded, err
+}
+
+func (s *SQLProposalStore) DeleteProject(ctx context.Context, projectID string) (int, error) {
+	projectID = strings.TrimSpace(projectID)
+	rows, err := s.client.DB().QueryContext(ctx, fmt.Sprintf(`SELECT id FROM %s WHERE project_id = ?`, s.proposals), projectID)
+	if err != nil {
+		return 0, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, err
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	tx, err := s.client.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	args := make([]any, len(ids))
+	for idx, id := range ids {
+		args[idx] = id
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE proposal_id IN (%s)`, s.attempts, storage.Placeholders(len(ids))), args...); err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE id IN (%s)`, s.proposals, storage.Placeholders(len(ids))), args...); err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(ids), nil
+}
+
+func (s *SQLProposalStore) Clear(ctx context.Context) (int, error) {
+	tx, err := s.client.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	res, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s`, s.proposals))
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s`, s.attempts)); err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(affected), nil
+}
+
+type proposalSQLExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (s *SQLProposalStore) upsertProposal(ctx context.Context, execer proposalSQLExecer, record ProposalRecord) error {
+	proposalRaw, err := encodeProposalJSON(record.Proposal)
+	if err != nil {
+		return err
+	}
+	latestResult := ""
+	if record.LatestResult != nil {
+		raw, err := encodeApplyResultJSON(*record.LatestResult)
+		if err != nil {
+			return err
+		}
+		latestResult = string(raw)
+	}
+	_, err = execer.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	id, project_id, source, source_id, proposal, fingerprint, status, latest_result,
+	created_at, updated_at, applied_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+	project_id = excluded.project_id,
+	source = excluded.source,
+	source_id = excluded.source_id,
+	proposal = excluded.proposal,
+	fingerprint = excluded.fingerprint,
+	status = excluded.status,
+	latest_result = excluded.latest_result,
+	updated_at = excluded.updated_at,
+	applied_at = excluded.applied_at`, s.proposals),
+		record.ID,
+		record.ProjectID,
+		record.Source,
+		record.SourceID,
+		string(proposalRaw),
+		record.Fingerprint,
+		record.Status,
+		latestResult,
+		formatProposalStoreTime(record.CreatedAt),
+		formatProposalStoreTime(record.UpdatedAt),
+		formatProposalStoreTimePtr(record.AppliedAt),
+	)
+	return err
+}
+
+func (s *SQLProposalStore) insertAttempt(ctx context.Context, execer proposalSQLExecer, attempt ApplyAttempt) error {
+	raw, err := encodeApplyResultJSON(attempt.Result)
+	if err != nil {
+		return err
+	}
+	_, err = execer.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (
+	id, proposal_id, status, confirmed, result, error_type, error_message, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.attempts),
+		attempt.ID,
+		attempt.ProposalID,
+		attempt.Status,
+		boolToProposalStoreDB(attempt.Confirmed),
+		string(raw),
+		attempt.ErrorType,
+		attempt.ErrorMessage,
+		formatProposalStoreTime(attempt.CreatedAt),
+	)
+	return err
+}
+
+func (s *SQLProposalStore) getProposalOnly(ctx context.Context, id string) (ProposalRecord, bool, error) {
+	return s.getProposalOnlyWith(ctx, s.client.DB(), id)
+}
+
+func (s *SQLProposalStore) getProposalOnlyWith(ctx context.Context, queryer proposalSQLQueryer, id string) (ProposalRecord, bool, error) {
+	row := queryer.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT id, project_id, source, source_id, proposal, fingerprint, status, latest_result,
+	created_at, updated_at, applied_at
+FROM %s
+WHERE id = ?`, s.proposals), strings.TrimSpace(id))
+	record, err := scanProposalRecord(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ProposalRecord{}, false, nil
+	}
+	if err != nil {
+		return ProposalRecord{}, false, err
+	}
+	return record, true, nil
+}
+
+type proposalSQLQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (s *SQLProposalStore) listAttempts(ctx context.Context, proposalID string) ([]ApplyAttempt, error) {
+	rows, err := s.client.DB().QueryContext(ctx, fmt.Sprintf(`
+SELECT id, proposal_id, status, confirmed, result, error_type, error_message, created_at
+FROM %s
+WHERE proposal_id = ?
+ORDER BY created_at ASC, id ASC`, s.attempts), strings.TrimSpace(proposalID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var attempts []ApplyAttempt
+	for rows.Next() {
+		attempt, err := scanApplyAttempt(rows)
+		if err != nil {
+			return nil, err
+		}
+		attempts = append(attempts, attempt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return attempts, nil
+}
+
+type proposalRecordScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanProposalRecord(row proposalRecordScanner) (ProposalRecord, error) {
+	var record ProposalRecord
+	var proposalRaw, latestRaw, createdAt, updatedAt, appliedAt string
+	if err := row.Scan(
+		&record.ID,
+		&record.ProjectID,
+		&record.Source,
+		&record.SourceID,
+		&proposalRaw,
+		&record.Fingerprint,
+		&record.Status,
+		&latestRaw,
+		&createdAt,
+		&updatedAt,
+		&appliedAt,
+	); err != nil {
+		return ProposalRecord{}, err
+	}
+	if err := json.Unmarshal([]byte(proposalRaw), &record.Proposal); err != nil {
+		return ProposalRecord{}, fmt.Errorf("%w: decode proposal record: %v", ErrInvalid, err)
+	}
+	if strings.TrimSpace(latestRaw) != "" {
+		var result ApplyResult
+		if err := json.Unmarshal([]byte(latestRaw), &result); err != nil {
+			return ProposalRecord{}, fmt.Errorf("%w: decode proposal latest result: %v", ErrInvalid, err)
+		}
+		record.LatestResult = &result
+	}
+	var err error
+	if record.CreatedAt, err = parseProposalStoreTime(createdAt); err != nil {
+		return ProposalRecord{}, err
+	}
+	if record.UpdatedAt, err = parseProposalStoreTime(updatedAt); err != nil {
+		return ProposalRecord{}, err
+	}
+	if parsed, err := parseProposalStoreTime(appliedAt); err != nil {
+		return ProposalRecord{}, err
+	} else if !parsed.IsZero() {
+		record.AppliedAt = &parsed
+	}
+	return normalizeProposalRecord(record, record.UpdatedAt), nil
+}
+
+type applyAttemptScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanApplyAttempt(row applyAttemptScanner) (ApplyAttempt, error) {
+	var attempt ApplyAttempt
+	var confirmed int
+	var resultRaw, createdAt string
+	if err := row.Scan(
+		&attempt.ID,
+		&attempt.ProposalID,
+		&attempt.Status,
+		&confirmed,
+		&resultRaw,
+		&attempt.ErrorType,
+		&attempt.ErrorMessage,
+		&createdAt,
+	); err != nil {
+		return ApplyAttempt{}, err
+	}
+	attempt.Confirmed = confirmed != 0
+	if strings.TrimSpace(resultRaw) != "" {
+		if err := json.Unmarshal([]byte(resultRaw), &attempt.Result); err != nil {
+			return ApplyAttempt{}, fmt.Errorf("%w: decode proposal apply attempt result: %v", ErrInvalid, err)
+		}
+	}
+	var err error
+	if attempt.CreatedAt, err = parseProposalStoreTime(createdAt); err != nil {
+		return ApplyAttempt{}, err
+	}
+	return normalizeApplyAttempt(attempt, attempt.CreatedAt), nil
+}
+
+func boolToProposalStoreDB(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func formatProposalStoreTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func formatProposalStoreTimePtr(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return formatProposalStoreTime(*value)
+}
+
+func parseProposalStoreTime(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parsed.UTC(), nil
+}

--- a/internal/projectassistant/review_follow_up_draft.go
+++ b/internal/projectassistant/review_follow_up_draft.go
@@ -70,8 +70,11 @@ func (s *Service) draftReviewFollowUp(ctx context.Context, input DraftInput, dra
 	}
 
 	return s.Propose(ctx, ProposalInput{
-		Title:   title,
-		Summary: fmt.Sprintf("Create a review follow-up handoff and queued %s assignment for %q.", driverKind, target.workItem.Title),
+		ProjectID: target.workItem.ProjectID,
+		Source:    ProposalSourceReviewFollowUp,
+		SourceID:  target.artifact.ID,
+		Title:     title,
+		Summary:   fmt.Sprintf("Create a review follow-up handoff and queued %s assignment for %q.", driverKind, target.workItem.Title),
 		Actions: []Action{
 			{
 				Kind:   ActionCreateHandoff,

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -58,9 +58,9 @@ type Service struct {
 	projectSkills    projectskills.Store
 	memory           memory.Store
 	memoryCandidates memory.CandidateStore
+	proposals        ProposalStore
 	llm              LLMClient
 	idgen            IDGenerator
-	applyProgress    map[string]*applyProgress
 }
 
 type Stores struct {
@@ -71,15 +71,20 @@ type Stores struct {
 	ProjectSkills    projectskills.Store
 	Memory           memory.Store
 	MemoryCandidates memory.CandidateStore
+	Proposals        ProposalStore
 	LLM              LLMClient
 }
 
 type ProposalInput struct {
-	ID      string
-	Title   string
-	Summary string
-	Actions []Action
-	TraceID string
+	ID        string
+	ProjectID string
+	Source    string
+	SourceID  string
+	Title     string
+	Summary   string
+	Actions   []Action
+	Warnings  []string
+	TraceID   string
 }
 
 type DraftInput struct {
@@ -162,12 +167,6 @@ func (e *ApplyError) Unwrap() error {
 	return e.Err
 }
 
-type applyProgress struct {
-	fingerprint string
-	complete    bool
-	results     []ActionResult
-}
-
 type actionFingerprint struct {
 	Kind   string            `json:"kind"`
 	Target map[string]string `json:"target,omitempty"`
@@ -183,6 +182,10 @@ func NewService(stores Stores, idgen IDGenerator) *Service {
 			return fmt.Sprintf("%s_%d", strings.TrimSpace(prefix), defaultIDCounter.Add(1))
 		}
 	}
+	proposals := stores.Proposals
+	if proposals == nil {
+		proposals = NewMemoryProposalStore()
+	}
 	return &Service{
 		projects:         stores.Projects,
 		chats:            stores.Chats,
@@ -191,13 +194,32 @@ func NewService(stores Stores, idgen IDGenerator) *Service {
 		projectSkills:    stores.ProjectSkills,
 		memory:           stores.Memory,
 		memoryCandidates: stores.MemoryCandidates,
+		proposals:        proposals,
 		llm:              stores.LLM,
 		idgen:            idgen,
-		applyProgress:    make(map[string]*applyProgress),
 	}
 }
 
-func (s *Service) Propose(_ context.Context, input ProposalInput) (Proposal, error) {
+func (s *Service) Propose(ctx context.Context, input ProposalInput) (Proposal, error) {
+	proposal, err := s.buildProposal(input)
+	if err != nil {
+		return Proposal{}, err
+	}
+	record, err := s.storeProposal(ctx, proposal, input.ProjectID, input.Source, input.SourceID)
+	if err != nil {
+		return Proposal{}, err
+	}
+	return record.Proposal, nil
+}
+
+func (s *Service) Proposal(ctx context.Context, id string) (ProposalRecord, bool, error) {
+	if s == nil || s.proposals == nil {
+		return ProposalRecord{}, false, ErrStoreNotConfigured
+	}
+	return s.proposals.GetProposal(ctx, id)
+}
+
+func (s *Service) buildProposal(input ProposalInput) (Proposal, error) {
 	if s == nil {
 		return Proposal{}, ErrStoreNotConfigured
 	}
@@ -223,9 +245,29 @@ func (s *Service) Propose(_ context.Context, input ProposalInput) (Proposal, err
 		Title:                title,
 		Summary:              strings.TrimSpace(input.Summary),
 		Actions:              actions,
+		Warnings:             append([]string(nil), input.Warnings...),
 		RequiresConfirmation: true,
 		TraceID:              strings.TrimSpace(input.TraceID),
 	}, nil
+}
+
+func (s *Service) storeProposal(ctx context.Context, proposal Proposal, projectID, source, sourceID string) (ProposalRecord, error) {
+	if s == nil || s.proposals == nil {
+		return ProposalRecord{}, ErrStoreNotConfigured
+	}
+	fingerprint, err := actionSetFingerprint(proposal.Actions)
+	if err != nil {
+		return ProposalRecord{}, err
+	}
+	return s.proposals.UpsertProposal(ctx, ProposalRecord{
+		ID:          proposal.ID,
+		ProjectID:   strings.TrimSpace(projectID),
+		Source:      strings.TrimSpace(source),
+		SourceID:    strings.TrimSpace(sourceID),
+		Proposal:    proposal,
+		Status:      ProposalStatusProposed,
+		Fingerprint: fingerprint,
+	})
 }
 
 func (s *Service) Draft(ctx context.Context, input DraftInput) (Proposal, error) {
@@ -280,8 +322,11 @@ func (s *Service) draftDeterministic(ctx context.Context, input DraftInput, draf
 			patch["root_id"] = rootID
 		}
 		proposalInput = ProposalInput{
-			Title:   firstNonEmpty(request.title, fmt.Sprintf("Queue %s for %s", roleLabel, draftContext.SelectedWork.Title)),
-			Summary: fmt.Sprintf("Create a queued %s assignment on the selected work item.", draftContext.Selection.DriverKind),
+			ProjectID: draftContext.Project.ID,
+			Source:    ProposalSourceDraft,
+			SourceID:  DraftModeDeterministic,
+			Title:     firstNonEmpty(request.title, fmt.Sprintf("Queue %s for %s", roleLabel, draftContext.SelectedWork.Title)),
+			Summary:   fmt.Sprintf("Create a queued %s assignment on the selected work item.", draftContext.Selection.DriverKind),
 			Actions: []Action{{
 				Kind:   ActionCreateAssignment,
 				Target: map[string]string{"project_id": draftContext.Project.ID},
@@ -302,8 +347,11 @@ func (s *Service) draftDeterministic(ctx context.Context, input DraftInput, draf
 			patch["owner_role_id"] = draftContext.Selection.RoleID
 		}
 		proposalInput = ProposalInput{
-			Title:   firstNonEmpty(request.title, "Create project work item"),
-			Summary: "Create a ready work item from the current assistant draft.",
+			ProjectID: draftContext.Project.ID,
+			Source:    ProposalSourceDraft,
+			SourceID:  DraftModeDeterministic,
+			Title:     firstNonEmpty(request.title, "Create project work item"),
+			Summary:   "Create a ready work item from the current assistant draft.",
 			Actions: []Action{{
 				Kind:   ActionCreateWorkItem,
 				Target: map[string]string{"project_id": draftContext.Project.ID},

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -28,6 +28,7 @@ type assistantFixture struct {
 	projectSkills    projectskills.Store
 	memoryEntries    memory.Store
 	memoryCandidates memory.CandidateStore
+	proposals        ProposalStore
 }
 
 type assistantFixtureBuilder struct {
@@ -71,6 +72,48 @@ func TestService_ProposeRejectsUnknownActionKind(t *testing.T) {
 	})
 	if !errors.Is(err, ErrUnknownActionKind) {
 		t.Fatalf("Propose err = %v, want ErrUnknownActionKind", err)
+	}
+}
+
+func TestService_ProposeStoresProposalRecordAcrossStores(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+
+			proposal, err := fixture.service.Propose(ctx, ProposalInput{
+				ProjectID: "proj_store",
+				Source:    ProposalSourceAPI,
+				Title:     "Create stored work",
+				Summary:   "Persist the proposal record.",
+				Actions: []Action{{
+					Kind:   ActionCreateWorkItem,
+					Target: map[string]string{"project_id": "proj_store"},
+					Patch:  rawPatch(t, map[string]string{"project_id": "proj_store", "title": "Stored work"}),
+				}},
+				Warnings: []string{"review before applying"},
+				TraceID:  "trace_store",
+			})
+			if err != nil {
+				t.Fatalf("Propose: %v", err)
+			}
+
+			record, ok, err := fixture.service.Proposal(ctx, proposal.ID)
+			if err != nil || !ok {
+				t.Fatalf("Proposal ok=%v err=%v, want stored record", ok, err)
+			}
+			if record.ID != proposal.ID || record.ProjectID != "proj_store" || record.Source != ProposalSourceAPI || record.Status != ProposalStatusProposed {
+				t.Fatalf("record = %+v, want proposed API record scoped to project", record)
+			}
+			if record.Proposal.TraceID != "trace_store" || len(record.Proposal.Warnings) != 1 || record.Proposal.Warnings[0] != "review before applying" {
+				t.Fatalf("stored proposal = %+v, want trace and warnings", record.Proposal)
+			}
+			if record.Fingerprint == "" {
+				t.Fatalf("fingerprint is empty")
+			}
+		})
 	}
 }
 
@@ -1752,6 +1795,44 @@ func TestService_ApplyLoopFailureReportsCommittedProgressAcrossStores(t *testing
 			if len(assignments) != 0 {
 				t.Fatalf("assignments = %+v, want no assignment after injected apply failure", assignments)
 			}
+			record, ok, err := fixture.service.Proposal(ctx, proposal.ID)
+			if err != nil || !ok {
+				t.Fatalf("Proposal ok=%v err=%v, want partial record", ok, err)
+			}
+			if record.Status != ApplyStatusPartialDueToRuntimeFailure || record.LatestResult == nil || record.LatestResult.CommittedActionCount != 1 || len(record.ApplyAttempts) != 1 {
+				t.Fatalf("record = %+v, want partial latest result and one attempt", record)
+			}
+
+			resumed := NewService(Stores{
+				Projects:         fixture.projects,
+				Chats:            fixture.chats,
+				Work:             fixture.work,
+				ProjectSkills:    fixture.projectSkills,
+				Memory:           fixture.memoryEntries,
+				MemoryCandidates: fixture.memoryCandidates,
+				Proposals:        fixture.proposals,
+			}, func(prefix string) string { return prefix + "_resume" })
+			result, err = resumed.Apply(ctx, proposal, true)
+			if err != nil {
+				t.Fatalf("resumed Apply: %v", err)
+			}
+			if !result.Applied || result.CommittedActionCount != 2 || len(result.Actions) != 2 {
+				t.Fatalf("resumed result = %+v, want second action applied from ledger progress", result)
+			}
+			assignments, err = fixture.work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: project.ID, WorkItemID: "work_loop_partial"})
+			if err != nil {
+				t.Fatalf("ListAssignments after resume: %v", err)
+			}
+			if len(assignments) != 1 || assignments[0].ID != "asgn_loop_partial" {
+				t.Fatalf("assignments after resume = %+v, want one resumed assignment", assignments)
+			}
+			record, ok, err = resumed.Proposal(ctx, proposal.ID)
+			if err != nil || !ok {
+				t.Fatalf("Proposal after resume ok=%v err=%v, want record", ok, err)
+			}
+			if record.Status != ApplyStatusApplied || record.LatestResult == nil || !record.LatestResult.Applied || len(record.ApplyAttempts) != 2 {
+				t.Fatalf("record after resume = %+v, want applied latest result and two attempts", record)
+			}
 		})
 	}
 }
@@ -2201,14 +2282,16 @@ func newMemoryAssistantFixture(t *testing.T) assistantFixture {
 	workStore := projectwork.NewMemoryStore()
 	projectSkillStore := projectskills.NewMemoryStore()
 	memoryStore := memory.NewMemoryStore()
+	proposalStore := NewMemoryProposalStore()
 	return assistantFixture{
-		service:          projectassistantService(projectStore, chatStore, workStore, projectSkillStore, memoryStore),
+		service:          projectassistantService(projectStore, chatStore, workStore, projectSkillStore, memoryStore, proposalStore),
 		projects:         projectStore,
 		chats:            chatStore,
 		work:             workStore,
 		projectSkills:    projectSkillStore,
 		memoryEntries:    memoryStore,
 		memoryCandidates: memoryStore,
+		proposals:        proposalStore,
 	}
 }
 
@@ -2247,18 +2330,23 @@ func newSQLiteAssistantFixture(t *testing.T) assistantFixture {
 	if err != nil {
 		t.Fatalf("new memory sqlite store: %v", err)
 	}
+	proposalStore, err := NewSQLiteProposalStore(ctx, client)
+	if err != nil {
+		t.Fatalf("new project assistant proposal sqlite store: %v", err)
+	}
 	return assistantFixture{
-		service:          projectassistantService(projectStore, chatStore, workStore, projectSkillStore, memoryStore),
+		service:          projectassistantService(projectStore, chatStore, workStore, projectSkillStore, memoryStore, proposalStore),
 		projects:         projectStore,
 		chats:            chatStore,
 		work:             workStore,
 		projectSkills:    projectSkillStore,
 		memoryEntries:    memoryStore,
 		memoryCandidates: memoryStore,
+		proposals:        proposalStore,
 	}
 }
 
-func projectassistantService(projectStore projects.Store, chatStore chat.Store, workStore projectwork.Store, projectSkillStore projectskills.Store, memoryStore memory.Store) *Service {
+func projectassistantService(projectStore projects.Store, chatStore chat.Store, workStore projectwork.Store, projectSkillStore projectskills.Store, memoryStore memory.Store, proposalStore ProposalStore) *Service {
 	var candidateStore memory.CandidateStore
 	if candidates, ok := memoryStore.(memory.CandidateStore); ok {
 		candidateStore = candidates
@@ -2270,6 +2358,7 @@ func projectassistantService(projectStore projects.Store, chatStore chat.Store, 
 		ProjectSkills:    projectSkillStore,
 		Memory:           memoryStore,
 		MemoryCandidates: candidateStore,
+		Proposals:        proposalStore,
 	}, sequenceIDGenerator())
 }
 

--- a/internal/projectassistantapp/application.go
+++ b/internal/projectassistantapp/application.go
@@ -24,6 +24,7 @@ type Options struct {
 	ProjectSkills    projectskills.Store
 	Memory           memory.Store
 	MemoryCandidates memory.CandidateStore
+	Proposals        projectassistant.ProposalStore
 	LLM              projectassistant.LLMClient
 	IDGenerator      projectassistant.IDGenerator
 }
@@ -77,6 +78,7 @@ func New(options Options) *Application {
 			ProjectSkills:    options.ProjectSkills,
 			Memory:           options.Memory,
 			MemoryCandidates: options.MemoryCandidates,
+			Proposals:        options.Proposals,
 			LLM:              options.LLM,
 		}, options.IDGenerator),
 	}
@@ -120,6 +122,7 @@ func (app *Application) Propose(ctx context.Context, command ProposeCommand) (pr
 	}
 	return app.service.Propose(ctx, projectassistant.ProposalInput{
 		ID:      command.ID,
+		Source:  projectassistant.ProposalSourceAPI,
 		Title:   command.Title,
 		Summary: command.Summary,
 		Actions: command.Actions,
@@ -132,4 +135,11 @@ func (app *Application) Apply(ctx context.Context, command ApplyCommand) (projec
 		return projectassistant.ApplyResult{}, projectassistant.ErrStoreNotConfigured
 	}
 	return app.service.Apply(ctx, command.Proposal, command.Confirm)
+}
+
+func (app *Application) Proposal(ctx context.Context, id string) (projectassistant.ProposalRecord, bool, error) {
+	if app == nil || app.service == nil {
+		return projectassistant.ProposalRecord{}, false, projectassistant.ErrStoreNotConfigured
+	}
+	return app.service.Proposal(ctx, id)
 }

--- a/ui/src/features/projects/projectDisplay.ts
+++ b/ui/src/features/projects/projectDisplay.ts
@@ -78,6 +78,7 @@ export function formatProjectDeleteSummary(result: ProjectDeleteRecord): string 
     countLabel(result.chat_sessions_deleted, "chat"),
     countLabel(result.project_work_rows_deleted, "work row"),
     countLabel(result.project_skills_deleted, "skill"),
+    countLabel(result.project_assistant_proposals_deleted ?? 0, "assistant proposal"),
     countLabel(result.memory_entries_deleted, "memory entry", "memory entries"),
     countLabel(result.memory_candidates_deleted, "memory candidate"),
   ].filter(Boolean);

--- a/ui/src/features/projects/useProjectAssistantController.test.ts
+++ b/ui/src/features/projects/useProjectAssistantController.test.ts
@@ -1,15 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ApiError } from "../../lib/api";
+import * as api from "../../lib/api";
 import type { ProjectAssistantProposal } from "../../types/project";
 import {
   projectAssistantApplyErrorMessage,
   projectAssistantContextPayload,
   projectAssistantDraftPayload,
   projectAssistantResultWorkItemID,
+  useProjectAssistantController,
 } from "./useProjectAssistantController";
 
 describe("Project Assistant controller helpers", () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
   it("builds context and draft payloads from panel form state", () => {
     const form = {
       request: "Queue review",
@@ -68,9 +75,9 @@ describe("Project Assistant controller helpers", () => {
   });
 
   it("renders conflict and partial apply errors with proposal context", () => {
-    expect(projectAssistantApplyErrorMessage(new ApiError("conflict", 409, "conflict"))).toContain(
-      "proposal is stale",
-    );
+    expect(
+      projectAssistantApplyErrorMessage(new api.ApiError("conflict", 409, "conflict")),
+    ).toContain("proposal is stale");
 
     const proposal: ProjectAssistantProposal = {
       id: "pa_partial",
@@ -83,7 +90,7 @@ describe("Project Assistant controller helpers", () => {
       ],
     };
     const partial = projectAssistantApplyErrorMessage(
-      new ApiError("partial", 409, "conflict", {
+      new api.ApiError("partial", 409, "conflict", {
         fields: {
           failed_action_index: 1,
           partial_result: {
@@ -105,7 +112,7 @@ describe("Project Assistant controller helpers", () => {
     expect(partial).toContain("failed at action 2 (create memory candidate)");
 
     const blocked = projectAssistantApplyErrorMessage(
-      new ApiError("blocked", 404, "not_found", {
+      new api.ApiError("blocked", 404, "not_found", {
         fields: {
           apply_status: "blocked_before_apply",
           failed_action_index: 1,
@@ -131,7 +138,7 @@ describe("Project Assistant controller helpers", () => {
     expect(blocked).not.toContain("applied 0 of 2 actions");
 
     const blockedResume = projectAssistantApplyErrorMessage(
-      new ApiError("blocked", 404, "not_found", {
+      new api.ApiError("blocked", 404, "not_found", {
         fields: {
           apply_status: "blocked_before_apply",
           failed_action_index: 1,
@@ -157,7 +164,7 @@ describe("Project Assistant controller helpers", () => {
     expect(blockedResume).toContain("create assignment asgn_1");
 
     const serverCountedPartial = projectAssistantApplyErrorMessage(
-      new ApiError("partial", 409, "conflict", {
+      new api.ApiError("partial", 409, "conflict", {
         fields: {
           apply_status: "partial_due_to_runtime_failure",
           failed_action_index: 1,
@@ -178,5 +185,71 @@ describe("Project Assistant controller helpers", () => {
       }),
     );
     expect(serverCountedPartial).toContain("applied 1 of 3 actions");
+  });
+
+  it("restores the last proposal record for the selected project", async () => {
+    const proposal: ProjectAssistantProposal = {
+      id: "pa_recover",
+      title: "Recover proposal",
+      summary: "",
+      requires_confirmation: true,
+      actions: [
+        { kind: "create_work_item", patch: {} },
+        { kind: "create_assignment", patch: {} },
+      ],
+    };
+    vi.spyOn(api, "getProjectAssistantProposal").mockResolvedValue({
+      object: "project_assistant.proposal_record",
+      data: {
+        id: "pa_recover",
+        project_id: "proj_1",
+        proposal,
+        status: "partial_due_to_runtime_failure",
+        latest_result: {
+          proposal_id: "pa_recover",
+          status: "partial_due_to_runtime_failure",
+          applied: false,
+          actions: [{ kind: "create_work_item", id: "work_1" }],
+          total_action_count: 2,
+          committed_action_count: 1,
+          failed_action_index: 1,
+          resume_action_index: 1,
+        },
+        apply_attempts: [],
+        created_at: "2026-06-22T10:00:00Z",
+        updated_at: "2026-06-22T10:01:00Z",
+      },
+    });
+    window.sessionStorage.setItem("hecate.projectAssistant.lastProposal.proj_1", "pa_recover");
+
+    const { result } = renderHook(() =>
+      useProjectAssistantController({
+        project: {
+          id: "proj_1",
+          name: "Project",
+          roots: [],
+          created_at: "2026-06-22T10:00:00Z",
+          updated_at: "2026-06-22T10:00:00Z",
+        },
+        selectedProjectID: "proj_1",
+        selectedWorkItemID: "",
+        selectedWorkItem: null,
+        onProjectDiscovered: vi.fn(),
+        onSkillsDiscovered: vi.fn(),
+        onSkillsLoadState: vi.fn(),
+        onDiscoveringContext: vi.fn(),
+        onDiscoveringSkills: vi.fn(),
+        onMemoryError: vi.fn(),
+        onSkillsError: vi.fn(),
+        refreshProjects: vi.fn(async () => undefined),
+        loadWorkForProject: vi.fn(async () => ""),
+        loadWorkItemDetail: vi.fn(async () => undefined),
+        loadProjectMemory: vi.fn(async () => undefined),
+      }),
+    );
+
+    await waitFor(() => expect(result.current.proposal?.id).toBe("pa_recover"));
+    expect(result.current.error).toContain("applied 1 of 2 actions");
+    expect(result.current.error).toContain("failed at action 2 (create assignment)");
   });
 });

--- a/ui/src/features/projects/useProjectAssistantController.ts
+++ b/ui/src/features/projects/useProjectAssistantController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   ApiError,
@@ -7,6 +7,7 @@ import {
   discoverProjectSkills,
   draftProjectAssistant,
   getProjectAssistantContext,
+  getProjectAssistantProposal,
 } from "../../lib/api";
 import type {
   ProjectAssistantApplyResult,
@@ -15,6 +16,7 @@ import type {
   ProjectAssistantContextRecord,
   ProjectAssistantDraftPayload,
   ProjectAssistantProposal,
+  ProjectAssistantProposalRecord,
   ProjectRecord,
   ProjectSkillRecord,
   ProjectWorkItemRecord,
@@ -27,6 +29,7 @@ import {
 
 type LoadState = "idle" | "loading" | "loaded" | "error";
 type ProjectAssistantStatus = "idle" | "proposing" | "applying" | "applied";
+const PROJECT_ASSISTANT_LAST_PROPOSAL_PREFIX = "hecate.projectAssistant.lastProposal.";
 
 type Options = {
   project: ProjectRecord | null;
@@ -58,6 +61,65 @@ export function useProjectAssistantController(options: Options) {
   const [status, setStatus] = useState<ProjectAssistantStatus>("idle");
   const [error, setError] = useState("");
   const [bootstrapPending, setBootstrapPending] = useState(false);
+  const previousProjectID = useRef("");
+
+  useEffect(() => {
+    const projectID = options.project?.id || options.selectedProjectID;
+    if (previousProjectID.current === projectID) return;
+    previousProjectID.current = projectID;
+    setProposal(null);
+    setChatDraftSource(null);
+    setApplyResult(null);
+    setContext(null);
+    setContextError("");
+    setContextStatus("idle");
+    setError("");
+    setStatus("idle");
+  }, [options.project?.id, options.selectedProjectID]);
+
+  useEffect(() => {
+    const projectID = options.project?.id || options.selectedProjectID;
+    if (!projectID || proposal || applyResult || status !== "idle") return;
+    const proposalID = readProjectAssistantProposalID(projectID);
+    if (!proposalID) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const payload = await getProjectAssistantProposal(proposalID);
+        if (cancelled) return;
+        const record = payload.data;
+        if (!projectAssistantProposalRecordMatchesProject(record, projectID)) {
+          clearProjectAssistantProposalID(projectID);
+          return;
+        }
+        if (record.latest_result?.applied) {
+          setApplyResult(record.latest_result);
+          setProposal(null);
+          setChatDraftSource(null);
+          setError("");
+          setStatus("applied");
+          return;
+        }
+        if (record.status === "applied") {
+          clearProjectAssistantProposalID(projectID);
+          return;
+        }
+        setProposal(record.proposal);
+        setChatDraftSource(null);
+        setApplyResult(null);
+        setError(projectAssistantProposalRecordError(record));
+        setStatus("idle");
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 404) {
+          clearProjectAssistantProposalID(projectID);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [applyResult, options.project?.id, options.selectedProjectID, proposal, status]);
 
   const propose = useCallback(
     async (form: ProjectAssistantDraftForm, workItemID?: string) => {
@@ -73,6 +135,7 @@ export function useProjectAssistantController(options: Options) {
             workItemID ?? options.selectedWorkItem?.id,
           ),
         );
+        rememberProjectAssistantProposalID(options.project.id, payload.data.id);
         setProposal(payload.data);
         setChatDraftSource(null);
         setStatus("idle");
@@ -103,6 +166,7 @@ export function useProjectAssistantController(options: Options) {
           draft_mode: "review_follow_up",
           review_artifact_id: reviewArtifactID,
         });
+        rememberProjectAssistantProposalID(options.project.id, payload.data.id);
         setProposal(payload.data);
         setChatDraftSource(null);
         setStatus("idle");
@@ -144,6 +208,7 @@ export function useProjectAssistantController(options: Options) {
           projectID,
         ),
       );
+      rememberProjectAssistantProposalID(projectID, payload.data.id);
       setProposal(payload.data);
       setChatDraftSource(null);
       setContext(null);
@@ -184,6 +249,9 @@ export function useProjectAssistantController(options: Options) {
       nextProposal: ProjectAssistantProposal,
       sourceOptions?: { chatDraftSource?: ProjectAssistantChatDraftSource | null },
     ) => {
+      if (options.selectedProjectID) {
+        rememberProjectAssistantProposalID(options.selectedProjectID, nextProposal.id);
+      }
       setProposal(nextProposal);
       setChatDraftSource(sourceOptions?.chatDraftSource ?? null);
       setApplyResult(null);
@@ -193,7 +261,7 @@ export function useProjectAssistantController(options: Options) {
       setError("");
       setStatus("idle");
     },
-    [],
+    [options.selectedProjectID],
   );
 
   const apply = useCallback(async () => {
@@ -203,6 +271,7 @@ export function useProjectAssistantController(options: Options) {
     setError("");
     try {
       const payload = await applyProjectAssistant({ proposal: currentProposal, confirm: true });
+      rememberProjectAssistantProposalID(options.selectedProjectID, currentProposal.id);
       setApplyResult(payload.data);
       setProposal(null);
       setChatDraftSource(null);
@@ -234,6 +303,9 @@ export function useProjectAssistantController(options: Options) {
   }, [options, proposal]);
 
   const dismiss = useCallback(() => {
+    if (options.selectedProjectID) {
+      clearProjectAssistantProposalID(options.selectedProjectID);
+    }
     setProposal(null);
     setChatDraftSource(null);
     setApplyResult(null);
@@ -242,7 +314,7 @@ export function useProjectAssistantController(options: Options) {
     setContextStatus("idle");
     setError("");
     setStatus("idle");
-  }, []);
+  }, [options.selectedProjectID]);
 
   return {
     apply,
@@ -339,11 +411,61 @@ function projectAssistantPartialApplyErrorMessage(
     projectAssistantNonNegativeInteger(partialResult.total_action_count) ??
     proposal?.actions.length ??
     Math.max(appliedCount, failedActionIndex + 1);
-  const landed = projectAssistantAppliedActionsSummary(partialResult.actions);
-  const failed = projectAssistantFailedActionSummary(proposal, failedActionIndex);
   const status =
     projectAssistantApplyStatus(error.fields.apply_status) ??
     projectAssistantApplyStatus(partialResult.status);
+  if (status !== "blocked_before_apply" && status !== "partial_due_to_runtime_failure") return "";
+  return projectAssistantApplyProgressMessage({
+    status,
+    partialResult,
+    proposal,
+    failedActionIndex,
+    appliedCount,
+    totalCount,
+  });
+}
+
+function projectAssistantProposalRecordError(record: ProjectAssistantProposalRecord): string {
+  const partialResult = record.latest_result;
+  if (!partialResult || partialResult.applied) return "";
+  const status = projectAssistantApplyStatus(partialResult.status);
+  if (status !== "blocked_before_apply" && status !== "partial_due_to_runtime_failure") return "";
+  const failedActionIndex = projectAssistantNonNegativeInteger(partialResult.failed_action_index);
+  if (failedActionIndex === null) return "";
+  const appliedCount =
+    projectAssistantNonNegativeInteger(partialResult.committed_action_count) ??
+    partialResult.actions.length;
+  const totalCount =
+    projectAssistantNonNegativeInteger(partialResult.total_action_count) ??
+    record.proposal.actions.length ??
+    Math.max(appliedCount, failedActionIndex + 1);
+  return projectAssistantApplyProgressMessage({
+    status,
+    partialResult,
+    proposal: record.proposal,
+    failedActionIndex,
+    appliedCount,
+    totalCount,
+  });
+}
+
+function projectAssistantApplyProgressMessage({
+  status,
+  partialResult,
+  proposal,
+  failedActionIndex,
+  appliedCount,
+  totalCount,
+}: {
+  status: "blocked_before_apply" | "partial_due_to_runtime_failure";
+  partialResult: ProjectAssistantApplyResult;
+  proposal?: ProjectAssistantProposal;
+  failedActionIndex: number;
+  appliedCount: number;
+  totalCount: number;
+}): string {
+  const landed = projectAssistantAppliedActionsSummary(partialResult.actions);
+  const failed = projectAssistantFailedActionSummary(proposal, failedActionIndex);
   if (status === "blocked_before_apply") {
     if (appliedCount > 0) {
       return `Project Assistant blocked this proposal before applying additional actions. ${appliedCount} of ${totalCount} action${totalCount === 1 ? "" : "s"} ${appliedCount === 1 ? "was" : "were"} already committed${landed}. It failed at action ${failedActionIndex + 1}${failed}. Fix the target state, then apply the same proposal again.`;
@@ -351,6 +473,35 @@ function projectAssistantPartialApplyErrorMessage(
     return `Project Assistant blocked this proposal before applying any actions. It failed at action ${failedActionIndex + 1}${failed}. Fix the target state, then apply the same proposal again.`;
   }
   return `Project Assistant applied ${appliedCount} of ${totalCount} actions${landed}. It then failed at action ${failedActionIndex + 1}${failed}. Apply the same proposal again after fixing the target state to resume from the next unapplied action.`;
+}
+
+function projectAssistantProposalRecordMatchesProject(
+  record: ProjectAssistantProposalRecord,
+  projectID: string,
+): boolean {
+  const recordProjectID = record.project_id?.trim();
+  return !recordProjectID || recordProjectID === projectID;
+}
+
+function projectAssistantProposalStorageKey(projectID: string): string {
+  return `${PROJECT_ASSISTANT_LAST_PROPOSAL_PREFIX}${projectID}`;
+}
+
+function rememberProjectAssistantProposalID(projectID: string, proposalID: string) {
+  const scopedProjectID = projectID.trim();
+  const id = proposalID.trim();
+  if (!scopedProjectID || !id || typeof window === "undefined") return;
+  window.sessionStorage.setItem(projectAssistantProposalStorageKey(scopedProjectID), id);
+}
+
+function readProjectAssistantProposalID(projectID: string): string {
+  if (!projectID.trim() || typeof window === "undefined") return "";
+  return window.sessionStorage.getItem(projectAssistantProposalStorageKey(projectID.trim())) ?? "";
+}
+
+function clearProjectAssistantProposalID(projectID: string) {
+  if (!projectID.trim() || typeof window === "undefined") return;
+  window.sessionStorage.removeItem(projectAssistantProposalStorageKey(projectID.trim()));
 }
 
 function projectAssistantAppliedActionsSummary(actions: ProjectAssistantApplyResult["actions"]) {
@@ -403,7 +554,8 @@ function projectAssistantNonNegativeInteger(value: unknown): number | null {
 }
 
 function projectAssistantApplyStatus(value: unknown): ProjectAssistantApplyStatus | undefined {
-  return value === "applied" ||
+  return value === "applying" ||
+    value === "applied" ||
     value === "blocked_before_apply" ||
     value === "partial_due_to_runtime_failure"
     ? value

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -38,6 +38,7 @@ import {
   getProjectAssignmentPreflight,
   getProjectAssignments,
   getProjectActivity,
+  getProjectAssistantProposal,
   getProjectHealth,
   getProjectCollaborationArtifacts,
   getProjectHandoffs,
@@ -187,6 +188,19 @@ describe("api client", () => {
     );
     expect(result.data.role).toBe("admin");
     expect(result.data.capabilities?.local_providers_allowed).toBe(true);
+  });
+
+  it("fetches Project Assistant proposal records by id", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ object: "project_assistant.proposal_record", data: { id: "pa_1" } }),
+    );
+
+    await getProjectAssistantProposal("pa/1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/project-assistant/proposals/pa%2F1",
+      expect.objectContaining({ method: "GET" }),
+    );
   });
 
   it("returns chat payload plus runtime headers", async () => {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -83,6 +83,7 @@ import type {
   ProjectAssistantContextPayload,
   ProjectAssistantContextResponse,
   ProjectAssistantDraftPayload,
+  ProjectAssistantProposalRecordResponse,
   ProjectAssistantProposalResponse,
   ProjectAssistantProposePayload,
   ProjectAssignmentLaunchReadinessResponse,
@@ -572,6 +573,14 @@ export async function applyProjectAssistant(
     method: "POST",
     body: payload,
   });
+}
+
+export async function getProjectAssistantProposal(
+  proposalID: string,
+): Promise<ProjectAssistantProposalRecordResponse> {
+  return fetchJSON<ProjectAssistantProposalRecordResponse>(
+    `${HECATE_API}/project-assistant/proposals/${encodeURIComponent(proposalID)}`,
+  );
 }
 
 export async function getProjectMemory(

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -61,6 +61,7 @@ export type ProjectDeleteRecord = {
   chat_sessions_deleted: number;
   project_work_rows_deleted: number;
   project_skills_deleted: number;
+  project_assistant_proposals_deleted?: number;
   memory_entries_deleted: number;
   memory_candidates_deleted: number;
 };
@@ -94,9 +95,12 @@ export type ProjectAssistantActionResult = {
 };
 
 export type ProjectAssistantApplyStatus =
+  | "applying"
   | "applied"
   | "blocked_before_apply"
   | "partial_due_to_runtime_failure";
+
+export type ProjectAssistantProposalStatus = "proposed" | ProjectAssistantApplyStatus;
 
 export type ProjectAssistantApplyResult = {
   proposal_id: string;
@@ -117,6 +121,36 @@ export type ProjectAssistantProposalResponse = {
 export type ProjectAssistantApplyResponse = {
   object: string;
   data: ProjectAssistantApplyResult;
+};
+
+export type ProjectAssistantApplyAttempt = {
+  id: string;
+  proposal_id: string;
+  status: ProjectAssistantApplyStatus;
+  confirmed: boolean;
+  result: ProjectAssistantApplyResult;
+  error_type?: string;
+  error_message?: string;
+  created_at: string;
+};
+
+export type ProjectAssistantProposalRecord = {
+  id: string;
+  project_id?: string;
+  source?: string;
+  source_id?: string;
+  proposal: ProjectAssistantProposal;
+  status: ProjectAssistantProposalStatus;
+  latest_result?: ProjectAssistantApplyResult;
+  apply_attempts?: ProjectAssistantApplyAttempt[];
+  created_at: string;
+  updated_at: string;
+  applied_at?: string;
+};
+
+export type ProjectAssistantProposalRecordResponse = {
+  object: string;
+  data: ProjectAssistantProposalRecord;
 };
 
 export type ProjectAssistantContextSelection = {


### PR DESCRIPTION
## Summary

- Add a durable Project Assistant proposal ledger with memory, SQLite, and Postgres-backed stores.
- Record latest apply progress and terminal apply attempts so partial proposals can resume after restart.
- Expose `GET /hecate/v1/project-assistant/proposals/{id}` for read-only recovery, and clean proposal records during project delete/reset.
- Restore the last project proposal in the Projects UI when the selected project reloads.

## Notes

- Apply remains operator-confirmed; this does not add auto-apply or hidden autonomous behavior.
- Memory candidates remain candidates; there are no automatic durable memory writes.
- The proposal endpoint is read-only and scoped to reload/recovery, not a proposal history browser.

## Validation

- `go test ./internal/projectassistant ./internal/projectassistantapp ./internal/projectapp ./internal/api`
- `go test ./...`
- `go vet ./...`
- `cd ui && bun run format:check`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run test`
- `cd ui && bun run build`
