### PR TITLE
feat: report Cairnline read readiness

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -109,12 +109,15 @@ Cairnline authoritative.
 
 For operator-triggered experiments, Hecate exposes local-only Cairnline bridge
 endpoints. `GET /hecate/v1/projects/backend-status` reports the configured
-coordination backend and whether Cairnline is actually authoritative. Today,
-`HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a replacement-readiness
-intent flag only: it reports `cairnline_configured_inactive`, while Hecate
-stores remain authoritative. `GET /hecate/v1/projects/{id}/cairnline/read-model`
-seeds an in-memory Cairnline service from the current Hecate stores and returns
-the portable operations brief and activity projection without writing files.
+coordination backend, whether the Cairnline read adapter can project the full
+current Hecate project graph, and whether Cairnline is actually authoritative.
+Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
+replacement-readiness intent flag only: when the current stores are fully wired
+it reports `cairnline_read_adapter_ready`, while Hecate stores remain
+authoritative and live Projects reads/writes still use the Hecate-native API.
+`GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
+Cairnline service from the current Hecate stores and returns the portable
+operations brief and activity projection without writing files.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
 differences, so bucket/status semantics can be fixed before any backend switch.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -355,8 +355,11 @@ and durable grants so transcripts and approval history move together.
 
 `HECATE_PROJECTS_COORDINATION_BACKEND=hecate|cairnline` is separate from the
 storage backend. The default is `hecate`. `cairnline` records replacement intent
-for local bridge experiments, but live Projects reads/writes still use
-Hecate-native stores until the Cairnline adapter and migration path are ready.
+for local bridge experiments. When the Cairnline read adapter is fully wired,
+`GET /hecate/v1/projects/backend-status` reports
+`read_model_switch_ready=true`, but live Projects reads/writes still use
+Hecate-native stores until live read routing, the write adapter, and migration
+path are ready.
 
 Deployment-specific notes:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2200,8 +2200,11 @@ being built.
 `authoritative_backend` remains `hecate` until Hecate can run project read/write
 flows against Cairnline without UI-local fallback state. When
 `configured_backend=cairnline`, Hecate still serves live Projects APIs from the
-current Hecate-native stores; the Cairnline bridge endpoints remain
-replacement-readiness proofs.
+current Hecate-native stores. `read_model_switch_ready=true` means the
+Cairnline read adapter is wired well enough to project the full current Hecate
+project graph for replacement-readiness checks; it does not mean live Projects
+reads have switched. `write_adapter_ready=false` means writes and migration are
+still Hecate-owned.
 
 Example response:
 
@@ -2214,13 +2217,13 @@ Example response:
     "storage_backend": "sqlite",
     "cairnline_bridge_ready": true,
     "cairnline_authoritative": false,
-    "read_model_switch_ready": false,
+    "read_model_switch_ready": true,
     "write_adapter_ready": false,
-    "status": "cairnline_configured_inactive",
-    "detail": "Cairnline is configured as the future Projects coordination backend, but Hecate stores remain authoritative until the feature-flagged adapter and migration path land.",
+    "status": "cairnline_read_adapter_ready",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the read adapter can project current Hecate stores. Hecate stores remain authoritative until live read routing, writes, and migration are ready.",
     "warnings": [
-      "Project reads and writes still use Hecate-native stores.",
-      "Cairnline bridge endpoints are replacement-readiness proofs, not the live backend."
+      "Live project APIs still read and write Hecate-native stores.",
+      "Cairnline write adapter and migration path are not ready."
     ],
     "replacement_readiness_url": "/hecate/v1/projects/{id}/cairnline/read-model"
   }

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -24,21 +24,65 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		StorageBackend:          storageBackend,
 		CairnlineBridgeReady:    true,
 		CairnlineAuthoritative:  false,
-		ReadModelSwitchReady:    false,
 		WriteAdapterReady:       false,
 		ReplacementReadinessURL: projectCoordinationBackendReadinessURL,
 	}
 	switch configured {
 	case "cairnline":
-		response.Status = "cairnline_configured_inactive"
-		response.Detail = "Cairnline is configured as the future Projects coordination backend, but Hecate stores remain authoritative until the feature-flagged adapter and migration path land."
+		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
+		response.ReadModelSwitchReady = readReady
+		if readReady {
+			response.Status = "cairnline_read_adapter_ready"
+			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the read adapter can project current Hecate stores. Hecate stores remain authoritative until live read routing, writes, and migration are ready."
+			response.Warnings = []string{
+				"Live project APIs still read and write Hecate-native stores.",
+				"Cairnline write adapter and migration path are not ready.",
+			}
+			return response
+		}
+		response.Status = "cairnline_configured_read_adapter_missing_sources"
+		response.Detail = "Cairnline is configured as the future Projects coordination backend, but the read adapter cannot project the full Hecate project graph from the currently wired stores."
 		response.Warnings = []string{
 			"Project reads and writes still use Hecate-native stores.",
-			"Cairnline bridge endpoints are replacement-readiness proofs, not the live backend.",
 		}
+		response.Warnings = append(response.Warnings, sourceWarnings...)
 	default:
 		response.Status = "hecate_authoritative"
 		response.Detail = "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks."
 	}
 	return response
+}
+
+func (h *Handler) cairnlineReadModelReadiness() (bool, []string) {
+	if h == nil {
+		return false, []string{"Hecate handler is not configured."}
+	}
+	sources := h.cairnlineSnapshotSources()
+	missing := make([]string, 0, 6)
+	if sources.Projects == nil {
+		missing = append(missing, "projects store")
+	}
+	if sources.AgentProfiles == nil {
+		missing = append(missing, "agent profiles store")
+	}
+	if sources.Skills == nil {
+		missing = append(missing, "project skills store")
+	}
+	if sources.Work == nil {
+		missing = append(missing, "project work store")
+	}
+	if sources.Memory == nil {
+		missing = append(missing, "project memory store")
+	}
+	if sources.MemoryCandidates == nil {
+		missing = append(missing, "project memory candidates store")
+	}
+	if len(missing) == 0 {
+		return true, nil
+	}
+	warnings := make([]string, 0, len(missing))
+	for _, name := range missing {
+		warnings = append(warnings, "Cairnline read adapter is missing "+name+".")
+	}
+	return false, warnings
 }

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -25,7 +25,7 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	}
 }
 
-func TestProjectCoordinationBackendStatus_CairnlineConfiguredInactive(t *testing.T) {
+func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *testing.T) {
 	handler := &Handler{config: config.Config{
 		Projects: config.ProjectsConfig{
 			Backend:             "sqlite",
@@ -34,11 +34,31 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredInactive(t *testing
 	}}
 
 	status := handler.projectCoordinationBackendStatus()
-	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_configured_inactive" {
-		t.Fatalf("status = %+v, want configured Cairnline with Hecate still authoritative", status)
+	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_configured_read_adapter_missing_sources" {
+		t.Fatalf("status = %+v, want configured Cairnline with missing read-adapter sources", status)
 	}
 	if status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || len(status.Warnings) == 0 {
-		t.Fatalf("status = %+v, want inactive adapter warnings", status)
+		t.Fatalf("status = %+v, want read adapter missing-source warnings", status)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadAdapterReady(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CoordinationBackend: "cairnline",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_read_adapter_ready" {
+		t.Fatalf("status = %+v, want configured Cairnline with read adapter ready", status)
+	}
+	if status.CairnlineAuthoritative || !status.ReadModelSwitchReady || status.WriteAdapterReady {
+		t.Fatalf("status = %+v, want read adapter ready but Hecate still authoritative", status)
+	}
+	if len(status.Warnings) == 0 {
+		t.Fatalf("status = %+v, want write-adapter/migration warning", status)
 	}
 }
 
@@ -64,5 +84,8 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	}
 	if response.Object != "project_coordination_backend_status" || response.Data.ConfiguredBackend != "cairnline" || response.Data.AuthoritativeBackend != "hecate" {
 		t.Fatalf("response = %+v, want Cairnline configured but Hecate authoritative", response)
+	}
+	if !response.Data.ReadModelSwitchReady || response.Data.Status != "cairnline_read_adapter_ready" {
+		t.Fatalf("response = %+v, want Cairnline read adapter ready for fully wired test handler", response)
 	}
 }


### PR DESCRIPTION
## Summary
- report Cairnline read adapter readiness from wired Hecate project stores
- keep Hecate as the authoritative Projects backend until live read routing, writes, and migration are ready
- update runtime/operator/design docs for the readiness semantics

## Validation
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'\n- GOCACHE="$PWD/.gocache" go test ./internal/cairnlinebridge\n- just agent-docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge\n- GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/cairnlinebridge\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go vet ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n