### PR TITLE
feat: align Cairnline bridge handoff parity

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -94,8 +94,9 @@ Hecate project-shaped records:
 - project identity, roots, and context-source metadata;
 - agent profiles and execution posture;
 - skills metadata, roles, work items, and root-scoped assignments;
-- collaboration evidence links, reviews, handoffs, accepted memory entries, and
-  memory candidates with decision state.
+- collaboration evidence links, reviews, handoffs with source/target refs and
+  linked artifacts/memory/context, accepted memory entries, and memory
+  candidates with decision state.
 
 This bridge proves the portable Cairnline model can receive the core
 coordination graph and produce assignment launch packets with the expected

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260626191525-1d13e2a3d8a4
+	github.com/hecatehq/cairnline v0.0.0-20260626193850-f0d37bd990da
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/hecatehq/cairnline v0.0.0-20260626170038-16d4c3a275ec h1:+jMCl9e0xrU0
 github.com/hecatehq/cairnline v0.0.0-20260626170038-16d4c3a275ec/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/hecatehq/cairnline v0.0.0-20260626191525-1d13e2a3d8a4 h1:GxDgQVdY9DISIXjvtDGvMvx772x/oL59EnrHdoTbZXM=
 github.com/hecatehq/cairnline v0.0.0-20260626191525-1d13e2a3d8a4/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260626193850-f0d37bd990da h1:LPDvkPuxcDN9acRR7Vc03NVx6QEIbMJSTfptSMw8vhw=
+github.com/hecatehq/cairnline v0.0.0-20260626193850-f0d37bd990da/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -300,16 +300,28 @@ func Review(artifact projectwork.CollaborationArtifact) (cairnline.Review, bool)
 
 func Handoff(handoff projectwork.Handoff) cairnline.Handoff {
 	return cairnline.Handoff{
-		ID:         strings.TrimSpace(handoff.ID),
-		ProjectID:  strings.TrimSpace(handoff.ProjectID),
-		WorkItemID: strings.TrimSpace(handoff.WorkItemID),
-		FromRoleID: strings.TrimSpace(handoff.CreatedByRoleID),
-		ToRoleID:   strings.TrimSpace(handoff.TargetRoleID),
-		Title:      strings.TrimSpace(handoff.Title),
-		Body:       handoffBody(handoff),
-		Status:     cairnline.HandoffStatusOpen,
-		CreatedAt:  handoff.CreatedAt,
-		UpdatedAt:  handoff.UpdatedAt,
+		ID:                    strings.TrimSpace(handoff.ID),
+		ProjectID:             strings.TrimSpace(handoff.ProjectID),
+		WorkItemID:            strings.TrimSpace(handoff.WorkItemID),
+		SourceAssignmentID:    strings.TrimSpace(handoff.SourceAssignmentID),
+		SourceRunID:           strings.TrimSpace(handoff.SourceRunID),
+		SourceChatSessionID:   strings.TrimSpace(handoff.SourceChatSessionID),
+		SourceMessageID:       strings.TrimSpace(handoff.SourceMessageID),
+		FromRoleID:            strings.TrimSpace(handoff.CreatedByRoleID),
+		ToRoleID:              strings.TrimSpace(handoff.TargetRoleID),
+		TargetAssignmentID:    strings.TrimSpace(handoff.TargetAssignmentID),
+		TargetWorkItemID:      strings.TrimSpace(handoff.TargetWorkItemID),
+		Title:                 strings.TrimSpace(handoff.Title),
+		Body:                  firstNonEmpty(strings.TrimSpace(handoff.Summary), handoffBody(handoff)),
+		RecommendedNextAction: strings.TrimSpace(handoff.RecommendedNextAction),
+		LinkedArtifactIDs:     compactStrings(handoff.LinkedArtifactIDs),
+		LinkedMemoryIDs:       compactStrings(handoff.LinkedMemoryIDs),
+		ContextRefs:           compactStrings(handoff.ContextRefs),
+		Status:                HandoffStatus(handoff.Status),
+		ProvenanceKind:        strings.TrimSpace(handoff.ProvenanceKind),
+		TrustLabel:            strings.TrimSpace(handoff.TrustLabel),
+		CreatedAt:             handoff.CreatedAt,
+		UpdatedAt:             handoff.UpdatedAt,
 	}
 }
 
@@ -425,6 +437,19 @@ func MemoryCandidateStatus(status string) string {
 		return cairnline.MemoryCandidateRejected
 	default:
 		return cairnline.MemoryCandidatePending
+	}
+}
+
+func HandoffStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case projectwork.HandoffStatusAccepted:
+		return cairnline.HandoffStatusAccepted
+	case projectwork.HandoffStatusSuperseded:
+		return cairnline.HandoffStatusSuperseded
+	case projectwork.HandoffStatusDismissed:
+		return cairnline.HandoffStatusDismissed
+	default:
+		return cairnline.HandoffStatusOpen
 	}
 }
 

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -56,6 +56,12 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if len(packet.Handoffs) != 1 || packet.Handoffs[0].ID != "handoff_review" || packet.Handoffs[0].FromRoleID != "bridge_developer" || packet.Handoffs[0].ToRoleID != "bridge_reviewer" {
 		t.Fatalf("packet handoffs = %+v, want mapped handoff roles", packet.Handoffs)
 	}
+	if packet.Handoffs[0].SourceAssignmentID != "asgn_external" || packet.Handoffs[0].SourceRunID != "run_external" || packet.Handoffs[0].TargetAssignmentID != "asgn_bridge" || packet.Handoffs[0].TargetWorkItemID != "work_bridge" || packet.Handoffs[0].Status != cairnline.HandoffStatusOpen {
+		t.Fatalf("packet handoff refs = %+v, want structured source/target refs and open status", packet.Handoffs[0])
+	}
+	if packet.Handoffs[0].RecommendedNextAction == "" || len(packet.Handoffs[0].LinkedArtifactIDs) != 2 || len(packet.Handoffs[0].LinkedMemoryIDs) != 1 || len(packet.Handoffs[0].ContextRefs) != 1 || packet.Handoffs[0].ProvenanceKind != "agent_draft" || packet.Handoffs[0].TrustLabel != "operator_reviewed" {
+		t.Fatalf("packet handoff metadata = %+v, want linked artifacts/memory/context provenance", packet.Handoffs[0])
+	}
 	if len(packet.Memory) != 1 || packet.Memory[0].ID != "mem_bridge" || packet.Memory[0].TrustLabel != memory.TrustLabelOperatorMemory {
 		t.Fatalf("packet memory = %+v, want mapped accepted memory", packet.Memory)
 	}
@@ -153,6 +159,9 @@ func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	}
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("reopened launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
+	}
+	if packet.Handoffs[0].SourceAssignmentID != "asgn_external" || packet.Handoffs[0].TargetAssignmentID != "asgn_bridge" || len(packet.Handoffs[0].LinkedArtifactIDs) != 2 || packet.Handoffs[0].TrustLabel != "operator_reviewed" {
+		t.Fatalf("reopened handoff = %+v, want persisted structured refs and provenance", packet.Handoffs[0])
 	}
 }
 
@@ -328,7 +337,12 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			ProjectID:             "proj_hecate",
 			WorkItemID:            "work_bridge",
 			SourceAssignmentID:    "asgn_external",
+			SourceRunID:           "run_external",
+			SourceChatSessionID:   "chat_123",
+			SourceMessageID:       "msg_123",
 			TargetRoleID:          "bridge_reviewer",
+			TargetAssignmentID:    "asgn_bridge",
+			TargetWorkItemID:      "work_bridge",
 			Title:                 "Review bridge parity",
 			Summary:               "Artifact parity is ready for review.",
 			RecommendedNextAction: "Verify launch packets include evidence, reviews, handoffs, and memory candidates.",
@@ -336,6 +350,8 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			LinkedMemoryIDs:       []string{"memcand_bridge"},
 			ContextRefs:           []string{"ctx_123"},
 			Status:                projectwork.HandoffStatusPending,
+			ProvenanceKind:        "agent_draft",
+			TrustLabel:            "operator_reviewed",
 			CreatedByRoleID:       "bridge_developer",
 			CreatedAt:             now,
 			UpdatedAt:             now,


### PR DESCRIPTION
## Summary
- update the Hecate bridge to the Cairnline handoff metadata contract
- map Hecate handoff source/target refs, linked artifacts, linked memory, context refs, provenance, trust label, and status into Cairnline
- extend bridge tests to cover in-memory launch packets and reopened SQLite persistence
- update the Projects design note with the handoff parity now covered by the bridge

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/cairnlinebridge ./internal/api -run 'Test.*Cairnline'\n- GOCACHE="$PWD/.gocache" go vet ./internal/cairnlinebridge ./internal/api\n- git diff --check\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go vet ./...\n- GOCACHE="$PWD/.gocache" go build ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n- just agent-docs-check