### PR TITLE
fix(ui): warm external agent readiness in chats

### DIFF
--- a/ui/src/app/state/providersAndModels.test.tsx
+++ b/ui/src/app/state/providersAndModels.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -9,14 +9,15 @@ import {
 import type { ReactNode } from "react";
 
 const getProviderPresetsMock = vi.fn();
+const probeAgentAdapterMock = vi.fn();
 const warnMock = vi.fn();
 
 vi.mock("../../lib/api", () => ({
   getProviderPresets: (...args: unknown[]) => getProviderPresetsMock(...args),
+  probeAgentAdapter: (...args: unknown[]) => probeAgentAdapterMock(...args),
   // Stubs for other api symbols the slice imports — unused in these tests.
   getProviders: vi.fn(),
   getModels: vi.fn(),
-  probeAgentAdapter: vi.fn(),
 }));
 
 vi.mock("../../lib/log", () => ({
@@ -31,6 +32,7 @@ function Wrapper({ children }: { children: ReactNode }) {
 
 beforeEach(() => {
   getProviderPresetsMock.mockReset();
+  probeAgentAdapterMock.mockReset();
   warnMock.mockReset();
 });
 
@@ -145,5 +147,57 @@ describe("useEnsureProviderPresetsLoaded", () => {
     await waitFor(() => {
       expect(getProviderPresetsMock).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe("probeAgentAdapter", () => {
+  it("dedupes concurrent probes for the same adapter", async () => {
+    let resolveProbe: (value: unknown) => void = () => {};
+    probeAgentAdapterMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveProbe = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useProvidersAndModels(), { wrapper: Wrapper });
+    let first: Promise<unknown> | undefined;
+    let second: Promise<unknown> | undefined;
+
+    act(() => {
+      first = result.current.actions.probeAgentAdapter("codex");
+      second = result.current.actions.probeAgentAdapter("codex");
+    });
+
+    expect(probeAgentAdapterMock).toHaveBeenCalledTimes(1);
+    expect(probeAgentAdapterMock).toHaveBeenCalledWith("codex");
+
+    await act(async () => {
+      resolveProbe({
+        object: "agent_adapter_probe",
+        data: {
+          adapter: {
+            id: "codex",
+            name: "Codex",
+            kind: "acp",
+            command: "codex-acp-adapter",
+            available: true,
+            status: "available",
+            supports_authenticate: false,
+            supports_logout: false,
+          },
+          health: {
+            adapter_id: "codex",
+            status: "ready",
+            stage: "ready",
+            duration_ms: 42,
+          },
+        },
+      });
+      await Promise.all([first, second]);
+    });
+
+    expect(result.current.state.agentAdapterHealthByID.get("codex")).toMatchObject({
+      status: "ready",
+    });
+    expect(result.current.state.agentAdapterHealthLoadingByID.has("codex")).toBe(false);
   });
 });

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -167,6 +167,7 @@ export function ProvidersAndModelsProvider({
     reducer,
     seededState ? { ...initialState, ...seededState } : initialState,
   );
+  const probeAgentAdapterInFlightRef = useRef(new Map<string, Promise<ProbeAdapterResult>>());
 
   const setProviders = useCallback(
     (next: SetStateAction<ProviderStatusResponse["data"]>) =>
@@ -225,24 +226,31 @@ export function ProvidersAndModelsProvider({
 
   const probeAgentAdapter = useCallback(async (adapterID: string): Promise<ProbeAdapterResult> => {
     if (!adapterID) return { ok: false, error: "Adapter id required to probe." };
-    dispatch({ type: "agentAdapterHealthLoading/set", adapterID, loading: true });
-    try {
-      const payload = await probeAgentAdapterRequest(adapterID);
-      dispatch({ type: "agentAdapterHealth/set", adapterID, record: payload.data.health });
-      dispatch({
-        type: "agentAdapters/set",
-        next: (current) =>
-          current.map((item) => (item.id === adapterID ? payload.data.adapter : item)),
-      });
-      return { ok: true, health: payload.data.health };
-    } catch (error) {
-      return {
-        ok: false,
-        error: error instanceof Error ? error.message : "Failed to probe adapter.",
-      };
-    } finally {
-      dispatch({ type: "agentAdapterHealthLoading/set", adapterID, loading: false });
-    }
+    const inFlight = probeAgentAdapterInFlightRef.current.get(adapterID);
+    if (inFlight) return inFlight;
+    const probe: Promise<ProbeAdapterResult> = (async (): Promise<ProbeAdapterResult> => {
+      dispatch({ type: "agentAdapterHealthLoading/set", adapterID, loading: true });
+      try {
+        const payload = await probeAgentAdapterRequest(adapterID);
+        dispatch({ type: "agentAdapterHealth/set", adapterID, record: payload.data.health });
+        dispatch({
+          type: "agentAdapters/set",
+          next: (current) =>
+            current.map((item) => (item.id === adapterID ? payload.data.adapter : item)),
+        });
+        return { ok: true, health: payload.data.health };
+      } catch (error) {
+        return {
+          ok: false,
+          error: error instanceof Error ? error.message : "Failed to probe adapter.",
+        };
+      } finally {
+        probeAgentAdapterInFlightRef.current.delete(adapterID);
+        dispatch({ type: "agentAdapterHealthLoading/set", adapterID, loading: false });
+      }
+    })();
+    probeAgentAdapterInFlightRef.current.set(adapterID, probe);
+    return probe;
   }, []);
 
   const actions = useMemo<ProvidersAndModelsActions>(

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -1,13 +1,17 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useChat } from "../../app/state/chat";
 import { useProvidersAndModels } from "../../app/state/providersAndModels";
 import { useProjects } from "../../app/state/projects";
+import { useAgentAdapterActions } from "../../app/state/coordinators/agentAdapters";
 import { useChatActions } from "../../app/state/coordinators/chat";
 import { useNewChatAgentID, useChatTarget } from "../../app/state/derived";
 import { useWiredSettingsActions } from "../../app/state/coordinators/wired";
+import { useRuntime } from "../../app/state/runtime";
+import { shouldAutoProbeExternalAgentReadiness } from "../../lib/external-agent-readiness";
 import { formatAbsoluteTime } from "../../lib/format";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
+import { isRemoteRuntimeSession } from "../../lib/runtime-utils";
 import type { AgentAdapterRecord } from "../../types/agent-adapter";
 import type { ChatSessionRecord } from "../../types/chat";
 import { ProjectScopePanel } from "../projects/ProjectScopePanel";
@@ -53,8 +57,13 @@ export function ChatSidebar({
   const chat = useChat();
   const providersAndModels = useProvidersAndModels();
   const projects = useProjects();
+  const runtime = useRuntime();
   const chatTarget = useChatTarget();
   const { actions: settingsActions } = useWiredSettingsActions();
+  const agentAdapterActions = useAgentAdapterActions({
+    setNoticeMessage: settingsActions.setNoticeMessage,
+  });
+  const probeAgentAdapter = agentAdapterActions.probeAgentAdapter;
   const chatActions = useChatActions({
     chatTarget,
     setNoticeMessage: settingsActions.setNoticeMessage,
@@ -64,6 +73,8 @@ export function ChatSidebar({
   const activeChatSessionID = chat.state.activeChatSessionID;
   const agentAdapters = providersAndModels.state.agentAdapters;
   const agentAdapterHealthByID = providersAndModels.state.agentAdapterHealthByID;
+  const agentAdapterHealthLoadingByID = providersAndModels.state.agentAdapterHealthLoadingByID;
+  const autoProbedAdapterIDs = useRef(new Set<string>());
   const [sidebarQuery, setSidebarQuery] = useState("");
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
@@ -108,6 +119,31 @@ export function ChatSidebar({
     const health = agentID === "hecate" ? undefined : agentAdapterHealthByID.get(agentID);
     return chatAgentOptionStatus(agentID, adapter, health);
   }
+
+  useEffect(() => {
+    const remoteRuntime = isRemoteRuntimeSession(runtime.state.sessionInfo);
+    for (const adapter of agentAdapters) {
+      if (
+        !shouldAutoProbeExternalAgentReadiness(
+          adapter,
+          agentAdapterHealthByID.get(adapter.id) ?? null,
+          Boolean(agentAdapterHealthLoadingByID.get(adapter.id)),
+          remoteRuntime,
+        )
+      ) {
+        continue;
+      }
+      if (autoProbedAdapterIDs.current.has(adapter.id)) continue;
+      autoProbedAdapterIDs.current.add(adapter.id);
+      void probeAgentAdapter(adapter.id);
+    }
+  }, [
+    agentAdapters,
+    agentAdapterHealthByID,
+    agentAdapterHealthLoadingByID,
+    probeAgentAdapter,
+    runtime.state.sessionInfo,
+  ]);
 
   function selectProjectScope(projectID: string) {
     const scopedSessions = filterSidebarSessionsByProject(sessions, projectID);

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -4481,6 +4481,38 @@ describe("ChatView external-agent target", () => {
     expect(setNewChatAgent).toHaveBeenCalledWith("claude_code");
   });
 
+  it("checks available external agents when Chats opens", async () => {
+    const probeAgentAdapter = vi.fn(async () => null);
+    const { state, actions } = setup(
+      {
+        chatTarget: "external_agent",
+        newChatAgentID: "codex",
+        agentAdapterID: "codex",
+        activeChatSessionID: "",
+        activeChatSession: null,
+        agentWorkspace: "/tmp/hecate",
+        agentAdapters: [
+          {
+            id: "codex",
+            name: "Codex",
+            kind: "acp",
+            command: "codex-acp-adapter",
+            available: true,
+            status: "available",
+            cost_mode: "external",
+            auth_status: "unknown",
+          },
+        ],
+      },
+      { probeAgentAdapter },
+    );
+
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledWith("codex"));
+    expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
+  });
+
   it("shows Claude Code local auth repair when the agent reports auth required", async () => {
     const onNavigate = vi.fn();
     const { state, actions } = setup({

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -19,6 +19,7 @@ import {
   humanizeProbeError,
   resolveExternalAgentReadiness,
   shouldShowProbeError,
+  shouldAutoProbeExternalAgentReadiness,
   type ExternalAgentReadinessTone,
 } from "../../lib/external-agent-readiness";
 import {
@@ -168,7 +169,7 @@ export function ConnectionsPanel({
   useEffect(() => {
     for (const adapter of agentAdapters) {
       if (
-        !shouldAutoProbeAdapter(
+        !shouldAutoProbeExternalAgentReadiness(
           adapter,
           agentAdapterHealthByID.get(adapter.id) ?? null,
           Boolean(agentAdapterHealthLoadingByID.get(adapter.id)),
@@ -766,17 +767,6 @@ function AdapterStatusSection({
       </div>
     </div>
   );
-}
-
-function shouldAutoProbeAdapter(
-  adapter: AgentAdapterRecord,
-  health: AgentAdapterHealthRecord | null,
-  loading: boolean,
-  remoteRuntime: boolean,
-): boolean {
-  if (!adapter.available || health || loading) return false;
-  if (remoteRuntime && adapter.remote_credential_ok !== true) return false;
-  return adapter.auth_status === "ok" || adapter.auth_status === "unknown" || !adapter.auth_status;
 }
 
 function AdapterStatusRow({

--- a/ui/src/lib/external-agent-readiness.ts
+++ b/ui/src/lib/external-agent-readiness.ts
@@ -148,6 +148,17 @@ export function resolveExternalAgentReadiness(
   };
 }
 
+export function shouldAutoProbeExternalAgentReadiness(
+  adapter: AgentAdapterRecord,
+  health: AgentAdapterHealthRecord | null,
+  loading: boolean,
+  remoteRuntime: boolean,
+): boolean {
+  if (!adapter.available || health || loading) return false;
+  if (remoteRuntime && adapter.remote_credential_ok !== true) return false;
+  return adapter.auth_status === "ok" || adapter.auth_status === "unknown" || !adapter.auth_status;
+}
+
 export function externalAgentLoginCommand(adapter: AgentAdapterRecord): string {
   switch (adapter.id) {
     case "codex":


### PR DESCRIPTION
## Summary
- auto-check installed external agents when the Chats sidebar opens
- share the auto-probe predicate with Connections so local and remote runtime behavior stays consistent
- add a ChatView regression test for the no-Connections-detour flow

## Tests
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/features/chats/ChatView.test.tsx
- cd ui && bun run test -- src/features/chats/ChatView.test.tsx src/features/settings/SettingsView.test.tsx src/lib/external-agent-readiness.test.ts
- cd ui && bun run test