### PR TITLE
fix(dev): run serve from just recipes

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -198,7 +198,7 @@ Agent installer is fetched from Cursor's official install URL and checked
 against a pinned SHA-256 before it runs; update the checksum only after
 reviewing the new installer contents.
 
-If a `docker run` (or `docker compose up`) errors with `bind: address already in use` on `:8765`, a previous `just dev` / `just run` / `./hecate` is still listening from another shell. Free the port with `just stop` and retry; `just dev`, `just run`, and `just serve` also auto-run `stop` before starting so successive launches don't pile up.
+If a `docker run` (or `docker compose up`) errors with `bind: address already in use` on `:8765`, a previous `just dev` / `just run` / `./hecate serve` is still listening from another shell. Free the port with `just stop` and retry; `just dev`, `just run`, and `just serve` also auto-run `stop` before starting so successive launches don't pile up.
 
 ## Binary install
 
@@ -208,21 +208,21 @@ The release workflow publishes static, single-file binaries for `linux+darwin ×
 # pick the right tarball for your OS / arch
 curl -LO https://github.com/hecatehq/hecate/releases/download/v0.2.0-alpha.4/hecate_0.2.0-alpha.4_linux_amd64.tar.gz
 tar -xzf hecate_0.2.0-alpha.4_linux_amd64.tar.gz
-./hecate
+./hecate serve
 ```
 
-The `hecate` binary starts the gateway service, embeds the React operator UI, listens on `127.0.0.1:8765` by default, and stores state under `HECATE_DATA_DIR` (default `.data/`). No additional runtime dependencies — the binaries are statically linked and CGO-free.
+The `hecate serve` command starts the gateway service, embeds the React operator UI, listens on `127.0.0.1:8765` by default, and stores state under `HECATE_DATA_DIR` (default `.data/`). No additional runtime dependencies — the binaries are statically linked and CGO-free.
 
 To bind the bare binary beyond loopback, set both variables and provide your own network protection:
 
 ```bash
-HECATE_ADDRESS=0.0.0.0:8765 HECATE_ALLOW_NON_LOOPBACK_BIND=1 ./hecate
+HECATE_ADDRESS=0.0.0.0:8765 HECATE_ALLOW_NON_LOOPBACK_BIND=1 ./hecate serve
 ```
 
 To pin the data directory to a known location:
 
 ```bash
-HECATE_DATA_DIR=/var/lib/hecate ./hecate
+HECATE_DATA_DIR=/var/lib/hecate ./hecate serve
 ```
 
 For systemd, launchd, or supervisor wrappers, the only requirements are: the working directory is writable for `HECATE_DATA_DIR`, port 8765 is available, and `.env` (if used) sits in the working directory or is sourced into the unit file. The binary path itself can live anywhere on `$PATH`.

--- a/just/go.just
+++ b/just/go.just
@@ -53,7 +53,7 @@ coverage: _go-cache
 
 # Free :8765 by killing whatever is listening there. Useful before
 # `docker run -p 8765:8765 ...` or any local relaunch where a stale
-# `just dev` / `just run` / `./hecate` would otherwise produce
+# `just dev` / `just run` / `./hecate serve` would otherwise produce
 # "address already in use".
 # Stop any gateway process listening on :8765.
 stop:
@@ -76,7 +76,7 @@ run *args: _go-cache
 	  esac; \
 	done; \
 	if [ "$needs_reset" = "1" ]; then just reset-dev > /dev/null; else just stop; fi
-	{{go_env}} go run ./cmd/hecate
+	{{go_env}} go run ./cmd/hecate serve
 
 # Run the pre-built ./hecate binary. The `stop` dependency frees :8765 if a
 # stale process is still listening, so a forgotten Ctrl-C never blocks a
@@ -113,7 +113,7 @@ dev *args: _go-cache
 	set +a; \
 	HECATE_ALLOWED_ORIGINS="${HECATE_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173}"; \
 	export HECATE_ALLOWED_ORIGINS; \
-	{{go_env}} go run ./cmd/hecate
+	{{go_env}} go run ./cmd/hecate serve
 
 # Run the gateway from source with external-agent adapter visuals forced to a
 # known state. This is visual-only: it changes discovery/probe readiness
@@ -137,7 +137,7 @@ dev-agent-adapters overrides *args: _go-cache
 	set +a; \
 	HECATE_ALLOWED_ORIGINS="${HECATE_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173}"; \
 	export HECATE_ALLOWED_ORIGINS; \
-	HECATE_AGENT_ADAPTER_DEV_OVERRIDES="{{overrides}}" {{go_env}} go run ./cmd/hecate
+	HECATE_AGENT_ADAPTER_DEV_OVERRIDES="{{overrides}}" {{go_env}} go run ./cmd/hecate serve
 
 # Run the gateway with all external-agent adapters shown as not installed.
 # Useful for manually testing first-run External Agent onboarding.

--- a/just/recipes_test.go
+++ b/just/recipes_test.go
@@ -1,0 +1,54 @@
+package just_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeRecipesStartServeCommand(t *testing.T) {
+	if _, err := exec.LookPath("just"); err != nil {
+		t.Skip("just binary not available")
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "run",
+			args: []string{"--dry-run", "run"},
+			want: "go run ./cmd/hecate serve",
+		},
+		{
+			name: "dev",
+			args: []string{"--dry-run", "dev"},
+			want: "go run ./cmd/hecate serve",
+		},
+		{
+			name: "dev agent adapters",
+			args: []string{"--dry-run", "dev-agent-adapters", "all=missing"},
+			want: `HECATE_AGENT_ADAPTER_DEV_OVERRIDES="all=missing" GOCACHE="$PWD/.gocache" go run ./cmd/hecate serve`,
+		},
+		{
+			name: "prebuilt serve",
+			args: []string{"--dry-run", "serve"},
+			want: "./hecate serve",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("just", tt.args...)
+			cmd.Dir = ".."
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("just %s failed: %v\n%s", strings.Join(tt.args, " "), err, out)
+			}
+			if !strings.Contains(string(out), tt.want) {
+				t.Fatalf("just %s output missing %q:\n%s", strings.Join(tt.args, " "), tt.want, out)
+			}
+		})
+	}
+}

--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -5,7 +5,7 @@
 //   just screenshots                     # from repo root
 //
 // Prerequisites:
-//   1. `just reset-dev && ./hecate &` — gateway running on
+//   1. `just reset-dev && ./hecate serve &` — gateway running on
 //      127.0.0.1:8765 with fresh state.
 //   2. ollama running on :11434 with `ollama pull llama3.1:8b` (optional;
 //      used only to seed one realistic trace row for the observability


### PR DESCRIPTION
## Summary

- update source-run Just recipes to call `hecate serve` explicitly
- refresh docs/scripts that still showed bare `./hecate` as the runtime command
- add a regression test that pins runtime recipes to the serve subcommand

## Tests

- `GOCACHE="$PWD/.gocache" go test ./just`
- `just --dry-run dev`
- `just --dry-run run`
- `just --dry-run dev-agent-adapters all=missing`
- `just docs-format-check`
- `git diff --check`
