### PR TITLE
fix(ui): show external agent terminal policy

### DIFF
--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -944,7 +944,11 @@ function AdapterStatusRow({
             </span>
           )}
         </div>
-        <AdapterCapabilitiesSummary adapter={adapter} health={health} />
+        <AdapterCapabilitiesSummary
+          adapter={adapter}
+          health={health}
+          remoteRuntime={remoteRuntime}
+        />
         {showHealthDetail && health && detail && (
           <div
             data-testid={`external-agents-adapter-${adapter.id}-detail`}
@@ -1087,41 +1091,64 @@ function AdapterStatusRow({
 function AdapterCapabilitiesSummary({
   adapter,
   health,
+  remoteRuntime,
 }: {
   adapter: AgentAdapterRecord;
   health: AgentAdapterHealthRecord | null;
+  remoteRuntime: boolean;
 }) {
   const capabilities = visibleAdapterCapabilities(adapter, health);
+  const showTerminalPolicy = capabilities.some(
+    (capability) => capability.id === "terminal_rpc" && capability.status === "operator_opt_in",
+  );
   if (!capabilities.length) return null;
   return (
-    <div
-      data-testid={`external-agents-adapter-${adapter.id}-capabilities`}
-      aria-label={`${adapter.name || adapter.id} ACP capabilities`}
-      style={{ display: "flex", flexWrap: "wrap", gap: 5, marginTop: 7 }}
-    >
-      {capabilities.map((capability) => {
-        const suffix = capabilityStatusSuffix(capability.status);
-        return (
-          <span
-            key={capability.id}
-            title={capability.description}
-            style={{
-              border: "1px solid var(--border)",
-              borderRadius: 6,
-              color: "var(--t2)",
-              fontFamily: "var(--font-mono)",
-              fontSize: 10,
-              lineHeight: 1.25,
-              padding: "3px 6px",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {capability.name || capability.id}
-            {suffix && <span style={{ color: "var(--t3)" }}> · {suffix}</span>}
-          </span>
-        );
-      })}
-    </div>
+    <>
+      <div
+        data-testid={`external-agents-adapter-${adapter.id}-capabilities`}
+        aria-label={`${adapter.name || adapter.id} ACP capabilities`}
+        style={{ display: "flex", flexWrap: "wrap", gap: 5, marginTop: 7 }}
+      >
+        {capabilities.map((capability) => {
+          const suffix = capabilityStatusSuffix(capability.status);
+          return (
+            <span
+              key={capability.id}
+              title={capability.description}
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                color: "var(--t2)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                lineHeight: 1.25,
+                padding: "3px 6px",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {capability.name || capability.id}
+              {suffix && <span style={{ color: "var(--t3)" }}> · {suffix}</span>}
+            </span>
+          );
+        })}
+      </div>
+      {showTerminalPolicy && (
+        <div
+          data-testid={`external-agents-adapter-${adapter.id}-terminal-policy`}
+          style={{ marginTop: 5, fontSize: 11, color: "var(--t3)", lineHeight: 1.4 }}
+        >
+          ACP terminals are disabled until policy flags are enabled:{" "}
+          <code>HECATE_AGENT_ADAPTER_TERMINALS=1</code>
+          {remoteRuntime && (
+            <>
+              {" "}
+              and <code>HECATE_REMOTE_ALLOW_ACP_TERMINALS=1</code>
+            </>
+          )}
+          <span>. Terminal creation still requires External Agent approval.</span>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -544,11 +544,18 @@ describe("Connections external-agent panel", () => {
     });
     render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
-    const capabilities = await screen.findByTestId("external-agents-adapter-codex-capabilities");
+    const row = await screen.findByTestId("external-agents-adapter-codex");
+    const capabilities = within(row).getByTestId("external-agents-adapter-codex-capabilities");
     expect(within(capabilities).getByText("sessions")).toBeTruthy();
     expect(within(capabilities).getByText("permissions")).toBeTruthy();
     expect(within(capabilities).getByText(/config/)).toHaveTextContent("if advertised");
     expect(within(capabilities).getByText(/terminal RPC/)).toHaveTextContent("opt-in");
+    expect(
+      within(row).getByTestId("external-agents-adapter-codex-terminal-policy"),
+    ).toHaveTextContent("HECATE_AGENT_ADAPTER_TERMINALS=1");
+    expect(
+      within(row).getByTestId("external-agents-adapter-codex-terminal-policy"),
+    ).not.toHaveTextContent("HECATE_REMOTE_ALLOW_ACP_TERMINALS");
     expect(within(capabilities).queryByText("login")).toBeNull();
     expect(within(capabilities).queryByText("logout")).toBeNull();
   });
@@ -828,6 +835,7 @@ describe("Connections external-agent panel", () => {
               cost_mode: "external",
               supports_authenticate: true,
               supports_logout: true,
+              capabilities: [capability("terminal_rpc", "terminal RPC", "operator_opt_in")],
             },
           ],
         }),
@@ -838,6 +846,9 @@ describe("Connections external-agent panel", () => {
       expect(
         within(row).getByTestId("external-agents-adapter-codex-auth-policy"),
       ).toHaveTextContent("Local ACP login/logout actions are disabled in remote runtime");
+      expect(
+        within(row).getByTestId("external-agents-adapter-codex-terminal-policy"),
+      ).toHaveTextContent("HECATE_REMOTE_ALLOW_ACP_TERMINALS=1");
       expect(within(row).queryByRole("button", { name: /Sign in Codex/i })).toBeNull();
       expect(within(row).queryByRole("button", { name: /Sign out Codex/i })).toBeNull();
     });


### PR DESCRIPTION
## Summary
- Show the ACP terminal policy gate directly in the External Agent capability matrix when terminal RPC is still operator opt-in.
- Include the extra remote-runtime terminal flag in hosted runtime sessions.
- Add UI regression coverage for both local and remote policy copy.

## Validation
- `cd ui && bun run format`
- `cd ui && bun run test -- src/features/settings/SettingsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run test`