### PR TITLE
feat: route work item reads through Cairnline

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -114,10 +114,11 @@ current Hecate project graph, and whether Cairnline is actually authoritative.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 it reports `cairnline_read_routes_ready`, and the live project activity inbox
-plus operations brief can use the Cairnline read model for portable assignment
-and work operations. Hecate stores remain authoritative, Hecate-specific
-runtime enrichment and setup/action projection remain in Hecate, and other live
-Projects reads/writes still use the Hecate-native API.
+plus work-item list/detail, closeout readiness, and operations brief can use
+the Cairnline read model for portable work state. Hecate stores remain
+authoritative, Hecate-specific runtime enrichment and setup/action projection
+remain in Hecate, and other live Projects reads/writes still use the
+Hecate-native API.
 `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
 Cairnline service from the current Hecate stores and returns the portable
 operations brief and activity projection without writing files.
@@ -142,8 +143,9 @@ after these gates are met:
   artifact, handoff, accepted-memory, and memory-candidate flows.
 - Hecate has feature-flagged adapters that can run all read/write Projects
   flows against Cairnline without UI-local fallback state. The first live read
-  routes are activity and operations brief; setup/context, work detail, and
-  write routes still need their own switch points.
+  routes are activity, work-item list/detail, closeout readiness, and
+  operations brief; setup/context and write routes still need their own switch
+  points.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha.
 - Context packets, setup/health/operations summaries, activity projections, and

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -357,10 +357,11 @@ and durable grants so transcripts and approval history move together.
 storage backend. The default is `hecate`. `cairnline` records replacement intent
 for local bridge experiments. When the Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
-`read_model_switch_ready=true`, and the project activity inbox plus operations
-brief can be served from the Cairnline read model. Other live Projects
-reads/writes still use Hecate-native stores until the remaining read routes,
-write adapter, and migration path are ready.
+`read_model_switch_ready=true`, and the project work-item list/detail, closeout
+readiness, activity inbox, and operations brief can be served from the
+Cairnline read model. Other live Projects reads/writes still use Hecate-native
+stores until the remaining read routes, write adapter, and migration path are
+ready.
 
 Deployment-specific notes:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2221,9 +2221,9 @@ Example response:
     "read_model_switch_ready": true,
     "write_adapter_ready": false,
     "status": "cairnline_read_routes_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the activity and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the work-item, activity, readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
     "warnings": [
-      "Only the project activity and operations brief live read routes use Cairnline.",
+      "Only the project work-item, activity, readiness, and operations brief live read routes use Cairnline.",
       "Other project APIs still read and write Hecate-native stores.",
       "Cairnline write adapter and migration path are not ready."
     ],
@@ -3298,6 +3298,10 @@ summaries in `assignments` when assignments exist, so callers can render list
 status/count signals without issuing one assignment request per work item.
 The nested assignment objects use the same shape as
 `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, the work-item set is read from the
+Cairnline read model and then enriched with Hecate runtime assignment
+projection. `read_backend` identifies that read-model source.
 
 #### `POST /hecate/v1/projects/{id}/work-items`
 
@@ -3325,6 +3329,7 @@ Returns:
   "data": {
     "id": "work_...",
     "project_id": "proj_...",
+    "read_backend": "hecate",
     "title": "Backend substrate",
     "brief": "Persist coordination metadata only.",
     "status": "ready",
@@ -3340,7 +3345,9 @@ Returns:
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}`
 
-Returns one work item or `404 not_found`.
+Returns one work item or `404 not_found`. Under the same Cairnline read-route
+switch described above, the selected work item is read from Cairnline and
+enriched with Hecate assignment runtime projection.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/readiness`
 
@@ -3359,6 +3366,7 @@ operator still applies the durable `status="done"` mutation through
   "data": {
     "project_id": "proj_...",
     "work_item_id": "work_...",
+    "read_backend": "hecate",
     "ready": false,
     "status": "blocked",
     "title": "Closeout is blocked",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -33,9 +33,9 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.ReadModelSwitchReady = readReady
 		if readReady {
 			response.Status = "cairnline_read_routes_ready"
-			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the activity and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
+			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the work-item, activity, readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
 			response.Warnings = []string{
-				"Only the project activity and operations brief live read routes use Cairnline.",
+				"Only the project work-item, activity, readiness, and operations brief live read routes use Cairnline.",
 				"Other project APIs still read and write Hecate-native stores.",
 				"Cairnline write adapter and migration path are not ready.",
 			}

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -182,6 +182,7 @@ type ProjectWorkItemEnvelope struct {
 type ProjectWorkItemResponse struct {
 	ID              string                          `json:"id"`
 	ProjectID       string                          `json:"project_id"`
+	ReadBackend     string                          `json:"read_backend,omitempty"`
 	Title           string                          `json:"title"`
 	Brief           string                          `json:"brief,omitempty"`
 	Status          string                          `json:"status"`
@@ -417,25 +418,10 @@ func (h *Handler) HandleProjectWorkItems(w http.ResponseWriter, r *http.Request)
 	if !h.requireProject(w, r, projectID) {
 		return
 	}
-	items, err := h.projectWork.ListWorkItems(r.Context(), projectID)
+	data, err := h.renderProjectWorkItems(r.Context(), projectID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
-	}
-	assignments, err := h.projectWork.ListAssignments(r.Context(), projectwork.AssignmentFilter{ProjectID: projectID})
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
-	data := make([]ProjectWorkItemResponse, 0, len(items))
-	for _, item := range items {
-		projected, err := h.renderProjectedProjectWorkItemWithAssignments(r.Context(), item, assignmentsByWorkItem[item.ID])
-		if err != nil {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-		data = append(data, projected)
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkItemsResponse{Object: "project_work_items", Data: data})
 }
@@ -478,6 +464,19 @@ func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) 
 	if !h.requireProject(w, r, projectID) {
 		return
 	}
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		projected, err := h.renderCairnlineProjectWorkItem(r.Context(), projectID, r.PathValue("work_item_id"))
+		if err != nil {
+			if errors.Is(err, projectwork.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+				return
+			}
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
+		return
+	}
 	item, ok, err := h.projectWork.GetWorkItem(r.Context(), projectID, r.PathValue("work_item_id"))
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -492,6 +491,7 @@ func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) 
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	projected.ReadBackend = "hecate"
 	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
 }
 

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) renderProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectWorkItems(ctx, projectID)
+	}
+	items, err := h.projectWork.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return nil, err
+	}
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	data := make([]ProjectWorkItemResponse, 0, len(items))
+	for _, item := range items {
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
+		if err != nil {
+			return nil, err
+		}
+		projected.ReadBackend = "hecate"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := service.ListWorkItems(ctx, snapshot.Project.ID)
+	if err != nil {
+		return nil, err
+	}
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(snapshot.Assignments)
+	data := make([]ProjectWorkItemResponse, 0, len(items))
+	for _, item := range items {
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, projectWorkItemFromCairnline(item), assignmentsByWorkItem[item.ID])
+		if err != nil {
+			return nil, err
+		}
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineProjectWorkItem(ctx context.Context, projectID, workItemID string) (ProjectWorkItemResponse, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return ProjectWorkItemResponse{}, err
+	}
+	items, err := service.ListWorkItems(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectWorkItemResponse{}, err
+	}
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(snapshot.Assignments)
+	for _, item := range items {
+		if item.ID != workItemID {
+			continue
+		}
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, projectWorkItemFromCairnline(item), assignmentsByWorkItem[item.ID])
+		if err != nil {
+			return ProjectWorkItemResponse{}, err
+		}
+		projected.ReadBackend = "cairnline"
+		return projected, nil
+	}
+	return ProjectWorkItemResponse{}, projectwork.ErrNotFound
+}
+
+func (h *Handler) renderCairnlineProjectWorkItemReadiness(ctx context.Context, projectID, workItemID string) (ProjectWorkItemReadinessResponse, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	readiness, err := service.WorkItemCloseoutReadiness(ctx, snapshot.Project.ID, workItemID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return ProjectWorkItemReadinessResponse{}, projectwork.ErrNotFound
+	}
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	return renderCairnlineProjectWorkItemReadiness(readiness), nil
+}
+
+func (h *Handler) cairnlineProjectWorkService(ctx context.Context, projectID string) (*cairnline.Service, cairnlinebridge.Snapshot, error) {
+	service := cairnline.NewMemoryService()
+	snapshot, err := cairnlinebridge.SeedProjectFromStores(ctx, service, h.cairnlineSnapshotSources(), projectID)
+	if err != nil {
+		return nil, cairnlinebridge.Snapshot{}, err
+	}
+	return service, snapshot, nil
+}
+
+func projectWorkItemFromCairnline(item cairnline.WorkItem) projectwork.WorkItem {
+	return projectwork.WorkItem{
+		ID:              item.ID,
+		ProjectID:       item.ProjectID,
+		Title:           item.Title,
+		Brief:           item.Brief,
+		Status:          item.Status,
+		Priority:        item.Priority,
+		OwnerRoleID:     item.OwnerRoleID,
+		RootID:          item.RootID,
+		ReviewerRoleIDs: append([]string(nil), item.ReviewerRoleIDs...),
+		CreatedAt:       item.CreatedAt,
+		UpdatedAt:       item.UpdatedAt,
+	}
+}
+
+func renderCairnlineProjectWorkItemReadiness(readiness cairnline.WorkItemCloseoutReadiness) ProjectWorkItemReadinessResponse {
+	return ProjectWorkItemReadinessResponse{
+		ProjectID:                    readiness.ProjectID,
+		WorkItemID:                   readiness.WorkItemID,
+		ReadBackend:                  "cairnline",
+		Ready:                        readiness.Ready,
+		Status:                       readiness.Status,
+		Title:                        readiness.Title,
+		Detail:                       readiness.Detail,
+		Blockers:                     append([]string(nil), readiness.Blockers...),
+		Warnings:                     append([]string(nil), readiness.Warnings...),
+		AssignmentCount:              readiness.AssignmentCount,
+		CompletedAssignments:         readiness.CompletedAssignments,
+		ReviewFollowUpCount:          readiness.ReviewFollowUpCount,
+		ReviewFollowUpArtifactIDs:    append([]string(nil), readiness.ReviewFollowUpArtifactIDs...),
+		ReviewFollowUps:              renderCairnlineProjectWorkItemReviewFollowUps(readiness.ReviewFollowUps),
+		MissingEvidenceAssignmentIDs: append([]string(nil), readiness.MissingEvidenceAssignmentIDs...),
+	}
+}
+
+func renderCairnlineProjectWorkItemReviewFollowUps(items []cairnline.ReviewFollowUpReadiness) []ProjectWorkItemReviewFollowUpResponse {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]ProjectWorkItemReviewFollowUpResponse, 0, len(items))
+	for _, item := range items {
+		out = append(out, ProjectWorkItemReviewFollowUpResponse{
+			ArtifactID:           item.ArtifactID,
+			Title:                item.Title,
+			Status:               item.Status,
+			Blocker:              item.Blocker,
+			ReviewedAssignmentID: item.ReviewedAssignmentID,
+			ReviewVerdict:        item.ReviewVerdict,
+			ReviewRisk:           item.ReviewRisk,
+		})
+	}
+	return out
+}

--- a/internal/api/handler_project_work_readiness.go
+++ b/internal/api/handler_project_work_readiness.go
@@ -17,6 +17,7 @@ type ProjectWorkItemReadinessEnvelope struct {
 type ProjectWorkItemReadinessResponse struct {
 	ProjectID                    string                                  `json:"project_id"`
 	WorkItemID                   string                                  `json:"work_item_id"`
+	ReadBackend                  string                                  `json:"read_backend,omitempty"`
 	Ready                        bool                                    `json:"ready"`
 	Status                       string                                  `json:"status"`
 	Title                        string                                  `json:"title"`
@@ -59,6 +60,9 @@ func (h *Handler) HandleProjectWorkItemReadiness(w http.ResponseWriter, r *http.
 }
 
 func (h *Handler) renderProjectWorkItemReadiness(ctx context.Context, projectID, workItemID string) (ProjectWorkItemReadinessResponse, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectWorkItemReadiness(ctx, projectID, workItemID)
+	}
 	readiness, err := h.projectWorkApplication().WorkItemReadiness(ctx, projectID, workItemID)
 	if err != nil {
 		return ProjectWorkItemReadinessResponse{}, err
@@ -70,6 +74,7 @@ func renderProjectWorkItemReadiness(readiness projectworkapp.WorkItemReadiness) 
 	return ProjectWorkItemReadinessResponse{
 		ProjectID:                    readiness.ProjectID,
 		WorkItemID:                   readiness.WorkItemID,
+		ReadBackend:                  "hecate",
 		Ready:                        readiness.Ready,
 		Status:                       readiness.Status,
 		Title:                        readiness.Title,

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3105,6 +3105,91 @@ func TestProjectWorkAPI_ProjectActivityCairnlineConfiguredUsesReadModel(t *testi
 	}
 }
 
+func TestProjectWorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	seedProjectWorkProjectionTest(t, handler)
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_needs_evidence",
+		ProjectID: "proj_projection",
+		Title:     "Needs evidence",
+		Status:    projectwork.WorkItemStatusReview,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem(work_needs_evidence): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_needs_evidence",
+		ProjectID:  "proj_projection",
+		WorkItemID: "work_needs_evidence",
+		RoleID:     "role_projection",
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_needs_evidence): %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list work items status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listed ProjectWorkItemsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode work items: %v", err)
+	}
+	awaitingListItem := findProjectWorkItemForTest(t, listed.Data, "work_awaiting")
+	if awaitingListItem.ReadBackend != "cairnline" {
+		t.Fatalf("listed work item read_backend = %q, want cairnline", awaitingListItem.ReadBackend)
+	}
+	if awaitingListItem.Status != projectwork.WorkItemStatusRunning || len(awaitingListItem.Assignments) != 1 || awaitingListItem.Assignments[0].ExecutionRef == nil {
+		t.Fatalf("listed work item = %+v, want Hecate runtime projection over Cairnline work item", awaitingListItem)
+	}
+	evidenceListItem := findProjectWorkItemForTest(t, listed.Data, "work_needs_evidence")
+	if evidenceListItem.ReadBackend != "cairnline" || evidenceListItem.Status != projectwork.WorkItemStatusDone {
+		t.Fatalf("listed evidence work item = %+v, want Cairnline item with completed assignment projection", evidenceListItem)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_awaiting", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get work item status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var detail ProjectWorkItemEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode work item detail: %v", err)
+	}
+	if detail.Data.ReadBackend != "cairnline" || detail.Data.Status != projectwork.WorkItemStatusRunning || len(detail.Data.Assignments) != 1 {
+		t.Fatalf("work item detail = %+v, want Cairnline read backend with projected assignment", detail.Data)
+	}
+	if detail.Data.Assignments[0].ExecutionRef == nil || detail.Data.Assignments[0].ExecutionRef.PendingApprovalCount != 1 {
+		t.Fatalf("detail assignment = %+v, want Hecate approval projection", detail.Data.Assignments[0])
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_needs_evidence/readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var readiness ProjectWorkItemReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &readiness); err != nil {
+		t.Fatalf("decode readiness: %v", err)
+	}
+	if readiness.Data.ReadBackend != "cairnline" || readiness.Data.Ready || readiness.Data.Status != "blocked" {
+		t.Fatalf("readiness = %+v, want blocked Cairnline readiness", readiness.Data)
+	}
+	if len(readiness.Data.MissingEvidenceAssignmentIDs) != 1 || readiness.Data.MissingEvidenceAssignmentIDs[0] != "asgn_needs_evidence" {
+		t.Fatalf("missing evidence = %+v, want asgn_needs_evidence", readiness.Data.MissingEvidenceAssignmentIDs)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_missing_from_cairnline", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work item status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_ProjectActivityShowsFreshQueuedAssignments(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectWorkTestServer()
@@ -3886,6 +3971,17 @@ func findProjectActivityItemForTest(t *testing.T, items []ProjectActivityItemRes
 	}
 	t.Fatalf("activity assignment %s not found in %+v", assignmentID, items)
 	return ProjectActivityItemResponse{}
+}
+
+func findProjectWorkItemForTest(t *testing.T, items []ProjectWorkItemResponse, workItemID string) ProjectWorkItemResponse {
+	t.Helper()
+	for _, item := range items {
+		if item.ID == workItemID {
+			return item
+		}
+	}
+	t.Fatalf("work item %s not found in %+v", workItemID, items)
+	return ProjectWorkItemResponse{}
 }
 
 func allProjectActivityItemsForTest(data ProjectActivityDataResponse) []ProjectActivityItemResponse {


### PR DESCRIPTION
Summary
- Route project work-item list/detail reads through the Cairnline read model when `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the read adapter is ready.
- Route selected work-item closeout readiness through Cairnline while preserving Hecate runtime assignment projection for list/detail responses.
- Add `read_backend` markers to work-item and readiness responses for read-model source visibility.
- Update backend status and docs to reflect the expanded live read-route scope.

Scope
- Hecate stores remain authoritative.
- Writes, setup/context routes, migration, and rollback are still Hecate-owned/future work.

Validation
- `just agent-docs-check`
- `GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProject(WorkAPI_ProjectActivity|WorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel|WorkAPI_PatchDoneRequiresCloseoutReadiness|CoordinationBackendStatus|OperationsBrief)'`\n- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/cairnlinebridge`\n- `GOCACHE="$PWD/.gocache" go test ./...`\n- `GOCACHE="$PWD/.gocache" go vet ./...`\n- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`