### PR TITLE
feat: add Cairnline backend status

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -108,9 +108,13 @@ Hecate task/external-agent execution, migrate existing local data, or make
 Cairnline authoritative.
 
 For operator-triggered experiments, Hecate exposes local-only Cairnline bridge
-endpoints. `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an
-in-memory Cairnline service from the current Hecate stores and returns the
-portable operations brief and activity projection without writing files.
+endpoints. `GET /hecate/v1/projects/backend-status` reports the configured
+coordination backend and whether Cairnline is actually authoritative. Today,
+`HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a replacement-readiness
+intent flag only: it reports `cairnline_configured_inactive`, while Hecate
+stores remain authoritative. `GET /hecate/v1/projects/{id}/cairnline/read-model`
+seeds an in-memory Cairnline service from the current Hecate stores and returns
+the portable operations brief and activity projection without writing files.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
 differences, so bucket/status semantics can be fixed before any backend switch.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -353,6 +353,11 @@ The project backend also carries project memory, project work, project skills,
 and agent profiles. The chat backend also carries external-agent approval rows
 and durable grants so transcripts and approval history move together.
 
+`HECATE_PROJECTS_COORDINATION_BACKEND=hecate|cairnline` is separate from the
+storage backend. The default is `hecate`. `cairnline` records replacement intent
+for local bridge experiments, but live Projects reads/writes still use
+Hecate-native stores until the Cairnline adapter and migration path are ready.
+
 Deployment-specific notes:
 
 - The docker image **defaults to `sqlite`** for every durable subsystem,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -456,6 +456,12 @@ sequenceDiagram
 - `HECATE_BACKEND=memory|sqlite|postgres` controls all Hecate-owned durable state,
   including tasks, the task queue, projects, project memory, chats, usage
   events, and settings.
+- `HECATE_PROJECTS_COORDINATION_BACKEND=hecate|cairnline` records the intended
+  Projects coordination authority. The default is `hecate`. `cairnline` is an
+  opt-in replacement-readiness setting only: Hecate-native stores remain
+  authoritative until the feature-flagged Cairnline read/write adapter and
+  migration path land. Use
+  `GET /hecate/v1/projects/backend-status` to inspect the effective state.
 - `HECATE_POSTGRES_URL=postgres://...` or `DATABASE_URL=postgres://...` is
   required when `HECATE_BACKEND=postgres`. Optional Postgres knobs:
   `HECATE_POSTGRES_TABLE_PREFIX`, `HECATE_POSTGRES_MAX_OPEN_CONNS`, and
@@ -2179,6 +2185,44 @@ The response reports the scoped records Hecate cleaned up:
     "project_skills_deleted": 1,
     "memory_entries_deleted": 3,
     "memory_candidates_deleted": 4
+  }
+}
+```
+
+### `GET /hecate/v1/projects/backend-status`
+
+Local-only endpoint that reports the configured Projects coordination backend
+and the backend that is actually authoritative for live project reads/writes.
+It exists to make the Cairnline replacement switch explicit while the adapter is
+being built.
+
+`configured_backend` reflects `HECATE_PROJECTS_COORDINATION_BACKEND`.
+`authoritative_backend` remains `hecate` until Hecate can run project read/write
+flows against Cairnline without UI-local fallback state. When
+`configured_backend=cairnline`, Hecate still serves live Projects APIs from the
+current Hecate-native stores; the Cairnline bridge endpoints remain
+replacement-readiness proofs.
+
+Example response:
+
+```json
+{
+  "object": "project_coordination_backend_status",
+  "data": {
+    "configured_backend": "cairnline",
+    "authoritative_backend": "hecate",
+    "storage_backend": "sqlite",
+    "cairnline_bridge_ready": true,
+    "cairnline_authoritative": false,
+    "read_model_switch_ready": false,
+    "write_adapter_ready": false,
+    "status": "cairnline_configured_inactive",
+    "detail": "Cairnline is configured as the future Projects coordination backend, but Hecate stores remain authoritative until the feature-flagged adapter and migration path land.",
+    "warnings": [
+      "Project reads and writes still use Hecate-native stores.",
+      "Cairnline bridge endpoints are replacement-readiness proofs, not the live backend."
+    ],
+    "replacement_readiness_url": "/hecate/v1/projects/{id}/cairnline/read-model"
   }
 }
 ```

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -1,0 +1,44 @@
+package api
+
+import "net/http"
+
+const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
+
+func (h *Handler) HandleProjectCoordinationBackendStatus(w http.ResponseWriter, r *http.Request) {
+	WriteJSON(w, http.StatusOK, ProjectCoordinationBackendStatusEnvelope{
+		Object: "project_coordination_backend_status",
+		Data:   h.projectCoordinationBackendStatus(),
+	})
+}
+
+func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendStatusResponse {
+	configured := "hecate"
+	storageBackend := ""
+	if h != nil {
+		configured = h.config.ProjectsCoordinationBackend()
+		storageBackend = h.config.Projects.Backend
+	}
+	response := ProjectCoordinationBackendStatusResponse{
+		ConfiguredBackend:       configured,
+		AuthoritativeBackend:    "hecate",
+		StorageBackend:          storageBackend,
+		CairnlineBridgeReady:    true,
+		CairnlineAuthoritative:  false,
+		ReadModelSwitchReady:    false,
+		WriteAdapterReady:       false,
+		ReplacementReadinessURL: projectCoordinationBackendReadinessURL,
+	}
+	switch configured {
+	case "cairnline":
+		response.Status = "cairnline_configured_inactive"
+		response.Detail = "Cairnline is configured as the future Projects coordination backend, but Hecate stores remain authoritative until the feature-flagged adapter and migration path land."
+		response.Warnings = []string{
+			"Project reads and writes still use Hecate-native stores.",
+			"Cairnline bridge endpoints are replacement-readiness proofs, not the live backend.",
+		}
+	default:
+		response.Status = "hecate_authoritative"
+		response.Detail = "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks."
+	}
+	return response
+}

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+)
+
+func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.T) {
+	handler := &Handler{config: config.Config{
+		Projects: config.ProjectsConfig{Backend: "sqlite"},
+	}}
+
+	status := handler.projectCoordinationBackendStatus()
+	if status.ConfiguredBackend != "hecate" || status.AuthoritativeBackend != "hecate" || status.StorageBackend != "sqlite" {
+		t.Fatalf("status = %+v, want Hecate authoritative over sqlite project storage", status)
+	}
+	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || len(status.Warnings) != 0 {
+		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineConfiguredInactive(t *testing.T) {
+	handler := &Handler{config: config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CoordinationBackend: "cairnline",
+		},
+	}}
+
+	status := handler.projectCoordinationBackendStatus()
+	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_configured_inactive" {
+		t.Fatalf("status = %+v, want configured Cairnline with Hecate still authoritative", status)
+	}
+	if status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || len(status.Warnings) == 0 {
+		t.Fatalf("status = %+v, want inactive adapter warnings", status)
+	}
+}
+
+func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	cfg := config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CoordinationBackend: "cairnline",
+		},
+	}
+	server := newTestHTTPHandlerForProviders(logger, nil, cfg)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/backend-status", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("backend status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	var response ProjectCoordinationBackendStatusEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode backend status: %v", err)
+	}
+	if response.Object != "project_coordination_backend_status" || response.Data.ConfiguredBackend != "cairnline" || response.Data.AuthoritativeBackend != "hecate" {
+		t.Fatalf("response = %+v, want Cairnline configured but Hecate authoritative", response)
+	}
+}

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -368,6 +368,25 @@ type ProjectCairnlineParityDifference struct {
 	Cairnline int    `json:"cairnline"`
 }
 
+type ProjectCoordinationBackendStatusEnvelope struct {
+	Object string                                   `json:"object"`
+	Data   ProjectCoordinationBackendStatusResponse `json:"data"`
+}
+
+type ProjectCoordinationBackendStatusResponse struct {
+	ConfiguredBackend       string   `json:"configured_backend"`
+	AuthoritativeBackend    string   `json:"authoritative_backend"`
+	StorageBackend          string   `json:"storage_backend"`
+	CairnlineBridgeReady    bool     `json:"cairnline_bridge_ready"`
+	CairnlineAuthoritative  bool     `json:"cairnline_authoritative"`
+	ReadModelSwitchReady    bool     `json:"read_model_switch_ready"`
+	WriteAdapterReady       bool     `json:"write_adapter_ready"`
+	Status                  string   `json:"status"`
+	Detail                  string   `json:"detail"`
+	Warnings                []string `json:"warnings,omitempty"`
+	ReplacementReadinessURL string   `json:"replacement_readiness_url,omitempty"`
+}
+
 type AgentProfileResponse struct {
 	Object string                   `json:"object"`
 	Data   AgentProfileResponseItem `json:"data"`

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -21,6 +21,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodDelete, path: "/hecate/v1/terminals/{terminal_id}"},
 	{method: http.MethodPost, path: "/hecate/v1/system/reset-data"},
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/cairnline/export"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -73,6 +73,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	// to them for shared defaults, memory, and context assembly.
 	mux.HandleFunc("GET /hecate/v1/projects", handler.HandleProjects)
 	mux.HandleFunc("POST /hecate/v1/projects", handler.HandleCreateProject)
+	mux.HandleFunc("GET /hecate/v1/projects/backend-status", handler.HandleProjectCoordinationBackendStatus)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/context", handler.HandleProjectAssistantContext)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/draft", handler.HandleProjectAssistantDraft)
 	mux.HandleFunc("POST /hecate/v1/project-assistant/propose", handler.HandleProjectAssistantPropose)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,7 +226,12 @@ type ChatConfig struct {
 }
 
 type ProjectsConfig struct {
-	Backend string
+	Backend             string
+	CoordinationBackend string
+}
+
+func (c Config) ProjectsCoordinationBackend() string {
+	return normalizeProjectsCoordinationBackend(c.Projects.CoordinationBackend)
 }
 
 type OTelSignalConfig struct {
@@ -469,7 +474,8 @@ func LoadFromEnv() Config {
 			SessionsBackend: storageBackend,
 		},
 		Projects: ProjectsConfig{
-			Backend: storageBackend,
+			Backend:             storageBackend,
+			CoordinationBackend: strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_COORDINATION_BACKEND", "hecate"))),
 		},
 		OTel: loadOTelFromEnv(),
 		Governor: GovernorConfig{
@@ -553,6 +559,7 @@ func (c Config) Validate() error {
 	for _, backend := range c.storageBackends() {
 		validateBackend("HECATE_BACKEND", backend, "memory", "sqlite", "postgres")
 	}
+	validateBackend("HECATE_PROJECTS_COORDINATION_BACKEND", c.ProjectsCoordinationBackend(), "hecate", "cairnline")
 	if postgresRequired(c) && strings.TrimSpace(c.Postgres.DatabaseURL) == "" {
 		errs = append(errs, errors.New("HECATE_POSTGRES_URL or DATABASE_URL is required when HECATE_BACKEND=postgres"))
 	}
@@ -1126,6 +1133,14 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func normalizeProjectsCoordinationBackend(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "hecate"
+	}
+	return value
 }
 
 func normalizeValues(values []string) []string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -432,6 +432,35 @@ func TestValidateRejectsInvalidBackendNames(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvProjectsCoordinationBackend(t *testing.T) {
+	cfg := LoadFromEnv()
+	if got := cfg.ProjectsCoordinationBackend(); got != "hecate" {
+		t.Fatalf("ProjectsCoordinationBackend() = %q, want hecate", got)
+	}
+
+	t.Setenv("HECATE_PROJECTS_COORDINATION_BACKEND", " Cairnline ")
+	cfg = LoadFromEnv()
+	if got := cfg.ProjectsCoordinationBackend(); got != "cairnline" {
+		t.Fatalf("ProjectsCoordinationBackend() = %q, want cairnline", got)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil for cairnline coordination backend opt-in", err)
+	}
+}
+
+func TestValidateRejectsInvalidProjectsCoordinationBackend(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Projects.CoordinationBackend = "cairnline_shadow"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid projects coordination backend error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_PROJECTS_COORDINATION_BACKEND") {
+		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_COORDINATION_BACKEND", err)
+	}
+}
+
 func TestValidateRejectsPostgresBackendWithoutDatabaseURL(t *testing.T) {
 	cfg := LoadFromEnv()
 	cfg.Server.ControlPlaneBackend = "postgres"


### PR DESCRIPTION
## Summary
- add HECATE_PROJECTS_COORDINATION_BACKEND as an explicit future coordination-backend selector
- expose local-only GET /hecate/v1/projects/backend-status so operators can see that Cairnline is configured but not authoritative yet
- document the distinction between Hecate storage backend and Cairnline replacement-readiness intent

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/config ./internal/api -run 'Test(LoadFromEnvProjectsCoordinationBackend|ValidateRejectsInvalidProjectsCoordinationBackend|ProjectCoordinationBackendStatus|RemoteRuntimeEndpointPolicyCoversRegisteredHecateRoutes)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/config ./internal/api
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/config ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...