### PR TITLE
feat: route assignment reads through Cairnline

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -114,11 +114,11 @@ current Hecate project graph, and whether Cairnline is actually authoritative.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 it reports `cairnline_read_routes_ready`, and the live project activity inbox
-plus setup readiness, work-item list/detail, closeout readiness, and operations
-brief can use the Cairnline read model for portable setup/work state. Hecate
-stores remain authoritative, Hecate-specific runtime enrichment and
-setup/action wording remain in Hecate, and other live Projects reads/writes
-still use the Hecate-native API.
+plus setup readiness, work-item list/detail, assignment-list, closeout
+readiness, and operations brief can use the Cairnline read model for portable
+setup/work state. Hecate stores remain authoritative, Hecate-specific runtime
+enrichment and setup/action wording remain in Hecate, and other live Projects
+reads/writes still use the Hecate-native API.
 `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
 Cairnline service from the current Hecate stores and returns the portable
 operations brief and activity projection without writing files.
@@ -143,9 +143,9 @@ after these gates are met:
   artifact, handoff, accepted-memory, and memory-candidate flows.
 - Hecate has feature-flagged adapters that can run all read/write Projects
   flows against Cairnline without UI-local fallback state. The first live read
-  routes are setup readiness, activity, work-item list/detail, closeout
-  readiness, and operations brief; assignment/context and write routes still
-  need their own switch points.
+  routes are setup readiness, activity, work-item list/detail, assignment
+  lists, closeout readiness, and operations brief; assignment context and write
+  routes still need their own switch points.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha.
 - Context packets, setup/health/operations summaries, activity projections, and

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -358,10 +358,10 @@ storage backend. The default is `hecate`. `cairnline` records replacement intent
 for local bridge experiments. When the Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project setup readiness, work-item
-list/detail, closeout readiness, activity inbox, and operations brief can be
-served from the Cairnline read model. Other live Projects reads/writes still
-use Hecate-native stores until the remaining read routes, write adapter, and
-migration path are ready.
+list/detail, assignment-list, closeout readiness, activity inbox, and
+operations brief can be served from the Cairnline read model. Other live
+Projects reads/writes still use Hecate-native stores until the remaining read
+routes, write adapter, and migration path are ready.
 
 Deployment-specific notes:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2221,9 +2221,9 @@ Example response:
     "read_model_switch_ready": true,
     "write_adapter_ready": false,
     "status": "cairnline_read_routes_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the setup-readiness, work-item, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the setup-readiness, work-item, assignment-list, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
     "warnings": [
-      "Only the project setup-readiness, work-item, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
+      "Only the project setup-readiness, work-item, assignment-list, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
       "Other project APIs still read and write Hecate-native stores.",
       "Cairnline write adapter and migration path are not ready."
     ],
@@ -3424,6 +3424,11 @@ Deletes the work item and its assignments and collaboration artifacts.
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
 
 Lists assignment metadata for a work item.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, the assignment set is read from the
+Cairnline read model and then enriched with Hecate runtime execution projection.
+`read_backend` identifies that read-model source. Assignment context,
+preflight, and start/prepare routes remain Hecate-native.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -33,9 +33,9 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.ReadModelSwitchReady = readReady
 		if readReady {
 			response.Status = "cairnline_read_routes_ready"
-			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the setup-readiness, work-item, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
+			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the setup-readiness, work-item, assignment-list, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
 			response.Warnings = []string{
-				"Only the project setup-readiness, work-item, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
+				"Only the project setup-readiness, work-item, assignment-list, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
 				"Other project APIs still read and write Hecate-native stores.",
 				"Cairnline write adapter and migration path are not ready.",
 			}

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -241,6 +241,7 @@ type ProjectWorkAssignmentResponse struct {
 	ID           string                                     `json:"id"`
 	ProjectID    string                                     `json:"project_id"`
 	WorkItemID   string                                     `json:"work_item_id"`
+	ReadBackend  string                                     `json:"read_backend,omitempty"`
 	RoleID       string                                     `json:"role_id"`
 	RootID       string                                     `json:"root_id,omitempty"`
 	DriverKind   string                                     `json:"driver_kind"`
@@ -492,6 +493,7 @@ func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	projected.ReadBackend = "hecate"
+	markProjectWorkAssignmentReadBackend(projected.Assignments, "hecate")
 	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
 }
 
@@ -544,6 +546,15 @@ func (h *Handler) HandleProjectWorkAssignments(w http.ResponseWriter, r *http.Re
 	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		data, err := h.renderCairnlineProjectWorkAssignments(r.Context(), projectID, workItemID)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectWorkAssignmentsResponse{Object: "project_assignments", Data: data})
+		return
+	}
 	items, err := h.projectWork.ListAssignments(r.Context(), projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -556,6 +567,7 @@ func (h *Handler) HandleProjectWorkAssignments(w http.ResponseWriter, r *http.Re
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
+		projected.ReadBackend = "hecate"
 		data = append(data, projected)
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentsResponse{Object: "project_assignments", Data: data})

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
@@ -29,6 +30,7 @@ func (h *Handler) renderProjectWorkItems(ctx context.Context, projectID string) 
 			return nil, err
 		}
 		projected.ReadBackend = "hecate"
+		markProjectWorkAssignmentReadBackend(projected.Assignments, "hecate")
 		data = append(data, projected)
 	}
 	return data, nil
@@ -51,6 +53,7 @@ func (h *Handler) renderCairnlineProjectWorkItems(ctx context.Context, projectID
 			return nil, err
 		}
 		projected.ReadBackend = "cairnline"
+		markProjectWorkAssignmentReadBackend(projected.Assignments, "cairnline")
 		data = append(data, projected)
 	}
 	return data, nil
@@ -75,9 +78,45 @@ func (h *Handler) renderCairnlineProjectWorkItem(ctx context.Context, projectID,
 			return ProjectWorkItemResponse{}, err
 		}
 		projected.ReadBackend = "cairnline"
+		markProjectWorkAssignmentReadBackend(projected.Assignments, "cairnline")
 		return projected, nil
 	}
 	return ProjectWorkItemResponse{}, projectwork.ErrNotFound
+}
+
+func (h *Handler) renderCairnlineProjectWorkAssignments(ctx context.Context, projectID, workItemID string) ([]ProjectWorkAssignmentResponse, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := service.ListAssignments(ctx, snapshot.Project.ID)
+	if err != nil {
+		return nil, err
+	}
+	nativeByID := projectWorkAssignmentsByID(snapshot.Assignments)
+	data := make([]ProjectWorkAssignmentResponse, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item.WorkItemID) != workItemID {
+			continue
+		}
+		assignment := projectWorkAssignmentFromCairnline(item)
+		if native, ok := nativeByID[item.ID]; ok {
+			assignment = native
+		}
+		projected, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if err != nil {
+			return nil, err
+		}
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func markProjectWorkAssignmentReadBackend(items []ProjectWorkAssignmentResponse, backend string) {
+	for index := range items {
+		items[index].ReadBackend = backend
+	}
 }
 
 func (h *Handler) renderCairnlineProjectWorkItemReadiness(ctx context.Context, projectID, workItemID string) (ProjectWorkItemReadinessResponse, error) {
@@ -117,6 +156,57 @@ func projectWorkItemFromCairnline(item cairnline.WorkItem) projectwork.WorkItem 
 		ReviewerRoleIDs: append([]string(nil), item.ReviewerRoleIDs...),
 		CreatedAt:       item.CreatedAt,
 		UpdatedAt:       item.UpdatedAt,
+	}
+}
+
+func projectWorkAssignmentsByID(items []projectwork.Assignment) map[string]projectwork.Assignment {
+	out := make(map[string]projectwork.Assignment, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func projectWorkAssignmentFromCairnline(item cairnline.Assignment) projectwork.Assignment {
+	return projectwork.Assignment{
+		ID:         item.ID,
+		ProjectID:  item.ProjectID,
+		WorkItemID: item.WorkItemID,
+		RoleID:     item.RoleID,
+		RootID:     item.RootID,
+		DriverKind: projectWorkAssignmentDriverFromCairnline(item.ExecutionMode),
+		Status:     projectWorkAssignmentStatusFromCairnline(item.Status),
+		ExecutionRef: projectwork.NormalizeAssignmentExecutionRef(projectwork.AssignmentExecutionRef{
+			ContextSnapshotID: item.ContextSnapshotID,
+		}),
+		CreatedAt: item.CreatedAt,
+		UpdatedAt: item.UpdatedAt,
+	}
+}
+
+func projectWorkAssignmentDriverFromCairnline(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case cairnline.ExecutionExternalAdapter:
+		return projectwork.AssignmentDriverExternalAgent
+	default:
+		return projectwork.AssignmentDriverHecateTask
+	}
+}
+
+func projectWorkAssignmentStatusFromCairnline(status string) string {
+	switch strings.TrimSpace(status) {
+	case cairnline.AssignmentRunning, cairnline.AssignmentClaimed:
+		return projectwork.AssignmentStatusRunning
+	case cairnline.AssignmentReview:
+		return projectwork.AssignmentStatusAwaitingApproval
+	case cairnline.AssignmentCompleted:
+		return projectwork.AssignmentStatusCompleted
+	case cairnline.AssignmentFailed:
+		return projectwork.AssignmentStatusFailed
+	case cairnline.AssignmentCancelled:
+		return projectwork.AssignmentStatusCancelled
+	default:
+		return projectwork.AssignmentStatusQueued
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3143,7 +3143,7 @@ func TestProjectWorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel(t *t
 	if awaitingListItem.ReadBackend != "cairnline" {
 		t.Fatalf("listed work item read_backend = %q, want cairnline", awaitingListItem.ReadBackend)
 	}
-	if awaitingListItem.Status != projectwork.WorkItemStatusRunning || len(awaitingListItem.Assignments) != 1 || awaitingListItem.Assignments[0].ExecutionRef == nil {
+	if awaitingListItem.Status != projectwork.WorkItemStatusRunning || len(awaitingListItem.Assignments) != 1 || awaitingListItem.Assignments[0].ExecutionRef == nil || awaitingListItem.Assignments[0].ReadBackend != "cairnline" {
 		t.Fatalf("listed work item = %+v, want Hecate runtime projection over Cairnline work item", awaitingListItem)
 	}
 	evidenceListItem := findProjectWorkItemForTest(t, listed.Data, "work_needs_evidence")
@@ -3160,11 +3160,27 @@ func TestProjectWorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel(t *t
 	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
 		t.Fatalf("decode work item detail: %v", err)
 	}
-	if detail.Data.ReadBackend != "cairnline" || detail.Data.Status != projectwork.WorkItemStatusRunning || len(detail.Data.Assignments) != 1 {
+	if detail.Data.ReadBackend != "cairnline" || detail.Data.Status != projectwork.WorkItemStatusRunning || len(detail.Data.Assignments) != 1 || detail.Data.Assignments[0].ReadBackend != "cairnline" {
 		t.Fatalf("work item detail = %+v, want Cairnline read backend with projected assignment", detail.Data)
 	}
 	if detail.Data.Assignments[0].ExecutionRef == nil || detail.Data.Assignments[0].ExecutionRef.PendingApprovalCount != 1 {
 		t.Fatalf("detail assignment = %+v, want Hecate approval projection", detail.Data.Assignments[0])
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_awaiting/assignments", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list assignments status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignments ProjectWorkAssignmentsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignments); err != nil {
+		t.Fatalf("decode assignments: %v", err)
+	}
+	if len(assignments.Data) != 1 || assignments.Data[0].ID != "asgn_awaiting" || assignments.Data[0].ReadBackend != "cairnline" {
+		t.Fatalf("assignments = %+v, want Cairnline-backed assignment list", assignments.Data)
+	}
+	if assignments.Data[0].Status != projectwork.AssignmentStatusAwaitingApproval || assignments.Data[0].ExecutionRef == nil || assignments.Data[0].ExecutionRef.PendingApprovalCount != 1 {
+		t.Fatalf("assignment projection = %+v, want Hecate approval projection over Cairnline assignment list", assignments.Data[0])
 	}
 
 	rec = httptest.NewRecorder()


### PR DESCRIPTION
Summary
- Route project assignment-list reads through the Cairnline read model when `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the read adapter is ready.
- Add `read_backend` to assignment responses and mark embedded assignment summaries in work-item list/detail reads.
- Preserve Hecate runtime execution projection over Cairnline assignment membership so task/chat refs, pending approvals, and projected status remain visible.
- Update replacement-readiness docs/status wording.

Scope
- Hecate stores remain authoritative.
- Assignment context, preflight, start/prepare, writes, migration, and rollback are still Hecate-owned/future work.

Validation
- `just agent-docs-check`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel|TestProjectCoordinationBackendStatus'`
- `GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge`
- `GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/cairnlinebridge`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go vet ./...`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`

Note
- The first sandboxed `go test ./internal/api ./internal/cairnlinebridge` attempt hit the known `httptest` bind restriction; the same command passed with normal execution permissions.