### PR TITLE
fix(agentadapters): harden ACP terminal cleanup

### DIFF
--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -235,6 +236,61 @@ func TestSessionManagerRunsACPTerminalCallbackThroughAdapterProcess(t *testing.T
 	}
 }
 
+func TestSessionManagerCloseSessionCleansUnreleasedACPTerminal(t *testing.T) {
+	if os.Getenv("HECATE_FAKE_ACP_AGENT") == "1" {
+		return
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell cleanup semantics")
+	}
+	installFakeACPExecutable(t, "codex-acp-adapter")
+	workspace := t.TempDir()
+
+	manager := NewSessionManager()
+	manager.SetTerminalSupportEnabled(true)
+	manager.SetApprovalCoordinator(NewApprovalCoordinator(CoordinatorOptions{Mode: ModeAuto}))
+	t.Cleanup(func() { _ = manager.Shutdown(context.Background()) })
+	var activityCapture acpSessionActivityCapture
+
+	const sessionID = "chat_terminal_unreleased"
+	result, err := manager.Run(context.Background(), RunRequest{
+		SessionID:      sessionID,
+		AdapterID:      "codex",
+		Workspace:      workspace,
+		Prompt:         "terminal command no release",
+		Timeout:        5 * time.Second,
+		MaxOutputBytes: 64 * 1024,
+		OnActivity:     activityCapture.record,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(result.Output, "terminal output: terminal retained") {
+		t.Fatalf("Run output = %q, want retained terminal output", result.Output)
+	}
+	activities := activityCapture.snapshot()
+	var terminalTool *Activity
+	for i := range activities {
+		if activities[i].ID == "tool:terminal_ref_unreleased" {
+			terminalTool = &activities[i]
+			break
+		}
+	}
+	if terminalTool == nil {
+		t.Fatalf("Run activities = %+v, want terminal-ref tool activity", activities)
+	}
+	if !strings.Contains(terminalTool.ArtifactPreview, "terminal retained") {
+		t.Fatalf("terminal-ref tool preview = %q, want retained terminal output", terminalTool.ArtifactPreview)
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := manager.CloseSession(closeCtx, sessionID); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	waitForFileContent(t, filepath.Join(workspace, "terminal-closed.txt"), "closed")
+}
+
 type acpSessionActivityCapture struct {
 	mu         sync.Mutex
 	activities []Activity
@@ -261,6 +317,23 @@ func firstTerminalActivityID(activities []Activity) string {
 		}
 	}
 	return ""
+}
+
+func waitForFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			last = string(raw)
+			if strings.Contains(last, want) {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("%s content = %q, want %q before deadline", path, last, want)
 }
 
 func TestSessionManagerPreservesACPStopReason(t *testing.T) {
@@ -3312,6 +3385,47 @@ func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (ac
 		}
 		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
 	}
+	if prompt == "terminal command no release" {
+		cwd := session.cwd
+		terminal, err := a.conn.CreateTerminal(turnCtx, acp.CreateTerminalRequest{
+			SessionId: params.SessionId,
+			Command:   "sh",
+			Args:      []string{"-c", "trap 'printf closed > terminal-closed.txt; exit 0' TERM; printf 'terminal retained\n'; while :; do sleep 1; done"},
+			Cwd:       &cwd,
+		})
+		if err != nil {
+			return acp.PromptResponse{}, err
+		}
+		output, err := a.waitForTerminalOutput(turnCtx, params.SessionId, terminal.TerminalId, "terminal retained")
+		if err != nil {
+			return acp.PromptResponse{}, err
+		}
+		status := acp.ToolCallStatusCompleted
+		kind := acp.ToolKindExecute
+		if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{
+			SessionId: params.SessionId,
+			Update: acp.SessionUpdate{
+				ToolCallUpdate: &acp.SessionToolCallUpdate{
+					ToolCallId: acp.ToolCallId("terminal_ref_unreleased"),
+					Status:     &status,
+					Kind:       &kind,
+					Title:      acp.Ptr("Terminal command"),
+					Content: []acp.ToolCallContent{
+						acp.ToolTerminalRef(terminal.TerminalId),
+					},
+				},
+			},
+		}); err != nil {
+			return acp.PromptResponse{}, err
+		}
+		if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{
+			SessionId: params.SessionId,
+			Update:    acp.UpdateAgentMessageText("terminal output: " + strings.TrimSpace(output.Output)),
+		}); err != nil {
+			return acp.PromptResponse{}, err
+		}
+		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+	}
 
 	if err := a.conn.SessionUpdate(turnCtx, acp.SessionNotification{
 		SessionId: params.SessionId,
@@ -3332,6 +3446,32 @@ func (a *fakeACPAgent) Prompt(ctx context.Context, params acp.PromptRequest) (ac
 		return acp.PromptResponse{}, err
 	}
 	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+}
+
+func (a *fakeACPAgent) waitForTerminalOutput(ctx context.Context, sessionID acp.SessionId, terminalID string, want string) (acp.TerminalOutputResponse, error) {
+	deadline := time.Now().Add(3 * time.Second)
+	var last acp.TerminalOutputResponse
+	for time.Now().Before(deadline) {
+		output, err := a.conn.TerminalOutput(ctx, acp.TerminalOutputRequest{
+			SessionId:  sessionID,
+			TerminalId: terminalID,
+		})
+		if err != nil {
+			return acp.TerminalOutputResponse{}, err
+		}
+		last = output
+		if strings.Contains(output.Output, want) {
+			return output, nil
+		}
+		timer := time.NewTimer(20 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return acp.TerminalOutputResponse{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return last, fmt.Errorf("terminal output = %q, want %q before deadline", last.Output, want)
 }
 
 func fakeACPRequestPermission() acp.RequestPermissionRequest {

--- a/internal/agentadapters/acp_terminal.go
+++ b/internal/agentadapters/acp_terminal.go
@@ -138,12 +138,15 @@ func (c *acpChatClient) ReleaseTerminal(ctx context.Context, params acp.ReleaseT
 	if !c.terminalsEnabled {
 		return acp.ReleaseTerminalResponse{}, acp.NewMethodNotFound(acp.ClientMethodTerminalRelease)
 	}
-	item, err := c.removeTerminal(params.TerminalId)
+	item, err := c.lookupTerminal(params.TerminalId)
 	if err != nil {
 		return acp.ReleaseTerminalResponse{}, err
 	}
 	doneBeforeClose := terminalDone(item)
 	if err := item.term.Close(ctx); err != nil {
+		return acp.ReleaseTerminalResponse{}, err
+	}
+	if _, err := c.removeTerminal(params.TerminalId); err != nil {
 		return acp.ReleaseTerminalResponse{}, err
 	}
 	c.rememberTerminalPreview(item)

--- a/internal/agentadapters/acp_terminal_rpc_test.go
+++ b/internal/agentadapters/acp_terminal_rpc_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	acp "github.com/coder/acp-go-sdk"
+
+	"github.com/hecatehq/hecate/internal/workspace"
 )
 
 func TestAcpChatClientTerminalRPCsDisabledByDefault(t *testing.T) {
@@ -142,6 +144,53 @@ func TestAcpChatClientTerminalToolOutputPreviewSurvivesRemoval(t *testing.T) {
 	preview, ok = client.terminalToolOutputPreview("term_123")
 	if !ok || preview != "terminal output" {
 		t.Fatalf("terminalToolOutputPreview(removed) = %q, %v; want retained removed output", preview, ok)
+	}
+}
+
+func TestAcpChatClientReleaseTerminalKeepsHandleWhenCloseFails(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close failed")
+	term := &fakeWorkspaceTerminal{
+		id:       "term_close_error",
+		outputCh: make(chan workspace.OutputChunk),
+		closeErr: closeErr,
+	}
+	client := &acpChatClient{terminalsEnabled: true}
+	item := &acpTerminal{
+		id:          term.id,
+		commandLine: "sh -c 'sleep 60'",
+		cwd:         t.TempDir(),
+		term:        term,
+		output:      newACPTerminalOutputBuffer(1024),
+		done:        make(chan struct{}),
+	}
+	item.output.append("still readable\n")
+	client.storeTerminal(item)
+
+	if _, err := client.ReleaseTerminal(context.Background(), acp.ReleaseTerminalRequest{TerminalId: term.id}); !errors.Is(err, closeErr) {
+		t.Fatalf("ReleaseTerminal error = %v, want close failure", err)
+	}
+	output, err := client.TerminalOutput(context.Background(), acp.TerminalOutputRequest{TerminalId: term.id})
+	if err != nil {
+		t.Fatalf("TerminalOutput after failed release: %v", err)
+	}
+	if !strings.Contains(output.Output, "still readable") {
+		t.Fatalf("TerminalOutput after failed release = %q, want retained active output", output.Output)
+	}
+	if preview, ok := client.terminalToolOutputPreview(term.id); !ok || !strings.Contains(preview, "still readable") {
+		t.Fatalf("terminalToolOutputPreview after failed release = %q, %v; want retained active output", preview, ok)
+	}
+
+	term.closeErr = nil
+	if _, err := client.ReleaseTerminal(context.Background(), acp.ReleaseTerminalRequest{TerminalId: term.id}); err != nil {
+		t.Fatalf("ReleaseTerminal retry: %v", err)
+	}
+	if _, err := client.TerminalOutput(context.Background(), acp.TerminalOutputRequest{TerminalId: term.id}); err == nil {
+		t.Fatal("TerminalOutput after successful release succeeded; want not found")
+	}
+	if preview, ok := client.terminalToolOutputPreview(term.id); !ok || !strings.Contains(preview, "still readable") {
+		t.Fatalf("terminalToolOutputPreview after successful release = %q, %v; want retained removed output", preview, ok)
 	}
 }
 
@@ -448,6 +497,36 @@ func newTerminalTestClient(workspace string, mode ApprovalMode) (*acpChatClient,
 			Store: store,
 		}),
 	}, store
+}
+
+type fakeWorkspaceTerminal struct {
+	id       string
+	outputCh chan workspace.OutputChunk
+	closeErr error
+}
+
+func (t *fakeWorkspaceTerminal) ID() string {
+	return t.id
+}
+
+func (t *fakeWorkspaceTerminal) Output() <-chan workspace.OutputChunk {
+	return t.outputCh
+}
+
+func (t *fakeWorkspaceTerminal) Write(context.Context, string) error {
+	return nil
+}
+
+func (t *fakeWorkspaceTerminal) WaitForExit(context.Context) (workspace.Result, error) {
+	return workspace.Result{ExitCode: 0}, nil
+}
+
+func (t *fakeWorkspaceTerminal) Kill(context.Context) error {
+	return nil
+}
+
+func (t *fakeWorkspaceTerminal) Close(context.Context) error {
+	return t.closeErr
 }
 
 func TestAcpChatClientWriteTextFileRejectsSymlinkEscape(t *testing.T) {

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -847,6 +847,11 @@ function AdapterStatusRow({
     !showLocalAuthSetup &&
     !showRemoteCredentialSetup &&
     !showAuthenticateAction;
+  const showRemoteAuthPolicy =
+    remoteRuntime &&
+    adapter.available &&
+    (adapterAuthenticateSupportedByHecate(adapter, health) ||
+      adapterLogoutSupportedByHecate(adapter, health));
 
   return (
     <div
@@ -995,6 +1000,20 @@ function AdapterStatusRow({
             onTestAgain={() => onProbeAdapter(adapter)}
             testing={loading}
           />
+        )}
+        {showRemoteAuthPolicy && (
+          <div
+            data-testid={`external-agents-adapter-${adapter.id}-auth-policy`}
+            style={{
+              marginTop: 6,
+              fontSize: 11,
+              color: "var(--t3)",
+              lineHeight: 1.4,
+            }}
+          >
+            Local ACP login/logout actions are disabled in remote runtime. Configure remote
+            credentials for hosted sessions instead.
+          </div>
         )}
       </div>
       <div

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -805,6 +805,43 @@ describe("Connections external-agent panel", () => {
       expect(row).toHaveTextContent("load session yes");
     });
 
+    it("explains local ACP auth actions are disabled in remote runtime", async () => {
+      const { state, actions } = setup(
+        withAdapter({
+          sessionInfo: {
+            role: "operator",
+            remote_identity: {
+              actor_id: "actor_1",
+              org_id: "org_1",
+              project_id: "project_1",
+              runtime_id: "runtime_1",
+            },
+          },
+          agentAdapters: [
+            {
+              id: "codex",
+              name: "Codex",
+              kind: "acp",
+              command: "codex-acp-adapter",
+              available: true,
+              status: "available",
+              cost_mode: "external",
+              supports_authenticate: true,
+              supports_logout: true,
+            },
+          ],
+        }),
+      );
+      render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
+
+      const row = await screen.findByTestId("external-agents-adapter-codex");
+      expect(
+        within(row).getByTestId("external-agents-adapter-codex-auth-policy"),
+      ).toHaveTextContent("Local ACP login/logout actions are disabled in remote runtime");
+      expect(within(row).queryByRole("button", { name: /Sign in Codex/i })).toBeNull();
+      expect(within(row).queryByRole("button", { name: /Sign out Codex/i })).toBeNull();
+    });
+
     it("shows missing adapters as setup notifications", async () => {
       const { state, actions } = setup(
         withAdapter({


### PR DESCRIPTION
## Summary
- Keep ACP terminal handles registered when `terminal/release` close fails, so output and retained previews survive and release can be retried.
- Add fake-adapter coverage for retained terminal previews and cleanup when sessions close with unreleased terminals.
- Explain the remote-runtime ACP auth/logout policy in Connections when local actions are unavailable.

## Validation
- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters -run "TestAcpChatClientTerminal|TestSessionManager.*Terminal|TestACPTurnSurfacesTerminalContentPreview"`
- `GOCACHE="$PWD/.gocache" go test ./internal/agentadapters ./internal/api ./internal/orchestrator`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
- `just test-acp-release-smoke`
- `cd ui && bun run typecheck`
- `cd ui && bun run test`

## Release readiness checked
- `make release-check` and `make real-cli-smoke` passed in both adapter repos.
- Adapter `v0.1.0` release archives, checksums, and attestations verified for Codex and Claude Code adapters.
- Adapter repos needed no code changes for this pass.