### PR TITLE
feat: add Cairnline read model adapter

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -106,11 +106,14 @@ state. It deliberately does not switch storage, proxy live API requests, replace
 Hecate task/external-agent execution, migrate existing local data, or make
 Cairnline authoritative.
 
-For operator-triggered experiments, Hecate exposes a local-only
-`POST /hecate/v1/projects/{id}/cairnline/export` endpoint that writes a
-refreshable Cairnline SQLite export under Hecate's data directory. The export
-uses the same bridge and is useful for inspecting replacement parity, but it is
-still an artifact, not the live Projects backend.
+For operator-triggered experiments, Hecate exposes local-only Cairnline bridge
+endpoints. `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an
+in-memory Cairnline service from the current Hecate stores and returns the
+portable operations brief and activity projection without writing files.
+`POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
+SQLite export under Hecate's data directory. Both use the same bridge and are
+useful for inspecting replacement parity, but they are still proofs, not the
+live Projects backend.
 
 Hecate is ready to replace its internal Projects backend with Cairnline only
 after these gates are met:

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2183,6 +2183,74 @@ The response reports the scoped records Hecate cleaned up:
 }
 ```
 
+### `GET /hecate/v1/projects/{id}/cairnline/read-model`
+
+Local-only experimental bridge endpoint. It loads the selected project from
+Hecate's authoritative Projects stores, seeds an in-memory Cairnline service,
+and returns Cairnline's portable read projections for the project without
+writing an export database.
+
+The response is useful for replacement-readiness checks: it shows whether
+Cairnline can reconstruct the portable operations brief and activity inbox from
+current Hecate state. It does not make Cairnline authoritative, does not proxy
+live Projects reads or writes, and does not migrate Hecate's stores.
+
+Example response:
+
+```json
+{
+  "object": "project_cairnline_read_model",
+  "data": {
+    "project_id": "proj_...",
+    "agent_profile_count": 4,
+    "skill_count": 3,
+    "role_count": 6,
+    "work_item_count": 2,
+    "assignment_count": 5,
+    "artifact_count": 4,
+    "handoff_count": 1,
+    "memory_entry_count": 3,
+    "memory_candidate_count": 2,
+    "operations": {
+      "project_id": "proj_...",
+      "status": "attention",
+      "title": "Project needs attention",
+      "counts": {
+        "work_items": 2,
+        "open_work_items": 1,
+        "assignments": 5,
+        "active_assignments": 1,
+        "blocked_assignments": 0,
+        "pending_memory_candidates": 2,
+        "review_follow_ups": 0,
+        "missing_evidence": 1,
+        "open_handoffs": 1,
+        "closeout_ready": 0
+      }
+    },
+    "activity": {
+      "project_id": "proj_...",
+      "counts": {
+        "assignments": 5,
+        "queued": 1,
+        "completed": 3,
+        "active": 1
+      },
+      "buckets": {
+        "active": [
+          {
+            "bucket": "active",
+            "assignment_id": "asgn_...",
+            "work_item_id": "work_...",
+            "status": "queued"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
 ### `POST /hecate/v1/projects/{id}/cairnline/export`
 
 Local-only experimental bridge endpoint. It loads the selected project from

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -67,6 +67,51 @@ func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.
 	})
 }
 
+func (h *Handler) HandleProjectCairnlineReadModel(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("id"))
+	snapshot, err := cairnlinebridge.LoadSnapshot(r.Context(), h.cairnlineSnapshotSources(), projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	service := cairnline.NewMemoryService()
+	if err := cairnlinebridge.Seed(r.Context(), service, snapshot); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	operations, err := service.ProjectOperationsBrief(r.Context(), snapshot.Project.ID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	activity, err := service.ProjectActivity(r.Context(), snapshot.Project.ID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineReadModelResponse{
+		Object: "project_cairnline_read_model",
+		Data: ProjectCairnlineReadModelResponseItem{
+			ProjectID:            snapshot.Project.ID,
+			AgentProfileCount:    len(snapshot.AgentProfiles),
+			SkillCount:           len(snapshot.Skills),
+			RoleCount:            len(snapshot.Roles),
+			WorkItemCount:        len(snapshot.WorkItems),
+			AssignmentCount:      len(snapshot.Assignments),
+			ArtifactCount:        len(snapshot.Artifacts),
+			HandoffCount:         len(snapshot.Handoffs),
+			MemoryEntryCount:     len(snapshot.MemoryEntries),
+			MemoryCandidateCount: len(snapshot.MemoryCandidates),
+			Operations:           operations,
+			Activity:             activity,
+		},
+	})
+}
+
 func (h *Handler) cairnlineSnapshotSources() cairnlinebridge.SnapshotSources {
 	return cairnlinebridge.SnapshotSources{
 		Projects:         h.projects,

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -134,6 +134,23 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 		"suggested_source_id":   handoff.Data.ID,
 	}))
 
+	readModel := mustRequestJSON[ProjectCairnlineReadModelResponse](client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/cairnline/read-model", "")
+	if readModel.Object != "project_cairnline_read_model" || readModel.Data.ProjectID != projectID {
+		t.Fatalf("read model envelope = %+v, want project_cairnline_read_model for project", readModel)
+	}
+	if readModel.Data.WorkItemCount != 1 || readModel.Data.AssignmentCount != 1 || readModel.Data.ArtifactCount != 2 || readModel.Data.HandoffCount != 1 || readModel.Data.MemoryEntryCount != 1 || readModel.Data.MemoryCandidateCount != 1 {
+		t.Fatalf("read model counts = %+v, want bridged project counts", readModel.Data)
+	}
+	if readModel.Data.Operations.Status != cairnline.ProjectOperationsStatusAttention || readModel.Data.Operations.Counts.ActiveAssignments != 1 || readModel.Data.Operations.Counts.PendingMemoryCandidates != 1 || readModel.Data.Operations.Counts.OpenHandoffs != 1 {
+		t.Fatalf("read model operations = %+v, want active assignment, pending memory, and handoff attention", readModel.Data.Operations)
+	}
+	if readModel.Data.Activity.Counts.Assignments != 1 || readModel.Data.Activity.Counts.Active != 1 || readModel.Data.Activity.Counts.Queued != 1 || len(readModel.Data.Activity.Buckets.Active) != 1 || readModel.Data.Activity.Buckets.Active[0].AssignmentID != assignment.Data.ID {
+		t.Fatalf("read model activity = %+v, want queued assignment activity", readModel.Data.Activity)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
+		t.Fatalf("read-model export dir stat error = %v, want not exist before export", err)
+	}
+
 	first := mustRequestJSON[ProjectCairnlineExportResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/cairnline/export", "")
 	second := mustRequestJSON[ProjectCairnlineExportResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/cairnline/export", "")
 	if first.Data.DatabasePath != second.Data.DatabasePath {
@@ -191,6 +208,7 @@ func TestProjectCairnlineExportAPI_MissingProjectDoesNotCreateExportDir(t *testi
 	server := NewServer(quietLogger(), handler)
 	client := newAPITestClient(t, server)
 
+	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/proj_missing/cairnline/read-model", "")
 	client.mustRequestStatus(http.StatusNotFound, http.MethodPost, "/hecate/v1/projects/proj_missing/cairnline/export", "")
 	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
 		t.Fatalf("export dir stat error = %v, want not exist", err)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -307,6 +308,26 @@ type ProjectCairnlineExportResponseItem struct {
 	HandoffCount         int    `json:"handoff_count"`
 	MemoryEntryCount     int    `json:"memory_entry_count"`
 	MemoryCandidateCount int    `json:"memory_candidate_count"`
+}
+
+type ProjectCairnlineReadModelResponse struct {
+	Object string                                `json:"object"`
+	Data   ProjectCairnlineReadModelResponseItem `json:"data"`
+}
+
+type ProjectCairnlineReadModelResponseItem struct {
+	ProjectID            string                           `json:"project_id"`
+	AgentProfileCount    int                              `json:"agent_profile_count"`
+	SkillCount           int                              `json:"skill_count"`
+	RoleCount            int                              `json:"role_count"`
+	WorkItemCount        int                              `json:"work_item_count"`
+	AssignmentCount      int                              `json:"assignment_count"`
+	ArtifactCount        int                              `json:"artifact_count"`
+	HandoffCount         int                              `json:"handoff_count"`
+	MemoryEntryCount     int                              `json:"memory_entry_count"`
+	MemoryCandidateCount int                              `json:"memory_candidate_count"`
+	Operations           cairnline.ProjectOperationsBrief `json:"operations"`
+	Activity             cairnline.ProjectActivity        `json:"activity"`
 }
 
 type AgentProfileResponse struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -21,6 +21,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodDelete, path: "/hecate/v1/terminals/{terminal_id}"},
 	{method: http.MethodPost, path: "/hecate/v1/system/reset-data"},
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/cairnline/export"},
 	{method: http.MethodPost, path: "/hecate/v1/mcp/probe"},
 	{method: http.MethodGet, path: "/hecate/v1/mcp/registry/servers"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -81,6 +81,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/cairnline/export", handler.HandleExportProjectToCairnline)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots", handler.HandleCreateProjectRoot)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots/discover", handler.HandleDiscoverProjectRoots)


### PR DESCRIPTION
## Summary
- add a local-only Cairnline read-model endpoint for Hecate Projects
- seed an in-memory Cairnline service from live Hecate stores and return operations/activity projections
- document the endpoint as a replacement-readiness probe, not an authoritative backend switch

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnlineExportAPI|TestRemoteRuntimeEndpointPolicyCoversRegisteredHecateRoutes'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api ./internal/cairnlinebridge
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go build ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...