### PR TITLE
feat: align Cairnline bridge memory parity

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -94,7 +94,8 @@ Hecate project-shaped records:
 - project identity, roots, and context-source metadata;
 - agent profiles and execution posture;
 - skills metadata, roles, work items, and root-scoped assignments;
-- collaboration evidence links, reviews, handoffs, and memory candidates.
+- collaboration evidence links, reviews, handoffs, accepted memory entries, and
+  memory candidates with decision state.
 
 This bridge proves the portable Cairnline model can receive the core
 coordination graph and produce assignment launch packets with the expected
@@ -112,8 +113,8 @@ Hecate is ready to replace its internal Projects backend with Cairnline only
 after these gates are met:
 
 - Cairnline has durable storage and MCP/API parity for Hecate's project, role,
-  profile, skill, work item, assignment, artifact, handoff, and memory-candidate
-  flows.
+  profile, skill, work item, assignment, artifact, handoff, accepted-memory, and
+  memory-candidate flows.
 - Hecate has a feature-flagged adapter that can run read/write Projects flows
   against Cairnline without UI-local fallback state.
 - Import/export or migration covers existing Hecate local stores and can be

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2217,6 +2217,7 @@ Example response:
     "assignment_count": 5,
     "artifact_count": 4,
     "handoff_count": 1,
+    "memory_entry_count": 3,
     "memory_candidate_count": 2
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260626170038-16d4c3a275ec
+	github.com/hecatehq/cairnline v0.0.0-20260626191525-1d13e2a3d8a4
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hecatehq/cairnline v0.0.0-20260626170038-16d4c3a275ec h1:+jMCl9e0xrU0iIrUmfGWMH8BziaaIzyuOhOjHyPT49Q=
 github.com/hecatehq/cairnline v0.0.0-20260626170038-16d4c3a275ec/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260626191525-1d13e2a3d8a4 h1:GxDgQVdY9DISIXjvtDGvMvx772x/oL59EnrHdoTbZXM=
+github.com/hecatehq/cairnline v0.0.0-20260626191525-1d13e2a3d8a4/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -61,6 +61,7 @@ func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.
 			AssignmentCount:      len(snapshot.Assignments),
 			ArtifactCount:        len(snapshot.Artifacts),
 			HandoffCount:         len(snapshot.Handoffs),
+			MemoryEntryCount:     len(snapshot.MemoryEntries),
 			MemoryCandidateCount: len(snapshot.MemoryCandidates),
 		},
 	})
@@ -72,6 +73,7 @@ func (h *Handler) cairnlineSnapshotSources() cairnlinebridge.SnapshotSources {
 		AgentProfiles:    h.agentProfiles,
 		Skills:           h.projectSkills,
 		Work:             h.projectWork,
+		Memory:           h.memory,
 		MemoryCandidates: h.memoryCandidates,
 	}
 }

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -111,6 +111,19 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 		"recommended_next_action": "Inspect the exported launch packet.",
 		"created_by_role_id":      role.Data.ID,
 	}))
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:         "mem_export",
+		Scope:      memory.ScopeProject,
+		ProjectID:  projectID,
+		Title:      "Export replacement gate",
+		Body:       "Cairnline export should preserve accepted project memory.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		SourceID:   handoff.Data.ID,
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Create memory entry: %v", err)
+	}
 	mustRequestJSONStatus[ProjectMemoryCandidateResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates", projectJourneyJSON(t, map[string]any{
 		"id":                    "memcand_export",
 		"title":                 "Export gate",
@@ -126,7 +139,7 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if first.Data.DatabasePath != second.Data.DatabasePath {
 		t.Fatalf("export paths = %q/%q, want refresh to same path", first.Data.DatabasePath, second.Data.DatabasePath)
 	}
-	if second.Data.ProjectID != projectID || second.Data.WorkItemCount != 1 || second.Data.AssignmentCount != 1 || second.Data.ArtifactCount != 2 || second.Data.HandoffCount != 1 || second.Data.MemoryCandidateCount != 1 {
+	if second.Data.ProjectID != projectID || second.Data.WorkItemCount != 1 || second.Data.AssignmentCount != 1 || second.Data.ArtifactCount != 2 || second.Data.HandoffCount != 1 || second.Data.MemoryEntryCount != 1 || second.Data.MemoryCandidateCount != 1 {
 		t.Fatalf("export response = %+v, want project counts", second.Data)
 	}
 	if !filepath.IsAbs(second.Data.DatabasePath) {
@@ -148,8 +161,8 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if packet.Project.ID != projectID || packet.Assignment.RootID != project.Data.Roots[0].ID {
 		t.Fatalf("packet project/assignment = %+v/%+v, want exported root-scoped assignment", packet.Project, packet.Assignment)
 	}
-	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.MemoryCandidates) != 1 {
-		t.Fatalf("packet counts evidence=%d reviews=%d handoffs=%d memory=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.MemoryCandidates))
+	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
+		t.Fatalf("packet counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -305,6 +305,7 @@ type ProjectCairnlineExportResponseItem struct {
 	AssignmentCount      int    `json:"assignment_count"`
 	ArtifactCount        int    `json:"artifact_count"`
 	HandoffCount         int    `json:"handoff_count"`
+	MemoryEntryCount     int    `json:"memory_entry_count"`
 	MemoryCandidateCount int    `json:"memory_candidate_count"`
 }
 

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -27,6 +27,7 @@ type Snapshot struct {
 	Assignments      []projectwork.Assignment
 	Artifacts        []projectwork.CollaborationArtifact
 	Handoffs         []projectwork.Handoff
+	MemoryEntries    []memory.Entry
 	MemoryCandidates []memory.Candidate
 }
 
@@ -96,9 +97,21 @@ func Seed(ctx context.Context, service *cairnline.Service, snapshot Snapshot) er
 			return err
 		}
 	}
-	for _, candidate := range snapshot.MemoryCandidates {
-		if _, err := service.CreateMemoryCandidate(ctx, MemoryCandidate(candidate)); err != nil {
+	for _, entry := range snapshot.MemoryEntries {
+		if _, err := service.CreateMemoryEntry(ctx, MemoryEntry(entry)); err != nil {
 			return err
+		}
+	}
+	for _, candidate := range snapshot.MemoryCandidates {
+		item := MemoryCandidate(candidate)
+		created, err := service.CreateMemoryCandidate(ctx, item)
+		if err != nil {
+			return err
+		}
+		if created.Status != item.Status || created.StatusReason != item.StatusReason || created.PromotedMemoryID != item.PromotedMemoryID {
+			if _, err := service.UpdateMemoryCandidate(ctx, item); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -300,18 +313,58 @@ func Handoff(handoff projectwork.Handoff) cairnline.Handoff {
 	}
 }
 
+func MemoryEntry(entry memory.Entry) cairnline.MemoryEntry {
+	return cairnline.MemoryEntry{
+		ID:         strings.TrimSpace(entry.ID),
+		ProjectID:  strings.TrimSpace(entry.ProjectID),
+		Title:      strings.TrimSpace(entry.Title),
+		Body:       strings.TrimSpace(entry.Body),
+		TrustLabel: strings.TrimSpace(entry.TrustLabel),
+		SourceKind: strings.TrimSpace(entry.SourceKind),
+		SourceID:   strings.TrimSpace(entry.SourceID),
+		Enabled:    entry.Enabled,
+		CreatedAt:  entry.CreatedAt,
+		UpdatedAt:  entry.UpdatedAt,
+	}
+}
+
 func MemoryCandidate(candidate memory.Candidate) cairnline.MemoryCandidate {
 	return cairnline.MemoryCandidate{
-		ID:         strings.TrimSpace(candidate.ID),
-		ProjectID:  strings.TrimSpace(candidate.ProjectID),
-		Title:      strings.TrimSpace(candidate.Title),
-		Body:       strings.TrimSpace(candidate.Body),
-		Status:     cairnline.MemoryCandidateProposed,
-		TrustLabel: strings.TrimSpace(candidate.SuggestedTrustLabel),
-		SourceRef:  memoryCandidateSourceRef(candidate),
-		CreatedAt:  candidate.CreatedAt,
-		UpdatedAt:  candidate.UpdatedAt,
+		ID:                  strings.TrimSpace(candidate.ID),
+		ProjectID:           strings.TrimSpace(candidate.ProjectID),
+		Title:               strings.TrimSpace(candidate.Title),
+		Body:                strings.TrimSpace(candidate.Body),
+		SuggestedKind:       strings.TrimSpace(candidate.SuggestedKind),
+		SuggestedTrustLabel: strings.TrimSpace(candidate.SuggestedTrustLabel),
+		SuggestedSourceKind: strings.TrimSpace(candidate.SuggestedSourceKind),
+		SuggestedSourceID:   strings.TrimSpace(candidate.SuggestedSourceID),
+		SourceRefs:          MemoryCandidateSourceRefs(candidate.SourceRefs),
+		Status:              MemoryCandidateStatus(candidate.Status),
+		StatusReason:        strings.TrimSpace(candidate.StatusReason),
+		PromotedMemoryID:    strings.TrimSpace(candidate.PromotedMemoryID),
+		CreatedAt:           candidate.CreatedAt,
+		UpdatedAt:           candidate.UpdatedAt,
 	}
+}
+
+func MemoryCandidateSourceRefs(refs []memory.CandidateSourceRef) []cairnline.MemoryCandidateSourceRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]cairnline.MemoryCandidateSourceRef, 0, len(refs))
+	for _, ref := range refs {
+		item := cairnline.MemoryCandidateSourceRef{
+			Kind:  strings.TrimSpace(ref.Kind),
+			ID:    strings.TrimSpace(ref.ID),
+			Title: strings.TrimSpace(ref.Title),
+			URL:   strings.TrimSpace(ref.URL),
+		}
+		if item.Kind == "" && item.ID == "" && item.Title == "" && item.URL == "" {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
 }
 
 func ExecutionMode(driverKind string) string {
@@ -361,6 +414,17 @@ func ReviewRisk(risk string) string {
 		return cairnline.ReviewRiskHigh
 	default:
 		return ""
+	}
+}
+
+func MemoryCandidateStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case memory.CandidateStatusPromoted:
+		return cairnline.MemoryCandidatePromoted
+	case memory.CandidateStatusRejected:
+		return cairnline.MemoryCandidateRejected
+	default:
+		return cairnline.MemoryCandidatePending
 	}
 }
 
@@ -477,17 +541,6 @@ func handoffBody(handoff projectwork.Handoff) string {
 		labelList("Linked memory", handoff.LinkedMemoryIDs),
 		labelList("Context refs", handoff.ContextRefs),
 	)
-}
-
-func memoryCandidateSourceRef(candidate memory.Candidate) string {
-	if value := labelPair(candidate.SuggestedSourceKind, candidate.SuggestedSourceID); value != "" {
-		return value
-	}
-	if len(candidate.SourceRefs) == 0 {
-		return ""
-	}
-	ref := candidate.SourceRefs[0]
-	return firstNonEmpty(labelPair(ref.Kind, ref.ID), strings.TrimSpace(ref.URL), strings.TrimSpace(ref.Title))
 }
 
 func labelValue(label, value string) string {

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -56,8 +56,19 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if len(packet.Handoffs) != 1 || packet.Handoffs[0].ID != "handoff_review" || packet.Handoffs[0].FromRoleID != "bridge_developer" || packet.Handoffs[0].ToRoleID != "bridge_reviewer" {
 		t.Fatalf("packet handoffs = %+v, want mapped handoff roles", packet.Handoffs)
 	}
-	if len(packet.MemoryCandidates) != 1 || packet.MemoryCandidates[0].ID != "memcand_bridge" || packet.MemoryCandidates[0].TrustLabel != memory.TrustLabelGenerated || packet.MemoryCandidates[0].SourceRef != "handoff:handoff_review" {
+	if len(packet.Memory) != 1 || packet.Memory[0].ID != "mem_bridge" || packet.Memory[0].TrustLabel != memory.TrustLabelOperatorMemory {
+		t.Fatalf("packet memory = %+v, want mapped accepted memory", packet.Memory)
+	}
+	if len(packet.MemoryCandidates) != 1 || packet.MemoryCandidates[0].ID != "memcand_bridge" || packet.MemoryCandidates[0].SuggestedTrustLabel != memory.TrustLabelGenerated || packet.MemoryCandidates[0].SuggestedSourceID != "handoff_review" || len(packet.MemoryCandidates[0].SourceRefs) != 1 {
 		t.Fatalf("packet memory candidates = %+v, want mapped memory candidate provenance", packet.MemoryCandidates)
+	}
+	candidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{ProjectID: "proj_hecate", IncludeResolved: true})
+	if err != nil {
+		t.Fatalf("ListMemoryCandidates(include resolved) error = %v", err)
+	}
+	rejectedCandidate := findCairnlineMemoryCandidate(candidates, "memcand_rejected")
+	if len(candidates) != 2 || rejectedCandidate == nil || rejectedCandidate.Status != cairnline.MemoryCandidateRejected || rejectedCandidate.StatusReason != "Already captured" {
+		t.Fatalf("all memory candidates = %+v, want pending and rejected state preserved", candidates)
 	}
 
 	externalPacket, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_external")
@@ -92,8 +103,8 @@ func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	if len(loaded.Skills) != len(snapshot.Skills) || len(loaded.WorkItems) != len(snapshot.WorkItems) || len(loaded.Assignments) != len(snapshot.Assignments) {
 		t.Fatalf("loaded counts skills=%d work=%d assignments=%d, want %d/%d/%d", len(loaded.Skills), len(loaded.WorkItems), len(loaded.Assignments), len(snapshot.Skills), len(snapshot.WorkItems), len(snapshot.Assignments))
 	}
-	if len(loaded.Artifacts) != len(snapshot.Artifacts) || len(loaded.Handoffs) != len(snapshot.Handoffs) || len(loaded.MemoryCandidates) != len(snapshot.MemoryCandidates) {
-		t.Fatalf("loaded collaboration counts artifacts=%d handoffs=%d memory=%d, want %d/%d/%d", len(loaded.Artifacts), len(loaded.Handoffs), len(loaded.MemoryCandidates), len(snapshot.Artifacts), len(snapshot.Handoffs), len(snapshot.MemoryCandidates))
+	if len(loaded.Artifacts) != len(snapshot.Artifacts) || len(loaded.Handoffs) != len(snapshot.Handoffs) || len(loaded.MemoryEntries) != len(snapshot.MemoryEntries) || len(loaded.MemoryCandidates) != len(snapshot.MemoryCandidates) {
+		t.Fatalf("loaded collaboration counts artifacts=%d handoffs=%d memory_entries=%d memory_candidates=%d, want %d/%d/%d/%d", len(loaded.Artifacts), len(loaded.Handoffs), len(loaded.MemoryEntries), len(loaded.MemoryCandidates), len(snapshot.Artifacts), len(snapshot.Handoffs), len(snapshot.MemoryEntries), len(snapshot.MemoryCandidates))
 	}
 
 	service := cairnline.NewMemoryService()
@@ -104,8 +115,8 @@ func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AssignmentLaunchPacket() loaded snapshot error = %v", err)
 	}
-	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.MemoryCandidates) != 1 {
-		t.Fatalf("loaded launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.MemoryCandidates))
+	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
+		t.Fatalf("loaded launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
 	}
 }
 
@@ -140,8 +151,8 @@ func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	if packet.Project.ID != snapshot.Project.ID || packet.Assignment.RootID != "root_main" {
 		t.Fatalf("reopened packet project/assignment = %+v/%+v, want persisted root-scoped launch packet", packet.Project, packet.Assignment)
 	}
-	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.MemoryCandidates) != 1 {
-		t.Fatalf("reopened launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.MemoryCandidates))
+	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
+		t.Fatalf("reopened launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
 	}
 }
 
@@ -329,6 +340,19 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			CreatedAt:             now,
 			UpdatedAt:             now,
 		}},
+		MemoryEntries: []memory.Entry{{
+			ID:         "mem_bridge",
+			Scope:      memory.ScopeProject,
+			ProjectID:  "proj_hecate",
+			Title:      "Bridge replacement gate",
+			Body:       "Cairnline replacement requires artifact parity before backend migration.",
+			TrustLabel: memory.TrustLabelOperatorMemory,
+			SourceKind: memory.SourceKindOperator,
+			SourceID:   "handoff_review",
+			Enabled:    true,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}},
 		MemoryCandidates: []memory.Candidate{{
 			ID:                  "memcand_bridge",
 			ProjectID:           "proj_hecate",
@@ -338,7 +362,24 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			SuggestedTrustLabel: memory.TrustLabelGenerated,
 			SuggestedSourceKind: "handoff",
 			SuggestedSourceID:   "handoff_review",
-			Status:              memory.CandidateStatusPending,
+			SourceRefs: []memory.CandidateSourceRef{{
+				Kind:  "handoff",
+				ID:    "handoff_review",
+				Title: "Review bridge parity",
+			}},
+			Status:    memory.CandidateStatusPending,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}, {
+			ID:                  "memcand_rejected",
+			ProjectID:           "proj_hecate",
+			Title:               "Rejected bridge note",
+			Body:                "This suggestion was already captured.",
+			SuggestedKind:       "coordination_note",
+			SuggestedTrustLabel: memory.TrustLabelGenerated,
+			SuggestedSourceKind: memory.SourceKindGenerated,
+			Status:              memory.CandidateStatusRejected,
+			StatusReason:        "Already captured",
 			CreatedAt:           now,
 			UpdatedAt:           now,
 		}},
@@ -346,12 +387,14 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 }
 
 func bridgeMemorySources() SnapshotSources {
+	memoryStore := memory.NewMemoryStore()
 	return SnapshotSources{
 		Projects:         projects.NewMemoryStore(),
 		AgentProfiles:    agentprofiles.NewMemoryStore(),
 		Skills:           projectskills.NewMemoryStore(),
 		Work:             projectwork.NewMemoryStore(),
-		MemoryCandidates: memory.NewMemoryStore(),
+		Memory:           memoryStore,
+		MemoryCandidates: memoryStore,
 	}
 }
 
@@ -393,6 +436,11 @@ func seedHecateSources(t *testing.T, ctx context.Context, sources SnapshotSource
 			t.Fatalf("Create handoff %q: %v", handoff.ID, err)
 		}
 	}
+	for _, entry := range snapshot.MemoryEntries {
+		if _, err := sources.Memory.Create(ctx, entry); err != nil {
+			t.Fatalf("Create memory entry %q: %v", entry.ID, err)
+		}
+	}
 	for _, candidate := range snapshot.MemoryCandidates {
 		if _, err := sources.MemoryCandidates.CreateCandidate(ctx, candidate); err != nil {
 			t.Fatalf("Create memory candidate %q: %v", candidate.ID, err)
@@ -416,4 +464,13 @@ func hasRole(roles []projectwork.AgentRoleProfile, id string) bool {
 		}
 	}
 	return false
+}
+
+func findCairnlineMemoryCandidate(candidates []cairnline.MemoryCandidate, id string) *cairnline.MemoryCandidate {
+	for idx := range candidates {
+		if candidates[idx].ID == id {
+			return &candidates[idx]
+		}
+	}
+	return nil
 }

--- a/internal/cairnlinebridge/snapshot.go
+++ b/internal/cairnlinebridge/snapshot.go
@@ -20,6 +20,7 @@ type SnapshotSources struct {
 	AgentProfiles    agentprofiles.Store
 	Skills           projectskills.Store
 	Work             projectwork.Store
+	Memory           memory.Store
 	MemoryCandidates memory.CandidateStore
 }
 
@@ -87,10 +88,19 @@ func LoadSnapshot(ctx context.Context, sources SnapshotSources, projectID string
 		return Snapshot{}, err
 	}
 	var memoryCandidates []memory.Candidate
+	var memoryEntries []memory.Entry
+	if sources.Memory != nil {
+		memoryEntries, err = sources.Memory.List(ctx, memory.Filter{
+			ProjectID:       projectID,
+			IncludeDisabled: true,
+		})
+		if err != nil {
+			return Snapshot{}, err
+		}
+	}
 	if sources.MemoryCandidates != nil {
 		memoryCandidates, err = sources.MemoryCandidates.ListCandidates(ctx, memory.CandidateFilter{
 			ProjectID: projectID,
-			Status:    memory.CandidateStatusPending,
 		})
 		if err != nil {
 			return Snapshot{}, err
@@ -105,6 +115,7 @@ func LoadSnapshot(ctx context.Context, sources SnapshotSources, projectID string
 		Assignments:      assignments,
 		Artifacts:        artifacts,
 		Handoffs:         handoffs,
+		MemoryEntries:    memoryEntries,
 		MemoryCandidates: memoryCandidates,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- update Hecate's Cairnline bridge to the memory/candidate lifecycle shape from the latest Cairnline core
- export accepted project memory entries and all memory candidate decision state into the refreshable Cairnline SQLite artifact
- document accepted-memory parity as part of the replacement-readiness gate

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge ./internal/api -run 'Test.*Cairnline'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/cairnlinebridge ./internal/api
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./...