### PR TITLE
feat: preserve Cairnline default roots

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -91,7 +91,7 @@ It can load Hecate project state from the current project/profile/skills/work
 stores, then seed a memory-backed or SQLite-backed Cairnline service from
 Hecate project-shaped records:
 
-- project identity, roots, and context-source metadata;
+- project identity, roots, default root, and context-source metadata;
 - agent profiles and execution posture;
 - skills metadata, roles, work items, and root-scoped assignments;
 - assignment-scoped collaboration evidence links, reviews, handoffs with

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2188,7 +2188,9 @@ The response reports the scoped records Hecate cleaned up:
 Local-only experimental bridge endpoint. It loads the selected project from
 Hecate's authoritative Projects stores, seeds an in-memory Cairnline service,
 and returns Cairnline's portable read projections for the project without
-writing an export database.
+writing an export database. The seeded project preserves root and
+`default_root_id` metadata so replacement-readiness checks exercise Hecate's
+workspace-resolution inputs.
 
 The response is useful for replacement-readiness checks: it shows whether
 Cairnline can reconstruct the portable operations brief and activity inbox from
@@ -2308,7 +2310,7 @@ Example response:
 
 Local-only experimental bridge endpoint. It loads the selected project from
 Hecate's authoritative Projects stores and writes a refreshable Cairnline SQLite
-export at:
+export that preserves root and `default_root_id` metadata at:
 
 ```text
 {HECATE_DATA_DIR}/cairnline/projects/{safe_project_id}.db

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260626212410-4e3929dfa184
+	github.com/hecatehq/cairnline v0.0.0-20260626214301-4812d93dc3e3
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/hecatehq/cairnline v0.0.0-20260626204537-3951231973c8 h1:nDw2o3nK3YEc
 github.com/hecatehq/cairnline v0.0.0-20260626204537-3951231973c8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/hecatehq/cairnline v0.0.0-20260626212410-4e3929dfa184 h1:xQuGMKOsKiqx0QAbzSFjLGDaIclz2cFEPTbqhqhePGc=
 github.com/hecatehq/cairnline v0.0.0-20260626212410-4e3929dfa184/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260626214301-4812d93dc3e3 h1:7Is743BjVy9/jJ1Do/ub3xN0PgXmjvadzyxvj85UJWg=
+github.com/hecatehq/cairnline v0.0.0-20260626214301-4812d93dc3e3/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -197,8 +197,8 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AssignmentLaunchPacket from exported DB: %v", err)
 	}
-	if packet.Project.ID != projectID || packet.Assignment.RootID != project.Data.Roots[0].ID {
-		t.Fatalf("packet project/assignment = %+v/%+v, want exported root-scoped assignment", packet.Project, packet.Assignment)
+	if packet.Project.ID != projectID || packet.Project.DefaultRootID != project.Data.DefaultRootID || packet.Assignment.RootID != project.Data.Roots[0].ID {
+		t.Fatalf("packet project/assignment = %+v/%+v, want exported default root and root-scoped assignment", packet.Project, packet.Assignment)
 	}
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("packet counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -123,6 +123,7 @@ func Project(project projects.Project) cairnline.Project {
 		Name:           strings.TrimSpace(project.Name),
 		Description:    strings.TrimSpace(project.Description),
 		Roots:          Roots(project.Roots),
+		DefaultRootID:  strings.TrimSpace(project.DefaultRootID),
 		ContextSources: Sources(project.ContextSources),
 		CreatedAt:      project.CreatedAt,
 		UpdatedAt:      project.UpdatedAt,

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -29,8 +29,8 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AssignmentLaunchPacket() error = %v", err)
 	}
-	if packet.Project.ID != "proj_hecate" || packet.WorkItem.RootID != "root_main" {
-		t.Fatalf("packet project/work = %+v/%+v, want Hecate project with root-scoped work", packet.Project, packet.WorkItem)
+	if packet.Project.ID != "proj_hecate" || packet.Project.DefaultRootID != "root_main" || packet.WorkItem.RootID != "root_main" {
+		t.Fatalf("packet project/work = %+v/%+v, want Hecate project with default root and root-scoped work", packet.Project, packet.WorkItem)
 	}
 	if packet.Role == nil || packet.Role.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
 		t.Fatalf("packet role = %+v, want orchestrated role from Hecate task driver", packet.Role)
@@ -232,8 +232,8 @@ func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AssignmentLaunchPacket() reopened error = %v", err)
 	}
-	if packet.Project.ID != snapshot.Project.ID || packet.Assignment.RootID != "root_main" {
-		t.Fatalf("reopened packet project/assignment = %+v/%+v, want persisted root-scoped launch packet", packet.Project, packet.Assignment)
+	if packet.Project.ID != snapshot.Project.ID || packet.Project.DefaultRootID != "root_main" || packet.Assignment.RootID != "root_main" {
+		t.Fatalf("reopened packet project/assignment = %+v/%+v, want persisted default root and root-scoped launch packet", packet.Project, packet.Assignment)
 	}
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("reopened launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
@@ -300,6 +300,7 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 				GitBranch: "main",
 				Active:    true,
 			}},
+			DefaultRootID: "root_main",
 			ContextSources: []projects.ContextSource{{
 				ID:         "src_agents",
 				Kind:       "workspace_instruction",


### PR DESCRIPTION
## Summary

- bump Cairnline to the default-root build
- map Hecate project `default_root_id` into Cairnline projects
- assert default-root preservation in bridge and export tests
- update bridge docs to describe root/default-root preservation

## Why

Hecate workspace resolution uses project default roots. Cairnline needs that metadata in the bridge before it can become a viable Projects backend candidate.

## Validation

- `GOCACHE="$PWD/.gocache" go test ./internal/cairnlinebridge`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCairnlineExportAPI|TestRemoteRuntimeEndpointPolicyCoversRegisteredHecateRoutes'`\n- `GOCACHE="$PWD/.gocache" go vet ./internal/cairnlinebridge ./internal/api`\n- `just agent-docs-check`\n- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/cairnlinebridge`\n- `GOCACHE="$PWD/.gocache" go build ./...`\n- `GOCACHE="$PWD/.gocache" go test ./...`\n- `GOCACHE="$PWD/.gocache" go vet ./...`\n- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`