### PR TITLE
feat: align Cairnline bridge operations brief

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -100,10 +100,10 @@ Hecate project-shaped records:
 
 This bridge proves the portable Cairnline model can receive the core
 coordination graph and produce assignment launch packets with the expected
-metadata. It also exercises Cairnline's read-only closeout readiness against
-seeded Hecate work state. It deliberately does not switch storage, proxy live
-API requests, replace Hecate task/external-agent execution, migrate existing
-local data, or make Cairnline authoritative.
+metadata. It also exercises Cairnline's read-only closeout readiness and
+project operations brief against seeded Hecate work state. It deliberately does
+not switch storage, proxy live API requests, replace Hecate task/external-agent
+execution, migrate existing local data, or make Cairnline authoritative.
 
 For operator-triggered experiments, Hecate exposes a local-only
 `POST /hecate/v1/projects/{id}/cairnline/export` endpoint that writes a

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260626200254-97e8a1941b73
+	github.com/hecatehq/cairnline v0.0.0-20260626202944-3bc029427433
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/hecatehq/cairnline v0.0.0-20260626193850-f0d37bd990da h1:LPDvkPuxcDN9
 github.com/hecatehq/cairnline v0.0.0-20260626193850-f0d37bd990da/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/hecatehq/cairnline v0.0.0-20260626200254-97e8a1941b73 h1:wT6D6NBQRYJCN3BLAVVy7fw1o1KKHpTdRViahx1YUNA=
 github.com/hecatehq/cairnline v0.0.0-20260626200254-97e8a1941b73/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260626202944-3bc029427433 h1:gcQHv57K2vA5MhIYquW510jRVXXPQhfPkm2nJcKhCbo=
+github.com/hecatehq/cairnline v0.0.0-20260626202944-3bc029427433/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -164,6 +164,13 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("packet counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
 	}
+	brief, err := service.ProjectOperationsBrief(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("ProjectOperationsBrief from exported DB: %v", err)
+	}
+	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Counts.Assignments != 1 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
+		t.Fatalf("operations brief = %+v, want exported active assignment, pending memory, and handoff attention", brief)
+	}
 }
 
 func TestProjectCairnlineExportAPI_MissingProjectDoesNotCreateExportDir(t *testing.T) {

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -75,6 +75,21 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if readiness.CompletedAssignments != 1 || len(readiness.MissingEvidenceAssignmentIDs) != 0 {
 		t.Fatalf("work readiness = %+v, want completed external assignment covered by mapped evidence", readiness)
 	}
+	brief, err := service.ProjectOperationsBrief(ctx, "proj_hecate")
+	if err != nil {
+		t.Fatalf("ProjectOperationsBrief() error = %v", err)
+	}
+	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Next.Kind != cairnline.ProjectOperationKindReviewFollowUp {
+		t.Fatalf("operations brief = %+v, want review follow-up next", brief)
+	}
+	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.ReviewFollowUps != 1 || brief.Counts.OpenHandoffs != 1 || brief.Counts.MissingEvidence != 0 {
+		t.Fatalf("operations counts = %+v, want active assignment, memory candidate, review follow-up, and open handoff", brief.Counts)
+	}
+	if !hasCairnlineOperation(brief.Items, cairnline.ProjectOperationKindAssignment, "work_bridge", "asgn_bridge") ||
+		!hasCairnlineOperation(brief.Items, cairnline.ProjectOperationKindHandoff, "work_bridge", "handoff_review") ||
+		!hasCairnlineOperation(brief.Items, cairnline.ProjectOperationKindReviewFollowUp, "work_bridge", "art_review") {
+		t.Fatalf("operations items = %+v, want assignment, handoff, and review follow-up items", brief.Items)
+	}
 	candidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{ProjectID: "proj_hecate", IncludeResolved: true})
 	if err != nil {
 		t.Fatalf("ListMemoryCandidates(include resolved) error = %v", err)
@@ -133,6 +148,28 @@ func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	}
 }
 
+func TestProjectOperationsBriefFromStores(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	sources := bridgeMemorySources()
+	snapshot := bridgeSnapshotFixture(now)
+	seedHecateSources(t, ctx, sources, snapshot)
+
+	brief, loaded, err := ProjectOperationsBriefFromStores(ctx, sources, snapshot.Project.ID)
+	if err != nil {
+		t.Fatalf("ProjectOperationsBriefFromStores() error = %v", err)
+	}
+	if loaded.Project.ID != snapshot.Project.ID || len(loaded.Assignments) != len(snapshot.Assignments) {
+		t.Fatalf("loaded snapshot = %+v, want project and assignment state", loaded)
+	}
+	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Next.Kind != cairnline.ProjectOperationKindReviewFollowUp {
+		t.Fatalf("operations brief = %+v, want review follow-up attention from seeded Hecate stores", brief)
+	}
+	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
+		t.Fatalf("operations counts = %+v, want assignment, memory, and handoff parity", brief.Counts)
+	}
+}
+
 func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
@@ -179,6 +216,13 @@ func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	}
 	if readiness.CompletedAssignments != 1 || len(readiness.MissingEvidenceAssignmentIDs) != 0 {
 		t.Fatalf("reopened readiness = %+v, want completed external assignment covered by persisted evidence", readiness)
+	}
+	brief, err := reopened.ProjectOperationsBrief(ctx, snapshot.Project.ID)
+	if err != nil {
+		t.Fatalf("reopened ProjectOperationsBrief() error = %v", err)
+	}
+	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
+		t.Fatalf("reopened operations counts = %+v, want persisted operations parity", brief.Counts)
 	}
 }
 
@@ -506,4 +550,16 @@ func findCairnlineMemoryCandidate(candidates []cairnline.MemoryCandidate, id str
 		}
 	}
 	return nil
+}
+
+func hasCairnlineOperation(items []cairnline.ProjectOperationItem, kind, workItemID, refID string) bool {
+	for _, item := range items {
+		if item.Kind != kind || item.WorkItemID != workItemID {
+			continue
+		}
+		if item.AssignmentID == refID || item.ArtifactID == refID || item.MemoryCandidateID == refID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cairnlinebridge/snapshot.go
+++ b/internal/cairnlinebridge/snapshot.go
@@ -38,6 +38,19 @@ func SeedProjectFromStores(ctx context.Context, service *cairnline.Service, sour
 	return snapshot, nil
 }
 
+func ProjectOperationsBriefFromStores(ctx context.Context, sources SnapshotSources, projectID string) (cairnline.ProjectOperationsBrief, Snapshot, error) {
+	service := cairnline.NewMemoryService()
+	snapshot, err := SeedProjectFromStores(ctx, service, sources, projectID)
+	if err != nil {
+		return cairnline.ProjectOperationsBrief{}, Snapshot{}, err
+	}
+	brief, err := service.ProjectOperationsBrief(ctx, snapshot.Project.ID)
+	if err != nil {
+		return cairnline.ProjectOperationsBrief{}, Snapshot{}, err
+	}
+	return brief, snapshot, nil
+}
+
 func LoadSnapshot(ctx context.Context, sources SnapshotSources, projectID string) (Snapshot, error) {
 	projectID = strings.TrimSpace(projectID)
 	if sources.Projects == nil {


### PR DESCRIPTION
## Summary
- update Hecate to the Cairnline commit that exposes project operations briefs
- add a bridge helper that seeds Cairnline from Hecate stores and returns the portable operations brief
- assert operations brief parity for in-memory bridge state and exported Cairnline SQLite DBs
- update Projects design docs to include operations brief coverage in the bridge proof

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnlineExportAPI'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/cairnlinebridge ./internal/api
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go build ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...