### PR TITLE
feat: route operations reads through Cairnline

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -113,11 +113,13 @@ coordination backend, whether the Cairnline read adapter can project the full
 current Hecate project graph, and whether Cairnline is actually authoritative.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
-it reports `cairnline_read_adapter_ready`, while Hecate stores remain
-authoritative and live Projects reads/writes still use the Hecate-native API.
-`GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
-Cairnline service from the current Hecate stores and returns the portable
-operations brief and activity projection without writing files.
+it reports `cairnline_operations_read_route_ready`, and the live project
+operations brief can use the Cairnline read model for portable work operations.
+Hecate stores remain authoritative, Hecate-specific setup/action projection
+remains in Hecate, and other live Projects reads/writes still use the
+Hecate-native API. `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds
+an in-memory Cairnline service from the current Hecate stores and returns the
+portable operations brief and activity projection without writing files.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
 differences, so bucket/status semantics can be fixed before any backend switch.
@@ -137,8 +139,10 @@ after these gates are met:
 - Cairnline has durable storage and MCP/API parity for Hecate's project, role,
   profile, context-source provenance metadata, skill, work item, assignment,
   artifact, handoff, accepted-memory, and memory-candidate flows.
-- Hecate has a feature-flagged adapter that can run read/write Projects flows
-  against Cairnline without UI-local fallback state.
+- Hecate has feature-flagged adapters that can run all read/write Projects
+  flows against Cairnline without UI-local fallback state. The first live read
+  route is the operations brief; activity, setup/context, work detail, and
+  write routes still need their own switch points.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha.
 - Context packets, setup/health/operations summaries, activity projections, and

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -357,9 +357,10 @@ and durable grants so transcripts and approval history move together.
 storage backend. The default is `hecate`. `cairnline` records replacement intent
 for local bridge experiments. When the Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
-`read_model_switch_ready=true`, but live Projects reads/writes still use
-Hecate-native stores until live read routing, the write adapter, and migration
-path are ready.
+`read_model_switch_ready=true` and the project operations brief can be served
+from the Cairnline read model. Other live Projects reads/writes still use
+Hecate-native stores until the remaining read routes, write adapter, and
+migration path are ready.
 
 Deployment-specific notes:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2202,9 +2202,9 @@ flows against Cairnline without UI-local fallback state. When
 `configured_backend=cairnline`, Hecate still serves live Projects APIs from the
 current Hecate-native stores. `read_model_switch_ready=true` means the
 Cairnline read adapter is wired well enough to project the full current Hecate
-project graph for replacement-readiness checks; it does not mean live Projects
-reads have switched. `write_adapter_ready=false` means writes and migration are
-still Hecate-owned.
+project graph. In that state, the project operations brief can be served from
+the Cairnline read model, while other live Projects reads still use Hecate.
+`write_adapter_ready=false` means writes and migration are still Hecate-owned.
 
 Example response:
 
@@ -2219,10 +2219,11 @@ Example response:
     "cairnline_authoritative": false,
     "read_model_switch_ready": true,
     "write_adapter_ready": false,
-    "status": "cairnline_read_adapter_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the read adapter can project current Hecate stores. Hecate stores remain authoritative until live read routing, writes, and migration are ready.",
+    "status": "cairnline_operations_read_route_ready",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the operations brief read route is served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
     "warnings": [
-      "Live project APIs still read and write Hecate-native stores.",
+      "Only the project operations brief live read route uses Cairnline.",
+      "Other project APIs still read and write Hecate-native stores.",
       "Cairnline write adapter and migration path are not ready."
     ],
     "replacement_readiness_url": "/hecate/v1/projects/{id}/cairnline/read-model"
@@ -3049,6 +3050,7 @@ where the operator reviews the typed proposal before any durable mutation.
   "data": {
     "project_id": "proj_...",
     "generated_at": "2026-06-20T12:00:00Z",
+    "read_backend": "hecate",
     "summary": {
       "item_count": 2,
       "available_item_count": 2,
@@ -3113,6 +3115,12 @@ The response is a convenience contract for operator workspaces, not a new
 durable planner. Project Activity remains the source for live assignment
 buckets, Project Assistant remains the proposal author, and assignment start
 still goes through preflight and explicit operator confirmation.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, this endpoint uses the Cairnline read
+model for portable work operations and then projects those items into Hecate's
+existing cockpit action contract. Hecate-specific setup/defaults items and
+client actions remain Hecate-owned, so `read_backend` identifies the source of
+the work-operations read model rather than a full Projects backend switch.
 Items are capped after sorting by priority, then an explicit operation-kind
 urgency rank, then recency, then id. This keeps blocked or waiting work ahead of
 setup gaps, handoffs ahead of memory triage, and active/completion hygiene below

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -32,10 +32,11 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
 		response.ReadModelSwitchReady = readReady
 		if readReady {
-			response.Status = "cairnline_read_adapter_ready"
-			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the read adapter can project current Hecate stores. Hecate stores remain authoritative until live read routing, writes, and migration are ready."
+			response.Status = "cairnline_operations_read_route_ready"
+			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the operations brief read route is served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
 			response.Warnings = []string{
-				"Live project APIs still read and write Hecate-native stores.",
+				"Only the project operations brief live read route uses Cairnline.",
+				"Other project APIs still read and write Hecate-native stores.",
 				"Cairnline write adapter and migration path are not ready.",
 			}
 			return response

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -42,7 +42,7 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	}
 }
 
-func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadAdapterReady(t *testing.T) {
+func TestProjectCoordinationBackendStatus_CairnlineConfiguredOperationsReadRouteReady(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{
 			Backend:             "sqlite",
@@ -51,8 +51,8 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadAdapterReady(t 
 	}, quietLogger(), nil, nil, nil, nil)
 
 	status := handler.projectCoordinationBackendStatus()
-	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_read_adapter_ready" {
-		t.Fatalf("status = %+v, want configured Cairnline with read adapter ready", status)
+	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_operations_read_route_ready" {
+		t.Fatalf("status = %+v, want configured Cairnline with operations read route ready", status)
 	}
 	if status.CairnlineAuthoritative || !status.ReadModelSwitchReady || status.WriteAdapterReady {
 		t.Fatalf("status = %+v, want read adapter ready but Hecate still authoritative", status)
@@ -85,7 +85,7 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if response.Object != "project_coordination_backend_status" || response.Data.ConfiguredBackend != "cairnline" || response.Data.AuthoritativeBackend != "hecate" {
 		t.Fatalf("response = %+v, want Cairnline configured but Hecate authoritative", response)
 	}
-	if !response.Data.ReadModelSwitchReady || response.Data.Status != "cairnline_read_adapter_ready" {
-		t.Fatalf("response = %+v, want Cairnline read adapter ready for fully wired test handler", response)
+	if !response.Data.ReadModelSwitchReady || response.Data.Status != "cairnline_operations_read_route_ready" {
+		t.Fatalf("response = %+v, want Cairnline operations read route ready for fully wired test handler", response)
 	}
 }

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -36,6 +36,7 @@ type ProjectOperationsBriefEnvelope struct {
 type ProjectOperationsBriefResponse struct {
 	ProjectID   string                                `json:"project_id"`
 	GeneratedAt string                                `json:"generated_at"`
+	ReadBackend string                                `json:"read_backend,omitempty"`
 	Summary     ProjectOperationsBriefSummaryResponse `json:"summary"`
 	Items       []ProjectOperationsBriefItemResponse  `json:"items"`
 }
@@ -99,6 +100,14 @@ func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID st
 	if !ok {
 		return ProjectOperationsBriefResponse{}, projects.ErrNotFound
 	}
+	if h.projectOperationsUseCairnlineReadModel() {
+		return h.renderCairnlineProjectOperationsBrief(ctx, project)
+	}
+	return h.renderNativeProjectOperationsBrief(ctx, project)
+}
+
+func (h *Handler) renderNativeProjectOperationsBrief(ctx context.Context, project projects.Project) (ProjectOperationsBriefResponse, error) {
+	projectID := project.ID
 	activity, err := h.renderProjectActivity(ctx, projectID)
 	if err != nil {
 		return ProjectOperationsBriefResponse{}, err
@@ -143,8 +152,9 @@ func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID st
 	availableItemCount := len(items)
 	items = boundedProjectOperationsItems(items, projectOperationsBriefItemLimit)
 	response := ProjectOperationsBriefResponse{
-		ProjectID:   projectID,
+		ProjectID:   project.ID,
 		GeneratedAt: formatOptionalTime(time.Now().UTC()),
+		ReadBackend: "hecate",
 		Items:       items,
 	}
 	response.Summary.ItemCount = len(items)

--- a/internal/api/handler_project_operations_cairnline.go
+++ b/internal/api/handler_project_operations_cairnline.go
@@ -1,0 +1,304 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) projectOperationsUseCairnlineReadModel() bool {
+	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+		return false
+	}
+	ready, _ := h.cairnlineReadModelReadiness()
+	return ready
+}
+
+func (h *Handler) renderCairnlineProjectOperationsBrief(ctx context.Context, project projects.Project) (ProjectOperationsBriefResponse, error) {
+	brief, snapshot, err := cairnlinebridge.ProjectOperationsBriefFromStores(ctx, h.cairnlineSnapshotSources(), project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	workItemsByID := projectOperationsSnapshotWorkItemsByID(snapshot.WorkItems)
+	assignmentsByID := projectOperationsSnapshotAssignmentsByID(snapshot.Assignments)
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(snapshot.Assignments)
+	artifactsByID := projectOperationsSnapshotArtifactsByID(snapshot.Artifacts)
+	handoffsByID := projectOperationsSnapshotHandoffsByID(snapshot.Handoffs)
+
+	items := make([]ProjectOperationsBriefItemResponse, 0, len(brief.Items)+len(projectDefaultOperationItems(project))+1)
+	items = append(items, projectDefaultOperationItems(project)...)
+	for _, item := range brief.Items {
+		rendered, ok := projectOperationItemFromCairnline(project.ID, item, workItemsByID, assignmentsByID, assignmentsByWorkItem, artifactsByID, handoffsByID)
+		if ok {
+			items = append(items, rendered)
+		}
+	}
+	if brief.Counts.PendingMemoryCandidates > 0 {
+		items = append(items, memoryCandidateOperationItem(project.ID, brief.Counts.PendingMemoryCandidates))
+	}
+	if len(snapshot.WorkItems) == 0 {
+		items = append(items, assignmentGapOperationItems(project.ID, nil, nil)...)
+	}
+	if len(items) == 0 {
+		if item := latestWorkOperationItem(project.ID, snapshot.WorkItems); item != nil {
+			items = append(items, *item)
+		}
+	}
+
+	sortProjectOperationsItems(items)
+	availableItemCount := len(items)
+	items = boundedProjectOperationsItems(items, projectOperationsBriefItemLimit)
+	response := ProjectOperationsBriefResponse{
+		ProjectID:   project.ID,
+		GeneratedAt: formatOptionalTime(firstNonZeroTime(brief.CreatedAt, time.Now().UTC())),
+		ReadBackend: "cairnline",
+		Items:       items,
+	}
+	response.Summary.ItemCount = len(items)
+	response.Summary.AvailableItemCount = availableItemCount
+	response.Summary.OmittedItemCount = availableItemCount - len(items)
+	response.Summary.ItemLimit = projectOperationsBriefItemLimit
+	response.Summary.PendingMemoryCandidateCount = brief.Counts.PendingMemoryCandidates
+	response.Summary.PendingHandoffCount = brief.Counts.OpenHandoffs
+	for _, item := range items {
+		switch item.Priority {
+		case projectOperationsPriorityHigh:
+			response.Summary.HighCount++
+		case projectOperationsPriorityMedium:
+			response.Summary.MediumCount++
+		case projectOperationsPriorityLow:
+			response.Summary.LowCount++
+		}
+	}
+	return response, nil
+}
+
+func projectOperationItemFromCairnline(projectID string, item cairnline.ProjectOperationItem, workItems map[string]projectwork.WorkItem, assignments map[string]projectwork.Assignment, assignmentsByWorkItem map[string][]projectwork.Assignment, artifacts map[string]projectwork.CollaborationArtifact, handoffs map[string]projectwork.Handoff) (ProjectOperationsBriefItemResponse, bool) {
+	switch strings.TrimSpace(item.Kind) {
+	case cairnline.ProjectOperationKindAssignment:
+		return assignmentOperationItemFromCairnline(projectID, item, workItems, assignments)
+	case cairnline.ProjectOperationKindHandoff:
+		handoff, ok := handoffs[item.ArtifactID]
+		if !ok {
+			return genericCairnlineOperationItem(projectID, item, "review_pending_handoff", projectOperationsPriorityMedium, "Open handoff"), true
+		}
+		return handoffOperationItem(projectID, handoff), true
+	case cairnline.ProjectOperationKindMissingEvidence:
+		workItem, workOK := workItems[item.WorkItemID]
+		assignment, assignmentOK := assignments[item.AssignmentID]
+		if workOK && assignmentOK {
+			return completionEvidenceOperationItem(projectID, workItem, assignment), true
+		}
+		return genericCairnlineOperationItem(projectID, item, "record_completion_evidence", projectOperationsPriorityLow, "Open work"), true
+	case cairnline.ProjectOperationKindReviewFollowUp:
+		workItem, workOK := workItems[item.WorkItemID]
+		artifact, artifactOK := artifacts[item.ArtifactID]
+		if workOK && artifactOK {
+			return reviewFollowUpOperationItem(projectID, workItem, artifact), true
+		}
+		return genericCairnlineOperationItem(projectID, item, "review_follow_up", projectOperationsPriorityMedium, "Open review"), true
+	case cairnline.ProjectOperationKindCloseoutReady:
+		workItem, ok := workItems[item.WorkItemID]
+		if !ok {
+			return genericCairnlineOperationItem(projectID, item, "close_work_item", projectOperationsPriorityLow, "Open closeout"), true
+		}
+		return closeWorkItemOperationItem(projectID, workItem, assignmentsByWorkItem[workItem.ID]), true
+	case cairnline.ProjectOperationKindWorkItem:
+		workItem, ok := workItems[item.WorkItemID]
+		if !ok {
+			return genericCairnlineOperationItem(projectID, item, "prepare_first_assignment", projectOperationsPriorityMedium, "Draft assignment"), true
+		}
+		rendered := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
+		target := ProjectOperationsBriefTargetResponse{
+			Surface:    "work",
+			ProjectID:  projectID,
+			WorkItemID: workItem.ID,
+		}
+		return ProjectOperationsBriefItemResponse{
+			ID:          projectOperationsItemID("prepare_first_assignment", projectID, workItem.ID),
+			Kind:        "prepare_first_assignment",
+			Priority:    projectOperationsPriorityMedium,
+			Title:       "Prepare first assignment: " + firstNonEmpty(workItem.Title, workItem.ID),
+			Detail:      firstNonEmpty(item.Detail, "This work item has no queued or running assignments yet."),
+			ActionLabel: "Draft assignment",
+			Status:      firstNonEmpty(workItem.Status, projectwork.WorkItemStatusReady),
+			Target:      target,
+			Action:      projectOperationsDraftProjectProposalAction(projectID, workItem.ID, "Queue an assignment for "+firstNonEmpty(workItem.Title, workItem.ID)),
+			WorkItem:    &rendered,
+			UpdatedAt:   formatOptionalTime(firstNonZeroTime(item.UpdatedAt, projectworkTime(workItem.UpdatedAt, workItem.CreatedAt))),
+		}, true
+	case cairnline.ProjectOperationKindMemoryCandidate:
+		return ProjectOperationsBriefItemResponse{}, false
+	default:
+		return genericCairnlineOperationItem(projectID, item, strings.TrimSpace(item.Kind), cairnlineOperationPriority(item), "Open work"), true
+	}
+}
+
+func assignmentOperationItemFromCairnline(projectID string, item cairnline.ProjectOperationItem, workItems map[string]projectwork.WorkItem, assignments map[string]projectwork.Assignment) (ProjectOperationsBriefItemResponse, bool) {
+	assignment, assignmentOK := assignments[item.AssignmentID]
+	workItem := workItems[item.WorkItemID]
+	if !assignmentOK {
+		return genericCairnlineOperationItem(projectID, item, "inspect_stale_assignment", projectOperationsPriorityHigh, "Open work"), true
+	}
+	status := strings.TrimSpace(item.Status)
+	status = firstNonEmpty(assignment.Status, status)
+	if assignment.Status == projectwork.AssignmentStatusAwaitingApproval ||
+		assignment.ExecutionRef.Status == projectwork.AssignmentStatusAwaitingApproval ||
+		assignment.ExecutionRef.PendingApprovalCount > 0 {
+		return assignmentOperationItemFromHecate(projectID, workItem, assignment, "approve_assignment", projectOperationsPriorityHigh, "Review pending approval", projectActivityApprovalSummary(assignment), "Open approval", "awaiting_approval", "blocked"), true
+	}
+	switch status {
+	case projectwork.AssignmentStatusQueued:
+		return assignmentOperationItemFromHecate(projectID, workItem, assignment, "start_queued_assignment", projectOperationsPriorityHigh, "Review queued assignment", "Open launch preflight before starting this assignment.", "Review start", "not_started", "blocked"), true
+	case projectwork.AssignmentStatusFailed:
+		return assignmentOperationItemFromHecate(projectID, workItem, assignment, "review_failed_assignment", projectOperationsPriorityHigh, "Review failed assignment", firstNonEmpty(item.Detail, "failed run"), "Open work", "failed", "blocked"), true
+	case projectwork.AssignmentStatusCancelled:
+		return assignmentOperationItemFromHecate(projectID, workItem, assignment, "review_cancelled_assignment", projectOperationsPriorityMedium, "Review cancelled assignment", firstNonEmpty(item.Detail, "cancelled"), "Open work", "cancelled", "blocked"), true
+	case projectwork.AssignmentStatusRunning, cairnline.AssignmentClaimed, cairnline.AssignmentReview:
+		return assignmentOperationItemFromHecate(projectID, workItem, assignment, "inspect_active_assignment", projectOperationsPriorityLow, "Inspect active assignment", firstNonEmpty(item.Detail, "running"), "Inspect work", "running", "active"), true
+	default:
+		return assignmentOperationItemFromHecate(projectID, workItem, assignment, "inspect_stale_assignment", projectOperationsPriorityHigh, "Inspect stale assignment link", firstNonEmpty(item.Detail, "stale assignment link"), "Open work", "stale_unknown", "blocked"), true
+	}
+}
+
+func assignmentOperationItemFromHecate(projectID string, workItem projectwork.WorkItem, assignment projectwork.Assignment, kind, priority, titlePrefix, detail, actionLabel, status, bucket string) ProjectOperationsBriefItemResponse {
+	renderedWorkItem := renderProjectActivityWorkItem(renderProjectWorkItem(workItem))
+	renderedAssignment := renderProjectWorkAssignment(assignment)
+	target := ProjectOperationsBriefTargetResponse{
+		Surface:        "work",
+		ProjectID:      projectID,
+		WorkItemID:     firstNonEmpty(workItem.ID, assignment.WorkItemID),
+		AssignmentID:   assignment.ID,
+		ActivityBucket: bucket,
+	}
+	action := projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, target.AssignmentID, "", target.ActivityBucket)
+	if kind == "start_queued_assignment" {
+		action = projectOperationsOpenAssignmentPreflightAction(target.ProjectID, target.WorkItemID, target.AssignmentID, target.ActivityBucket)
+	}
+	return ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID(kind, projectID, assignment.ID),
+		Kind:        kind,
+		Priority:    priority,
+		Title:       titlePrefix + ": " + firstNonEmpty(workItem.Title, assignment.ID),
+		Detail:      detail,
+		ActionLabel: actionLabel,
+		Status:      status,
+		Target:      target,
+		Action:      action,
+		WorkItem:    &renderedWorkItem,
+		Assignment:  &renderedAssignment,
+		UpdatedAt:   formatOptionalTime(projectworkTime(assignment.UpdatedAt, assignment.StartedAt, assignment.CreatedAt, workItem.UpdatedAt, workItem.CreatedAt)),
+	}
+}
+
+func handoffOperationItem(projectID string, handoff projectwork.Handoff) ProjectOperationsBriefItemResponse {
+	rendered := renderProjectHandoff(handoff)
+	target := ProjectOperationsBriefTargetResponse{
+		Surface:      "work",
+		ProjectID:    projectID,
+		WorkItemID:   handoff.WorkItemID,
+		HandoffID:    handoff.ID,
+		AssignmentID: firstNonEmpty(handoff.TargetAssignmentID, handoff.SourceAssignmentID),
+	}
+	return ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID("review_pending_handoff", projectID, handoff.ID),
+		Kind:        "review_pending_handoff",
+		Priority:    projectOperationsPriorityMedium,
+		Title:       "Review pending handoff: " + firstNonEmpty(handoff.Title, handoff.ID),
+		Detail:      firstNonEmpty(handoff.RecommendedNextAction, handoff.Summary, "Review the handoff and decide the next assignment."),
+		ActionLabel: "Open handoff",
+		Status:      handoff.Status,
+		Target:      target,
+		Action:      projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, target.AssignmentID, target.HandoffID, ""),
+		Handoff:     &rendered,
+		UpdatedAt:   formatOptionalTime(projectworkTime(handoff.UpdatedAt, handoff.CreatedAt)),
+	}
+}
+
+func genericCairnlineOperationItem(projectID string, item cairnline.ProjectOperationItem, kind, priority, actionLabel string) ProjectOperationsBriefItemResponse {
+	target := ProjectOperationsBriefTargetResponse{
+		Surface:      "work",
+		ProjectID:    projectID,
+		WorkItemID:   item.WorkItemID,
+		AssignmentID: item.AssignmentID,
+	}
+	return ProjectOperationsBriefItemResponse{
+		ID:          projectOperationsItemID(kind, projectID, firstNonEmpty(item.AssignmentID, item.ArtifactID, item.MemoryCandidateID, item.WorkItemID)),
+		Kind:        kind,
+		Priority:    priority,
+		Title:       item.Title,
+		Detail:      item.Detail,
+		ActionLabel: actionLabel,
+		Status:      item.Status,
+		Target:      target,
+		Action:      projectOperationsOpenWorkItemAction(target.ProjectID, target.WorkItemID, target.AssignmentID, "", ""),
+		UpdatedAt:   formatOptionalTime(item.UpdatedAt),
+	}
+}
+
+func projectActivityApprovalSummary(assignment projectwork.Assignment) string {
+	if assignment.ExecutionRef.PendingApprovalCount > 0 {
+		if assignment.ExecutionRef.PendingApprovalCount == 1 {
+			return "1 approval pending"
+		}
+		return intString(assignment.ExecutionRef.PendingApprovalCount) + " approvals pending"
+	}
+	return "awaiting approval"
+}
+
+func cairnlineOperationPriority(item cairnline.ProjectOperationItem) string {
+	switch strings.TrimSpace(item.Severity) {
+	case cairnline.ProjectOperationSeverityBlocked:
+		return projectOperationsPriorityHigh
+	case cairnline.ProjectOperationSeverityAction:
+		return projectOperationsPriorityMedium
+	default:
+		return projectOperationsPriorityLow
+	}
+}
+
+func projectOperationsSnapshotWorkItemsByID(items []projectwork.WorkItem) map[string]projectwork.WorkItem {
+	out := make(map[string]projectwork.WorkItem, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func projectOperationsSnapshotAssignmentsByID(items []projectwork.Assignment) map[string]projectwork.Assignment {
+	out := make(map[string]projectwork.Assignment, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func projectOperationsSnapshotArtifactsByID(items []projectwork.CollaborationArtifact) map[string]projectwork.CollaborationArtifact {
+	out := make(map[string]projectwork.CollaborationArtifact, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func projectOperationsSnapshotHandoffsByID(items []projectwork.Handoff) map[string]projectwork.Handoff {
+	out := make(map[string]projectwork.Handoff, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Time{}
+}

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -102,6 +103,9 @@ func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
 	if response.Object != "project_operations_brief" || response.Data.ProjectID != "proj_ops" {
 		t.Fatalf("operations envelope = %+v, want project_operations_brief for project", response)
 	}
+	if response.Data.ReadBackend != "hecate" {
+		t.Fatalf("operations read_backend = %q, want hecate", response.Data.ReadBackend)
+	}
 	if response.Data.Summary.PendingMemoryCandidateCount != 1 || response.Data.Summary.PendingHandoffCount != 1 {
 		t.Fatalf("operations summary = %+v, want memory candidate and handoff counts", response.Data.Summary)
 	}
@@ -141,6 +145,86 @@ func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
 	}
 	if len(afterAssignments) != len(beforeAssignments) || len(afterCandidates) != len(beforeCandidates) {
 		t.Fatalf("operations brief mutated project state: assignments %d->%d candidates %d->%d", len(beforeAssignments), len(afterAssignments), len(beforeCandidates), len(afterCandidates))
+	}
+}
+
+func TestProjectOperationsBrief_CairnlineConfiguredUsesReadModel(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_cairnline_ops",
+		Name:            "Cairnline Operations",
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-5",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_cairnline_ops",
+		ProjectID: "proj_cairnline_ops",
+		Title:     "Exercise Cairnline operations",
+		Status:    projectwork.WorkItemStatusRunning,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_cairnline_approval",
+		ProjectID:  "proj_cairnline_ops",
+		WorkItemID: "work_cairnline_ops",
+		RoleID:     "software_developer",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusAwaitingApproval,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:                 projectwork.AssignmentExecutionKindTaskRun,
+			TaskID:               "task_cairnline",
+			RunID:                "run_cairnline",
+			Status:               projectwork.AssignmentStatusAwaitingApproval,
+			PendingApprovalCount: 2,
+		},
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+	if _, err := handler.memoryCandidates.CreateCandidate(t.Context(), memory.Candidate{
+		ID:        "memcand_cairnline_ops",
+		ProjectID: "proj_cairnline_ops",
+		Title:     "Cairnline memory",
+		Body:      "Operations keeps memory review visible.",
+		Status:    memory.CandidateStatusPending,
+	}); err != nil {
+		t.Fatalf("CreateCandidate: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_cairnline_ops/operations/brief", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operations brief status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectOperationsBriefEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode operations brief: %v", err)
+	}
+	if response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("operations read_backend = %q, want cairnline", response.Data.ReadBackend)
+	}
+	if response.Data.Summary.PendingMemoryCandidateCount != 1 {
+		t.Fatalf("operations summary = %+v, want pending memory candidate from Cairnline read model", response.Data.Summary)
+	}
+	approval := findProjectOperationsItemForTest(t, response.Data.Items, "approve_assignment")
+	if approval.Target.AssignmentID != "asgn_cairnline_approval" || approval.Action.Type != projectOperationsActionOpenWorkItem || approval.Status != "awaiting_approval" {
+		t.Fatalf("approval item = %+v, want Hecate action projection over Cairnline assignment item", approval)
+	}
+	if approval.Detail != "2 approvals pending" {
+		t.Fatalf("approval detail = %q, want pending approval count preserved", approval.Detail)
+	}
+	memoryItem := findProjectOperationsItemForTest(t, response.Data.Items, "review_memory_candidates")
+	if memoryItem.Target.Surface != "memory" || memoryItem.Action.Type != projectOperationsActionOpenMemoryReview {
+		t.Fatalf("memory item = %+v, want memory review action", memoryItem)
 	}
 }
 


### PR DESCRIPTION
## Summary
- route `/hecate/v1/projects/{id}/operations/brief` through the Cairnline read model when `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the read adapter is ready
- project Cairnline portable operation items into Hecate cockpit actions while keeping Hecate-specific setup/default rows in Hecate
- report the active operations read route in backend status and document the partial switch semantics

## Validation
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProject(OperationsBrief|CoordinationBackendStatus)'\n- GOCACHE="$PWD/.gocache" go test ./internal/cairnlinebridge\n- just agent-docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge\n- GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/cairnlinebridge\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go vet ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n