### PR TITLE
feat(ui): surface terminal tool activity

### DIFF
--- a/ui/src/features/chats/HecateTaskApprovalsBanner.test.ts
+++ b/ui/src/features/chats/HecateTaskApprovalsBanner.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatSessionRecord } from "../../types/chat";
+import { pendingHecateTaskApprovals } from "./HecateTaskApprovalsBanner";
+
+function session(overrides: Partial<ChatSessionRecord> = {}): ChatSessionRecord {
+  return {
+    id: "chat-1",
+    title: "Task-backed chat",
+    task_id: "task-1",
+    latest_run_id: "run-1",
+    workspace: "/workspace",
+    status: "awaiting_approval",
+    messages: [],
+    ...overrides,
+  };
+}
+
+describe("pendingHecateTaskApprovals", () => {
+  it("classifies native terminal tool approval reasons as terminal tools", () => {
+    const approvals = pendingHecateTaskApprovals(
+      session({
+        messages: [
+          {
+            id: "msg-1",
+            role: "assistant",
+            content: "",
+            activities: [
+              {
+                id: "task:approval:ap-1",
+                type: "approval",
+                title: "agent_loop_tool_call",
+                kind: "agent_loop_approval",
+                status: "awaiting_approval",
+                needs_action: true,
+                detail:
+                  "Agent requested tools that require approval: terminal_open - awaiting_approval",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(approvals).toHaveLength(1);
+    expect(approvals[0].kind).toBe("terminal_tool");
+    expect(approvals[0].detail).toBe("terminal_open");
+  });
+});

--- a/ui/src/features/chats/HecateTaskApprovalsBanner.tsx
+++ b/ui/src/features/chats/HecateTaskApprovalsBanner.tsx
@@ -1,4 +1,5 @@
 import { formatLocaleTime } from "../../lib/format";
+import { hasAgentTerminalToolMention } from "../../lib/agent-terminal-tools";
 import type { ChatActivityRecord, ChatSegmentRecord, ChatSessionRecord } from "../../types/chat";
 import { ChatNoticeFrame, ChatNoticeHeader, ChatNoticeRow } from "./ChatNotice";
 import { toChatSegmentViewModel } from "./chatTurnViewModels";
@@ -59,6 +60,7 @@ function taskApprovalDisplayKind(activity: ChatActivityRecord): string {
     return kind;
   }
   const haystack = `${activity.title || ""} ${activity.detail || ""}`.toLowerCase();
+  if (hasAgentTerminalToolMention(haystack)) return "terminal_tool";
   if (haystack.includes("shell_exec")) return "shell_command";
   if (haystack.includes("git_exec")) return "git_exec";
   if (haystack.includes("file_write")) return "file_write";
@@ -262,6 +264,8 @@ function describeTaskApprovalKind(kind: string): string {
       return "Approval";
     case "shell_command":
       return "Shell execution";
+    case "terminal_tool":
+      return "Terminal tool";
     case "git_exec":
       return "Git execution";
     case "file_write":

--- a/ui/src/features/runs/TaskDetail.test.tsx
+++ b/ui/src/features/runs/TaskDetail.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -1470,6 +1470,28 @@ describe("TaskDetail steps timeline — MCP tool distinction", () => {
     });
   }
 
+  function makeTerminalStep(overrides: Partial<TaskStepRecord> = {}): TaskStepRecord {
+    return makeStep({
+      id: "step-terminal",
+      kind: "tool",
+      tool_name: "terminal_open",
+      title: "terminal_open (completed)",
+      input: {
+        command: "python",
+        args: ["watch.py", "--tail"],
+        working_directory: ".",
+      },
+      output_summary: {
+        terminal_id: "term_01HX",
+        running: false,
+        output_bytes: 2048,
+        exit_code: 0,
+        truncated: true,
+      },
+      ...overrides,
+    });
+  }
+
   it("renders an MCP badge on namespaced tool steps", () => {
     const { render } = setup({ steps: [makeMcpStep()] });
     render();
@@ -1507,6 +1529,50 @@ describe("TaskDetail steps timeline — MCP tool distinction", () => {
     expect(screen.queryByLabelText(/mcp tool call/i)).toBeNull();
     // Built-in keeps its title verbatim.
     expect(screen.getByText("shell_exec (completed)")).toBeTruthy();
+  });
+
+  it("renders terminal tool steps as terminal operation rows", () => {
+    const { render } = setup({ steps: [makeTerminalStep()] });
+    render();
+    expect(screen.getByLabelText(/terminal tool call/i)).toBeTruthy();
+    expect(screen.getByText("terminal")).toBeTruthy();
+    expect(screen.getByText("open")).toBeTruthy();
+    expect(screen.queryByText("terminal_open (completed)")).toBeNull();
+  });
+
+  it("expanded StepDetail summarizes terminal command and state", async () => {
+    const { render, user } = setup({ steps: [makeTerminalStep()] });
+    render();
+    await user.click(screen.getByRole("button", { name: /step terminal_open/i }));
+
+    const details = screen.getByLabelText(/terminal tool details/i);
+    expect(within(details).getByText("python watch.py --tail")).toBeTruthy();
+    expect(within(details).getByText("term_01HX")).toBeTruthy();
+    expect(within(details).getByText(".")).toBeTruthy();
+    expect(within(details).getByText("exit 0")).toBeTruthy();
+    expect(within(details).getByText("2.0kb")).toBeTruthy();
+    expect(within(details).getByText("yes")).toBeTruthy();
+  });
+
+  it("expanded StepDetail summarizes terminal writes without inventing a command", async () => {
+    const { render, user } = setup({
+      steps: [
+        makeTerminalStep({
+          tool_name: "terminal_write",
+          title: "terminal_write (completed)",
+          input: { terminal_id: "term_02", input_chars: 12 },
+          output_summary: { terminal_id: "term_02", running: true, output_bytes: 0 },
+        }),
+      ],
+    });
+    render();
+    await user.click(screen.getByRole("button", { name: /step terminal_write/i }));
+
+    const details = screen.getByLabelText(/terminal tool details/i);
+    expect(within(details).queryByText(/^command$/)).toBeNull();
+    expect(within(details).getByText("term_02")).toBeTruthy();
+    expect(within(details).getByText("12 chars")).toBeTruthy();
+    expect(within(details).getByText("running")).toBeTruthy();
   });
 
   it("expanded StepDetail breaks out transport, server, and tool labels for MCP steps", async () => {

--- a/ui/src/features/runs/TaskDetail.tsx
+++ b/ui/src/features/runs/TaskDetail.tsx
@@ -15,6 +15,11 @@ import {
   formatLocaleTime,
   formatMicrosUSD,
 } from "../../lib/format";
+import {
+  agentTerminalToolOperation,
+  agentTerminalToolTitle,
+  isAgentTerminalToolName,
+} from "../../lib/agent-terminal-tools";
 import { providerDisplayName } from "../../lib/provider-utils";
 import { ContextInspectorModalTrigger } from "../shared/ContextInspector";
 import { Badge, BrandAvatar, CopyableID, Dot, Icon, Icons, Modal } from "../shared/ui";
@@ -1328,6 +1333,38 @@ function StepRowTitle({ step }: { step: TaskStepRecord }) {
     flex: 1,
   } as const;
   const mcp = splitNamespacedToolName(step.tool_name);
+  const terminalToolTitle = agentTerminalToolTitle(step.tool_name);
+  const terminalOperation = agentTerminalToolOperation(step.tool_name);
+  if (terminalToolTitle && terminalOperation) {
+    return (
+      <span
+        style={{ ...baseStyle, display: "inline-flex", alignItems: "center", gap: 6, minWidth: 0 }}
+        title={step.tool_name}
+      >
+        <span
+          className="badge badge-muted"
+          aria-label="Terminal tool call"
+          style={{ fontSize: 9, fontFamily: "var(--font-mono)", padding: "1px 5px", flexShrink: 0 }}
+        >
+          TERM
+        </span>
+        <span
+          style={{
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <span style={{ color: "var(--t2)" }}>terminal</span>
+          <span style={{ color: "var(--t3)", margin: "0 4px" }}>·</span>
+          <span style={{ color: "var(--t0)", fontFamily: "var(--font-mono)" }}>
+            {terminalOperation}
+          </span>
+        </span>
+      </span>
+    );
+  }
   if (mcp) {
     return (
       <span
@@ -1623,9 +1660,185 @@ function TaskActivityOutputPreview({ artifact }: { artifact: TaskActivityRecord 
   );
 }
 
+function TerminalStepSummary({ step }: { step: TaskStepRecord }) {
+  const input = step.input ?? {};
+  const output = step.output_summary ?? {};
+  const command = terminalCommandPreview(input);
+  const cwd = stringField(input, "working_directory");
+  const terminalID = stringField(output, "terminal_id") || stringField(input, "terminal_id");
+  const inputChars = numberField(input, "input_chars");
+  const timeoutMS = numberField(input, "timeout_ms");
+  const outputBytes = numberField(output, "output_bytes");
+  const error = stringField(output, "error");
+  const state = terminalStateLabel(output);
+  const facts = [
+    terminalID ? { label: "terminal", value: terminalID } : null,
+    cwd ? { label: "cwd", value: cwd } : null,
+    inputChars !== undefined ? { label: "stdin", value: `${inputChars} chars` } : null,
+    timeoutMS !== undefined ? { label: "timeout", value: `${timeoutMS}ms` } : null,
+    state ? { label: "state", value: state, tone: stateTone(state) } : null,
+    outputBytes !== undefined ? { label: "output", value: formatTerminalBytes(outputBytes) } : null,
+    boolField(output, "truncated") ? { label: "truncated", value: "yes" } : null,
+  ].filter((item): item is { label: string; value: string; tone?: "green" | "red" | "amber" } =>
+    Boolean(item),
+  );
+
+  return (
+    <div
+      aria-label="Terminal tool details"
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        background: "var(--bg0)",
+        padding: "7px 8px",
+        display: "grid",
+        gap: 7,
+      }}
+    >
+      {command && (
+        <div
+          style={{
+            display: "grid",
+            gap: 3,
+          }}
+        >
+          <span style={{ color: "var(--t3)", fontFamily: "var(--font-mono)", fontSize: 10 }}>
+            command
+          </span>
+          <code
+            style={{
+              color: "var(--t1)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              overflowWrap: "anywhere",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {command}
+          </code>
+        </div>
+      )}
+      {facts.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {facts.map((fact) => (
+            <span
+              key={fact.label}
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: 999,
+                color: "var(--t2)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                padding: "3px 7px",
+              }}
+            >
+              <span style={{ color: "var(--t3)" }}>{fact.label}</span>{" "}
+              <span style={{ color: terminalFactValueColor(fact.tone) }}>{fact.value}</span>
+            </span>
+          ))}
+        </div>
+      )}
+      {error && (
+        <pre
+          style={{
+            margin: 0,
+            padding: "6px 8px",
+            fontSize: 11,
+            fontFamily: "var(--font-mono)",
+            color: "var(--red)",
+            background: "var(--bg2)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm)",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        >
+          {error}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function terminalCommandPreview(input: Record<string, unknown>): string {
+  const command = stringField(input, "command");
+  const args = stringArrayField(input, "args");
+  const parts = [command, ...args].filter(Boolean);
+  if (parts.length === 0) return "";
+  return parts.map(quoteTerminalCommandPart).join(" ");
+}
+
+function quoteTerminalCommandPart(value: string): string {
+  if (!/[\s"'\\$`]/.test(value)) return value;
+  return JSON.stringify(value);
+}
+
+function terminalStateLabel(output: Record<string, unknown>): string {
+  if (boolField(output, "timeout")) return "timed out";
+  const running = booleanField(output, "running");
+  if (running === true) return "running";
+  const exitCode = numberField(output, "exit_code");
+  if (exitCode !== undefined) return `exit ${exitCode}`;
+  if (running === false) return "closed";
+  return "";
+}
+
+function stateTone(state: string): "green" | "red" | "amber" | undefined {
+  if (state === "running") return "amber";
+  if (state === "timed out") return "amber";
+  if (state === "exit 0" || state === "closed") return "green";
+  if (state.startsWith("exit ")) return "red";
+  return undefined;
+}
+
+function terminalFactValueColor(tone?: "green" | "red" | "amber"): string {
+  switch (tone) {
+    case "green":
+      return "var(--green)";
+    case "red":
+      return "var(--red)";
+    case "amber":
+      return "var(--amber)";
+    default:
+      return "var(--t1)";
+  }
+}
+
+function formatTerminalBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}b`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)}kb`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}mb`;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanField(record: Record<string, unknown>, key: string): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function boolField(record: Record<string, unknown>, key: string): boolean {
+  return booleanField(record, key) === true;
+}
+
+function stringArrayField(record: Record<string, unknown>, key: string): string[] {
+  const value = record[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim() !== "");
+}
+
 function StepDetail({ step }: { step: TaskStepRecord }) {
   const duration = formatDurationRange(step.started_at, step.finished_at);
   const mcp = splitNamespacedToolName(step.tool_name);
+  const isTerminalTool = isAgentTerminalToolName(step.tool_name);
   return (
     <div
       style={{
@@ -1707,6 +1920,7 @@ function StepDetail({ step }: { step: TaskStepRecord }) {
           </span>
         )}
       </div>
+      {isTerminalTool && <TerminalStepSummary step={step} />}
       {/* Hint pointing operators to the conversation viewer where
           the upstream server's full text result is rendered. The
           step's output_summary captures only is_error + text_size

--- a/ui/src/features/runs/taskDetailHelpers.ts
+++ b/ui/src/features/runs/taskDetailHelpers.ts
@@ -187,6 +187,8 @@ export function describeApprovalKind(kind: string): string {
   switch (kind) {
     case "shell_command":
       return "Shell execution";
+    case "terminal_tool":
+      return "Terminal tool";
     case "git_exec":
       return "Git execution";
     case "file_write":

--- a/ui/src/features/transcript/transcriptActivityHelpers.test.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.test.ts
@@ -280,6 +280,15 @@ describe("activityDisplay", () => {
     );
   });
 
+  it("humanizes native terminal tool calls", () => {
+    expect(activityDisplay(activity({ type: "tool_call", title: "terminal_open" })).title).toBe(
+      "Opened terminal",
+    );
+    expect(activityDisplay(activity({ type: "tool_call", title: "terminal_wait" })).title).toBe(
+      "Waited for terminal",
+    );
+  });
+
   it("falls back to 'Used tool' for opaque call ids", () => {
     expect(activityDisplay(activity({ type: "tool_call", title: "call_abc123def456" })).title).toBe(
       "Used tool",

--- a/ui/src/features/transcript/transcriptActivityHelpers.ts
+++ b/ui/src/features/transcript/transcriptActivityHelpers.ts
@@ -1,4 +1,5 @@
 import type { ChatActivityRecord } from "../../types/chat";
+import { agentTerminalToolActivityTitle } from "../../lib/agent-terminal-tools";
 
 const terminalRunSummaryTypes = new Set(["run_result", "completed", "failed", "cancelled"]);
 
@@ -355,6 +356,8 @@ function toolActivityTitle(activity: ChatActivityRecord): string {
   const normalized = raw.toLowerCase();
   const normalizedKind = (activity.kind || "").trim().toLowerCase();
   const toolHint = `${activity.kind ?? ""} ${activity.detail ?? ""}`.trim().toLowerCase();
+  const terminalTitle = agentTerminalToolActivityTitle(normalized);
+  if (terminalTitle) return terminalTitle;
 
   if (opaqueToolCallID(raw)) {
     if (toolHint.includes("execute") || toolHint.includes("command") || toolHint.includes("shell"))

--- a/ui/src/lib/agent-approval-labels.test.ts
+++ b/ui/src/lib/agent-approval-labels.test.ts
@@ -11,6 +11,8 @@ describe("agent approval labels", () => {
   it("humanizes known tool kinds and leaves unknown kinds readable", () => {
     expect(agentApprovalToolKindLabel("file_write")).toBe("file write");
     expect(agentApprovalToolKindLabel("shell_exec")).toBe("shell command");
+    expect(agentApprovalToolKindLabel("terminal_open")).toBe("terminal tool");
+    expect(agentApprovalToolKindLabel("terminal")).toBe("terminal tool");
     expect(agentApprovalToolKindLabel("mcp")).toBe("MCP tool");
     expect(agentApprovalToolKindLabel("custom_tool")).toBe("custom tool");
   });
@@ -22,6 +24,9 @@ describe("agent approval labels", () => {
     expect(agentApprovalToolLabel({ tool_kind: "file_write", tool_name: "apply_patch" })).toBe(
       "file write · apply_patch",
     );
+    expect(
+      agentApprovalToolLabel({ tool_kind: "agent_loop_tool_call", tool_name: "terminal_open" }),
+    ).toBe("terminal tool · Terminal open");
   });
 
   it("names broad MCP scopes as MCP-wide grants", () => {

--- a/ui/src/lib/agent-approval-labels.ts
+++ b/ui/src/lib/agent-approval-labels.ts
@@ -1,3 +1,5 @@
+import { agentTerminalToolTitle, isAgentTerminalToolName } from "./agent-terminal-tools";
+
 type ApprovalToolLike = {
   tool_kind?: string;
   tool_name?: string;
@@ -12,6 +14,7 @@ const TOOL_KIND_LABELS: Record<string, string> = {
   file_delete: "file delete",
   search: "search",
   think: "thinking",
+  terminal: "terminal tool",
   mcp: "MCP tool",
   other: "other tool",
 };
@@ -19,12 +22,15 @@ const TOOL_KIND_LABELS: Record<string, string> = {
 export function agentApprovalToolKindLabel(toolKind?: string): string {
   const trimmed = (toolKind ?? "").trim();
   if (!trimmed) return "tool";
+  if (isAgentTerminalToolName(trimmed)) return "terminal tool";
   return TOOL_KIND_LABELS[trimmed] ?? trimmed.replaceAll("_", " ");
 }
 
 export function agentApprovalToolLabel(item: ApprovalToolLike): string {
   const kindLabel = agentApprovalToolKindLabel(item.tool_kind);
   const toolName = item.tool_name?.trim();
+  const terminalToolLabel = agentTerminalToolTitle(toolName);
+  if (terminalToolLabel) return `terminal tool · ${terminalToolLabel}`;
   return toolName ? `${kindLabel} · ${toolName}` : kindLabel;
 }
 

--- a/ui/src/lib/agent-terminal-tools.test.ts
+++ b/ui/src/lib/agent-terminal-tools.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agentTerminalToolActivityTitle,
+  agentTerminalToolOperation,
+  agentTerminalToolTitle,
+  hasAgentTerminalToolMention,
+  isAgentTerminalToolName,
+} from "./agent-terminal-tools";
+
+describe("agent terminal tools", () => {
+  it("recognizes and labels native terminal tool names", () => {
+    expect(isAgentTerminalToolName("terminal_open")).toBe(true);
+    expect(agentTerminalToolOperation("terminal_open")).toBe("open");
+    expect(agentTerminalToolTitle("terminal_open")).toBe("Terminal open");
+    expect(agentTerminalToolActivityTitle("terminal_wait")).toBe("Waited for terminal");
+  });
+
+  it("finds terminal tool mentions in approval text", () => {
+    expect(
+      hasAgentTerminalToolMention(
+        "Agent requested tools that require approval: terminal_write - awaiting_approval",
+      ),
+    ).toBe(true);
+    expect(hasAgentTerminalToolMention("shell_exec - awaiting_approval")).toBe(false);
+    expect(hasAgentTerminalToolMention("terminal_opened is not a tool name")).toBe(false);
+  });
+});

--- a/ui/src/lib/agent-terminal-tools.ts
+++ b/ui/src/lib/agent-terminal-tools.ts
@@ -1,0 +1,55 @@
+const TERMINAL_TOOL_LABELS = {
+  terminal_open: {
+    operation: "open",
+    rowTitle: "Terminal open",
+    activityTitle: "Opened terminal",
+  },
+  terminal_write: {
+    operation: "write",
+    rowTitle: "Terminal write",
+    activityTitle: "Wrote to terminal",
+  },
+  terminal_read: {
+    operation: "read",
+    rowTitle: "Terminal read",
+    activityTitle: "Read terminal",
+  },
+  terminal_wait: {
+    operation: "wait",
+    rowTitle: "Terminal wait",
+    activityTitle: "Waited for terminal",
+  },
+  terminal_kill: {
+    operation: "kill",
+    rowTitle: "Terminal kill",
+    activityTitle: "Killed terminal",
+  },
+} as const;
+
+export type AgentTerminalToolName = keyof typeof TERMINAL_TOOL_LABELS;
+
+const TERMINAL_TOOL_NAMES = new Set<string>(Object.keys(TERMINAL_TOOL_LABELS));
+const TERMINAL_TOOL_MENTION_RE = /\bterminal_(?:open|write|read|wait|kill)\b/i;
+
+export function isAgentTerminalToolName(value?: string): value is AgentTerminalToolName {
+  return TERMINAL_TOOL_NAMES.has((value ?? "").trim());
+}
+
+export function agentTerminalToolOperation(value?: string): string | undefined {
+  const name = (value ?? "").trim();
+  return isAgentTerminalToolName(name) ? TERMINAL_TOOL_LABELS[name].operation : undefined;
+}
+
+export function agentTerminalToolTitle(value?: string): string | undefined {
+  const name = (value ?? "").trim();
+  return isAgentTerminalToolName(name) ? TERMINAL_TOOL_LABELS[name].rowTitle : undefined;
+}
+
+export function agentTerminalToolActivityTitle(value?: string): string | undefined {
+  const name = (value ?? "").trim();
+  return isAgentTerminalToolName(name) ? TERMINAL_TOOL_LABELS[name].activityTitle : undefined;
+}
+
+export function hasAgentTerminalToolMention(value?: string): boolean {
+  return TERMINAL_TOOL_MENTION_RE.test(value ?? "");
+}

--- a/ui/src/lib/agent-terminal-tools.ts
+++ b/ui/src/lib/agent-terminal-tools.ts
@@ -28,8 +28,16 @@ const TERMINAL_TOOL_LABELS = {
 
 export type AgentTerminalToolName = keyof typeof TERMINAL_TOOL_LABELS;
 
-const TERMINAL_TOOL_NAMES = new Set<string>(Object.keys(TERMINAL_TOOL_LABELS));
-const TERMINAL_TOOL_MENTION_RE = /\bterminal_(?:open|write|read|wait|kill)\b/i;
+const TERMINAL_TOOL_NAME_LIST = Object.keys(TERMINAL_TOOL_LABELS);
+const TERMINAL_TOOL_NAMES = new Set<string>(TERMINAL_TOOL_NAME_LIST);
+const TERMINAL_TOOL_MENTION_RE = new RegExp(
+  `\\b(?:${TERMINAL_TOOL_NAME_LIST.map(escapeRegExp).join("|")})\\b`,
+  "i",
+);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 export function isAgentTerminalToolName(value?: string): value is AgentTerminalToolName {
   return TERMINAL_TOOL_NAMES.has((value ?? "").trim());


### PR DESCRIPTION
## Summary

- add shared UI labels for native terminal tools
- render terminal tool steps with terminal-specific row labels and expanded command/state/output facts
- humanize terminal tool activity in transcript rows and task-backed approval banners
- cover the new labels and rendering with focused UI tests

## Tests

- cd ui && bun run test -- TaskDetail.test.tsx transcriptActivityHelpers.test.ts agent-approval-labels.test.ts HecateTaskApprovalsBanner.test.ts
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- git diff --check