### PR TITLE
feat: route setup readiness through Cairnline

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -114,11 +114,11 @@ current Hecate project graph, and whether Cairnline is actually authoritative.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 it reports `cairnline_read_routes_ready`, and the live project activity inbox
-plus work-item list/detail, closeout readiness, and operations brief can use
-the Cairnline read model for portable work state. Hecate stores remain
-authoritative, Hecate-specific runtime enrichment and setup/action projection
-remain in Hecate, and other live Projects reads/writes still use the
-Hecate-native API.
+plus setup readiness, work-item list/detail, closeout readiness, and operations
+brief can use the Cairnline read model for portable setup/work state. Hecate
+stores remain authoritative, Hecate-specific runtime enrichment and
+setup/action wording remain in Hecate, and other live Projects reads/writes
+still use the Hecate-native API.
 `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
 Cairnline service from the current Hecate stores and returns the portable
 operations brief and activity projection without writing files.
@@ -143,9 +143,9 @@ after these gates are met:
   artifact, handoff, accepted-memory, and memory-candidate flows.
 - Hecate has feature-flagged adapters that can run all read/write Projects
   flows against Cairnline without UI-local fallback state. The first live read
-  routes are activity, work-item list/detail, closeout readiness, and
-  operations brief; setup/context and write routes still need their own switch
-  points.
+  routes are setup readiness, activity, work-item list/detail, closeout
+  readiness, and operations brief; assignment/context and write routes still
+  need their own switch points.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha.
 - Context packets, setup/health/operations summaries, activity projections, and

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -357,11 +357,11 @@ and durable grants so transcripts and approval history move together.
 storage backend. The default is `hecate`. `cairnline` records replacement intent
 for local bridge experiments. When the Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
-`read_model_switch_ready=true`, and the project work-item list/detail, closeout
-readiness, activity inbox, and operations brief can be served from the
-Cairnline read model. Other live Projects reads/writes still use Hecate-native
-stores until the remaining read routes, write adapter, and migration path are
-ready.
+`read_model_switch_ready=true`, and project setup readiness, work-item
+list/detail, closeout readiness, activity inbox, and operations brief can be
+served from the Cairnline read model. Other live Projects reads/writes still
+use Hecate-native stores until the remaining read routes, write adapter, and
+migration path are ready.
 
 Deployment-specific notes:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2221,9 +2221,9 @@ Example response:
     "read_model_switch_ready": true,
     "write_adapter_ready": false,
     "status": "cairnline_read_routes_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the work-item, activity, readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the setup-readiness, work-item, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
     "warnings": [
-      "Only the project work-item, activity, readiness, and operations brief live read routes use Cairnline.",
+      "Only the project setup-readiness, work-item, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
       "Other project APIs still read and write Hecate-native stores.",
       "Cairnline write adapter and migration path are not ready."
     ],
@@ -2960,6 +2960,11 @@ The endpoint does not create tasks, runs, chats, proposals, roles, work items,
 memory entries, memory candidates, or skills. Checklist actions route the
 operator to existing typed surfaces: Project Settings, Project Assistant setup,
 or explicit work-item creation.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, the portable setup counts are read from
+the Cairnline read model and then projected into Hecate's setup checklist/action
+contract. Hecate still owns Hecate-specific provider/model default checks.
+`read_backend` identifies the setup-state read-model source.
 
 ```json
 {
@@ -2967,6 +2972,7 @@ or explicit work-item creation.
   "data": {
     "project_id": "proj_...",
     "generated_at": "2026-06-20T12:00:00Z",
+    "read_backend": "hecate",
     "show_onboarding": true,
     "setup_started": false,
     "first_work_ready": false,

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -33,9 +33,9 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.ReadModelSwitchReady = readReady
 		if readReady {
 			response.Status = "cairnline_read_routes_ready"
-			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the work-item, activity, readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
+			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the setup-readiness, work-item, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
 			response.Warnings = []string{
-				"Only the project work-item, activity, readiness, and operations brief live read routes use Cairnline.",
+				"Only the project setup-readiness, work-item, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
 				"Other project APIs still read and write Hecate-native stores.",
 				"Cairnline write adapter and migration path are not ready.",
 			}

--- a/internal/api/handler_project_setup_readiness.go
+++ b/internal/api/handler_project_setup_readiness.go
@@ -31,6 +31,7 @@ type ProjectSetupReadinessEnvelope struct {
 type ProjectSetupReadinessResponse struct {
 	ProjectID      string                               `json:"project_id"`
 	GeneratedAt    string                               `json:"generated_at"`
+	ReadBackend    string                               `json:"read_backend,omitempty"`
 	ShowOnboarding bool                                 `json:"show_onboarding"`
 	SetupStarted   bool                                 `json:"setup_started"`
 	FirstWorkReady bool                                 `json:"first_work_ready"`
@@ -84,6 +85,9 @@ func (h *Handler) HandleProjectSetupReadiness(w http.ResponseWriter, r *http.Req
 }
 
 func (h *Handler) renderProjectSetupReadiness(ctx context.Context, projectID string) (ProjectSetupReadinessResponse, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectSetupReadiness(ctx, projectID)
+	}
 	project, ok, err := h.projects.Get(ctx, projectID)
 	if err != nil {
 		return ProjectSetupReadinessResponse{}, err
@@ -122,6 +126,7 @@ func (h *Handler) renderProjectSetupReadiness(ctx context.Context, projectID str
 	return ProjectSetupReadinessResponse{
 		ProjectID:      project.ID,
 		GeneratedAt:    formatOptionalTime(time.Now().UTC()),
+		ReadBackend:    "hecate",
 		ShowOnboarding: summary.WorkItemCount == 0 && !setupStarted,
 		SetupStarted:   setupStarted,
 		FirstWorkReady: firstWorkReady,

--- a/internal/api/handler_project_setup_readiness_cairnline.go
+++ b/internal/api/handler_project_setup_readiness_cairnline.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) renderCairnlineProjectSetupReadiness(ctx context.Context, projectID string) (ProjectSetupReadinessResponse, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	roles, err := service.ListRoles(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	workItems, err := service.ListWorkItems(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	entries, err := service.ListMemoryEntries(ctx, snapshot.Project.ID, true)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	candidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+		ProjectID: snapshot.Project.ID,
+		Status:    cairnline.MemoryCandidatePending,
+	})
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	skills, err := service.ListProjectSkills(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+
+	project := snapshot.Project
+	summary := projectSetupReadinessSummary(
+		project,
+		projectWorkItemsFromCairnline(workItems),
+		projectSetupRolesFromCairnline(roles),
+		projectSetupSkillsFromCairnline(skills),
+		projectSetupMemoryEntriesFromCairnline(entries),
+		projectSetupMemoryCandidatesFromCairnline(candidates),
+	)
+	setupStarted := summary.EnabledContextSourceCount > 0 ||
+		summary.RoleCount > 0 ||
+		summary.SkillCount > 0 ||
+		summary.SavedMemoryCount > 0 ||
+		summary.PendingMemoryCandidateCount > 0
+	firstWorkReady := summary.WorkItemCount == 0 && setupStarted
+	return ProjectSetupReadinessResponse{
+		ProjectID:      project.ID,
+		GeneratedAt:    formatOptionalTime(time.Now().UTC()),
+		ReadBackend:    "cairnline",
+		ShowOnboarding: summary.WorkItemCount == 0 && !setupStarted,
+		SetupStarted:   setupStarted,
+		FirstWorkReady: firstWorkReady,
+		Summary:        summary,
+		PrimaryAction:  projectSetupReadinessAction(projectSetupReadinessActionBootstrap, project.ID, "Set up project"),
+		Checks:         projectSetupReadinessChecks(project, summary),
+	}, nil
+}
+
+func projectWorkItemsFromCairnline(items []cairnline.WorkItem) []projectwork.WorkItem {
+	out := make([]projectwork.WorkItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectWorkItemFromCairnline(item))
+	}
+	return out
+}
+
+func projectSetupRolesFromCairnline(items []cairnline.Role) []projectwork.AgentRoleProfile {
+	out := make([]projectwork.AgentRoleProfile, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectwork.AgentRoleProfile{
+			ID:                  item.ID,
+			ProjectID:           item.ProjectID,
+			Name:                item.Name,
+			Description:         item.Description,
+			Instructions:        item.Instructions,
+			DefaultAgentProfile: item.DefaultProfileID,
+			DefaultDriverKind:   item.DefaultExecutionMode,
+			SkillIDs:            append([]string(nil), item.DefaultSkillIDs...),
+		})
+	}
+	return out
+}
+
+func projectSetupSkillsFromCairnline(items []cairnline.ProjectSkill) []projectskills.Skill {
+	out := make([]projectskills.Skill, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectskills.Skill{
+			ID:          item.ID,
+			ProjectID:   item.ProjectID,
+			Title:       item.Title,
+			Description: item.Description,
+			Path:        item.Path,
+			RootID:      item.RootID,
+			Format:      item.Format,
+			Enabled:     item.Enabled,
+			Status:      item.Status,
+			TrustLabel:  item.TrustLabel,
+		})
+	}
+	return out
+}
+
+func projectSetupMemoryEntriesFromCairnline(items []cairnline.MemoryEntry) []memory.Entry {
+	out := make([]memory.Entry, 0, len(items))
+	for _, item := range items {
+		out = append(out, memory.Entry{
+			ID:        item.ID,
+			ProjectID: item.ProjectID,
+			Title:     item.Title,
+			Body:      item.Body,
+			Enabled:   item.Enabled,
+		})
+	}
+	return out
+}
+
+func projectSetupMemoryCandidatesFromCairnline(items []cairnline.MemoryCandidate) []memory.Candidate {
+	out := make([]memory.Candidate, 0, len(items))
+	for _, item := range items {
+		out = append(out, memory.Candidate{
+			ID:        item.ID,
+			ProjectID: item.ProjectID,
+			Title:     item.Title,
+			Body:      item.Body,
+			Status:    item.Status,
+		})
+	}
+	return out
+}

--- a/internal/api/handler_project_setup_readiness_test.go
+++ b/internal/api/handler_project_setup_readiness_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
@@ -42,6 +43,9 @@ func TestProjectSetupReadiness_ReadOnlyPristineProject(t *testing.T) {
 	}
 	if response.Object != "project_setup_readiness" || response.Data.ProjectID != "proj_setup" {
 		t.Fatalf("setup readiness envelope = %+v, want project_setup_readiness for project", response)
+	}
+	if response.Data.ReadBackend != "hecate" {
+		t.Fatalf("setup readiness read_backend = %q, want hecate", response.Data.ReadBackend)
 	}
 	if !response.Data.ShowOnboarding || response.Data.SetupStarted || response.Data.FirstWorkReady {
 		t.Fatalf("setup readiness flags = %+v, want onboarding for pristine project", response.Data)
@@ -147,6 +151,9 @@ func TestProjectSetupReadiness_SetupStartedFirstWorkReady(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode setup readiness: %v", err)
 	}
+	if response.Data.ReadBackend != "hecate" {
+		t.Fatalf("setup readiness read_backend = %q, want hecate", response.Data.ReadBackend)
+	}
 	if response.Data.ShowOnboarding || !response.Data.SetupStarted || !response.Data.FirstWorkReady {
 		t.Fatalf("setup readiness flags = %+v, want setup started and first work ready", response.Data)
 	}
@@ -165,6 +172,88 @@ func TestProjectSetupReadiness_SetupStartedFirstWorkReady(t *testing.T) {
 	firstWork := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, "first_work_item")
 	if firstWork.Status != projectSetupReadinessStatusTodo || firstWork.Action == nil || firstWork.Action.Type != projectSetupReadinessActionCreateWorkItem {
 		t.Fatalf("first work check = %+v, want create-work todo", firstWork)
+	}
+}
+
+func TestProjectSetupReadiness_CairnlineConfiguredUsesReadModel(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	root := t.TempDir()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_cairnline_setup",
+		Name:            "Cairnline setup",
+		Description:     "Coordinate setup through Cairnline reads.",
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-5",
+		Roots:           []projects.Root{{ID: "root_cairnline", Path: root, Kind: "git", Active: true}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_cairnline",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Path:    "AGENTS.md",
+			Enabled: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:        "role_cairnline",
+		ProjectID: "proj_cairnline_setup",
+		Name:      "Coordinator",
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := handler.projectSkills.UpsertDiscovered(t.Context(), "proj_cairnline_setup", []projectskills.Skill{{
+		ID:        "skill_cairnline",
+		ProjectID: "proj_cairnline_setup",
+		Path:      "skills/cairnline/SKILL.md",
+		Enabled:   true,
+		Status:    projectskills.StatusAvailable,
+	}}); err != nil {
+		t.Fatalf("UpsertDiscovered: %v", err)
+	}
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:        "mem_cairnline",
+		ProjectID: "proj_cairnline_setup",
+		Title:     "Setup posture",
+		Body:      "Use Cairnline for portable setup reads.",
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Create memory: %v", err)
+	}
+	if _, err := handler.memoryCandidates.CreateCandidate(t.Context(), memory.Candidate{
+		ID:        "memcand_cairnline",
+		ProjectID: "proj_cairnline_setup",
+		Title:     "Candidate",
+		Body:      "Review me.",
+		Status:    memory.CandidateStatusPending,
+	}); err != nil {
+		t.Fatalf("CreateCandidate: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_cairnline_setup/setup-readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("setup readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectSetupReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode setup readiness: %v", err)
+	}
+	if response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("setup readiness read_backend = %q, want cairnline", response.Data.ReadBackend)
+	}
+	if response.Data.ShowOnboarding || !response.Data.SetupStarted || !response.Data.FirstWorkReady {
+		t.Fatalf("setup readiness flags = %+v, want Cairnline setup started and first work ready", response.Data)
+	}
+	if response.Data.Summary.EnabledContextSourceCount != 1 || response.Data.Summary.RoleCount != 1 || response.Data.Summary.SkillCount != 1 || response.Data.Summary.SavedMemoryCount != 1 || response.Data.Summary.PendingMemoryCandidateCount != 1 {
+		t.Fatalf("setup readiness summary = %+v, want Cairnline-backed setup counts", response.Data.Summary)
+	}
+	if response.Data.Summary.MissingDefaults || !response.Data.Summary.HasPurpose || !response.Data.Summary.HasActiveRoot {
+		t.Fatalf("setup readiness summary = %+v, want Hecate defaults/purpose/root over Cairnline setup counts", response.Data.Summary)
 	}
 }
 


### PR DESCRIPTION
Summary
- Route project setup readiness through the Cairnline read model when `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the read adapter is ready.
- Read portable setup counts from Cairnline while keeping Hecate-specific checklist/action wording and provider/model default checks in Hecate.
- Add `read_backend` to setup-readiness responses and update replacement-readiness docs/status wording.

Scope
- Hecate stores remain authoritative.
- Assignment context reads, writes, migration, and rollback are still Hecate-owned/future work.

Validation
- `just agent-docs-check`
- `GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProject(SetupReadiness|CoordinationBackendStatus|WorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel|OperationsBrief|WorkAPI_ProjectActivity)'`
- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/cairnlinebridge`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go vet ./...`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`