### PR TITLE
feat: add Cairnline bridge proof

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,9 @@ internal/
                           command shaping, id defaults, driver defaults,
                           store error boundaries, execution refs, activity
                           projection/status signals
+  cairnlinebridge/      Hecate Projects → Cairnline mapping proof for future
+                          portable coordination integration; not the active
+                          Projects backend
   projectassistant/     Project Assistant proposal domain: context building,
                           deterministic/model/bootstrap drafting, validation,
                           confirmed apply semantics

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -79,6 +79,43 @@ Raw paths are not stable enough to be the durable identity:
 - Synchronizing external-agent private memory into Hecate memory.
 - Treating a project as a billing/accounting boundary.
 
+## Cairnline Extraction
+
+Cairnline is the future portable coordination core for Projects-like state. It
+is not the active Hecate Projects backend yet. Hecate currently remains the
+runtime authority for project APIs, UI, task execution, approvals, external
+agent supervision, traces, and context-packet rendering.
+
+The current `internal/cairnlinebridge` package is a replacement-readiness proof.
+It can seed a Cairnline service from Hecate project-shaped records:
+
+- project identity, roots, and context-source metadata;
+- agent profiles and execution posture;
+- skills metadata, roles, work items, and root-scoped assignments;
+- collaboration evidence links, reviews, handoffs, and memory candidates.
+
+This bridge proves the portable Cairnline model can receive the core
+coordination graph and produce assignment launch packets with the expected
+metadata. It deliberately does not switch storage, proxy live API requests,
+replace Hecate task/external-agent execution, migrate existing local data, or
+make Cairnline authoritative.
+
+Hecate is ready to replace its internal Projects backend with Cairnline only
+after these gates are met:
+
+- Cairnline has durable storage and MCP/API parity for Hecate's project, role,
+  profile, skill, work item, assignment, artifact, handoff, and memory-candidate
+  flows.
+- Hecate has a feature-flagged adapter that can run read/write Projects flows
+  against Cairnline without UI-local fallback state.
+- Import/export or migration covers existing Hecate local stores and can be
+  rolled back during alpha.
+- Context packets, setup/health/operations summaries, activity projections, and
+  closeout gates match current Hecate behavior or have documented intentional
+  differences.
+- Dogfooding covers at least one real Hecate development project from project
+  creation through assignment, evidence, review, handoff, and closeout.
+
 ## Data Model
 
 Sketch:

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -102,6 +102,12 @@ metadata. It deliberately does not switch storage, proxy live API requests,
 replace Hecate task/external-agent execution, migrate existing local data, or
 make Cairnline authoritative.
 
+For operator-triggered experiments, Hecate exposes a local-only
+`POST /hecate/v1/projects/{id}/cairnline/export` endpoint that writes a
+refreshable Cairnline SQLite export under Hecate's data directory. The export
+uses the same bridge and is useful for inspecting replacement parity, but it is
+still an artifact, not the live Projects backend.
+
 Hecate is ready to replace its internal Projects backend with Cairnline only
 after these gates are met:
 

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -87,7 +87,8 @@ runtime authority for project APIs, UI, task execution, approvals, external
 agent supervision, traces, and context-packet rendering.
 
 The current `internal/cairnlinebridge` package is a replacement-readiness proof.
-It can seed a Cairnline service from Hecate project-shaped records:
+It can load Hecate project state from the current project/profile/skills/work
+stores, then seed a Cairnline service from Hecate project-shaped records:
 
 - project identity, roots, and context-source metadata;
 - agent profiles and execution posture;

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -88,7 +88,8 @@ agent supervision, traces, and context-packet rendering.
 
 The current `internal/cairnlinebridge` package is a replacement-readiness proof.
 It can load Hecate project state from the current project/profile/skills/work
-stores, then seed a Cairnline service from Hecate project-shaped records:
+stores, then seed a memory-backed or SQLite-backed Cairnline service from
+Hecate project-shaped records:
 
 - project identity, roots, and context-source metadata;
 - agent profiles and execution posture;

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2183,6 +2183,45 @@ The response reports the scoped records Hecate cleaned up:
 }
 ```
 
+### `POST /hecate/v1/projects/{id}/cairnline/export`
+
+Local-only experimental bridge endpoint. It loads the selected project from
+Hecate's authoritative Projects stores and writes a refreshable Cairnline SQLite
+export at:
+
+```text
+{HECATE_DATA_DIR}/cairnline/projects/{safe_project_id}.db
+```
+
+If `HECATE_DATA_DIR` is unset, Hecate uses `.data` relative to the runtime
+process. The caller cannot choose the output path. Re-running the endpoint
+replaces the same project export after the Hecate snapshot has been loaded, so a
+missing project does not wipe an existing export.
+
+This endpoint is an interoperability and replacement-readiness proof only. It
+does not make Cairnline authoritative, does not proxy live Projects reads or
+writes, and does not migrate Hecate's stores.
+
+Example response:
+
+```json
+{
+  "object": "project_cairnline_export",
+  "data": {
+    "project_id": "proj_...",
+    "database_path": "/Users/alice/.hecate/cairnline/projects/proj_....db",
+    "agent_profile_count": 4,
+    "skill_count": 3,
+    "role_count": 6,
+    "work_item_count": 2,
+    "assignment_count": 5,
+    "artifact_count": 4,
+    "handoff_count": 1,
+    "memory_candidate_count": 2
+  }
+}
+```
+
 ### Project Memory
 
 Project memory is explicit operator-approved context. Hecate never writes these

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
+	github.com/hecatehq/cairnline v0.0.0-20260626170038-16d4c3a275ec
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/hecatehq/cairnline v0.0.0-20260626170038-16d4c3a275ec h1:+jMCl9e0xrU0iIrUmfGWMH8BziaaIzyuOhOjHyPT49Q=
+github.com/hecatehq/cairnline v0.0.0-20260626170038-16d4c3a275ec/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("id"))
+	dbPath, err := h.cairnlineExportPath(projectID)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	snapshot, err := cairnlinebridge.LoadSnapshot(r.Context(), h.cairnlineSnapshotSources(), projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	// This local-only experiment owns its project export file. Replacing it
+	// keeps repeated operator-triggered exports deterministic while avoiding a
+	// live-backend switch or any mutation of Hecate's authoritative stores.
+	if err := removeCairnlineExportFiles(dbPath); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	service, store, err := cairnline.NewSQLiteService(r.Context(), dbPath)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	defer store.Close()
+	if err := cairnlinebridge.Seed(r.Context(), service, snapshot); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineExportResponse{
+		Object: "project_cairnline_export",
+		Data: ProjectCairnlineExportResponseItem{
+			ProjectID:            snapshot.Project.ID,
+			DatabasePath:         dbPath,
+			AgentProfileCount:    len(snapshot.AgentProfiles),
+			SkillCount:           len(snapshot.Skills),
+			RoleCount:            len(snapshot.Roles),
+			WorkItemCount:        len(snapshot.WorkItems),
+			AssignmentCount:      len(snapshot.Assignments),
+			ArtifactCount:        len(snapshot.Artifacts),
+			HandoffCount:         len(snapshot.Handoffs),
+			MemoryCandidateCount: len(snapshot.MemoryCandidates),
+		},
+	})
+}
+
+func (h *Handler) cairnlineSnapshotSources() cairnlinebridge.SnapshotSources {
+	return cairnlinebridge.SnapshotSources{
+		Projects:         h.projects,
+		AgentProfiles:    h.agentProfiles,
+		Skills:           h.projectSkills,
+		Work:             h.projectWork,
+		MemoryCandidates: h.memoryCandidates,
+	}
+}
+
+func (h *Handler) cairnlineExportPath(projectID string) (string, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return "", errors.New("project id is required")
+	}
+	dataDir := strings.TrimSpace(h.config.Server.DataDir)
+	if dataDir == "" {
+		dataDir = ".data"
+	}
+	path := filepath.Join(dataDir, "cairnline", "projects", safeCairnlineExportName(projectID)+".db")
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return path, nil
+}
+
+func safeCairnlineExportName(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "project"
+	}
+	return out
+}
+
+func removeCairnlineExportFiles(dbPath string) error {
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
+	dataDir := t.TempDir()
+	handler := NewHandler(config.Config{Server: config.ServerConfig{DataDir: dataDir}}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+	root := t.TempDir()
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name":           "Cairnline Export",
+		"workspace_path": root,
+		"workspace_kind": "git",
+	}))
+	projectID := project.Data.ID
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                  "bridge_profile",
+		Name:                "Bridge profile",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		ToolsEnabled:        true,
+		WritesAllowed:       true,
+	}); err != nil {
+		t.Fatalf("Create profile: %v", err)
+	}
+	if _, err := handler.projectSkills.UpsertDiscovered(t.Context(), projectID, []projectskills.Skill{{
+		ID:          "backend",
+		ProjectID:   projectID,
+		Title:       "Backend",
+		Path:        "docs-ai/skills/backend/SKILL.md",
+		RootID:      project.Data.Roots[0].ID,
+		Format:      projectskills.FormatSkillMD,
+		Enabled:     true,
+		Status:      projectskills.StatusAvailable,
+		TrustLabel:  projectskills.TrustWorkspaceSkill,
+		Description: "Backend guidance.",
+	}}); err != nil {
+		t.Fatalf("Upsert skills: %v", err)
+	}
+	role := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                    "bridge_developer",
+		"name":                  "Bridge Developer",
+		"default_agent_profile": "bridge_profile",
+		"default_driver_kind":   projectwork.AssignmentDriverHecateTask,
+		"skill_ids":             []string{"backend"},
+	}))
+	reviewer := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                    "bridge_reviewer",
+		"name":                  "Bridge Reviewer",
+		"default_agent_profile": "bridge_profile",
+		"default_driver_kind":   projectwork.AssignmentDriverHecateTask,
+	}))
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":                "work_export",
+		"title":             "Export to Cairnline",
+		"brief":             "Prove Hecate can write a Cairnline DB.",
+		"owner_role_id":     role.Data.ID,
+		"reviewer_role_ids": []string{reviewer.Data.ID},
+		"root_id":           project.Data.Roots[0].ID,
+	}))
+	assignment := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_export",
+		"role_id":     role.Data.ID,
+		"driver_kind": projectwork.AssignmentDriverHecateTask,
+		"root_id":     project.Data.Roots[0].ID,
+	}))
+	mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                     "art_review",
+		"kind":                   projectwork.ArtifactKindReview,
+		"title":                  "Review",
+		"body":                   "Looks usable for export.",
+		"author_role_id":         reviewer.Data.ID,
+		"reviewed_assignment_id": assignment.Data.ID,
+		"review_verdict":         projectwork.ReviewVerdictApproved,
+		"review_risk":            projectwork.ReviewRiskLow,
+	}))
+	mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                   "art_evidence",
+		"kind":                 projectwork.ArtifactKindEvidenceLink,
+		"title":                "Evidence",
+		"body":                 "Export verified by test.",
+		"evidence_url":         "https://example.test/run",
+		"evidence_trust_label": projectwork.EvidenceTrustOperatorProvided,
+	}))
+	handoff := mustRequestJSONStatus[ProjectHandoffEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/handoffs", projectJourneyJSON(t, map[string]any{
+		"id":                      "handoff_export",
+		"target_role_id":          reviewer.Data.ID,
+		"title":                   "Review export",
+		"summary":                 "Cairnline export is ready.",
+		"recommended_next_action": "Inspect the exported launch packet.",
+		"created_by_role_id":      role.Data.ID,
+	}))
+	mustRequestJSONStatus[ProjectMemoryCandidateResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates", projectJourneyJSON(t, map[string]any{
+		"id":                    "memcand_export",
+		"title":                 "Export gate",
+		"body":                  "Cairnline export should preserve collaboration state.",
+		"suggested_kind":        "coordination_note",
+		"suggested_trust_label": memory.TrustLabelGenerated,
+		"suggested_source_kind": "handoff",
+		"suggested_source_id":   handoff.Data.ID,
+	}))
+
+	first := mustRequestJSON[ProjectCairnlineExportResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/cairnline/export", "")
+	second := mustRequestJSON[ProjectCairnlineExportResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/cairnline/export", "")
+	if first.Data.DatabasePath != second.Data.DatabasePath {
+		t.Fatalf("export paths = %q/%q, want refresh to same path", first.Data.DatabasePath, second.Data.DatabasePath)
+	}
+	if second.Data.ProjectID != projectID || second.Data.WorkItemCount != 1 || second.Data.AssignmentCount != 1 || second.Data.ArtifactCount != 2 || second.Data.HandoffCount != 1 || second.Data.MemoryCandidateCount != 1 {
+		t.Fatalf("export response = %+v, want project counts", second.Data)
+	}
+	if !filepath.IsAbs(second.Data.DatabasePath) {
+		t.Fatalf("database path = %q, want absolute path", second.Data.DatabasePath)
+	}
+	if filepath.Dir(second.Data.DatabasePath) != filepath.Join(dataDir, "cairnline", "projects") {
+		t.Fatalf("database path = %q, want under data dir %q", second.Data.DatabasePath, dataDir)
+	}
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), second.Data.DatabasePath)
+	if err != nil {
+		t.Fatalf("Open exported Cairnline DB: %v", err)
+	}
+	defer store.Close()
+	packet, err := service.AssignmentLaunchPacket(t.Context(), projectID, assignment.Data.ID)
+	if err != nil {
+		t.Fatalf("AssignmentLaunchPacket from exported DB: %v", err)
+	}
+	if packet.Project.ID != projectID || packet.Assignment.RootID != project.Data.Roots[0].ID {
+		t.Fatalf("packet project/assignment = %+v/%+v, want exported root-scoped assignment", packet.Project, packet.Assignment)
+	}
+	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.MemoryCandidates) != 1 {
+		t.Fatalf("packet counts evidence=%d reviews=%d handoffs=%d memory=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.MemoryCandidates))
+	}
+}
+
+func TestProjectCairnlineExportAPI_MissingProjectDoesNotCreateExportDir(t *testing.T) {
+	dataDir := t.TempDir()
+	handler := NewHandler(config.Config{Server: config.ServerConfig{DataDir: dataDir}}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	client.mustRequestStatus(http.StatusNotFound, http.MethodPost, "/hecate/v1/projects/proj_missing/cairnline/export", "")
+	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
+		t.Fatalf("export dir stat error = %v, want not exist", err)
+	}
+}

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -290,6 +290,24 @@ type ProjectDeleteResponseItem struct {
 	MemoryCandidatesDeleted          int    `json:"memory_candidates_deleted"`
 }
 
+type ProjectCairnlineExportResponse struct {
+	Object string                             `json:"object"`
+	Data   ProjectCairnlineExportResponseItem `json:"data"`
+}
+
+type ProjectCairnlineExportResponseItem struct {
+	ProjectID            string `json:"project_id"`
+	DatabasePath         string `json:"database_path"`
+	AgentProfileCount    int    `json:"agent_profile_count"`
+	SkillCount           int    `json:"skill_count"`
+	RoleCount            int    `json:"role_count"`
+	WorkItemCount        int    `json:"work_item_count"`
+	AssignmentCount      int    `json:"assignment_count"`
+	ArtifactCount        int    `json:"artifact_count"`
+	HandoffCount         int    `json:"handoff_count"`
+	MemoryCandidateCount int    `json:"memory_candidate_count"`
+}
+
 type AgentProfileResponse struct {
 	Object string                   `json:"object"`
 	Data   AgentProfileResponseItem `json:"data"`

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -21,6 +21,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodDelete, path: "/hecate/v1/terminals/{terminal_id}"},
 	{method: http.MethodPost, path: "/hecate/v1/system/reset-data"},
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/cairnline/export"},
 	{method: http.MethodPost, path: "/hecate/v1/mcp/probe"},
 	{method: http.MethodGet, path: "/hecate/v1/mcp/registry/servers"},
 	{method: http.MethodGet, path: "/hecate/v1/settings/providers/local-discovery"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -81,6 +81,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("POST /hecate/v1/projects/{id}/cairnline/export", handler.HandleExportProjectToCairnline)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots", handler.HandleCreateProjectRoot)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots/discover", handler.HandleDiscoverProjectRoots)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots/worktrees", handler.HandleCreateProjectWorktreeRoot)

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -1,0 +1,345 @@
+// Package cairnlinebridge maps Hecate Projects records into Cairnline's
+// portable coordination model.
+//
+// This package is an integration proof, not a runtime backend switch. Hecate
+// remains the execution/orchestration authority; Cairnline receives durable
+// coordination records that can later back MCP pull or migration experiments.
+package cairnlinebridge
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+type Snapshot struct {
+	Project       projects.Project
+	AgentProfiles []agentprofiles.Profile
+	Skills        []projectskills.Skill
+	Roles         []projectwork.AgentRoleProfile
+	WorkItems     []projectwork.WorkItem
+	Assignments   []projectwork.Assignment
+}
+
+func Seed(ctx context.Context, service *cairnline.Service, snapshot Snapshot) error {
+	if _, err := service.CreateProject(ctx, Project(snapshot.Project)); err != nil {
+		return err
+	}
+	profilesByID := make(map[string]agentprofiles.Profile, len(snapshot.AgentProfiles))
+	for _, profile := range snapshot.AgentProfiles {
+		profilesByID[profile.ID] = profile
+		if _, err := service.CreateAgentProfile(ctx, AgentProfile(profile)); err != nil {
+			return err
+		}
+		if _, err := service.CreateExecutionProfile(ctx, ExecutionProfile(profile)); err != nil {
+			return err
+		}
+	}
+	for _, skill := range snapshot.Skills {
+		if _, err := service.CreateProjectSkill(ctx, ProjectSkill(skill)); err != nil {
+			return err
+		}
+	}
+	rolesByID := make(map[string]projectwork.AgentRoleProfile, len(snapshot.Roles))
+	for _, role := range snapshot.Roles {
+		rolesByID[role.ID] = role
+		if _, err := service.CreateRole(ctx, Role(role)); err != nil {
+			return err
+		}
+	}
+	for _, item := range snapshot.WorkItems {
+		if _, err := service.CreateWorkItem(ctx, WorkItem(item)); err != nil {
+			return err
+		}
+	}
+	for _, assignment := range snapshot.Assignments {
+		role := rolesByID[assignment.RoleID]
+		profile := profilesByID[role.DefaultAgentProfile]
+		item := Assignment(assignment, role, profile)
+		if _, err := service.CreateAssignment(ctx, item); err != nil {
+			return err
+		}
+		if err := syncAssignmentStatus(ctx, service, item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Project(project projects.Project) cairnline.Project {
+	return cairnline.Project{
+		ID:             strings.TrimSpace(project.ID),
+		Name:           strings.TrimSpace(project.Name),
+		Description:    strings.TrimSpace(project.Description),
+		Roots:          Roots(project.Roots),
+		ContextSources: Sources(project.ContextSources),
+		CreatedAt:      project.CreatedAt,
+		UpdatedAt:      project.UpdatedAt,
+	}
+}
+
+func Roots(items []projects.Root) []cairnline.Root {
+	out := make([]cairnline.Root, 0, len(items))
+	for _, item := range items {
+		out = append(out, cairnline.Root{
+			ID:        strings.TrimSpace(item.ID),
+			Path:      strings.TrimSpace(item.Path),
+			Kind:      strings.TrimSpace(item.Kind),
+			GitRemote: strings.TrimSpace(item.GitRemote),
+			GitBranch: strings.TrimSpace(item.GitBranch),
+			Active:    item.Active,
+		})
+	}
+	return out
+}
+
+func Sources(items []projects.ContextSource) []cairnline.Source {
+	out := make([]cairnline.Source, 0, len(items))
+	for _, item := range items {
+		out = append(out, cairnline.Source{
+			ID:         strings.TrimSpace(item.ID),
+			Kind:       strings.TrimSpace(item.Kind),
+			Title:      strings.TrimSpace(item.Title),
+			Locator:    strings.TrimSpace(item.Path),
+			Enabled:    item.Enabled,
+			TrustLabel: strings.TrimSpace(item.TrustLabel),
+		})
+	}
+	return out
+}
+
+func AgentProfile(profile agentprofiles.Profile) cairnline.AgentProfile {
+	return cairnline.AgentProfile{
+		ID:           strings.TrimSpace(profile.ID),
+		Name:         strings.TrimSpace(profile.Name),
+		Description:  strings.TrimSpace(profile.Description),
+		Instructions: strings.TrimSpace(profile.Instructions),
+		MemoryPolicy: strings.TrimSpace(profile.ProjectMemoryPolicy),
+		SourcePolicy: strings.TrimSpace(profile.ContextSourcePolicy),
+		SkillIDs:     compactStrings(profile.SkillIDs),
+		CreatedAt:    profile.CreatedAt,
+		UpdatedAt:    profile.UpdatedAt,
+	}
+}
+
+func ExecutionProfile(profile agentprofiles.Profile) cairnline.ExecutionProfile {
+	return cairnline.ExecutionProfile{
+		ID:             firstNonEmpty(strings.TrimSpace(profile.ExecutionProfile), strings.TrimSpace(profile.ID)),
+		Name:           strings.TrimSpace(profile.Name),
+		Description:    strings.TrimSpace(profile.Description),
+		AgentKind:      executionAgentKind(profile),
+		ModelHint:      strings.TrimSpace(profile.ModelHint),
+		ProviderHint:   strings.TrimSpace(profile.ProviderHint),
+		ToolsPolicy:    boolPolicy(profile.ToolsEnabled),
+		WritesPolicy:   boolPolicy(profile.WritesAllowed),
+		NetworkPolicy:  boolPolicy(profile.NetworkAllowed),
+		ApprovalPolicy: strings.TrimSpace(profile.ApprovalPolicy),
+		AdapterOptions: stringMapAny(profile.ExternalAgentOptions),
+		CreatedAt:      profile.CreatedAt,
+		UpdatedAt:      profile.UpdatedAt,
+	}
+}
+
+func ProjectSkill(skill projectskills.Skill) cairnline.ProjectSkill {
+	return cairnline.ProjectSkill{
+		ID:          strings.TrimSpace(skill.ID),
+		ProjectID:   strings.TrimSpace(skill.ProjectID),
+		Title:       strings.TrimSpace(skill.Title),
+		Description: strings.TrimSpace(skill.Description),
+		Path:        strings.TrimSpace(skill.Path),
+		RootID:      strings.TrimSpace(skill.RootID),
+		Format:      strings.TrimSpace(skill.Format),
+		Enabled:     skill.Enabled,
+		Status:      strings.TrimSpace(skill.Status),
+		TrustLabel:  strings.TrimSpace(skill.TrustLabel),
+		SourceRefs:  compactStrings(skill.SourceContextSourceIDs),
+		Warnings:    compactStrings(skill.Warnings),
+		CreatedAt:   skill.CreatedAt,
+		UpdatedAt:   skill.UpdatedAt,
+	}
+}
+
+func Role(role projectwork.AgentRoleProfile) cairnline.Role {
+	return cairnline.Role{
+		ID:                   strings.TrimSpace(role.ID),
+		ProjectID:            strings.TrimSpace(role.ProjectID),
+		Name:                 strings.TrimSpace(role.Name),
+		Description:          strings.TrimSpace(role.Description),
+		Instructions:         strings.TrimSpace(role.Instructions),
+		DefaultProfileID:     strings.TrimSpace(role.DefaultAgentProfile),
+		DefaultSkillIDs:      compactStrings(role.SkillIDs),
+		DefaultExecutionMode: ExecutionMode(role.DefaultDriverKind),
+	}
+}
+
+func WorkItem(item projectwork.WorkItem) cairnline.WorkItem {
+	return cairnline.WorkItem{
+		ID:              strings.TrimSpace(item.ID),
+		ProjectID:       strings.TrimSpace(item.ProjectID),
+		Title:           strings.TrimSpace(item.Title),
+		Brief:           strings.TrimSpace(item.Brief),
+		Status:          strings.TrimSpace(item.Status),
+		Priority:        strings.TrimSpace(item.Priority),
+		OwnerRoleID:     strings.TrimSpace(item.OwnerRoleID),
+		ReviewerRoleIDs: compactStrings(item.ReviewerRoleIDs),
+		RootID:          strings.TrimSpace(item.RootID),
+		CreatedAt:       item.CreatedAt,
+		UpdatedAt:       item.UpdatedAt,
+	}
+}
+
+func Assignment(assignment projectwork.Assignment, role projectwork.AgentRoleProfile, profile agentprofiles.Profile) cairnline.Assignment {
+	return cairnline.Assignment{
+		ID:                 strings.TrimSpace(assignment.ID),
+		ProjectID:          strings.TrimSpace(assignment.ProjectID),
+		WorkItemID:         strings.TrimSpace(assignment.WorkItemID),
+		RoleID:             strings.TrimSpace(assignment.RoleID),
+		RootID:             strings.TrimSpace(assignment.RootID),
+		ProfileID:          strings.TrimSpace(role.DefaultAgentProfile),
+		ExecutionProfileID: firstNonEmpty(strings.TrimSpace(profile.ExecutionProfile), strings.TrimSpace(profile.ID)),
+		ExecutionMode:      ExecutionMode(assignment.DriverKind),
+		Status:             AssignmentStatus(assignment.Status),
+		DesiredAgent: cairnline.DesiredAgent{
+			Kind:     DesiredAgentKind(assignment.DriverKind),
+			SkillIDs: compactStrings(role.SkillIDs),
+		},
+		ExecutionRef:      assignmentExecutionRef(assignment.ExecutionRef),
+		ContextSnapshotID: strings.TrimSpace(assignment.ExecutionRef.ContextSnapshotID),
+		CreatedAt:         assignment.CreatedAt,
+		UpdatedAt:         assignment.UpdatedAt,
+	}
+}
+
+func ExecutionMode(driverKind string) string {
+	switch strings.TrimSpace(driverKind) {
+	case projectwork.AssignmentDriverHecateTask:
+		return cairnline.ExecutionOrchestrated
+	case projectwork.AssignmentDriverExternalAgent:
+		return cairnline.ExecutionExternalAdapter
+	default:
+		return cairnline.ExecutionMCPPull
+	}
+}
+
+func AssignmentStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval:
+		return cairnline.AssignmentRunning
+	case projectwork.AssignmentStatusCompleted:
+		return cairnline.AssignmentCompleted
+	case projectwork.AssignmentStatusFailed:
+		return cairnline.AssignmentFailed
+	case projectwork.AssignmentStatusCancelled:
+		return cairnline.AssignmentCancelled
+	default:
+		return cairnline.AssignmentQueued
+	}
+}
+
+func DesiredAgentKind(driverKind string) string {
+	if strings.TrimSpace(driverKind) == projectwork.AssignmentDriverHecateTask {
+		return "hecate"
+	}
+	return cairnline.DesiredAgentAny
+}
+
+func syncAssignmentStatus(ctx context.Context, service *cairnline.Service, assignment cairnline.Assignment) error {
+	switch assignment.Status {
+	case cairnline.AssignmentQueued:
+		return nil
+	case cairnline.AssignmentRunning, cairnline.AssignmentReview:
+		if _, err := service.ClaimAssignment(ctx, assignment.ProjectID, assignment.ID, claimedBy(assignment)); err != nil {
+			return err
+		}
+		_, err := service.UpdateAssignmentStatus(ctx, assignment.ProjectID, assignment.ID, assignment.Status, assignment.ExecutionRef)
+		return err
+	case cairnline.AssignmentCompleted, cairnline.AssignmentFailed, cairnline.AssignmentCancelled:
+		_, err := service.CompleteAssignment(ctx, assignment.ProjectID, assignment.ID, assignment.Status, assignment.ExecutionRef)
+		return err
+	default:
+		return nil
+	}
+}
+
+func claimedBy(assignment cairnline.Assignment) string {
+	if assignment.DesiredAgent.Kind == "hecate" {
+		return "hecate"
+	}
+	return "external_adapter"
+}
+
+func executionAgentKind(profile agentprofiles.Profile) string {
+	if profile.ExternalAgentKind != "" {
+		return strings.TrimSpace(profile.ExternalAgentKind)
+	}
+	switch strings.TrimSpace(profile.Surface) {
+	case agentprofiles.SurfaceHecateTask, agentprofiles.SurfaceHecateChat:
+		return "hecate"
+	case agentprofiles.SurfaceExternalAgent:
+		return cairnline.DesiredAgentAny
+	default:
+		return cairnline.DesiredAgentAny
+	}
+}
+
+func assignmentExecutionRef(ref projectwork.AssignmentExecutionRef) string {
+	return firstNonEmpty(
+		strings.TrimSpace(ref.RunID),
+		strings.TrimSpace(ref.TaskID),
+		strings.TrimSpace(ref.ChatSessionID),
+		strings.TrimSpace(ref.ContextSnapshotID),
+	)
+}
+
+func boolPolicy(value bool) string {
+	if value {
+		return "allow"
+	}
+	return "block"
+}
+
+func compactStrings(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func stringMapAny(items map[string]string) map[string]any {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(items))
+	for key, value := range items {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(value)
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -12,18 +12,22 @@ import (
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 type Snapshot struct {
-	Project       projects.Project
-	AgentProfiles []agentprofiles.Profile
-	Skills        []projectskills.Skill
-	Roles         []projectwork.AgentRoleProfile
-	WorkItems     []projectwork.WorkItem
-	Assignments   []projectwork.Assignment
+	Project          projects.Project
+	AgentProfiles    []agentprofiles.Profile
+	Skills           []projectskills.Skill
+	Roles            []projectwork.AgentRoleProfile
+	WorkItems        []projectwork.WorkItem
+	Assignments      []projectwork.Assignment
+	Artifacts        []projectwork.CollaborationArtifact
+	Handoffs         []projectwork.Handoff
+	MemoryCandidates []memory.Candidate
 }
 
 func Seed(ctx context.Context, service *cairnline.Service, snapshot Snapshot) error {
@@ -65,6 +69,29 @@ func Seed(ctx context.Context, service *cairnline.Service, snapshot Snapshot) er
 			return err
 		}
 		if err := syncAssignmentStatus(ctx, service, item); err != nil {
+			return err
+		}
+	}
+	for _, artifact := range snapshot.Artifacts {
+		if item, ok := Evidence(artifact); ok {
+			if _, err := service.CreateEvidence(ctx, item); err != nil {
+				return err
+			}
+			continue
+		}
+		if item, ok := Review(artifact); ok {
+			if _, err := service.CreateReview(ctx, item); err != nil {
+				return err
+			}
+		}
+	}
+	for _, handoff := range snapshot.Handoffs {
+		if _, err := service.CreateHandoff(ctx, Handoff(handoff)); err != nil {
+			return err
+		}
+	}
+	for _, candidate := range snapshot.MemoryCandidates {
+		if _, err := service.CreateMemoryCandidate(ctx, MemoryCandidate(candidate)); err != nil {
 			return err
 		}
 	}
@@ -215,6 +242,72 @@ func Assignment(assignment projectwork.Assignment, role projectwork.AgentRolePro
 	}
 }
 
+func Evidence(artifact projectwork.CollaborationArtifact) (cairnline.Evidence, bool) {
+	if strings.TrimSpace(artifact.Kind) != projectwork.ArtifactKindEvidenceLink {
+		return cairnline.Evidence{}, false
+	}
+	return cairnline.Evidence{
+		ID:         strings.TrimSpace(artifact.ID),
+		ProjectID:  strings.TrimSpace(artifact.ProjectID),
+		WorkItemID: strings.TrimSpace(artifact.WorkItemID),
+		Title:      strings.TrimSpace(artifact.Title),
+		Body:       strings.TrimSpace(artifact.Body),
+		Locator:    firstNonEmpty(strings.TrimSpace(artifact.EvidenceURL), strings.TrimSpace(artifact.EvidenceExternalID)),
+		TrustLabel: firstNonEmpty(strings.TrimSpace(artifact.EvidenceTrustLabel), projectwork.EvidenceTrustOperatorProvided),
+		CreatedAt:  artifact.CreatedAt,
+		UpdatedAt:  artifact.UpdatedAt,
+	}, true
+}
+
+func Review(artifact projectwork.CollaborationArtifact) (cairnline.Review, bool) {
+	if strings.TrimSpace(artifact.Kind) != projectwork.ArtifactKindReview {
+		return cairnline.Review{}, false
+	}
+	return cairnline.Review{
+		ID:             strings.TrimSpace(artifact.ID),
+		ProjectID:      strings.TrimSpace(artifact.ProjectID),
+		WorkItemID:     strings.TrimSpace(artifact.WorkItemID),
+		AssignmentID:   firstNonEmpty(strings.TrimSpace(artifact.ReviewedAssignmentID), strings.TrimSpace(artifact.AssignmentID)),
+		ReviewerRoleID: strings.TrimSpace(artifact.AuthorRoleID),
+		Title:          strings.TrimSpace(artifact.Title),
+		Body:           strings.TrimSpace(artifact.Body),
+		Verdict:        ReviewVerdict(artifact.ReviewVerdict),
+		Risk:           ReviewRisk(artifact.ReviewRisk),
+		Status:         cairnline.ReviewStatusRecorded,
+		CreatedAt:      artifact.CreatedAt,
+		UpdatedAt:      artifact.UpdatedAt,
+	}, true
+}
+
+func Handoff(handoff projectwork.Handoff) cairnline.Handoff {
+	return cairnline.Handoff{
+		ID:         strings.TrimSpace(handoff.ID),
+		ProjectID:  strings.TrimSpace(handoff.ProjectID),
+		WorkItemID: strings.TrimSpace(handoff.WorkItemID),
+		FromRoleID: strings.TrimSpace(handoff.CreatedByRoleID),
+		ToRoleID:   strings.TrimSpace(handoff.TargetRoleID),
+		Title:      strings.TrimSpace(handoff.Title),
+		Body:       handoffBody(handoff),
+		Status:     cairnline.HandoffStatusOpen,
+		CreatedAt:  handoff.CreatedAt,
+		UpdatedAt:  handoff.UpdatedAt,
+	}
+}
+
+func MemoryCandidate(candidate memory.Candidate) cairnline.MemoryCandidate {
+	return cairnline.MemoryCandidate{
+		ID:         strings.TrimSpace(candidate.ID),
+		ProjectID:  strings.TrimSpace(candidate.ProjectID),
+		Title:      strings.TrimSpace(candidate.Title),
+		Body:       strings.TrimSpace(candidate.Body),
+		Status:     cairnline.MemoryCandidateProposed,
+		TrustLabel: strings.TrimSpace(candidate.SuggestedTrustLabel),
+		SourceRef:  memoryCandidateSourceRef(candidate),
+		CreatedAt:  candidate.CreatedAt,
+		UpdatedAt:  candidate.UpdatedAt,
+	}
+}
+
 func ExecutionMode(driverKind string) string {
 	switch strings.TrimSpace(driverKind) {
 	case projectwork.AssignmentDriverHecateTask:
@@ -238,6 +331,30 @@ func AssignmentStatus(status string) string {
 		return cairnline.AssignmentCancelled
 	default:
 		return cairnline.AssignmentQueued
+	}
+}
+
+func ReviewVerdict(verdict string) string {
+	switch strings.TrimSpace(verdict) {
+	case projectwork.ReviewVerdictApproved:
+		return cairnline.ReviewVerdictPass
+	case projectwork.ReviewVerdictBlocked:
+		return cairnline.ReviewVerdictBlocked
+	default:
+		return cairnline.ReviewVerdictConcerns
+	}
+}
+
+func ReviewRisk(risk string) string {
+	switch strings.TrimSpace(risk) {
+	case projectwork.ReviewRiskLow:
+		return cairnline.ReviewRiskLow
+	case projectwork.ReviewRiskMedium:
+		return cairnline.ReviewRiskMedium
+	case projectwork.ReviewRiskHigh:
+		return cairnline.ReviewRiskHigh
+	default:
+		return ""
 	}
 }
 
@@ -342,4 +459,64 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func handoffBody(handoff projectwork.Handoff) string {
+	return joinParagraphs(
+		strings.TrimSpace(handoff.Summary),
+		labelValue("Recommended next action", handoff.RecommendedNextAction),
+		labelValue("Source assignment", handoff.SourceAssignmentID),
+		labelValue("Target assignment", handoff.TargetAssignmentID),
+		labelList("Linked artifacts", handoff.LinkedArtifactIDs),
+		labelList("Linked memory", handoff.LinkedMemoryIDs),
+		labelList("Context refs", handoff.ContextRefs),
+	)
+}
+
+func memoryCandidateSourceRef(candidate memory.Candidate) string {
+	if value := labelPair(candidate.SuggestedSourceKind, candidate.SuggestedSourceID); value != "" {
+		return value
+	}
+	if len(candidate.SourceRefs) == 0 {
+		return ""
+	}
+	ref := candidate.SourceRefs[0]
+	return firstNonEmpty(labelPair(ref.Kind, ref.ID), strings.TrimSpace(ref.URL), strings.TrimSpace(ref.Title))
+}
+
+func labelValue(label, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return label + ": " + value
+}
+
+func labelPair(kind, id string) string {
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	if kind == "" || id == "" {
+		return ""
+	}
+	return kind + ":" + id
+}
+
+func labelList(label string, values []string) string {
+	values = compactStrings(values)
+	if len(values) == 0 {
+		return ""
+	}
+	return label + ": " + strings.Join(values, ", ")
+}
+
+func joinParagraphs(values ...string) string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	return strings.Join(out, "\n\n")
 }

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -35,12 +35,18 @@ func Seed(ctx context.Context, service *cairnline.Service, snapshot Snapshot) er
 		return err
 	}
 	profilesByID := make(map[string]agentprofiles.Profile, len(snapshot.AgentProfiles))
+	executionProfileIDs := make(map[string]struct{}, len(snapshot.AgentProfiles))
 	for _, profile := range snapshot.AgentProfiles {
 		profilesByID[profile.ID] = profile
 		if _, err := service.CreateAgentProfile(ctx, AgentProfile(profile)); err != nil {
 			return err
 		}
-		if _, err := service.CreateExecutionProfile(ctx, ExecutionProfile(profile)); err != nil {
+		executionProfile := ExecutionProfile(profile)
+		if _, ok := executionProfileIDs[executionProfile.ID]; ok {
+			continue
+		}
+		executionProfileIDs[executionProfile.ID] = struct{}{}
+		if _, err := service.CreateExecutionProfile(ctx, executionProfile); err != nil {
 			return err
 		}
 	}

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -85,6 +86,17 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			SkillIDs:            []string{"backend", "backend"},
 			CreatedAt:           now,
 			UpdatedAt:           now,
+		}, {
+			ID:                  "reviewer_qa",
+			ProjectID:           "proj_hecate",
+			Name:                "Reviewer QA",
+			Description:         "Reviews behavior, risks, and verification gaps.",
+			Instructions:        "Prioritize concrete defects.",
+			DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
+			DefaultAgentProfile: "implementation",
+			SkillIDs:            []string{"backend"},
+			CreatedAt:           now,
+			UpdatedAt:           now,
 		}},
 		WorkItems: []projectwork.WorkItem{{
 			ID:              "work_bridge",
@@ -126,6 +138,63 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			CreatedAt: now,
 			UpdatedAt: now,
 		}},
+		Artifacts: []projectwork.CollaborationArtifact{{
+			ID:                 "art_evidence",
+			ProjectID:          "proj_hecate",
+			WorkItemID:         "work_bridge",
+			AssignmentID:       "asgn_external",
+			Kind:               projectwork.ArtifactKindEvidenceLink,
+			Title:              "CI run",
+			Body:               "Focused bridge tests passed.",
+			EvidenceURL:        "https://github.com/hecatehq/hecate/actions/runs/123",
+			EvidenceProvider:   "github",
+			EvidenceTrustLabel: projectwork.EvidenceTrustOperatorProvided,
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}, {
+			ID:                   "art_review",
+			ProjectID:            "proj_hecate",
+			WorkItemID:           "work_bridge",
+			Kind:                 projectwork.ArtifactKindReview,
+			Title:                "Bridge review",
+			Body:                 "Needs one follow-up around artifact parity.",
+			AuthorRoleID:         "reviewer_qa",
+			ReviewedAssignmentID: "asgn_external",
+			ReviewVerdict:        projectwork.ReviewVerdictChangesRequested,
+			ReviewRisk:           projectwork.ReviewRiskMedium,
+			CreatedAt:            now,
+			UpdatedAt:            now,
+		}},
+		Handoffs: []projectwork.Handoff{{
+			ID:                    "handoff_review",
+			ProjectID:             "proj_hecate",
+			WorkItemID:            "work_bridge",
+			SourceAssignmentID:    "asgn_external",
+			TargetRoleID:          "reviewer_qa",
+			Title:                 "Review bridge parity",
+			Summary:               "Artifact parity is ready for review.",
+			RecommendedNextAction: "Verify launch packets include evidence, reviews, handoffs, and memory candidates.",
+			LinkedArtifactIDs:     []string{"art_evidence", "art_review"},
+			LinkedMemoryIDs:       []string{"memcand_bridge"},
+			ContextRefs:           []string{"ctx_123"},
+			Status:                projectwork.HandoffStatusPending,
+			CreatedByRoleID:       "software_developer",
+			CreatedAt:             now,
+			UpdatedAt:             now,
+		}},
+		MemoryCandidates: []memory.Candidate{{
+			ID:                  "memcand_bridge",
+			ProjectID:           "proj_hecate",
+			Title:               "Bridge replacement gate",
+			Body:                "Cairnline replacement requires artifact parity before backend migration.",
+			SuggestedKind:       "coordination_note",
+			SuggestedTrustLabel: memory.TrustLabelGenerated,
+			SuggestedSourceKind: "handoff",
+			SuggestedSourceID:   "handoff_review",
+			Status:              memory.CandidateStatusPending,
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		}},
 	}
 
 	if err := Seed(ctx, service, snapshot); err != nil {
@@ -153,6 +222,18 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	}
 	if len(packet.Skills) != 1 || packet.Skills[0].ID != "backend" || len(packet.Skills[0].SourceRefs) != 1 {
 		t.Fatalf("packet skills = %+v, want mapped backend skill with provenance", packet.Skills)
+	}
+	if len(packet.Evidence) != 1 || packet.Evidence[0].ID != "art_evidence" || packet.Evidence[0].Locator != "https://github.com/hecatehq/hecate/actions/runs/123" {
+		t.Fatalf("packet evidence = %+v, want mapped evidence link", packet.Evidence)
+	}
+	if len(packet.Reviews) != 1 || packet.Reviews[0].ID != "art_review" || packet.Reviews[0].AssignmentID != "asgn_external" || packet.Reviews[0].Verdict != cairnline.ReviewVerdictConcerns || packet.Reviews[0].Risk != cairnline.ReviewRiskMedium {
+		t.Fatalf("packet reviews = %+v, want mapped review with reduced verdict", packet.Reviews)
+	}
+	if len(packet.Handoffs) != 1 || packet.Handoffs[0].ID != "handoff_review" || packet.Handoffs[0].FromRoleID != "software_developer" || packet.Handoffs[0].ToRoleID != "reviewer_qa" {
+		t.Fatalf("packet handoffs = %+v, want mapped handoff roles", packet.Handoffs)
+	}
+	if len(packet.MemoryCandidates) != 1 || packet.MemoryCandidates[0].ID != "memcand_bridge" || packet.MemoryCandidates[0].TrustLabel != memory.TrustLabelGenerated || packet.MemoryCandidates[0].SourceRef != "handoff:handoff_review" {
+		t.Fatalf("packet memory candidates = %+v, want mapped memory candidate provenance", packet.MemoryCandidates)
 	}
 
 	externalPacket, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_external")

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -18,7 +18,117 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	service := cairnline.NewMemoryService()
 	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
 
-	snapshot := Snapshot{
+	snapshot := bridgeSnapshotFixture(now)
+
+	if err := Seed(ctx, service, snapshot); err != nil {
+		t.Fatalf("Seed() error = %v", err)
+	}
+
+	packet, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_bridge")
+	if err != nil {
+		t.Fatalf("AssignmentLaunchPacket() error = %v", err)
+	}
+	if packet.Project.ID != "proj_hecate" || packet.WorkItem.RootID != "root_main" {
+		t.Fatalf("packet project/work = %+v/%+v, want Hecate project with root-scoped work", packet.Project, packet.WorkItem)
+	}
+	if packet.Role == nil || packet.Role.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
+		t.Fatalf("packet role = %+v, want orchestrated role from Hecate task driver", packet.Role)
+	}
+	if packet.Profile == nil || packet.Profile.ID != "bridge_implementation" || packet.Profile.MemoryPolicy != agentprofiles.MemoryInclude {
+		t.Fatalf("packet profile = %+v, want mapped Hecate agent profile", packet.Profile)
+	}
+	if packet.ExecutionProfile == nil || packet.ExecutionProfile.AgentKind != "hecate" || packet.ExecutionProfile.WritesPolicy != "allow" || packet.ExecutionProfile.NetworkPolicy != "block" {
+		t.Fatalf("packet execution profile = %+v, want mapped Hecate execution posture", packet.ExecutionProfile)
+	}
+	if packet.Assignment.ExecutionMode != cairnline.ExecutionOrchestrated || packet.Assignment.RootID != "root_main" || packet.Assignment.ContextSnapshotID != "ctx_123" {
+		t.Fatalf("packet assignment = %+v, want orchestrated root-scoped assignment", packet.Assignment)
+	}
+	if len(packet.Skills) != 1 || packet.Skills[0].ID != "backend" || len(packet.Skills[0].SourceRefs) != 1 {
+		t.Fatalf("packet skills = %+v, want mapped backend skill with provenance", packet.Skills)
+	}
+	if len(packet.Evidence) != 1 || packet.Evidence[0].ID != "art_evidence" || packet.Evidence[0].Locator != "https://github.com/hecatehq/hecate/actions/runs/123" {
+		t.Fatalf("packet evidence = %+v, want mapped evidence link", packet.Evidence)
+	}
+	if len(packet.Reviews) != 1 || packet.Reviews[0].ID != "art_review" || packet.Reviews[0].AssignmentID != "asgn_external" || packet.Reviews[0].Verdict != cairnline.ReviewVerdictConcerns || packet.Reviews[0].Risk != cairnline.ReviewRiskMedium {
+		t.Fatalf("packet reviews = %+v, want mapped review with reduced verdict", packet.Reviews)
+	}
+	if len(packet.Handoffs) != 1 || packet.Handoffs[0].ID != "handoff_review" || packet.Handoffs[0].FromRoleID != "bridge_developer" || packet.Handoffs[0].ToRoleID != "bridge_reviewer" {
+		t.Fatalf("packet handoffs = %+v, want mapped handoff roles", packet.Handoffs)
+	}
+	if len(packet.MemoryCandidates) != 1 || packet.MemoryCandidates[0].ID != "memcand_bridge" || packet.MemoryCandidates[0].TrustLabel != memory.TrustLabelGenerated || packet.MemoryCandidates[0].SourceRef != "handoff:handoff_review" {
+		t.Fatalf("packet memory candidates = %+v, want mapped memory candidate provenance", packet.MemoryCandidates)
+	}
+
+	externalPacket, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_external")
+	if err != nil {
+		t.Fatalf("AssignmentLaunchPacket() external error = %v", err)
+	}
+	if externalPacket.Assignment.Status != cairnline.AssignmentCompleted || externalPacket.Assignment.ExecutionMode != cairnline.ExecutionExternalAdapter || externalPacket.Assignment.ExecutionRef != "chat_123" {
+		t.Fatalf("external assignment = %+v, want completed external-adapter assignment", externalPacket.Assignment)
+	}
+}
+
+func TestLoadSnapshotReadsHecateStores(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	sources := bridgeMemorySources()
+	snapshot := bridgeSnapshotFixture(now)
+	seedHecateSources(t, ctx, sources, snapshot)
+
+	loaded, err := LoadSnapshot(ctx, sources, snapshot.Project.ID)
+	if err != nil {
+		t.Fatalf("LoadSnapshot() error = %v", err)
+	}
+	if loaded.Project.ID != snapshot.Project.ID {
+		t.Fatalf("loaded project = %+v, want %q", loaded.Project, snapshot.Project.ID)
+	}
+	if !hasAgentProfile(loaded.AgentProfiles, "bridge_implementation") {
+		t.Fatalf("loaded profiles missing bridge_implementation: %+v", loaded.AgentProfiles)
+	}
+	if !hasRole(loaded.Roles, "bridge_developer") || !hasRole(loaded.Roles, "bridge_reviewer") {
+		t.Fatalf("loaded roles missing bridge roles: %+v", loaded.Roles)
+	}
+	if len(loaded.Skills) != len(snapshot.Skills) || len(loaded.WorkItems) != len(snapshot.WorkItems) || len(loaded.Assignments) != len(snapshot.Assignments) {
+		t.Fatalf("loaded counts skills=%d work=%d assignments=%d, want %d/%d/%d", len(loaded.Skills), len(loaded.WorkItems), len(loaded.Assignments), len(snapshot.Skills), len(snapshot.WorkItems), len(snapshot.Assignments))
+	}
+	if len(loaded.Artifacts) != len(snapshot.Artifacts) || len(loaded.Handoffs) != len(snapshot.Handoffs) || len(loaded.MemoryCandidates) != len(snapshot.MemoryCandidates) {
+		t.Fatalf("loaded collaboration counts artifacts=%d handoffs=%d memory=%d, want %d/%d/%d", len(loaded.Artifacts), len(loaded.Handoffs), len(loaded.MemoryCandidates), len(snapshot.Artifacts), len(snapshot.Handoffs), len(snapshot.MemoryCandidates))
+	}
+
+	service := cairnline.NewMemoryService()
+	if err := Seed(ctx, service, loaded); err != nil {
+		t.Fatalf("Seed() loaded snapshot error = %v", err)
+	}
+	packet, err := service.AssignmentLaunchPacket(ctx, snapshot.Project.ID, "asgn_bridge")
+	if err != nil {
+		t.Fatalf("AssignmentLaunchPacket() loaded snapshot error = %v", err)
+	}
+	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.MemoryCandidates) != 1 {
+		t.Fatalf("loaded launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.MemoryCandidates))
+	}
+}
+
+func TestExecutionModeMapsHecateDrivers(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+		want   string
+	}{
+		{name: "hecate task", driver: projectwork.AssignmentDriverHecateTask, want: cairnline.ExecutionOrchestrated},
+		{name: "external agent", driver: projectwork.AssignmentDriverExternalAgent, want: cairnline.ExecutionExternalAdapter},
+		{name: "unspecified", driver: "", want: cairnline.ExecutionMCPPull},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExecutionMode(tt.driver); got != tt.want {
+				t.Fatalf("ExecutionMode(%q) = %q, want %q", tt.driver, got, tt.want)
+			}
+		})
+	}
+}
+
+func bridgeSnapshotFixture(now time.Time) Snapshot {
+	return Snapshot{
 		Project: projects.Project{
 			ID:          "proj_hecate",
 			Name:        "Hecate",
@@ -43,8 +153,8 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			UpdatedAt: now,
 		},
 		AgentProfiles: []agentprofiles.Profile{{
-			ID:                  "implementation",
-			Name:                "Implementation",
+			ID:                  "bridge_implementation",
+			Name:                "Bridge Implementation",
 			Description:         "Implement scoped changes with tests.",
 			Instructions:        "Prefer small, reviewable changes.",
 			Surface:             agentprofiles.SurfaceHecateTask,
@@ -76,24 +186,24 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			UpdatedAt:              now,
 		}},
 		Roles: []projectwork.AgentRoleProfile{{
-			ID:                  "software_developer",
+			ID:                  "bridge_developer",
 			ProjectID:           "proj_hecate",
 			Name:                "Software Developer",
 			Description:         "Implements backend and shared behavior.",
 			Instructions:        "Keep handlers thin.",
 			DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
-			DefaultAgentProfile: "implementation",
+			DefaultAgentProfile: "bridge_implementation",
 			SkillIDs:            []string{"backend", "backend"},
 			CreatedAt:           now,
 			UpdatedAt:           now,
 		}, {
-			ID:                  "reviewer_qa",
+			ID:                  "bridge_reviewer",
 			ProjectID:           "proj_hecate",
 			Name:                "Reviewer QA",
 			Description:         "Reviews behavior, risks, and verification gaps.",
 			Instructions:        "Prioritize concrete defects.",
 			DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
-			DefaultAgentProfile: "implementation",
+			DefaultAgentProfile: "bridge_implementation",
 			SkillIDs:            []string{"backend"},
 			CreatedAt:           now,
 			UpdatedAt:           now,
@@ -105,9 +215,9 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			Brief:           "Prove Hecate can seed Cairnline coordination state.",
 			Status:          projectwork.WorkItemStatusReady,
 			Priority:        "normal",
-			OwnerRoleID:     "software_developer",
+			OwnerRoleID:     "bridge_developer",
 			RootID:          "root_main",
-			ReviewerRoleIDs: []string{"reviewer_qa"},
+			ReviewerRoleIDs: []string{"bridge_reviewer"},
 			CreatedAt:       now,
 			UpdatedAt:       now,
 		}},
@@ -115,7 +225,7 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			ID:         "asgn_bridge",
 			ProjectID:  "proj_hecate",
 			WorkItemID: "work_bridge",
-			RoleID:     "software_developer",
+			RoleID:     "bridge_developer",
 			RootID:     "root_main",
 			DriverKind: projectwork.AssignmentDriverHecateTask,
 			Status:     projectwork.AssignmentStatusQueued,
@@ -128,7 +238,7 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			ID:         "asgn_external",
 			ProjectID:  "proj_hecate",
 			WorkItemID: "work_bridge",
-			RoleID:     "software_developer",
+			RoleID:     "bridge_developer",
 			RootID:     "root_main",
 			DriverKind: projectwork.AssignmentDriverExternalAgent,
 			Status:     projectwork.AssignmentStatusCompleted,
@@ -158,7 +268,7 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			Kind:                 projectwork.ArtifactKindReview,
 			Title:                "Bridge review",
 			Body:                 "Needs one follow-up around artifact parity.",
-			AuthorRoleID:         "reviewer_qa",
+			AuthorRoleID:         "bridge_reviewer",
 			ReviewedAssignmentID: "asgn_external",
 			ReviewVerdict:        projectwork.ReviewVerdictChangesRequested,
 			ReviewRisk:           projectwork.ReviewRiskMedium,
@@ -170,7 +280,7 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			ProjectID:             "proj_hecate",
 			WorkItemID:            "work_bridge",
 			SourceAssignmentID:    "asgn_external",
-			TargetRoleID:          "reviewer_qa",
+			TargetRoleID:          "bridge_reviewer",
 			Title:                 "Review bridge parity",
 			Summary:               "Artifact parity is ready for review.",
 			RecommendedNextAction: "Verify launch packets include evidence, reviews, handoffs, and memory candidates.",
@@ -178,7 +288,7 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			LinkedMemoryIDs:       []string{"memcand_bridge"},
 			ContextRefs:           []string{"ctx_123"},
 			Status:                projectwork.HandoffStatusPending,
-			CreatedByRoleID:       "software_developer",
+			CreatedByRoleID:       "bridge_developer",
 			CreatedAt:             now,
 			UpdatedAt:             now,
 		}},
@@ -196,70 +306,77 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 			UpdatedAt:           now,
 		}},
 	}
+}
 
-	if err := Seed(ctx, service, snapshot); err != nil {
-		t.Fatalf("Seed() error = %v", err)
-	}
-
-	packet, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_bridge")
-	if err != nil {
-		t.Fatalf("AssignmentLaunchPacket() error = %v", err)
-	}
-	if packet.Project.ID != "proj_hecate" || packet.WorkItem.RootID != "root_main" {
-		t.Fatalf("packet project/work = %+v/%+v, want Hecate project with root-scoped work", packet.Project, packet.WorkItem)
-	}
-	if packet.Role == nil || packet.Role.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
-		t.Fatalf("packet role = %+v, want orchestrated role from Hecate task driver", packet.Role)
-	}
-	if packet.Profile == nil || packet.Profile.ID != "implementation" || packet.Profile.MemoryPolicy != agentprofiles.MemoryInclude {
-		t.Fatalf("packet profile = %+v, want mapped Hecate agent profile", packet.Profile)
-	}
-	if packet.ExecutionProfile == nil || packet.ExecutionProfile.AgentKind != "hecate" || packet.ExecutionProfile.WritesPolicy != "allow" || packet.ExecutionProfile.NetworkPolicy != "block" {
-		t.Fatalf("packet execution profile = %+v, want mapped Hecate execution posture", packet.ExecutionProfile)
-	}
-	if packet.Assignment.ExecutionMode != cairnline.ExecutionOrchestrated || packet.Assignment.RootID != "root_main" || packet.Assignment.ContextSnapshotID != "ctx_123" {
-		t.Fatalf("packet assignment = %+v, want orchestrated root-scoped assignment", packet.Assignment)
-	}
-	if len(packet.Skills) != 1 || packet.Skills[0].ID != "backend" || len(packet.Skills[0].SourceRefs) != 1 {
-		t.Fatalf("packet skills = %+v, want mapped backend skill with provenance", packet.Skills)
-	}
-	if len(packet.Evidence) != 1 || packet.Evidence[0].ID != "art_evidence" || packet.Evidence[0].Locator != "https://github.com/hecatehq/hecate/actions/runs/123" {
-		t.Fatalf("packet evidence = %+v, want mapped evidence link", packet.Evidence)
-	}
-	if len(packet.Reviews) != 1 || packet.Reviews[0].ID != "art_review" || packet.Reviews[0].AssignmentID != "asgn_external" || packet.Reviews[0].Verdict != cairnline.ReviewVerdictConcerns || packet.Reviews[0].Risk != cairnline.ReviewRiskMedium {
-		t.Fatalf("packet reviews = %+v, want mapped review with reduced verdict", packet.Reviews)
-	}
-	if len(packet.Handoffs) != 1 || packet.Handoffs[0].ID != "handoff_review" || packet.Handoffs[0].FromRoleID != "software_developer" || packet.Handoffs[0].ToRoleID != "reviewer_qa" {
-		t.Fatalf("packet handoffs = %+v, want mapped handoff roles", packet.Handoffs)
-	}
-	if len(packet.MemoryCandidates) != 1 || packet.MemoryCandidates[0].ID != "memcand_bridge" || packet.MemoryCandidates[0].TrustLabel != memory.TrustLabelGenerated || packet.MemoryCandidates[0].SourceRef != "handoff:handoff_review" {
-		t.Fatalf("packet memory candidates = %+v, want mapped memory candidate provenance", packet.MemoryCandidates)
-	}
-
-	externalPacket, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_external")
-	if err != nil {
-		t.Fatalf("AssignmentLaunchPacket() external error = %v", err)
-	}
-	if externalPacket.Assignment.Status != cairnline.AssignmentCompleted || externalPacket.Assignment.ExecutionMode != cairnline.ExecutionExternalAdapter || externalPacket.Assignment.ExecutionRef != "chat_123" {
-		t.Fatalf("external assignment = %+v, want completed external-adapter assignment", externalPacket.Assignment)
+func bridgeMemorySources() SnapshotSources {
+	return SnapshotSources{
+		Projects:         projects.NewMemoryStore(),
+		AgentProfiles:    agentprofiles.NewMemoryStore(),
+		Skills:           projectskills.NewMemoryStore(),
+		Work:             projectwork.NewMemoryStore(),
+		MemoryCandidates: memory.NewMemoryStore(),
 	}
 }
 
-func TestExecutionModeMapsHecateDrivers(t *testing.T) {
-	tests := []struct {
-		name   string
-		driver string
-		want   string
-	}{
-		{name: "hecate task", driver: projectwork.AssignmentDriverHecateTask, want: cairnline.ExecutionOrchestrated},
-		{name: "external agent", driver: projectwork.AssignmentDriverExternalAgent, want: cairnline.ExecutionExternalAdapter},
-		{name: "unspecified", driver: "", want: cairnline.ExecutionMCPPull},
+func seedHecateSources(t *testing.T, ctx context.Context, sources SnapshotSources, snapshot Snapshot) {
+	t.Helper()
+	if _, err := sources.Projects.Create(ctx, snapshot.Project); err != nil {
+		t.Fatalf("Create project: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ExecutionMode(tt.driver); got != tt.want {
-				t.Fatalf("ExecutionMode(%q) = %q, want %q", tt.driver, got, tt.want)
-			}
-		})
+	for _, profile := range snapshot.AgentProfiles {
+		if _, err := sources.AgentProfiles.Create(ctx, profile); err != nil {
+			t.Fatalf("Create profile %q: %v", profile.ID, err)
+		}
 	}
+	if _, err := sources.Skills.UpsertDiscovered(ctx, snapshot.Project.ID, snapshot.Skills); err != nil {
+		t.Fatalf("Upsert skills: %v", err)
+	}
+	for _, role := range snapshot.Roles {
+		if _, err := sources.Work.CreateRole(ctx, role); err != nil {
+			t.Fatalf("Create role %q: %v", role.ID, err)
+		}
+	}
+	for _, item := range snapshot.WorkItems {
+		if _, err := sources.Work.CreateWorkItem(ctx, item); err != nil {
+			t.Fatalf("Create work item %q: %v", item.ID, err)
+		}
+	}
+	for _, assignment := range snapshot.Assignments {
+		if _, err := sources.Work.CreateAssignment(ctx, assignment); err != nil {
+			t.Fatalf("Create assignment %q: %v", assignment.ID, err)
+		}
+	}
+	for _, artifact := range snapshot.Artifacts {
+		if _, err := sources.Work.CreateArtifact(ctx, artifact); err != nil {
+			t.Fatalf("Create artifact %q: %v", artifact.ID, err)
+		}
+	}
+	for _, handoff := range snapshot.Handoffs {
+		if _, err := sources.Work.CreateHandoff(ctx, handoff); err != nil {
+			t.Fatalf("Create handoff %q: %v", handoff.ID, err)
+		}
+	}
+	for _, candidate := range snapshot.MemoryCandidates {
+		if _, err := sources.MemoryCandidates.CreateCandidate(ctx, candidate); err != nil {
+			t.Fatalf("Create memory candidate %q: %v", candidate.ID, err)
+		}
+	}
+}
+
+func hasAgentProfile(profiles []agentprofiles.Profile, id string) bool {
+	for _, profile := range profiles {
+		if profile.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRole(roles []projectwork.AgentRoleProfile, id string) bool {
+	for _, role := range roles {
+		if role.ID == id {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -1,0 +1,184 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	snapshot := Snapshot{
+		Project: projects.Project{
+			ID:          "proj_hecate",
+			Name:        "Hecate",
+			Description: "Local AI operations console.",
+			Roots: []projects.Root{{
+				ID:        "root_main",
+				Path:      "/Users/alice/dev/hecate",
+				Kind:      "local",
+				GitRemote: "git@github.com:hecatehq/hecate.git",
+				GitBranch: "main",
+				Active:    true,
+			}},
+			ContextSources: []projects.ContextSource{{
+				ID:         "src_agents",
+				Kind:       "workspace_instruction",
+				Title:      "AGENTS.md",
+				Path:       "AGENTS.md",
+				Enabled:    true,
+				TrustLabel: "workspace_guidance",
+			}},
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		AgentProfiles: []agentprofiles.Profile{{
+			ID:                  "implementation",
+			Name:                "Implementation",
+			Description:         "Implement scoped changes with tests.",
+			Instructions:        "Prefer small, reviewable changes.",
+			Surface:             agentprofiles.SurfaceHecateTask,
+			ProviderHint:        "ollama",
+			ModelHint:           "qwen3-coder",
+			ToolsEnabled:        true,
+			WritesAllowed:       true,
+			NetworkAllowed:      false,
+			ApprovalPolicy:      agentprofiles.ApprovalRequire,
+			ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+			ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+			SkillIDs:            []string{"backend"},
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		}},
+		Skills: []projectskills.Skill{{
+			ID:                     "backend",
+			ProjectID:              "proj_hecate",
+			Title:                  "Backend",
+			Description:            "Backend implementation guidance.",
+			Path:                   "docs-ai/skills/backend/SKILL.md",
+			RootID:                 "root_main",
+			Format:                 projectskills.FormatSkillMD,
+			Enabled:                true,
+			Status:                 projectskills.StatusAvailable,
+			TrustLabel:             projectskills.TrustWorkspaceSkill,
+			SourceContextSourceIDs: []string{"src_agents"},
+			CreatedAt:              now,
+			UpdatedAt:              now,
+		}},
+		Roles: []projectwork.AgentRoleProfile{{
+			ID:                  "software_developer",
+			ProjectID:           "proj_hecate",
+			Name:                "Software Developer",
+			Description:         "Implements backend and shared behavior.",
+			Instructions:        "Keep handlers thin.",
+			DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
+			DefaultAgentProfile: "implementation",
+			SkillIDs:            []string{"backend", "backend"},
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		}},
+		WorkItems: []projectwork.WorkItem{{
+			ID:              "work_bridge",
+			ProjectID:       "proj_hecate",
+			Title:           "Bridge Cairnline",
+			Brief:           "Prove Hecate can seed Cairnline coordination state.",
+			Status:          projectwork.WorkItemStatusReady,
+			Priority:        "normal",
+			OwnerRoleID:     "software_developer",
+			RootID:          "root_main",
+			ReviewerRoleIDs: []string{"reviewer_qa"},
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}},
+		Assignments: []projectwork.Assignment{{
+			ID:         "asgn_bridge",
+			ProjectID:  "proj_hecate",
+			WorkItemID: "work_bridge",
+			RoleID:     "software_developer",
+			RootID:     "root_main",
+			DriverKind: projectwork.AssignmentDriverHecateTask,
+			Status:     projectwork.AssignmentStatusQueued,
+			ExecutionRef: projectwork.AssignmentExecutionRef{
+				ContextSnapshotID: "ctx_123",
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}, {
+			ID:         "asgn_external",
+			ProjectID:  "proj_hecate",
+			WorkItemID: "work_bridge",
+			RoleID:     "software_developer",
+			RootID:     "root_main",
+			DriverKind: projectwork.AssignmentDriverExternalAgent,
+			Status:     projectwork.AssignmentStatusCompleted,
+			ExecutionRef: projectwork.AssignmentExecutionRef{
+				ChatSessionID: "chat_123",
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}},
+	}
+
+	if err := Seed(ctx, service, snapshot); err != nil {
+		t.Fatalf("Seed() error = %v", err)
+	}
+
+	packet, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_bridge")
+	if err != nil {
+		t.Fatalf("AssignmentLaunchPacket() error = %v", err)
+	}
+	if packet.Project.ID != "proj_hecate" || packet.WorkItem.RootID != "root_main" {
+		t.Fatalf("packet project/work = %+v/%+v, want Hecate project with root-scoped work", packet.Project, packet.WorkItem)
+	}
+	if packet.Role == nil || packet.Role.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
+		t.Fatalf("packet role = %+v, want orchestrated role from Hecate task driver", packet.Role)
+	}
+	if packet.Profile == nil || packet.Profile.ID != "implementation" || packet.Profile.MemoryPolicy != agentprofiles.MemoryInclude {
+		t.Fatalf("packet profile = %+v, want mapped Hecate agent profile", packet.Profile)
+	}
+	if packet.ExecutionProfile == nil || packet.ExecutionProfile.AgentKind != "hecate" || packet.ExecutionProfile.WritesPolicy != "allow" || packet.ExecutionProfile.NetworkPolicy != "block" {
+		t.Fatalf("packet execution profile = %+v, want mapped Hecate execution posture", packet.ExecutionProfile)
+	}
+	if packet.Assignment.ExecutionMode != cairnline.ExecutionOrchestrated || packet.Assignment.RootID != "root_main" || packet.Assignment.ContextSnapshotID != "ctx_123" {
+		t.Fatalf("packet assignment = %+v, want orchestrated root-scoped assignment", packet.Assignment)
+	}
+	if len(packet.Skills) != 1 || packet.Skills[0].ID != "backend" || len(packet.Skills[0].SourceRefs) != 1 {
+		t.Fatalf("packet skills = %+v, want mapped backend skill with provenance", packet.Skills)
+	}
+
+	externalPacket, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_external")
+	if err != nil {
+		t.Fatalf("AssignmentLaunchPacket() external error = %v", err)
+	}
+	if externalPacket.Assignment.Status != cairnline.AssignmentCompleted || externalPacket.Assignment.ExecutionMode != cairnline.ExecutionExternalAdapter || externalPacket.Assignment.ExecutionRef != "chat_123" {
+		t.Fatalf("external assignment = %+v, want completed external-adapter assignment", externalPacket.Assignment)
+	}
+}
+
+func TestExecutionModeMapsHecateDrivers(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+		want   string
+	}{
+		{name: "hecate task", driver: projectwork.AssignmentDriverHecateTask, want: cairnline.ExecutionOrchestrated},
+		{name: "external agent", driver: projectwork.AssignmentDriverExternalAgent, want: cairnline.ExecutionExternalAdapter},
+		{name: "unspecified", driver: "", want: cairnline.ExecutionMCPPull},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExecutionMode(tt.driver); got != tt.want {
+				t.Fatalf("ExecutionMode(%q) = %q, want %q", tt.driver, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -2,6 +2,7 @@ package cairnlinebridge
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -105,6 +106,42 @@ func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	}
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("loaded launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.MemoryCandidates))
+	}
+}
+
+func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	sources := bridgeMemorySources()
+	snapshot := bridgeSnapshotFixture(now)
+	seedHecateSources(t, ctx, sources, snapshot)
+	dbPath := filepath.Join(t.TempDir(), "cairnline.db")
+
+	service, store, err := cairnline.NewSQLiteService(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteService() error = %v", err)
+	}
+	if _, err := SeedProjectFromStores(ctx, service, sources, snapshot.Project.ID); err != nil {
+		t.Fatalf("SeedProjectFromStores() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close seeded store: %v", err)
+	}
+
+	reopened, reopenedStore, err := cairnline.NewSQLiteService(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen NewSQLiteService() error = %v", err)
+	}
+	defer reopenedStore.Close()
+	packet, err := reopened.AssignmentLaunchPacket(ctx, snapshot.Project.ID, "asgn_bridge")
+	if err != nil {
+		t.Fatalf("AssignmentLaunchPacket() reopened error = %v", err)
+	}
+	if packet.Project.ID != snapshot.Project.ID || packet.Assignment.RootID != "root_main" {
+		t.Fatalf("reopened packet project/assignment = %+v/%+v, want persisted root-scoped launch packet", packet.Project, packet.Assignment)
+	}
+	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.MemoryCandidates) != 1 {
+		t.Fatalf("reopened launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.MemoryCandidates))
 	}
 }
 

--- a/internal/cairnlinebridge/snapshot.go
+++ b/internal/cairnlinebridge/snapshot.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -20,6 +21,20 @@ type SnapshotSources struct {
 	Skills           projectskills.Store
 	Work             projectwork.Store
 	MemoryCandidates memory.CandidateStore
+}
+
+func SeedProjectFromStores(ctx context.Context, service *cairnline.Service, sources SnapshotSources, projectID string) (Snapshot, error) {
+	if service == nil {
+		return Snapshot{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	snapshot, err := LoadSnapshot(ctx, sources, projectID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if err := Seed(ctx, service, snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
 }
 
 func LoadSnapshot(ctx context.Context, sources SnapshotSources, projectID string) (Snapshot, error) {

--- a/internal/cairnlinebridge/snapshot.go
+++ b/internal/cairnlinebridge/snapshot.go
@@ -1,0 +1,95 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+var ErrSourceNotConfigured = errors.New("cairnline bridge source not configured")
+
+type SnapshotSources struct {
+	Projects         projects.Store
+	AgentProfiles    agentprofiles.Store
+	Skills           projectskills.Store
+	Work             projectwork.Store
+	MemoryCandidates memory.CandidateStore
+}
+
+func LoadSnapshot(ctx context.Context, sources SnapshotSources, projectID string) (Snapshot, error) {
+	projectID = strings.TrimSpace(projectID)
+	if sources.Projects == nil {
+		return Snapshot{}, errors.Join(ErrSourceNotConfigured, errors.New("projects store is required"))
+	}
+	if sources.AgentProfiles == nil {
+		return Snapshot{}, errors.Join(ErrSourceNotConfigured, errors.New("agent profiles store is required"))
+	}
+	if sources.Work == nil {
+		return Snapshot{}, errors.Join(ErrSourceNotConfigured, errors.New("project work store is required"))
+	}
+	project, ok, err := sources.Projects.Get(ctx, projectID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if !ok {
+		return Snapshot{}, projects.ErrNotFound
+	}
+	profiles, err := sources.AgentProfiles.List(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	var skills []projectskills.Skill
+	if sources.Skills != nil {
+		skills, err = sources.Skills.List(ctx, projectID)
+		if err != nil {
+			return Snapshot{}, err
+		}
+	}
+	roles, err := sources.Work.ListRoles(ctx, projectID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	workItems, err := sources.Work.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	assignments, err := sources.Work.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return Snapshot{}, err
+	}
+	artifacts, err := sources.Work.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID})
+	if err != nil {
+		return Snapshot{}, err
+	}
+	handoffs, err := sources.Work.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID})
+	if err != nil {
+		return Snapshot{}, err
+	}
+	var memoryCandidates []memory.Candidate
+	if sources.MemoryCandidates != nil {
+		memoryCandidates, err = sources.MemoryCandidates.ListCandidates(ctx, memory.CandidateFilter{
+			ProjectID: projectID,
+			Status:    memory.CandidateStatusPending,
+		})
+		if err != nil {
+			return Snapshot{}, err
+		}
+	}
+	return Snapshot{
+		Project:          project,
+		AgentProfiles:    profiles,
+		Skills:           skills,
+		Roles:            roles,
+		WorkItems:        workItems,
+		Assignments:      assignments,
+		Artifacts:        artifacts,
+		Handoffs:         handoffs,
+		MemoryCandidates: memoryCandidates,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- add a non-runtime Hecate Projects to Cairnline bridge package
- pin the public Cairnline module and seed Cairnline from Hecate project/profile/skill/role/work/assignment records
- cover root-scoped assignments, execution-mode mapping, status preservation, profile posture, skills, and launch-packet metadata

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge ./internal/projects ./internal/projectwork ./internal/projectskills ./internal/agentprofiles
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./... (rerun outside sandbox because httptest listeners need local bind permission)
- just agent-docs-check
- just docs-check
- git diff --check