### PR TITLE
feat: route activity reads through Cairnline

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -113,13 +113,14 @@ coordination backend, whether the Cairnline read adapter can project the full
 current Hecate project graph, and whether Cairnline is actually authoritative.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
-it reports `cairnline_operations_read_route_ready`, and the live project
-operations brief can use the Cairnline read model for portable work operations.
-Hecate stores remain authoritative, Hecate-specific setup/action projection
-remains in Hecate, and other live Projects reads/writes still use the
-Hecate-native API. `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds
-an in-memory Cairnline service from the current Hecate stores and returns the
-portable operations brief and activity projection without writing files.
+it reports `cairnline_read_routes_ready`, and the live project activity inbox
+plus operations brief can use the Cairnline read model for portable assignment
+and work operations. Hecate stores remain authoritative, Hecate-specific
+runtime enrichment and setup/action projection remain in Hecate, and other live
+Projects reads/writes still use the Hecate-native API.
+`GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
+Cairnline service from the current Hecate stores and returns the portable
+operations brief and activity projection without writing files.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
 differences, so bucket/status semantics can be fixed before any backend switch.
@@ -141,7 +142,7 @@ after these gates are met:
   artifact, handoff, accepted-memory, and memory-candidate flows.
 - Hecate has feature-flagged adapters that can run all read/write Projects
   flows against Cairnline without UI-local fallback state. The first live read
-  route is the operations brief; activity, setup/context, work detail, and
+  routes are activity and operations brief; setup/context, work detail, and
   write routes still need their own switch points.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -357,10 +357,10 @@ and durable grants so transcripts and approval history move together.
 storage backend. The default is `hecate`. `cairnline` records replacement intent
 for local bridge experiments. When the Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
-`read_model_switch_ready=true` and the project operations brief can be served
-from the Cairnline read model. Other live Projects reads/writes still use
-Hecate-native stores until the remaining read routes, write adapter, and
-migration path are ready.
+`read_model_switch_ready=true`, and the project activity inbox plus operations
+brief can be served from the Cairnline read model. Other live Projects
+reads/writes still use Hecate-native stores until the remaining read routes,
+write adapter, and migration path are ready.
 
 Deployment-specific notes:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2202,8 +2202,9 @@ flows against Cairnline without UI-local fallback state. When
 `configured_backend=cairnline`, Hecate still serves live Projects APIs from the
 current Hecate-native stores. `read_model_switch_ready=true` means the
 Cairnline read adapter is wired well enough to project the full current Hecate
-project graph. In that state, the project operations brief can be served from
-the Cairnline read model, while other live Projects reads still use Hecate.
+project graph. In that state, the project activity inbox and operations brief
+can be served from the Cairnline read model, while other live Projects reads
+still use Hecate.
 `write_adapter_ready=false` means writes and migration are still Hecate-owned.
 
 Example response:
@@ -2219,10 +2220,10 @@ Example response:
     "cairnline_authoritative": false,
     "read_model_switch_ready": true,
     "write_adapter_ready": false,
-    "status": "cairnline_operations_read_route_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the operations brief read route is served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
+    "status": "cairnline_read_routes_ready",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the activity and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
     "warnings": [
-      "Only the project operations brief live read route uses Cairnline.",
+      "Only the project activity and operations brief live read routes use Cairnline.",
       "Other project APIs still read and write Hecate-native stores.",
       "Cairnline write adapter and migration path are not ready."
     ],
@@ -2691,12 +2692,19 @@ The top-level envelope follows the Hecate-native convention:
 
 Activity items are exposed through `data.recent` and the `data.buckets`
 collections. There is no top-level `data.items` list.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, this endpoint uses the Cairnline read
+model for the portable assignment activity set and then enriches those rows with
+Hecate runtime, linked chat, artifact, handoff, and cockpit bucket metadata.
+`read_backend` identifies the source of the assignment activity read model, not
+a full Projects backend switch.
 
 ```json
 {
   "object": "project_activity",
   "data": {
     "project_id": "proj_...",
+    "read_backend": "hecate",
     "summary": {
       "work_item_count": 3,
       "assignment_count": 5,

--- a/internal/api/handler_project_activity.go
+++ b/internal/api/handler_project_activity.go
@@ -17,10 +17,11 @@ type ProjectActivityEnvelope struct {
 }
 
 type ProjectActivityDataResponse struct {
-	ProjectID string                         `json:"project_id"`
-	Summary   ProjectActivitySummaryResponse `json:"summary"`
-	Buckets   ProjectActivityBucketsResponse `json:"buckets"`
-	Recent    []ProjectActivityItemResponse  `json:"recent"`
+	ProjectID   string                         `json:"project_id"`
+	ReadBackend string                         `json:"read_backend,omitempty"`
+	Summary     ProjectActivitySummaryResponse `json:"summary"`
+	Buckets     ProjectActivityBucketsResponse `json:"buckets"`
+	Recent      []ProjectActivityItemResponse  `json:"recent"`
 }
 
 type ProjectActivitySummaryResponse struct {
@@ -105,6 +106,13 @@ type ProjectActivityHandoffSummaryResponse struct {
 }
 
 func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectActivity(ctx, projectID)
+	}
+	return h.renderNativeProjectActivity(ctx, projectID)
+}
+
+func (h *Handler) renderNativeProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
 	roles, err := h.projectWork.ListRoles(ctx, projectID)
 	if err != nil {
 		return ProjectActivityDataResponse{}, err
@@ -161,8 +169,9 @@ func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (
 	sortProjectActivityItems(items)
 
 	response := ProjectActivityDataResponse{
-		ProjectID: projectID,
-		Recent:    boundedProjectActivityItems(items, 20),
+		ProjectID:   projectID,
+		ReadBackend: "hecate",
+		Recent:      boundedProjectActivityItems(items, 20),
 	}
 	response.Summary.WorkItemCount = len(workItems)
 	response.Summary.AssignmentCount = len(assignments)

--- a/internal/api/handler_project_activity_cairnline.go
+++ b/internal/api/handler_project_activity_cairnline.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) renderCairnlineProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
+	activity, snapshot, err := cairnlinebridge.ProjectActivityFromStores(ctx, h.cairnlineSnapshotSources(), projectID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(snapshot.Assignments)
+	projectedWorkItems := make(map[string]ProjectWorkItemResponse, len(snapshot.WorkItems))
+	projectedAssignments := make(map[string]ProjectWorkAssignmentResponse, len(snapshot.Assignments))
+	for _, item := range snapshot.WorkItems {
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
+		if err != nil {
+			return ProjectActivityDataResponse{}, err
+		}
+		projectedWorkItems[item.ID] = projected
+		for _, assignment := range projected.Assignments {
+			projectedAssignments[assignment.ID] = assignment
+		}
+	}
+	rolesByID := projectActivitySnapshotRolesByID(snapshot.Roles)
+	linkedChats := h.projectActivityLinkedChats(ctx, projectID, snapshot.Assignments)
+	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(snapshot.Artifacts)
+	handoffsByAssignment, handoffsByWorkItem := groupProjectActivityHandoffs(snapshot.Handoffs)
+
+	items := make([]ProjectActivityItemResponse, 0, len(activity.Items))
+	for _, item := range activity.Items {
+		projectedWorkItem, ok := projectedWorkItems[item.WorkItemID]
+		if !ok {
+			continue
+		}
+		projectedAssignment, ok := projectedAssignments[item.AssignmentID]
+		if !ok {
+			continue
+		}
+		activityArtifacts := artifactsByAssignment[projectedAssignment.ID]
+		if len(activityArtifacts) == 0 {
+			activityArtifacts = artifactsByWorkItem[projectedAssignment.WorkItemID]
+		}
+		activityHandoffs := handoffsByAssignment[projectedAssignment.ID]
+		if len(activityHandoffs) == 0 {
+			activityHandoffs = handoffsByWorkItem[projectedAssignment.WorkItemID]
+		}
+		role, _ := rolesByID[projectedAssignment.RoleID]
+		items = append(items, renderProjectActivityItem(projectedWorkItem, projectedAssignment, role, activityArtifacts, activityHandoffs, linkedChats[projectedAssignment.ID]))
+	}
+	sortProjectActivityItems(items)
+
+	response := ProjectActivityDataResponse{
+		ProjectID:   projectID,
+		ReadBackend: "cairnline",
+		Recent:      boundedProjectActivityItems(items, 20),
+	}
+	response.Summary.WorkItemCount = len(snapshot.WorkItems)
+	response.Summary.AssignmentCount = activity.Counts.Assignments
+	for _, item := range items {
+		switch projectActivityBucket(item) {
+		case "active":
+			response.Buckets.Active = append(response.Buckets.Active, item)
+			response.Summary.ActiveCount++
+		case "blocked":
+			response.Buckets.Blocked = append(response.Buckets.Blocked, item)
+			response.Summary.BlockedCount++
+		case "completed":
+			response.Buckets.Completed = append(response.Buckets.Completed, item)
+			response.Summary.CompletedCount++
+		}
+	}
+	response.Buckets.Recent = response.Recent
+	response.Summary.RecentCount = len(response.Recent)
+	response.Buckets.Active = boundedProjectActivityItems(response.Buckets.Active, 20)
+	response.Buckets.Blocked = boundedProjectActivityItems(response.Buckets.Blocked, 20)
+	response.Buckets.Completed = boundedProjectActivityItems(response.Buckets.Completed, 20)
+	return response, nil
+}
+
+func projectActivitySnapshotRolesByID(items []projectwork.AgentRoleProfile) map[string]projectwork.AgentRoleProfile {
+	out := make(map[string]projectwork.AgentRoleProfile, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -96,12 +96,12 @@ func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	nativeActivity, err := h.renderProjectActivity(r.Context(), projectID)
+	nativeActivity, err := h.renderNativeProjectActivity(r.Context(), projectID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	nativeOperations, err := h.renderProjectOperationsBrief(r.Context(), projectID)
+	nativeOperations, err := h.renderNativeProjectOperationsBriefByID(r.Context(), projectID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -32,10 +32,10 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
 		response.ReadModelSwitchReady = readReady
 		if readReady {
-			response.Status = "cairnline_operations_read_route_ready"
-			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the operations brief read route is served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
+			response.Status = "cairnline_read_routes_ready"
+			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the activity and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
 			response.Warnings = []string{
-				"Only the project operations brief live read route uses Cairnline.",
+				"Only the project activity and operations brief live read routes use Cairnline.",
 				"Other project APIs still read and write Hecate-native stores.",
 				"Cairnline write adapter and migration path are not ready.",
 			}

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -42,7 +42,7 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	}
 }
 
-func TestProjectCoordinationBackendStatus_CairnlineConfiguredOperationsReadRouteReady(t *testing.T) {
+func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{
 			Backend:             "sqlite",
@@ -51,8 +51,8 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredOperationsReadRoute
 	}, quietLogger(), nil, nil, nil, nil)
 
 	status := handler.projectCoordinationBackendStatus()
-	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_operations_read_route_ready" {
-		t.Fatalf("status = %+v, want configured Cairnline with operations read route ready", status)
+	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_read_routes_ready" {
+		t.Fatalf("status = %+v, want configured Cairnline with read routes ready", status)
 	}
 	if status.CairnlineAuthoritative || !status.ReadModelSwitchReady || status.WriteAdapterReady {
 		t.Fatalf("status = %+v, want read adapter ready but Hecate still authoritative", status)
@@ -85,7 +85,7 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if response.Object != "project_coordination_backend_status" || response.Data.ConfiguredBackend != "cairnline" || response.Data.AuthoritativeBackend != "hecate" {
 		t.Fatalf("response = %+v, want Cairnline configured but Hecate authoritative", response)
 	}
-	if !response.Data.ReadModelSwitchReady || response.Data.Status != "cairnline_operations_read_route_ready" {
-		t.Fatalf("response = %+v, want Cairnline operations read route ready for fully wired test handler", response)
+	if !response.Data.ReadModelSwitchReady || response.Data.Status != "cairnline_read_routes_ready" {
+		t.Fatalf("response = %+v, want Cairnline read routes ready for fully wired test handler", response)
 	}
 }

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -100,8 +100,19 @@ func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID st
 	if !ok {
 		return ProjectOperationsBriefResponse{}, projects.ErrNotFound
 	}
-	if h.projectOperationsUseCairnlineReadModel() {
+	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectOperationsBrief(ctx, project)
+	}
+	return h.renderNativeProjectOperationsBrief(ctx, project)
+}
+
+func (h *Handler) renderNativeProjectOperationsBriefByID(ctx context.Context, projectID string) (ProjectOperationsBriefResponse, error) {
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	if !ok {
+		return ProjectOperationsBriefResponse{}, projects.ErrNotFound
 	}
 	return h.renderNativeProjectOperationsBrief(ctx, project)
 }

--- a/internal/api/handler_project_operations_cairnline.go
+++ b/internal/api/handler_project_operations_cairnline.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
-func (h *Handler) projectOperationsUseCairnlineReadModel() bool {
+func (h *Handler) projectReadRoutesUseCairnlineReadModel() bool {
 	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
 		return false
 	}

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2967,6 +2967,9 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 			if response.Object != "project_activity" || response.Data.ProjectID != "proj_projection" {
 				t.Fatalf("activity envelope = %+v, want project_activity for project", response)
 			}
+			if response.Data.ReadBackend != "hecate" {
+				t.Fatalf("activity read_backend = %q, want hecate", response.Data.ReadBackend)
+			}
 			if response.Data.Summary.WorkItemCount == 0 || response.Data.Summary.AssignmentCount == 0 {
 				t.Fatalf("activity summary = %+v, want work and assignment counts", response.Data.Summary)
 			}
@@ -3063,6 +3066,42 @@ func TestProjectWorkAPI_ProjectActivity(t *testing.T) {
 				t.Fatalf("recent activity = %+v buckets=%+v, want mirrored recent list", response.Data.Recent, response.Data.Buckets.Recent)
 			}
 		})
+	}
+}
+
+func TestProjectWorkAPI_ProjectActivityCairnlineConfiguredUsesReadModel(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	seedProjectWorkProjectionTest(t, handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/activity", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("activity status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectActivityEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode activity: %v", err)
+	}
+	if response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("activity read_backend = %q, want cairnline", response.Data.ReadBackend)
+	}
+	if response.Data.Summary.WorkItemCount == 0 || response.Data.Summary.AssignmentCount == 0 || response.Data.Summary.RecentCount == 0 {
+		t.Fatalf("activity summary = %+v, want Cairnline-backed activity counts", response.Data.Summary)
+	}
+	awaiting := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_awaiting")
+	if awaiting.BlockingSignal != "awaiting_approval" || awaiting.StatusSummary != "1 approval pending" || awaiting.Assignment.ExecutionRef == nil {
+		t.Fatalf("awaiting activity = %+v, want Hecate approval projection over Cairnline activity", awaiting)
+	}
+	if awaiting.WorkItem.Title != "work_awaiting" || awaiting.Role.Name != "Projection engineer" {
+		t.Fatalf("awaiting context = %+v role=%+v, want work and role enrichment", awaiting.WorkItem, awaiting.Role)
+	}
+	completed := findProjectActivityItemForTest(t, response.Data.Buckets.Completed, "asgn_completed")
+	if completed.ArtifactSummary.Count != 1 || completed.HandoffSummary.Count != 1 {
+		t.Fatalf("completed activity = %+v, want artifact and handoff enrichment", completed)
 	}
 }
 


### PR DESCRIPTION
Summary
- Route Project Activity through the Cairnline read model when `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the read adapter is ready.
- Preserve Hecate runtime, linked chat, artifact, handoff, and cockpit bucket enrichment over Cairnline assignment activity rows.
- Keep Cairnline parity reports comparing against explicit native renderers after live read routes switch.
- Update runtime/operator/design docs and backend status wording for the activity + operations read-route scope.

Validation
- `just agent-docs-check`
- `GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge`
- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/cairnlinebridge`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go vet ./...`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`