### PR TITLE
feat: add Cairnline parity report

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -110,6 +110,9 @@ For operator-triggered experiments, Hecate exposes local-only Cairnline bridge
 endpoints. `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an
 in-memory Cairnline service from the current Hecate stores and returns the
 portable operations brief and activity projection without writing files.
+`GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
+native cockpit counts with that Cairnline read model and returns explicit
+differences, so bucket/status semantics can be fixed before any backend switch.
 `POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
 SQLite export under Hecate's data directory. Both use the same bridge and are
 useful for inspecting replacement parity, but they are still proofs, not the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2251,6 +2251,70 @@ Example response:
 }
 ```
 
+### `GET /hecate/v1/projects/{id}/cairnline/parity-report`
+
+Local-only experimental bridge endpoint. It loads the same in-memory Cairnline
+read model as `/cairnline/read-model`, renders Hecate's native project activity
+and operations brief, then compares the shared counts.
+
+This endpoint is a replacement-readiness report, not a backend switch. A
+non-matching report does not mean either model is wrong; it means the current
+Cairnline portable model and Hecate cockpit model still differ on at least one
+count or semantic bucket that should be reviewed before Cairnline becomes
+authoritative.
+
+Example response:
+
+```json
+{
+  "object": "project_cairnline_parity_report",
+  "data": {
+    "project_id": "proj_...",
+    "match": false,
+    "differences": [
+      {
+        "path": "activity.active",
+        "hecate": 0,
+        "cairnline": 1
+      },
+      {
+        "path": "activity.blocked",
+        "hecate": 1,
+        "cairnline": 0
+      }
+    ],
+    "hecate": {
+      "activity": {
+        "work_items": 1,
+        "assignments": 1,
+        "active": 0,
+        "blocked": 1,
+        "completed": 0,
+        "recent": 1
+      },
+      "operations": {
+        "pending_memory_candidates": 1,
+        "open_handoffs": 1
+      }
+    },
+    "cairnline": {
+      "activity": {
+        "work_items": 1,
+        "assignments": 1,
+        "active": 1,
+        "blocked": 0,
+        "completed": 0,
+        "recent": 1
+      },
+      "operations": {
+        "pending_memory_candidates": 1,
+        "open_handoffs": 1
+      }
+    }
+  }
+}
+```
+
 ### `POST /hecate/v1/projects/{id}/cairnline/export`
 
 Local-only experimental bridge endpoint. It loads the selected project from

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"os"
@@ -69,7 +70,7 @@ func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.
 
 func (h *Handler) HandleProjectCairnlineReadModel(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("id"))
-	snapshot, err := cairnlinebridge.LoadSnapshot(r.Context(), h.cairnlineSnapshotSources(), projectID)
+	readModel, err := h.projectCairnlineReadModel(r.Context(), projectID)
 	if errors.Is(err, projects.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
@@ -78,37 +79,136 @@ func (h *Handler) HandleProjectCairnlineReadModel(w http.ResponseWriter, r *http
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	service := cairnline.NewMemoryService()
-	if err := cairnlinebridge.Seed(r.Context(), service, snapshot); err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	operations, err := service.ProjectOperationsBrief(r.Context(), snapshot.Project.ID)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	activity, err := service.ProjectActivity(r.Context(), snapshot.Project.ID)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
 	WriteJSON(w, http.StatusOK, ProjectCairnlineReadModelResponse{
 		Object: "project_cairnline_read_model",
-		Data: ProjectCairnlineReadModelResponseItem{
-			ProjectID:            snapshot.Project.ID,
-			AgentProfileCount:    len(snapshot.AgentProfiles),
-			SkillCount:           len(snapshot.Skills),
-			RoleCount:            len(snapshot.Roles),
-			WorkItemCount:        len(snapshot.WorkItems),
-			AssignmentCount:      len(snapshot.Assignments),
-			ArtifactCount:        len(snapshot.Artifacts),
-			HandoffCount:         len(snapshot.Handoffs),
-			MemoryEntryCount:     len(snapshot.MemoryEntries),
-			MemoryCandidateCount: len(snapshot.MemoryCandidates),
-			Operations:           operations,
-			Activity:             activity,
+		Data:   readModel,
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("id"))
+	readModel, err := h.projectCairnlineReadModel(r.Context(), projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	nativeActivity, err := h.renderProjectActivity(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	nativeOperations, err := h.renderProjectOperationsBrief(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	report := projectCairnlineParityReport(projectID, nativeActivity, nativeOperations, readModel)
+	WriteJSON(w, http.StatusOK, ProjectCairnlineParityReportResponse{
+		Object: "project_cairnline_parity_report",
+		Data:   report,
+	})
+}
+
+func (h *Handler) projectCairnlineReadModel(ctx context.Context, projectID string) (ProjectCairnlineReadModelResponseItem, error) {
+	snapshot, err := cairnlinebridge.LoadSnapshot(ctx, h.cairnlineSnapshotSources(), projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	if err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	service := cairnline.NewMemoryService()
+	if err := cairnlinebridge.Seed(ctx, service, snapshot); err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	operations, err := service.ProjectOperationsBrief(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	activity, err := service.ProjectActivity(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	return ProjectCairnlineReadModelResponseItem{
+		ProjectID:            snapshot.Project.ID,
+		AgentProfileCount:    len(snapshot.AgentProfiles),
+		SkillCount:           len(snapshot.Skills),
+		RoleCount:            len(snapshot.Roles),
+		WorkItemCount:        len(snapshot.WorkItems),
+		AssignmentCount:      len(snapshot.Assignments),
+		ArtifactCount:        len(snapshot.Artifacts),
+		HandoffCount:         len(snapshot.Handoffs),
+		MemoryEntryCount:     len(snapshot.MemoryEntries),
+		MemoryCandidateCount: len(snapshot.MemoryCandidates),
+		Operations:           operations,
+		Activity:             activity,
+	}, nil
+}
+
+func projectCairnlineParityReport(projectID string, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
+	hecate := ProjectCairnlineParitySnapshot{
+		Activity: ProjectCairnlineActivityParityCounts{
+			WorkItems:   nativeActivity.Summary.WorkItemCount,
+			Assignments: nativeActivity.Summary.AssignmentCount,
+			Active:      nativeActivity.Summary.ActiveCount,
+			Blocked:     nativeActivity.Summary.BlockedCount,
+			Completed:   nativeActivity.Summary.CompletedCount,
+			Recent:      nativeActivity.Summary.RecentCount,
 		},
+		Operations: ProjectCairnlineOperationsParityCounts{
+			PendingMemoryCandidates: nativeOperations.Summary.PendingMemoryCandidateCount,
+			OpenHandoffs:            nativeOperations.Summary.PendingHandoffCount,
+		},
+	}
+	cairnline := ProjectCairnlineParitySnapshot{
+		Activity: ProjectCairnlineActivityParityCounts{
+			WorkItems:   readModel.WorkItemCount,
+			Assignments: readModel.Activity.Counts.Assignments,
+			Active:      readModel.Activity.Counts.Active,
+			Blocked:     readModel.Activity.Counts.Blocked,
+			Completed:   readModel.Activity.Counts.Completed,
+			Recent:      len(readModel.Activity.Buckets.Recent),
+		},
+		Operations: ProjectCairnlineOperationsParityCounts{
+			PendingMemoryCandidates: readModel.Operations.Counts.PendingMemoryCandidates,
+			OpenHandoffs:            readModel.Operations.Counts.OpenHandoffs,
+		},
+	}
+	differences := projectCairnlineParityDifferences(hecate, cairnline)
+	return ProjectCairnlineParityReportResponseItem{
+		ProjectID:   projectID,
+		Match:       len(differences) == 0,
+		Differences: differences,
+		Hecate:      hecate,
+		Cairnline:   cairnline,
+	}
+}
+
+func projectCairnlineParityDifferences(hecate, cairnline ProjectCairnlineParitySnapshot) []ProjectCairnlineParityDifference {
+	var differences []ProjectCairnlineParityDifference
+	differences = appendProjectCairnlineParityDifference(differences, "activity.work_items", hecate.Activity.WorkItems, cairnline.Activity.WorkItems)
+	differences = appendProjectCairnlineParityDifference(differences, "activity.assignments", hecate.Activity.Assignments, cairnline.Activity.Assignments)
+	differences = appendProjectCairnlineParityDifference(differences, "activity.active", hecate.Activity.Active, cairnline.Activity.Active)
+	differences = appendProjectCairnlineParityDifference(differences, "activity.blocked", hecate.Activity.Blocked, cairnline.Activity.Blocked)
+	differences = appendProjectCairnlineParityDifference(differences, "activity.completed", hecate.Activity.Completed, cairnline.Activity.Completed)
+	differences = appendProjectCairnlineParityDifference(differences, "activity.recent", hecate.Activity.Recent, cairnline.Activity.Recent)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.pending_memory_candidates", hecate.Operations.PendingMemoryCandidates, cairnline.Operations.PendingMemoryCandidates)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.open_handoffs", hecate.Operations.OpenHandoffs, cairnline.Operations.OpenHandoffs)
+	return differences
+}
+
+func appendProjectCairnlineParityDifference(differences []ProjectCairnlineParityDifference, path string, hecate, cairnline int) []ProjectCairnlineParityDifference {
+	if hecate == cairnline {
+		return differences
+	}
+	return append(differences, ProjectCairnlineParityDifference{
+		Path:      path,
+		Hecate:    hecate,
+		Cairnline: cairnline,
 	})
 }
 

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -150,6 +150,26 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
 		t.Fatalf("read-model export dir stat error = %v, want not exist before export", err)
 	}
+	parity := mustRequestJSON[ProjectCairnlineParityReportResponse](client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/cairnline/parity-report", "")
+	if parity.Object != "project_cairnline_parity_report" || parity.Data.ProjectID != projectID {
+		t.Fatalf("parity envelope = %+v, want project_cairnline_parity_report for project", parity)
+	}
+	if parity.Data.Match {
+		t.Fatalf("parity report = %+v, want queued-assignment bucket drift surfaced before replacement", parity.Data)
+	}
+	if parity.Data.Hecate.Activity.WorkItems != 1 || parity.Data.Hecate.Activity.Assignments != 1 || parity.Data.Cairnline.Activity.WorkItems != 1 || parity.Data.Cairnline.Activity.Assignments != 1 {
+		t.Fatalf("parity activity counts = hecate %+v cairnline %+v, want matching work/assignment counts", parity.Data.Hecate.Activity, parity.Data.Cairnline.Activity)
+	}
+	if parity.Data.Hecate.Operations.PendingMemoryCandidates != 1 || parity.Data.Cairnline.Operations.PendingMemoryCandidates != 1 || parity.Data.Hecate.Operations.OpenHandoffs != 1 || parity.Data.Cairnline.Operations.OpenHandoffs != 1 {
+		t.Fatalf("parity operations counts = hecate %+v cairnline %+v, want matching memory and handoff counts", parity.Data.Hecate.Operations, parity.Data.Cairnline.Operations)
+	}
+	if !hasProjectCairnlineParityDifferenceForTest(parity.Data.Differences, "activity.active", 0, 1) ||
+		!hasProjectCairnlineParityDifferenceForTest(parity.Data.Differences, "activity.blocked", 1, 0) {
+		t.Fatalf("parity differences = %+v, want queued-assignment active/blocked drift", parity.Data.Differences)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
+		t.Fatalf("parity export dir stat error = %v, want not exist before export", err)
+	}
 
 	first := mustRequestJSON[ProjectCairnlineExportResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/cairnline/export", "")
 	second := mustRequestJSON[ProjectCairnlineExportResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/cairnline/export", "")
@@ -208,9 +228,19 @@ func TestProjectCairnlineExportAPI_MissingProjectDoesNotCreateExportDir(t *testi
 	server := NewServer(quietLogger(), handler)
 	client := newAPITestClient(t, server)
 
+	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/proj_missing/cairnline/parity-report", "")
 	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/proj_missing/cairnline/read-model", "")
 	client.mustRequestStatus(http.StatusNotFound, http.MethodPost, "/hecate/v1/projects/proj_missing/cairnline/export", "")
 	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
 		t.Fatalf("export dir stat error = %v, want not exist", err)
 	}
+}
+
+func hasProjectCairnlineParityDifferenceForTest(items []ProjectCairnlineParityDifference, path string, hecate, cairnline int) bool {
+	for _, item := range items {
+		if item.Path == path && item.Hecate == hecate && item.Cairnline == cairnline {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -330,6 +330,44 @@ type ProjectCairnlineReadModelResponseItem struct {
 	Activity             cairnline.ProjectActivity        `json:"activity"`
 }
 
+type ProjectCairnlineParityReportResponse struct {
+	Object string                                   `json:"object"`
+	Data   ProjectCairnlineParityReportResponseItem `json:"data"`
+}
+
+type ProjectCairnlineParityReportResponseItem struct {
+	ProjectID   string                             `json:"project_id"`
+	Match       bool                               `json:"match"`
+	Differences []ProjectCairnlineParityDifference `json:"differences,omitempty"`
+	Hecate      ProjectCairnlineParitySnapshot     `json:"hecate"`
+	Cairnline   ProjectCairnlineParitySnapshot     `json:"cairnline"`
+}
+
+type ProjectCairnlineParitySnapshot struct {
+	Activity   ProjectCairnlineActivityParityCounts   `json:"activity"`
+	Operations ProjectCairnlineOperationsParityCounts `json:"operations"`
+}
+
+type ProjectCairnlineActivityParityCounts struct {
+	WorkItems   int `json:"work_items"`
+	Assignments int `json:"assignments"`
+	Active      int `json:"active"`
+	Blocked     int `json:"blocked"`
+	Completed   int `json:"completed"`
+	Recent      int `json:"recent"`
+}
+
+type ProjectCairnlineOperationsParityCounts struct {
+	PendingMemoryCandidates int `json:"pending_memory_candidates"`
+	OpenHandoffs            int `json:"open_handoffs"`
+}
+
+type ProjectCairnlineParityDifference struct {
+	Path      string `json:"path"`
+	Hecate    int    `json:"hecate"`
+	Cairnline int    `json:"cairnline"`
+}
+
 type AgentProfileResponse struct {
 	Object string                   `json:"object"`
 	Data   AgentProfileResponseItem `json:"data"`

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -21,6 +21,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodDelete, path: "/hecate/v1/terminals/{terminal_id}"},
 	{method: http.MethodPost, path: "/hecate/v1/system/reset-data"},
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/cairnline/export"},
 	{method: http.MethodPost, path: "/hecate/v1/mcp/probe"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -81,6 +81,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/cairnline/export", handler.HandleExportProjectToCairnline)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots", handler.HandleCreateProjectRoot)


### PR DESCRIPTION
## Summary
- add a local-only Cairnline parity-report endpoint for Projects replacement readiness
- compare Hecate native activity/operations counts with the Cairnline read model
- surface explicit differences, including the current queued-assignment active/blocked bucket drift

## Notes
This is still diagnostic only. Hecate Projects remains authoritative; the report helps decide which Cairnline semantics must align before a backend switch.

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnlineExportAPI|TestRemoteRuntimeEndpointPolicyCoversRegisteredHecateRoutes'
- git diff --check
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go build ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...