### PR TITLE
feat: align Cairnline queued assignment parity

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -118,6 +118,11 @@ SQLite export under Hecate's data directory. Both use the same bridge and are
 useful for inspecting replacement parity, but they are still proofs, not the
 live Projects backend.
 
+Current read-model parity includes queued-assignment attention semantics:
+Hecate and Cairnline both count a queued assignment as blocked/attention rather
+than active work. The parity report remains valuable for finding later drift,
+but this known bucket mismatch is closed.
+
 Hecate is ready to replace its internal Projects backend with Cairnline only
 after these gates are met:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2219,8 +2219,8 @@ Example response:
         "work_items": 2,
         "open_work_items": 1,
         "assignments": 5,
-        "active_assignments": 1,
-        "blocked_assignments": 0,
+        "active_assignments": 0,
+        "blocked_assignments": 1,
         "pending_memory_candidates": 2,
         "review_follow_ups": 0,
         "missing_evidence": 1,
@@ -2234,12 +2234,13 @@ Example response:
         "assignments": 5,
         "queued": 1,
         "completed": 3,
-        "active": 1
+        "active": 0,
+        "blocked": 1
       },
       "buckets": {
-        "active": [
+        "blocked": [
           {
-            "bucket": "active",
+            "bucket": "blocked",
             "assignment_id": "asgn_...",
             "work_item_id": "work_...",
             "status": "queued"
@@ -2270,19 +2271,7 @@ Example response:
   "object": "project_cairnline_parity_report",
   "data": {
     "project_id": "proj_...",
-    "match": false,
-    "differences": [
-      {
-        "path": "activity.active",
-        "hecate": 0,
-        "cairnline": 1
-      },
-      {
-        "path": "activity.blocked",
-        "hecate": 1,
-        "cairnline": 0
-      }
-    ],
+    "match": true,
     "hecate": {
       "activity": {
         "work_items": 1,
@@ -2301,8 +2290,8 @@ Example response:
       "activity": {
         "work_items": 1,
         "assignments": 1,
-        "active": 1,
-        "blocked": 0,
+        "active": 0,
+        "blocked": 1,
         "completed": 0,
         "recent": 1
       },

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260626204537-3951231973c8
+	github.com/hecatehq/cairnline v0.0.0-20260626212410-4e3929dfa184
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/hecatehq/cairnline v0.0.0-20260626202944-3bc029427433 h1:gcQHv57K2vA5
 github.com/hecatehq/cairnline v0.0.0-20260626202944-3bc029427433/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/hecatehq/cairnline v0.0.0-20260626204537-3951231973c8 h1:nDw2o3nK3YEc0E6TV2Th4imU6j5i2rARTW5WDqudkiw=
 github.com/hecatehq/cairnline v0.0.0-20260626204537-3951231973c8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260626212410-4e3929dfa184 h1:xQuGMKOsKiqx0QAbzSFjLGDaIclz2cFEPTbqhqhePGc=
+github.com/hecatehq/cairnline v0.0.0-20260626212410-4e3929dfa184/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -141,11 +141,11 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if readModel.Data.WorkItemCount != 1 || readModel.Data.AssignmentCount != 1 || readModel.Data.ArtifactCount != 2 || readModel.Data.HandoffCount != 1 || readModel.Data.MemoryEntryCount != 1 || readModel.Data.MemoryCandidateCount != 1 {
 		t.Fatalf("read model counts = %+v, want bridged project counts", readModel.Data)
 	}
-	if readModel.Data.Operations.Status != cairnline.ProjectOperationsStatusAttention || readModel.Data.Operations.Counts.ActiveAssignments != 1 || readModel.Data.Operations.Counts.PendingMemoryCandidates != 1 || readModel.Data.Operations.Counts.OpenHandoffs != 1 {
-		t.Fatalf("read model operations = %+v, want active assignment, pending memory, and handoff attention", readModel.Data.Operations)
+	if readModel.Data.Operations.Status != cairnline.ProjectOperationsStatusAttention || readModel.Data.Operations.Counts.ActiveAssignments != 0 || readModel.Data.Operations.Counts.BlockedAssignments != 1 || readModel.Data.Operations.Counts.PendingMemoryCandidates != 1 || readModel.Data.Operations.Counts.OpenHandoffs != 1 {
+		t.Fatalf("read model operations = %+v, want blocked queued assignment, pending memory, and handoff attention", readModel.Data.Operations)
 	}
-	if readModel.Data.Activity.Counts.Assignments != 1 || readModel.Data.Activity.Counts.Active != 1 || readModel.Data.Activity.Counts.Queued != 1 || len(readModel.Data.Activity.Buckets.Active) != 1 || readModel.Data.Activity.Buckets.Active[0].AssignmentID != assignment.Data.ID {
-		t.Fatalf("read model activity = %+v, want queued assignment activity", readModel.Data.Activity)
+	if readModel.Data.Activity.Counts.Assignments != 1 || readModel.Data.Activity.Counts.Active != 0 || readModel.Data.Activity.Counts.Blocked != 1 || readModel.Data.Activity.Counts.Queued != 1 || len(readModel.Data.Activity.Buckets.Blocked) != 1 || readModel.Data.Activity.Buckets.Blocked[0].AssignmentID != assignment.Data.ID {
+		t.Fatalf("read model activity = %+v, want blocked queued assignment activity", readModel.Data.Activity)
 	}
 	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
 		t.Fatalf("read-model export dir stat error = %v, want not exist before export", err)
@@ -154,18 +154,20 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if parity.Object != "project_cairnline_parity_report" || parity.Data.ProjectID != projectID {
 		t.Fatalf("parity envelope = %+v, want project_cairnline_parity_report for project", parity)
 	}
-	if parity.Data.Match {
-		t.Fatalf("parity report = %+v, want queued-assignment bucket drift surfaced before replacement", parity.Data)
+	if !parity.Data.Match {
+		t.Fatalf("parity report = %+v, want queued-assignment semantics aligned", parity.Data)
 	}
 	if parity.Data.Hecate.Activity.WorkItems != 1 || parity.Data.Hecate.Activity.Assignments != 1 || parity.Data.Cairnline.Activity.WorkItems != 1 || parity.Data.Cairnline.Activity.Assignments != 1 {
 		t.Fatalf("parity activity counts = hecate %+v cairnline %+v, want matching work/assignment counts", parity.Data.Hecate.Activity, parity.Data.Cairnline.Activity)
 	}
+	if parity.Data.Hecate.Activity.Active != 0 || parity.Data.Cairnline.Activity.Active != 0 || parity.Data.Hecate.Activity.Blocked != 1 || parity.Data.Cairnline.Activity.Blocked != 1 {
+		t.Fatalf("parity activity buckets = hecate %+v cairnline %+v, want matching blocked queued assignment counts", parity.Data.Hecate.Activity, parity.Data.Cairnline.Activity)
+	}
 	if parity.Data.Hecate.Operations.PendingMemoryCandidates != 1 || parity.Data.Cairnline.Operations.PendingMemoryCandidates != 1 || parity.Data.Hecate.Operations.OpenHandoffs != 1 || parity.Data.Cairnline.Operations.OpenHandoffs != 1 {
 		t.Fatalf("parity operations counts = hecate %+v cairnline %+v, want matching memory and handoff counts", parity.Data.Hecate.Operations, parity.Data.Cairnline.Operations)
 	}
-	if !hasProjectCairnlineParityDifferenceForTest(parity.Data.Differences, "activity.active", 0, 1) ||
-		!hasProjectCairnlineParityDifferenceForTest(parity.Data.Differences, "activity.blocked", 1, 0) {
-		t.Fatalf("parity differences = %+v, want queued-assignment active/blocked drift", parity.Data.Differences)
+	if len(parity.Data.Differences) != 0 {
+		t.Fatalf("parity differences = %+v, want none for aligned queued assignment semantics", parity.Data.Differences)
 	}
 	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
 		t.Fatalf("parity export dir stat error = %v, want not exist before export", err)
@@ -205,15 +207,15 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProjectOperationsBrief from exported DB: %v", err)
 	}
-	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Counts.Assignments != 1 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
-		t.Fatalf("operations brief = %+v, want exported active assignment, pending memory, and handoff attention", brief)
+	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Counts.Assignments != 1 || brief.Counts.ActiveAssignments != 0 || brief.Counts.BlockedAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
+		t.Fatalf("operations brief = %+v, want exported blocked queued assignment, pending memory, and handoff attention", brief)
 	}
 	activity, err := service.ProjectActivity(t.Context(), projectID)
 	if err != nil {
 		t.Fatalf("ProjectActivity from exported DB: %v", err)
 	}
-	if activity.Counts.Assignments != 1 || activity.Counts.Active != 1 || activity.Counts.Queued != 1 || len(activity.Buckets.Active) != 1 || activity.Buckets.Active[0].AssignmentID != assignment.Data.ID {
-		t.Fatalf("activity = %+v, want exported queued assignment activity", activity)
+	if activity.Counts.Assignments != 1 || activity.Counts.Active != 0 || activity.Counts.Blocked != 1 || activity.Counts.Queued != 1 || len(activity.Buckets.Blocked) != 1 || activity.Buckets.Blocked[0].AssignmentID != assignment.Data.ID {
+		t.Fatalf("activity = %+v, want exported blocked queued assignment activity", activity)
 	}
 }
 
@@ -234,13 +236,4 @@ func TestProjectCairnlineExportAPI_MissingProjectDoesNotCreateExportDir(t *testi
 	if _, err := os.Stat(filepath.Join(dataDir, "cairnline")); !os.IsNotExist(err) {
 		t.Fatalf("export dir stat error = %v, want not exist", err)
 	}
-}
-
-func hasProjectCairnlineParityDifferenceForTest(items []ProjectCairnlineParityDifference, path string, hecate, cairnline int) bool {
-	for _, item := range items {
-		if item.Path == path && item.Hecate == hecate && item.Cairnline == cairnline {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -79,11 +79,11 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProjectOperationsBrief() error = %v", err)
 	}
-	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Next.Kind != cairnline.ProjectOperationKindReviewFollowUp {
-		t.Fatalf("operations brief = %+v, want review follow-up next", brief)
+	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Next.Kind != cairnline.ProjectOperationKindAssignment || brief.Next.AssignmentID != "asgn_bridge" {
+		t.Fatalf("operations brief = %+v, want queued assignment next", brief)
 	}
-	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.ReviewFollowUps != 1 || brief.Counts.OpenHandoffs != 1 || brief.Counts.MissingEvidence != 0 {
-		t.Fatalf("operations counts = %+v, want active assignment, memory candidate, review follow-up, and open handoff", brief.Counts)
+	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 0 || brief.Counts.BlockedAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.ReviewFollowUps != 1 || brief.Counts.OpenHandoffs != 1 || brief.Counts.MissingEvidence != 0 {
+		t.Fatalf("operations counts = %+v, want blocked queued assignment, memory candidate, review follow-up, and open handoff", brief.Counts)
 	}
 	if !hasCairnlineOperation(brief.Items, cairnline.ProjectOperationKindAssignment, "work_bridge", "asgn_bridge") ||
 		!hasCairnlineOperation(brief.Items, cairnline.ProjectOperationKindHandoff, "work_bridge", "handoff_review") ||
@@ -94,12 +94,12 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProjectActivity() error = %v", err)
 	}
-	if activity.Counts.Assignments != 2 || activity.Counts.Active != 1 || activity.Counts.Completed != 1 || len(activity.Buckets.Active) != 1 || len(activity.Buckets.Completed) != 1 {
-		t.Fatalf("activity = %+v, want active and completed assignment buckets", activity)
+	if activity.Counts.Assignments != 2 || activity.Counts.Active != 0 || activity.Counts.Blocked != 1 || activity.Counts.Completed != 1 || len(activity.Buckets.Blocked) != 1 || len(activity.Buckets.Completed) != 1 {
+		t.Fatalf("activity = %+v, want blocked and completed assignment buckets", activity)
 	}
-	if !hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketActive, "work_bridge", "asgn_bridge") ||
+	if !hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketBlocked, "work_bridge", "asgn_bridge") ||
 		!hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketCompleted, "work_bridge", "asgn_external") {
-		t.Fatalf("activity items = %+v, want active Hecate task and completed external assignment", activity.Items)
+		t.Fatalf("activity items = %+v, want blocked queued assignment and completed external assignment", activity.Items)
 	}
 	candidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{ProjectID: "proj_hecate", IncludeResolved: true})
 	if err != nil {
@@ -173,12 +173,12 @@ func TestProjectActivityFromStores(t *testing.T) {
 	if loaded.Project.ID != snapshot.Project.ID || len(loaded.Assignments) != len(snapshot.Assignments) {
 		t.Fatalf("loaded snapshot = %+v, want project and assignment state", loaded)
 	}
-	if activity.Counts.Assignments != 2 || activity.Counts.Active != 1 || activity.Counts.Completed != 1 {
-		t.Fatalf("activity counts = %+v, want seeded active/completed assignments", activity.Counts)
+	if activity.Counts.Assignments != 2 || activity.Counts.Active != 0 || activity.Counts.Blocked != 1 || activity.Counts.Completed != 1 {
+		t.Fatalf("activity counts = %+v, want seeded blocked/completed assignments", activity.Counts)
 	}
-	if !hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketActive, "work_bridge", "asgn_bridge") ||
+	if !hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketBlocked, "work_bridge", "asgn_bridge") ||
 		!hasCairnlineActivity(activity.Items, cairnline.ProjectActivityBucketCompleted, "work_bridge", "asgn_external") {
-		t.Fatalf("activity items = %+v, want active and completed assignment metadata", activity.Items)
+		t.Fatalf("activity items = %+v, want blocked and completed assignment metadata", activity.Items)
 	}
 }
 
@@ -196,10 +196,10 @@ func TestProjectOperationsBriefFromStores(t *testing.T) {
 	if loaded.Project.ID != snapshot.Project.ID || len(loaded.Assignments) != len(snapshot.Assignments) {
 		t.Fatalf("loaded snapshot = %+v, want project and assignment state", loaded)
 	}
-	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Next.Kind != cairnline.ProjectOperationKindReviewFollowUp {
-		t.Fatalf("operations brief = %+v, want review follow-up attention from seeded Hecate stores", brief)
+	if brief.Status != cairnline.ProjectOperationsStatusAttention || brief.Next == nil || brief.Next.Kind != cairnline.ProjectOperationKindAssignment || brief.Next.AssignmentID != "asgn_bridge" {
+		t.Fatalf("operations brief = %+v, want queued assignment attention from seeded Hecate stores", brief)
 	}
-	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
+	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 0 || brief.Counts.BlockedAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
 		t.Fatalf("operations counts = %+v, want assignment, memory, and handoff parity", brief.Counts)
 	}
 }
@@ -255,14 +255,14 @@ func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopened ProjectOperationsBrief() error = %v", err)
 	}
-	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
+	if brief.Counts.Assignments != 2 || brief.Counts.ActiveAssignments != 0 || brief.Counts.BlockedAssignments != 1 || brief.Counts.PendingMemoryCandidates != 1 || brief.Counts.OpenHandoffs != 1 {
 		t.Fatalf("reopened operations counts = %+v, want persisted operations parity", brief.Counts)
 	}
 	activity, err := reopened.ProjectActivity(ctx, snapshot.Project.ID)
 	if err != nil {
 		t.Fatalf("reopened ProjectActivity() error = %v", err)
 	}
-	if activity.Counts.Assignments != 2 || activity.Counts.Active != 1 || activity.Counts.Completed != 1 || len(activity.Buckets.Recent) != 2 {
+	if activity.Counts.Assignments != 2 || activity.Counts.Active != 0 || activity.Counts.Blocked != 1 || activity.Counts.Completed != 1 || len(activity.Buckets.Recent) != 2 {
 		t.Fatalf("reopened activity = %+v, want persisted activity parity", activity)
 	}
 }


### PR DESCRIPTION
## Summary

- bump Cairnline to the queued-assignment attention build
- update Hecate bridge/API tests so queued assignments are blocked/attention in both read models
- refresh runtime/design docs to show the known queued bucket drift is closed

## Validation

- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCairnlineExportAPI|TestRemoteRuntimeEndpointPolicyCoversRegisteredHecateRoutes'`\n- `GOCACHE="$PWD/.gocache" go test ./internal/cairnlinebridge`\n- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/cairnlinebridge`\n- `GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge`\n- `just agent-docs-check`\n- `GOCACHE="$PWD/.gocache" go build ./...`\n- `GOCACHE="$PWD/.gocache" go vet ./...`\n- `GOCACHE="$PWD/.gocache" go test ./...`\n- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`