### PR TITLE
fix(runtime): sandbox ACP terminal commands

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -244,7 +244,10 @@ record command/cwd/status/exit output previews from the active ACP turn, and
 reuse retained terminal output for ACP tool-call terminal refs when available,
 instead of adding an operator-facing embedded terminal API/UI. Session shutdown
 cleanup should mark unreleased ACP terminals as cancelled and retain their
-bounded output preview before removing them from the client terminal map.
+bounded output preview before removing them from the client terminal map. Keep
+terminal spawning on the same safety path as one-shot shell execution:
+`LocalWorkspace.OpenTerminal` must reject policy-invalid commands before spawn
+and apply the sandbox OS wrapper when one is available.
 
 Hecate owns the ACP process/session boundary, not provider-specific adapter
 implementation parity. Tests in this repository should use the repo-local fake

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -583,7 +583,9 @@ External Agent approval coordinator as adapter `RequestPermission`: prompt mode
 pauses before spawn, deny mode rejects before spawn, and auto mode remains an
 explicit operator opt-in. If approved, Hecate starts the requested command in
 the selected workspace, rejects working directories outside that workspace,
-retains bounded merged stdout/stderr for `terminal/output`, supports
+applies the same static command policy checks and OS sandbox wrapper path used
+by one-shot shell tasks, retains bounded merged stdout/stderr for
+`terminal/output`, supports
 `terminal/wait_for_exit`, `terminal/kill`, and invalidates the terminal after
 `terminal/release`. Terminal output retention truncates from the beginning at a
 valid UTF-8 boundary when the agent supplies `outputByteLimit`. Env variable

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -585,12 +585,14 @@ explicit operator opt-in. If approved, Hecate starts the requested command in
 the selected workspace, rejects working directories outside that workspace,
 applies the same static command policy checks and OS sandbox wrapper path used
 by one-shot shell tasks, retains bounded merged stdout/stderr for
-`terminal/output`, supports
-`terminal/wait_for_exit`, `terminal/kill`, and invalidates the terminal after
-`terminal/release`. Terminal output retention truncates from the beginning at a
-valid UTF-8 boundary when the agent supplies `outputByteLimit`. Env variable
-names are included in approval context; env values are not persisted in the
-approval payload. Terminal lifecycle callbacks are also projected into the
+`terminal/output`, supports `terminal/wait_for_exit`, `terminal/kill`, and
+invalidates the terminal after `terminal/release`. Interactive terminal
+requests without an initial command cannot be statically inspected; they rely
+on the OS sandbox wrapper and approval gate for containment. Terminal output
+retention truncates from the beginning at a valid UTF-8 boundary when the agent
+supplies `outputByteLimit`. Env variable names are included in approval
+context; env values are not persisted in the approval payload. Terminal
+lifecycle callbacks are also projected into the
 chat activity timeline as `terminal` rows: Hecate records the command, working
 directory, running/completed/failed/cancelled status, exit code when available,
 and a bounded output preview after the process exits. When an ACP tool-call

--- a/internal/sandbox/exec.go
+++ b/internal/sandbox/exec.go
@@ -522,6 +522,15 @@ func validateCommand(command string, policy Policy) error {
 	return nil
 }
 
+// ValidateCommand applies the same best-effort static command policy checks
+// used by LocalExecutor before a process is spawned. Workspace-level process
+// surfaces such as terminals call this before constructing their own exec.Cmd
+// so shell tools and long-lived terminals reject the same obvious read-only and
+// network-policy violations.
+func ValidateCommand(command string, policy Policy) error {
+	return validateCommand(command, policy)
+}
+
 // extractCommandURLs pulls out http(s) URLs that appear as
 // whitespace-separated tokens in the command string. Designed
 // for the common cases — `curl https://x`, `wget http://y`,

--- a/internal/sandbox/wrapper.go
+++ b/internal/sandbox/wrapper.go
@@ -177,6 +177,14 @@ func applyWrapper(cmd *exec.Cmd, workspace string, network bool) {
 	cmd.Args = argv
 }
 
+// ApplyWrapper rewrites cmd in place with the same OS-level sandbox wrapper
+// LocalExecutor uses for one-shot shell execution. Long-lived workspace
+// processes use this to keep terminal and shell execution on the same
+// isolation path when bwrap or sandbox-exec is available.
+func ApplyWrapper(cmd *exec.Cmd, workspace string, network bool) {
+	applyWrapper(cmd, workspace, network)
+}
+
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/workspace/local_terminal.go
+++ b/internal/workspace/local_terminal.go
@@ -293,6 +293,13 @@ func buildTerminalCommand(opts TerminalOptions) (*exec.Cmd, error) {
 		return nil, err
 	}
 
+	policyCommand := terminalPolicyCommand(opts.Command, opts.Args)
+	if policyCommand != "" {
+		if err := sandbox.ValidateCommand(policyCommand, opts.Policy); err != nil {
+			return nil, err
+		}
+	}
+
 	var cmd *exec.Cmd
 	switch {
 	case opts.Command == "" && runtime.GOOS == "windows":
@@ -304,6 +311,7 @@ func buildTerminalCommand(opts TerminalOptions) (*exec.Cmd, error) {
 	}
 
 	cmd.Dir = resolvedDir
+	sandbox.ApplyWrapper(cmd, resolvedDir, opts.Policy.Network)
 
 	// Build env: sandbox's sanitized base set + caller overrides.
 	// Operators who want to inject secrets should use the credential
@@ -315,4 +323,18 @@ func buildTerminalCommand(opts TerminalOptions) (*exec.Cmd, error) {
 	}
 	cmd.Env = env
 	return cmd, nil
+}
+
+func terminalPolicyCommand(command string, args []string) string {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return ""
+	}
+	if len(args) == 0 {
+		return command
+	}
+	parts := make([]string, 0, 1+len(args))
+	parts = append(parts, command)
+	parts = append(parts, args...)
+	return strings.Join(parts, " ")
 }

--- a/internal/workspace/local_terminal.go
+++ b/internal/workspace/local_terminal.go
@@ -330,6 +330,10 @@ func terminalPolicyCommand(command string, args []string) string {
 	if command == "" {
 		return ""
 	}
+	// Static policy validation is intentionally best-effort. Join argv into
+	// the same kind of approximate command text validateCommand already
+	// inspects for one-shot shell strings; the OS wrapper is the real
+	// containment layer for exact argv semantics and interactive input.
 	if len(args) == 0 {
 		return command
 	}

--- a/internal/workspace/local_terminal_test.go
+++ b/internal/workspace/local_terminal_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hecatehq/hecate/internal/sandbox"
 )
 
 // TestLocalTerminal_OneShotCaptureExit drives a terminal through the
@@ -200,4 +202,56 @@ func TestLocalTerminal_RejectsOutsideAllowedRoot(t *testing.T) {
 	if err == nil {
 		t.Fatal("OpenTerminal succeeded with cwd outside AllowedRoot; expected sandbox refusal")
 	}
+}
+
+func TestBuildTerminalCommandRejectsPolicyViolationsBeforeSpawn(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, err := buildTerminalCommand(TerminalOptions{
+		Command:          "touch",
+		Args:             []string{"blocked.txt"},
+		WorkingDirectory: dir,
+		Policy:           Policy{AllowedRoot: dir, ReadOnly: true},
+	})
+	if err == nil {
+		t.Fatal("buildTerminalCommand succeeded with mutating read-only command; want sandbox refusal")
+	}
+	if !strings.Contains(err.Error(), "write access is disabled") {
+		t.Fatalf("buildTerminalCommand error = %v, want read-only policy error", err)
+	}
+}
+
+func TestBuildTerminalCommandAppliesSandboxWrapper(t *testing.T) {
+	reset := sandbox.SetWrapperForTesting(sandbox.WrapperBwrap)
+	defer reset()
+
+	dir := t.TempDir()
+	cmd, err := buildTerminalCommand(TerminalOptions{
+		Command:          "echo",
+		Args:             []string{"hello"},
+		WorkingDirectory: dir,
+		Policy:           Policy{AllowedRoot: dir},
+	})
+	if err != nil {
+		t.Fatalf("buildTerminalCommand: %v", err)
+	}
+	if len(cmd.Args) == 0 || cmd.Args[0] != "/usr/bin/bwrap" {
+		t.Fatalf("terminal argv = %#v, want bwrap wrapper", cmd.Args)
+	}
+	if !containsString(cmd.Args, "--bind") || !containsString(cmd.Args, dir) {
+		t.Fatalf("terminal argv = %#v, want workspace bind", cmd.Args)
+	}
+	if !containsString(cmd.Args, "--unshare-net") {
+		t.Fatalf("terminal argv = %#v, want network isolation by default", cmd.Args)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- expose sandbox command validation and OS-wrapper application for workspace process surfaces
- route LocalWorkspace terminal commands through the same static policy checks and bwrap/sandbox-exec wrapping path as one-shot shell execution
- document the terminal safety invariant in runtime docs and backend agent guidance

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/sandbox ./internal/workspace ./internal/agentadapters
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 5m ./internal/workspace ./internal/agentadapters
- just docs-format-check