### PR TITLE
feat: align Cairnline bridge activity brief

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -100,10 +100,11 @@ Hecate project-shaped records:
 
 This bridge proves the portable Cairnline model can receive the core
 coordination graph and produce assignment launch packets with the expected
-metadata. It also exercises Cairnline's read-only closeout readiness and
-project operations brief against seeded Hecate work state. It deliberately does
-not switch storage, proxy live API requests, replace Hecate task/external-agent
-execution, migrate existing local data, or make Cairnline authoritative.
+metadata. It also exercises Cairnline's read-only closeout readiness, project
+operations brief, and project activity projection against seeded Hecate work
+state. It deliberately does not switch storage, proxy live API requests, replace
+Hecate task/external-agent execution, migrate existing local data, or make
+Cairnline authoritative.
 
 For operator-triggered experiments, Hecate exposes a local-only
 `POST /hecate/v1/projects/{id}/cairnline/export` endpoint that writes a

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260626202944-3bc029427433
+	github.com/hecatehq/cairnline v0.0.0-20260626204537-3951231973c8
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/hecatehq/cairnline v0.0.0-20260626200254-97e8a1941b73 h1:wT6D6NBQRYJC
 github.com/hecatehq/cairnline v0.0.0-20260626200254-97e8a1941b73/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/hecatehq/cairnline v0.0.0-20260626202944-3bc029427433 h1:gcQHv57K2vA5MhIYquW510jRVXXPQhfPkm2nJcKhCbo=
 github.com/hecatehq/cairnline v0.0.0-20260626202944-3bc029427433/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260626204537-3951231973c8 h1:nDw2o3nK3YEc0E6TV2Th4imU6j5i2rARTW5WDqudkiw=
+github.com/hecatehq/cairnline v0.0.0-20260626204537-3951231973c8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -171,6 +171,13 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Counts.Assignments != 1 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
 		t.Fatalf("operations brief = %+v, want exported active assignment, pending memory, and handoff attention", brief)
 	}
+	activity, err := service.ProjectActivity(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("ProjectActivity from exported DB: %v", err)
+	}
+	if activity.Counts.Assignments != 1 || activity.Counts.Active != 1 || activity.Counts.Queued != 1 || len(activity.Buckets.Active) != 1 || activity.Buckets.Active[0].AssignmentID != assignment.Data.ID {
+		t.Fatalf("activity = %+v, want exported queued assignment activity", activity)
+	}
 }
 
 func TestProjectCairnlineExportAPI_MissingProjectDoesNotCreateExportDir(t *testing.T) {

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -90,6 +90,17 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 		!hasCairnlineOperation(brief.Items, cairnline.ProjectOperationKindReviewFollowUp, "work_bridge", "art_review") {
 		t.Fatalf("operations items = %+v, want assignment, handoff, and review follow-up items", brief.Items)
 	}
+	activity, err := service.ProjectActivity(ctx, "proj_hecate")
+	if err != nil {
+		t.Fatalf("ProjectActivity() error = %v", err)
+	}
+	if activity.Counts.Assignments != 2 || activity.Counts.Active != 1 || activity.Counts.Completed != 1 || len(activity.Buckets.Active) != 1 || len(activity.Buckets.Completed) != 1 {
+		t.Fatalf("activity = %+v, want active and completed assignment buckets", activity)
+	}
+	if !hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketActive, "work_bridge", "asgn_bridge") ||
+		!hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketCompleted, "work_bridge", "asgn_external") {
+		t.Fatalf("activity items = %+v, want active Hecate task and completed external assignment", activity.Items)
+	}
 	candidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{ProjectID: "proj_hecate", IncludeResolved: true})
 	if err != nil {
 		t.Fatalf("ListMemoryCandidates(include resolved) error = %v", err)
@@ -145,6 +156,29 @@ func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	}
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("loaded launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
+	}
+}
+
+func TestProjectActivityFromStores(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	sources := bridgeMemorySources()
+	snapshot := bridgeSnapshotFixture(now)
+	seedHecateSources(t, ctx, sources, snapshot)
+
+	activity, loaded, err := ProjectActivityFromStores(ctx, sources, snapshot.Project.ID)
+	if err != nil {
+		t.Fatalf("ProjectActivityFromStores() error = %v", err)
+	}
+	if loaded.Project.ID != snapshot.Project.ID || len(loaded.Assignments) != len(snapshot.Assignments) {
+		t.Fatalf("loaded snapshot = %+v, want project and assignment state", loaded)
+	}
+	if activity.Counts.Assignments != 2 || activity.Counts.Active != 1 || activity.Counts.Completed != 1 {
+		t.Fatalf("activity counts = %+v, want seeded active/completed assignments", activity.Counts)
+	}
+	if !hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketActive, "work_bridge", "asgn_bridge") ||
+		!hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketCompleted, "work_bridge", "asgn_external") {
+		t.Fatalf("activity items = %+v, want active and completed assignment metadata", activity.Items)
 	}
 }
 
@@ -223,6 +257,13 @@ func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	}
 	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
 		t.Fatalf("reopened operations counts = %+v, want persisted operations parity", brief.Counts)
+	}
+	activity, err := reopened.ProjectActivity(ctx, snapshot.Project.ID)
+	if err != nil {
+		t.Fatalf("reopened ProjectActivity() error = %v", err)
+	}
+	if activity.Counts.Assignments != 2 || activity.Counts.Active != 1 || activity.Counts.Completed != 1 || len(activity.Buckets.Recent) != 2 {
+		t.Fatalf("reopened activity = %+v, want persisted activity parity", activity)
 	}
 }
 
@@ -558,6 +599,15 @@ func hasCairnlineOperation(items []cairnline.ProjectOperationItem, kind, workIte
 			continue
 		}
 		if item.AssignmentID == refID || item.ArtifactID == refID || item.MemoryCandidateID == refID {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCairnlineActivity(items []cairnline.ProjectActivityItem, bucket, workItemID, assignmentID string) bool {
+	for _, item := range items {
+		if item.Bucket == bucket && item.WorkItemID == workItemID && item.AssignmentID == assignmentID && item.WorkItemTitle != "" && item.RoleName != "" {
 			return true
 		}
 	}

--- a/internal/cairnlinebridge/snapshot.go
+++ b/internal/cairnlinebridge/snapshot.go
@@ -51,6 +51,19 @@ func ProjectOperationsBriefFromStores(ctx context.Context, sources SnapshotSourc
 	return brief, snapshot, nil
 }
 
+func ProjectActivityFromStores(ctx context.Context, sources SnapshotSources, projectID string) (cairnline.ProjectActivity, Snapshot, error) {
+	service := cairnline.NewMemoryService()
+	snapshot, err := SeedProjectFromStores(ctx, service, sources, projectID)
+	if err != nil {
+		return cairnline.ProjectActivity{}, Snapshot{}, err
+	}
+	activity, err := service.ProjectActivity(ctx, snapshot.Project.ID)
+	if err != nil {
+		return cairnline.ProjectActivity{}, Snapshot{}, err
+	}
+	return activity, snapshot, nil
+}
+
 func LoadSnapshot(ctx context.Context, sources SnapshotSources, projectID string) (Snapshot, error) {
 	projectID = strings.TrimSpace(projectID)
 	if sources.Projects == nil {


### PR DESCRIPTION
## Summary
- update Hecate to the Cairnline commit that exposes project activity projections
- add a bridge helper that seeds Cairnline from Hecate stores and returns ProjectActivity
- assert activity parity for in-memory bridge state and exported Cairnline SQLite DBs
- update Projects design docs to include activity projection coverage in the bridge proof

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnlineExportAPI'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/cairnlinebridge ./internal/api
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go build ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...