### PR TITLE
feat: align Cairnline bridge closeout readiness

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -94,15 +94,16 @@ Hecate project-shaped records:
 - project identity, roots, and context-source metadata;
 - agent profiles and execution posture;
 - skills metadata, roles, work items, and root-scoped assignments;
-- collaboration evidence links, reviews, handoffs with source/target refs and
-  linked artifacts/memory/context, accepted memory entries, and memory
-  candidates with decision state.
+- assignment-scoped collaboration evidence links, reviews, handoffs with
+  source/target refs and linked artifacts/memory/context, accepted memory
+  entries, and memory candidates with decision state.
 
 This bridge proves the portable Cairnline model can receive the core
 coordination graph and produce assignment launch packets with the expected
-metadata. It deliberately does not switch storage, proxy live API requests,
-replace Hecate task/external-agent execution, migrate existing local data, or
-make Cairnline authoritative.
+metadata. It also exercises Cairnline's read-only closeout readiness against
+seeded Hecate work state. It deliberately does not switch storage, proxy live
+API requests, replace Hecate task/external-agent execution, migrate existing
+local data, or make Cairnline authoritative.
 
 For operator-triggered experiments, Hecate exposes a local-only
 `POST /hecate/v1/projects/{id}/cairnline/export` endpoint that writes a

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260626193850-f0d37bd990da
+	github.com/hecatehq/cairnline v0.0.0-20260626200254-97e8a1941b73
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/hecatehq/cairnline v0.0.0-20260626191525-1d13e2a3d8a4 h1:GxDgQVdY9DIS
 github.com/hecatehq/cairnline v0.0.0-20260626191525-1d13e2a3d8a4/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/hecatehq/cairnline v0.0.0-20260626193850-f0d37bd990da h1:LPDvkPuxcDN9acRR7Vc03NVx6QEIbMJSTfptSMw8vhw=
 github.com/hecatehq/cairnline v0.0.0-20260626193850-f0d37bd990da/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260626200254-97e8a1941b73 h1:wT6D6NBQRYJCN3BLAVVy7fw1o1KKHpTdRViahx1YUNA=
+github.com/hecatehq/cairnline v0.0.0-20260626200254-97e8a1941b73/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -266,15 +266,16 @@ func Evidence(artifact projectwork.CollaborationArtifact) (cairnline.Evidence, b
 		return cairnline.Evidence{}, false
 	}
 	return cairnline.Evidence{
-		ID:         strings.TrimSpace(artifact.ID),
-		ProjectID:  strings.TrimSpace(artifact.ProjectID),
-		WorkItemID: strings.TrimSpace(artifact.WorkItemID),
-		Title:      strings.TrimSpace(artifact.Title),
-		Body:       strings.TrimSpace(artifact.Body),
-		Locator:    firstNonEmpty(strings.TrimSpace(artifact.EvidenceURL), strings.TrimSpace(artifact.EvidenceExternalID)),
-		TrustLabel: firstNonEmpty(strings.TrimSpace(artifact.EvidenceTrustLabel), projectwork.EvidenceTrustOperatorProvided),
-		CreatedAt:  artifact.CreatedAt,
-		UpdatedAt:  artifact.UpdatedAt,
+		ID:           strings.TrimSpace(artifact.ID),
+		ProjectID:    strings.TrimSpace(artifact.ProjectID),
+		WorkItemID:   strings.TrimSpace(artifact.WorkItemID),
+		AssignmentID: strings.TrimSpace(artifact.AssignmentID),
+		Title:        strings.TrimSpace(artifact.Title),
+		Body:         strings.TrimSpace(artifact.Body),
+		Locator:      firstNonEmpty(strings.TrimSpace(artifact.EvidenceURL), strings.TrimSpace(artifact.EvidenceExternalID)),
+		TrustLabel:   firstNonEmpty(strings.TrimSpace(artifact.EvidenceTrustLabel), projectwork.EvidenceTrustOperatorProvided),
+		CreatedAt:    artifact.CreatedAt,
+		UpdatedAt:    artifact.UpdatedAt,
 	}, true
 }
 

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -47,8 +47,8 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if len(packet.Skills) != 1 || packet.Skills[0].ID != "backend" || len(packet.Skills[0].SourceRefs) != 1 {
 		t.Fatalf("packet skills = %+v, want mapped backend skill with provenance", packet.Skills)
 	}
-	if len(packet.Evidence) != 1 || packet.Evidence[0].ID != "art_evidence" || packet.Evidence[0].Locator != "https://github.com/hecatehq/hecate/actions/runs/123" {
-		t.Fatalf("packet evidence = %+v, want mapped evidence link", packet.Evidence)
+	if len(packet.Evidence) != 1 || packet.Evidence[0].ID != "art_evidence" || packet.Evidence[0].AssignmentID != "asgn_external" || packet.Evidence[0].Locator != "https://github.com/hecatehq/hecate/actions/runs/123" {
+		t.Fatalf("packet evidence = %+v, want mapped assignment-scoped evidence link", packet.Evidence)
 	}
 	if len(packet.Reviews) != 1 || packet.Reviews[0].ID != "art_review" || packet.Reviews[0].AssignmentID != "asgn_external" || packet.Reviews[0].Verdict != cairnline.ReviewVerdictConcerns || packet.Reviews[0].Risk != cairnline.ReviewRiskMedium {
 		t.Fatalf("packet reviews = %+v, want mapped review with reduced verdict", packet.Reviews)
@@ -67,6 +67,13 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	}
 	if len(packet.MemoryCandidates) != 1 || packet.MemoryCandidates[0].ID != "memcand_bridge" || packet.MemoryCandidates[0].SuggestedTrustLabel != memory.TrustLabelGenerated || packet.MemoryCandidates[0].SuggestedSourceID != "handoff_review" || len(packet.MemoryCandidates[0].SourceRefs) != 1 {
 		t.Fatalf("packet memory candidates = %+v, want mapped memory candidate provenance", packet.MemoryCandidates)
+	}
+	readiness, err := service.WorkItemCloseoutReadiness(ctx, "proj_hecate", "work_bridge")
+	if err != nil {
+		t.Fatalf("WorkItemCloseoutReadiness() error = %v", err)
+	}
+	if readiness.CompletedAssignments != 1 || len(readiness.MissingEvidenceAssignmentIDs) != 0 {
+		t.Fatalf("work readiness = %+v, want completed external assignment covered by mapped evidence", readiness)
 	}
 	candidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{ProjectID: "proj_hecate", IncludeResolved: true})
 	if err != nil {
@@ -160,8 +167,18 @@ func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("reopened launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
 	}
+	if packet.Evidence[0].AssignmentID != "asgn_external" {
+		t.Fatalf("reopened evidence = %+v, want persisted assignment-scoped evidence", packet.Evidence[0])
+	}
 	if packet.Handoffs[0].SourceAssignmentID != "asgn_external" || packet.Handoffs[0].TargetAssignmentID != "asgn_bridge" || len(packet.Handoffs[0].LinkedArtifactIDs) != 2 || packet.Handoffs[0].TrustLabel != "operator_reviewed" {
 		t.Fatalf("reopened handoff = %+v, want persisted structured refs and provenance", packet.Handoffs[0])
+	}
+	readiness, err := reopened.WorkItemCloseoutReadiness(ctx, snapshot.Project.ID, "work_bridge")
+	if err != nil {
+		t.Fatalf("reopened WorkItemCloseoutReadiness() error = %v", err)
+	}
+	if readiness.CompletedAssignments != 1 || len(readiness.MissingEvidenceAssignmentIDs) != 0 {
+		t.Fatalf("reopened readiness = %+v, want completed external assignment covered by persisted evidence", readiness)
 	}
 }
 


### PR DESCRIPTION
## Summary
- update the Hecate bridge to the Cairnline closeout-readiness contract
- preserve assignment-scoped evidence when seeding Cairnline
- assert Cairnline closeout readiness sees completed Hecate assignments as covered by mapped evidence
- update the Projects design note with closeout-readiness bridge coverage

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/cairnlinebridge ./internal/api -run 'Test.*Cairnline'\n- GOCACHE="$PWD/.gocache" go test ./internal/cairnlinebridge ./internal/api\n- GOCACHE="$PWD/.gocache" go vet ./internal/cairnlinebridge ./internal/api\n- just agent-docs-check\n- git diff --check\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go vet ./...\n- GOCACHE="$PWD/.gocache" go build ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...