### PR TITLE
feat: expand Cairnline projects bridge

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -91,44 +91,156 @@ It can load Hecate project state from the current project/profile/skills/work
 stores, then seed a memory-backed or SQLite-backed Cairnline service from
 Hecate project-shaped records:
 
-- project identity, roots, default root, and context-source provenance metadata
-  including format, scope, source category, and trusted metadata labels;
-- agent profiles and execution posture;
+- project identity, roots, default root, project default profile/execution
+  posture references, and context-source provenance metadata including format,
+  scope, source category, and trusted metadata labels;
+- agent profiles and project/role execution posture;
 - skills metadata, roles, work items, and root-scoped assignments;
 - assignment-scoped collaboration evidence links, reviews, handoffs with
   source/target refs and linked artifacts/memory/context, accepted memory
-  entries, and memory candidates with decision state.
+  entries, memory candidates with decision state, and portable Project
+  Assistant proposal ledger records with root/default-root actions, warnings,
+  apply results, and attempts.
 
 This bridge proves the portable Cairnline model can receive the core
 coordination graph and produce assignment launch packets with the expected
-metadata. It also exercises Cairnline's read-only closeout readiness, project
-operations brief, and project activity projection against seeded Hecate work
-state. It deliberately does not switch storage, proxy live API requests, replace
-Hecate task/external-agent execution, migrate existing local data, or make
-Cairnline authoritative.
+metadata. The experimental read model also reports how many seeded assignments
+can produce a portable launch packet plus any packet warnings or
+per-assignment packet errors. It also exercises Cairnline's read-only closeout
+readiness, project operations brief, and project activity projection against
+seeded Hecate work state. It deliberately does not switch storage, proxy live
+API requests, replace Hecate task/external-agent execution, migrate existing
+local data, or make Cairnline authoritative.
 
 For operator-triggered experiments, Hecate exposes local-only Cairnline bridge
 endpoints. `GET /hecate/v1/projects/backend-status` reports the configured
 coordination backend, whether the Cairnline read adapter can project the full
-current Hecate project graph, and whether Cairnline is actually authoritative.
+current Hecate project graph, the live read-route families currently projected
+from Cairnline, the remaining write-adapter gap families, and whether Cairnline
+is actually authoritative.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 it reports `cairnline_read_routes_ready`, and the live project activity inbox
-plus setup readiness, health, work-item list/detail, assignment-list, closeout
-readiness, and operations brief can use the Cairnline read model for portable
-setup/work state. Hecate stores remain authoritative, Hecate-specific runtime
-enrichment and setup/action wording remain in Hecate, and other live Projects
-reads/writes still use the Hecate-native API.
+plus project list/detail, setup readiness, health, skills, memory entries,
+memory candidates, roles, work-item list/detail, assignment-list,
+assignment-context, launch-readiness, assignment-preflight, artifact-list,
+handoff-list, Project Assistant context and proposal reads, closeout readiness,
+and operations brief can use the Cairnline read model for portable setup/work
+state. Project Assistant draft generation also uses the Cairnline-projected
+context so preview and proposal assembly stay aligned, while the proposal
+ledger and apply remain Hecate-owned. Project list/detail reconstruct default
+profile and execution posture from Cairnline project/execution-profile records
+where available. Launch-readiness and assignment preflight read
+project/work/assignment/role coordination records from Cairnline when
+configured, then apply Hecate runtime validation. Native assignment preflight
+and start context packets can append inspect-only `cairnline_launch_packet`
+evidence so replacement reviews can compare Hecate's authoritative launch
+context with the portable launch packet Cairnline can build for the same
+assignment. Hecate stores remain authoritative, Hecate-specific runtime
+enrichment and setup/action wording remain in Hecate, and the Cairnline-backed
+operations brief assembles through Hecate's activity projection and cockpit
+action helpers so operator-facing actions stay parity-checked with the native
+route. Assignment-start is still a Hecate-native dispatch mutation, committed
+assignment-start results are best-effort mirrored for replacement evidence, and
+other live Projects reads/writes still use the Hecate-native API.
 `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
 Cairnline service from the current Hecate stores and returns the portable
 operations brief and activity projection without writing files.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
-differences, so bucket/status semantics can be fixed before any backend switch.
+differences for raw graph counts including execution-profile defaults,
+activity, operations, and the Project Assistant proposal ledger, plus portable
+launch-packet coverage, so import coverage, bucket/status semantics, portable
+ledger coverage, and assignment packet coverage can be fixed before any backend
+switch.
+`POST /hecate/v1/projects/cairnline/sync` writes a refreshable embedded
+Cairnline SQLite database for the full Hecate Projects graph under Hecate's
+data directory. It is a deterministic migration rehearsal and durable service
+boundary proof; the response compares Hecate snapshot counts with the written
+Cairnline database, including launch-packet coverage/warnings/errors, and also
+compares normalized record ID sets plus semantic record-content digests so
+same-count/different-record and same-ID/wrong-field drift are visible. It
+reports count-level, ID-set, and content-digest differences. It is not a
+dual-write path and does not make Cairnline authoritative.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is configured, live
+project identity, root create/update/delete/discovery/worktree-creation,
+context-source create/update/delete/discovery, and project-default mutations
+still commit to Hecate stores first, then best-effort mirror the portable
+identity shape into the embedded Cairnline database. This mirror is
+replacement-readiness evidence only: Hecate remains authoritative and mirror
+failures are logged.
+Project skill discovery and metadata updates follow the same non-authoritative
+mirror pattern for metadata-only skill records; the mirror never loads, injects,
+or executes `SKILL.md` bodies.
+Project role and work-item create/update/delete routes also mirror coordination
+metadata into Cairnline after Hecate commits; when a mirrored role references
+an agent profile, the mirror also seeds that profile metadata and execution
+posture so the role can validate in Cairnline. Assignment create/update/delete
+routes mirror coordination metadata and lifecycle status after Hecate commits;
+assignment-start remains a Hecate-owned write gap because dispatch still carries
+runtime coupling that needs a narrower switch point, but successful start
+results and start-side conflict/cleanup states are best-effort mirrored after
+Hecate commits them. Linked external-agent chat reconciliation also mirrors the
+committed assignment status/ref when Hecate updates the linked assignment from a
+chat session. Collaboration artifact creation, including generic artifacts,
+evidence links, and reviews, and handoff create/update/delete routes also mirror
+portable collaboration metadata after Hecate commits. Project memory entry and
+memory-candidate create/update/resolve
+routes mirror accepted memory and reviewable candidate state after Hecate
+commits, including disabled state, provenance, status reason, and promoted
+memory references. Global agent-profile create/update/delete routes also
+mirror portable profile metadata and execution posture after Hecate commits;
+the delete mirror removes only the profile record because execution-profile
+posture can be shared. Project Assistant draft/propose/apply routes mirror the
+proposal ledger and committed apply side effects after Hecate commits proposal
+records and apply attempts.
 `POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
 SQLite export under Hecate's data directory. Both use the same bridge and are
 useful for inspecting replacement parity, but they are still proofs, not the
 live Projects backend.
+
+The first non-authoritative write-adapter seams exist in `cairnlinebridge` for
+project identity, embedded roots, context sources, project defaults,
+project-level execution-profile cleanup, agent-profile upserts/deletes with
+execution-posture upsert, project skill metadata upserts,
+role upserts/deletes with role-level execution-profile cleanup, work-item
+upserts/deletes, assignment metadata upsert/delete plus lifecycle-status sync,
+and project memory entry/candidate upserts and deletes. Create-if-missing seams
+exist for generic collaboration artifacts, evidence links, and reviews because
+Hecate and Cairnline both expose those as record/list contracts today; handoffs
+have upsert/delete coverage because they are mutable coordination records. The
+skill seam preserves operator-disabled state and discovered-at provenance while
+remaining metadata-only; it never loads, injects, or executes `SKILL.md` bodies.
+The memory seam preserves accepted-memory fields, disabled state, candidate
+provenance, and resolved candidate state including Hecate-owned promoted memory
+IDs. The assignment seam updates existing role/root/profile/driver/context
+metadata while preserving Cairnline lifecycle transitions through claim,
+progress, and completion methods. These seams prove the Cairnline service can
+accept Hecate's project/root/source, skill, role, work-item, assignment,
+collaboration, handoff, and memory mutation shapes, but live API routes still
+write Hecate stores first. Live mirror seams reported as
+`project-identity-live-mirror` cover project identity/root
+create/update/delete/discovery/worktree-creation and context-source
+create/update/delete/discovery mutations plus project defaults;
+`agent-profiles-live-mirror` covers global
+agent-profile create/update/delete metadata; `project-skills-live-mirror`
+covers project skill discovery/update metadata; `project-roles-live-mirror`,
+`project-work-items-live-mirror`, `project-assignments-live-mirror`,
+`project-assignment-start-result-live-mirror`,
+`project-assignment-chat-reconcile-live-mirror`,
+`project-collaboration-live-mirror`, and `project-handoffs-live-mirror` cover
+durable coordination, committed assignment-start/reconciliation results, and
+collaboration records; `project-memory-live-mirror` and
+`project-memory-candidates-live-mirror` cover accepted memory and reviewable
+memory-candidate records; and
+`project-assistant-proposal-ledger-live-mirror` and
+`project-assistant-apply-side-effects-live-mirror` cover Project Assistant
+proposal records, apply-attempt history, and committed apply side effects before
+assignment-start/runtime handoff. None are write authority. Backend status
+reports these proofs as
+`write_adapter_seams`, while `write_adapter_gaps`
+remains the machine-readable live-route stop list until route switch points,
+atomic promotion semantics, and migration/rollback semantics are implemented.
 
 Current read-model parity includes queued-assignment attention semantics:
 Hecate and Cairnline both count a queued assignment as blocked/attention rather
@@ -140,14 +252,30 @@ after these gates are met:
 
 - Cairnline has durable storage and MCP/API parity for Hecate's project, role,
   profile, context-source provenance metadata, skill, work item, assignment,
-  artifact, handoff, accepted-memory, and memory-candidate flows.
+  artifact, handoff, accepted-memory, memory-candidate, and assistant-proposal
+  ledger flows.
 - Hecate has feature-flagged adapters that can run all read/write Projects
   flows against Cairnline without UI-local fallback state. The first live read
-  routes are setup readiness, health, activity, work-item list/detail, assignment
-  lists, closeout readiness, and operations brief; assignment context and write
-  routes still need their own switch points.
+  routes are project list/detail, setup readiness, health, skills, memory
+  entries, memory candidates, roles, activity, work-item list/detail, assignment
+  lists, assignment context, launch-readiness, assignment preflight, artifact
+  lists, handoff lists, Project Assistant context/proposal reads, closeout
+  readiness, and operations brief. Draft generation may use the
+  Cairnline-projected context, but proposal ledger writes and apply authority
+  remain Hecate-owned while committed assistant side effects are mirrored as
+  non-authoritative Cairnline replacement evidence. Assignment preflight/start
+  packets may carry non-authoritative
+  Cairnline launch-packet evidence, but assignment-start remains a Hecate-owned
+  write gap; committed start and linked-chat reconciliation results may be
+  mirrored only as replacement evidence. Backend-status `write_adapter_seams`
+  lists non-authoritative proof
+  coverage; `write_adapter_gaps` remains the machine-readable stop list for
+  mutation families that still need live switch points before authority can
+  move.
 - Import/export or migration covers existing Hecate local stores and can be
-  rolled back during alpha.
+  rolled back during alpha; the embedded Cairnline sync database proves a
+  durable all-project seed with count-level, ID-set, and content-digest parity
+  before it becomes a write path.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -59,8 +59,19 @@ backend yet.
 Hecate should replace its internal Projects stores with Cairnline only after:
 
 - Cairnline covers Hecate's current project, role, profile, skill, work item,
-  assignment, evidence, review, handoff, memory-candidate, root, and closeout
-  flows.
+  assignment, generic artifact, evidence, review, handoff, memory-candidate,
+  assistant-proposal ledger and committed apply side effects, root, and
+  closeout flows.
+- Cairnline skill discovery remains compatible with Hecate's current
+  `.agents/skills`, `.hecate/skills`, and enabled guidance-linked local skill
+  roots while keeping Cairnline-native `.cairnline/skills` available for
+  standalone projects.
+- Hecate project-level and role-level default profile/provider/model posture is
+  preserved as Cairnline project/role profile and execution-profile defaults,
+  so assignment launch packets do not silently fall back to agent-profile
+  execution hints when a project or role is more specific; Hecate's
+  replacement-readiness parity report counts execution profiles so this
+  posture mapping is observable.
 - Hecate has an adapter from Hecate task / External Agent execution records to
   Cairnline assignment coordination records.
 - Hecate can migrate or import/export existing local project state.
@@ -184,6 +195,7 @@ work_items.closeout_readiness
 
 assignments.list
 assignments.create
+assignments.update
 assignments.claim
 assignments.context
 assignments.launch_packet
@@ -326,6 +338,63 @@ launch agents. Those remain explicit operator or orchestrator actions.
 - Hecate can initially continue using its internal Projects implementation.
 - Hecate can use the MCP server for side-by-side interoperability and the
   public Go package for controlled embed experiments.
+- Current Hecate embed experiments can serve project list/detail, setup
+  readiness, health, skills, memory, memory candidates, roles, work items,
+  assignment lists, assignment context, launch-readiness, assignment preflight,
+  generic/evidence/review artifact lists, handoff lists, Project Assistant
+  context/proposal reads, activity, closeout readiness, and operations brief
+  reads from a Cairnline-seeded read model while Hecate stores remain
+  authoritative.
+- Project Assistant draft generation can use the same Cairnline-projected
+  context as the inspect endpoint, so proposal assembly is exercised against the
+  portable read model while proposal persistence and apply remain Hecate-owned.
+- Hecate launch-readiness and assignment preflight can read Cairnline
+  project/work/assignment/role coordination records before applying Hecate-owned
+  runtime validation. Native assignment preflight/start context packets can
+  append inspect-only Cairnline launch-packet evidence when the read adapter is
+  active, so operators can compare portable launch-packet coverage with
+  Hecate's authoritative dispatch context before cutover. Hecate can also
+  mirror committed assignment-start results as replacement evidence, but this
+  does not make assignment-start Cairnline-backed.
+- The Hecate parity report compares raw graph counts, derived activity and
+  operations counts, Project Assistant proposal-ledger counts, and launch-packet
+  coverage before any backend switch.
+- The Hecate backend-status endpoint exposes the live Cairnline read-route
+  coverage, non-authoritative bridge write seams, and remaining live-route
+  write-adapter gap families as structured fields, so replacement readiness can
+  be tracked without parsing warning prose.
+- Hecate has a non-authoritative bridge write seam for project identity,
+  embedded roots, context sources, project defaults, and project-level
+  execution-profile cleanup. Hecate also has a non-authoritative project skill
+  metadata upsert seam that preserves operator-disabled state and provenance
+  without loading or executing skill bodies, agent-profile upsert/delete seams,
+  role/work-item upsert seams, assignment metadata upsert/delete plus
+  lifecycle-status sync, committed start-result mirror, linked-chat
+  reconciliation mirror, create-if-missing generic artifact/evidence/review seams, handoff
+  upsert/delete seams, plus accepted-memory and memory-candidate seams that
+  preserve metadata, disabled state, provenance, resolved candidate state, and
+  Hecate-owned promoted memory IDs. The project identity/root
+  discovery/worktree-creation/context-source discovery seam, the global
+  agent-profile seam, the metadata-only project-skill discovery/update seam, the
+  role/work-item/assignment coordination seams, the assignment start/reconcile
+  result seams, the collaboration artifact create seam, the handoff mutation
+  seam, and the accepted-memory and memory-candidate seams, plus the Project Assistant
+  proposal-ledger seam, are now wired as best-effort live mirrors into the
+  embedded Cairnline DB when the Cairnline backend is configured, but Hecate
+  still commits first and remains authoritative. Role mirrors also seed
+  referenced agent-profile metadata/execution posture when the profile store is
+  available.
+  Assignment-start dispatch is still a Hecate-owned write
+  gap. Artifact/evidence/review update/delete semantics are absent because
+  Hecate currently records those as immutable collaboration artifacts. Route
+  switch points, atomic promotion semantics, migration, rollback, and the rest
+  of the mutation families must land before Cairnline can become authoritative.
+- Hecate can write a refreshable embedded Cairnline SQLite sync database for
+  the full Projects graph as a migration rehearsal before any dual-write or
+  authoritative write adapter exists. The sync response compares aggregate
+  Hecate snapshot counts, normalized record ID sets, and semantic
+  record-content digests with the embedded database and reports count-level,
+  ID-set, and content-digest differences.
 - After V0 stabilizes, Hecate may embed the portable core as its Projects
   backend or talk to the MCP server as a separate local coordination process.
 - Hecate remains the richer cockpit and orchestrator for supervised Hecate

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -357,11 +357,55 @@ and durable grants so transcripts and approval history move together.
 storage backend. The default is `hecate`. `cairnline` records replacement intent
 for local bridge experiments. When the Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
-`read_model_switch_ready=true`, and project setup readiness, work-item
-list/detail, assignment-list, closeout readiness, health, activity inbox, and
-operations brief can be served from the Cairnline read model. Other live
-Projects reads/writes still use Hecate-native stores until the remaining read
-routes, write adapter, and migration path are ready.
+`read_model_switch_ready=true`, and project list/detail, setup readiness,
+health, skills, memory entries, memory candidates, roles, work-item
+list/detail, assignment-list, assignment-context, launch-readiness,
+assignment-preflight, artifact-list, handoff-list, Project Assistant
+context/proposal reads, closeout readiness, activity inbox, and operations brief
+can be served from the Cairnline read model. Project Assistant draft generation
+also uses the Cairnline-projected context in this mode, while proposal ledger
+writes and apply authority remain Hecate-owned; committed assistant side
+effects are best-effort mirrored into Cairnline as replacement-readiness
+evidence. Launch-readiness and assignment preflight read Cairnline coordination
+records before applying Hecate runtime checks.
+Assignment preflight/start context packets may include inspect-only Cairnline
+launch-packet evidence for replacement review, but Hecate still owns dispatch,
+task/external agent supervision, approvals, and assignment mutation. Project
+identity, root create/update/delete/discovery/worktree-creation,
+context-source create/update/delete/discovery, and default mutations still
+write Hecate stores first and then best-effort mirror into the embedded
+Cairnline database; this is replacement-readiness evidence, not write authority.
+Project skill discovery and
+metadata updates also best-effort mirror metadata-only skill records after the
+Hecate store commit; the mirror does not load or execute skill bodies. Project
+role and work-item mutations likewise mirror coordination metadata after Hecate
+commits. Role mirroring seeds referenced agent-profile metadata and execution
+posture when available, and global agent-profile CRUD now best-effort mirrors
+portable profile metadata and execution posture after Hecate commits. Assignment
+create/update/delete, collaboration artifact creation, and handoff
+create/update/delete mutations also best-effort mirror portable metadata after
+Hecate commits, but assignment start/dispatch remains Hecate-owned. Project
+memory entry and memory-candidate mutations also
+best-effort mirror accepted memory and reviewable candidate state after Hecate
+commits. Project Assistant draft/propose/apply ledger mutations likewise
+best-effort mirror proposal records, apply attempts, and committed apply side
+effects after Hecate commits.
+Other live Projects reads/writes still use Hecate-native
+stores until the remaining read routes, write adapter, and migration path are
+ready. Current bridge write experiments cover non-authoritative
+project/root/source/defaults, agent profiles, skills, roles, work items,
+assignment metadata upsert/delete plus lifecycle-status sync, memory,
+memory-candidate, create-only collaboration artifact/evidence/review, and
+handoff shapes. Backend status reports those proof seams separately from the
+live-route `write_adapter_gaps`; only `project-identity-live-mirror`,
+`agent-profiles-live-mirror`, `project-skills-live-mirror`,
+`project-roles-live-mirror`, `project-work-items-live-mirror`,
+`project-assignments-live-mirror`, `project-collaboration-live-mirror`,
+`project-handoffs-live-mirror`, `project-memory-live-mirror`, and
+`project-memory-candidates-live-mirror`, plus
+`project-assistant-proposal-ledger-live-mirror` and
+`project-assistant-apply-side-effects-live-mirror` are wired to live mutations,
+and all remain non-authoritative.
 
 Deployment-specific notes:
 

--- a/docs/operator/desktop-app.md
+++ b/docs/operator/desktop-app.md
@@ -187,7 +187,7 @@ the ones likely to bite an operator:
   click "More info" on the SmartScreen warning. Document in release
   notes when shipping an unsigned build.
 - **Window close and `cmd+Q` both quit cleanly.** The red-X, `cmd+Q`, and the menu "Quit Hecate" item all funnel through the same path. If any agent runs are in-flight, a native confirmation dialog appears ("X tasks still running. Quitting Hecate will stop them.") with Quit anyway / Keep running. On confirm — or when there are no running tasks — the gateway is asked to drain via `POST /hecate/v1/system/shutdown` (same code path as `SIGINT`/`SIGTERM`) before the app exits, so MCP subprocesses are torn down cleanly and no run is left stuck in `running`.
-- **Reset local data does not relaunch the app.** Settings → Maintenance → Danger zone calls `POST /hecate/v1/system/reset-data`, closes live external-agent chat sessions, removes Hecate-owned projects, chats, tasks, provider setup, policy rules, and saved external-agent grants, then clears remaining configured SQL backend table rows in place. Workspace files and external CLI auth files stay on disk.
+- **Reset local data does not relaunch the app.** Settings → Maintenance → Danger zone calls `POST /hecate/v1/system/reset-data`, closes live external-agent chat sessions, removes Hecate-owned projects, chats, tasks, provider setup, policy rules, and saved external-agent grants, then clears remaining configured SQL backend table rows and embedded Cairnline mirror files in place. Workspace files and external CLI auth files stay on disk.
 - **Data dir is platform-specific.** Settings saved on macOS don't migrate
   to a Linux build of the same version. Multi-machine users keep separate
   config per platform.

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -188,6 +188,18 @@ Builds the same project-scoped context packet and role/driver selection that
 use this endpoint to show what `Auto` resolved to before asking the server to
 draft a proposal.
 
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is enabled and the
+backend-status route reports `read_model_switch_ready=true`, Hecate builds this
+packet from the Cairnline read model and marks it with
+`read_backend: "cairnline"`. The same projected context is used for Project
+Assistant draft generation so preview and proposal assembly stay aligned.
+The adapter preserves Hecate-owned projection details such as native snapshot
+timestamps and Hecate-only metadata while using Cairnline as the portable graph
+source, so ordering-sensitive context such as recent activity stays compatible
+with the Hecate-native path during replacement-readiness testing.
+Proposal ledger writes and proposal apply remain Hecate-owned until the
+Cairnline write adapter is authoritative.
+
 The v0 context packet is item-limited and body-budgeted. It includes project
 defaults, roots, context-source metadata, the selected work item when present,
 loaded project roles, recent assignments, accepted project memory, pending

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -625,7 +625,7 @@ POST /hecate/v1/mcp/probe
 
 Tool names come back un-namespaced — the operator wants to see what the upstream itself calls them, not the gateway's runtime alias. MCP Apps metadata is preserved when present: `_meta` is the raw upstream object, `ui_resource_uri` and `ui_visibility` are derived convenience fields, and `model_visible: false` means the tool is app-only and will not be shown to the agent-loop model. Bounded by a 10-second deadline; a stuck upstream surfaces as a 400 with the diagnostic rather than wedging the request.
 
-`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, plugin registry records, agent profiles, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are asked to delete their native ACP session before their rows disappear. If an adapter does not support `session/delete`, Hecate falls back to `session/close` and still tears down the owned process. When SQLite or Postgres is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. Workspace files and external CLI auth files are not touched. The endpoint is local-only and blocked in remote runtime mode: non-loopback sockets and forwarded-client headers are rejected.
+`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, plugin registry records, agent profiles, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are asked to delete their native ACP session before their rows disappear. If an adapter does not support `session/delete`, Hecate falls back to `session/close` and still tears down the owned process. When SQLite or Postgres is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. It also removes the embedded Cairnline mirror database files under the Hecate data directory so replacement-readiness mirrors cannot resurrect stale project state after reset. Workspace files and external CLI auth files are not touched. The endpoint is local-only and blocked in remote runtime mode: non-loopback sockets and forwarded-client headers are rejected.
 
 ```json
 → 200
@@ -641,7 +641,8 @@ Tool names come back un-namespaced — the operator wants to see what the upstre
     "providers_deleted": 1,
     "policy_rules_deleted": 1,
     "agent_approval_grants_deleted": 1,
-    "database_rows_deleted": 8
+    "database_rows_deleted": 8,
+    "cairnline_mirror_files_deleted": 1
   }
 }
 ```
@@ -1681,6 +1682,16 @@ start supervised work.
 ### `GET /hecate/v1/projects`
 
 Lists projects ordered by recent activity, then update/create time.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, this endpoint renders portable project
+identity, roots, default root, and context-source metadata from the Cairnline
+read model and marks each item with `read_backend: "cairnline"`. Project
+default profile and execution posture are read from Cairnline's project and
+execution-profile records where available; Hecate-only timestamps such as
+`last_opened_at` remain enriched from Hecate's native project store. Create,
+update, delete, root, and context-source mutations still commit to
+Hecate-native stores first; when Cairnline is configured they also best-effort
+mirror the portable project identity shape into the embedded Cairnline database.
 
 ```json
 GET /hecate/v1/projects
@@ -1690,6 +1701,7 @@ GET /hecate/v1/projects
   "data": [
     {
       "id": "proj_...",
+      "read_backend": "hecate",
       "name": "Hecate",
       "description": "Gateway and agent runtime",
       "roots": [
@@ -2202,11 +2214,61 @@ flows against Cairnline without UI-local fallback state. When
 `configured_backend=cairnline`, Hecate still serves live Projects APIs from the
 current Hecate-native stores. `read_model_switch_ready=true` means the
 Cairnline read adapter is wired well enough to project the full current Hecate
-project graph. In that state, project setup readiness, project health, work
-items, assignment lists, closeout readiness, activity inbox, and operations
-brief can be served from the Cairnline read model, while other live Projects
-reads still use Hecate.
-`write_adapter_ready=false` means writes and migration are still Hecate-owned.
+project graph, including the Project Assistant proposal ledger. In that state,
+project list/detail reads, project setup readiness, project health, skills,
+memory entries, memory candidates, roles, work items, assignment lists,
+assignment context previews, assignment launch-readiness, assignment preflight,
+artifact lists, handoff lists, Project Assistant context/proposal reads,
+closeout readiness, activity inbox, and operations brief can be served from the
+Cairnline read model, while other live Projects reads still use Hecate.
+`read_routes` lists the live read families currently backed by the Cairnline
+read model. `write_adapter_ready=false` means writes and migration are still
+Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
+can write Cairnline-shaped records during tests or local sync rehearsals;
+`write_adapter_gaps` lists mutation families whose live Hecate routes are not
+Cairnline-backed yet and therefore still block authority switch.
+Non-authoritative bridge seams currently cover project/root/source/defaults,
+agent profiles, skills, roles, work items, assignment metadata upsert/delete plus
+lifecycle-status sync, create-if-missing generic artifacts/evidence/reviews,
+handoffs, memory entries, memory candidates, Project Assistant proposal-ledger
+import, and all-project sync rehearsal. The additional
+`project-identity-live-mirror` seam means project create/update/delete plus root
+create/update/delete/discovery/worktree-creation, context-source
+create/update/delete/discovery, and project-default mutations still commit to
+Hecate stores first, then best-effort mirror the portable project identity shape
+into the embedded Cairnline database when Cairnline is configured. That mirror
+is not write authority.
+`project-skills-live-mirror` similarly mirrors metadata-only
+project skill discovery/update records after Hecate commits; it does not load,
+inject, or execute `SKILL.md` bodies. `agent-profiles-live-mirror` mirrors
+global agent-profile create/update/delete metadata and execution posture after
+Hecate commits; delete removes only the portable profile record because
+execution-profile posture can be shared. `project-roles-live-mirror` and
+`project-work-items-live-mirror` mirror role/work-item coordination metadata
+after Hecate commits. Role mirroring also seeds the referenced agent profile and
+execution posture when the profile store is available, so Cairnline role
+validation can pass without requiring a full sync first.
+`project-assignments-live-mirror` mirrors assignment create/update/delete
+coordination metadata and lifecycle status after Hecate commits. Mirror failures
+are logged. `project-assignment-start-result-live-mirror` best-effort mirrors
+committed assignment-start results after Hecate-owned dispatch completes or
+returns a committed cleanup/conflict state; it is replacement evidence, not
+runtime write authority. `project-assignment-chat-reconcile-live-mirror`
+best-effort mirrors assignment status/ref updates committed by linked
+external-agent chat reconciliation. `project-collaboration-live-mirror` mirrors
+collaboration artifact creation, including generic artifacts, evidence links,
+and reviews, and `project-handoffs-live-mirror` mirrors handoff
+create/update/delete mutations after Hecate commits. `project-memory-live-mirror`
+mirrors accepted project memory entries and `project-memory-candidates-live-mirror`
+mirrors reviewable candidate state after Hecate commits, including
+promoted/rejected status and promoted memory references.
+`project-assistant-proposal-ledger-live-mirror`
+mirrors Project Assistant draft/propose/apply proposal records and apply-attempt
+history after Hecate commits. `project-assistant-apply-side-effects-live-mirror`
+mirrors committed apply side effects after Hecate commits. Assignment-start
+dispatch and other non-mirrored live mutation routes still write only
+Hecate-native stores.
+`sync_readiness_url` points at the all-project embedded SQLite rehearsal sync.
 
 Example response:
 
@@ -2221,14 +2283,96 @@ Example response:
     "cairnline_authoritative": false,
     "read_model_switch_ready": true,
     "write_adapter_ready": false,
-    "status": "cairnline_read_routes_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the setup-readiness, health, work-item, assignment-list, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
-    "warnings": [
-      "Only the project setup-readiness, health, work-item, assignment-list, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
-      "Other project APIs still read and write Hecate-native stores.",
-      "Cairnline write adapter and migration path are not ready."
+    "read_routes": [
+      "project-list",
+      "project-detail",
+      "setup-readiness",
+      "health",
+      "skills",
+      "memory",
+      "memory-candidate",
+      "roles",
+      "work-item",
+      "assignment-list",
+      "assignment-context",
+      "launch-readiness",
+      "assignment-preflight",
+      "artifact-list",
+      "handoff-list",
+      "project-assistant-context",
+      "project-assistant-proposal",
+      "activity",
+      "closeout-readiness",
+      "operations-brief"
     ],
-    "replacement_readiness_url": "/hecate/v1/projects/{id}/cairnline/read-model"
+    "write_adapter_seams": [
+      "projects",
+      "roots",
+      "context-sources",
+      "project-defaults",
+      "project-identity-live-mirror",
+      "agent-profiles",
+      "agent-profiles-live-mirror",
+      "skills",
+      "project-skills-live-mirror",
+      "roles",
+      "project-roles-live-mirror",
+      "work-items",
+      "project-work-items-live-mirror",
+      "assignments",
+      "assignment-status",
+      "project-assignments-live-mirror",
+      "project-assignment-start-result-live-mirror",
+      "project-assignment-chat-reconcile-live-mirror",
+      "artifacts-create",
+      "evidence-create",
+      "reviews-create",
+      "project-collaboration-live-mirror",
+      "handoffs",
+      "project-handoffs-live-mirror",
+      "memory",
+      "project-memory-live-mirror",
+      "memory-candidates",
+      "project-memory-candidates-live-mirror",
+      "project-assistant-proposal-ledger-import",
+      "project-assistant-proposal-ledger-live-mirror",
+      "project-assistant-apply-side-effects-live-mirror",
+      "sync-rehearsal"
+    ],
+    "write_adapter_gaps": [
+      "projects",
+      "roots",
+      "context-sources",
+      "agent-profiles",
+      "skills",
+      "memory",
+      "memory-candidates",
+      "roles",
+      "work-items",
+      "assignments",
+      "assignment-start",
+      "artifacts",
+      "handoffs",
+      "project-assistant-proposals",
+      "migration-cutover"
+    ],
+    "status": "cairnline_read_routes_ready",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
+    "warnings": [
+      "Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
+      "Project identity, root create/update/delete/discovery/worktree-creation, context-source create/update/delete/discovery, and default mutations still write Hecate-native stores first, then best-effort mirror into the embedded Cairnline database.",
+      "Agent profile create/update/delete mutations still write Hecate-native stores first, then best-effort mirror portable profile metadata and execution posture into Cairnline.",
+      "Project skill discovery and metadata updates still write Hecate-native stores first, then best-effort mirror metadata-only skill records into Cairnline.",
+      "Project role and work-item mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline.",
+      "Project assignment create/update/delete mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results.",
+      "Project collaboration artifact creation and handoff mutations still write Hecate-native stores first, then best-effort mirror portable collaboration metadata into Cairnline.",
+      "Project memory entry and memory-candidate mutations still write Hecate-native stores first, then best-effort mirror accepted memory and reviewable candidate state into Cairnline.",
+      "Project Assistant proposal draft/propose/apply ledger mutations still write Hecate-native stores first, then best-effort mirror proposal records plus committed apply side effects into Cairnline.",
+      "Other project mutation routes still write only Hecate-native stores.",
+      "Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready."
+    ],
+    "replacement_readiness_url": "/hecate/v1/projects/{id}/cairnline/read-model",
+    "sync_readiness_url": "/hecate/v1/projects/cairnline/sync"
   }
 }
 ```
@@ -2239,10 +2383,17 @@ Local-only experimental bridge endpoint. It loads the selected project from
 Hecate's authoritative Projects stores, seeds an in-memory Cairnline service,
 and returns Cairnline's portable read projections for the project without
 writing an export database. The seeded project preserves roots,
-`default_root_id`, and context-source provenance metadata including source
-format, scope, category, trust label, and metadata labels so
-replacement-readiness checks exercise Hecate's workspace and context-control
-inputs.
+`default_root_id`, project default profile/execution-profile references, and
+context-source provenance metadata including source format, scope, category,
+trust label, and metadata labels so replacement-readiness checks exercise
+Hecate's workspace, launch-default, and context-control inputs. It also imports
+portable Project Assistant proposal ledger records,
+including root/default-root actions, proposal warnings, latest apply results,
+and apply attempts, without replaying proposal actions. The read model attempts
+to generate a portable Cairnline assignment launch packet for every seeded
+assignment and reports packet coverage, warnings, and errors separately from
+Hecate's runtime-specific context packets. A launch packet that builds with
+warnings is replacement evidence, but not a clean parity pass.
 
 The response is useful for replacement-readiness checks: it shows whether
 Cairnline can reconstruct the portable operations brief and activity inbox from
@@ -2256,7 +2407,10 @@ Example response:
   "object": "project_cairnline_read_model",
   "data": {
     "project_id": "proj_...",
+    "root_count": 1,
+    "context_source_count": 2,
     "agent_profile_count": 4,
+    "execution_profile_count": 5,
     "skill_count": 3,
     "role_count": 6,
     "work_item_count": 2,
@@ -2265,6 +2419,9 @@ Example response:
     "handoff_count": 1,
     "memory_entry_count": 3,
     "memory_candidate_count": 2,
+    "assistant_proposal_count": 1,
+    "launch_packet_count": 5,
+    "launch_packet_warning_count": 0,
     "operations": {
       "project_id": "proj_...",
       "status": "attention",
@@ -2310,13 +2467,14 @@ Example response:
 
 Local-only experimental bridge endpoint. It loads the same in-memory Cairnline
 read model as `/cairnline/read-model`, renders Hecate's native project activity
-and operations brief, then compares the shared counts.
+and operations brief, then compares raw graph counts, shared derived counts, and
+assignment launch-packet coverage.
 
 This endpoint is a replacement-readiness report, not a backend switch. A
 non-matching report does not mean either model is wrong; it means the current
 Cairnline portable model and Hecate cockpit model still differ on at least one
-count or semantic bucket that should be reviewed before Cairnline becomes
-authoritative.
+count, semantic bucket, or portable launch-packet coverage check that should be
+reviewed before Cairnline becomes authoritative.
 
 Example response:
 
@@ -2327,6 +2485,20 @@ Example response:
     "project_id": "proj_...",
     "match": true,
     "hecate": {
+      "graph": {
+        "roots": 1,
+        "context_sources": 2,
+        "agent_profiles": 4,
+        "execution_profiles": 5,
+        "skills": 3,
+        "roles": 6,
+        "work_items": 1,
+        "assignments": 1,
+        "artifacts": 4,
+        "handoffs": 1,
+        "memory_entries": 3,
+        "memory_candidates": 2
+      },
       "activity": {
         "work_items": 1,
         "assignments": 1,
@@ -2338,9 +2510,31 @@ Example response:
       "operations": {
         "pending_memory_candidates": 1,
         "open_handoffs": 1
+      },
+      "assistant": {
+        "proposals": 1
+      },
+      "launch_packets": {
+        "assignments": 1,
+        "warnings": 0,
+        "errors": 0
       }
     },
     "cairnline": {
+      "graph": {
+        "roots": 1,
+        "context_sources": 2,
+        "agent_profiles": 4,
+        "execution_profiles": 5,
+        "skills": 3,
+        "roles": 6,
+        "work_items": 1,
+        "assignments": 1,
+        "artifacts": 4,
+        "handoffs": 1,
+        "memory_entries": 3,
+        "memory_candidates": 2
+      },
       "activity": {
         "work_items": 1,
         "assignments": 1,
@@ -2352,8 +2546,97 @@ Example response:
       "operations": {
         "pending_memory_candidates": 1,
         "open_handoffs": 1
+      },
+      "assistant": {
+        "proposals": 1
+      },
+      "launch_packets": {
+        "assignments": 1,
+        "warnings": 0,
+        "errors": 0
       }
     }
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sync`
+
+Local-only experimental bridge endpoint. It loads every project from Hecate's
+authoritative Projects stores, writes a single refreshable embedded Cairnline
+SQLite database, then compares aggregate Hecate snapshot counts with aggregate
+counts, record ID sets, and semantic record-content digests read back from that
+database:
+
+```text
+{HECATE_DATA_DIR}/cairnline/embedded/projects.db
+```
+
+If `HECATE_DATA_DIR` is unset, Hecate uses `.data` relative to the runtime
+process. The caller cannot choose the output path. Re-running the endpoint
+replaces the same embedded sync database after the Hecate snapshots have been
+loaded, so it is deterministic and remains a migration rehearsal rather than a
+live dual-write path.
+
+This endpoint does not make Cairnline authoritative, does not proxy live
+Projects reads or writes, and does not migrate Hecate's stores. It exists to
+prove Hecate can seed a durable all-project Cairnline database before the write
+adapter and migration path exist. `match: false` means the sync completed but
+the written database no longer mirrors the source graph and launch-packet
+coverage at the count, record-ID, or semantic-record-content level; see
+`differences` for count mismatches, `id_differences` for same-family ID drift,
+and `content_differences` for same-path/same-ID records whose normalized
+Cairnline-shaped JSON digests differ. Content digests intentionally omit
+volatile write timestamps and do not expose raw project, memory, or artifact
+bodies in the response.
+
+Example response:
+
+```json
+{
+  "object": "project_cairnline_sync",
+  "data": {
+    "database_path": "/Users/alice/.hecate/cairnline/embedded/projects.db",
+    "match": true,
+    "hecate": {
+      "projects": 2,
+      "roots": 2,
+      "context_sources": 3,
+      "agent_profiles": 4,
+      "execution_profiles": 5,
+      "skills": 3,
+      "roles": 8,
+      "work_items": 2,
+      "assignments": 5,
+      "artifacts": 4,
+      "handoffs": 1,
+      "memory_entries": 3,
+      "memory_candidates": 2,
+      "assistant_proposals": 1,
+      "launch_packets": 5,
+      "launch_warnings": 0,
+      "launch_errors": 0
+    },
+    "cairnline": {
+      "projects": 2,
+      "roots": 2,
+      "context_sources": 3,
+      "agent_profiles": 4,
+      "execution_profiles": 5,
+      "skills": 3,
+      "roles": 8,
+      "work_items": 2,
+      "assignments": 5,
+      "artifacts": 4,
+      "handoffs": 1,
+      "memory_entries": 3,
+      "memory_candidates": 2,
+      "assistant_proposals": 1,
+      "launch_packets": 5,
+      "launch_warnings": 0,
+      "launch_errors": 0
+    },
+    "authoritative": false
   }
 }
 ```
@@ -2363,7 +2646,7 @@ Example response:
 Local-only experimental bridge endpoint. It loads the selected project from
 Hecate's authoritative Projects stores and writes a refreshable Cairnline SQLite
 export that preserves roots, `default_root_id`, and context-source provenance
-metadata at:
+metadata plus portable Project Assistant proposal ledger records at:
 
 ```text
 {HECATE_DATA_DIR}/cairnline/projects/{safe_project_id}.db
@@ -2376,7 +2659,8 @@ missing project does not wipe an existing export.
 
 This endpoint is an interoperability and replacement-readiness proof only. It
 does not make Cairnline authoritative, does not proxy live Projects reads or
-writes, and does not migrate Hecate's stores.
+writes, and does not migrate Hecate's stores. Response counts are read back
+from the written Cairnline database, not copied from the Hecate snapshot.
 
 Example response:
 
@@ -2386,7 +2670,10 @@ Example response:
   "data": {
     "project_id": "proj_...",
     "database_path": "/Users/alice/.hecate/cairnline/projects/proj_....db",
+    "root_count": 1,
+    "context_source_count": 2,
     "agent_profile_count": 4,
+    "execution_profile_count": 5,
     "skill_count": 3,
     "role_count": 6,
     "work_item_count": 2,
@@ -2394,7 +2681,8 @@ Example response:
     "artifact_count": 4,
     "handoff_count": 1,
     "memory_entry_count": 3,
-    "memory_candidate_count": 2
+    "memory_candidate_count": 2,
+    "assistant_proposal_count": 1
   }
 }
 ```
@@ -2429,6 +2717,11 @@ Memory entry fields:
 
 Lists enabled project memory entries by default. Pass
 `include_disabled=true` to inspect disabled entries too.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, this endpoint renders accepted project
+memory from the Cairnline read model and marks each item with
+`read_backend: "cairnline"`. Create, update, and delete requests still mutate
+Hecate's native memory stores until the Cairnline write adapter is ready.
 
 ```json
 GET /hecate/v1/projects/proj_.../memory?include_disabled=true
@@ -2440,6 +2733,7 @@ GET /hecate/v1/projects/proj_.../memory?include_disabled=true
       "id": "mem_...",
       "scope": "project",
       "project_id": "proj_...",
+      "read_backend": "hecate",
       "title": "Commit style",
       "body": "Use conventional commits.",
       "trust_label": "operator_memory",
@@ -2475,6 +2769,7 @@ POST /hecate/v1/projects/proj_.../memory
     "id": "mem_...",
     "scope": "project",
     "project_id": "proj_...",
+    "read_backend": "hecate",
     "title": "Review posture",
     "body": "Keep generated summaries labelled.",
     "trust_label": "operator_memory",
@@ -2501,6 +2796,12 @@ snapshotted the entry are not rewritten.
 Lists pending memory candidates by default. Pass `include_resolved=true` to
 include promoted and rejected candidates, or `status=pending|promoted|rejected`
 to filter explicitly.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, this endpoint renders memory candidates
+from the Cairnline read model and marks each item with
+`read_backend: "cairnline"`. Candidate creation, promotion, and rejection still
+mutate Hecate's native memory-candidate store until the Cairnline write adapter
+is ready.
 
 Candidates are review artifacts, not durable memory. Operators should inspect
 the candidate body, suggested trust/source fields, and `source_refs` before
@@ -2517,6 +2818,7 @@ GET /hecate/v1/projects/proj_.../memory/candidates
     {
       "id": "memcand_...",
       "project_id": "proj_...",
+      "read_backend": "hecate",
       "title": "Generated summary",
       "body": "Keep generated context labelled until reviewed.",
       "suggested_kind": "note",
@@ -3138,8 +3440,9 @@ buckets, Project Assistant remains the proposal author, and assignment start
 still goes through preflight and explicit operator confirmation.
 When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
 reports `read_model_switch_ready=true`, this endpoint uses the Cairnline read
-model for portable work operations and then projects those items into Hecate's
-existing cockpit action contract. Hecate-specific setup/defaults items and
+model for portable project/work/artifact/handoff/memory rows, then assembles the
+operator-facing brief through the same Hecate activity projection and cockpit
+action helpers as the native route. Hecate-specific setup/defaults items and
 client actions remain Hecate-owned, so `read_backend` identifies the source of
 the work-operations read model rather than a full Projects backend switch.
 Items are capped after sorting by priority, then an explicit operation-kind
@@ -3151,6 +3454,12 @@ operator-gated work when the brief has more candidates than it can show.
 
 Lists persisted project skills. These are project metadata records, not loaded
 runtime instructions. Bodies are never returned.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, this endpoint renders the portable skill
+registry from the Cairnline read model and marks each item with
+`read_backend: "cairnline"`. Hecate-only advisory fields such as
+`suggested_tools` and `required_permissions` are still enriched from the Hecate
+snapshot because they are not part of Cairnline's portable core skill contract.
 
 ```json
 {
@@ -3159,6 +3468,7 @@ runtime instructions. Bodies are never returned.
     {
       "id": "backend",
       "project_id": "proj_...",
+      "read_backend": "hecate",
       "title": "Backend",
       "description": "Build backend changes.",
       "path": ".hecate/skills/backend/SKILL.md",
@@ -3234,6 +3544,12 @@ Skill status values are `available`, `missing`, `invalid`, and `conflict`.
 
 Lists built-in roles plus custom roles for the project.
 
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
+reports `read_model_switch_ready=true`, this endpoint uses the Cairnline read
+model and enriches the portable roles with Hecate built-in flags plus
+role-level provider/model execution defaults. `read_backend` identifies the
+source of the role read model.
+
 ```json
 {
   "object": "project_roles",
@@ -3245,7 +3561,8 @@ Lists built-in roles plus custom roles for the project.
       "description": "Owns technical direction, boundaries, and system trade-offs.",
       "default_driver_kind": "hecate_task",
       "default_agent_profile": "architecture",
-      "built_in": true
+      "built_in": true,
+      "read_backend": "hecate"
     },
     {
       "id": "role_...",
@@ -3259,6 +3576,7 @@ Lists built-in roles plus custom roles for the project.
       "default_agent_profile": "implementation",
       "skill_ids": ["release"],
       "built_in": false,
+      "read_backend": "hecate",
       "created_at": "2026-06-03T12:00:00Z",
       "updated_at": "2026-06-03T12:00:00Z"
     }
@@ -3506,8 +3824,19 @@ or external-agent execution.
 Returns the best available context packet for the assignment. Hecate resolves
 linked Task/Run packets first, then falls back to the assignment-stored packet
 created by an External Agent start, then to a linked Chat `chat_session_id` +
-`message_id` from `execution_ref` when present. Unstarted assignments, rows
-without a stored packet or execution link, or older runs that predate snapshots return
+`message_id` from `execution_ref` when present.
+
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the Cairnline read
+adapter is ready, the endpoint falls back to an inspectable Cairnline
+assignment launch/context preview if no persisted Hecate execution packet
+exists. That preview is deterministic, metadata-oriented, and read-only: it
+does not create a Task, Run, Chat session, external-agent execution, memory
+entry, artifact, or assignment update. It shows portable project/work/role,
+profile, skill, source, memory, evidence, review, and handoff metadata so the
+operator can inspect what Cairnline would hand to a compatible orchestrator.
+
+With the default Hecate backend, unstarted assignments, rows without a stored
+packet or execution link, or older runs that predate snapshots return
 `404 not_found`. The Projects cockpit uses this endpoint for the assignment
 `Inspect context` action so operators can inspect the resolved profile, launch
 instructions, memory, project sources, work context, runtime refs, and skipped
@@ -3523,6 +3852,13 @@ support; active execution; workspace/root resolution; profile and skills
 resolution; native provider/model readiness; and External Agent adapter/options
 resolution.
 
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the Cairnline read
+adapter is ready, the project/work/assignment/role coordination records are
+read from the Cairnline read model and the response includes
+`read_backend: "cairnline"`. Hecate still owns the runtime launch checks:
+task-store/runner availability, active execution lookup, workspace validation,
+provider/model readiness, and External Agent adapter validation.
+
 The response envelope is:
 
 ```json
@@ -3532,6 +3868,7 @@ The response envelope is:
     "project_id": "proj_123",
     "work_item_id": "work_123",
     "assignment_id": "asgn_123",
+    "read_backend": "hecate",
     "ready": false,
     "status": "blocked",
     "title": "Launch is blocked",
@@ -3597,6 +3934,16 @@ item when the gateway is wired. That item is operator evidence, not the UI
 authority; clients should gate launch confirmation with the typed
 `/launch-readiness` projection rather than parsing context item copy.
 
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the Cairnline read
+adapter is ready, preflight reads the project/work/assignment/role coordination
+records from the Cairnline read model before applying Hecate-owned runtime
+validation. It also appends an inspect-only `runtime` /
+`cairnline_launch_packet` item. That item reports whether Cairnline can build a
+portable assignment launch packet and summarizes portable project/work/root,
+role, profile, execution profile, skills, evidence, reviews, handoffs, memory,
+and memory-candidate counts. It is replacement-readiness evidence only; Hecate
+still owns dispatch validation and the subsequent start/prepare mutation.
+
 The Projects cockpit uses this endpoint before `Start assignment`, `Prepare
 chat`, and `Start from handoff` so the operator can review the effective launch
 context before dispatch. The UI disables confirmation when
@@ -3656,7 +4003,11 @@ The persisted context packet records the resolved profile and applies its
 project memory/context-source policies. For native assignments, it also records
 the same `runtime` / `launch_readiness` metadata captured by preflight so later
 run-context inspection can show what provider/model readiness looked like when
-the assignment was started. `include` / `include_enabled` make the
+the assignment was started. When the Cairnline read adapter is active, the
+persisted packet also includes the same inspect-only `runtime` /
+`cairnline_launch_packet` replacement-readiness evidence captured by preflight;
+Hecate still owns task creation, route checks, approvals, and assignment
+mutation. `include` / `include_enabled` make the
 enabled project records active in the packet and add a `prompt_context`
 instructions item summarizing what was loaded into the native assignment prompt.
 `visible_only` / `inherit` keep records inspect-only, and `exclude` omits them
@@ -3745,7 +4096,11 @@ partial state.
 
 Lists structured handoff records for the project. Optional query parameters:
 `work_item_id=<id>` and `status=<pending|accepted|superseded|dismissed>`.
-Responses use `{ "object": "project_handoffs", "data": [...] }`.
+Responses use `{ "object": "project_handoffs", "data": [...] }`. When
+`HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend-status route
+reports `read_model_switch_ready=true`, list responses are projected from
+Cairnline and include `read_backend: "cairnline"` on each handoff; writes still
+mutate Hecate's native project-work store.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs`
 
@@ -3839,6 +4194,11 @@ entries, tasks, runs, chats, work items, or assignments.
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts`
 
 Lists collaboration artifacts attached to a work item.
+When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend-status
+route reports `read_model_switch_ready=true`, this list is projected from
+Cairnline and includes `read_backend: "cairnline"` on each artifact. The
+portable projection includes generic collaboration artifacts plus evidence and
+review records.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts`
 
@@ -3941,10 +4301,22 @@ Endpoints:
 - `POST /hecate/v1/chat/sessions/{id}/project-assistant/draft`
 
 `context` returns the v0 item-limited and body-budgeted project packet plus the
-inspectable Auto role/driver selection that `draft` will use. It includes
-project context-source metadata, but not source file bodies. Memory and
-memory-candidate bodies are truncated at per-body byte limits and carry returned
-byte counts, original byte counts, truncation flags, and cheap token estimates.
+inspectable Auto role/driver selection that `draft` will use. The response
+includes `read_backend` (`hecate` or `cairnline`). Under
+`HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`, this context packet is built
+from the Cairnline read model. Draft generation uses that same
+Cairnline-projected context so preview and proposal assembly do not drift,
+while proposal ledger writes and apply authority remain Hecate-owned.
+The projection keeps Hecate-owned compatibility details such as native snapshot
+timestamps and Hecate-only metadata where the current UI/model context depends
+on them; Cairnline supplies the portable project graph, not final write
+authority.
+Committed assistant side effects are best-effort mirrored into the embedded
+Cairnline database as replacement-readiness evidence.
+It includes project context-source metadata, but not source file bodies. Memory
+and memory-candidate bodies are truncated at per-body byte limits and carry
+returned byte counts, original byte counts, truncation flags, and cheap token
+estimates.
 `draft` creates proposal data only; it does not create a chat message, task,
 run, assignment, or external agent session. `draft_mode` defaults to
 `deterministic`; `draft_mode: "bootstrap"` deterministically proposes memory

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260626215734-a74b927f2bb3
+	github.com/hecatehq/cairnline v0.0.0-20260627233806-3ad8b2b37fac
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.0.0-20260626215734-a74b927f2bb3 h1:Hmg/jQqiDKrr0mKB2vB3s1pkVH8ml7A0WixSVUObpgM=
-github.com/hecatehq/cairnline v0.0.0-20260626215734-a74b927f2bb3/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260627233806-3ad8b2b37fac h1:5mfPIBfJ/Kg1LJ2hOjHokuEdQbPerk6VhyhTSMEc9Ng=
+github.com/hecatehq/cairnline v0.0.0-20260627233806-3ad8b2b37fac/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_agent_profiles.go
+++ b/internal/api/handler_agent_profiles.go
@@ -42,6 +42,7 @@ func (h *Handler) HandleCreateAgentProfile(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorAgentProfileToCairnline(r.Context(), "agent_profile_create", profile)
 	WriteJSON(w, http.StatusCreated, AgentProfileResponse{Object: "agent_profile", Data: renderAgentProfile(profile)})
 }
 
@@ -82,11 +83,13 @@ func (h *Handler) HandleUpdateAgentProfile(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorAgentProfileToCairnline(r.Context(), "agent_profile_update", profile)
 	WriteJSON(w, http.StatusOK, AgentProfileResponse{Object: "agent_profile", Data: renderAgentProfile(profile)})
 }
 
 func (h *Handler) HandleDeleteAgentProfile(w http.ResponseWriter, r *http.Request) {
-	if err := h.agentProfiles.Delete(r.Context(), r.PathValue("id")); errors.Is(err, agentprofiles.ErrNotFound) {
+	profileID := r.PathValue("id")
+	if err := h.agentProfiles.Delete(r.Context(), profileID); errors.Is(err, agentprofiles.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
 		return
 	} else if errors.Is(err, agentprofiles.ErrBuiltIn) {
@@ -96,6 +99,7 @@ func (h *Handler) HandleDeleteAgentProfile(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorAgentProfileDeleteToCairnline(r.Context(), "agent_profile_delete", profileID)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/api/handler_agent_profiles_test.go
+++ b/internal/api/handler_agent_profiles_test.go
@@ -8,12 +8,22 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/config"
 )
 
 func newAgentProfilesTestServer() http.Handler {
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
 	return NewServer(quietLogger(), handler)
+}
+
+func newAgentProfilesCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	return handler, NewServer(quietLogger(), handler)
 }
 
 func TestAgentProfilesAPI_CRUD(t *testing.T) {
@@ -91,6 +101,64 @@ func TestAgentProfilesAPI_CRUD(t *testing.T) {
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/agent-profiles/prof_backend", nil))
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("delete status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentProfilesAPI_MirrorsMutationsToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newAgentProfilesCairnlineMirrorTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-profiles", bytes.NewReader([]byte(`{
+		"id":"prof_cairnline",
+		"name":"Cairnline profile",
+		"description":"Mirrored posture",
+		"instructions":"Use project context deliberately.",
+		"project_memory_policy":"include",
+		"context_source_policy":"include_enabled",
+		"skill_ids":["implementation"],
+		"execution_profile":"profile_execution",
+		"provider_hint":"openai",
+		"model_hint":"gpt-5",
+		"tools_enabled":true,
+		"writes_allowed":true,
+		"network_allowed":false,
+		"approval_policy":"require",
+		"external_agent_kind":"hecate"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	profile := getMirroredCairnlineAgentProfileForTest(t, handler, "prof_cairnline")
+	if profile.Name != "Cairnline profile" || profile.MemoryPolicy != "include" || profile.SourcePolicy != "include_enabled" || !stringSliceContains(profile.SkillIDs, "implementation") {
+		t.Fatalf("mirrored profile after create = %+v, want profile metadata", profile)
+	}
+	if !cairnlineExecutionProfileIDExistsForTest(t, handler, "profile_execution") {
+		t.Fatalf("mirrored execution profiles missing profile_execution")
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/agent-profiles/prof_cairnline", bytes.NewReader([]byte(`{
+		"name":"Updated Cairnline profile",
+		"project_memory_policy":"visible_only",
+		"skill_ids":["review"]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	profile = getMirroredCairnlineAgentProfileForTest(t, handler, "prof_cairnline")
+	if profile.Name != "Updated Cairnline profile" || profile.MemoryPolicy != "visible_only" || !stringSliceContains(profile.SkillIDs, "review") || stringSliceContains(profile.SkillIDs, "implementation") {
+		t.Fatalf("mirrored profile after patch = %+v, want patched profile metadata", profile)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/agent-profiles/prof_cairnline", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+	assertCairnlineAgentProfileMissingForTest(t, handler, "prof_cairnline")
+	if !cairnlineExecutionProfileIDExistsForTest(t, handler, "profile_execution") {
+		t.Fatalf("delete should leave shared execution profile posture in place")
 	}
 }
 
@@ -179,4 +247,70 @@ func TestAgentProfilesAPI_GeneratesIDsAndReturnsNotFound(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("delete missing status = %d body=%s, want 404", rec.Code, rec.Body.String())
 	}
+}
+
+func getMirroredCairnlineAgentProfileForTest(t *testing.T, handler *Handler, id string) cairnline.AgentProfile {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	profiles, err := service.ListAgentProfiles(t.Context())
+	if err != nil {
+		t.Fatalf("ListAgentProfiles: %v", err)
+	}
+	for _, profile := range profiles {
+		if profile.ID == id {
+			return profile
+		}
+	}
+	t.Fatalf("mirrored Cairnline agent profile %q not found in %+v", id, profiles)
+	return cairnline.AgentProfile{}
+}
+
+func assertCairnlineAgentProfileMissingForTest(t *testing.T, handler *Handler, id string) {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	profiles, err := service.ListAgentProfiles(t.Context())
+	if err != nil {
+		t.Fatalf("ListAgentProfiles: %v", err)
+	}
+	for _, profile := range profiles {
+		if profile.ID == id {
+			t.Fatalf("mirrored Cairnline agent profile %q still exists: %+v", id, profile)
+		}
+	}
+}
+
+func cairnlineExecutionProfileIDExistsForTest(t *testing.T, handler *Handler, id string) bool {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	items, err := service.ListExecutionProfiles(t.Context())
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles: %v", err)
+	}
+	for _, item := range items {
+		if item.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContains(items []string, value string) bool {
+	for _, item := range items {
+		if item == value {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -199,11 +199,14 @@ func (h *Handler) contextPacketForProjectAssignment(ctx context.Context, assignm
 		return packet, ok, err
 	}
 	if h == nil || h.agentChat == nil || strings.TrimSpace(ref.ChatSessionID) == "" || strings.TrimSpace(ref.MessageID) == "" {
-		return chat.ContextPacket{}, false, nil
+		return h.contextPacketForCairnlineProjectAssignment(ctx, assignment)
 	}
 	session, ok, err := h.agentChat.Get(ctx, ref.ChatSessionID)
-	if err != nil || !ok {
+	if err != nil {
 		return chat.ContextPacket{}, false, err
+	}
+	if !ok {
+		return h.contextPacketForCairnlineProjectAssignment(ctx, assignment)
 	}
 	for _, message := range session.Messages {
 		if message.ID != strings.TrimSpace(ref.MessageID) {
@@ -212,7 +215,7 @@ func (h *Handler) contextPacketForProjectAssignment(ctx context.Context, assignm
 		packet, found := chatcontext.FromSessionMessage(session, message.ID)
 		return packet, found, nil
 	}
-	return chat.ContextPacket{}, false, nil
+	return h.contextPacketForCairnlineProjectAssignment(ctx, assignment)
 }
 
 func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Session, provider, model, systemPrompt string) chat.ContextPacket {

--- a/internal/api/handler_chat_context_cairnline.go
+++ b/internal/api/handler_chat_context_cairnline.go
@@ -1,0 +1,728 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+const cairnlineAssignmentContextReason = "Inspectable Cairnline read-model launch packet; Hecate has not created a task/chat execution snapshot for this assignment"
+const cairnlineAssignmentLaunchEvidenceReason = "Portable Cairnline launch packet evidence for replacement-readiness review"
+
+func (h *Handler) contextPacketForCairnlineProjectAssignment(ctx context.Context, assignment projectwork.Assignment) (chat.ContextPacket, bool, error) {
+	if h == nil || !h.projectReadRoutesUseCairnlineReadModel() {
+		return chat.ContextPacket{}, false, nil
+	}
+	launch, err := h.cairnlineAssignmentLaunchPacket(ctx, assignment)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return chat.ContextPacket{}, false, nil
+	}
+	if err != nil {
+		return chat.ContextPacket{}, false, err
+	}
+	return cairnlineAssignmentLaunchContextPacket(launch), true, nil
+}
+
+func (h *Handler) cairnlineAssignmentLaunchPacket(ctx context.Context, assignment projectwork.Assignment) (cairnline.AssignmentLaunchPacket, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, assignment.ProjectID)
+	if err != nil {
+		return cairnline.AssignmentLaunchPacket{}, err
+	}
+	return service.AssignmentLaunchPacket(ctx, snapshot.Project.ID, assignment.ID)
+}
+
+func cairnlineAssignmentLaunchContextPacket(launch cairnline.AssignmentLaunchPacket) chat.ContextPacket {
+	root, rootOK, rootSelection := selectedCairnlineRoot(launch.Project, launch.WorkItem, launch.Assignment)
+	workspace := ""
+	if rootOK {
+		workspace = strings.TrimSpace(root.Path)
+	}
+	provider, model, executionProfile := "", "", strings.TrimSpace(launch.Assignment.ExecutionProfileID)
+	if launch.ExecutionProfile != nil {
+		provider = strings.TrimSpace(launch.ExecutionProfile.ProviderHint)
+		model = strings.TrimSpace(launch.ExecutionProfile.ModelHint)
+		executionProfile = firstNonEmptyString(strings.TrimSpace(launch.ExecutionProfile.ID), executionProfile)
+	}
+	packet := baseChatContextPacket(firstNonEmptyString(strings.TrimSpace(launch.Assignment.ExecutionMode), cairnline.ExecutionMCPPull), provider, model, workspace)
+	packet.ID = firstNonEmptyString(strings.TrimSpace(launch.Assignment.ContextSnapshotID), "cairnline_assignment_context_"+strings.TrimSpace(launch.Assignment.ID))
+	packet.ExecutionProfile = executionProfile
+	packet.SystemPromptIncluded = false
+	packet.Refs = &chat.ContextRefs{
+		ProjectID:    strings.TrimSpace(launch.Project.ID),
+		WorkItemID:   strings.TrimSpace(launch.WorkItem.ID),
+		AssignmentID: strings.TrimSpace(launch.Assignment.ID),
+		RoleID:       strings.TrimSpace(launch.Assignment.RoleID),
+	}
+
+	appendCairnlineProjectSummary(&packet, launch.Project)
+	appendCairnlineWorkItem(&packet, launch.WorkItem)
+	appendCairnlineAssignment(&packet, launch.Assignment)
+	if rootOK {
+		appendCairnlineRoot(&packet, root, rootSelection)
+	}
+	if launch.Role != nil {
+		appendCairnlineRole(&packet, *launch.Role)
+	}
+	if launch.Profile != nil {
+		appendCairnlineAgentProfile(&packet, *launch.Profile)
+	}
+	if launch.ExecutionProfile != nil {
+		appendCairnlineExecutionProfile(&packet, *launch.ExecutionProfile)
+	}
+	appendCairnlineProjectSkills(&packet, launch)
+	appendCairnlineMemory(&packet, launch.Memory)
+	appendCairnlineMemoryCandidates(&packet, launch.MemoryCandidates)
+	appendCairnlineProjectSources(&packet, launch.Project.ContextSources)
+	appendCairnlineAssignmentArtifacts(&packet, launch)
+	appendCairnlineAssignmentHandoffs(&packet, launch)
+	appendCairnlineLaunchRuntime(&packet, launch)
+	return packet
+}
+
+func (h *Handler) appendCairnlineAssignmentLaunchPacketEvidence(ctx context.Context, packet *chat.ContextPacket, assignment projectwork.Assignment) {
+	if h == nil || packet == nil || !h.projectReadRoutesUseCairnlineReadModel() {
+		return
+	}
+	launch, err := h.cairnlineAssignmentLaunchPacket(ctx, assignment)
+	if err != nil {
+		appendCairnlineAssignmentLaunchPacketEvidenceError(packet, assignment, err)
+		return
+	}
+	appendCairnlineAssignmentLaunchPacketEvidenceItem(packet, launch)
+}
+
+func appendCairnlineAssignmentLaunchPacketEvidenceItem(packet *chat.ContextPacket, launch cairnline.AssignmentLaunchPacket) {
+	root, rootOK, rootSelection := selectedCairnlineRoot(launch.Project, launch.WorkItem, launch.Assignment)
+	rootID, rootPath := "", ""
+	rootDetail := "none"
+	if rootOK {
+		rootID = strings.TrimSpace(root.ID)
+		rootPath = strings.TrimSpace(root.Path)
+		rootDetail = firstNonEmptyString(rootID, "unresolved") + " (" + firstNonEmptyString(rootPath, "no path") + "; " + firstNonEmptyString(rootSelection, "fallback") + ")"
+	}
+	profileID := strings.TrimSpace(launch.Assignment.ProfileID)
+	if launch.Profile != nil {
+		profileID = firstNonEmptyString(strings.TrimSpace(launch.Profile.ID), profileID)
+	}
+	executionProfileID := strings.TrimSpace(launch.Assignment.ExecutionProfileID)
+	if launch.ExecutionProfile != nil {
+		executionProfileID = firstNonEmptyString(strings.TrimSpace(launch.ExecutionProfile.ID), executionProfileID)
+	}
+	roleLabel := strings.TrimSpace(launch.Assignment.RoleID)
+	if launch.Role != nil && strings.TrimSpace(launch.Role.Name) != "" {
+		roleLabel = firstNonEmptyString(roleLabel, strings.TrimSpace(launch.Role.ID)) + " (" + strings.TrimSpace(launch.Role.Name) + ")"
+	}
+	body := []string{
+		"Ready: true",
+		"Project: " + firstNonEmptyString(strings.TrimSpace(launch.Project.ID), "unknown"),
+		"Work item: " + firstNonEmptyString(strings.TrimSpace(launch.WorkItem.ID), "unknown"),
+		"Assignment: " + firstNonEmptyString(strings.TrimSpace(launch.Assignment.ID), "unknown"),
+		"Execution mode: " + firstNonEmptyString(strings.TrimSpace(launch.Assignment.ExecutionMode), cairnline.ExecutionMCPPull),
+		"Role: " + firstNonEmptyString(roleLabel, "none"),
+		"Desired agent: " + firstNonEmptyString(strings.TrimSpace(launch.Assignment.DesiredAgent.Kind), cairnline.DesiredAgentAny),
+		"Profile: " + firstNonEmptyString(profileID, "inherit"),
+		"Execution profile: " + firstNonEmptyString(executionProfileID, "inherit"),
+		"Root: " + rootDetail,
+		fmt.Sprintf("Skills: %d; artifacts: %d; evidence: %d; reviews: %d; handoffs: %d; memory: %d; memory candidates: %d",
+			len(launch.Skills),
+			len(launch.Artifacts),
+			len(launch.Evidence),
+			len(launch.Reviews),
+			len(launch.Handoffs),
+			len(launch.Memory),
+			len(launch.MemoryCandidates),
+		),
+	}
+	if launchID := strings.TrimSpace(launch.ID); launchID != "" {
+		body = append(body, "Launch packet: "+launchID)
+	}
+	if len(launch.Warnings) > 0 {
+		body = append(body, "Warnings: "+strings.Join(compactContextIDs(launch.Warnings), " "))
+	}
+	metadata := cairnlineAssignmentLaunchPacketEvidenceMetadata(launch, rootID, rootPath, true, "")
+	appendCairnlineAssignmentLaunchPacketEvidenceSource(packet, strings.Join(body, "\n"), metadata)
+}
+
+func appendCairnlineAssignmentLaunchPacketEvidenceError(packet *chat.ContextPacket, assignment projectwork.Assignment, err error) {
+	message := strings.TrimSpace(err.Error())
+	if errors.Is(err, cairnline.ErrNotFound) {
+		message = "Cairnline launch packet not found for assignment " + firstNonEmptyString(strings.TrimSpace(assignment.ID), "unknown")
+	}
+	body := strings.Join([]string{
+		"Ready: false",
+		"Assignment: " + firstNonEmptyString(strings.TrimSpace(assignment.ID), "unknown"),
+		"Error: " + firstNonEmptyString(message, "Cairnline launch packet could not be built."),
+	}, "\n")
+	metadata := map[string]string{
+		"read_backend":  "cairnline",
+		"ready":         "false",
+		"project_id":    strings.TrimSpace(assignment.ProjectID),
+		"work_item_id":  strings.TrimSpace(assignment.WorkItemID),
+		"assignment_id": strings.TrimSpace(assignment.ID),
+		"role_id":       strings.TrimSpace(assignment.RoleID),
+		"error":         firstNonEmptyString(message, "Cairnline launch packet could not be built."),
+	}
+	appendCairnlineAssignmentLaunchPacketEvidenceSource(packet, body, metadata)
+}
+
+func appendCairnlineAssignmentLaunchPacketEvidenceSource(packet *chat.ContextPacket, body string, metadata map[string]string) {
+	appendContextPacketSourceWithSection(packet, contextSectionRuntime, chat.ContextSource{
+		Kind:   "cairnline_launch_packet",
+		Label:  "Cairnline launch packet",
+		Detail: strings.TrimSpace(metadata["assignment_id"]),
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "cairnline_launch_packet",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          "cairnline.assignment_launch_packet",
+		Title:           "Cairnline launch packet",
+		Body:            body,
+		Included:        false,
+		InclusionReason: cairnlineAssignmentLaunchEvidenceReason,
+		Metadata:        metadata,
+	})
+}
+
+func cairnlineAssignmentLaunchPacketEvidenceMetadata(launch cairnline.AssignmentLaunchPacket, rootID, rootPath string, ready bool, errorMessage string) map[string]string {
+	metadata := map[string]string{
+		"read_backend":           "cairnline",
+		"ready":                  fmt.Sprintf("%t", ready),
+		"project_id":             strings.TrimSpace(launch.Project.ID),
+		"work_item_id":           strings.TrimSpace(launch.WorkItem.ID),
+		"assignment_id":          strings.TrimSpace(launch.Assignment.ID),
+		"role_id":                strings.TrimSpace(launch.Assignment.RoleID),
+		"root_id":                strings.TrimSpace(rootID),
+		"root_path":              strings.TrimSpace(rootPath),
+		"execution_mode":         firstNonEmptyString(strings.TrimSpace(launch.Assignment.ExecutionMode), cairnline.ExecutionMCPPull),
+		"desired_agent":          firstNonEmptyString(strings.TrimSpace(launch.Assignment.DesiredAgent.Kind), cairnline.DesiredAgentAny),
+		"profile_id":             strings.TrimSpace(launch.Assignment.ProfileID),
+		"execution_profile_id":   strings.TrimSpace(launch.Assignment.ExecutionProfileID),
+		"skill_count":            fmt.Sprintf("%d", len(launch.Skills)),
+		"artifact_count":         fmt.Sprintf("%d", len(launch.Artifacts)),
+		"evidence_count":         fmt.Sprintf("%d", len(launch.Evidence)),
+		"review_count":           fmt.Sprintf("%d", len(launch.Reviews)),
+		"handoff_count":          fmt.Sprintf("%d", len(launch.Handoffs)),
+		"memory_count":           fmt.Sprintf("%d", len(launch.Memory)),
+		"memory_candidate_count": fmt.Sprintf("%d", len(launch.MemoryCandidates)),
+	}
+	if launch.Profile != nil {
+		metadata["profile_id"] = firstNonEmptyString(strings.TrimSpace(launch.Profile.ID), metadata["profile_id"])
+	}
+	if launch.ExecutionProfile != nil {
+		metadata["execution_profile_id"] = firstNonEmptyString(strings.TrimSpace(launch.ExecutionProfile.ID), metadata["execution_profile_id"])
+	}
+	if launchID := strings.TrimSpace(launch.ID); launchID != "" {
+		metadata["launch_packet_id"] = launchID
+	}
+	if len(launch.Warnings) > 0 {
+		metadata["warnings"] = strings.Join(compactContextIDs(launch.Warnings), " ")
+	}
+	if errorMessage = strings.TrimSpace(errorMessage); errorMessage != "" {
+		metadata["error"] = errorMessage
+	}
+	return metadata
+}
+
+func appendCairnlineProjectSummary(packet *chat.ContextPacket, project cairnline.Project) {
+	label := firstNonEmptyString(strings.TrimSpace(project.Name), strings.TrimSpace(project.ID), "Project")
+	body := "Description: " + firstNonEmptyString(strings.TrimSpace(project.Description), "No description recorded.")
+	if rootID := strings.TrimSpace(project.DefaultRootID); rootID != "" {
+		body += "\nDefault root: " + rootID
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProject, chat.ContextSource{
+		Kind:   "project",
+		Label:  label,
+		Detail: strings.TrimSpace(project.ID),
+		Trust:  contextTrustProject,
+	}, chat.ContextItem{
+		Kind:            "project",
+		TrustLevel:      contextTrustProject,
+		Origin:          strings.TrimSpace(project.ID),
+		Title:           label,
+		Body:            body,
+		Included:        true,
+		InclusionReason: cairnlineAssignmentContextReason,
+	})
+}
+
+func appendCairnlineWorkItem(packet *chat.ContextPacket, item cairnline.WorkItem) {
+	body := []string{
+		"Status: " + firstNonEmptyString(strings.TrimSpace(item.Status), "unknown"),
+		"Priority: " + firstNonEmptyString(strings.TrimSpace(item.Priority), "normal"),
+		"Brief: " + firstNonEmptyString(strings.TrimSpace(item.Brief), "No brief recorded."),
+	}
+	if owner := strings.TrimSpace(item.OwnerRoleID); owner != "" {
+		body = append(body, "Owner role: "+owner)
+	}
+	if reviewers := compactContextIDs(item.ReviewerRoleIDs); len(reviewers) > 0 {
+		body = append(body, "Reviewer roles: "+strings.Join(reviewers, ", "))
+	}
+	if rootID := strings.TrimSpace(item.RootID); rootID != "" {
+		body = append(body, "Root: "+rootID)
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "work_item",
+		Label:  firstNonEmptyString(strings.TrimSpace(item.Title), strings.TrimSpace(item.ID)),
+		Detail: strings.TrimSpace(item.ID),
+		Trust:  contextTrustProject,
+	}, chat.ContextItem{
+		Kind:            "work_item",
+		TrustLevel:      contextTrustProject,
+		Origin:          strings.TrimSpace(item.ID),
+		Title:           firstNonEmptyString(strings.TrimSpace(item.Title), strings.TrimSpace(item.ID)),
+		Body:            strings.Join(body, "\n"),
+		Included:        true,
+		InclusionReason: cairnlineAssignmentContextReason,
+	})
+}
+
+func appendCairnlineAssignment(packet *chat.ContextPacket, item cairnline.Assignment) {
+	body := []string{
+		"Status: " + firstNonEmptyString(strings.TrimSpace(item.Status), "unknown"),
+		"Execution mode: " + firstNonEmptyString(strings.TrimSpace(item.ExecutionMode), cairnline.ExecutionMCPPull),
+		"Role: " + firstNonEmptyString(strings.TrimSpace(item.RoleID), "none"),
+		"Desired agent: " + firstNonEmptyString(strings.TrimSpace(item.DesiredAgent.Kind), cairnline.DesiredAgentAny),
+		"Profile: " + firstNonEmptyString(strings.TrimSpace(item.ProfileID), "inherit"),
+		"Execution profile: " + firstNonEmptyString(strings.TrimSpace(item.ExecutionProfileID), "inherit"),
+	}
+	if rootID := strings.TrimSpace(item.RootID); rootID != "" {
+		body = append(body, "Root override: "+rootID)
+	}
+	if skills := compactContextIDs(item.DesiredAgent.SkillIDs); len(skills) > 0 {
+		body = append(body, "Desired skills: "+strings.Join(skills, ", "))
+	}
+	if claimedBy := strings.TrimSpace(item.ClaimedBy); claimedBy != "" {
+		body = append(body, "Claimed by: "+claimedBy)
+	}
+	if executionRef := strings.TrimSpace(item.ExecutionRef); executionRef != "" {
+		body = append(body, "Execution ref: "+executionRef)
+	}
+	if contextSnapshotID := strings.TrimSpace(item.ContextSnapshotID); contextSnapshotID != "" {
+		body = append(body, "Context snapshot: "+contextSnapshotID)
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "assignment",
+		Label:  firstNonEmptyString(strings.TrimSpace(item.ID), "Assignment"),
+		Detail: strings.TrimSpace(item.ExecutionMode),
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "assignment",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          strings.TrimSpace(item.ID),
+		Title:           "Assignment",
+		Body:            strings.Join(body, "\n"),
+		Included:        true,
+		InclusionReason: cairnlineAssignmentContextReason,
+	})
+}
+
+func appendCairnlineRoot(packet *chat.ContextPacket, root cairnline.Root, selection string) {
+	body := []string{
+		"Root ID: " + firstNonEmptyString(strings.TrimSpace(root.ID), "unresolved"),
+		"Path: " + firstNonEmptyString(strings.TrimSpace(root.Path), "none"),
+		"Kind: " + firstNonEmptyString(strings.TrimSpace(root.Kind), "local"),
+		"Active: " + boolLabel(root.Active),
+		"Selection: " + firstNonEmptyString(strings.TrimSpace(selection), "project root fallback"),
+	}
+	if branch := strings.TrimSpace(root.GitBranch); branch != "" {
+		body = append(body, "Git branch: "+branch)
+	}
+	if remote := strings.TrimSpace(root.GitRemote); remote != "" {
+		body = append(body, "Git remote: "+remote)
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "project_root",
+		Label:  firstNonEmptyString(strings.TrimSpace(root.ID), "Project root"),
+		Detail: strings.TrimSpace(root.Path),
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "project_root",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          firstNonEmptyString(strings.TrimSpace(root.ID), "project_root"),
+		Title:           "Project root",
+		Body:            strings.Join(body, "\n"),
+		Included:        true,
+		InclusionReason: cairnlineAssignmentContextReason,
+	})
+}
+
+func appendCairnlineRole(packet *chat.ContextPacket, role cairnline.Role) {
+	body := []string{
+		"Description: " + firstNonEmptyString(strings.TrimSpace(role.Description), "No description recorded."),
+		"Instructions: " + firstNonEmptyString(strings.TrimSpace(role.Instructions), "No role instructions recorded."),
+		"Default profile: " + firstNonEmptyString(strings.TrimSpace(role.DefaultProfileID), "none"),
+		"Default execution profile: " + firstNonEmptyString(strings.TrimSpace(role.DefaultExecutionProfileID), "none"),
+		"Default execution mode: " + firstNonEmptyString(strings.TrimSpace(role.DefaultExecutionMode), "inherit"),
+	}
+	if skills := compactContextIDs(role.DefaultSkillIDs); len(skills) > 0 {
+		body = append(body, "Default skills: "+strings.Join(skills, ", "))
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProjectWork, chat.ContextSource{
+		Kind:   "role",
+		Label:  firstNonEmptyString(strings.TrimSpace(role.Name), strings.TrimSpace(role.ID)),
+		Detail: strings.TrimSpace(role.ID),
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "role",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          strings.TrimSpace(role.ID),
+		Title:           firstNonEmptyString(strings.TrimSpace(role.Name), strings.TrimSpace(role.ID)),
+		Body:            strings.Join(body, "\n"),
+		Included:        true,
+		InclusionReason: cairnlineAssignmentContextReason,
+	})
+}
+
+func appendCairnlineAgentProfile(packet *chat.ContextPacket, profile cairnline.AgentProfile) {
+	body := []string{
+		"ID: " + strings.TrimSpace(profile.ID),
+		"Name: " + firstNonEmptyString(strings.TrimSpace(profile.Name), strings.TrimSpace(profile.ID)),
+		"Context policy: " + firstNonEmptyString(strings.TrimSpace(profile.ContextPolicy), "inherit"),
+		"Memory policy: " + firstNonEmptyString(strings.TrimSpace(profile.MemoryPolicy), "inherit"),
+		"Source policy: " + firstNonEmptyString(strings.TrimSpace(profile.SourcePolicy), "inherit"),
+	}
+	if description := strings.TrimSpace(profile.Description); description != "" {
+		body = append(body, "Description: "+description)
+	}
+	if instructions := strings.TrimSpace(profile.Instructions); instructions != "" {
+		body = append(body, "Instructions:\n"+instructions)
+	}
+	if skills := compactContextIDs(profile.SkillIDs); len(skills) > 0 {
+		body = append(body, "Skills: "+strings.Join(skills, ", "))
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProfile, chat.ContextSource{
+		Kind:   "agent_profile",
+		Label:  firstNonEmptyString(strings.TrimSpace(profile.Name), strings.TrimSpace(profile.ID)),
+		Detail: strings.TrimSpace(profile.ID),
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "agent_profile",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          strings.TrimSpace(profile.ID),
+		Title:           firstNonEmptyString(strings.TrimSpace(profile.Name), strings.TrimSpace(profile.ID)),
+		Body:            strings.Join(body, "\n"),
+		Included:        true,
+		InclusionReason: cairnlineAssignmentContextReason,
+	})
+}
+
+func appendCairnlineExecutionProfile(packet *chat.ContextPacket, profile cairnline.ExecutionProfile) {
+	body := []string{
+		"ID: " + strings.TrimSpace(profile.ID),
+		"Name: " + firstNonEmptyString(strings.TrimSpace(profile.Name), strings.TrimSpace(profile.ID)),
+		"Agent kind: " + firstNonEmptyString(strings.TrimSpace(profile.AgentKind), cairnline.DesiredAgentAny),
+		"Provider hint: " + firstNonEmptyString(strings.TrimSpace(profile.ProviderHint), "inherit"),
+		"Model hint: " + firstNonEmptyString(strings.TrimSpace(profile.ModelHint), "inherit"),
+		"Tools policy: " + firstNonEmptyString(strings.TrimSpace(profile.ToolsPolicy), "inherit"),
+		"Writes policy: " + firstNonEmptyString(strings.TrimSpace(profile.WritesPolicy), "inherit"),
+		"Network policy: " + firstNonEmptyString(strings.TrimSpace(profile.NetworkPolicy), "inherit"),
+		"Approval policy: " + firstNonEmptyString(strings.TrimSpace(profile.ApprovalPolicy), "inherit"),
+	}
+	if description := strings.TrimSpace(profile.Description); description != "" {
+		body = append(body, "Description: "+description)
+	}
+	if keys := cairnlineAdapterOptionKeys(profile.AdapterOptions); len(keys) > 0 {
+		body = append(body, "Adapter option keys: "+strings.Join(keys, ", "))
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionProfile, chat.ContextSource{
+		Kind:   "execution_profile",
+		Label:  firstNonEmptyString(strings.TrimSpace(profile.Name), strings.TrimSpace(profile.ID)),
+		Detail: strings.TrimSpace(profile.ID),
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "execution_profile",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          strings.TrimSpace(profile.ID),
+		Title:           firstNonEmptyString(strings.TrimSpace(profile.Name), strings.TrimSpace(profile.ID)),
+		Body:            strings.Join(body, "\n"),
+		Included:        true,
+		InclusionReason: cairnlineAssignmentContextReason,
+	})
+}
+
+func appendCairnlineProjectSkills(packet *chat.ContextPacket, launch cairnline.AssignmentLaunchPacket) {
+	requested := cairnlineRequestedSkillIDs(launch)
+	if len(requested) == 0 && len(launch.Skills) == 0 {
+		return
+	}
+	body := []string{
+		"Requested: " + firstNonEmptyString(strings.Join(requested, ", "), "none"),
+	}
+	if len(launch.Skills) > 0 {
+		resolved := make([]string, 0, len(launch.Skills))
+		for _, skill := range launch.Skills {
+			detail := firstNonEmptyString(strings.TrimSpace(skill.ID), strings.TrimSpace(skill.Title), "skill")
+			if path := strings.TrimSpace(skill.Path); path != "" {
+				detail += " (" + path + ")"
+			}
+			if status := strings.TrimSpace(skill.Status); status != "" {
+				detail += "; status: " + status
+			}
+			if trust := strings.TrimSpace(skill.TrustLabel); trust != "" {
+				detail += "; trust: " + trust
+			}
+			if len(skill.Warnings) > 0 {
+				detail += "; warnings: " + strings.Join(compactContextIDs(skill.Warnings), " ")
+			}
+			resolved = append(resolved, detail)
+		}
+		body = append(body, "Resolved enabled skills: "+strings.Join(resolved, ", "))
+	} else {
+		body = append(body, "Resolved enabled skills: none")
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionSkills, chat.ContextSource{
+		Kind:   "project_skills",
+		Label:  "Project skills",
+		Detail: strings.Join(requested, ","),
+		Trust:  projectskills.TrustWorkspaceSkill,
+	}, chat.ContextItem{
+		Kind:            "project_skills",
+		TrustLevel:      projectskills.TrustWorkspaceSkill,
+		Origin:          "project_skills",
+		Title:           "Project skills",
+		Body:            strings.Join(body, "\n"),
+		Included:        len(launch.Skills) > 0,
+		InclusionReason: "Cairnline resolved skill metadata for this assignment; skill bodies are not injected",
+	})
+}
+
+func appendCairnlineMemory(packet *chat.ContextPacket, entries []cairnline.MemoryEntry) {
+	for _, entry := range entries {
+		appendProjectMemoryEntry(packet, memory.Entry{
+			ID:         strings.TrimSpace(entry.ID),
+			ProjectID:  strings.TrimSpace(entry.ProjectID),
+			Title:      strings.TrimSpace(entry.Title),
+			Body:       strings.TrimSpace(entry.Body),
+			TrustLabel: strings.TrimSpace(entry.TrustLabel),
+			SourceKind: strings.TrimSpace(entry.SourceKind),
+			SourceID:   strings.TrimSpace(entry.SourceID),
+			Enabled:    entry.Enabled,
+			CreatedAt:  entry.CreatedAt,
+			UpdatedAt:  entry.UpdatedAt,
+		}, false, "Inspectable Cairnline memory only; this read-model endpoint does not inject memory bodies into a model prompt")
+	}
+}
+
+func appendCairnlineMemoryCandidates(packet *chat.ContextPacket, candidates []cairnline.MemoryCandidate) {
+	for _, candidate := range candidates {
+		trust := firstNonEmptyString(strings.TrimSpace(candidate.SuggestedTrustLabel), contextTrustRuntimeState)
+		appendContextPacketSourceWithSection(packet, contextSectionMemory, chat.ContextSource{
+			Kind:   "memory_candidate",
+			Label:  firstNonEmptyString(strings.TrimSpace(candidate.Title), strings.TrimSpace(candidate.ID)),
+			Detail: strings.TrimSpace(candidate.ID),
+			Trust:  trust,
+		}, chat.ContextItem{
+			Kind:            "memory_candidate",
+			TrustLevel:      trust,
+			Origin:          strings.TrimSpace(candidate.ID),
+			Title:           firstNonEmptyString(strings.TrimSpace(candidate.Title), strings.TrimSpace(candidate.ID)),
+			Body:            strings.TrimSpace(candidate.Body),
+			Included:        false,
+			InclusionReason: "Pending memory candidate is inspectable only until the operator promotes it",
+			Metadata: map[string]string{
+				"status":                strings.TrimSpace(candidate.Status),
+				"suggested_kind":        strings.TrimSpace(candidate.SuggestedKind),
+				"suggested_source_kind": strings.TrimSpace(candidate.SuggestedSourceKind),
+				"suggested_source_id":   strings.TrimSpace(candidate.SuggestedSourceID),
+			},
+		})
+	}
+}
+
+func appendCairnlineProjectSources(packet *chat.ContextPacket, sources []cairnline.Source) {
+	for _, source := range sources {
+		trust := firstNonEmptyString(strings.TrimSpace(source.TrustLabel), contextTrustWorkspaceGuidance)
+		appendContextPacketSourceWithSection(packet, contextSectionSources, chat.ContextSource{
+			Kind:   projectContextSourceKind(source.Kind),
+			Label:  firstNonEmptyString(strings.TrimSpace(source.Title), strings.TrimSpace(source.ID)),
+			Detail: strings.TrimSpace(source.Locator),
+			Trust:  trust,
+		}, chat.ContextItem{
+			Kind:            projectContextSourceKind(source.Kind),
+			TrustLevel:      trust,
+			Origin:          firstNonEmptyString(strings.TrimSpace(source.ID), strings.TrimSpace(source.Locator)),
+			Title:           firstNonEmptyString(strings.TrimSpace(source.Title), strings.TrimSpace(source.ID)),
+			BodyRef:         strings.TrimSpace(source.Locator),
+			Included:        false,
+			InclusionReason: "Cairnline source metadata is inspectable only; source file bodies are not loaded by this endpoint",
+			Metadata: map[string]string{
+				"enabled":         boolLabel(source.Enabled),
+				"format":          strings.TrimSpace(source.Format),
+				"scope":           strings.TrimSpace(source.Scope),
+				"source_category": strings.TrimSpace(source.SourceCategory),
+			},
+		})
+	}
+}
+
+func appendCairnlineAssignmentArtifacts(packet *chat.ContextPacket, launch cairnline.AssignmentLaunchPacket) {
+	items := make([]projectwork.CollaborationArtifact, 0, len(launch.Artifacts)+len(launch.Evidence)+len(launch.Reviews))
+	for _, item := range launch.Artifacts {
+		items = append(items, projectWorkArtifactFromCairnline(item))
+	}
+	for _, item := range launch.Evidence {
+		items = append(items, projectHealthEvidenceFromCairnline(item))
+	}
+	for _, item := range launch.Reviews {
+		items = append(items, projectHealthReviewFromCairnline(item))
+	}
+	if len(items) == 0 {
+		return
+	}
+	appendProjectAssignmentArtifacts(packet, filterAssignmentArtifacts(items, launch.Assignment.ID), false, "Collaboration artifact is inspectable Cairnline project evidence; not injected into a model prompt")
+}
+
+func appendCairnlineAssignmentHandoffs(packet *chat.ContextPacket, launch cairnline.AssignmentLaunchPacket) {
+	items := make([]projectwork.Handoff, 0, len(launch.Handoffs))
+	for _, item := range launch.Handoffs {
+		items = append(items, projectHealthHandoffFromCairnline(item))
+	}
+	appendProjectAssignmentHandoffs(packet, filterAssignmentHandoffs(items, launch.Assignment.ID, launch.Assignment.RoleID), false, "Handoff metadata is inspectable Cairnline project evidence; not injected into a model prompt")
+}
+
+func appendCairnlineLaunchRuntime(packet *chat.ContextPacket, launch cairnline.AssignmentLaunchPacket) {
+	body := []string{
+		"Read backend: cairnline",
+		"Launch packet kind: " + firstNonEmptyString(strings.TrimSpace(launch.Kind), "assignment"),
+		"Portable execution mode: " + firstNonEmptyString(strings.TrimSpace(launch.Assignment.ExecutionMode), cairnline.ExecutionMCPPull),
+		"Preview only: Hecate stores remain authoritative and no task, chat session, or external-agent run is created by this context read.",
+	}
+	if launchID := strings.TrimSpace(launch.ID); launchID != "" {
+		body = append(body, "Cairnline launch packet: "+launchID)
+	}
+	if len(launch.Warnings) > 0 {
+		body = append(body, "Warnings: "+strings.Join(compactContextIDs(launch.Warnings), " "))
+	}
+	appendContextPacketSourceWithSection(packet, contextSectionRuntime, chat.ContextSource{
+		Kind:   "cairnline_assignment_context",
+		Label:  "Cairnline assignment context",
+		Detail: strings.TrimSpace(launch.Assignment.ID),
+		Trust:  contextTrustRuntimeState,
+	}, chat.ContextItem{
+		Kind:            "cairnline_assignment_context",
+		TrustLevel:      contextTrustRuntimeState,
+		Origin:          "cairnline.assignment_launch_packet",
+		Title:           "Cairnline assignment context",
+		Body:            strings.Join(body, "\n"),
+		Included:        false,
+		InclusionReason: "Read-model preview only",
+		Metadata: map[string]string{
+			"read_backend":   "cairnline",
+			"launch_preview": "true",
+		},
+	})
+}
+
+func selectedCairnlineRoot(project cairnline.Project, workItem cairnline.WorkItem, assignment cairnline.Assignment) (cairnline.Root, bool, string) {
+	if root, ok := cairnlineRootByID(project.Roots, assignment.RootID); ok {
+		return root, true, "assignment override"
+	}
+	if root, ok := cairnlineRootByID(project.Roots, workItem.RootID); ok {
+		return root, true, "work item default"
+	}
+	if root, ok := cairnlineRootByID(project.Roots, project.DefaultRootID); ok {
+		return root, true, "project default"
+	}
+	for _, root := range project.Roots {
+		if root.Active {
+			return root, true, "active project root"
+		}
+	}
+	if len(project.Roots) > 0 {
+		return project.Roots[0], true, "first project root"
+	}
+	return cairnline.Root{}, false, ""
+}
+
+func cairnlineRootByID(roots []cairnline.Root, id string) (cairnline.Root, bool) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return cairnline.Root{}, false
+	}
+	for _, root := range roots {
+		if strings.TrimSpace(root.ID) == id {
+			return root, true
+		}
+	}
+	return cairnline.Root{}, false
+}
+
+func cairnlineRequestedSkillIDs(launch cairnline.AssignmentLaunchPacket) []string {
+	var ids []string
+	ids = append(ids, launch.Assignment.DesiredAgent.SkillIDs...)
+	if launch.Role != nil {
+		ids = append(ids, launch.Role.DefaultSkillIDs...)
+	}
+	if launch.Profile != nil {
+		ids = append(ids, launch.Profile.SkillIDs...)
+	}
+	for _, skill := range launch.Skills {
+		ids = append(ids, skill.ID)
+	}
+	return compactContextIDs(ids)
+}
+
+func cairnlineAdapterOptionKeys(options map[string]any) []string {
+	keys := make([]string, 0, len(options))
+	for key := range options {
+		if trimmed := strings.TrimSpace(key); trimmed != "" {
+			keys = append(keys, trimmed)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func compactContextIDs(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func filterAssignmentArtifacts(items []projectwork.CollaborationArtifact, assignmentID string) []projectwork.CollaborationArtifact {
+	assignmentID = strings.TrimSpace(assignmentID)
+	if assignmentID == "" {
+		return items
+	}
+	filtered := make([]projectwork.CollaborationArtifact, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item.AssignmentID) == "" || strings.TrimSpace(item.AssignmentID) == assignmentID {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func filterAssignmentHandoffs(items []projectwork.Handoff, assignmentID, roleID string) []projectwork.Handoff {
+	assignmentID = strings.TrimSpace(assignmentID)
+	roleID = strings.TrimSpace(roleID)
+	if assignmentID == "" && roleID == "" {
+		return items
+	}
+	filtered := make([]projectwork.Handoff, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item.SourceAssignmentID) == assignmentID || strings.TrimSpace(item.TargetAssignmentID) == assignmentID || strings.TrimSpace(item.TargetRoleID) == roleID {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}

--- a/internal/api/handler_chat_project_work.go
+++ b/internal/api/handler_chat_project_work.go
@@ -12,7 +12,11 @@ func (h *Handler) reconcileProjectAssignmentsForChat(ctx context.Context, sessio
 	if h == nil || h.projectWork == nil || strings.TrimSpace(session.ProjectID) == "" || strings.TrimSpace(session.ID) == "" {
 		return
 	}
-	if _, err := h.projectWorkApplication().ReconcileChatSessionAssignments(ctx, session); err != nil && h.logger != nil {
+	result, err := h.projectWorkApplication().ReconcileChatSessionAssignments(ctx, session)
+	for _, assignment := range result.Updated {
+		h.mirrorProjectAssignmentToCairnline(ctx, "project_assignment_chat_reconcile", assignment)
+	}
+	if err != nil && h.logger != nil {
 		h.logger.WarnContext(ctx, "project.assignment_chat_reconcile_failed",
 			slog.String("project_id", session.ProjectID),
 			slog.String("chat_session_id", session.ID),

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -11,8 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/agentcontrols"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/chatcontext"
 	"github.com/hecatehq/hecate/internal/orchestrator"
@@ -36,6 +38,7 @@ type ProjectAssignmentLaunchReadinessResponse struct {
 	ProjectID        string                                             `json:"project_id"`
 	WorkItemID       string                                             `json:"work_item_id"`
 	AssignmentID     string                                             `json:"assignment_id"`
+	ReadBackend      string                                             `json:"read_backend,omitempty"`
 	GeneratedAt      string                                             `json:"generated_at"`
 	Ready            bool                                               `json:"ready"`
 	Status           string                                             `json:"status"`
@@ -79,6 +82,15 @@ func (h *Handler) HandleProjectWorkAssignmentLaunchReadiness(w http.ResponseWrit
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
 		return
 	}
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		readiness, err := h.renderCairnlineProjectAssignmentLaunchReadiness(ctx, projectID, workItemID, assignmentID)
+		if err != nil {
+			WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectAssignmentLaunchReadinessEnvelope{Object: "project_assignment_launch_readiness", Data: readiness})
+		return
+	}
 	project, ok, err := h.projects.Get(ctx, projectID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -116,6 +128,7 @@ func (h *Handler) HandleProjectWorkAssignmentLaunchReadiness(w http.ResponseWrit
 		WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
 		return
 	}
+	readiness.ReadBackend = "hecate"
 	WriteJSON(w, http.StatusOK, ProjectAssignmentLaunchReadinessEnvelope{Object: "project_assignment_launch_readiness", Data: readiness})
 }
 
@@ -126,6 +139,28 @@ func (h *Handler) HandleProjectWorkAssignmentPreflight(w http.ResponseWriter, r 
 	assignmentID := r.PathValue("assignment_id")
 	if h.projects == nil || h.projectWork == nil {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
+		return
+	}
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		inputs, err := h.cairnlineProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
+		if err != nil {
+			WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+			return
+		}
+		if !inputs.RoleOK {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment role not found")
+			return
+		}
+		if projectWorkAssignmentIsTerminal(inputs.Assignment.Status) {
+			WriteError(w, http.StatusConflict, errCodeConflict, "terminal assignments cannot be started")
+			return
+		}
+		contextPacket, err := h.projectAssignmentPreflightContext(ctx, inputs.Project, inputs.WorkItem, inputs.Assignment, inputs.Role)
+		if err != nil {
+			WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+			return
+		}
+		writeChatContextPacket(w, contextPacket)
 		return
 	}
 	project, ok, err := h.projects.Get(ctx, projectID)
@@ -311,6 +346,99 @@ func (h *Handler) renderProjectAssignmentLaunchReadiness(ctx context.Context, pr
 	return readiness, nil
 }
 
+func (h *Handler) renderCairnlineProjectAssignmentLaunchReadiness(ctx context.Context, projectID, workItemID, assignmentID string) (ProjectAssignmentLaunchReadinessResponse, error) {
+	inputs, err := h.cairnlineProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
+	if err != nil {
+		return ProjectAssignmentLaunchReadinessResponse{}, err
+	}
+	readiness, err := h.renderProjectAssignmentLaunchReadiness(ctx, inputs.Project, inputs.WorkItem, inputs.Assignment, inputs.Role, inputs.RoleOK)
+	if err != nil {
+		return ProjectAssignmentLaunchReadinessResponse{}, err
+	}
+	readiness.ReadBackend = "cairnline"
+	return readiness, nil
+}
+
+type projectAssignmentLaunchInputs struct {
+	Project    projects.Project
+	WorkItem   projectwork.WorkItem
+	Assignment projectwork.Assignment
+	Role       projectwork.AgentRoleProfile
+	RoleOK     bool
+}
+
+func (h *Handler) cairnlineProjectAssignmentLaunchInputs(ctx context.Context, projectID, workItemID, assignmentID string) (projectAssignmentLaunchInputs, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "project not found")
+	}
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if ok, err := cairnlineProjectWorkItemExists(ctx, service, snapshot.Project.ID, workItemID); err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	} else if !ok {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "work item not found")
+	}
+	launch, err := service.AssignmentLaunchPacket(ctx, snapshot.Project.ID, assignmentID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
+	}
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if strings.TrimSpace(launch.WorkItem.ID) != strings.TrimSpace(workItemID) {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
+	}
+	projectExecutionProfile, err := cairnlineExecutionProfileByID(ctx, service, launch.Project.DefaultExecutionProfileID)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	project := projectFromCairnline(launch.Project, projectExecutionProfile, snapshot.Project)
+	workItem := projectWorkItemFromCairnline(launch.WorkItem)
+	assignment := projectWorkAssignmentFromCairnline(launch.Assignment)
+	if native, ok := projectWorkAssignmentsByID(snapshot.Assignments)[assignment.ID]; ok {
+		assignment.ExecutionRef = native.ExecutionRef
+	}
+	role, roleOK, err := cairnlineLaunchRole(ctx, service, snapshot, launch)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	return projectAssignmentLaunchInputs{
+		Project:    project,
+		WorkItem:   workItem,
+		Assignment: assignment,
+		Role:       role,
+		RoleOK:     roleOK,
+	}, nil
+}
+
+func cairnlineProjectWorkItemExists(ctx context.Context, service *cairnline.Service, projectID, workItemID string) (bool, error) {
+	items, err := service.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return false, err
+	}
+	workItemID = strings.TrimSpace(workItemID)
+	for _, item := range items {
+		if strings.TrimSpace(item.ID) == workItemID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func cairnlineLaunchRole(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot, launch cairnline.AssignmentLaunchPacket) (projectwork.AgentRoleProfile, bool, error) {
+	if launch.Role == nil {
+		return projectwork.AgentRoleProfile{ID: strings.TrimSpace(launch.Assignment.RoleID)}, false, nil
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, false, err
+	}
+	role := projectWorkRoleFromCairnline(*launch.Role, cairnlineExecutionProfilesByID(executionProfiles), projectWorkRolesByID(snapshot.Roles)[launch.Role.ID])
+	return role, true, nil
+}
+
 func (h *Handler) populateTaskAssignmentLaunchReadiness(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, readiness *ProjectAssignmentLaunchReadinessResponse) error {
 	plan, err := h.projectWorkApplication().ResolveTaskAssignmentLaunchPlan(ctx, project, workItem, assignment, role)
 	if err != nil {
@@ -443,6 +571,7 @@ func (h *Handler) projectHecateTaskAssignmentPreflightContext(ctx context.Contex
 	if err := h.appendProjectAssignmentLaunchReadiness(ctx, &packet, plan.RequestedProvider, plan.RequestedModel); err != nil {
 		return chat.ContextPacket{}, err
 	}
+	h.appendCairnlineAssignmentLaunchPacketEvidence(ctx, &packet, assignment)
 	appendProjectAssignmentLaunchPreflight(&packet, projectwork.AssignmentDriverHecateTask, []string{
 		"Task: created on start",
 		"Run: created on start",
@@ -470,6 +599,7 @@ func (h *Handler) projectExternalAgentAssignmentPreflightContext(ctx context.Con
 		return chat.ContextPacket{}, err
 	}
 	packet := h.projectExternalAgentAssignmentContextPacket(ctx, project, workItem, assignment, role, plan, "")
+	h.appendCairnlineAssignmentLaunchPacketEvidence(ctx, &packet, assignment)
 	appendProjectAssignmentLaunchPreflight(&packet, projectwork.AssignmentDriverExternalAgent, []string{
 		"External agent: " + firstNonEmptyString(plan.Adapter.Name, plan.AdapterID),
 		"Adapter ID: " + plan.AdapterID,
@@ -584,6 +714,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	if err := h.appendProjectAssignmentLaunchReadiness(ctx, &contextPacket, plan.RequestedProvider, plan.RequestedModel); err != nil {
 		h.logProjectAssignmentLaunchReadinessError(ctx, err)
 	}
+	h.appendCairnlineAssignmentLaunchPacketEvidence(ctx, &contextPacket, assignment)
 	if contextPacket.ID == "" {
 		contextPacket.ID = newChatID("ctx")
 	}
@@ -611,6 +742,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		resultAssignment := assignment
 		if result != nil && result.Assignment.ID != "" {
 			resultAssignment = result.Assignment
+			h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
 		}
 		if errors.Is(err, projectworkapp.ErrAssignmentStartConflict) {
 			projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, resultAssignment)
@@ -638,6 +770,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	if result.SpanID != "" {
 		w.Header().Set("X-Span-Id", result.SpanID)
 	}
+	h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
 	projected, err := h.renderProjectedProjectWorkAssignment(ctx, result.Assignment)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -690,6 +823,7 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 	sessionID := newChatID("chat")
 	contextPacket := h.projectExternalAgentAssignmentContextPacket(ctx, project, workItem, assignment, role, plan, sessionID)
 	contextPacket.ID = firstNonEmptyString(contextPacket.ID, newChatID("ctx"))
+	h.appendCairnlineAssignmentLaunchPacketEvidence(ctx, &contextPacket, assignment)
 
 	session := chat.Session{
 		ID:              sessionID,
@@ -723,6 +857,7 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		resultAssignment := assignment
 		if result != nil && result.Assignment.ID != "" {
 			resultAssignment = result.Assignment
+			h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
 		}
 		if errors.Is(err, projectworkapp.ErrAssignmentStartConflict) {
 			projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, resultAssignment)
@@ -736,12 +871,22 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
 	projected, err := h.renderProjectedProjectWorkAssignment(ctx, result.Assignment)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+}
+
+func (h *Handler) mirrorProjectAssignmentStartResultToCairnline(ctx context.Context, assignment projectwork.Assignment) {
+	if strings.TrimSpace(assignment.ID) == "" {
+		return
+	}
+	if err := h.writeProjectAssignmentToCairnline(ctx, assignment); err != nil {
+		h.logCairnlineMirrorError(ctx, "project_assignment_start_result", assignment.ProjectID, err)
+	}
 }
 
 func decodeOptionalProjectWorkAssignmentStartRequest(w http.ResponseWriter, r *http.Request) (startProjectWorkAssignmentRequest, bool) {

--- a/internal/api/handler_project_assignment_launch_readiness_test.go
+++ b/internal/api/handler_project_assignment_launch_readiness_test.go
@@ -51,6 +51,9 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessReturnsNativePlanWithoutSideEff
 	if readiness.Object != "project_assignment_launch_readiness" {
 		t.Fatalf("object = %q, want project_assignment_launch_readiness", readiness.Object)
 	}
+	if readiness.Data.ReadBackend != "hecate" {
+		t.Fatalf("read_backend = %q, want hecate", readiness.Data.ReadBackend)
+	}
 	if !readiness.Data.Ready || readiness.Data.Status != projectAssignmentLaunchReadinessStatusReady {
 		t.Fatalf("readiness = %+v, want ready", readiness.Data)
 	}
@@ -92,6 +95,40 @@ func launchReadinessWarningContains(items []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessUsesCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineReadTestServer()
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: workspace,
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/launch-readiness", "")
+	if readiness.Data.ReadBackend != "cairnline" {
+		t.Fatalf("read_backend = %q, want cairnline", readiness.Data.ReadBackend)
+	}
+	if !readiness.Data.Ready || readiness.Data.Status != projectAssignmentLaunchReadinessStatusReady {
+		t.Fatalf("readiness = %+v, want Cairnline-backed ready launch projection", readiness.Data)
+	}
+	if readiness.Data.ProjectID != "proj_start" || readiness.Data.WorkItemID != "work_start" || readiness.Data.AssignmentID != "asgn_start" {
+		t.Fatalf("refs = %+v, want Cairnline-projected project/work/assignment refs", readiness.Data)
+	}
+	if readiness.Data.DriverKind != projectwork.AssignmentDriverHecateTask || readiness.Data.Workspace != workspace || readiness.Data.RootID != "root_start" {
+		t.Fatalf("launch target = %+v, want Cairnline-projected workspace/root with Hecate runtime validation", readiness.Data)
+	}
+	if readiness.Data.Provider != "anthropic" || readiness.Data.Model != "claude-sonnet-4" || readiness.Data.ExecutionProfile != "coding_agent" {
+		t.Fatalf("launch hints = provider/model/profile %q/%q/%q, want Cairnline-projected role defaults", readiness.Data.Provider, readiness.Data.Model, readiness.Data.ExecutionProfile)
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want no task created by Cairnline launch readiness", tasks)
+	}
 }
 
 func TestProjectWorkAPI_AssignmentLaunchReadinessSurfacesBlockedModel(t *testing.T) {

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
 
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
 	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
@@ -57,13 +60,26 @@ func (h *Handler) HandleProjectAssistantContext(w http.ResponseWriter, r *http.R
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant context request")
 		return
 	}
-	context, err := h.projectAssistantApplication().Context(r.Context(), projectassistantapp.ContextCommand{
-		ProjectID:  req.ProjectID,
-		WorkItemID: req.WorkItemID,
-		Request:    req.Request,
-		RoleID:     req.RoleID,
-		DriverKind: req.DriverKind,
-	})
+	var context projectassistant.DraftContext
+	var err error
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		context, err = h.cairnlineProjectAssistantContext(r.Context(), projectassistant.ContextInput{
+			ProjectID:  req.ProjectID,
+			WorkItemID: req.WorkItemID,
+			Request:    req.Request,
+			RoleID:     req.RoleID,
+			DriverKind: req.DriverKind,
+		})
+	} else {
+		context, err = h.projectAssistantApplication().Context(r.Context(), projectassistantapp.ContextCommand{
+			ProjectID:  req.ProjectID,
+			WorkItemID: req.WorkItemID,
+			Request:    req.Request,
+			RoleID:     req.RoleID,
+			DriverKind: req.DriverKind,
+		})
+		context.ReadBackend = "hecate"
+	}
 	if err != nil {
 		writeProjectAssistantError(w, err)
 		return
@@ -80,7 +96,7 @@ func (h *Handler) HandleProjectAssistantDraft(w http.ResponseWriter, r *http.Req
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid project assistant draft request")
 		return
 	}
-	proposal, err := h.projectAssistantApplication().Draft(r.Context(), projectassistantapp.DraftCommand{
+	proposal, err := h.projectAssistantDraft(r.Context(), projectassistantapp.DraftCommand{
 		ProjectID:        req.ProjectID,
 		WorkItemID:       req.WorkItemID,
 		Request:          req.Request,
@@ -97,6 +113,7 @@ func (h *Handler) HandleProjectAssistantDraft(w http.ResponseWriter, r *http.Req
 		writeProjectAssistantError(w, err)
 		return
 	}
+	h.mirrorProjectAssistantProposalByIDToCairnline(r.Context(), "project_assistant_draft", proposal.ID)
 	WriteJSON(w, http.StatusOK, map[string]any{
 		"object": "project_assistant.proposal",
 		"data":   proposal,
@@ -132,7 +149,7 @@ func (h *Handler) HandleChatProjectAssistantDraft(w http.ResponseWriter, r *http
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request is required")
 		return
 	}
-	proposal, err := h.projectAssistantApplication().Draft(r.Context(), projectassistantapp.DraftCommand{
+	proposal, err := h.projectAssistantDraft(r.Context(), projectassistantapp.DraftCommand{
 		ProjectID:  projectID,
 		WorkItemID: req.WorkItemID,
 		Request:    req.Request,
@@ -146,10 +163,18 @@ func (h *Handler) HandleChatProjectAssistantDraft(w http.ResponseWriter, r *http
 		writeProjectAssistantError(w, err)
 		return
 	}
+	h.mirrorProjectAssistantProposalByIDToCairnline(r.Context(), "project_assistant_chat_draft", proposal.ID)
 	WriteJSON(w, http.StatusOK, map[string]any{
 		"object": "project_assistant.proposal",
 		"data":   proposal,
 	})
+}
+
+func (h *Handler) projectAssistantDraft(ctx context.Context, command projectassistantapp.DraftCommand) (projectassistant.Proposal, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.cairnlineProjectAssistantDraft(ctx, command)
+	}
+	return h.projectAssistantApplication().Draft(ctx, command)
 }
 
 func (h *Handler) HandleProjectAssistantPropose(w http.ResponseWriter, r *http.Request) {
@@ -169,6 +194,7 @@ func (h *Handler) HandleProjectAssistantPropose(w http.ResponseWriter, r *http.R
 		writeProjectAssistantError(w, err)
 		return
 	}
+	h.mirrorProjectAssistantProposalByIDToCairnline(r.Context(), "project_assistant_propose", proposal.ID)
 	WriteJSON(w, http.StatusOK, map[string]any{
 		"object": "project_assistant.proposal",
 		"data":   proposal,
@@ -176,6 +202,22 @@ func (h *Handler) HandleProjectAssistantPropose(w http.ResponseWriter, r *http.R
 }
 
 func (h *Handler) HandleProjectAssistantProposal(w http.ResponseWriter, r *http.Request) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		record, ok, err := h.cairnlineProjectAssistantProposal(r.Context(), r.PathValue("id"))
+		if err != nil {
+			writeProjectAssistantError(w, err)
+			return
+		}
+		if !ok {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project assistant proposal not found")
+			return
+		}
+		WriteJSON(w, http.StatusOK, map[string]any{
+			"object": "project_assistant.proposal_record",
+			"data":   record,
+		})
+		return
+	}
 	record, ok, err := h.projectAssistantApplication().Proposal(r.Context(), r.PathValue("id"))
 	if err != nil {
 		writeProjectAssistantError(w, err)
@@ -191,6 +233,26 @@ func (h *Handler) HandleProjectAssistantProposal(w http.ResponseWriter, r *http.
 	})
 }
 
+func (h *Handler) cairnlineProjectAssistantProposal(ctx context.Context, id string) (projectassistant.ProposalRecord, bool, error) {
+	snapshots, err := cairnlinebridge.LoadSnapshots(ctx, h.cairnlineSnapshotSources())
+	if err != nil {
+		return projectassistant.ProposalRecord{}, false, err
+	}
+	service := cairnline.NewMemoryService()
+	if err := cairnlinebridge.SeedSnapshots(ctx, service, snapshots); err != nil {
+		return projectassistant.ProposalRecord{}, false, err
+	}
+	item, err := service.GetAssistantProposal(ctx, id)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return projectassistant.ProposalRecord{}, false, nil
+	}
+	if err != nil {
+		return projectassistant.ProposalRecord{}, false, err
+	}
+	record, ok := cairnlinebridge.ProjectAssistantProposalRecord(item)
+	return record, ok, nil
+}
+
 func (h *Handler) HandleProjectAssistantApply(w http.ResponseWriter, r *http.Request) {
 	var req projectAssistantApplyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -202,9 +264,16 @@ func (h *Handler) HandleProjectAssistantApply(w http.ResponseWriter, r *http.Req
 		Confirm:  req.Confirm,
 	})
 	if err != nil {
+		var applyErr *projectassistant.ApplyError
+		if errors.As(err, &applyErr) {
+			h.mirrorProjectAssistantApplyResultToCairnline(r.Context(), "project_assistant_apply_partial", applyErr.Result)
+		}
+		h.mirrorProjectAssistantProposalByIDToCairnline(r.Context(), "project_assistant_apply_error", req.Proposal.ID)
 		writeProjectAssistantApplyError(w, err)
 		return
 	}
+	h.mirrorProjectAssistantApplyResultToCairnline(r.Context(), "project_assistant_apply_result", result)
+	h.mirrorProjectAssistantProposalByIDToCairnline(r.Context(), "project_assistant_apply", firstNonEmpty(result.ProposalID, req.Proposal.ID))
 	WriteJSON(w, http.StatusOK, map[string]any{
 		"object": "project_assistant.apply_result",
 		"data":   result,

--- a/internal/api/handler_project_assistant_cairnline.go
+++ b/internal/api/handler_project_assistant_cairnline.go
@@ -1,0 +1,233 @@
+package api
+
+import (
+	"context"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projectassistantapp"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) cairnlineProjectAssistantContext(ctx context.Context, input projectassistant.ContextInput) (projectassistant.DraftContext, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, input.ProjectID)
+	if err != nil {
+		return projectassistant.DraftContext{}, err
+	}
+	seed, err := h.cairnlineProjectAssistantContextSeed(ctx, service, snapshot)
+	if err != nil {
+		return projectassistant.DraftContext{}, err
+	}
+	draftContext, err := projectassistant.NewService(projectassistant.Stores{
+		Projects:         seed.projects,
+		Work:             seed.work,
+		ProjectSkills:    seed.skills,
+		Memory:           seed.memory,
+		MemoryCandidates: seed.memory,
+	}, nil).Context(ctx, input)
+	if err != nil {
+		return projectassistant.DraftContext{}, err
+	}
+	draftContext.ReadBackend = "cairnline"
+	return draftContext, nil
+}
+
+func (h *Handler) cairnlineProjectAssistantDraft(ctx context.Context, command projectassistantapp.DraftCommand) (projectassistant.Proposal, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, command.ProjectID)
+	if err != nil {
+		return projectassistant.Proposal{}, err
+	}
+	seed, err := h.cairnlineProjectAssistantContextSeed(ctx, service, snapshot)
+	if err != nil {
+		return projectassistant.Proposal{}, err
+	}
+	return projectassistant.NewService(projectassistant.Stores{
+		Projects:         seed.projects,
+		Chats:            h.agentChat,
+		Work:             seed.work,
+		ProjectSkills:    seed.skills,
+		Memory:           seed.memory,
+		MemoryCandidates: seed.memory,
+		Proposals:        h.projectAssistantProposals,
+		LLM:              gatewayAgentLLMClient{service: h.service},
+	}, newOpaqueTaskResourceID).Draft(ctx, projectassistant.DraftInput{
+		ProjectID:        command.ProjectID,
+		WorkItemID:       command.WorkItemID,
+		Request:          command.Request,
+		RoleID:           command.RoleID,
+		DriverKind:       command.DriverKind,
+		DraftMode:        command.DraftMode,
+		ReviewArtifactID: command.ReviewArtifactID,
+		Provider:         command.Provider,
+		Model:            command.Model,
+		RequestID:        command.RequestID,
+		TraceID:          command.TraceID,
+	})
+}
+
+type cairnlineProjectAssistantContextSeed struct {
+	projects *projects.MemoryStore
+	work     *projectwork.MemoryStore
+	skills   *projectskills.MemoryStore
+	memory   *memory.MemoryStore
+}
+
+func (h *Handler) cairnlineProjectAssistantContextSeed(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) (cairnlineProjectAssistantContextSeed, error) {
+	var seed cairnlineProjectAssistantContextSeed
+	projectID := snapshot.Project.ID
+	project, err := service.GetProject(ctx, projectID)
+	if err != nil {
+		return seed, err
+	}
+	executionProfile, err := cairnlineExecutionProfileByID(ctx, service, project.DefaultExecutionProfileID)
+	if err != nil {
+		return seed, err
+	}
+	seed.projects = projects.NewMemoryStore()
+	if _, err := seed.projects.Create(ctx, projectFromCairnline(project, executionProfile, snapshot.Project)); err != nil {
+		return seed, err
+	}
+
+	seed.work = projectwork.NewMemoryStore()
+	if err := seedCairnlineProjectAssistantWork(ctx, seed.work, service, snapshot); err != nil {
+		return seed, err
+	}
+
+	seed.skills = projectskills.NewMemoryStore()
+	if err := seedCairnlineProjectAssistantSkills(ctx, seed.skills, service, snapshot); err != nil {
+		return seed, err
+	}
+
+	seed.memory = memory.NewMemoryStore()
+	if err := seedCairnlineProjectAssistantMemory(ctx, seed.memory, service, projectID); err != nil {
+		return seed, err
+	}
+	return seed, nil
+}
+
+func seedCairnlineProjectAssistantWork(ctx context.Context, store *projectwork.MemoryStore, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) error {
+	projectID := snapshot.Project.ID
+	roles, err := service.ListRoles(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return err
+	}
+	executionProfilesByID := cairnlineExecutionProfilesByID(executionProfiles)
+	nativeRolesByID := projectWorkRolesByID(snapshot.Roles)
+	for _, role := range roles {
+		if projectwork.IsBuiltInRoleID(role.ID) {
+			continue
+		}
+		if _, err := store.CreateRole(ctx, projectWorkRoleFromCairnline(role, executionProfilesByID, nativeRolesByID[role.ID])); err != nil {
+			return err
+		}
+	}
+
+	workItems, err := service.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	nativeWorkItemsByID := projectWorkItemsByID(snapshot.WorkItems)
+	for _, item := range workItems {
+		workItem := projectWorkItemFromCairnline(item)
+		if native, ok := nativeWorkItemsByID[item.ID]; ok {
+			workItem = native
+		}
+		if _, err := store.CreateWorkItem(ctx, workItem); err != nil {
+			return err
+		}
+	}
+
+	assignments, err := service.ListAssignments(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	nativeAssignmentsByID := projectWorkAssignmentsByID(snapshot.Assignments)
+	for _, item := range assignments {
+		assignment := projectWorkAssignmentFromCairnline(item)
+		if native, ok := nativeAssignmentsByID[item.ID]; ok {
+			assignment = native
+		}
+		if _, err := store.CreateAssignment(ctx, assignment); err != nil {
+			return err
+		}
+	}
+	for _, item := range workItems {
+		artifacts, err := cairnlineProjectWorkArtifacts(ctx, service, projectID, item.ID)
+		if err != nil {
+			return err
+		}
+		for _, artifact := range artifacts {
+			if _, err := store.CreateArtifact(ctx, artifact); err != nil {
+				return err
+			}
+		}
+		handoffs, err := cairnlineProjectHandoffs(ctx, service, projectID, item.ID, "")
+		if err != nil {
+			return err
+		}
+		for _, handoff := range handoffs {
+			if _, err := store.CreateHandoff(ctx, handoff); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func projectWorkItemsByID(items []projectwork.WorkItem) map[string]projectwork.WorkItem {
+	out := make(map[string]projectwork.WorkItem, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func seedCairnlineProjectAssistantSkills(ctx context.Context, store *projectskills.MemoryStore, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) error {
+	projectID := snapshot.Project.ID
+	items, err := service.ListProjectSkills(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	skills := make([]projectskills.Skill, 0, len(items))
+	nativeByID := projectSkillsByID(snapshot.Skills)
+	for _, item := range items {
+		skills = append(skills, projectSkillFromCairnline(item, nativeByID[item.ID]))
+	}
+	if _, err := store.UpsertDiscovered(ctx, projectID, skills); err != nil {
+		return err
+	}
+	return nil
+}
+
+func seedCairnlineProjectAssistantMemory(ctx context.Context, store *memory.MemoryStore, service *cairnline.Service, projectID string) error {
+	entries, err := service.ListMemoryEntries(ctx, projectID, true)
+	if err != nil {
+		return err
+	}
+	for _, item := range entries {
+		if _, err := store.Create(ctx, projectMemoryFromCairnline(item)); err != nil {
+			return err
+		}
+	}
+	candidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+		ProjectID:       projectID,
+		IncludeResolved: true,
+	})
+	if err != nil {
+		return err
+	}
+	for _, item := range candidates {
+		if _, err := store.CreateCandidate(ctx, projectMemoryCandidateFromCairnline(item)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -2,20 +2,29 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projectassistantapp"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
@@ -64,6 +73,51 @@ func newProjectAssistantTestHandler() (*Handler, http.Handler) {
 	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
 	handler.SetMemoryStore(memory.NewMemoryStore())
 	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectAssistantCairnlineReadTestHandler() (*Handler, http.Handler) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetAgentChatStore(chat.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectAssistantCairnlineMirrorTestHandler(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetAgentChatStore(chat.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func poisonNativeProjectAssistantCache(handler *Handler) {
+	handler.projectAssistantMu.Lock()
+	defer handler.projectAssistantMu.Unlock()
+	handler.projectAssistant = projectassistantapp.New(projectassistantapp.Options{})
+}
+
+type failingCreateAssignmentProjectWorkStore struct {
+	projectwork.Store
+	err error
+}
+
+func (s failingCreateAssignmentProjectWorkStore) CreateAssignment(context.Context, projectwork.Assignment) (projectwork.Assignment, error) {
+	return projectwork.Assignment{}, s.err
 }
 
 func TestProjectAssistantAPI_ContextBuildsSelectionPacket(t *testing.T) {
@@ -119,6 +173,9 @@ func TestProjectAssistantAPI_ContextBuildsSelectionPacket(t *testing.T) {
 	}
 	if response.Object != "project_assistant.context" || response.Data.Project.ID != project.ID || response.Data.SelectedWork == nil || response.Data.SelectedWork.ID != workItem.ID {
 		t.Fatalf("context response = %+v, want project assistant context with selected work", response)
+	}
+	if response.Data.ReadBackend != "hecate" {
+		t.Fatalf("read_backend = %q, want hecate", response.Data.ReadBackend)
 	}
 	if response.Data.Selection.RoleID != role.ID || response.Data.Selection.DriverKind != projectwork.AssignmentDriverExternalAgent || response.Data.Selection.RoleSource != "selected_work_owner" {
 		t.Fatalf("selection = %+v, want owner role and external driver", response.Data.Selection)
@@ -194,6 +251,489 @@ func TestProjectAssistantAPI_ContextBudgetsMemoryBodies(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantAPI_ContextUsesCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineReadTestHandler()
+
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_context_cairnline",
+		Name:            "Cairnline Context",
+		Description:     "Read model context fixture",
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-5",
+		DefaultRootID:   "root_cairnline",
+		Roots: []projects.Root{{
+			ID:     "root_cairnline",
+			Path:   t.TempDir(),
+			Kind:   "git",
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:         "ctx_cairnline_agents",
+			Kind:       "workspace_instruction",
+			Title:      "AGENTS.md",
+			Path:       "AGENTS.md",
+			Enabled:    true,
+			Format:     "agents_md",
+			TrustLabel: "workspace_guidance",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	role, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:                "planner_cairnline",
+		ProjectID:         project.ID,
+		Name:              "Planner",
+		DefaultDriverKind: projectwork.AssignmentDriverExternalAgent,
+		SkillIDs:          []string{"planning"},
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	workItem, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:          "work_context_cairnline",
+		ProjectID:   project.ID,
+		Title:       "Plan through Cairnline",
+		Status:      projectwork.WorkItemStatusReady,
+		OwnerRoleID: role.ID,
+		RootID:      "root_cairnline",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_context_cairnline",
+		ProjectID:  project.ID,
+		WorkItemID: workItem.ID,
+		RoleID:     role.ID,
+		RootID:     workItem.RootID,
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusQueued,
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+	if _, err := handler.projectSkills.UpsertDiscovered(t.Context(), project.ID, []projectskills.Skill{{
+		ID:                     "planning",
+		ProjectID:              project.ID,
+		Title:                  "Planning skill",
+		Description:            "Shape reviewable project work.",
+		Path:                   ".agents/skills/planning/SKILL.md",
+		Format:                 projectskills.FormatSkillMD,
+		Enabled:                true,
+		Status:                 projectskills.StatusAvailable,
+		TrustLabel:             projectskills.TrustWorkspaceSkill,
+		SourceContextSourceIDs: []string{"ctx_cairnline_agents"},
+	}}); err != nil {
+		t.Fatalf("UpsertDiscovered: %v", err)
+	}
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:         "mem_context_cairnline",
+		ProjectID:  project.ID,
+		Title:      "Cairnline memory",
+		Body:       "Assistant context should read memory through the Cairnline projection.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Create memory: %v", err)
+	}
+	if _, err := handler.memoryCandidates.CreateCandidate(t.Context(), memory.Candidate{
+		ID:                  "cand_context_cairnline",
+		ProjectID:           project.ID,
+		Title:               "Pending Cairnline candidate",
+		Body:                "Pending candidates should remain visible.",
+		SuggestedTrustLabel: memory.TrustLabelGenerated,
+		SuggestedSourceKind: memory.SourceKindGenerated,
+		Status:              memory.CandidateStatusPending,
+	}); err != nil {
+		t.Fatalf("CreateCandidate: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/context", bytes.NewReader([]byte(`{
+		"project_id":"proj_context_cairnline",
+		"work_item_id":"work_context_cairnline",
+		"request":"Queue planning"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("context status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response projectAssistantContextResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode context response: %v", err)
+	}
+	if response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("read_backend = %q, want cairnline", response.Data.ReadBackend)
+	}
+	if response.Data.Project.ID != project.ID || response.Data.Project.DefaultModel != "gpt-5" {
+		t.Fatalf("context project = %+v, want Cairnline-projected project defaults", response.Data.Project)
+	}
+	if response.Data.SelectedWork == nil || response.Data.SelectedWork.ID != workItem.ID || response.Data.Selection.RoleID != role.ID || response.Data.Selection.DriverKind != projectwork.AssignmentDriverExternalAgent {
+		t.Fatalf("selected work/selection = %+v/%+v, want Cairnline-projected work owner and driver", response.Data.SelectedWork, response.Data.Selection)
+	}
+	if len(response.Data.Skills) != 1 || response.Data.Skills[0].ID != "planning" || len(response.Data.Skills[0].SourceContextSourceIDs) != 1 {
+		t.Fatalf("skills = %+v, want Cairnline-projected skill metadata and provenance", response.Data.Skills)
+	}
+	if len(response.Data.Assignments) != 1 || response.Data.Assignments[0].ID != "asgn_context_cairnline" {
+		t.Fatalf("assignments = %+v, want Cairnline-projected assignment", response.Data.Assignments)
+	}
+	if len(response.Data.Memory) != 1 || response.Data.Memory[0].ID != "mem_context_cairnline" || len(response.Data.MemoryCandidates) != 1 || response.Data.MemoryCandidates[0].ID != "cand_context_cairnline" {
+		t.Fatalf("memory/candidates = %+v/%+v, want Cairnline-projected memory context", response.Data.Memory, response.Data.MemoryCandidates)
+	}
+}
+
+func TestProjectAssistantAPI_ContextCairnlineMatchesHecate(t *testing.T) {
+	t.Parallel()
+	hecateHandler, hecateServer := newProjectAssistantTestHandler()
+	cairnlineHandler, cairnlineServer := newProjectAssistantCairnlineReadTestHandler()
+	rootPath := filepath.Join(t.TempDir(), "workspace")
+	projectID, workItemID := seedProjectAssistantContextParityFixture(t, hecateHandler, rootPath)
+	seedProjectAssistantContextParityFixture(t, cairnlineHandler, rootPath)
+	poisonNativeProjectAssistantCache(cairnlineHandler)
+
+	body := []byte(`{
+		"project_id":"` + projectID + `",
+		"work_item_id":"` + workItemID + `",
+		"request":"Queue architecture follow-up"
+	}`)
+	hecateRec := httptest.NewRecorder()
+	hecateServer.ServeHTTP(hecateRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/context", bytes.NewReader(body)))
+	if hecateRec.Code != http.StatusOK {
+		t.Fatalf("hecate context status = %d body=%s, want 200", hecateRec.Code, hecateRec.Body.String())
+	}
+	cairnlineRec := httptest.NewRecorder()
+	cairnlineServer.ServeHTTP(cairnlineRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/context", bytes.NewReader(body)))
+	if cairnlineRec.Code != http.StatusOK {
+		t.Fatalf("cairnline context status = %d body=%s, want 200", cairnlineRec.Code, cairnlineRec.Body.String())
+	}
+	var hecateResponse, cairnlineResponse projectAssistantContextResponse
+	if err := json.Unmarshal(hecateRec.Body.Bytes(), &hecateResponse); err != nil {
+		t.Fatalf("decode hecate context response: %v", err)
+	}
+	if err := json.Unmarshal(cairnlineRec.Body.Bytes(), &cairnlineResponse); err != nil {
+		t.Fatalf("decode cairnline context response: %v", err)
+	}
+	if hecateResponse.Data.ReadBackend != "hecate" {
+		t.Fatalf("hecate read_backend = %q, want hecate", hecateResponse.Data.ReadBackend)
+	}
+	if cairnlineResponse.Data.ReadBackend != "cairnline" {
+		t.Fatalf("cairnline read_backend = %q, want cairnline", cairnlineResponse.Data.ReadBackend)
+	}
+
+	hecateContext := normalizeProjectAssistantContextForParity(hecateResponse.Data)
+	cairnlineContext := normalizeProjectAssistantContextForParity(cairnlineResponse.Data)
+	if !reflect.DeepEqual(hecateContext, cairnlineContext) {
+		t.Fatalf("assistant context mismatch after normalization:\n%s", projectAssistantContextParityMismatch(hecateContext, cairnlineContext))
+	}
+}
+
+func TestProjectAssistantAPI_DraftCairnlineMatchesHecate(t *testing.T) {
+	t.Parallel()
+	hecateHandler, hecateServer := newProjectAssistantTestHandler()
+	cairnlineHandler, cairnlineServer := newProjectAssistantCairnlineReadTestHandler()
+	rootPath := filepath.Join(t.TempDir(), "workspace")
+	projectID, workItemID := seedProjectAssistantContextParityFixture(t, hecateHandler, rootPath)
+	seedProjectAssistantContextParityFixture(t, cairnlineHandler, rootPath)
+	poisonNativeProjectAssistantCache(cairnlineHandler)
+
+	body := []byte(`{
+		"project_id":"` + projectID + `",
+		"work_item_id":"` + workItemID + `",
+		"request":"Queue architecture follow-up\nValidate deterministic draft parity.",
+		"draft_mode":"deterministic"
+	}`)
+	hecateRec := httptest.NewRecorder()
+	hecateServer.ServeHTTP(hecateRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/draft", bytes.NewReader(body)))
+	if hecateRec.Code != http.StatusOK {
+		t.Fatalf("hecate draft status = %d body=%s, want 200", hecateRec.Code, hecateRec.Body.String())
+	}
+	cairnlineRec := httptest.NewRecorder()
+	cairnlineServer.ServeHTTP(cairnlineRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/draft", bytes.NewReader(body)))
+	if cairnlineRec.Code != http.StatusOK {
+		t.Fatalf("cairnline draft status = %d body=%s, want 200", cairnlineRec.Code, cairnlineRec.Body.String())
+	}
+	var hecateResponse, cairnlineResponse projectAssistantProposalResponse
+	if err := json.Unmarshal(hecateRec.Body.Bytes(), &hecateResponse); err != nil {
+		t.Fatalf("decode hecate draft response: %v", err)
+	}
+	if err := json.Unmarshal(cairnlineRec.Body.Bytes(), &cairnlineResponse); err != nil {
+		t.Fatalf("decode cairnline draft response: %v", err)
+	}
+
+	hecateProposal := normalizeProjectAssistantProposalForParity(t, hecateResponse.Data)
+	cairnlineProposal := normalizeProjectAssistantProposalForParity(t, cairnlineResponse.Data)
+	if !reflect.DeepEqual(hecateProposal, cairnlineProposal) {
+		t.Fatalf("assistant draft mismatch after normalization:\n%s", projectAssistantProposalParityMismatch(hecateProposal, cairnlineProposal))
+	}
+}
+
+func seedProjectAssistantContextParityFixture(t *testing.T, handler *Handler, rootPath string) (string, string) {
+	t.Helper()
+	ctx := t.Context()
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	projectID := "proj_assistant_context_parity"
+	rootID := "root_assistant_context_parity"
+	workItemID := "work_assistant_context_parity"
+	roleID := "role_context_architect"
+	compactToolOutput := true
+	if _, err := handler.agentProfiles.Create(ctx, agentprofiles.Profile{
+		ID:                  "profile_context_architect",
+		Name:                "Context Architect",
+		Description:         "Plans durable project coordination work.",
+		Instructions:        "Prefer small, reviewable work with explicit evidence.",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ProviderHint:        "openai",
+		ModelHint:           "gpt-5-mini",
+		ExecutionProfile:    "exec_context_architect",
+		ToolsEnabled:        true,
+		WritesAllowed:       true,
+		NetworkAllowed:      false,
+		ApprovalPolicy:      agentprofiles.ApprovalRequire,
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		SkillIDs:            []string{"skill_context_architecture"},
+		CreatedAt:           now,
+		UpdatedAt:           now.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("Create profile: %v", err)
+	}
+	if _, err := handler.projects.Create(ctx, projects.Project{
+		ID:                       projectID,
+		Name:                     "Assistant Context Parity",
+		Description:              "Ensures Cairnline assistant context matches Hecate context.",
+		DefaultRootID:            rootID,
+		DefaultProvider:          "openai",
+		DefaultModel:             "gpt-5-mini",
+		DefaultAgentProfile:      "profile_context_architect",
+		DefaultWorkspaceMode:     "worktree",
+		DefaultSystemPrompt:      "Use project context only after operator approval.",
+		DefaultCompactToolOutput: &compactToolOutput,
+		Roots: []projects.Root{{
+			ID:        rootID,
+			Path:      rootPath,
+			Kind:      "git",
+			GitRemote: "https://github.com/hecatehq/hecate.git",
+			GitBranch: "main",
+			Active:    true,
+			CreatedAt: now,
+			UpdatedAt: now.Add(time.Minute),
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:             "ctx_assistant_agents",
+			Kind:           "workspace_instruction",
+			Title:          "AGENTS.md",
+			Path:           "AGENTS.md",
+			Enabled:        true,
+			Format:         "agents_md",
+			Scope:          "workspace",
+			TrustLabel:     "workspace_guidance",
+			SourceCategory: "instructions",
+			Metadata:       map[string]string{"root_id": rootID},
+			CreatedAt:      now.Add(2 * time.Minute),
+			UpdatedAt:      now.Add(3 * time.Minute),
+		}},
+		CreatedAt: now,
+		UpdatedAt: now.Add(4 * time.Minute),
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(ctx, projectwork.AgentRoleProfile{
+		ID:                  roleID,
+		ProjectID:           projectID,
+		Name:                "Context Architect",
+		Description:         "Turns project context into reviewable work.",
+		Instructions:        "Preserve provenance and ask for review before closeout.",
+		DefaultDriverKind:   projectwork.AssignmentDriverExternalAgent,
+		DefaultProvider:     "openai",
+		DefaultModel:        "gpt-5-mini",
+		DefaultAgentProfile: "profile_context_architect",
+		SkillIDs:            []string{"skill_context_architecture"},
+		CreatedAt:           now.Add(5 * time.Minute),
+		UpdatedAt:           now.Add(6 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
+		ID:              workItemID,
+		ProjectID:       projectID,
+		Title:           "Plan assistant parity work",
+		Brief:           "Create a reviewable slice that proves Cairnline context parity.",
+		Status:          projectwork.WorkItemStatusReady,
+		Priority:        "normal",
+		OwnerRoleID:     roleID,
+		RootID:          rootID,
+		ReviewerRoleIDs: []string{"reviewer_qa"},
+		CreatedAt:       now.Add(7 * time.Minute),
+		UpdatedAt:       now.Add(8 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
+		ID:         "asgn_assistant_context_parity",
+		ProjectID:  projectID,
+		WorkItemID: workItemID,
+		RoleID:     roleID,
+		RootID:     rootID,
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusQueued,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:              projectwork.AssignmentExecutionKindContextSnapshot,
+			ContextSnapshotID: "ctxsnap_assistant_context_parity",
+			Status:            "queued",
+		},
+		CreatedAt: now.Add(9 * time.Minute),
+		UpdatedAt: now.Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateAssignment: %v", err)
+	}
+	toolsAllowed := true
+	writesAllowed := true
+	networkAllowed := false
+	if _, err := handler.projectSkills.UpsertDiscovered(ctx, projectID, []projectskills.Skill{{
+		ID:                     "skill_context_architecture",
+		ProjectID:              projectID,
+		Title:                  "Context architecture",
+		Description:            "Plans project work with explicit context provenance.",
+		Path:                   ".agents/skills/context-architecture/SKILL.md",
+		RootID:                 rootID,
+		Format:                 projectskills.FormatSkillMD,
+		SuggestedTools:         []string{"read", "write"},
+		RequiredPermissions:    projectskills.RequiredPermissions{Tools: &toolsAllowed, Writes: &writesAllowed, Network: &networkAllowed},
+		Enabled:                true,
+		Status:                 projectskills.StatusAvailable,
+		TrustLabel:             projectskills.TrustWorkspaceSkill,
+		SourceContextSourceIDs: []string{"ctx_assistant_agents"},
+		Warnings:               []string{"metadata-only skill body not injected"},
+		DiscoveredAt:           now.Add(11 * time.Minute),
+		CreatedAt:              now.Add(11 * time.Minute),
+		UpdatedAt:              now.Add(12 * time.Minute),
+	}}); err != nil {
+		t.Fatalf("UpsertDiscovered: %v", err)
+	}
+	if _, err := handler.memory.Create(ctx, memory.Entry{
+		ID:         "mem_assistant_context_parity",
+		Scope:      memory.ScopeProject,
+		ProjectID:  projectID,
+		Title:      "Assistant context parity decision",
+		Body:       "Cairnline must preserve the Project Assistant context packet before replacing Hecate Projects reads.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		SourceID:   "operator",
+		Enabled:    true,
+		CreatedAt:  now.Add(13 * time.Minute),
+		UpdatedAt:  now.Add(14 * time.Minute),
+	}); err != nil {
+		t.Fatalf("Create memory: %v", err)
+	}
+	if _, err := handler.memoryCandidates.CreateCandidate(ctx, memory.Candidate{
+		ID:                  "cand_assistant_context_parity",
+		ProjectID:           projectID,
+		Title:               "Candidate from workspace guidance",
+		Body:                "Workspace guidance may become memory only after operator review.",
+		SuggestedKind:       "workspace_guidance",
+		SuggestedTrustLabel: memory.TrustLabelGenerated,
+		SuggestedSourceKind: memory.SourceKindGenerated,
+		SuggestedSourceID:   "ctx_assistant_agents",
+		SourceRefs: []memory.CandidateSourceRef{{
+			Kind:  "context_source",
+			ID:    "ctx_assistant_agents",
+			Title: "AGENTS.md",
+		}},
+		Status:    memory.CandidateStatusPending,
+		CreatedAt: now.Add(15 * time.Minute),
+		UpdatedAt: now.Add(16 * time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateCandidate: %v", err)
+	}
+	return projectID, workItemID
+}
+
+func normalizeProjectAssistantContextForParity(item projectassistant.DraftContext) projectassistant.DraftContext {
+	item.ReadBackend = ""
+	item.Project.CreatedAt = time.Time{}
+	item.Project.UpdatedAt = time.Time{}
+	for idx := range item.Project.ContextSources {
+		item.Project.ContextSources[idx].CreatedAt = time.Time{}
+		item.Project.ContextSources[idx].UpdatedAt = time.Time{}
+	}
+	if item.SelectedWork != nil {
+		item.SelectedWork.CreatedAt = time.Time{}
+		item.SelectedWork.UpdatedAt = time.Time{}
+	}
+	for idx := range item.Roles {
+		item.Roles[idx].CreatedAt = time.Time{}
+		item.Roles[idx].UpdatedAt = time.Time{}
+	}
+	for idx := range item.Skills {
+		item.Skills[idx].DiscoveredAt = time.Time{}
+		item.Skills[idx].CreatedAt = time.Time{}
+		item.Skills[idx].UpdatedAt = time.Time{}
+	}
+	for idx := range item.Assignments {
+		item.Assignments[idx].CreatedAt = time.Time{}
+		item.Assignments[idx].UpdatedAt = time.Time{}
+		item.Assignments[idx].StartedAt = nil
+		item.Assignments[idx].CompletedAt = nil
+	}
+	for idx := range item.Memory {
+		item.Memory[idx].CreatedAt = time.Time{}
+		item.Memory[idx].UpdatedAt = time.Time{}
+	}
+	for idx := range item.MemoryCandidates {
+		item.MemoryCandidates[idx].CreatedAt = time.Time{}
+		item.MemoryCandidates[idx].UpdatedAt = time.Time{}
+	}
+	for idx := range item.RecentActivity {
+		item.RecentActivity[idx].UpdatedAt = time.Time{}
+	}
+	return item
+}
+
+func projectAssistantContextParityMismatch(hecate, cairnline projectassistant.DraftContext) string {
+	hecateJSON, hecateErr := json.MarshalIndent(hecate, "", "  ")
+	cairnlineJSON, cairnlineErr := json.MarshalIndent(cairnline, "", "  ")
+	if hecateErr != nil || cairnlineErr != nil {
+		return "hecate and cairnline context differ"
+	}
+	return "hecate:\n" + string(hecateJSON) + "\n\ncairnline:\n" + string(cairnlineJSON)
+}
+
+func normalizeProjectAssistantProposalForParity(t *testing.T, item projectassistant.Proposal) projectassistant.Proposal {
+	t.Helper()
+	item.ID = ""
+	item.TraceID = ""
+	for idx := range item.Actions {
+		item.Actions[idx].Patch = canonicalProjectAssistantPatchForParity(t, item.Actions[idx].Patch)
+	}
+	return item
+}
+
+func canonicalProjectAssistantPatchForParity(t *testing.T, raw json.RawMessage) json.RawMessage {
+	t.Helper()
+	if len(raw) == 0 {
+		return nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("decode proposal patch: %v", err)
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encode canonical proposal patch: %v", err)
+	}
+	return canonical
+}
+
+func projectAssistantProposalParityMismatch(hecate, cairnline projectassistant.Proposal) string {
+	hecateJSON, hecateErr := json.MarshalIndent(hecate, "", "  ")
+	cairnlineJSON, cairnlineErr := json.MarshalIndent(cairnline, "", "  ")
+	if hecateErr != nil || cairnlineErr != nil {
+		return "hecate and cairnline proposals differ"
+	}
+	return "hecate:\n" + string(hecateJSON) + "\n\ncairnline:\n" + string(cairnlineJSON)
+}
+
 func TestProjectAssistantAPI_DraftCreatesAssignmentProposal(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantTestHandler()
@@ -240,6 +780,380 @@ func TestProjectAssistantAPI_DraftCreatesAssignmentProposal(t *testing.T) {
 	}
 	if patch["project_id"] != project.ID || patch["work_item_id"] != workItem.ID || patch["role_id"] != "product_manager" || patch["root_id"] != "root_api" || patch["driver_kind"] != projectwork.AssignmentDriverExternalAgent {
 		t.Fatalf("patch = %+v, want selected project/work/owner role/root/external driver", patch)
+	}
+}
+
+func TestProjectAssistantAPI_DraftUsesCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineReadTestHandler()
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_cairnline_draft",
+		Name: "Cairnline Draft",
+		Roots: []projects.Root{{
+			ID:     "root_cairnline_draft",
+			Path:   t.TempDir(),
+			Active: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	role, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:                "architect_cairnline_draft",
+		ProjectID:         project.ID,
+		Name:              "Architect",
+		DefaultDriverKind: projectwork.AssignmentDriverExternalAgent,
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	workItem, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:          "work_cairnline_draft",
+		ProjectID:   project.ID,
+		Title:       "Plan next Cairnline-backed task",
+		Brief:       "Draft an assignment from the portable read model.",
+		Status:      projectwork.WorkItemStatusReady,
+		OwnerRoleID: role.ID,
+		RootID:      "root_cairnline_draft",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	poisonNativeProjectAssistantCache(handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/draft", bytes.NewReader([]byte(`{
+		"project_id":"proj_cairnline_draft",
+		"work_item_id":"work_cairnline_draft",
+		"request":"Queue Architect\nPrepare the next project slice."
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("draft status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposed projectAssistantProposalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposed); err != nil {
+		t.Fatalf("decode draft response: %v", err)
+	}
+	if proposed.Object != "project_assistant.proposal" || len(proposed.Data.Actions) != 1 {
+		t.Fatalf("draft response = %+v, want one proposal action", proposed)
+	}
+	var patch map[string]string
+	if err := json.Unmarshal(proposed.Data.Actions[0].Patch, &patch); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if patch["project_id"] != project.ID || patch["work_item_id"] != workItem.ID || patch["role_id"] != role.ID || patch["root_id"] != workItem.RootID || patch["driver_kind"] != projectwork.AssignmentDriverExternalAgent {
+		t.Fatalf("patch = %+v, want Cairnline-projected owner/root/default driver", patch)
+	}
+	if _, ok, err := handler.projectAssistantProposals.GetProposal(t.Context(), proposed.Data.ID); err != nil || !ok {
+		t.Fatalf("GetProposal(%q) = ok %v err %v, want Cairnline draft stored in Hecate proposal ledger", proposed.Data.ID, ok, err)
+	}
+}
+
+func TestProjectAssistantAPI_MirrorsProposalLedgerToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	client := newAPITestClient(t, server)
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_pa_mirror",
+		Name: "Assistant Mirror",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	drafted := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/draft", `{
+		"project_id":"proj_pa_mirror",
+		"request":"Capture the first reviewable work item."
+	}`)
+	if drafted.Object != "project_assistant.proposal" || drafted.Data.ID == "" || len(drafted.Data.Actions) != 1 {
+		t.Fatalf("draft response = %+v, want one mirrored proposal action", drafted)
+	}
+	mirroredDraft := getMirroredCairnlineAssistantProposalForTest(t, handler, drafted.Data.ID)
+	if mirroredDraft.ProjectID != "proj_pa_mirror" || mirroredDraft.Status != cairnline.AssistantProposalStatusProposed || mirroredDraft.Source != cairnline.AssistantProposalSourceAssistant || len(mirroredDraft.Proposal.Actions) != 1 {
+		t.Fatalf("mirrored draft = %+v, want proposed assistant-sourced ledger record", mirroredDraft)
+	}
+
+	proposed := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/propose", `{
+		"id":"pa_mirror_apply",
+		"title":"Create mirrored work",
+		"summary":"Create a work item and mirror the apply ledger.",
+		"actions":[{
+			"kind":"create_work_item",
+			"reason":"The project needs one reviewable task.",
+			"patch":{
+				"id":"work_pa_mirror",
+				"project_id":"proj_pa_mirror",
+				"title":"Mirror assistant ledger",
+				"brief":"Verify the Project Assistant proposal ledger mirrors to Cairnline.",
+				"status":"ready"
+			}
+		}]
+	}`)
+	mirroredProposal := getMirroredCairnlineAssistantProposalForTest(t, handler, proposed.Data.ID)
+	if mirroredProposal.Status != cairnline.AssistantProposalStatusProposed || mirroredProposal.Source != cairnline.AssistantProposalSourceAPI || len(mirroredProposal.ApplyAttempts) != 0 {
+		t.Fatalf("mirrored proposal = %+v, want proposed API ledger without attempts", mirroredProposal)
+	}
+
+	applied := mustRequestJSON[projectAssistantApplyResponse](client, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposed.Data,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.ProposalID != proposed.Data.ID {
+		t.Fatalf("apply response = %+v, want applied proposal", applied)
+	}
+	mirroredApplied := getMirroredCairnlineAssistantProposalForTest(t, handler, proposed.Data.ID)
+	if mirroredApplied.Status != cairnline.AssistantProposalStatusApplied || mirroredApplied.LatestResult == nil || !mirroredApplied.LatestResult.Applied || len(mirroredApplied.ApplyAttempts) != 1 || mirroredApplied.AppliedAt == nil {
+		t.Fatalf("mirrored applied proposal = %+v, want applied ledger result and one attempt", mirroredApplied)
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	workItem, err := service.GetWorkItem(t.Context(), "proj_pa_mirror", "work_pa_mirror")
+	if err != nil {
+		t.Fatalf("GetWorkItem(work_pa_mirror): %v", err)
+	}
+	if workItem.Title != "Mirror assistant ledger" || workItem.Status != cairnline.WorkStatusReady {
+		t.Fatalf("mirrored work item = %+v, want assistant-created work item", workItem)
+	}
+}
+
+func TestProjectAssistantAPI_ApplyMirrorsCoordinationGraphToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	client := newAPITestClient(t, server)
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_pa_apply_graph",
+		Name: "Assistant Apply Graph",
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	proposed := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/propose", `{
+		"id":"pa_apply_graph",
+		"title":"Create coordination graph",
+		"summary":"Create role, work, assignment, handoff, and memory candidate records.",
+		"actions":[{
+			"kind":"create_role",
+			"reason":"The work needs an implementation owner.",
+			"patch":{
+				"id":"role_apply_graph",
+				"project_id":"proj_pa_apply_graph",
+				"name":"Implementer",
+				"description":"Owns implementation tasks.",
+				"instructions":"Make scoped changes and leave evidence.",
+				"default_driver_kind":"external_agent",
+				"default_provider":"openai",
+				"default_model":"gpt-5",
+				"skill_ids":["backend"]
+			}
+		},{
+			"kind":"create_work_item",
+			"reason":"The project needs a reviewable task.",
+			"patch":{
+				"id":"work_apply_graph",
+				"project_id":"proj_pa_apply_graph",
+				"title":"Mirror assistant side effects",
+				"brief":"Verify Project Assistant apply side effects mirror to Cairnline.",
+				"status":"ready",
+				"priority":"normal",
+				"owner_role_id":"role_apply_graph",
+				"reviewer_role_ids":["role_apply_graph"]
+			}
+		},{
+			"kind":"create_assignment",
+			"reason":"Queue the implementation assignment.",
+			"patch":{
+				"id":"asgn_apply_graph",
+				"project_id":"proj_pa_apply_graph",
+				"work_item_id":"work_apply_graph",
+				"role_id":"role_apply_graph",
+				"driver_kind":"external_agent",
+				"status":"queued"
+			}
+		},{
+			"kind":"create_handoff",
+			"reason":"Record the follow-up context.",
+			"patch":{
+				"id":"handoff_apply_graph",
+				"project_id":"proj_pa_apply_graph",
+				"work_item_id":"work_apply_graph",
+				"source_assignment_id":"asgn_apply_graph",
+				"target_role_id":"role_apply_graph",
+				"title":"Implementation handoff",
+				"summary":"Use the mirrored assignment context.",
+				"recommended_next_action":"Start the queued assignment.",
+				"context_refs":["ctx:assistant-apply"],
+				"status":"pending",
+				"provenance_kind":"assistant",
+				"trust_label":"operator_reviewed",
+				"created_by_role_id":"role_apply_graph"
+			}
+		},{
+			"kind":"create_memory_candidate",
+			"reason":"Capture a reviewable lesson for the project.",
+			"patch":{
+				"id":"memcand_apply_graph",
+				"project_id":"proj_pa_apply_graph",
+				"title":"Assistant apply mirror coverage",
+				"body":"Project Assistant apply should mirror durable coordination records into Cairnline.",
+				"suggested_kind":"process",
+				"suggested_trust_label":"operator_reviewed",
+				"suggested_source_kind":"project_assistant",
+				"suggested_source_id":"pa_apply_graph",
+				"source_refs":[{"kind":"proposal","id":"pa_apply_graph","title":"Create coordination graph"}]
+			}
+		}]
+	}`)
+
+	applied := mustRequestJSON[projectAssistantApplyResponse](client, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposed.Data,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || applied.Data.CommittedActionCount != 5 || applied.Data.ResumeActionIndex != 5 {
+		t.Fatalf("apply response = %+v, want all coordination actions applied", applied.Data)
+	}
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+
+	roles, err := service.ListRoles(t.Context(), project.ID)
+	if err != nil {
+		t.Fatalf("ListRoles: %v", err)
+	}
+	var role cairnline.Role
+	for _, item := range roles {
+		if item.ID == "role_apply_graph" {
+			role = item
+			break
+		}
+	}
+	if role.ID == "" || role.Name != "Implementer" || role.DefaultExecutionMode != cairnline.ExecutionExternalAdapter || !reflect.DeepEqual(role.DefaultSkillIDs, []string{"backend"}) {
+		t.Fatalf("mirrored role = %+v, want external-agent implementer role with backend skill", role)
+	}
+
+	workItem, err := service.GetWorkItem(t.Context(), project.ID, "work_apply_graph")
+	if err != nil {
+		t.Fatalf("GetWorkItem: %v", err)
+	}
+	if workItem.Title != "Mirror assistant side effects" || workItem.OwnerRoleID != role.ID || !reflect.DeepEqual(workItem.ReviewerRoleIDs, []string{role.ID}) {
+		t.Fatalf("mirrored work item = %+v, want owner/reviewer role links", workItem)
+	}
+
+	assignment, err := service.GetAssignment(t.Context(), project.ID, "asgn_apply_graph")
+	if err != nil {
+		t.Fatalf("GetAssignment: %v", err)
+	}
+	if assignment.WorkItemID != workItem.ID || assignment.RoleID != role.ID || assignment.ExecutionMode != cairnline.ExecutionExternalAdapter || assignment.DesiredAgent.Kind != cairnline.DesiredAgentAny || !reflect.DeepEqual(assignment.DesiredAgent.SkillIDs, []string{"backend"}) {
+		t.Fatalf("mirrored assignment = %+v, want portable external-agent assignment with role skills", assignment)
+	}
+
+	handoff, err := service.GetHandoff(t.Context(), project.ID, workItem.ID, "handoff_apply_graph")
+	if err != nil {
+		t.Fatalf("GetHandoff: %v", err)
+	}
+	if handoff.SourceAssignmentID != assignment.ID || handoff.ToRoleID != role.ID || handoff.FromRoleID != role.ID || handoff.Status != cairnline.HandoffStatusOpen || handoff.Body != "Use the mirrored assignment context." || handoff.RecommendedNextAction != "Start the queued assignment." || !reflect.DeepEqual(handoff.ContextRefs, []string{"ctx:assistant-apply"}) {
+		t.Fatalf("mirrored handoff = %+v, want routed open handoff with context refs", handoff)
+	}
+
+	candidate, err := service.GetMemoryCandidate(t.Context(), project.ID, "memcand_apply_graph")
+	if err != nil {
+		t.Fatalf("GetMemoryCandidate: %v", err)
+	}
+	if candidate.Status != cairnline.MemoryCandidatePending || candidate.SuggestedSourceKind != "project_assistant" || candidate.SuggestedSourceID != "pa_apply_graph" || len(candidate.SourceRefs) != 1 || candidate.SourceRefs[0].ID != "pa_apply_graph" {
+		t.Fatalf("mirrored memory candidate = %+v, want pending assistant-sourced memory candidate", candidate)
+	}
+}
+
+func TestProjectAssistantAPI_PartialApplyMirrorsCommittedActionsToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	baseWork := projectwork.NewMemoryStore()
+	handler.SetProjectWorkStore(failingCreateAssignmentProjectWorkStore{
+		Store: baseWork,
+		err:   projectwork.ErrDuplicate,
+	})
+	client := newAPITestClient(t, server)
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_pa_partial_graph",
+		Name: "Assistant Partial Graph",
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:        "role_pa_partial",
+		ProjectID: project.ID,
+		Name:      "Implementer",
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	proposed := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/propose", `{
+		"id":"pa_partial_graph",
+		"title":"Partially create coordination graph",
+		"summary":"Create work, then fail assignment creation.",
+		"actions":[{
+			"kind":"create_work_item",
+			"reason":"The first action should commit.",
+			"patch":{
+				"id":"work_pa_partial",
+				"project_id":"proj_pa_partial_graph",
+				"title":"Committed partial work",
+				"brief":"This work item should mirror even when the next action fails.",
+				"status":"ready",
+				"priority":"normal",
+				"owner_role_id":"role_pa_partial"
+			}
+		},{
+			"kind":"create_assignment",
+			"reason":"The injected store failure should stop here.",
+			"patch":{
+				"id":"asgn_pa_partial",
+				"project_id":"proj_pa_partial_graph",
+				"work_item_id":"work_pa_partial",
+				"role_id":"role_pa_partial",
+				"driver_kind":"hecate_task",
+				"status":"queued"
+			}
+		}]
+	}`)
+
+	payload := mustRequestJSONStatus[projectAssistantErrorResponse](client, http.StatusConflict, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposed.Data,
+		"confirm":  true,
+	}))
+	if payload.Error.ApplyStatus != projectassistant.ApplyStatusPartialDueToRuntimeFailure || payload.Error.CommittedActionCount != 1 || payload.Error.ResumeActionIndex != 1 || payload.Error.FailedActionIndex != 1 {
+		t.Fatalf("partial apply error = %+v, want one committed action and failed assignment action", payload.Error)
+	}
+	if len(payload.Error.PartialResult.Actions) != 1 || payload.Error.PartialResult.Actions[0].ID != "work_pa_partial" {
+		t.Fatalf("partial result actions = %+v, want committed work item only", payload.Error.PartialResult.Actions)
+	}
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	workItem, err := service.GetWorkItem(t.Context(), project.ID, "work_pa_partial")
+	if err != nil {
+		t.Fatalf("GetWorkItem(work_pa_partial): %v", err)
+	}
+	if workItem.Title != "Committed partial work" || workItem.OwnerRoleID != "role_pa_partial" {
+		t.Fatalf("mirrored partial work item = %+v, want committed work item", workItem)
+	}
+	if _, err := service.GetAssignment(t.Context(), project.ID, "asgn_pa_partial"); err == nil {
+		t.Fatalf("GetAssignment(asgn_pa_partial) succeeded, want no mirrored failed assignment")
+	} else if !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("GetAssignment(asgn_pa_partial) err = %v, want ErrNotFound", err)
+	}
+	record := getMirroredCairnlineAssistantProposalForTest(t, handler, proposed.Data.ID)
+	if record.Status != cairnline.AssistantProposalStatusPartial || record.LatestResult == nil || record.LatestResult.AppliedActionCount != 1 || len(record.ApplyAttempts) != 1 {
+		t.Fatalf("mirrored partial proposal = %+v, want partial ledger with one attempt", record)
 	}
 }
 
@@ -331,6 +1245,104 @@ func TestProjectAssistantAPI_DraftReviewFollowUpProposal(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantAPI_DraftReviewFollowUpUsesCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineReadTestHandler()
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_cairnline_review_draft",
+		Name: "Cairnline Review Draft",
+		Roots: []projects.Root{{
+			ID:     "root_cairnline_review",
+			Path:   t.TempDir(),
+			Active: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	for _, role := range []projectwork.AgentRoleProfile{
+		{ID: "operator", ProjectID: project.ID, Name: "Operator"},
+		{ID: "implementation", ProjectID: project.ID, Name: "Implementation"},
+		{ID: "reviewer", ProjectID: project.ID, Name: "Reviewer"},
+	} {
+		if _, err := handler.projectWork.CreateRole(t.Context(), role); err != nil {
+			t.Fatalf("CreateRole(%s): %v", role.ID, err)
+		}
+	}
+	workItem, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:          "work_cairnline_review_draft",
+		ProjectID:   project.ID,
+		Title:       "Review follow-up through Cairnline",
+		Status:      projectwork.WorkItemStatusReview,
+		OwnerRoleID: "operator",
+		RootID:      "root_cairnline_review",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkItem: %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_cairnline_reviewed",
+		ProjectID:  project.ID,
+		WorkItemID: workItem.ID,
+		RoleID:     "implementation",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(reviewed): %v", err)
+	}
+	if _, err := handler.projectWork.CreateAssignment(t.Context(), projectwork.Assignment{
+		ID:         "asgn_cairnline_reviewer",
+		ProjectID:  project.ID,
+		WorkItemID: workItem.ID,
+		RoleID:     "reviewer",
+		DriverKind: projectwork.AssignmentDriverExternalAgent,
+		Status:     projectwork.AssignmentStatusCompleted,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(reviewer): %v", err)
+	}
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:                     "artifact_cairnline_review",
+		ProjectID:              project.ID,
+		WorkItemID:             workItem.ID,
+		AssignmentID:           "asgn_cairnline_reviewer",
+		Kind:                   projectwork.ArtifactKindReview,
+		Title:                  "Implementation review",
+		Body:                   "Verdict: Changes requested.",
+		ReviewedAssignmentID:   "asgn_cairnline_reviewed",
+		ReviewVerdict:          projectwork.ReviewVerdictChangesRequested,
+		ReviewRisk:             projectwork.ReviewRiskMedium,
+		ReviewFollowUpRequired: true,
+	}); err != nil {
+		t.Fatalf("CreateArtifact(review): %v", err)
+	}
+	poisonNativeProjectAssistantCache(handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/draft", bytes.NewReader([]byte(`{
+		"project_id":"proj_cairnline_review_draft",
+		"work_item_id":"work_cairnline_review_draft",
+		"draft_mode":"review_follow_up",
+		"review_artifact_id":"artifact_cairnline_review"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("draft review follow-up status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposed projectAssistantProposalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposed); err != nil {
+		t.Fatalf("decode draft response: %v", err)
+	}
+	if len(proposed.Data.Actions) != 3 || proposed.Data.Actions[0].Kind != projectassistant.ActionCreateHandoff || proposed.Data.Actions[1].Kind != projectassistant.ActionCreateAssignment || proposed.Data.Actions[2].Kind != projectassistant.ActionUpdateHandoff {
+		t.Fatalf("actions = %+v, want Cairnline-backed review follow-up handoff/assignment/link", proposed.Data.Actions)
+	}
+	var assignmentPatch map[string]string
+	if err := json.Unmarshal(proposed.Data.Actions[1].Patch, &assignmentPatch); err != nil {
+		t.Fatalf("decode assignment patch: %v", err)
+	}
+	if assignmentPatch["role_id"] != "implementation" || assignmentPatch["driver_kind"] != projectwork.AssignmentDriverHecateTask || assignmentPatch["root_id"] != workItem.RootID {
+		t.Fatalf("assignment patch = %+v, want reviewed assignment role/driver and work item root", assignmentPatch)
+	}
+}
+
 func TestProjectAssistantAPI_ChatDraftDerivesProjectFromSession(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantTestHandler()
@@ -391,6 +1403,64 @@ func TestProjectAssistantAPI_ChatDraftDerivesProjectFromSession(t *testing.T) {
 	}
 	if len(workItems) != 0 {
 		t.Fatalf("work items = %+v, want draft route not to mutate project work", workItems)
+	}
+}
+
+func TestProjectAssistantAPI_ChatDraftUsesCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineReadTestHandler()
+	project, err := handler.projects.Create(t.Context(), projects.Project{ID: "proj_chat_cairnline_draft", Name: "Chat Cairnline Draft"})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	session, err := handler.agentChat.Create(t.Context(), chat.Session{
+		ID:        "chat_cairnline_pa_draft",
+		Title:     "Project chat",
+		ProjectID: project.ID,
+		AgentID:   chat.DefaultAgentID,
+		Status:    "idle",
+	})
+	if err != nil {
+		t.Fatalf("Create chat: %v", err)
+	}
+	poisonNativeProjectAssistantCache(handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/chat/sessions/"+session.ID+"/project-assistant/draft", bytes.NewReader([]byte(`{
+		"request":"Plan Cairnline chat work\nCapture a portable draft."
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("chat draft status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposed projectAssistantProposalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposed); err != nil {
+		t.Fatalf("decode chat draft response: %v", err)
+	}
+	if proposed.Object != "project_assistant.proposal" || len(proposed.Data.Actions) != 1 || proposed.Data.Actions[0].Kind != projectassistant.ActionCreateWorkItem {
+		t.Fatalf("chat draft response = %+v, want Cairnline-backed create_work_item proposal", proposed)
+	}
+}
+
+func TestDraftProjectProposalUsesCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, _ := newProjectAssistantCairnlineReadTestHandler()
+	project, err := handler.projects.Create(t.Context(), projects.Project{ID: "proj_tool_cairnline_draft", Name: "Tool Cairnline Draft"})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	poisonNativeProjectAssistantCache(handler)
+
+	result, err := handler.DraftProjectProposal(t.Context(), orchestrator.ProjectAssistantDraftInput{
+		ProjectID: project.ID,
+		Request:   "Plan Cairnline tool work\nCapture a portable draft.",
+		RequestID: "req_tool_cairnline",
+		TraceID:   "trace_tool_cairnline",
+	})
+	if err != nil {
+		t.Fatalf("DraftProjectProposal() error = %v", err)
+	}
+	if result.ProjectID != project.ID || result.ProposalID == "" || result.ActionCount != 1 {
+		t.Fatalf("result = %+v, want Cairnline-backed one-action proposal", result)
 	}
 }
 
@@ -695,6 +1765,106 @@ func TestProjectAssistantAPI_ProposeAndApplyCreateProject(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantAPI_ProposalReadUsesCairnlineReadModel(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetAgentChatStore(chat.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_cairnline_proposal",
+		Name: "Cairnline Proposal",
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_cairnline_get",
+		Title:                "Create first task",
+		Summary:              "Queue one work item.",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{{
+			Kind:   projectassistant.ActionCreateWorkItem,
+			Target: map[string]string{"project_id": project.ID},
+			Patch: json.RawMessage(`{
+				"id":"work_cairnline_from_proposal",
+				"project_id":"proj_cairnline_proposal",
+				"title":"Cairnline-projected work",
+				"brief":"Read the proposal from the Cairnline read model.",
+				"status":"ready",
+				"priority":"normal"
+			}`),
+			Reason: "Capture the first reviewable work item.",
+		}},
+	}
+	if _, err := handler.projectAssistantProposals.UpsertProposal(t.Context(), projectassistant.ProposalRecord{
+		ID:        proposal.ID,
+		ProjectID: project.ID,
+		Source:    projectassistant.ProposalSourceDraft,
+		Proposal:  proposal,
+		Status:    projectassistant.ProposalStatusProposed,
+	}); err != nil {
+		t.Fatalf("Upsert proposal: %v", err)
+	}
+	result := projectassistant.ApplyResult{
+		ProposalID:           proposal.ID,
+		Status:               projectassistant.ApplyStatusApplied,
+		Applied:              true,
+		TotalActionCount:     1,
+		CommittedActionCount: 1,
+		ResumeActionIndex:    1,
+		Actions: []projectassistant.ActionResult{{
+			Kind: projectassistant.ActionCreateWorkItem,
+			ID:   "work_cairnline_from_proposal",
+			Data: map[string]string{
+				"project_id":   project.ID,
+				"work_item_id": "work_cairnline_from_proposal",
+			},
+		}},
+	}
+	if _, err := handler.projectAssistantProposals.RecordApplyAttempt(t.Context(), projectassistant.ApplyAttempt{
+		ID:         "paatt_cairnline_get",
+		ProposalID: proposal.ID,
+		Status:     projectassistant.ApplyStatusApplied,
+		Confirmed:  true,
+		Result:     result,
+	}); err != nil {
+		t.Fatalf("Record apply attempt: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/project-assistant/proposals/pa_cairnline_get", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get proposal status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response projectAssistantProposalRecordResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode proposal record response: %v", err)
+	}
+	if response.Object != "project_assistant.proposal_record" || response.Data.ID != proposal.ID || response.Data.ProjectID != project.ID {
+		t.Fatalf("proposal response = %+v, want Cairnline-projected proposal record", response)
+	}
+	if response.Data.Status != projectassistant.ApplyStatusApplied || response.Data.LatestResult == nil || response.Data.LatestResult.CommittedActionCount != 1 || len(response.Data.ApplyAttempts) != 1 {
+		t.Fatalf("proposal ledger = %+v, want applied latest result with one attempt", response.Data)
+	}
+	if len(response.Data.Proposal.Actions) != 1 || response.Data.Proposal.Actions[0].Kind != projectassistant.ActionCreateWorkItem || response.Data.Proposal.Actions[0].Reason != "Capture the first reviewable work item." {
+		t.Fatalf("proposal actions = %+v, want Hecate-shaped action projected from Cairnline", response.Data.Proposal.Actions)
+	}
+	var patch map[string]any
+	if err := json.Unmarshal(response.Data.Proposal.Actions[0].Patch, &patch); err != nil {
+		t.Fatalf("decode projected action patch: %v", err)
+	}
+	if patch["id"] != "work_cairnline_from_proposal" || patch["project_id"] != project.ID {
+		t.Fatalf("projected patch = %+v, want work item patch reconstructed from Cairnline", patch)
+	}
+}
+
 func TestProjectAssistantAPI_ApplyPreflightFailureIncludesEmptyProgress(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantTestHandler()
@@ -839,6 +2009,20 @@ func TestProjectAssistantAPI_ApplyDoneReturnsCloseoutReadiness(t *testing.T) {
 	if stored.Status == projectwork.WorkItemStatusDone {
 		t.Fatalf("stored status = %q, want closeout guard to keep item open", stored.Status)
 	}
+}
+
+func getMirroredCairnlineAssistantProposalForTest(t *testing.T, handler *Handler, proposalID string) cairnline.AssistantProposalRecord {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	record, err := service.GetAssistantProposal(t.Context(), proposalID)
+	if err != nil {
+		t.Fatalf("GetAssistantProposal(%q): %v", proposalID, err)
+	}
+	return record
 }
 
 func TestProjectAssistantAPI_RepeatedApplyConflicts(t *testing.T) {

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -2,16 +2,86 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
 )
+
+func (h *Handler) HandleSyncProjectsToCairnline(w http.ResponseWriter, r *http.Request) {
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	snapshots, err := cairnlinebridge.LoadSnapshots(r.Context(), h.cairnlineSnapshotSources())
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	// This is a replacement-readiness rehearsal, not a live backend switch.
+	// Replacing the local sync DB keeps repeated operator-triggered syncs
+	// deterministic while Hecate stores remain authoritative.
+	if err := removeCairnlineSQLiteFiles(dbPath); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	service, store, err := cairnline.NewSQLiteService(r.Context(), dbPath)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	defer store.Close()
+	if err := cairnlinebridge.SeedSnapshots(r.Context(), service, snapshots); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	hecateCounts := projectCairnlineSnapshotAllCounts(snapshots)
+	cairnlineCounts, err := projectCairnlineServiceAllCounts(r.Context(), service)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	differences := projectCairnlineSyncDifferences(hecateCounts, cairnlineCounts)
+	hecateIDs := projectCairnlineSnapshotAllIDSets(snapshots)
+	cairnlineIDs, err := projectCairnlineServiceAllIDSets(r.Context(), service)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	idDifferences := projectCairnlineSyncIDDifferences(hecateIDs, cairnlineIDs)
+	hecateContent := projectCairnlineSnapshotAllContentDigests(snapshots)
+	cairnlineContent, err := projectCairnlineServiceAllContentDigests(r.Context(), service)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	contentDifferences := projectCairnlineSyncContentDifferences(hecateContent, cairnlineContent)
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSyncResponse{
+		Object: "project_cairnline_sync",
+		Data: ProjectCairnlineSyncResponseItem{
+			DatabasePath:       dbPath,
+			Match:              len(differences) == 0 && len(idDifferences) == 0 && len(contentDifferences) == 0,
+			Differences:        differences,
+			IDDifferences:      idDifferences,
+			ContentDifferences: contentDifferences,
+			Hecate:             hecateCounts,
+			Cairnline:          cairnlineCounts,
+			Authoritative:      false,
+		},
+	})
+}
 
 func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("id"))
@@ -36,7 +106,7 @@ func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.
 	// This local-only experiment owns its project export file. Replacing it
 	// keeps repeated operator-triggered exports deterministic while avoiding a
 	// live-backend switch or any mutation of Hecate's authoritative stores.
-	if err := removeCairnlineExportFiles(dbPath); err != nil {
+	if err := removeCairnlineSQLiteFiles(dbPath); err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
@@ -50,20 +120,34 @@ func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	graph, err := projectCairnlineServiceGraphCounts(r.Context(), service, snapshot.Project.ID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	assistantProposals, err := service.ListAssistantProposals(r.Context(), snapshot.Project.ID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	WriteJSON(w, http.StatusOK, ProjectCairnlineExportResponse{
 		Object: "project_cairnline_export",
 		Data: ProjectCairnlineExportResponseItem{
-			ProjectID:            snapshot.Project.ID,
-			DatabasePath:         dbPath,
-			AgentProfileCount:    len(snapshot.AgentProfiles),
-			SkillCount:           len(snapshot.Skills),
-			RoleCount:            len(snapshot.Roles),
-			WorkItemCount:        len(snapshot.WorkItems),
-			AssignmentCount:      len(snapshot.Assignments),
-			ArtifactCount:        len(snapshot.Artifacts),
-			HandoffCount:         len(snapshot.Handoffs),
-			MemoryEntryCount:     len(snapshot.MemoryEntries),
-			MemoryCandidateCount: len(snapshot.MemoryCandidates),
+			ProjectID:              snapshot.Project.ID,
+			DatabasePath:           dbPath,
+			RootCount:              graph.Roots,
+			ContextSourceCount:     graph.ContextSources,
+			AgentProfileCount:      graph.AgentProfiles,
+			ExecutionProfileCount:  graph.ExecutionProfiles,
+			SkillCount:             graph.Skills,
+			RoleCount:              graph.Roles,
+			WorkItemCount:          graph.WorkItems,
+			AssignmentCount:        graph.Assignments,
+			ArtifactCount:          graph.Artifacts,
+			HandoffCount:           graph.Handoffs,
+			MemoryEntryCount:       graph.MemoryEntries,
+			MemoryCandidateCount:   graph.MemoryCandidates,
+			AssistantProposalCount: len(assistantProposals),
 		},
 	})
 }
@@ -87,11 +171,16 @@ func (h *Handler) HandleProjectCairnlineReadModel(w http.ResponseWriter, r *http
 
 func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("id"))
-	readModel, err := h.projectCairnlineReadModel(r.Context(), projectID)
+	snapshot, err := cairnlinebridge.LoadSnapshot(r.Context(), h.cairnlineSnapshotSources(), projectID)
 	if errors.Is(err, projects.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
 	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	readModel, err := projectCairnlineReadModelFromSnapshot(r.Context(), snapshot)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
@@ -106,7 +195,12 @@ func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	report := projectCairnlineParityReport(projectID, nativeActivity, nativeOperations, readModel)
+	nativeAssistantProposals, err := h.nativeProjectAssistantProposalCount(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	report := projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeActivity, nativeOperations, nativeAssistantProposals, readModel)
 	WriteJSON(w, http.StatusOK, ProjectCairnlineParityReportResponse{
 		Object: "project_cairnline_parity_report",
 		Data:   report,
@@ -121,8 +215,20 @@ func (h *Handler) projectCairnlineReadModel(ctx context.Context, projectID strin
 	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
+	return projectCairnlineReadModelFromSnapshot(ctx, snapshot)
+}
+
+func projectCairnlineReadModelFromSnapshot(ctx context.Context, snapshot cairnlinebridge.Snapshot) (ProjectCairnlineReadModelResponseItem, error) {
 	service := cairnline.NewMemoryService()
 	if err := cairnlinebridge.Seed(ctx, service, snapshot); err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	graph, err := projectCairnlineServiceGraphCounts(ctx, service, snapshot.Project.ID)
+	if err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	assistantProposals, err := service.ListAssistantProposals(ctx, snapshot.Project.ID)
+	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
 	operations, err := service.ProjectOperationsBrief(ctx, snapshot.Project.ID)
@@ -133,24 +239,919 @@ func (h *Handler) projectCairnlineReadModel(ctx context.Context, projectID strin
 	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
+	launchPackets := projectCairnlineLaunchPacketSummary(ctx, service, snapshot)
 	return ProjectCairnlineReadModelResponseItem{
-		ProjectID:            snapshot.Project.ID,
-		AgentProfileCount:    len(snapshot.AgentProfiles),
-		SkillCount:           len(snapshot.Skills),
-		RoleCount:            len(snapshot.Roles),
-		WorkItemCount:        len(snapshot.WorkItems),
-		AssignmentCount:      len(snapshot.Assignments),
-		ArtifactCount:        len(snapshot.Artifacts),
-		HandoffCount:         len(snapshot.Handoffs),
-		MemoryEntryCount:     len(snapshot.MemoryEntries),
-		MemoryCandidateCount: len(snapshot.MemoryCandidates),
-		Operations:           operations,
-		Activity:             activity,
+		ProjectID:                snapshot.Project.ID,
+		RootCount:                graph.Roots,
+		ContextSourceCount:       graph.ContextSources,
+		AgentProfileCount:        graph.AgentProfiles,
+		ExecutionProfileCount:    graph.ExecutionProfiles,
+		SkillCount:               graph.Skills,
+		RoleCount:                graph.Roles,
+		WorkItemCount:            graph.WorkItems,
+		AssignmentCount:          graph.Assignments,
+		ArtifactCount:            graph.Artifacts,
+		HandoffCount:             graph.Handoffs,
+		MemoryEntryCount:         graph.MemoryEntries,
+		MemoryCandidateCount:     graph.MemoryCandidates,
+		AssistantProposalCount:   len(assistantProposals),
+		LaunchPacketCount:        launchPackets.Count,
+		LaunchPacketWarningCount: launchPackets.WarningCount,
+		LaunchPacketErrors:       launchPackets.Errors,
+		Operations:               operations,
+		Activity:                 activity,
 	}, nil
 }
 
-func projectCairnlineParityReport(projectID string, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
+func projectCairnlineSnapshotGraphCounts(snapshot cairnlinebridge.Snapshot) ProjectCairnlineGraphParityCounts {
+	return ProjectCairnlineGraphParityCounts{
+		Roots:             len(snapshot.Project.Roots),
+		ContextSources:    len(snapshot.Project.ContextSources),
+		AgentProfiles:     len(snapshot.AgentProfiles),
+		ExecutionProfiles: cairnlinebridge.SnapshotExecutionProfileCount(snapshot),
+		Skills:            len(snapshot.Skills),
+		Roles:             len(snapshot.Roles),
+		WorkItems:         len(snapshot.WorkItems),
+		Assignments:       len(snapshot.Assignments),
+		Artifacts:         len(snapshot.Artifacts),
+		Handoffs:          len(snapshot.Handoffs),
+		MemoryEntries:     len(snapshot.MemoryEntries),
+		MemoryCandidates:  len(snapshot.MemoryCandidates),
+	}
+}
+
+func projectCairnlineServiceGraphCounts(ctx context.Context, service *cairnline.Service, projectID string) (ProjectCairnlineGraphParityCounts, error) {
+	var counts ProjectCairnlineGraphParityCounts
+	projects, err := service.ListProjects(ctx)
+	if err != nil {
+		return counts, err
+	}
+	var found bool
+	for _, project := range projects {
+		if project.ID != projectID {
+			continue
+		}
+		found = true
+		counts.Roots = len(project.Roots)
+		counts.ContextSources = len(project.ContextSources)
+		break
+	}
+	if !found {
+		return counts, cairnline.ErrNotFound
+	}
+	profiles, err := service.ListAgentProfiles(ctx)
+	if err != nil {
+		return counts, err
+	}
+	counts.AgentProfiles = len(profiles)
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return counts, err
+	}
+	counts.ExecutionProfiles = len(executionProfiles)
+	skills, err := service.ListProjectSkills(ctx, projectID)
+	if err != nil {
+		return counts, err
+	}
+	counts.Skills = len(skills)
+	roles, err := service.ListRoles(ctx, projectID)
+	if err != nil {
+		return counts, err
+	}
+	counts.Roles = len(roles)
+	workItems, err := service.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return counts, err
+	}
+	counts.WorkItems = len(workItems)
+	assignments, err := service.ListAssignments(ctx, projectID)
+	if err != nil {
+		return counts, err
+	}
+	counts.Assignments = len(assignments)
+	for _, workItem := range workItems {
+		artifacts, err := service.ListArtifacts(ctx, projectID, workItem.ID)
+		if err != nil {
+			return counts, err
+		}
+		evidence, err := service.ListEvidence(ctx, projectID, workItem.ID)
+		if err != nil {
+			return counts, err
+		}
+		reviews, err := service.ListReviews(ctx, projectID, workItem.ID)
+		if err != nil {
+			return counts, err
+		}
+		handoffs, err := service.ListHandoffs(ctx, projectID, workItem.ID)
+		if err != nil {
+			return counts, err
+		}
+		counts.Artifacts += len(artifacts) + len(evidence) + len(reviews)
+		counts.Handoffs += len(handoffs)
+	}
+	memoryEntries, err := service.ListMemoryEntries(ctx, projectID, true)
+	if err != nil {
+		return counts, err
+	}
+	counts.MemoryEntries = len(memoryEntries)
+	memoryCandidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+		ProjectID:       projectID,
+		IncludeResolved: true,
+	})
+	if err != nil {
+		return counts, err
+	}
+	counts.MemoryCandidates = len(memoryCandidates)
+	return counts, nil
+}
+
+func projectCairnlineSnapshotAllCounts(snapshots []cairnlinebridge.Snapshot) ProjectCairnlineSyncCounts {
+	var counts ProjectCairnlineSyncCounts
+	profileIDs := map[string]struct{}{}
+	executionProfileIDs := map[string]struct{}{}
+	addProfileID := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		profileIDs[id] = struct{}{}
+	}
+	addExecutionProfileID := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		executionProfileIDs[id] = struct{}{}
+	}
+	for _, snapshot := range snapshots {
+		counts.Projects++
+		counts.Roots += len(snapshot.Project.Roots)
+		counts.ContextSources += len(snapshot.Project.ContextSources)
+		counts.Skills += len(snapshot.Skills)
+		counts.Roles += len(snapshot.Roles)
+		counts.WorkItems += len(snapshot.WorkItems)
+		counts.Assignments += len(snapshot.Assignments)
+		counts.LaunchPackets += len(snapshot.Assignments)
+		counts.Artifacts += len(snapshot.Artifacts)
+		counts.Handoffs += len(snapshot.Handoffs)
+		counts.MemoryEntries += len(snapshot.MemoryEntries)
+		counts.MemoryCandidates += len(snapshot.MemoryCandidates)
+		counts.AssistantProposals += len(snapshot.AssistantProposals)
+		if executionProfile, ok := cairnlinebridge.ProjectExecutionProfile(snapshot.Project); ok {
+			addExecutionProfileID(executionProfile.ID)
+		}
+		for _, profile := range snapshot.AgentProfiles {
+			addProfileID(profile.ID)
+			addExecutionProfileID(cairnlinebridge.ExecutionProfile(profile).ID)
+		}
+		for _, role := range snapshot.Roles {
+			executionProfile, ok := cairnlinebridge.RoleExecutionProfile(role)
+			if !ok {
+				continue
+			}
+			addExecutionProfileID(executionProfile.ID)
+		}
+	}
+	counts.AgentProfiles = len(profileIDs)
+	counts.ExecutionProfiles = len(executionProfileIDs)
+	return counts
+}
+
+func projectCairnlineServiceAllCounts(ctx context.Context, service *cairnline.Service) (ProjectCairnlineSyncCounts, error) {
+	var counts ProjectCairnlineSyncCounts
+	projects, err := service.ListProjects(ctx)
+	if err != nil {
+		return counts, err
+	}
+	counts.Projects = len(projects)
+	profiles, err := service.ListAgentProfiles(ctx)
+	if err != nil {
+		return counts, err
+	}
+	counts.AgentProfiles = len(profiles)
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return counts, err
+	}
+	counts.ExecutionProfiles = len(executionProfiles)
+	for _, project := range projects {
+		counts.Roots += len(project.Roots)
+		counts.ContextSources += len(project.ContextSources)
+		skills, err := service.ListProjectSkills(ctx, project.ID)
+		if err != nil {
+			return counts, err
+		}
+		counts.Skills += len(skills)
+		roles, err := service.ListRoles(ctx, project.ID)
+		if err != nil {
+			return counts, err
+		}
+		counts.Roles += len(roles)
+		workItems, err := service.ListWorkItems(ctx, project.ID)
+		if err != nil {
+			return counts, err
+		}
+		counts.WorkItems += len(workItems)
+		assignments, err := service.ListAssignments(ctx, project.ID)
+		if err != nil {
+			return counts, err
+		}
+		counts.Assignments += len(assignments)
+		for _, assignment := range assignments {
+			packet, err := service.AssignmentLaunchPacket(ctx, project.ID, assignment.ID)
+			if err != nil {
+				counts.LaunchErrors++
+				continue
+			}
+			counts.LaunchPackets++
+			counts.LaunchWarnings += len(packet.Warnings)
+		}
+		for _, workItem := range workItems {
+			artifacts, err := service.ListArtifacts(ctx, project.ID, workItem.ID)
+			if err != nil {
+				return counts, err
+			}
+			evidence, err := service.ListEvidence(ctx, project.ID, workItem.ID)
+			if err != nil {
+				return counts, err
+			}
+			reviews, err := service.ListReviews(ctx, project.ID, workItem.ID)
+			if err != nil {
+				return counts, err
+			}
+			handoffs, err := service.ListHandoffs(ctx, project.ID, workItem.ID)
+			if err != nil {
+				return counts, err
+			}
+			counts.Artifacts += len(artifacts) + len(evidence) + len(reviews)
+			counts.Handoffs += len(handoffs)
+		}
+		memoryEntries, err := service.ListMemoryEntries(ctx, project.ID, true)
+		if err != nil {
+			return counts, err
+		}
+		counts.MemoryEntries += len(memoryEntries)
+		memoryCandidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+			ProjectID:       project.ID,
+			IncludeResolved: true,
+		})
+		if err != nil {
+			return counts, err
+		}
+		counts.MemoryCandidates += len(memoryCandidates)
+		assistantProposals, err := service.ListAssistantProposals(ctx, project.ID)
+		if err != nil {
+			return counts, err
+		}
+		counts.AssistantProposals += len(assistantProposals)
+	}
+	return counts, nil
+}
+
+func projectCairnlineSnapshotAllIDSets(snapshots []cairnlinebridge.Snapshot) ProjectCairnlineSyncIDSets {
+	var ids ProjectCairnlineSyncIDSets
+	seen := map[string]map[string]struct{}{}
+	for _, snapshot := range snapshots {
+		projectID := strings.TrimSpace(snapshot.Project.ID)
+		addProjectCairnlineSyncID(seen, &ids.Projects, "projects", projectID)
+		for _, root := range snapshot.Project.Roots {
+			addProjectCairnlineSyncID(seen, &ids.Roots, "roots", scopedCairnlineID(projectID, root.ID))
+		}
+		for _, source := range snapshot.Project.ContextSources {
+			addProjectCairnlineSyncID(seen, &ids.ContextSources, "context_sources", scopedCairnlineID(projectID, source.ID))
+		}
+		if executionProfile, ok := cairnlinebridge.ProjectExecutionProfile(snapshot.Project); ok {
+			addProjectCairnlineSyncID(seen, &ids.ExecutionProfiles, "execution_profiles", executionProfile.ID)
+		}
+		for _, profile := range snapshot.AgentProfiles {
+			addProjectCairnlineSyncID(seen, &ids.AgentProfiles, "agent_profiles", profile.ID)
+			addProjectCairnlineSyncID(seen, &ids.ExecutionProfiles, "execution_profiles", cairnlinebridge.ExecutionProfile(profile).ID)
+		}
+		for _, skill := range snapshot.Skills {
+			addProjectCairnlineSyncID(seen, &ids.Skills, "skills", scopedCairnlineID(projectID, skill.ID))
+		}
+		for _, role := range snapshot.Roles {
+			addProjectCairnlineSyncID(seen, &ids.Roles, "roles", scopedCairnlineID(projectID, role.ID))
+			if executionProfile, ok := cairnlinebridge.RoleExecutionProfile(role); ok {
+				addProjectCairnlineSyncID(seen, &ids.ExecutionProfiles, "execution_profiles", executionProfile.ID)
+			}
+		}
+		for _, item := range snapshot.WorkItems {
+			addProjectCairnlineSyncID(seen, &ids.WorkItems, "work_items", scopedCairnlineID(projectID, item.ID))
+		}
+		for _, assignment := range snapshot.Assignments {
+			assignmentID := scopedCairnlineID(projectID, assignment.ID)
+			addProjectCairnlineSyncID(seen, &ids.Assignments, "assignments", assignmentID)
+			addProjectCairnlineSyncID(seen, &ids.LaunchPackets, "launch_packets", assignmentID)
+		}
+		for _, artifact := range snapshot.Artifacts {
+			addProjectCairnlineSyncID(seen, &ids.Artifacts, "artifacts", scopedCairnlineID(projectID, artifact.WorkItemID, artifact.ID))
+		}
+		for _, handoff := range snapshot.Handoffs {
+			addProjectCairnlineSyncID(seen, &ids.Handoffs, "handoffs", scopedCairnlineID(projectID, handoff.WorkItemID, handoff.ID))
+		}
+		for _, entry := range snapshot.MemoryEntries {
+			addProjectCairnlineSyncID(seen, &ids.MemoryEntries, "memory_entries", scopedCairnlineID(projectID, entry.ID))
+		}
+		for _, candidate := range snapshot.MemoryCandidates {
+			addProjectCairnlineSyncID(seen, &ids.MemoryCandidates, "memory_candidates", scopedCairnlineID(projectID, candidate.ID))
+		}
+		for _, proposal := range snapshot.AssistantProposals {
+			addProjectCairnlineSyncID(seen, &ids.AssistantProposals, "assistant_proposals", scopedCairnlineID(projectID, proposal.ID))
+		}
+	}
+	sortProjectCairnlineSyncIDSets(&ids)
+	return ids
+}
+
+func projectCairnlineServiceAllIDSets(ctx context.Context, service *cairnline.Service) (ProjectCairnlineSyncIDSets, error) {
+	var ids ProjectCairnlineSyncIDSets
+	seen := map[string]map[string]struct{}{}
+	projects, err := service.ListProjects(ctx)
+	if err != nil {
+		return ids, err
+	}
+	profiles, err := service.ListAgentProfiles(ctx)
+	if err != nil {
+		return ids, err
+	}
+	for _, profile := range profiles {
+		addProjectCairnlineSyncID(seen, &ids.AgentProfiles, "agent_profiles", profile.ID)
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return ids, err
+	}
+	for _, profile := range executionProfiles {
+		addProjectCairnlineSyncID(seen, &ids.ExecutionProfiles, "execution_profiles", profile.ID)
+	}
+	for _, project := range projects {
+		projectID := strings.TrimSpace(project.ID)
+		addProjectCairnlineSyncID(seen, &ids.Projects, "projects", projectID)
+		for _, root := range project.Roots {
+			addProjectCairnlineSyncID(seen, &ids.Roots, "roots", scopedCairnlineID(projectID, root.ID))
+		}
+		for _, source := range project.ContextSources {
+			addProjectCairnlineSyncID(seen, &ids.ContextSources, "context_sources", scopedCairnlineID(projectID, source.ID))
+		}
+		skills, err := service.ListProjectSkills(ctx, projectID)
+		if err != nil {
+			return ids, err
+		}
+		for _, skill := range skills {
+			addProjectCairnlineSyncID(seen, &ids.Skills, "skills", scopedCairnlineID(projectID, skill.ID))
+		}
+		roles, err := service.ListRoles(ctx, projectID)
+		if err != nil {
+			return ids, err
+		}
+		for _, role := range roles {
+			addProjectCairnlineSyncID(seen, &ids.Roles, "roles", scopedCairnlineID(projectID, role.ID))
+		}
+		workItems, err := service.ListWorkItems(ctx, projectID)
+		if err != nil {
+			return ids, err
+		}
+		for _, workItem := range workItems {
+			workItemID := strings.TrimSpace(workItem.ID)
+			addProjectCairnlineSyncID(seen, &ids.WorkItems, "work_items", scopedCairnlineID(projectID, workItemID))
+			artifacts, err := service.ListArtifacts(ctx, projectID, workItemID)
+			if err != nil {
+				return ids, err
+			}
+			for _, artifact := range artifacts {
+				addProjectCairnlineSyncID(seen, &ids.Artifacts, "artifacts", scopedCairnlineID(projectID, workItemID, artifact.ID))
+			}
+			evidence, err := service.ListEvidence(ctx, projectID, workItemID)
+			if err != nil {
+				return ids, err
+			}
+			for _, item := range evidence {
+				addProjectCairnlineSyncID(seen, &ids.Artifacts, "artifacts", scopedCairnlineID(projectID, workItemID, item.ID))
+			}
+			reviews, err := service.ListReviews(ctx, projectID, workItemID)
+			if err != nil {
+				return ids, err
+			}
+			for _, item := range reviews {
+				addProjectCairnlineSyncID(seen, &ids.Artifacts, "artifacts", scopedCairnlineID(projectID, workItemID, item.ID))
+			}
+			handoffs, err := service.ListHandoffs(ctx, projectID, workItemID)
+			if err != nil {
+				return ids, err
+			}
+			for _, handoff := range handoffs {
+				addProjectCairnlineSyncID(seen, &ids.Handoffs, "handoffs", scopedCairnlineID(projectID, workItemID, handoff.ID))
+			}
+		}
+		assignments, err := service.ListAssignments(ctx, projectID)
+		if err != nil {
+			return ids, err
+		}
+		for _, assignment := range assignments {
+			assignmentID := scopedCairnlineID(projectID, assignment.ID)
+			addProjectCairnlineSyncID(seen, &ids.Assignments, "assignments", assignmentID)
+			if _, err := service.AssignmentLaunchPacket(ctx, projectID, assignment.ID); err == nil {
+				addProjectCairnlineSyncID(seen, &ids.LaunchPackets, "launch_packets", assignmentID)
+			}
+		}
+		memoryEntries, err := service.ListMemoryEntries(ctx, projectID, true)
+		if err != nil {
+			return ids, err
+		}
+		for _, entry := range memoryEntries {
+			addProjectCairnlineSyncID(seen, &ids.MemoryEntries, "memory_entries", scopedCairnlineID(projectID, entry.ID))
+		}
+		memoryCandidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+			ProjectID:       projectID,
+			IncludeResolved: true,
+		})
+		if err != nil {
+			return ids, err
+		}
+		for _, candidate := range memoryCandidates {
+			addProjectCairnlineSyncID(seen, &ids.MemoryCandidates, "memory_candidates", scopedCairnlineID(projectID, candidate.ID))
+		}
+		assistantProposals, err := service.ListAssistantProposals(ctx, projectID)
+		if err != nil {
+			return ids, err
+		}
+		for _, proposal := range assistantProposals {
+			addProjectCairnlineSyncID(seen, &ids.AssistantProposals, "assistant_proposals", scopedCairnlineID(projectID, proposal.ID))
+		}
+	}
+	sortProjectCairnlineSyncIDSets(&ids)
+	return ids, nil
+}
+
+type projectCairnlineContentDigests map[string]map[string]string
+
+func projectCairnlineSnapshotAllContentDigests(snapshots []cairnlinebridge.Snapshot) projectCairnlineContentDigests {
+	digests := projectCairnlineContentDigests{}
+	executionProfileDigests := map[string]struct{}{}
+	addExecutionProfile := func(profile cairnline.ExecutionProfile) {
+		id := strings.TrimSpace(profile.ID)
+		if id == "" {
+			return
+		}
+		if _, ok := executionProfileDigests[id]; ok {
+			return
+		}
+		executionProfileDigests[id] = struct{}{}
+		digests.add("execution_profiles", id, profile)
+	}
+	profileByID := map[string]agentprofiles.Profile{}
+	for _, snapshot := range snapshots {
+		for _, profile := range snapshot.AgentProfiles {
+			profileByID[profile.ID] = profile
+		}
+	}
+	for _, snapshot := range snapshots {
+		projectID := strings.TrimSpace(snapshot.Project.ID)
+		project := cairnlinebridge.Project(snapshot.Project)
+		digests.add("projects", projectID, project)
+		for _, root := range project.Roots {
+			digests.add("roots", scopedCairnlineID(projectID, root.ID), root)
+		}
+		for _, source := range project.ContextSources {
+			digests.add("context_sources", scopedCairnlineID(projectID, source.ID), source)
+		}
+		if executionProfile, ok := cairnlinebridge.ProjectExecutionProfile(snapshot.Project); ok {
+			addExecutionProfile(executionProfile)
+		}
+		for _, profile := range snapshot.AgentProfiles {
+			agentProfile := cairnlinebridge.AgentProfile(profile)
+			digests.add("agent_profiles", agentProfile.ID, agentProfile)
+			addExecutionProfile(cairnlinebridge.ExecutionProfile(profile))
+		}
+		for _, skill := range snapshot.Skills {
+			item := cairnlinebridge.ProjectSkill(skill)
+			digests.add("skills", scopedCairnlineID(projectID, item.ID), item)
+		}
+		roleByID := map[string]projectwork.AgentRoleProfile{}
+		for _, role := range snapshot.Roles {
+			roleByID[role.ID] = role
+			item := cairnlinebridge.Role(role)
+			digests.add("roles", scopedCairnlineID(projectID, item.ID), item)
+			if executionProfile, ok := cairnlinebridge.RoleExecutionProfile(role); ok {
+				addExecutionProfile(executionProfile)
+			}
+		}
+		for _, item := range snapshot.WorkItems {
+			workItem := cairnlinebridge.WorkItem(item)
+			digests.add("work_items", scopedCairnlineID(projectID, workItem.ID), workItem)
+		}
+		for _, assignment := range snapshot.Assignments {
+			role := roleByID[assignment.RoleID]
+			profile := profileByID[role.DefaultAgentProfile]
+			item := cairnlinebridge.Assignment(assignment, role, profile)
+			digests.add("assignments", scopedCairnlineID(projectID, item.ID), item)
+		}
+		for _, artifact := range snapshot.Artifacts {
+			if item, ok := cairnlinebridge.Artifact(artifact); ok {
+				digests.add("artifacts", scopedCairnlineID(projectID, item.WorkItemID, item.ID), item)
+				continue
+			}
+			if item, ok := cairnlinebridge.Evidence(artifact); ok {
+				digests.add("evidence", scopedCairnlineID(projectID, item.WorkItemID, item.ID), item)
+				continue
+			}
+			if item, ok := cairnlinebridge.Review(artifact); ok {
+				digests.add("reviews", scopedCairnlineID(projectID, item.WorkItemID, item.ID), item)
+			}
+		}
+		for _, handoff := range snapshot.Handoffs {
+			item := cairnlinebridge.Handoff(handoff)
+			digests.add("handoffs", scopedCairnlineID(projectID, item.WorkItemID, item.ID), item)
+		}
+		for _, entry := range snapshot.MemoryEntries {
+			item := cairnlinebridge.MemoryEntry(entry)
+			digests.add("memory_entries", scopedCairnlineID(projectID, item.ID), item)
+		}
+		for _, candidate := range snapshot.MemoryCandidates {
+			item := cairnlinebridge.MemoryCandidate(candidate)
+			digests.add("memory_candidates", scopedCairnlineID(projectID, item.ID), item)
+		}
+		for _, proposal := range snapshot.AssistantProposals {
+			item, ok := cairnlinebridge.AssistantProposalRecord(proposal)
+			if !ok {
+				continue
+			}
+			digests.add("assistant_proposals", scopedCairnlineID(projectID, item.ID), item)
+		}
+	}
+	return digests
+}
+
+func projectCairnlineServiceAllContentDigests(ctx context.Context, service *cairnline.Service) (projectCairnlineContentDigests, error) {
+	digests := projectCairnlineContentDigests{}
+	projects, err := service.ListProjects(ctx)
+	if err != nil {
+		return digests, err
+	}
+	profiles, err := service.ListAgentProfiles(ctx)
+	if err != nil {
+		return digests, err
+	}
+	for _, profile := range profiles {
+		digests.add("agent_profiles", profile.ID, profile)
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return digests, err
+	}
+	for _, profile := range executionProfiles {
+		digests.add("execution_profiles", profile.ID, profile)
+	}
+	for _, project := range projects {
+		projectID := strings.TrimSpace(project.ID)
+		digests.add("projects", projectID, project)
+		for _, root := range project.Roots {
+			digests.add("roots", scopedCairnlineID(projectID, root.ID), root)
+		}
+		for _, source := range project.ContextSources {
+			digests.add("context_sources", scopedCairnlineID(projectID, source.ID), source)
+		}
+		skills, err := service.ListProjectSkills(ctx, projectID)
+		if err != nil {
+			return digests, err
+		}
+		for _, skill := range skills {
+			digests.add("skills", scopedCairnlineID(projectID, skill.ID), skill)
+		}
+		roles, err := service.ListRoles(ctx, projectID)
+		if err != nil {
+			return digests, err
+		}
+		for _, role := range roles {
+			digests.add("roles", scopedCairnlineID(projectID, role.ID), role)
+		}
+		workItems, err := service.ListWorkItems(ctx, projectID)
+		if err != nil {
+			return digests, err
+		}
+		for _, workItem := range workItems {
+			workItemID := strings.TrimSpace(workItem.ID)
+			digests.add("work_items", scopedCairnlineID(projectID, workItemID), workItem)
+			artifacts, err := service.ListArtifacts(ctx, projectID, workItemID)
+			if err != nil {
+				return digests, err
+			}
+			for _, artifact := range artifacts {
+				digests.add("artifacts", scopedCairnlineID(projectID, workItemID, artifact.ID), artifact)
+			}
+			evidence, err := service.ListEvidence(ctx, projectID, workItemID)
+			if err != nil {
+				return digests, err
+			}
+			for _, item := range evidence {
+				digests.add("evidence", scopedCairnlineID(projectID, workItemID, item.ID), item)
+			}
+			reviews, err := service.ListReviews(ctx, projectID, workItemID)
+			if err != nil {
+				return digests, err
+			}
+			for _, item := range reviews {
+				digests.add("reviews", scopedCairnlineID(projectID, workItemID, item.ID), item)
+			}
+			handoffs, err := service.ListHandoffs(ctx, projectID, workItemID)
+			if err != nil {
+				return digests, err
+			}
+			for _, handoff := range handoffs {
+				digests.add("handoffs", scopedCairnlineID(projectID, workItemID, handoff.ID), handoff)
+			}
+		}
+		assignments, err := service.ListAssignments(ctx, projectID)
+		if err != nil {
+			return digests, err
+		}
+		for _, assignment := range assignments {
+			digests.add("assignments", scopedCairnlineID(projectID, assignment.ID), assignment)
+		}
+		memoryEntries, err := service.ListMemoryEntries(ctx, projectID, true)
+		if err != nil {
+			return digests, err
+		}
+		for _, entry := range memoryEntries {
+			digests.add("memory_entries", scopedCairnlineID(projectID, entry.ID), entry)
+		}
+		memoryCandidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+			ProjectID:       projectID,
+			IncludeResolved: true,
+		})
+		if err != nil {
+			return digests, err
+		}
+		for _, candidate := range memoryCandidates {
+			digests.add("memory_candidates", scopedCairnlineID(projectID, candidate.ID), candidate)
+		}
+		assistantProposals, err := service.ListAssistantProposals(ctx, projectID)
+		if err != nil {
+			return digests, err
+		}
+		for _, proposal := range assistantProposals {
+			digests.add("assistant_proposals", scopedCairnlineID(projectID, proposal.ID), proposal)
+		}
+	}
+	return digests, nil
+}
+
+func projectCairnlineSyncContentDifferences(hecate, cairnline projectCairnlineContentDigests) []ProjectCairnlineContentDifference {
+	var differences []ProjectCairnlineContentDifference
+	paths := unionProjectCairnlineContentDigestPaths(hecate, cairnline)
+	for _, path := range paths {
+		left := hecate[path]
+		right := cairnline[path]
+		ids := intersectionProjectCairnlineContentDigestIDs(left, right)
+		for _, id := range ids {
+			if left[id] == right[id] {
+				continue
+			}
+			differences = append(differences, ProjectCairnlineContentDifference{
+				Path:      path,
+				ID:        id,
+				Hecate:    left[id],
+				Cairnline: right[id],
+			})
+		}
+	}
+	return differences
+}
+
+func unionProjectCairnlineContentDigestPaths(left, right projectCairnlineContentDigests) []string {
+	seen := map[string]struct{}{}
+	for path := range left {
+		seen[path] = struct{}{}
+	}
+	for path := range right {
+		seen[path] = struct{}{}
+	}
+	paths := make([]string, 0, len(seen))
+	for path := range seen {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func intersectionProjectCairnlineContentDigestIDs(left, right map[string]string) []string {
+	if len(left) == 0 || len(right) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(left))
+	for id := range left {
+		if _, ok := right[id]; ok {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (digests projectCairnlineContentDigests) add(path, id string, value any) {
+	path = strings.TrimSpace(path)
+	id = strings.TrimSpace(id)
+	if path == "" || id == "" {
+		return
+	}
+	if digests[path] == nil {
+		digests[path] = map[string]string{}
+	}
+	digests[path][id] = projectCairnlineContentDigest(value)
+}
+
+func projectCairnlineContentDigest(value any) string {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		payload = []byte("{}")
+	}
+	var decoded any
+	if err := json.Unmarshal(payload, &decoded); err == nil {
+		stripVolatileProjectCairnlineDigestFields(decoded)
+		if canonicalPayload, err := json.Marshal(decoded); err == nil {
+			payload = canonicalPayload
+		}
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func stripVolatileProjectCairnlineDigestFields(value any) {
+	switch item := value.(type) {
+	case map[string]any:
+		for _, key := range []string{"created_at", "updated_at", "discovered_at", "applied_at"} {
+			delete(item, key)
+		}
+		for _, child := range item {
+			stripVolatileProjectCairnlineDigestFields(child)
+		}
+	case []any:
+		for _, child := range item {
+			stripVolatileProjectCairnlineDigestFields(child)
+		}
+	}
+}
+
+func projectCairnlineSyncIDDifferences(hecate, cairnline ProjectCairnlineSyncIDSets) []ProjectCairnlineIDDifference {
+	var differences []ProjectCairnlineIDDifference
+	differences = appendProjectCairnlineIDDifference(differences, "projects", hecate.Projects, cairnline.Projects)
+	differences = appendProjectCairnlineIDDifference(differences, "roots", hecate.Roots, cairnline.Roots)
+	differences = appendProjectCairnlineIDDifference(differences, "context_sources", hecate.ContextSources, cairnline.ContextSources)
+	differences = appendProjectCairnlineIDDifference(differences, "agent_profiles", hecate.AgentProfiles, cairnline.AgentProfiles)
+	differences = appendProjectCairnlineIDDifference(differences, "execution_profiles", hecate.ExecutionProfiles, cairnline.ExecutionProfiles)
+	differences = appendProjectCairnlineIDDifference(differences, "skills", hecate.Skills, cairnline.Skills)
+	differences = appendProjectCairnlineIDDifference(differences, "roles", hecate.Roles, cairnline.Roles)
+	differences = appendProjectCairnlineIDDifference(differences, "work_items", hecate.WorkItems, cairnline.WorkItems)
+	differences = appendProjectCairnlineIDDifference(differences, "assignments", hecate.Assignments, cairnline.Assignments)
+	differences = appendProjectCairnlineIDDifference(differences, "artifacts", hecate.Artifacts, cairnline.Artifacts)
+	differences = appendProjectCairnlineIDDifference(differences, "handoffs", hecate.Handoffs, cairnline.Handoffs)
+	differences = appendProjectCairnlineIDDifference(differences, "memory_entries", hecate.MemoryEntries, cairnline.MemoryEntries)
+	differences = appendProjectCairnlineIDDifference(differences, "memory_candidates", hecate.MemoryCandidates, cairnline.MemoryCandidates)
+	differences = appendProjectCairnlineIDDifference(differences, "assistant_proposals", hecate.AssistantProposals, cairnline.AssistantProposals)
+	differences = appendProjectCairnlineIDDifference(differences, "launch_packets", hecate.LaunchPackets, cairnline.LaunchPackets)
+	return differences
+}
+
+func appendProjectCairnlineIDDifference(differences []ProjectCairnlineIDDifference, path string, hecate, cairnline []string) []ProjectCairnlineIDDifference {
+	if equalStringSlices(hecate, cairnline) {
+		return differences
+	}
+	return append(differences, ProjectCairnlineIDDifference{
+		Path:      path,
+		Hecate:    append([]string(nil), hecate...),
+		Cairnline: append([]string(nil), cairnline...),
+	})
+}
+
+func addProjectCairnlineSyncID(seen map[string]map[string]struct{}, list *[]string, path, id string) {
+	id = strings.TrimSpace(id)
+	if id == "" || list == nil {
+		return
+	}
+	if seen[path] == nil {
+		seen[path] = map[string]struct{}{}
+	}
+	if _, ok := seen[path][id]; ok {
+		return
+	}
+	seen[path][id] = struct{}{}
+	*list = append(*list, id)
+}
+
+func sortProjectCairnlineSyncIDSets(ids *ProjectCairnlineSyncIDSets) {
+	if ids == nil {
+		return
+	}
+	sort.Strings(ids.Projects)
+	sort.Strings(ids.Roots)
+	sort.Strings(ids.ContextSources)
+	sort.Strings(ids.AgentProfiles)
+	sort.Strings(ids.ExecutionProfiles)
+	sort.Strings(ids.Skills)
+	sort.Strings(ids.Roles)
+	sort.Strings(ids.WorkItems)
+	sort.Strings(ids.Assignments)
+	sort.Strings(ids.Artifacts)
+	sort.Strings(ids.Handoffs)
+	sort.Strings(ids.MemoryEntries)
+	sort.Strings(ids.MemoryCandidates)
+	sort.Strings(ids.AssistantProposals)
+	sort.Strings(ids.LaunchPackets)
+}
+
+func scopedCairnlineID(parts ...string) string {
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return ""
+		}
+		out = append(out, part)
+	}
+	return strings.Join(out, "/")
+}
+
+func equalStringSlices(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for idx := range left {
+		if left[idx] != right[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+func projectCairnlineSyncDifferences(hecate, cairnline ProjectCairnlineSyncCounts) []ProjectCairnlineParityDifference {
+	var differences []ProjectCairnlineParityDifference
+	differences = appendProjectCairnlineParityDifference(differences, "projects", hecate.Projects, cairnline.Projects)
+	differences = appendProjectCairnlineParityDifference(differences, "roots", hecate.Roots, cairnline.Roots)
+	differences = appendProjectCairnlineParityDifference(differences, "context_sources", hecate.ContextSources, cairnline.ContextSources)
+	differences = appendProjectCairnlineParityDifference(differences, "agent_profiles", hecate.AgentProfiles, cairnline.AgentProfiles)
+	differences = appendProjectCairnlineParityDifference(differences, "execution_profiles", hecate.ExecutionProfiles, cairnline.ExecutionProfiles)
+	differences = appendProjectCairnlineParityDifference(differences, "skills", hecate.Skills, cairnline.Skills)
+	differences = appendProjectCairnlineParityDifference(differences, "roles", hecate.Roles, cairnline.Roles)
+	differences = appendProjectCairnlineParityDifference(differences, "work_items", hecate.WorkItems, cairnline.WorkItems)
+	differences = appendProjectCairnlineParityDifference(differences, "assignments", hecate.Assignments, cairnline.Assignments)
+	differences = appendProjectCairnlineParityDifference(differences, "artifacts", hecate.Artifacts, cairnline.Artifacts)
+	differences = appendProjectCairnlineParityDifference(differences, "handoffs", hecate.Handoffs, cairnline.Handoffs)
+	differences = appendProjectCairnlineParityDifference(differences, "memory_entries", hecate.MemoryEntries, cairnline.MemoryEntries)
+	differences = appendProjectCairnlineParityDifference(differences, "memory_candidates", hecate.MemoryCandidates, cairnline.MemoryCandidates)
+	differences = appendProjectCairnlineParityDifference(differences, "assistant_proposals", hecate.AssistantProposals, cairnline.AssistantProposals)
+	differences = appendProjectCairnlineParityDifference(differences, "launch_packets", hecate.LaunchPackets, cairnline.LaunchPackets)
+	differences = appendProjectCairnlineParityDifference(differences, "launch_warnings", hecate.LaunchWarnings, cairnline.LaunchWarnings)
+	differences = appendProjectCairnlineParityDifference(differences, "launch_errors", hecate.LaunchErrors, cairnline.LaunchErrors)
+	return differences
+}
+
+type projectCairnlineLaunchPacketSummaryData struct {
+	Count        int
+	WarningCount int
+	Errors       []ProjectCairnlineLaunchPacketError
+}
+
+func projectCairnlineLaunchPacketSummary(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) projectCairnlineLaunchPacketSummaryData {
+	var summary projectCairnlineLaunchPacketSummaryData
+	if service == nil {
+		for _, assignment := range snapshot.Assignments {
+			summary.Errors = append(summary.Errors, ProjectCairnlineLaunchPacketError{
+				AssignmentID: assignment.ID,
+				Error:        "cairnline service is not configured",
+			})
+		}
+		return summary
+	}
+	for _, assignment := range snapshot.Assignments {
+		packet, err := service.AssignmentLaunchPacket(ctx, snapshot.Project.ID, assignment.ID)
+		if err != nil {
+			summary.Errors = append(summary.Errors, ProjectCairnlineLaunchPacketError{
+				AssignmentID: assignment.ID,
+				Error:        err.Error(),
+			})
+			continue
+		}
+		summary.Count++
+		summary.WarningCount += len(packet.Warnings)
+	}
+	return summary
+}
+
+func (h *Handler) nativeProjectAssistantProposalCount(ctx context.Context, projectID string) (int, error) {
+	if h.projectAssistantProposals == nil {
+		return 0, nil
+	}
+	proposals, err := h.projectAssistantProposals.ListProposals(ctx, projectID)
+	if err != nil {
+		return 0, err
+	}
+	return len(proposals), nil
+}
+
+func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnlineGraphParityCounts, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, nativeAssistantProposals int, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
 	hecate := ProjectCairnlineParitySnapshot{
+		Graph: nativeGraph,
 		Activity: ProjectCairnlineActivityParityCounts{
 			WorkItems:   nativeActivity.Summary.WorkItemCount,
 			Assignments: nativeActivity.Summary.AssignmentCount,
@@ -163,8 +1164,30 @@ func projectCairnlineParityReport(projectID string, nativeActivity ProjectActivi
 			PendingMemoryCandidates: nativeOperations.Summary.PendingMemoryCandidateCount,
 			OpenHandoffs:            nativeOperations.Summary.PendingHandoffCount,
 		},
+		Assistant: ProjectCairnlineAssistantParityCounts{
+			Proposals: nativeAssistantProposals,
+		},
+		LaunchPackets: ProjectCairnlineLaunchPacketParityCounts{
+			Assignments: nativeActivity.Summary.AssignmentCount,
+			Warnings:    0,
+			Errors:      0,
+		},
 	}
 	cairnline := ProjectCairnlineParitySnapshot{
+		Graph: ProjectCairnlineGraphParityCounts{
+			Roots:             readModel.RootCount,
+			ContextSources:    readModel.ContextSourceCount,
+			AgentProfiles:     readModel.AgentProfileCount,
+			ExecutionProfiles: readModel.ExecutionProfileCount,
+			Skills:            readModel.SkillCount,
+			Roles:             readModel.RoleCount,
+			WorkItems:         readModel.WorkItemCount,
+			Assignments:       readModel.AssignmentCount,
+			Artifacts:         readModel.ArtifactCount,
+			Handoffs:          readModel.HandoffCount,
+			MemoryEntries:     readModel.MemoryEntryCount,
+			MemoryCandidates:  readModel.MemoryCandidateCount,
+		},
 		Activity: ProjectCairnlineActivityParityCounts{
 			WorkItems:   readModel.WorkItemCount,
 			Assignments: readModel.Activity.Counts.Assignments,
@@ -176,6 +1199,14 @@ func projectCairnlineParityReport(projectID string, nativeActivity ProjectActivi
 		Operations: ProjectCairnlineOperationsParityCounts{
 			PendingMemoryCandidates: readModel.Operations.Counts.PendingMemoryCandidates,
 			OpenHandoffs:            readModel.Operations.Counts.OpenHandoffs,
+		},
+		Assistant: ProjectCairnlineAssistantParityCounts{
+			Proposals: readModel.AssistantProposalCount,
+		},
+		LaunchPackets: ProjectCairnlineLaunchPacketParityCounts{
+			Assignments: readModel.LaunchPacketCount,
+			Warnings:    readModel.LaunchPacketWarningCount,
+			Errors:      len(readModel.LaunchPacketErrors),
 		},
 	}
 	differences := projectCairnlineParityDifferences(hecate, cairnline)
@@ -190,6 +1221,18 @@ func projectCairnlineParityReport(projectID string, nativeActivity ProjectActivi
 
 func projectCairnlineParityDifferences(hecate, cairnline ProjectCairnlineParitySnapshot) []ProjectCairnlineParityDifference {
 	var differences []ProjectCairnlineParityDifference
+	differences = appendProjectCairnlineParityDifference(differences, "graph.roots", hecate.Graph.Roots, cairnline.Graph.Roots)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.context_sources", hecate.Graph.ContextSources, cairnline.Graph.ContextSources)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.agent_profiles", hecate.Graph.AgentProfiles, cairnline.Graph.AgentProfiles)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.execution_profiles", hecate.Graph.ExecutionProfiles, cairnline.Graph.ExecutionProfiles)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.skills", hecate.Graph.Skills, cairnline.Graph.Skills)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.roles", hecate.Graph.Roles, cairnline.Graph.Roles)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.work_items", hecate.Graph.WorkItems, cairnline.Graph.WorkItems)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.assignments", hecate.Graph.Assignments, cairnline.Graph.Assignments)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.artifacts", hecate.Graph.Artifacts, cairnline.Graph.Artifacts)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.handoffs", hecate.Graph.Handoffs, cairnline.Graph.Handoffs)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.memory_entries", hecate.Graph.MemoryEntries, cairnline.Graph.MemoryEntries)
+	differences = appendProjectCairnlineParityDifference(differences, "graph.memory_candidates", hecate.Graph.MemoryCandidates, cairnline.Graph.MemoryCandidates)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.work_items", hecate.Activity.WorkItems, cairnline.Activity.WorkItems)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.assignments", hecate.Activity.Assignments, cairnline.Activity.Assignments)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.active", hecate.Activity.Active, cairnline.Activity.Active)
@@ -198,6 +1241,10 @@ func projectCairnlineParityDifferences(hecate, cairnline ProjectCairnlineParityS
 	differences = appendProjectCairnlineParityDifference(differences, "activity.recent", hecate.Activity.Recent, cairnline.Activity.Recent)
 	differences = appendProjectCairnlineParityDifference(differences, "operations.pending_memory_candidates", hecate.Operations.PendingMemoryCandidates, cairnline.Operations.PendingMemoryCandidates)
 	differences = appendProjectCairnlineParityDifference(differences, "operations.open_handoffs", hecate.Operations.OpenHandoffs, cairnline.Operations.OpenHandoffs)
+	differences = appendProjectCairnlineParityDifference(differences, "assistant.proposals", hecate.Assistant.Proposals, cairnline.Assistant.Proposals)
+	differences = appendProjectCairnlineParityDifference(differences, "launch_packets.assignments", hecate.LaunchPackets.Assignments, cairnline.LaunchPackets.Assignments)
+	differences = appendProjectCairnlineParityDifference(differences, "launch_packets.warnings", hecate.LaunchPackets.Warnings, cairnline.LaunchPackets.Warnings)
+	differences = appendProjectCairnlineParityDifference(differences, "launch_packets.errors", hecate.LaunchPackets.Errors, cairnline.LaunchPackets.Errors)
 	return differences
 }
 
@@ -220,6 +1267,7 @@ func (h *Handler) cairnlineSnapshotSources() cairnlinebridge.SnapshotSources {
 		Work:             h.projectWork,
 		Memory:           h.memory,
 		MemoryCandidates: h.memoryCandidates,
+		Proposals:        h.projectAssistantProposals,
 	}
 }
 
@@ -239,6 +1287,18 @@ func (h *Handler) cairnlineExportPath(projectID string) (string, error) {
 	return path, nil
 }
 
+func (h *Handler) cairnlineEmbeddedDatabasePath() string {
+	dataDir := strings.TrimSpace(h.config.Server.DataDir)
+	if dataDir == "" {
+		dataDir = ".data"
+	}
+	path := filepath.Join(dataDir, "cairnline", "embedded", "projects.db")
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return path
+}
+
 func safeCairnlineExportName(value string) string {
 	var b strings.Builder
 	for _, r := range value {
@@ -255,7 +1315,7 @@ func safeCairnlineExportName(value string) string {
 	return out
 }
 
-func removeCairnlineExportFiles(dbPath string) error {
+func removeCairnlineSQLiteFiles(dbPath string) error {
 	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
 		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err

--- a/internal/api/handler_project_cairnline_mirror.go
+++ b/internal/api/handler_project_cairnline_mirror.go
@@ -1,0 +1,703 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) mirrorProjectIdentityToCairnline(ctx context.Context, operation string, project projects.Project) {
+	if err := h.writeProjectIdentityToCairnline(ctx, project); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectDeleteToCairnline(ctx context.Context, operation string, project projects.Project) {
+	if err := h.deleteProjectIdentityFromCairnline(ctx, project); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectSkillsToCairnline(ctx context.Context, operation string, project projects.Project, skills []projectskills.Skill) {
+	if err := h.writeProjectSkillsToCairnline(ctx, project, skills); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectRoleToCairnline(ctx context.Context, operation string, project projects.Project, role projectwork.AgentRoleProfile) {
+	if err := h.writeProjectRoleToCairnline(ctx, project, role); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectRoleByIDToCairnline(ctx context.Context, operation, projectID string, role projectwork.AgentRoleProfile) {
+	project, ok := h.projectForCairnlineMirror(ctx, operation, projectID)
+	if !ok {
+		return
+	}
+	h.mirrorProjectRoleToCairnline(ctx, operation, project, role)
+}
+
+func (h *Handler) mirrorProjectRoleDeleteToCairnline(ctx context.Context, operation string, role projectwork.AgentRoleProfile) {
+	if err := h.deleteProjectRoleFromCairnline(ctx, role); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, role.ProjectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectWorkItemToCairnline(ctx context.Context, operation string, project projects.Project, item projectwork.WorkItem) {
+	if err := h.writeProjectWorkItemToCairnline(ctx, project, item); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectWorkItemByIDToCairnline(ctx context.Context, operation, projectID string, item projectwork.WorkItem) {
+	project, ok := h.projectForCairnlineMirror(ctx, operation, projectID)
+	if !ok {
+		return
+	}
+	h.mirrorProjectWorkItemToCairnline(ctx, operation, project, item)
+}
+
+func (h *Handler) mirrorProjectWorkItemDeleteToCairnline(ctx context.Context, operation, projectID, workItemID string) {
+	if err := h.deleteProjectWorkItemFromCairnline(ctx, projectID, workItemID); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectAssignmentToCairnline(ctx context.Context, operation string, assignment projectwork.Assignment) {
+	if err := h.writeProjectAssignmentToCairnline(ctx, assignment); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, assignment.ProjectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectAssignmentDeleteToCairnline(ctx context.Context, operation, projectID, assignmentID string) {
+	if err := h.deleteProjectAssignmentFromCairnline(ctx, projectID, assignmentID); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectArtifactToCairnline(ctx context.Context, operation string, artifact projectwork.CollaborationArtifact) {
+	if err := h.writeProjectArtifactToCairnline(ctx, artifact); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, artifact.ProjectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectHandoffToCairnline(ctx context.Context, operation string, handoff projectwork.Handoff) {
+	if err := h.writeProjectHandoffToCairnline(ctx, handoff); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, handoff.ProjectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectHandoffDeleteToCairnline(ctx context.Context, operation, projectID, workItemID, handoffID string) {
+	if err := h.deleteProjectHandoffFromCairnline(ctx, projectID, workItemID, handoffID); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectMemoryEntryToCairnline(ctx context.Context, operation string, entry memory.Entry) {
+	if err := h.writeProjectMemoryEntryToCairnline(ctx, entry); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, entry.ProjectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectMemoryEntryDeleteToCairnline(ctx context.Context, operation, projectID, memoryID string) {
+	if err := h.deleteProjectMemoryEntryFromCairnline(ctx, projectID, memoryID); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectMemoryCandidateToCairnline(ctx context.Context, operation string, candidate memory.Candidate) {
+	if err := h.writeProjectMemoryCandidateToCairnline(ctx, candidate); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, candidate.ProjectID, err)
+	}
+}
+
+func (h *Handler) mirrorAgentProfileToCairnline(ctx context.Context, operation string, profile agentprofiles.Profile) {
+	if err := h.writeAgentProfileToCairnline(ctx, profile); err != nil {
+		h.logCairnlineAgentProfileMirrorError(ctx, operation, profile.ID, err)
+	}
+}
+
+func (h *Handler) mirrorAgentProfileDeleteToCairnline(ctx context.Context, operation, profileID string) {
+	if err := h.deleteAgentProfileFromCairnline(ctx, profileID); err != nil {
+		h.logCairnlineAgentProfileMirrorError(ctx, operation, profileID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectAssistantProposalByIDToCairnline(ctx context.Context, operation, proposalID string) {
+	record, ok, err := h.loadProjectAssistantProposalForCairnlineMirror(ctx, proposalID)
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, "", err)
+		return
+	}
+	if !ok {
+		return
+	}
+	h.mirrorProjectAssistantProposalRecordToCairnline(ctx, operation, record)
+}
+
+func (h *Handler) mirrorProjectAssistantProposalRecordToCairnline(ctx context.Context, operation string, record projectassistant.ProposalRecord) {
+	if err := h.writeProjectAssistantProposalRecordToCairnline(ctx, record); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, record.ProjectID, err)
+	}
+}
+
+func (h *Handler) mirrorProjectAssistantApplyResultToCairnline(ctx context.Context, operation string, result projectassistant.ApplyResult) {
+	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+		return
+	}
+	for _, action := range result.Actions {
+		if err := h.writeProjectAssistantActionResultToCairnline(ctx, action); err != nil {
+			h.logCairnlineMirrorError(ctx, operation, projectAssistantActionResultProjectID(action), err)
+		}
+	}
+}
+
+func (h *Handler) projectForCairnlineMirror(ctx context.Context, operation, projectID string) (projects.Project, bool) {
+	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+		return projects.Project{}, false
+	}
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
+		return projects.Project{}, false
+	}
+	if !ok {
+		h.logCairnlineMirrorError(ctx, operation, projectID, errors.Join(cairnline.ErrNotFound, errors.New("project not found for Cairnline mirror")))
+		return projects.Project{}, false
+	}
+	return project, true
+}
+
+func (h *Handler) projectWorkRoleForCairnlineMirror(ctx context.Context, operation, projectID, roleID string) (projectwork.AgentRoleProfile, bool) {
+	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+		return projectwork.AgentRoleProfile{}, false
+	}
+	role, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, projectID, roleID)
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
+		return projectwork.AgentRoleProfile{}, false
+	}
+	return role, ok
+}
+
+func (h *Handler) loadProjectWorkRoleForCairnlineMirror(ctx context.Context, projectID, roleID string) (projectwork.AgentRoleProfile, bool, error) {
+	if h == nil || h.projectWork == nil {
+		return projectwork.AgentRoleProfile{}, false, errors.New("project work store is not configured")
+	}
+	roles, err := h.projectWork.ListRoles(ctx, projectID)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, false, err
+	}
+	roleID = strings.TrimSpace(roleID)
+	for _, role := range roles {
+		if role.ID == roleID {
+			return role, true, nil
+		}
+	}
+	return projectwork.AgentRoleProfile{}, false, nil
+}
+
+func (h *Handler) loadProjectWorkAssignmentForCairnlineMirror(ctx context.Context, projectID, assignmentID string) (projectwork.Assignment, bool, error) {
+	assignmentID = strings.TrimSpace(assignmentID)
+	if assignmentID == "" {
+		return projectwork.Assignment{}, false, nil
+	}
+	if h == nil || h.projectWork == nil {
+		return projectwork.Assignment{}, false, errors.New("project work store is not configured")
+	}
+	assignments, err := h.projectWork.ListAssignments(ctx, projectwork.AssignmentFilter{ProjectID: projectID})
+	if err != nil {
+		return projectwork.Assignment{}, false, err
+	}
+	for _, assignment := range assignments {
+		if assignment.ID == assignmentID {
+			return assignment, true, nil
+		}
+	}
+	return projectwork.Assignment{}, false, nil
+}
+
+func (h *Handler) loadProjectWorkItemForCairnlineMirror(ctx context.Context, projectID, workItemID string) (projectwork.WorkItem, bool, error) {
+	workItemID = strings.TrimSpace(workItemID)
+	if workItemID == "" {
+		return projectwork.WorkItem{}, false, nil
+	}
+	if h == nil || h.projectWork == nil {
+		return projectwork.WorkItem{}, false, errors.New("project work store is not configured")
+	}
+	return h.projectWork.GetWorkItem(ctx, projectID, workItemID)
+}
+
+func (h *Handler) loadProjectWorkHandoffForCairnlineMirror(ctx context.Context, projectID, handoffID string) (projectwork.Handoff, bool, error) {
+	handoffID = strings.TrimSpace(handoffID)
+	if handoffID == "" {
+		return projectwork.Handoff{}, false, nil
+	}
+	if h == nil || h.projectWork == nil {
+		return projectwork.Handoff{}, false, errors.New("project work store is not configured")
+	}
+	handoffs, err := h.projectWork.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID})
+	if err != nil {
+		return projectwork.Handoff{}, false, err
+	}
+	for _, handoff := range handoffs {
+		if handoff.ID == handoffID {
+			return handoff, true, nil
+		}
+	}
+	return projectwork.Handoff{}, false, nil
+}
+
+func (h *Handler) loadProjectMemoryCandidateForCairnlineMirror(ctx context.Context, projectID, candidateID string) (memory.Candidate, bool, error) {
+	candidateID = strings.TrimSpace(candidateID)
+	if candidateID == "" {
+		return memory.Candidate{}, false, nil
+	}
+	if h == nil || h.memoryCandidates == nil {
+		return memory.Candidate{}, false, errors.New("project memory candidate store is not configured")
+	}
+	return h.memoryCandidates.GetCandidate(ctx, projectID, candidateID)
+}
+
+func (h *Handler) loadProjectAssistantProposalForCairnlineMirror(ctx context.Context, proposalID string) (projectassistant.ProposalRecord, bool, error) {
+	proposalID = strings.TrimSpace(proposalID)
+	if proposalID == "" {
+		return projectassistant.ProposalRecord{}, false, nil
+	}
+	if h == nil || h.projectAssistantProposals == nil {
+		return projectassistant.ProposalRecord{}, false, errors.New("project assistant proposal store is not configured")
+	}
+	return h.projectAssistantProposals.GetProposal(ctx, proposalID)
+}
+
+func (h *Handler) writeProjectAssistantActionResultToCairnline(ctx context.Context, result projectassistant.ActionResult) error {
+	projectID := projectAssistantActionResultProjectID(result)
+	switch strings.TrimSpace(result.Kind) {
+	case projectassistant.ActionCreateProject,
+		projectassistant.ActionUpdateProject,
+		projectassistant.ActionAttachProjectRoot,
+		projectassistant.ActionRemoveProjectRoot,
+		projectassistant.ActionSetProjectDefaults:
+		project, ok := h.projectForCairnlineMirror(ctx, "project_assistant_apply_result", projectID)
+		if !ok {
+			return nil
+		}
+		return h.writeProjectIdentityToCairnline(ctx, project)
+	case projectassistant.ActionCreateRole:
+		project, ok := h.projectForCairnlineMirror(ctx, "project_assistant_apply_result", projectID)
+		if !ok {
+			return nil
+		}
+		role, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, projectID, projectAssistantActionResultValue(result, "role_id"))
+		if err != nil || !ok {
+			return err
+		}
+		return h.writeProjectRoleToCairnline(ctx, project, role)
+	case projectassistant.ActionCreateWorkItem, projectassistant.ActionUpdateWorkItem:
+		item, ok, err := h.loadProjectWorkItemForCairnlineMirror(ctx, projectID, projectAssistantActionResultValue(result, "work_item_id"))
+		if err != nil || !ok {
+			return err
+		}
+		project, ok := h.projectForCairnlineMirror(ctx, "project_assistant_apply_result", projectID)
+		if !ok {
+			return nil
+		}
+		return h.writeProjectWorkItemToCairnline(ctx, project, item)
+	case projectassistant.ActionCreateAssignment:
+		assignment, ok, err := h.loadProjectWorkAssignmentForCairnlineMirror(ctx, projectID, projectAssistantActionResultValue(result, "assignment_id"))
+		if err != nil || !ok {
+			return err
+		}
+		return h.writeProjectAssignmentToCairnline(ctx, assignment)
+	case projectassistant.ActionCreateHandoff, projectassistant.ActionUpdateHandoff:
+		handoff, ok, err := h.loadProjectWorkHandoffForCairnlineMirror(ctx, projectID, projectAssistantActionResultValue(result, "handoff_id"))
+		if err != nil || !ok {
+			return err
+		}
+		return h.writeProjectHandoffToCairnline(ctx, handoff)
+	case projectassistant.ActionCreateMemoryCandidate:
+		candidate, ok, err := h.loadProjectMemoryCandidateForCairnlineMirror(ctx, projectID, projectAssistantActionResultValue(result, "candidate_id"))
+		if err != nil || !ok {
+			return err
+		}
+		return h.writeProjectMemoryCandidateToCairnline(ctx, candidate)
+	default:
+		return nil
+	}
+}
+
+func projectAssistantActionResultProjectID(result projectassistant.ActionResult) string {
+	return projectAssistantActionResultValue(result, "project_id")
+}
+
+func projectAssistantActionResultValue(result projectassistant.ActionResult, key string) string {
+	if result.Data != nil {
+		if value := strings.TrimSpace(result.Data[key]); value != "" {
+			return value
+		}
+	}
+	return strings.TrimSpace(result.ID)
+}
+
+func (h *Handler) writeProjectIdentityToCairnline(ctx context.Context, project projects.Project) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		_, err := cairnlinebridge.UpsertProject(ctx, service, project)
+		return err
+	})
+}
+
+func (h *Handler) deleteProjectIdentityFromCairnline(ctx context.Context, project projects.Project) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := cairnlinebridge.DeleteProject(ctx, service, project); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
+}
+
+func (h *Handler) writeProjectRoleToCairnline(ctx context.Context, project projects.Project, role projectwork.AgentRoleProfile) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProject(ctx, service, project); err != nil {
+			return err
+		}
+		return h.writeProjectRoleRecordToCairnline(ctx, service, role)
+	})
+}
+
+func (h *Handler) writeProjectRoleRecordToCairnline(ctx context.Context, service *cairnline.Service, role projectwork.AgentRoleProfile) error {
+	if _, err := h.writeRoleAgentProfileToCairnline(ctx, service, role); err != nil {
+		return err
+	}
+	_, err := cairnlinebridge.UpsertRole(ctx, service, role)
+	return err
+}
+
+func (h *Handler) writeRoleAgentProfileToCairnline(ctx context.Context, service *cairnline.Service, role projectwork.AgentRoleProfile) (agentprofiles.Profile, error) {
+	profileID := strings.TrimSpace(role.DefaultAgentProfile)
+	if profileID == "" || h == nil || h.agentProfiles == nil {
+		return agentprofiles.Profile{}, nil
+	}
+	profile, ok, err := h.agentProfiles.Get(ctx, profileID)
+	if err != nil {
+		return agentprofiles.Profile{}, err
+	}
+	if !ok {
+		return agentprofiles.Profile{}, nil
+	}
+	_, err = cairnlinebridge.UpsertAgentProfile(ctx, service, profile)
+	return profile, err
+}
+
+func (h *Handler) deleteProjectRoleFromCairnline(ctx context.Context, role projectwork.AgentRoleProfile) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := cairnlinebridge.DeleteRole(ctx, service, role); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
+}
+
+func (h *Handler) writeProjectWorkItemToCairnline(ctx context.Context, project projects.Project, item projectwork.WorkItem) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProject(ctx, service, project); err != nil {
+			return err
+		}
+		_, err := cairnlinebridge.UpsertWorkItem(ctx, service, item)
+		return err
+	})
+}
+
+func (h *Handler) deleteProjectWorkItemFromCairnline(ctx context.Context, projectID, workItemID string) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := cairnlinebridge.DeleteWorkItem(ctx, service, projectID, workItemID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
+}
+
+func (h *Handler) writeProjectAssignmentToCairnline(ctx context.Context, assignment projectwork.Assignment) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		return h.writeProjectAssignmentRecordToCairnline(ctx, service, assignment)
+	})
+}
+
+func (h *Handler) writeProjectAssignmentRecordToCairnline(ctx context.Context, service *cairnline.Service, assignment projectwork.Assignment) error {
+	if err := h.writeProjectWorkItemDependencyToCairnline(ctx, service, "project_assignment_mutation", assignment.ProjectID, assignment.WorkItemID); err != nil {
+		return err
+	}
+	role, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, assignment.ProjectID, assignment.RoleID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.Join(cairnline.ErrNotFound, errors.New("assignment role not found for Cairnline mirror"))
+	}
+	profile, err := h.writeRoleAgentProfileToCairnline(ctx, service, role)
+	if err != nil {
+		return err
+	}
+	if _, err := cairnlinebridge.UpsertRole(ctx, service, role); err != nil {
+		return err
+	}
+	_, err = cairnlinebridge.UpsertAssignment(ctx, service, assignment, role, profile)
+	return err
+}
+
+func (h *Handler) writeProjectWorkItemDependencyToCairnline(ctx context.Context, service *cairnline.Service, operation, projectID, workItemID string) error {
+	if strings.TrimSpace(workItemID) == "" {
+		return nil
+	}
+	project, ok := h.projectForCairnlineMirror(ctx, operation, projectID)
+	if !ok {
+		return nil
+	}
+	if _, err := cairnlinebridge.UpsertProject(ctx, service, project); err != nil {
+		return err
+	}
+	if h == nil || h.projectWork == nil {
+		return errors.New("project work store is not configured")
+	}
+	workItem, ok, err := h.projectWork.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.Join(cairnline.ErrNotFound, errors.New("work item not found for Cairnline mirror"))
+	}
+	_, err = cairnlinebridge.UpsertWorkItem(ctx, service, workItem)
+	return err
+}
+
+func (h *Handler) writeProjectRoleDependencyToCairnline(ctx context.Context, service *cairnline.Service, projectID, roleID string) error {
+	roleID = strings.TrimSpace(roleID)
+	if roleID == "" {
+		return nil
+	}
+	role, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, projectID, roleID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.Join(cairnline.ErrNotFound, errors.New("role not found for Cairnline mirror"))
+	}
+	return h.writeProjectRoleRecordToCairnline(ctx, service, role)
+}
+
+func (h *Handler) writeProjectAssignmentDependencyToCairnline(ctx context.Context, service *cairnline.Service, projectID, assignmentID string) error {
+	assignment, ok, err := h.loadProjectWorkAssignmentForCairnlineMirror(ctx, projectID, assignmentID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		if strings.TrimSpace(assignmentID) == "" {
+			return nil
+		}
+		return errors.Join(cairnline.ErrNotFound, errors.New("assignment not found for Cairnline mirror"))
+	}
+	return h.writeProjectAssignmentRecordToCairnline(ctx, service, assignment)
+}
+
+func (h *Handler) deleteProjectAssignmentFromCairnline(ctx context.Context, projectID, assignmentID string) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := cairnlinebridge.DeleteAssignment(ctx, service, projectID, assignmentID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
+}
+
+func (h *Handler) writeProjectArtifactToCairnline(ctx context.Context, artifact projectwork.CollaborationArtifact) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.writeProjectWorkItemDependencyToCairnline(ctx, service, "project_artifact_mutation", artifact.ProjectID, artifact.WorkItemID); err != nil {
+			return err
+		}
+		if err := h.writeProjectRoleDependencyToCairnline(ctx, service, artifact.ProjectID, artifact.AuthorRoleID); err != nil {
+			return err
+		}
+		if err := h.writeProjectAssignmentDependencyToCairnline(ctx, service, artifact.ProjectID, artifact.AssignmentID); err != nil {
+			return err
+		}
+		if err := h.writeProjectAssignmentDependencyToCairnline(ctx, service, artifact.ProjectID, artifact.ReviewedAssignmentID); err != nil {
+			return err
+		}
+		switch strings.TrimSpace(artifact.Kind) {
+		case projectwork.ArtifactKindEvidenceLink:
+			_, err := cairnlinebridge.RecordEvidence(ctx, service, artifact)
+			return err
+		case projectwork.ArtifactKindReview:
+			_, err := cairnlinebridge.RecordReview(ctx, service, artifact)
+			return err
+		default:
+			_, err := cairnlinebridge.RecordArtifact(ctx, service, artifact)
+			return err
+		}
+	})
+}
+
+func (h *Handler) writeProjectHandoffToCairnline(ctx context.Context, handoff projectwork.Handoff) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.writeProjectWorkItemDependencyToCairnline(ctx, service, "project_handoff_mutation", handoff.ProjectID, handoff.WorkItemID); err != nil {
+			return err
+		}
+		if err := h.writeProjectWorkItemDependencyToCairnline(ctx, service, "project_handoff_mutation", handoff.ProjectID, handoff.TargetWorkItemID); err != nil {
+			return err
+		}
+		if err := h.writeProjectRoleDependencyToCairnline(ctx, service, handoff.ProjectID, handoff.CreatedByRoleID); err != nil {
+			return err
+		}
+		if err := h.writeProjectRoleDependencyToCairnline(ctx, service, handoff.ProjectID, handoff.TargetRoleID); err != nil {
+			return err
+		}
+		if err := h.writeProjectAssignmentDependencyToCairnline(ctx, service, handoff.ProjectID, handoff.SourceAssignmentID); err != nil {
+			return err
+		}
+		if err := h.writeProjectAssignmentDependencyToCairnline(ctx, service, handoff.ProjectID, handoff.TargetAssignmentID); err != nil {
+			return err
+		}
+		_, err := cairnlinebridge.UpsertHandoff(ctx, service, handoff)
+		return err
+	})
+}
+
+func (h *Handler) deleteProjectHandoffFromCairnline(ctx context.Context, projectID, workItemID, handoffID string) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := cairnlinebridge.DeleteHandoff(ctx, service, projectID, workItemID, handoffID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
+}
+
+func (h *Handler) writeProjectMemoryEntryToCairnline(ctx context.Context, entry memory.Entry) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		project, ok := h.projectForCairnlineMirror(ctx, "project_memory_mutation", entry.ProjectID)
+		if !ok {
+			return nil
+		}
+		if _, err := cairnlinebridge.UpsertProject(ctx, service, project); err != nil {
+			return err
+		}
+		_, err := cairnlinebridge.UpsertMemoryEntry(ctx, service, entry)
+		return err
+	})
+}
+
+func (h *Handler) deleteProjectMemoryEntryFromCairnline(ctx context.Context, projectID, memoryID string) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := cairnlinebridge.DeleteMemoryEntry(ctx, service, projectID, memoryID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
+}
+
+func (h *Handler) writeProjectMemoryCandidateToCairnline(ctx context.Context, candidate memory.Candidate) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		project, ok := h.projectForCairnlineMirror(ctx, "project_memory_candidate_mutation", candidate.ProjectID)
+		if !ok {
+			return nil
+		}
+		if _, err := cairnlinebridge.UpsertProject(ctx, service, project); err != nil {
+			return err
+		}
+		_, err := cairnlinebridge.UpsertMemoryCandidate(ctx, service, candidate)
+		return err
+	})
+}
+
+func (h *Handler) writeAgentProfileToCairnline(ctx context.Context, profile agentprofiles.Profile) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		_, err := cairnlinebridge.UpsertAgentProfile(ctx, service, profile)
+		return err
+	})
+}
+
+func (h *Handler) deleteAgentProfileFromCairnline(ctx context.Context, profileID string) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := cairnlinebridge.DeleteAgentProfile(ctx, service, profileID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
+}
+
+func (h *Handler) writeProjectAssistantProposalRecordToCairnline(ctx context.Context, record projectassistant.ProposalRecord) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		projectID := strings.TrimSpace(record.ProjectID)
+		if projectID != "" && h != nil && h.projects != nil {
+			project, ok, err := h.projects.Get(ctx, projectID)
+			if err != nil {
+				return err
+			}
+			if ok {
+				if _, err := cairnlinebridge.UpsertProject(ctx, service, project); err != nil {
+					return err
+				}
+			}
+		}
+		_, _, err := cairnlinebridge.UpsertAssistantProposalRecord(ctx, service, record)
+		return err
+	})
+}
+
+func (h *Handler) writeProjectSkillsToCairnline(ctx context.Context, project projects.Project, skills []projectskills.Skill) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProject(ctx, service, project); err != nil {
+			return err
+		}
+		_, err := cairnlinebridge.UpsertProjectSkills(ctx, service, skills)
+		return err
+	})
+}
+
+func (h *Handler) withCairnlineEmbeddedMirrorService(ctx context.Context, fn func(*cairnline.Service) error) error {
+	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+		return nil
+	}
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		return err
+	}
+	service, store, err := cairnline.NewSQLiteService(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	return fn(service)
+}
+
+func (h *Handler) logCairnlineMirrorError(ctx context.Context, operation, projectID string, err error) {
+	logger := slog.Default()
+	if h != nil && h.logger != nil {
+		logger = h.logger
+	}
+	logger.WarnContext(ctx, "cairnline project mirror write failed",
+		"operation", operation,
+		"project_id", projectID,
+		"err", err)
+}
+
+func (h *Handler) logCairnlineAgentProfileMirrorError(ctx context.Context, operation, profileID string, err error) {
+	logger := slog.Default()
+	if h != nil && h.logger != nil {
+		logger = h.logger
+	}
+	logger.WarnContext(ctx, "cairnline agent profile mirror write failed",
+		"operation", operation,
+		"profile_id", profileID,
+		"err", err)
+}

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -1,15 +1,18 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -133,13 +136,64 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 		"suggested_source_kind": "handoff",
 		"suggested_source_id":   handoff.Data.ID,
 	}))
+	proposalResult := projectassistant.ApplyResult{
+		ProposalID:           "pa_export",
+		Status:               projectassistant.ApplyStatusApplied,
+		Applied:              true,
+		TotalActionCount:     1,
+		CommittedActionCount: 1,
+		Actions: []projectassistant.ActionResult{{
+			Kind: projectassistant.ActionCreateWorkItem,
+			ID:   "work_export_followup",
+			Data: map[string]string{"project_id": projectID, "work_item_id": "work_export_followup"},
+		}},
+	}
+	if _, err := handler.projectAssistantProposals.UpsertProposal(t.Context(), projectassistant.ProposalRecord{
+		ID:        "pa_export",
+		ProjectID: projectID,
+		Source:    projectassistant.ProposalSourceDraft,
+		SourceID:  "deterministic",
+		Status:    projectassistant.ApplyStatusApplied,
+		Proposal: projectassistant.Proposal{
+			ID:      "pa_export",
+			Title:   "Capture export follow-up",
+			Summary: "Portable proposal ledger entry.",
+			Warnings: []string{
+				"Review exported assistant proposal before applying.",
+			},
+			Actions: []projectassistant.Action{{
+				Kind:   projectassistant.ActionCreateWorkItem,
+				Target: map[string]string{"project_id": projectID},
+				Patch:  mustRawProjectCairnlinePatch(t, map[string]string{"id": "work_export_followup", "project_id": projectID, "title": "Export follow-up"}),
+			}},
+			RequiresConfirmation: true,
+		},
+		LatestResult: &proposalResult,
+	}); err != nil {
+		t.Fatalf("Upsert assistant proposal: %v", err)
+	}
+	if _, err := handler.projectAssistantProposals.RecordApplyAttempt(t.Context(), projectassistant.ApplyAttempt{
+		ID:         "paatt_export",
+		ProposalID: "pa_export",
+		Status:     projectassistant.ApplyStatusApplied,
+		Confirmed:  true,
+		Result:     proposalResult,
+	}); err != nil {
+		t.Fatalf("Record assistant proposal attempt: %v", err)
+	}
 
 	readModel := mustRequestJSON[ProjectCairnlineReadModelResponse](client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/cairnline/read-model", "")
 	if readModel.Object != "project_cairnline_read_model" || readModel.Data.ProjectID != projectID {
 		t.Fatalf("read model envelope = %+v, want project_cairnline_read_model for project", readModel)
 	}
-	if readModel.Data.WorkItemCount != 1 || readModel.Data.AssignmentCount != 1 || readModel.Data.ArtifactCount != 2 || readModel.Data.HandoffCount != 1 || readModel.Data.MemoryEntryCount != 1 || readModel.Data.MemoryCandidateCount != 1 {
+	if readModel.Data.RootCount != 1 || readModel.Data.ContextSourceCount != 0 || readModel.Data.WorkItemCount != 1 || readModel.Data.AssignmentCount != 1 || readModel.Data.ArtifactCount != 2 || readModel.Data.HandoffCount != 1 || readModel.Data.MemoryEntryCount != 1 || readModel.Data.MemoryCandidateCount != 1 || readModel.Data.AssistantProposalCount != 1 || readModel.Data.LaunchPacketCount != 1 {
 		t.Fatalf("read model counts = %+v, want bridged project counts", readModel.Data)
+	}
+	if readModel.Data.AgentProfileCount == 0 || readModel.Data.ExecutionProfileCount == 0 {
+		t.Fatalf("read model profile counts = agent %d execution %d, want seeded built-in/project profiles", readModel.Data.AgentProfileCount, readModel.Data.ExecutionProfileCount)
+	}
+	if readModel.Data.LaunchPacketWarningCount != 0 || len(readModel.Data.LaunchPacketErrors) != 0 {
+		t.Fatalf("launch packet summary = warnings %d errors %+v, want clean portable packet coverage", readModel.Data.LaunchPacketWarningCount, readModel.Data.LaunchPacketErrors)
 	}
 	if readModel.Data.Operations.Status != cairnline.ProjectOperationsStatusAttention || readModel.Data.Operations.Counts.ActiveAssignments != 0 || readModel.Data.Operations.Counts.BlockedAssignments != 1 || readModel.Data.Operations.Counts.PendingMemoryCandidates != 1 || readModel.Data.Operations.Counts.OpenHandoffs != 1 {
 		t.Fatalf("read model operations = %+v, want blocked queued assignment, pending memory, and handoff attention", readModel.Data.Operations)
@@ -163,8 +217,17 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if parity.Data.Hecate.Activity.Active != 0 || parity.Data.Cairnline.Activity.Active != 0 || parity.Data.Hecate.Activity.Blocked != 1 || parity.Data.Cairnline.Activity.Blocked != 1 {
 		t.Fatalf("parity activity buckets = hecate %+v cairnline %+v, want matching blocked queued assignment counts", parity.Data.Hecate.Activity, parity.Data.Cairnline.Activity)
 	}
+	if parity.Data.Hecate.Graph.Roots != 1 || parity.Data.Cairnline.Graph.Roots != 1 || parity.Data.Hecate.Graph.ExecutionProfiles != readModel.Data.ExecutionProfileCount || parity.Data.Cairnline.Graph.ExecutionProfiles != readModel.Data.ExecutionProfileCount || parity.Data.Hecate.Graph.Artifacts != 2 || parity.Data.Cairnline.Graph.Artifacts != 2 || parity.Data.Hecate.Graph.MemoryEntries != 1 || parity.Data.Cairnline.Graph.MemoryEntries != 1 {
+		t.Fatalf("parity graph counts = hecate %+v cairnline %+v, want matching portable graph counts", parity.Data.Hecate.Graph, parity.Data.Cairnline.Graph)
+	}
 	if parity.Data.Hecate.Operations.PendingMemoryCandidates != 1 || parity.Data.Cairnline.Operations.PendingMemoryCandidates != 1 || parity.Data.Hecate.Operations.OpenHandoffs != 1 || parity.Data.Cairnline.Operations.OpenHandoffs != 1 {
 		t.Fatalf("parity operations counts = hecate %+v cairnline %+v, want matching memory and handoff counts", parity.Data.Hecate.Operations, parity.Data.Cairnline.Operations)
+	}
+	if parity.Data.Hecate.Assistant.Proposals != 1 || parity.Data.Cairnline.Assistant.Proposals != 1 {
+		t.Fatalf("parity assistant counts = hecate %+v cairnline %+v, want matching assistant proposal ledger counts", parity.Data.Hecate.Assistant, parity.Data.Cairnline.Assistant)
+	}
+	if parity.Data.Hecate.LaunchPackets.Assignments != 1 || parity.Data.Cairnline.LaunchPackets.Assignments != 1 || parity.Data.Hecate.LaunchPackets.Warnings != 0 || parity.Data.Cairnline.LaunchPackets.Warnings != 0 || parity.Data.Hecate.LaunchPackets.Errors != 0 || parity.Data.Cairnline.LaunchPackets.Errors != 0 {
+		t.Fatalf("parity launch packet counts = hecate %+v cairnline %+v, want complete launch packet coverage", parity.Data.Hecate.LaunchPackets, parity.Data.Cairnline.LaunchPackets)
 	}
 	if len(parity.Data.Differences) != 0 {
 		t.Fatalf("parity differences = %+v, want none for aligned queued assignment semantics", parity.Data.Differences)
@@ -178,7 +241,7 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if first.Data.DatabasePath != second.Data.DatabasePath {
 		t.Fatalf("export paths = %q/%q, want refresh to same path", first.Data.DatabasePath, second.Data.DatabasePath)
 	}
-	if second.Data.ProjectID != projectID || second.Data.WorkItemCount != 1 || second.Data.AssignmentCount != 1 || second.Data.ArtifactCount != 2 || second.Data.HandoffCount != 1 || second.Data.MemoryEntryCount != 1 || second.Data.MemoryCandidateCount != 1 {
+	if second.Data.ProjectID != projectID || second.Data.RootCount != 1 || second.Data.ContextSourceCount != 0 || second.Data.AgentProfileCount != readModel.Data.AgentProfileCount || second.Data.ExecutionProfileCount != readModel.Data.ExecutionProfileCount || second.Data.WorkItemCount != 1 || second.Data.AssignmentCount != 1 || second.Data.ArtifactCount != 2 || second.Data.HandoffCount != 1 || second.Data.MemoryEntryCount != 1 || second.Data.MemoryCandidateCount != 1 || second.Data.AssistantProposalCount != 1 {
 		t.Fatalf("export response = %+v, want project counts", second.Data)
 	}
 	if !filepath.IsAbs(second.Data.DatabasePath) {
@@ -200,8 +263,25 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if packet.Project.ID != projectID || packet.Project.DefaultRootID != project.Data.DefaultRootID || packet.Assignment.RootID != project.Data.Roots[0].ID {
 		t.Fatalf("packet project/assignment = %+v/%+v, want exported default root and root-scoped assignment", packet.Project, packet.Assignment)
 	}
+	executionProfiles, err := service.ListExecutionProfiles(t.Context())
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles from exported DB: %v", err)
+	}
+	if len(executionProfiles) != second.Data.ExecutionProfileCount {
+		t.Fatalf("execution profiles = %d, want exported count %d", len(executionProfiles), second.Data.ExecutionProfileCount)
+	}
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("packet counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
+	}
+	proposals, err := service.ListAssistantProposals(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("ListAssistantProposals from exported DB: %v", err)
+	}
+	if len(proposals) != 1 || proposals[0].ID != "pa_export" || proposals[0].Status != cairnline.AssistantProposalStatusApplied || proposals[0].LatestResult == nil || len(proposals[0].ApplyAttempts) != 1 {
+		t.Fatalf("assistant proposals = %+v, want exported proposal ledger", proposals)
+	}
+	if len(proposals[0].Proposal.Warnings) != 1 || proposals[0].Proposal.Warnings[0] != "Review exported assistant proposal before applying." {
+		t.Fatalf("assistant proposal warnings = %+v, want exported warnings", proposals[0].Proposal.Warnings)
 	}
 	brief, err := service.ProjectOperationsBrief(t.Context(), projectID)
 	if err != nil {
@@ -217,6 +297,316 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if activity.Counts.Assignments != 1 || activity.Counts.Active != 0 || activity.Counts.Blocked != 1 || activity.Counts.Queued != 1 || len(activity.Buckets.Blocked) != 1 || activity.Buckets.Blocked[0].AssignmentID != assignment.Data.ID {
 		t.Fatalf("activity = %+v, want exported blocked queued assignment activity", activity)
 	}
+}
+
+func TestProjectCairnlineSyncAPI_WritesDurableAllProjectsSQLiteDB(t *testing.T) {
+	dataDir := t.TempDir()
+	handler := NewHandler(config.Config{Server: config.ServerConfig{DataDir: dataDir}}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	root := t.TempDir()
+	firstProject := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name":           "Cairnline Sync One",
+		"workspace_path": root,
+		"workspace_kind": "git",
+	}))
+	secondProject := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Cairnline Sync Two",
+	}))
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                  "sync_profile",
+		Name:                "Sync profile",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		ProviderHint:        "openai",
+		ModelHint:           "gpt-5",
+	}); err != nil {
+		t.Fatalf("Create profile: %v", err)
+	}
+	role := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+firstProject.Data.ID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                    "sync_developer",
+		"name":                  "Sync Developer",
+		"default_agent_profile": "sync_profile",
+		"default_driver_kind":   projectwork.AssignmentDriverHecateTask,
+	}))
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+firstProject.Data.ID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_sync",
+		"title":         "Sync Projects to Cairnline",
+		"brief":         "Prove Hecate can write a durable all-project Cairnline DB.",
+		"owner_role_id": role.Data.ID,
+		"root_id":       firstProject.Data.Roots[0].ID,
+	}))
+	assignment := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+firstProject.Data.ID+"/work-items/"+work.Data.ID+"/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_sync",
+		"role_id":     role.Data.ID,
+		"driver_kind": projectwork.AssignmentDriverHecateTask,
+		"root_id":     firstProject.Data.Roots[0].ID,
+	}))
+
+	first := mustRequestJSON[ProjectCairnlineSyncResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/sync", "")
+	second := mustRequestJSON[ProjectCairnlineSyncResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/sync", "")
+	if first.Object != "project_cairnline_sync" || second.Object != "project_cairnline_sync" {
+		t.Fatalf("sync envelopes = %+v / %+v, want project_cairnline_sync", first, second)
+	}
+	if first.Data.DatabasePath != second.Data.DatabasePath {
+		t.Fatalf("sync paths = %q/%q, want refresh to same durable DB", first.Data.DatabasePath, second.Data.DatabasePath)
+	}
+	if second.Data.Authoritative {
+		t.Fatalf("sync response authoritative = true, want replacement rehearsal only")
+	}
+	if !second.Data.Match || len(second.Data.Differences) != 0 || len(second.Data.IDDifferences) != 0 || len(second.Data.ContentDifferences) != 0 {
+		t.Fatalf("sync parity = match %v differences %+v id_differences %+v content_differences %+v, want exact count, id, and content match", second.Data.Match, second.Data.Differences, second.Data.IDDifferences, second.Data.ContentDifferences)
+	}
+	if second.Data.Hecate.Projects != 2 || second.Data.Cairnline.Projects != 2 || second.Data.Hecate.Roots != 1 || second.Data.Cairnline.Roots != 1 || second.Data.Hecate.WorkItems != 1 || second.Data.Cairnline.WorkItems != 1 || second.Data.Hecate.Assignments != 1 || second.Data.Cairnline.Assignments != 1 {
+		t.Fatalf("sync counts = hecate %+v cairnline %+v, want two projects and one rooted assignment", second.Data.Hecate, second.Data.Cairnline)
+	}
+	if second.Data.Hecate.LaunchPackets != 1 || second.Data.Cairnline.LaunchPackets != 1 || second.Data.Hecate.LaunchWarnings != 0 || second.Data.Cairnline.LaunchWarnings != 0 || second.Data.Hecate.LaunchErrors != 0 || second.Data.Cairnline.LaunchErrors != 0 {
+		t.Fatalf("sync launch packet counts = hecate %+v cairnline %+v, want one clean packet", second.Data.Hecate, second.Data.Cairnline)
+	}
+	if second.Data.Hecate.AgentProfiles == 0 || second.Data.Cairnline.AgentProfiles == 0 || second.Data.Hecate.ExecutionProfiles == 0 || second.Data.Cairnline.ExecutionProfiles == 0 || second.Data.Hecate.Roles == 0 || second.Data.Cairnline.Roles == 0 {
+		t.Fatalf("sync profile/role counts = hecate %+v cairnline %+v, want seeded portable defaults", second.Data.Hecate, second.Data.Cairnline)
+	}
+	if !filepath.IsAbs(second.Data.DatabasePath) {
+		t.Fatalf("sync database path = %q, want absolute path", second.Data.DatabasePath)
+	}
+	if filepath.Dir(second.Data.DatabasePath) != filepath.Join(dataDir, "cairnline", "embedded") {
+		t.Fatalf("sync database path = %q, want embedded DB under data dir %q", second.Data.DatabasePath, dataDir)
+	}
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), second.Data.DatabasePath)
+	if err != nil {
+		t.Fatalf("Open synced Cairnline DB: %v", err)
+	}
+	defer store.Close()
+	projects, err := service.ListProjects(t.Context())
+	if err != nil {
+		t.Fatalf("ListProjects from synced DB: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("synced projects = %+v, want both Hecate projects", projects)
+	}
+	if _, err := service.GetProject(t.Context(), secondProject.Data.ID); err != nil {
+		t.Fatalf("GetProject(%s) from synced DB: %v", secondProject.Data.ID, err)
+	}
+	packet, err := service.AssignmentLaunchPacket(t.Context(), firstProject.Data.ID, assignment.Data.ID)
+	if err != nil {
+		t.Fatalf("AssignmentLaunchPacket from synced DB: %v", err)
+	}
+	if packet.Project.ID != firstProject.Data.ID || packet.Assignment.ID != assignment.Data.ID || packet.Assignment.RootID != firstProject.Data.Roots[0].ID {
+		t.Fatalf("packet = %+v, want synced rooted assignment launch packet", packet)
+	}
+}
+
+func TestProjectCairnlineSyncDifferences(t *testing.T) {
+	differences := projectCairnlineSyncDifferences(ProjectCairnlineSyncCounts{
+		Projects:          2,
+		ExecutionProfiles: 4,
+		Assignments:       1,
+		LaunchPackets:     1,
+	}, ProjectCairnlineSyncCounts{
+		Projects:          1,
+		ExecutionProfiles: 3,
+		Assignments:       1,
+		LaunchPackets:     0,
+		LaunchWarnings:    1,
+		LaunchErrors:      1,
+	})
+	if len(differences) != 5 {
+		t.Fatalf("sync differences = %+v, want project, execution profile, and launch packet mismatches only", differences)
+	}
+	if !hasProjectCairnlineParityDifference(differences, "projects", 2, 1) {
+		t.Fatalf("sync differences = %+v, want projects 2/1", differences)
+	}
+	if !hasProjectCairnlineParityDifference(differences, "execution_profiles", 4, 3) {
+		t.Fatalf("sync differences = %+v, want execution_profiles 4/3", differences)
+	}
+	if !hasProjectCairnlineParityDifference(differences, "launch_packets", 1, 0) {
+		t.Fatalf("sync differences = %+v, want launch_packets 1/0", differences)
+	}
+	if !hasProjectCairnlineParityDifference(differences, "launch_warnings", 0, 1) {
+		t.Fatalf("sync differences = %+v, want launch_warnings 0/1", differences)
+	}
+	if !hasProjectCairnlineParityDifference(differences, "launch_errors", 0, 1) {
+		t.Fatalf("sync differences = %+v, want launch_errors 0/1", differences)
+	}
+}
+
+func TestProjectCairnlineSyncIDDifferences(t *testing.T) {
+	differences := projectCairnlineSyncIDDifferences(ProjectCairnlineSyncIDSets{
+		Projects:      []string{"proj_a", "proj_b"},
+		WorkItems:     []string{"proj_a/work_a"},
+		LaunchPackets: []string{"proj_a/asgn_a"},
+	}, ProjectCairnlineSyncIDSets{
+		Projects:      []string{"proj_a", "proj_c"},
+		WorkItems:     []string{"proj_a/work_a"},
+		LaunchPackets: nil,
+	})
+	if len(differences) != 2 {
+		t.Fatalf("id differences = %+v, want project and launch packet mismatches only", differences)
+	}
+	if !hasProjectCairnlineIDDifference(differences, "projects", []string{"proj_a", "proj_b"}, []string{"proj_a", "proj_c"}) {
+		t.Fatalf("id differences = %+v, want projects mismatch", differences)
+	}
+	if !hasProjectCairnlineIDDifference(differences, "launch_packets", []string{"proj_a/asgn_a"}, nil) {
+		t.Fatalf("id differences = %+v, want launch packet mismatch", differences)
+	}
+}
+
+func TestProjectCairnlineSyncContentDifferences(t *testing.T) {
+	differences := projectCairnlineSyncContentDifferences(projectCairnlineContentDigests{
+		"projects": map[string]string{
+			"proj_a": "digest-a",
+			"proj_b": "digest-b",
+		},
+		"work_items": map[string]string{
+			"proj_a/work_a": "same",
+		},
+	}, projectCairnlineContentDigests{
+		"projects": map[string]string{
+			"proj_a": "digest-c",
+			"proj_c": "digest-d",
+		},
+		"work_items": map[string]string{
+			"proj_a/work_a": "same",
+		},
+	})
+	if len(differences) != 1 {
+		t.Fatalf("content differences = %+v, want only same-id project content mismatch", differences)
+	}
+	if !hasProjectCairnlineContentDifference(differences, "projects", "proj_a", "digest-a", "digest-c") {
+		t.Fatalf("content differences = %+v, want projects/proj_a digest mismatch", differences)
+	}
+}
+
+func TestProjectCairnlineContentDigestIgnoresVolatileTimestamps(t *testing.T) {
+	first := cairnline.Project{
+		ID:        "proj_digest",
+		Name:      "Digest parity",
+		CreatedAt: time.Date(2026, 6, 27, 10, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 6, 27, 10, 1, 0, 0, time.UTC),
+	}
+	second := first
+	second.CreatedAt = time.Date(2026, 6, 27, 11, 0, 0, 0, time.UTC)
+	second.UpdatedAt = time.Date(2026, 6, 27, 11, 1, 0, 0, time.UTC)
+	if projectCairnlineContentDigest(first) != projectCairnlineContentDigest(second) {
+		t.Fatalf("content digest changed across volatile timestamps")
+	}
+	second.Name = "Digest drift"
+	if projectCairnlineContentDigest(first) == projectCairnlineContentDigest(second) {
+		t.Fatalf("content digest ignored semantic project name change")
+	}
+}
+
+func TestProjectCairnlineParityReport_IncludesAssistantProposalDifferences(t *testing.T) {
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, 2, ProjectCairnlineReadModelResponseItem{
+		AssistantProposalCount: 1,
+	})
+	if report.Match {
+		t.Fatalf("parity report match = true, want assistant proposal mismatch")
+	}
+	if report.Hecate.Assistant.Proposals != 2 || report.Cairnline.Assistant.Proposals != 1 {
+		t.Fatalf("assistant parity counts = hecate %+v cairnline %+v, want 2/1", report.Hecate.Assistant, report.Cairnline.Assistant)
+	}
+	if len(report.Differences) != 1 || report.Differences[0].Path != "assistant.proposals" || report.Differences[0].Hecate != 2 || report.Differences[0].Cairnline != 1 {
+		t.Fatalf("assistant parity differences = %+v, want assistant.proposals 2/1", report.Differences)
+	}
+}
+
+func TestProjectCairnlineParityReport_IncludesGraphCountDifferences(t *testing.T) {
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{
+		Roots:             1,
+		ContextSources:    2,
+		ExecutionProfiles: 4,
+		Artifacts:         3,
+	}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
+		RootCount:             1,
+		ContextSourceCount:    1,
+		ExecutionProfileCount: 3,
+		ArtifactCount:         2,
+	})
+	if report.Match {
+		t.Fatalf("parity report match = true, want graph mismatch")
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "graph.context_sources", 2, 1) {
+		t.Fatalf("parity differences = %+v, want graph.context_sources 2/1", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "graph.execution_profiles", 4, 3) {
+		t.Fatalf("parity differences = %+v, want graph.execution_profiles 4/3", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "graph.artifacts", 3, 2) {
+		t.Fatalf("parity differences = %+v, want graph.artifacts 3/2", report.Differences)
+	}
+}
+
+func TestProjectCairnlineParityReport_IncludesLaunchPacketCoverageDifferences(t *testing.T) {
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{
+		Summary: ProjectActivitySummaryResponse{AssignmentCount: 2},
+	}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
+		LaunchPacketCount:        1,
+		LaunchPacketWarningCount: 2,
+		LaunchPacketErrors: []ProjectCairnlineLaunchPacketError{{
+			AssignmentID: "asgn_missing",
+			Error:        "assignment role was not found",
+		}},
+	})
+	if report.Match {
+		t.Fatalf("parity report match = true, want launch packet coverage mismatch")
+	}
+	if report.Hecate.LaunchPackets.Assignments != 2 || report.Cairnline.LaunchPackets.Assignments != 1 || report.Cairnline.LaunchPackets.Warnings != 2 || report.Cairnline.LaunchPackets.Errors != 1 {
+		t.Fatalf("launch packet parity counts = hecate %+v cairnline %+v, want expected 2, available 1, warnings 2, errors 1", report.Hecate.LaunchPackets, report.Cairnline.LaunchPackets)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "launch_packets.assignments", 2, 1) {
+		t.Fatalf("parity differences = %+v, want launch_packets.assignments 2/1", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "launch_packets.warnings", 0, 2) {
+		t.Fatalf("parity differences = %+v, want launch_packets.warnings 0/2", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "launch_packets.errors", 0, 1) {
+		t.Fatalf("parity differences = %+v, want launch_packets.errors 0/1", report.Differences)
+	}
+}
+
+func hasProjectCairnlineParityDifference(items []ProjectCairnlineParityDifference, path string, hecate, cairnline int) bool {
+	for _, item := range items {
+		if item.Path == path && item.Hecate == hecate && item.Cairnline == cairnline {
+			return true
+		}
+	}
+	return false
+}
+
+func hasProjectCairnlineIDDifference(items []ProjectCairnlineIDDifference, path string, hecate, cairnline []string) bool {
+	for _, item := range items {
+		if item.Path == path && equalStringSlices(item.Hecate, hecate) && equalStringSlices(item.Cairnline, cairnline) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasProjectCairnlineContentDifference(items []ProjectCairnlineContentDifference, path, id, hecate, cairnline string) bool {
+	for _, item := range items {
+		if item.Path == path && item.ID == id && item.Hecate == hecate && item.Cairnline == cairnline {
+			return true
+		}
+	}
+	return false
+}
+
+func mustRawProjectCairnlinePatch(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal proposal patch: %v", err)
+	}
+	return payload
 }
 
 func TestProjectCairnlineExportAPI_MissingProjectDoesNotCreateExportDir(t *testing.T) {

--- a/internal/api/handler_project_context_discovery.go
+++ b/internal/api/handler_project_context_discovery.go
@@ -41,6 +41,7 @@ func (h *Handler) HandleDiscoverProjectContextSources(w http.ResponseWriter, r *
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectIdentityToCairnline(r.Context(), "project_context_sources_discover", project)
 	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
 }
 

--- a/internal/api/handler_project_context_discovery_test.go
+++ b/internal/api/handler_project_context_discovery_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/projects"
 )
@@ -141,6 +142,58 @@ func TestProjectContextDiscovery_KeepsSamePathSourcesFromDifferentRoots(t *testi
 	}
 	if !roots["root_a"] || !roots["root_b"] || len(roots) != 2 {
 		t.Fatalf("discovered AGENTS roots = %+v, want root_a and root_b", roots)
+	}
+}
+
+func TestProjectContextDiscovery_MirrorsDiscoveredSourcesToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeDiscoveryFile(t, root, "AGENTS.md")
+
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+
+	if _, err := projectStore.Create(t.Context(), projects.Project{
+		ID:   "proj_guidance_mirror",
+		Name: "Guidance mirror",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   root,
+			Kind:   "local",
+			Active: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_guidance_mirror/context-sources/discover", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	project, err := service.GetProject(t.Context(), "proj_guidance_mirror")
+	if err != nil {
+		t.Fatalf("GetProject(proj_guidance_mirror): %v", err)
+	}
+	var found bool
+	for _, source := range project.ContextSources {
+		if source.Locator == "AGENTS.md" && source.Kind == "workspace_instruction" && source.Format == "agents_md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("mirrored context sources = %+v, want discovered AGENTS.md source", project.ContextSources)
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -3,6 +3,83 @@ package api
 import "net/http"
 
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
+const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
+
+var projectCairnlineReadRouteNames = []string{
+	"project-list",
+	"project-detail",
+	"setup-readiness",
+	"health",
+	"skills",
+	"memory",
+	"memory-candidate",
+	"roles",
+	"work-item",
+	"assignment-list",
+	"assignment-context",
+	"launch-readiness",
+	"assignment-preflight",
+	"artifact-list",
+	"handoff-list",
+	"project-assistant-context",
+	"project-assistant-proposal",
+	"activity",
+	"closeout-readiness",
+	"operations-brief",
+}
+
+var projectCairnlineWriteAdapterSeamNames = []string{
+	"projects",
+	"roots",
+	"context-sources",
+	"project-defaults",
+	"project-identity-live-mirror",
+	"agent-profiles",
+	"agent-profiles-live-mirror",
+	"skills",
+	"project-skills-live-mirror",
+	"roles",
+	"project-roles-live-mirror",
+	"work-items",
+	"project-work-items-live-mirror",
+	"assignments",
+	"assignment-status",
+	"project-assignments-live-mirror",
+	"project-assignment-start-result-live-mirror",
+	"project-assignment-chat-reconcile-live-mirror",
+	"artifacts-create",
+	"evidence-create",
+	"reviews-create",
+	"project-collaboration-live-mirror",
+	"handoffs",
+	"project-handoffs-live-mirror",
+	"memory",
+	"project-memory-live-mirror",
+	"memory-candidates",
+	"project-memory-candidates-live-mirror",
+	"project-assistant-proposal-ledger-import",
+	"project-assistant-proposal-ledger-live-mirror",
+	"project-assistant-apply-side-effects-live-mirror",
+	"sync-rehearsal",
+}
+
+var projectCairnlineWriteAdapterGapNames = []string{
+	"projects",
+	"roots",
+	"context-sources",
+	"agent-profiles",
+	"skills",
+	"memory",
+	"memory-candidates",
+	"roles",
+	"work-items",
+	"assignments",
+	"assignment-start",
+	"artifacts",
+	"handoffs",
+	"project-assistant-proposals",
+	"migration-cutover",
+}
 
 func (h *Handler) HandleProjectCoordinationBackendStatus(w http.ResponseWriter, r *http.Request) {
 	WriteJSON(w, http.StatusOK, ProjectCoordinationBackendStatusEnvelope{
@@ -26,18 +103,30 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineAuthoritative:  false,
 		WriteAdapterReady:       false,
 		ReplacementReadinessURL: projectCoordinationBackendReadinessURL,
+		SyncReadinessURL:        projectCoordinationBackendSyncReadinessURL,
 	}
 	switch configured {
 	case "cairnline":
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
+		response.WriteAdapterSeams = append([]string(nil), projectCairnlineWriteAdapterSeamNames...)
+		response.WriteAdapterGaps = append([]string(nil), projectCairnlineWriteAdapterGapNames...)
 		response.ReadModelSwitchReady = readReady
 		if readReady {
+			response.ReadRoutes = append([]string(nil), projectCairnlineReadRouteNames...)
 			response.Status = "cairnline_read_routes_ready"
-			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the setup-readiness, health, work-item, assignment-list, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
+			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
 			response.Warnings = []string{
-				"Only the project setup-readiness, health, work-item, assignment-list, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
-				"Other project APIs still read and write Hecate-native stores.",
-				"Cairnline write adapter and migration path are not ready.",
+				"Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
+				"Project identity, root create/update/delete/discovery/worktree-creation, context-source create/update/delete/discovery, and default mutations still write Hecate-native stores first, then best-effort mirror into the embedded Cairnline database.",
+				"Agent profile create/update/delete mutations still write Hecate-native stores first, then best-effort mirror portable profile metadata and execution posture into Cairnline.",
+				"Project skill discovery and metadata updates still write Hecate-native stores first, then best-effort mirror metadata-only skill records into Cairnline.",
+				"Project role and work-item mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline.",
+				"Project assignment create/update/delete mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results.",
+				"Project collaboration artifact creation and handoff mutations still write Hecate-native stores first, then best-effort mirror portable collaboration metadata into Cairnline.",
+				"Project memory entry and memory-candidate mutations still write Hecate-native stores first, then best-effort mirror accepted memory and reviewable candidate state into Cairnline.",
+				"Project Assistant proposal draft/propose/apply ledger mutations still write Hecate-native stores first, then best-effort mirror proposal records plus committed apply side effects into Cairnline.",
+				"Other project mutation routes still write only Hecate-native stores.",
+				"Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready.",
 			}
 			return response
 		}
@@ -59,7 +148,7 @@ func (h *Handler) cairnlineReadModelReadiness() (bool, []string) {
 		return false, []string{"Hecate handler is not configured."}
 	}
 	sources := h.cairnlineSnapshotSources()
-	missing := make([]string, 0, 6)
+	missing := make([]string, 0, 7)
 	if sources.Projects == nil {
 		missing = append(missing, "projects store")
 	}
@@ -77,6 +166,9 @@ func (h *Handler) cairnlineReadModelReadiness() (bool, []string) {
 	}
 	if sources.MemoryCandidates == nil {
 		missing = append(missing, "project memory candidates store")
+	}
+	if sources.Proposals == nil {
+		missing = append(missing, "project assistant proposal store")
 	}
 	if len(missing) == 0 {
 		return true, nil

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/config"
@@ -23,6 +24,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
+	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 {
+		t.Fatalf("status = %+v, want no Cairnline route/seam/gap lists until Cairnline is configured", status)
+	}
 }
 
 func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *testing.T) {
@@ -39,6 +43,18 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	}
 	if status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || len(status.Warnings) == 0 {
 		t.Fatalf("status = %+v, want read adapter missing-source warnings", status)
+	}
+	if !strings.Contains(strings.Join(status.Warnings, "\n"), "project assistant proposal store") {
+		t.Fatalf("warnings = %+v, want missing assistant proposal store warning", status.Warnings)
+	}
+	if len(status.ReadRoutes) != 0 {
+		t.Fatalf("read routes = %+v, want none until the read adapter is ready", status.ReadRoutes)
+	}
+	if !containsString(status.WriteAdapterGaps, "projects") || !containsString(status.WriteAdapterGaps, "migration-cutover") {
+		t.Fatalf("write gaps = %+v, want structured write-adapter gaps", status.WriteAdapterGaps)
+	}
+	if !containsString(status.WriteAdapterSeams, "projects") || !containsString(status.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(status.WriteAdapterSeams, "agent-profiles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(status.WriteAdapterSeams, "assignments") || !containsString(status.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(status.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(status.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(status.WriteAdapterSeams, "sync-rehearsal") {
+		t.Fatalf("write seams = %+v, want structured non-authoritative write-adapter seam coverage", status.WriteAdapterSeams)
 	}
 }
 
@@ -59,6 +75,18 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	}
 	if len(status.Warnings) == 0 {
 		t.Fatalf("status = %+v, want write-adapter/migration warning", status)
+	}
+	if !containsString(status.ReadRoutes, "project-list") || !containsString(status.ReadRoutes, "assignment-context") || !containsString(status.ReadRoutes, "launch-readiness") || !containsString(status.ReadRoutes, "assignment-preflight") || !containsString(status.ReadRoutes, "project-assistant-context") || !containsString(status.ReadRoutes, "project-assistant-proposal") || !containsString(status.ReadRoutes, "operations-brief") {
+		t.Fatalf("read routes = %+v, want structured Cairnline read-route coverage", status.ReadRoutes)
+	}
+	if !containsString(status.WriteAdapterGaps, "agent-profiles") || !containsString(status.WriteAdapterGaps, "assignments") || !containsString(status.WriteAdapterGaps, "project-assistant-proposals") || !containsString(status.WriteAdapterGaps, "migration-cutover") {
+		t.Fatalf("write gaps = %+v, want structured remaining write-adapter gaps", status.WriteAdapterGaps)
+	}
+	if !containsString(status.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(status.WriteAdapterSeams, "agent-profiles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(status.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(status.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(status.WriteAdapterSeams, "assignment-status") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-import") || !containsString(status.WriteAdapterSeams, "memory-candidates") {
+		t.Fatalf("write seams = %+v, want structured non-authoritative write-adapter seam coverage", status.WriteAdapterSeams)
+	}
+	if status.SyncReadinessURL != projectCoordinationBackendSyncReadinessURL {
+		t.Fatalf("sync readiness URL = %q, want %q", status.SyncReadinessURL, projectCoordinationBackendSyncReadinessURL)
 	}
 }
 
@@ -88,4 +116,16 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if !response.Data.ReadModelSwitchReady || response.Data.Status != "cairnline_read_routes_ready" {
 		t.Fatalf("response = %+v, want Cairnline read routes ready for fully wired test handler", response)
 	}
+	if !containsString(response.Data.ReadRoutes, "project-detail") || !containsString(response.Data.ReadRoutes, "launch-readiness") || !containsString(response.Data.ReadRoutes, "assignment-preflight") || !containsString(response.Data.ReadRoutes, "project-assistant-context") || !containsString(response.Data.ReadRoutes, "project-assistant-proposal") || !containsString(response.Data.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "handoffs") || !containsString(response.Data.WriteAdapterGaps, "memory-candidates") {
+		t.Fatalf("response routes/seams/gaps = %+v / %+v / %+v, want structured readiness details", response.Data.ReadRoutes, response.Data.WriteAdapterSeams, response.Data.WriteAdapterGaps)
+	}
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/handler_project_health_cairnline.go
+++ b/internal/api/handler_project_health_cairnline.go
@@ -169,6 +169,7 @@ func projectHealthEvidenceFromCairnline(item cairnline.Evidence) projectwork.Col
 		Kind:               projectwork.ArtifactKindEvidenceLink,
 		Title:              item.Title,
 		Body:               item.Body,
+		EvidenceSourceKind: projectwork.EvidenceSourceExternal,
 		EvidenceURL:        item.Locator,
 		EvidenceTrustLabel: item.TrustLabel,
 		CreatedAt:          item.CreatedAt,

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -257,6 +259,44 @@ func TestProjectHealth_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	if candidate.CandidateID != "memcand_health" || candidate.Action.CandidateID != "memcand_health" {
 		t.Fatalf("candidate attention = %+v, want Cairnline-backed memory candidate target", candidate)
 	}
+}
+
+func TestProjectHealth_CairnlineMatchesHecateProjectionGraph(t *testing.T) {
+	t.Parallel()
+	hecateHandler, hecateServer := newProjectWorkProjectionTestServer(t, "memory")
+	seedProjectWorkProjectionTest(t, hecateHandler)
+	cairnlineHandler, cairnlineServer := newProjectWorkCairnlineReadTestServer()
+	seedProjectWorkProjectionTest(t, cairnlineHandler)
+
+	hecate := mustRequestJSON[ProjectHealthEnvelope](newAPITestClient(t, hecateServer), http.MethodGet, "/hecate/v1/projects/proj_projection/health", "")
+	cairnline := mustRequestJSON[ProjectHealthEnvelope](newAPITestClient(t, cairnlineServer), http.MethodGet, "/hecate/v1/projects/proj_projection/health", "")
+	if hecate.Data.ReadBackend != "hecate" {
+		t.Fatalf("Hecate health read_backend = %q, want hecate", hecate.Data.ReadBackend)
+	}
+	if cairnline.Data.ReadBackend != "cairnline" {
+		t.Fatalf("Cairnline health read_backend = %q, want cairnline", cairnline.Data.ReadBackend)
+	}
+
+	hecateData := normalizeProjectHealthForParity(hecate.Data)
+	cairnlineData := normalizeProjectHealthForParity(cairnline.Data)
+	if !reflect.DeepEqual(hecateData, cairnlineData) {
+		t.Fatalf("health mismatch\nHecate:   %+v\nCairnline: %+v", hecateData, cairnlineData)
+	}
+}
+
+func normalizeProjectHealthForParity(item ProjectHealthResponse) ProjectHealthResponse {
+	item.GeneratedAt = ""
+	item.ReadBackend = ""
+	for idx := range item.Attention {
+		item.Attention[idx].Detail = normalizeProjectHealthDetailForParity(item.Attention[idx].Detail)
+	}
+	return item
+}
+
+var projectHealthParityUpdatedAtPattern = regexp.MustCompile(`updated [0-9TZ:.\-]+`)
+
+func normalizeProjectHealthDetailForParity(detail string) string {
+	return projectHealthParityUpdatedAtPattern.ReplaceAllString(detail, "updated <time>")
 }
 
 func TestProjectHealth_ProfileAndSkillReferences(t *testing.T) {

--- a/internal/api/handler_project_memory.go
+++ b/internal/api/handler_project_memory.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/memory"
 )
 
@@ -65,19 +67,12 @@ func (h *Handler) HandleProjectMemoryEntries(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	includeDisabled := requestBool(r, "include_disabled")
-	items, err := h.memory.List(r.Context(), memory.Filter{
-		ProjectID:       projectID,
-		IncludeDisabled: includeDisabled,
-	})
+	items, err := h.renderProjectMemoryEntries(r.Context(), projectID, includeDisabled)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	data := make([]ProjectMemoryResponseItem, 0, len(items))
-	for _, item := range items {
-		data = append(data, renderProjectMemory(item))
-	}
-	WriteJSON(w, http.StatusOK, ProjectMemoryListResponse{Object: "project_memory", Data: data})
+	WriteJSON(w, http.StatusOK, ProjectMemoryListResponse{Object: "project_memory", Data: items})
 }
 
 func (h *Handler) HandleCreateProjectMemoryEntry(w http.ResponseWriter, r *http.Request) {
@@ -120,7 +115,8 @@ func (h *Handler) HandleCreateProjectMemoryEntry(w http.ResponseWriter, r *http.
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusCreated, ProjectMemoryResponse{Object: "project_memory_entry", Data: renderProjectMemory(created)})
+	h.mirrorProjectMemoryEntryToCairnline(r.Context(), "project_memory_create", created)
+	WriteJSON(w, http.StatusCreated, ProjectMemoryResponse{Object: "project_memory_entry", Data: renderProjectMemory(created, "hecate")})
 }
 
 func (h *Handler) HandleProjectMemoryCandidates(w http.ResponseWriter, r *http.Request) {
@@ -128,27 +124,19 @@ func (h *Handler) HandleProjectMemoryCandidates(w http.ResponseWriter, r *http.R
 	if !h.requireProjectExists(w, r, projectID) {
 		return
 	}
-	candidateStore, ok := h.requireProjectMemoryCandidateStore(w)
-	if !ok {
+	if _, ok := h.requireProjectMemoryCandidateStore(w); !ok {
 		return
 	}
 	status := strings.TrimSpace(r.URL.Query().Get("status"))
 	if status == "" && !requestBool(r, "include_resolved") {
 		status = memory.CandidateStatusPending
 	}
-	items, err := candidateStore.ListCandidates(r.Context(), memory.CandidateFilter{
-		ProjectID: projectID,
-		Status:    status,
-	})
+	items, err := h.renderProjectMemoryCandidates(r.Context(), projectID, status, requestBool(r, "include_resolved"))
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	data := make([]ProjectMemoryCandidateResponseItem, 0, len(items))
-	for _, item := range items {
-		data = append(data, renderProjectMemoryCandidate(item))
-	}
-	WriteJSON(w, http.StatusOK, ProjectMemoryCandidateListResponse{Object: "project_memory_candidates", Data: data})
+	WriteJSON(w, http.StatusOK, ProjectMemoryCandidateListResponse{Object: "project_memory_candidates", Data: items})
 }
 
 func (h *Handler) HandleCreateProjectMemoryCandidate(w http.ResponseWriter, r *http.Request) {
@@ -189,7 +177,8 @@ func (h *Handler) HandleCreateProjectMemoryCandidate(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusCreated, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(created)})
+	h.mirrorProjectMemoryCandidateToCairnline(r.Context(), "project_memory_candidate_create", created)
+	WriteJSON(w, http.StatusCreated, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(created, "hecate")})
 }
 
 func (h *Handler) HandlePromoteProjectMemoryCandidate(w http.ResponseWriter, r *http.Request) {
@@ -245,7 +234,7 @@ func (h *Handler) HandlePromoteProjectMemoryCandidate(w http.ResponseWriter, r *
 	if req.SourceID != nil {
 		entry.SourceID = *req.SourceID
 	}
-	updated, _, err := candidateStore.PromoteCandidate(r.Context(), projectID, candidateID, entry)
+	updated, promotedEntry, err := candidateStore.PromoteCandidate(r.Context(), projectID, candidateID, entry)
 	if errors.Is(err, memory.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
@@ -266,7 +255,9 @@ func (h *Handler) HandlePromoteProjectMemoryCandidate(w http.ResponseWriter, r *
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(updated)})
+	h.mirrorProjectMemoryEntryToCairnline(r.Context(), "project_memory_candidate_promote_entry", promotedEntry)
+	h.mirrorProjectMemoryCandidateToCairnline(r.Context(), "project_memory_candidate_promote", updated)
+	WriteJSON(w, http.StatusOK, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(updated, "hecate")})
 }
 
 func (h *Handler) HandleRejectProjectMemoryCandidate(w http.ResponseWriter, r *http.Request) {
@@ -309,7 +300,8 @@ func (h *Handler) HandleRejectProjectMemoryCandidate(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(updated)})
+	h.mirrorProjectMemoryCandidateToCairnline(r.Context(), "project_memory_candidate_reject", updated)
+	WriteJSON(w, http.StatusOK, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(updated, "hecate")})
 }
 
 func (h *Handler) HandleUpdateProjectMemoryEntry(w http.ResponseWriter, r *http.Request) {
@@ -356,7 +348,8 @@ func (h *Handler) HandleUpdateProjectMemoryEntry(w http.ResponseWriter, r *http.
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectMemoryResponse{Object: "project_memory_entry", Data: renderProjectMemory(entry)})
+	h.mirrorProjectMemoryEntryToCairnline(r.Context(), "project_memory_update", entry)
+	WriteJSON(w, http.StatusOK, ProjectMemoryResponse{Object: "project_memory_entry", Data: renderProjectMemory(entry, "hecate")})
 }
 
 func (h *Handler) HandleDeleteProjectMemoryEntry(w http.ResponseWriter, r *http.Request) {
@@ -376,6 +369,7 @@ func (h *Handler) HandleDeleteProjectMemoryEntry(w http.ResponseWriter, r *http.
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectMemoryEntryDeleteToCairnline(r.Context(), "project_memory_delete", projectID, r.PathValue("memory_id"))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -416,26 +410,111 @@ func (h *Handler) requireProjectMemoryCandidateStore(w http.ResponseWriter) (mem
 	return h.memoryCandidates, true
 }
 
-func renderProjectMemory(entry memory.Entry) ProjectMemoryResponseItem {
+func (h *Handler) renderProjectMemoryEntries(ctx context.Context, projectID string, includeDisabled bool) ([]ProjectMemoryResponseItem, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectMemoryEntries(ctx, projectID, includeDisabled)
+	}
+	items, err := h.memory.List(ctx, memory.Filter{
+		ProjectID:       projectID,
+		IncludeDisabled: includeDisabled,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return renderProjectMemoryEntries(items, "hecate"), nil
+}
+
+func (h *Handler) renderCairnlineProjectMemoryEntries(ctx context.Context, projectID string, includeDisabled bool) ([]ProjectMemoryResponseItem, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := service.ListMemoryEntries(ctx, snapshot.Project.ID, includeDisabled)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectMemoryResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderProjectMemory(projectMemoryFromCairnline(item), "cairnline"))
+	}
+	return out, nil
+}
+
+func (h *Handler) renderProjectMemoryCandidates(ctx context.Context, projectID, status string, includeResolved bool) ([]ProjectMemoryCandidateResponseItem, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectMemoryCandidates(ctx, projectID, status, includeResolved)
+	}
+	if h.memoryCandidates == nil {
+		return nil, errors.New("project memory candidate store is not configured")
+	}
+	items, err := h.memoryCandidates.ListCandidates(ctx, memory.CandidateFilter{
+		ProjectID: projectID,
+		Status:    status,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return renderProjectMemoryCandidates(items, "hecate"), nil
+}
+
+func (h *Handler) renderCairnlineProjectMemoryCandidates(ctx context.Context, projectID, status string, includeResolved bool) ([]ProjectMemoryCandidateResponseItem, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+		ProjectID:       snapshot.Project.ID,
+		Status:          status,
+		IncludeResolved: includeResolved,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectMemoryCandidateResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderProjectMemoryCandidate(projectMemoryCandidateFromCairnline(item), "cairnline"))
+	}
+	return out, nil
+}
+
+func renderProjectMemoryEntries(items []memory.Entry, readBackend string) []ProjectMemoryResponseItem {
+	out := make([]ProjectMemoryResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderProjectMemory(item, readBackend))
+	}
+	return out
+}
+
+func renderProjectMemory(entry memory.Entry, readBackend string) ProjectMemoryResponseItem {
 	return ProjectMemoryResponseItem{
-		ID:         entry.ID,
-		Scope:      entry.Scope,
-		ProjectID:  entry.ProjectID,
-		Title:      entry.Title,
-		Body:       entry.Body,
-		TrustLabel: entry.TrustLabel,
-		SourceKind: entry.SourceKind,
-		SourceID:   entry.SourceID,
-		Enabled:    entry.Enabled,
-		CreatedAt:  formatOptionalTime(entry.CreatedAt),
-		UpdatedAt:  formatOptionalTime(entry.UpdatedAt),
+		ID:          entry.ID,
+		Scope:       entry.Scope,
+		ProjectID:   entry.ProjectID,
+		ReadBackend: readBackend,
+		Title:       entry.Title,
+		Body:        entry.Body,
+		TrustLabel:  entry.TrustLabel,
+		SourceKind:  entry.SourceKind,
+		SourceID:    entry.SourceID,
+		Enabled:     entry.Enabled,
+		CreatedAt:   formatOptionalTime(entry.CreatedAt),
+		UpdatedAt:   formatOptionalTime(entry.UpdatedAt),
 	}
 }
 
-func renderProjectMemoryCandidate(candidate memory.Candidate) ProjectMemoryCandidateResponseItem {
+func renderProjectMemoryCandidates(items []memory.Candidate, readBackend string) []ProjectMemoryCandidateResponseItem {
+	out := make([]ProjectMemoryCandidateResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderProjectMemoryCandidate(item, readBackend))
+	}
+	return out
+}
+
+func renderProjectMemoryCandidate(candidate memory.Candidate, readBackend string) ProjectMemoryCandidateResponseItem {
 	return ProjectMemoryCandidateResponseItem{
 		ID:                  candidate.ID,
 		ProjectID:           candidate.ProjectID,
+		ReadBackend:         readBackend,
 		Title:               candidate.Title,
 		Body:                candidate.Body,
 		SuggestedKind:       candidate.SuggestedKind,
@@ -449,6 +528,57 @@ func renderProjectMemoryCandidate(candidate memory.Candidate) ProjectMemoryCandi
 		CreatedAt:           formatOptionalTime(candidate.CreatedAt),
 		UpdatedAt:           formatOptionalTime(candidate.UpdatedAt),
 	}
+}
+
+func projectMemoryFromCairnline(item cairnline.MemoryEntry) memory.Entry {
+	return memory.Entry{
+		ID:         item.ID,
+		Scope:      memory.ScopeProject,
+		ProjectID:  item.ProjectID,
+		Title:      item.Title,
+		Body:       item.Body,
+		TrustLabel: item.TrustLabel,
+		SourceKind: item.SourceKind,
+		SourceID:   item.SourceID,
+		Enabled:    item.Enabled,
+		CreatedAt:  item.CreatedAt,
+		UpdatedAt:  item.UpdatedAt,
+	}
+}
+
+func projectMemoryCandidateFromCairnline(item cairnline.MemoryCandidate) memory.Candidate {
+	return memory.Candidate{
+		ID:                  item.ID,
+		ProjectID:           item.ProjectID,
+		Title:               item.Title,
+		Body:                item.Body,
+		SuggestedKind:       item.SuggestedKind,
+		SuggestedTrustLabel: item.SuggestedTrustLabel,
+		SuggestedSourceKind: item.SuggestedSourceKind,
+		SuggestedSourceID:   item.SuggestedSourceID,
+		SourceRefs:          projectMemoryCandidateSourceRefsFromCairnline(item.SourceRefs),
+		Status:              item.Status,
+		StatusReason:        item.StatusReason,
+		PromotedMemoryID:    item.PromotedMemoryID,
+		CreatedAt:           item.CreatedAt,
+		UpdatedAt:           item.UpdatedAt,
+	}
+}
+
+func projectMemoryCandidateSourceRefsFromCairnline(items []cairnline.MemoryCandidateSourceRef) []memory.CandidateSourceRef {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]memory.CandidateSourceRef, 0, len(items))
+	for _, item := range items {
+		out = append(out, memory.CandidateSourceRef{
+			Kind:  item.Kind,
+			ID:    item.ID,
+			Title: item.Title,
+			URL:   item.URL,
+		})
+	}
+	return out
 }
 
 func candidateSourceRefsFromRequest(refs []candidateSourceRefRequest) []memory.CandidateSourceRef {

--- a/internal/api/handler_project_memory_test.go
+++ b/internal/api/handler_project_memory_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"reflect"
 	"testing"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -20,6 +23,31 @@ func newProjectMemoryTestServer() http.Handler {
 	handler.SetProjectStore(projects.NewMemoryStore())
 	handler.SetMemoryStore(memory.NewMemoryStore())
 	return NewServer(quietLogger(), handler)
+}
+
+func newProjectMemoryCairnlineReadTestServer() http.Handler {
+	_, server := newProjectMemoryCairnlineReadTestHandler()
+	return server
+}
+
+func newProjectMemoryCairnlineReadTestHandler() (*Handler, http.Handler) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectMemoryCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
 }
 
 func TestProjectMemoryAPI_CRUD(t *testing.T) {
@@ -281,6 +309,231 @@ func TestProjectMemoryAPI_CandidateRejectFlow(t *testing.T) {
 	}
 }
 
+func TestProjectMemoryAPI_MirrorsMutationsToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectMemoryCairnlineMirrorTestServer(t)
+	client := newAPITestClient(t, server)
+	project := createMemoryTestProject(t, server, "Mirror Memory")
+	projectID := project.Data.ID
+
+	created := mustRequestJSONStatus[ProjectMemoryResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory", `{
+		"title":"Release practice",
+		"body":"Keep release notes reviewable.",
+		"trust_label":"operator_memory",
+		"source_kind":"operator",
+		"enabled":false
+	}`)
+	mirroredMemory := getMirroredCairnlineMemoryEntryForTest(t, handler, projectID, created.Data.ID)
+	if mirroredMemory.Title != "Release practice" || mirroredMemory.Body != "Keep release notes reviewable." || mirroredMemory.Enabled {
+		t.Fatalf("mirrored memory = %+v, want created disabled memory", mirroredMemory)
+	}
+
+	updated := mustRequestJSON[ProjectMemoryResponse](client, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/memory/"+created.Data.ID, `{
+		"title":"Release practice updated",
+		"enabled":true,
+		"source_kind":"handoff",
+		"source_id":"handoff_1"
+	}`)
+	mirroredMemory = getMirroredCairnlineMemoryEntryForTest(t, handler, projectID, updated.Data.ID)
+	if mirroredMemory.Title != "Release practice updated" || !mirroredMemory.Enabled || mirroredMemory.SourceKind != "handoff" || mirroredMemory.SourceID != "handoff_1" {
+		t.Fatalf("mirrored updated memory = %+v, want patched metadata", mirroredMemory)
+	}
+
+	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/memory/"+created.Data.ID, "")
+	assertCairnlineMemoryEntryMissingForTest(t, handler, projectID, created.Data.ID)
+
+	candidate := mustRequestJSONStatus[ProjectMemoryCandidateResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates", `{
+		"title":"Generated lesson",
+		"body":"Mention evidence in handoffs.",
+		"suggested_kind":"lesson",
+		"suggested_trust_label":"generated_summary",
+		"suggested_source_kind":"artifact",
+		"suggested_source_id":"art_1",
+		"source_refs":[{"kind":"artifact","id":"art_1","title":"Review artifact","url":"https://example.test/review"}]
+	}`)
+	mirroredCandidate := getMirroredCairnlineMemoryCandidateForTest(t, handler, projectID, candidate.Data.ID)
+	if mirroredCandidate.Status != cairnline.MemoryCandidatePending || len(mirroredCandidate.SourceRefs) != 1 || mirroredCandidate.SourceRefs[0].URL != "https://example.test/review" {
+		t.Fatalf("mirrored candidate = %+v, want pending source-ref metadata", mirroredCandidate)
+	}
+
+	promoted := mustRequestJSON[ProjectMemoryCandidateResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates/"+candidate.Data.ID+"/promote", `{
+		"title":"Reviewed lesson",
+		"body":"Mention evidence in handoffs after review.",
+		"trust_label":"operator_memory",
+		"source_kind":"operator",
+		"source_id":"art_1",
+		"enabled":true
+	}`)
+	if promoted.Data.PromotedMemoryID == "" {
+		t.Fatalf("promoted candidate = %+v, want promoted memory id", promoted.Data)
+	}
+	mirroredPromotedMemory := getMirroredCairnlineMemoryEntryForTest(t, handler, projectID, promoted.Data.PromotedMemoryID)
+	if mirroredPromotedMemory.Title != "Reviewed lesson" || mirroredPromotedMemory.Body != "Mention evidence in handoffs after review." || mirroredPromotedMemory.TrustLabel != "operator_memory" {
+		t.Fatalf("mirrored promoted memory = %+v, want reviewed entry", mirroredPromotedMemory)
+	}
+	mirroredCandidate = getMirroredCairnlineMemoryCandidateForTest(t, handler, projectID, candidate.Data.ID)
+	if mirroredCandidate.Status != cairnline.MemoryCandidatePromoted || mirroredCandidate.PromotedMemoryID != promoted.Data.PromotedMemoryID {
+		t.Fatalf("mirrored promoted candidate = %+v, want promoted status and memory ref", mirroredCandidate)
+	}
+
+	rejectCandidate := mustRequestJSONStatus[ProjectMemoryCandidateResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates", `{
+		"title":"Speculative lesson",
+		"body":"Skip tests when tired."
+	}`)
+	rejected := mustRequestJSON[ProjectMemoryCandidateResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates/"+rejectCandidate.Data.ID+"/reject", `{"reason":"Not durable project guidance"}`)
+	mirroredRejected := getMirroredCairnlineMemoryCandidateForTest(t, handler, projectID, rejected.Data.ID)
+	if mirroredRejected.Status != cairnline.MemoryCandidateRejected || mirroredRejected.StatusReason != "Not durable project guidance" || mirroredRejected.PromotedMemoryID != "" {
+		t.Fatalf("mirrored rejected candidate = %+v, want rejected reason without promoted memory", mirroredRejected)
+	}
+}
+
+func TestProjectMemoryAPI_ListUsesCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectMemoryCairnlineReadTestHandler()
+	project := createMemoryTestProject(t, server, "Cairnline Memory")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/memory", bytes.NewReader([]byte(`{
+		"title":"Enabled note",
+		"body":"Visible to project agents.",
+		"trust_label":"operator_memory",
+		"source_kind":"operator"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create enabled memory status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var enabled ProjectMemoryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &enabled); err != nil {
+		t.Fatalf("decode enabled memory: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/memory", bytes.NewReader([]byte(`{
+		"title":"Disabled note",
+		"body":"Keep inspectable but do not include by default.",
+		"enabled":false
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create disabled memory status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var disabled ProjectMemoryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &disabled); err != nil {
+		t.Fatalf("decode disabled memory: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/memory", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list enabled memory status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listed ProjectMemoryListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode enabled memory list: %v", err)
+	}
+	if len(listed.Data) != 1 || listed.Data[0].ID != enabled.Data.ID || listed.Data[0].ReadBackend != "cairnline" {
+		t.Fatalf("enabled memory list = %+v, want only enabled Cairnline-backed entry", listed.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/memory?include_disabled=true", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list all memory status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	listed = ProjectMemoryListResponse{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode all memory list: %v", err)
+	}
+	if len(listed.Data) != 2 {
+		t.Fatalf("all memory list = %+v, want enabled and disabled entries", listed.Data)
+	}
+	disabledEntry := projectMemoryResponseForTest(listed.Data, disabled.Data.ID)
+	if disabledEntry == nil || disabledEntry.ReadBackend != "cairnline" || disabledEntry.Enabled {
+		t.Fatalf("disabled memory entry = %+v, want disabled Cairnline-backed entry", disabledEntry)
+	}
+
+	nativeEntries, err := handler.memory.List(t.Context(), memory.Filter{
+		ProjectID:       project.Data.ID,
+		IncludeDisabled: true,
+	})
+	if err != nil {
+		t.Fatalf("List native memory entries: %v", err)
+	}
+	assertProjectMemoryProjectionParity(t, renderProjectMemoryEntries(nativeEntries, "hecate"), listed.Data)
+}
+
+func TestProjectMemoryAPI_CandidatesUseCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectMemoryCairnlineReadTestHandler()
+	project := createMemoryTestProject(t, server, "Cairnline Candidates")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/memory/candidates", bytes.NewReader([]byte(`{
+		"title":"Pending note",
+		"body":"Review before promotion.",
+		"suggested_kind":"note",
+		"suggested_trust_label":"generated_summary",
+		"source_refs":[{"kind":"handoff","id":"hand_1","title":"Handoff"}]
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create pending candidate status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var pending ProjectMemoryCandidateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &pending); err != nil {
+		t.Fatalf("decode pending candidate: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/memory/candidates", bytes.NewReader([]byte(`{
+		"title":"Rejected note",
+		"body":"Not durable enough."
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create rejected candidate status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var rejected ProjectMemoryCandidateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &rejected); err != nil {
+		t.Fatalf("decode rejected candidate: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/memory/candidates/"+rejected.Data.ID+"/reject", bytes.NewReader([]byte(`{"reason":"Not durable"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reject candidate status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/memory/candidates", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list pending candidates status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listed ProjectMemoryCandidateListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode pending candidate list: %v", err)
+	}
+	if len(listed.Data) != 1 || listed.Data[0].ID != pending.Data.ID || listed.Data[0].ReadBackend != "cairnline" || len(listed.Data[0].SourceRefs) != 1 {
+		t.Fatalf("pending candidate list = %+v, want pending Cairnline-backed candidate with source refs", listed.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/memory/candidates?include_resolved=true", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list all candidates status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	listed = ProjectMemoryCandidateListResponse{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode all candidate list: %v", err)
+	}
+	rejectedCandidate := projectMemoryCandidateResponseForTest(listed.Data, rejected.Data.ID)
+	if len(listed.Data) != 2 || rejectedCandidate == nil || rejectedCandidate.ReadBackend != "cairnline" || rejectedCandidate.Status != memory.CandidateStatusRejected || rejectedCandidate.StatusReason != "Not durable" {
+		t.Fatalf("all candidate list = %+v, want rejected Cairnline-backed candidate with reason", listed.Data)
+	}
+
+	nativeCandidates, err := handler.memoryCandidates.ListCandidates(t.Context(), memory.CandidateFilter{ProjectID: project.Data.ID})
+	if err != nil {
+		t.Fatalf("List native memory candidates: %v", err)
+	}
+	assertProjectMemoryCandidateProjectionParity(t, renderProjectMemoryCandidates(nativeCandidates, "hecate"), listed.Data)
+}
+
 func TestProjectMemoryAPI_ValidationAndScoping(t *testing.T) {
 	t.Parallel()
 	server := newProjectMemoryTestServer()
@@ -314,6 +567,108 @@ func TestProjectMemoryAPI_ValidationAndScoping(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("cross-project patch status = %d body=%s, want 404", rec.Code, rec.Body.String())
 	}
+}
+
+func projectMemoryResponseForTest(items []ProjectMemoryResponseItem, id string) *ProjectMemoryResponseItem {
+	for index := range items {
+		if items[index].ID == id {
+			return &items[index]
+		}
+	}
+	return nil
+}
+
+func projectMemoryCandidateResponseForTest(items []ProjectMemoryCandidateResponseItem, id string) *ProjectMemoryCandidateResponseItem {
+	for index := range items {
+		if items[index].ID == id {
+			return &items[index]
+		}
+	}
+	return nil
+}
+
+func assertProjectMemoryProjectionParity(t *testing.T, hecate, cairnline []ProjectMemoryResponseItem) {
+	t.Helper()
+	if len(hecate) != len(cairnline) {
+		t.Fatalf("memory projection count = hecate:%d cairnline:%d", len(hecate), len(cairnline))
+	}
+	normalizedHecate := append([]ProjectMemoryResponseItem(nil), hecate...)
+	normalizedCairnline := append([]ProjectMemoryResponseItem(nil), cairnline...)
+	for idx := range normalizedHecate {
+		if normalizedHecate[idx].ReadBackend != "hecate" {
+			t.Fatalf("hecate memory[%d] read_backend = %q, want hecate", idx, normalizedHecate[idx].ReadBackend)
+		}
+		if normalizedCairnline[idx].ReadBackend != "cairnline" {
+			t.Fatalf("cairnline memory[%d] read_backend = %q, want cairnline", idx, normalizedCairnline[idx].ReadBackend)
+		}
+		normalizedHecate[idx].ReadBackend = ""
+		normalizedCairnline[idx].ReadBackend = ""
+	}
+	if !reflect.DeepEqual(normalizedHecate, normalizedCairnline) {
+		t.Fatalf("memory projection mismatch\nhecate:   %+v\ncairnline: %+v", normalizedHecate, normalizedCairnline)
+	}
+}
+
+func assertProjectMemoryCandidateProjectionParity(t *testing.T, hecate, cairnline []ProjectMemoryCandidateResponseItem) {
+	t.Helper()
+	if len(hecate) != len(cairnline) {
+		t.Fatalf("memory candidate projection count = hecate:%d cairnline:%d", len(hecate), len(cairnline))
+	}
+	normalizedHecate := append([]ProjectMemoryCandidateResponseItem(nil), hecate...)
+	normalizedCairnline := append([]ProjectMemoryCandidateResponseItem(nil), cairnline...)
+	for idx := range normalizedHecate {
+		if normalizedHecate[idx].ReadBackend != "hecate" {
+			t.Fatalf("hecate memory candidate[%d] read_backend = %q, want hecate", idx, normalizedHecate[idx].ReadBackend)
+		}
+		if normalizedCairnline[idx].ReadBackend != "cairnline" {
+			t.Fatalf("cairnline memory candidate[%d] read_backend = %q, want cairnline", idx, normalizedCairnline[idx].ReadBackend)
+		}
+		normalizedHecate[idx].ReadBackend = ""
+		normalizedCairnline[idx].ReadBackend = ""
+	}
+	if !reflect.DeepEqual(normalizedHecate, normalizedCairnline) {
+		t.Fatalf("memory candidate projection mismatch\nhecate:   %+v\ncairnline: %+v", normalizedHecate, normalizedCairnline)
+	}
+}
+
+func getMirroredCairnlineMemoryEntryForTest(t *testing.T, handler *Handler, projectID, memoryID string) cairnline.MemoryEntry {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	entry, err := service.GetMemoryEntry(t.Context(), projectID, memoryID)
+	if err != nil {
+		t.Fatalf("GetMemoryEntry(%q, %q): %v", projectID, memoryID, err)
+	}
+	return entry
+}
+
+func assertCairnlineMemoryEntryMissingForTest(t *testing.T, handler *Handler, projectID, memoryID string) {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	if _, err := service.GetMemoryEntry(t.Context(), projectID, memoryID); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("GetMemoryEntry(%q, %q) error = %v, want Cairnline ErrNotFound", projectID, memoryID, err)
+	}
+}
+
+func getMirroredCairnlineMemoryCandidateForTest(t *testing.T, handler *Handler, projectID, candidateID string) cairnline.MemoryCandidate {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	candidate, err := service.GetMemoryCandidate(t.Context(), projectID, candidateID)
+	if err != nil {
+		t.Fatalf("GetMemoryCandidate(%q, %q): %v", projectID, candidateID, err)
+	}
+	return candidate
 }
 
 func TestProjectMemoryAPI_SQLiteBackendParity(t *testing.T) {

--- a/internal/api/handler_project_operations_cairnline.go
+++ b/internal/api/handler_project_operations_cairnline.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hecatehq/cairnline"
-	"github.com/hecatehq/hecate/internal/cairnlinebridge"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
@@ -20,32 +19,51 @@ func (h *Handler) projectReadRoutesUseCairnlineReadModel() bool {
 }
 
 func (h *Handler) renderCairnlineProjectOperationsBrief(ctx context.Context, project projects.Project) (ProjectOperationsBriefResponse, error) {
-	brief, snapshot, err := cairnlinebridge.ProjectOperationsBriefFromStores(ctx, h.cairnlineSnapshotSources(), project.ID)
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, project.ID)
 	if err != nil {
 		return ProjectOperationsBriefResponse{}, err
 	}
-	workItemsByID := projectOperationsSnapshotWorkItemsByID(snapshot.WorkItems)
-	assignmentsByID := projectOperationsSnapshotAssignmentsByID(snapshot.Assignments)
-	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(snapshot.Assignments)
-	artifactsByID := projectOperationsSnapshotArtifactsByID(snapshot.Artifacts)
-	handoffsByID := projectOperationsSnapshotHandoffsByID(snapshot.Handoffs)
+	activity, err := h.renderCairnlineProjectActivity(ctx, project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	cairnlineWorkItems, err := service.ListWorkItems(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	cairnlineAssignments, err := service.ListAssignments(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	workItems := projectWorkItemsFromCairnline(cairnlineWorkItems)
+	assignments := projectWorkAssignmentsFromCairnline(cairnlineAssignments, snapshot.Assignments)
+	artifacts, err := projectHealthCairnlineArtifacts(ctx, service, snapshot.Project.ID, cairnlineWorkItems)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	handoffs, err := projectHealthCairnlineHandoffs(ctx, service, snapshot.Project.ID, cairnlineWorkItems)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	pendingCandidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+		ProjectID: snapshot.Project.ID,
+		Status:    cairnline.MemoryCandidatePending,
+	})
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
 
-	items := make([]ProjectOperationsBriefItemResponse, 0, len(brief.Items)+len(projectDefaultOperationItems(project))+1)
+	items := make([]ProjectOperationsBriefItemResponse, 0, projectOperationsBriefItemLimit)
 	items = append(items, projectDefaultOperationItems(project)...)
-	for _, item := range brief.Items {
-		rendered, ok := projectOperationItemFromCairnline(project.ID, item, workItemsByID, assignmentsByID, assignmentsByWorkItem, artifactsByID, handoffsByID)
-		if ok {
-			items = append(items, rendered)
-		}
+	items = append(items, assignmentOperationItems(activity)...)
+	items = append(items, handoffOperationItems(project.ID, handoffs)...)
+	items = append(items, selectedWorkFollowThroughOperationItems(project.ID, workItems, assignments, artifacts, handoffs)...)
+	if len(pendingCandidates) > 0 {
+		items = append(items, memoryCandidateOperationItem(project.ID, len(pendingCandidates)))
 	}
-	if brief.Counts.PendingMemoryCandidates > 0 {
-		items = append(items, memoryCandidateOperationItem(project.ID, brief.Counts.PendingMemoryCandidates))
-	}
-	if len(snapshot.WorkItems) == 0 {
-		items = append(items, assignmentGapOperationItems(project.ID, nil, nil)...)
-	}
+	items = append(items, assignmentGapOperationItems(project.ID, workItems, assignments)...)
 	if len(items) == 0 {
-		if item := latestWorkOperationItem(project.ID, snapshot.WorkItems); item != nil {
+		if item := latestWorkOperationItem(project.ID, workItems); item != nil {
 			items = append(items, *item)
 		}
 	}
@@ -55,7 +73,7 @@ func (h *Handler) renderCairnlineProjectOperationsBrief(ctx context.Context, pro
 	items = boundedProjectOperationsItems(items, projectOperationsBriefItemLimit)
 	response := ProjectOperationsBriefResponse{
 		ProjectID:   project.ID,
-		GeneratedAt: formatOptionalTime(firstNonZeroTime(brief.CreatedAt, time.Now().UTC())),
+		GeneratedAt: formatOptionalTime(time.Now().UTC()),
 		ReadBackend: "cairnline",
 		Items:       items,
 	}
@@ -63,8 +81,12 @@ func (h *Handler) renderCairnlineProjectOperationsBrief(ctx context.Context, pro
 	response.Summary.AvailableItemCount = availableItemCount
 	response.Summary.OmittedItemCount = availableItemCount - len(items)
 	response.Summary.ItemLimit = projectOperationsBriefItemLimit
-	response.Summary.PendingMemoryCandidateCount = brief.Counts.PendingMemoryCandidates
-	response.Summary.PendingHandoffCount = brief.Counts.OpenHandoffs
+	response.Summary.PendingMemoryCandidateCount = len(pendingCandidates)
+	for _, handoff := range handoffs {
+		if handoff.Status == projectwork.HandoffStatusPending {
+			response.Summary.PendingHandoffCount++
+		}
+	}
 	for _, item := range items {
 		switch item.Priority {
 		case projectOperationsPriorityHigh:

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
+	"github.com/hecatehq/hecate/pkg/types"
 )
 
 func TestProjectOperationsBrief_ReadOnlyProjectOperations(t *testing.T) {
@@ -190,6 +192,39 @@ func TestProjectOperationsBrief_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CreateAssignment: %v", err)
 	}
+	base := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	if _, err := handler.taskStore.CreateTask(t.Context(), types.Task{
+		ID:          "task_cairnline",
+		Title:       "Cairnline approval task",
+		Status:      "awaiting_approval",
+		LatestRunID: "run_cairnline",
+		CreatedAt:   base,
+		UpdatedAt:   base.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := handler.taskStore.CreateRun(t.Context(), types.TaskRun{
+		ID:            "run_cairnline",
+		TaskID:        "task_cairnline",
+		Number:        1,
+		Status:        "awaiting_approval",
+		ApprovalCount: 2,
+		StartedAt:     base,
+	}); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	for _, approvalID := range []string{"ap_cairnline_1", "ap_cairnline_2"} {
+		if _, err := handler.taskStore.CreateApproval(t.Context(), types.TaskApproval{
+			ID:        approvalID,
+			TaskID:    "task_cairnline",
+			RunID:     "run_cairnline",
+			Kind:      "agent_loop_tool_call",
+			Status:    "pending",
+			CreatedAt: base,
+		}); err != nil {
+			t.Fatalf("CreateApproval(%s): %v", approvalID, err)
+		}
+	}
 	if _, err := handler.memoryCandidates.CreateCandidate(t.Context(), memory.Candidate{
 		ID:        "memcand_cairnline_ops",
 		ProjectID: "proj_cairnline_ops",
@@ -219,13 +254,62 @@ func TestProjectOperationsBrief_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	if approval.Target.AssignmentID != "asgn_cairnline_approval" || approval.Action.Type != projectOperationsActionOpenWorkItem || approval.Status != "awaiting_approval" {
 		t.Fatalf("approval item = %+v, want Hecate action projection over Cairnline assignment item", approval)
 	}
-	if approval.Detail != "2 approvals pending" {
+	if approval.Detail != "2 approval pending" {
 		t.Fatalf("approval detail = %q, want pending approval count preserved", approval.Detail)
 	}
 	memoryItem := findProjectOperationsItemForTest(t, response.Data.Items, "review_memory_candidates")
 	if memoryItem.Target.Surface != "memory" || memoryItem.Action.Type != projectOperationsActionOpenMemoryReview {
 		t.Fatalf("memory item = %+v, want memory review action", memoryItem)
 	}
+}
+
+func TestProjectOperationsBrief_CairnlineMatchesHecateProjectionGraph(t *testing.T) {
+	t.Parallel()
+	hecateHandler, hecateServer := newProjectWorkProjectionTestServer(t, "memory")
+	seedProjectWorkProjectionTest(t, hecateHandler)
+	cairnlineHandler, cairnlineServer := newProjectWorkCairnlineReadTestServer()
+	seedProjectWorkProjectionTest(t, cairnlineHandler)
+
+	hecate := mustRequestJSON[ProjectOperationsBriefEnvelope](newAPITestClient(t, hecateServer), http.MethodGet, "/hecate/v1/projects/proj_projection/operations/brief", "")
+	cairnline := mustRequestJSON[ProjectOperationsBriefEnvelope](newAPITestClient(t, cairnlineServer), http.MethodGet, "/hecate/v1/projects/proj_projection/operations/brief", "")
+	if hecate.Data.ReadBackend != "hecate" {
+		t.Fatalf("Hecate operations read_backend = %q, want hecate", hecate.Data.ReadBackend)
+	}
+	if cairnline.Data.ReadBackend != "cairnline" {
+		t.Fatalf("Cairnline operations read_backend = %q, want cairnline", cairnline.Data.ReadBackend)
+	}
+
+	hecateData := normalizeProjectOperationsBriefForParity(hecate.Data)
+	cairnlineData := normalizeProjectOperationsBriefForParity(cairnline.Data)
+	if !reflect.DeepEqual(hecateData, cairnlineData) {
+		t.Fatalf("operations mismatch\nHecate:   %+v\nCairnline: %+v", hecateData, cairnlineData)
+	}
+}
+
+func normalizeProjectOperationsBriefForParity(item ProjectOperationsBriefResponse) ProjectOperationsBriefResponse {
+	item.GeneratedAt = ""
+	item.ReadBackend = ""
+	for idx := range item.Items {
+		item.Items[idx].UpdatedAt = ""
+		if item.Items[idx].Assignment != nil {
+			item.Items[idx].Assignment.ReadBackend = ""
+			item.Items[idx].Assignment.CreatedAt = ""
+			item.Items[idx].Assignment.UpdatedAt = ""
+			item.Items[idx].Assignment.StartedAt = ""
+			item.Items[idx].Assignment.CompletedAt = ""
+			if item.Items[idx].Assignment.Execution != nil {
+				item.Items[idx].Assignment.Execution.StartedAt = ""
+				item.Items[idx].Assignment.Execution.FinishedAt = ""
+			}
+		}
+		if item.Items[idx].Handoff != nil {
+			item.Items[idx].Handoff.ReadBackend = ""
+			item.Items[idx].Handoff.CreatedAt = ""
+			item.Items[idx].Handoff.UpdatedAt = ""
+			item.Items[idx].Handoff.StatusChangedAt = ""
+		}
+	}
+	return item
 }
 
 func TestProjectOperationsBrief_SummaryReportsBoundedItems(t *testing.T) {

--- a/internal/api/handler_project_roots_discovery.go
+++ b/internal/api/handler_project_roots_discovery.go
@@ -58,6 +58,7 @@ func (h *Handler) HandleDiscoverProjectRoots(w http.ResponseWriter, r *http.Requ
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectIdentityToCairnline(r.Context(), "project_roots_discover", updated)
 	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(updated)})
 }
 
@@ -98,6 +99,7 @@ func (h *Handler) HandleCreateProjectWorktreeRoot(w http.ResponseWriter, r *http
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectIdentityToCairnline(r.Context(), "project_worktree_root_create", updated)
 	WriteJSON(w, http.StatusCreated, ProjectResponse{Object: "project", Data: renderProject(updated)})
 }
 

--- a/internal/api/handler_project_roots_discovery_test.go
+++ b/internal/api/handler_project_roots_discovery_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/projects"
 )
@@ -72,7 +73,10 @@ func TestProjectRootsDiscovery_MergesGitWorktrees(t *testing.T) {
 func TestProjectRoots_CreateWorktreeRoot(t *testing.T) {
 	t.Parallel()
 	repo := initProjectRootDiscoveryRepo(t)
-	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
 	projectStore := projects.NewMemoryStore()
 	handler.SetProjectStore(projectStore)
 	server := NewServer(quietLogger(), handler)
@@ -121,6 +125,25 @@ func TestProjectRoots_CreateWorktreeRoot(t *testing.T) {
 	}
 	if strings.TrimSpace(string(branch)) != "feature/create-root" {
 		t.Fatalf("created worktree branch = %q, want feature/create-root", strings.TrimSpace(string(branch)))
+	}
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	mirrored, err := service.GetProject(t.Context(), "proj_roots")
+	if err != nil {
+		t.Fatalf("GetProject(proj_roots): %v", err)
+	}
+	var mirroredRootFound bool
+	for _, root := range mirrored.Roots {
+		if root.ID == created.ID && root.Kind == "git_worktree" && root.GitBranch == "feature/create-root" && root.Active {
+			mirroredRootFound = true
+		}
+	}
+	if !mirroredRootFound || mirrored.DefaultRootID != created.ID {
+		t.Fatalf("mirrored roots = %+v default=%q, want created active worktree root as default", mirrored.Roots, mirrored.DefaultRootID)
 	}
 }
 

--- a/internal/api/handler_project_setup_readiness_test.go
+++ b/internal/api/handler_project_setup_readiness_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/config"
@@ -255,6 +256,91 @@ func TestProjectSetupReadiness_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	if response.Data.Summary.MissingDefaults || !response.Data.Summary.HasPurpose || !response.Data.Summary.HasActiveRoot {
 		t.Fatalf("setup readiness summary = %+v, want Hecate defaults/purpose/root over Cairnline setup counts", response.Data.Summary)
 	}
+}
+
+func TestProjectSetupReadiness_CairnlineMatchesHecate(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	hecateHandler, hecateServer := newProjectWorkTestServer()
+	seedProjectSetupReadinessReadyTest(t, hecateHandler, root)
+	cairnlineHandler, cairnlineServer := newProjectWorkCairnlineReadTestServer()
+	seedProjectSetupReadinessReadyTest(t, cairnlineHandler, root)
+
+	hecate := mustRequestJSON[ProjectSetupReadinessEnvelope](newAPITestClient(t, hecateServer), http.MethodGet, "/hecate/v1/projects/proj_setup_parity/setup-readiness", "")
+	cairnline := mustRequestJSON[ProjectSetupReadinessEnvelope](newAPITestClient(t, cairnlineServer), http.MethodGet, "/hecate/v1/projects/proj_setup_parity/setup-readiness", "")
+	if hecate.Data.ReadBackend != "hecate" {
+		t.Fatalf("Hecate setup readiness read_backend = %q, want hecate", hecate.Data.ReadBackend)
+	}
+	if cairnline.Data.ReadBackend != "cairnline" {
+		t.Fatalf("Cairnline setup readiness read_backend = %q, want cairnline", cairnline.Data.ReadBackend)
+	}
+
+	hecateData := normalizeProjectSetupReadinessForParity(hecate.Data)
+	cairnlineData := normalizeProjectSetupReadinessForParity(cairnline.Data)
+	if !reflect.DeepEqual(hecateData, cairnlineData) {
+		t.Fatalf("setup readiness mismatch\nHecate:   %+v\nCairnline: %+v", hecateData, cairnlineData)
+	}
+}
+
+func seedProjectSetupReadinessReadyTest(t *testing.T, handler *Handler, root string) {
+	t.Helper()
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:              "proj_setup_parity",
+		Name:            "Setup parity",
+		Description:     "Coordinate setup parity.",
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-5",
+		Roots:           []projects.Root{{ID: "root_setup_parity", Path: root, Kind: "git", Active: true}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_setup_parity",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Path:    "AGENTS.md",
+			Enabled: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:        "role_setup_parity",
+		ProjectID: "proj_setup_parity",
+		Name:      "Coordinator",
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := handler.projectSkills.UpsertDiscovered(t.Context(), "proj_setup_parity", []projectskills.Skill{{
+		ID:        "skill_setup_parity",
+		ProjectID: "proj_setup_parity",
+		Path:      "skills/setup/SKILL.md",
+		Enabled:   true,
+		Status:    projectskills.StatusAvailable,
+	}}); err != nil {
+		t.Fatalf("UpsertDiscovered: %v", err)
+	}
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:        "mem_setup_parity",
+		ProjectID: "proj_setup_parity",
+		Title:     "Setup posture",
+		Body:      "Keep setup explicit.",
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Create memory: %v", err)
+	}
+	if _, err := handler.memoryCandidates.CreateCandidate(t.Context(), memory.Candidate{
+		ID:        "memcand_setup_parity",
+		ProjectID: "proj_setup_parity",
+		Title:     "Candidate",
+		Body:      "Review me.",
+		Status:    memory.CandidateStatusPending,
+	}); err != nil {
+		t.Fatalf("CreateCandidate: %v", err)
+	}
+}
+
+func normalizeProjectSetupReadinessForParity(item ProjectSetupReadinessResponse) ProjectSetupReadinessResponse {
+	item.GeneratedAt = ""
+	item.ReadBackend = ""
+	return item
 }
 
 func findProjectSetupReadinessCheckForTest(t *testing.T, checks []ProjectSetupReadinessCheckResponse, id string) ProjectSetupReadinessCheckResponse {

--- a/internal/api/handler_project_skills.go
+++ b/internal/api/handler_project_skills.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/projectskills"
 )
 
@@ -31,12 +33,12 @@ func (h *Handler) HandleProjectSkills(w http.ResponseWriter, r *http.Request) {
 	if !h.requireProjectExists(w, r, r.PathValue("id")) {
 		return
 	}
-	items, err := h.projectSkills.List(r.Context(), r.PathValue("id"))
+	items, err := h.renderProjectSkills(r.Context(), r.PathValue("id"))
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectSkillsResponse{Object: "project_skills", Data: renderProjectSkills(items)})
+	WriteJSON(w, http.StatusOK, ProjectSkillsResponse{Object: "project_skills", Data: items})
 }
 
 func (h *Handler) HandleDiscoverProjectSkills(w http.ResponseWriter, r *http.Request) {
@@ -68,7 +70,8 @@ func (h *Handler) HandleDiscoverProjectSkills(w http.ResponseWriter, r *http.Req
 			items[idx].Warnings = appendUniqueProjectSkillWarnings(items[idx].Warnings, warnings...)
 		}
 	}
-	WriteJSON(w, http.StatusOK, ProjectSkillsResponse{Object: "project_skills", Data: renderProjectSkills(items)})
+	h.mirrorProjectSkillsToCairnline(r.Context(), "project_skills_discover", project, items)
+	WriteJSON(w, http.StatusOK, ProjectSkillsResponse{Object: "project_skills", Data: renderProjectSkills(items, "hecate")})
 }
 
 func (h *Handler) HandleUpdateProjectSkill(w http.ResponseWriter, r *http.Request) {
@@ -76,7 +79,13 @@ func (h *Handler) HandleUpdateProjectSkill(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project skills store is not configured")
 		return
 	}
-	if !h.requireProjectExists(w, r, r.PathValue("id")) {
+	project, ok, err := h.projects.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if !ok {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
 	}
 	var req updateProjectSkillRequest
@@ -109,21 +118,51 @@ func (h *Handler) HandleUpdateProjectSkill(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectSkillResponse{Object: "project_skill", Data: renderProjectSkill(item)})
+	h.mirrorProjectSkillsToCairnline(r.Context(), "project_skill_update", project, []projectskills.Skill{item})
+	WriteJSON(w, http.StatusOK, ProjectSkillResponse{Object: "project_skill", Data: renderProjectSkill(item, "hecate")})
 }
 
-func renderProjectSkills(items []projectskills.Skill) []ProjectSkillResponseItem {
+func (h *Handler) renderProjectSkills(ctx context.Context, projectID string) ([]ProjectSkillResponseItem, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectSkills(ctx, projectID)
+	}
+	items, err := h.projectSkills.List(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	return renderProjectSkills(items, "hecate"), nil
+}
+
+func (h *Handler) renderCairnlineProjectSkills(ctx context.Context, projectID string) ([]ProjectSkillResponseItem, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := service.ListProjectSkills(ctx, snapshot.Project.ID)
+	if err != nil {
+		return nil, err
+	}
+	nativeByID := projectSkillsByID(snapshot.Skills)
 	out := make([]ProjectSkillResponseItem, 0, len(items))
 	for _, item := range items {
-		out = append(out, renderProjectSkill(item))
+		out = append(out, renderProjectSkill(projectSkillFromCairnline(item, nativeByID[item.ID]), "cairnline"))
+	}
+	return out, nil
+}
+
+func renderProjectSkills(items []projectskills.Skill, readBackend string) []ProjectSkillResponseItem {
+	out := make([]ProjectSkillResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderProjectSkill(item, readBackend))
 	}
 	return out
 }
 
-func renderProjectSkill(item projectskills.Skill) ProjectSkillResponseItem {
+func renderProjectSkill(item projectskills.Skill, readBackend string) ProjectSkillResponseItem {
 	return ProjectSkillResponseItem{
 		ID:                     item.ID,
 		ProjectID:              item.ProjectID,
+		ReadBackend:            readBackend,
 		Title:                  item.Title,
 		Description:            item.Description,
 		Path:                   item.Path,
@@ -139,6 +178,36 @@ func renderProjectSkill(item projectskills.Skill) ProjectSkillResponseItem {
 		DiscoveredAt:           formatProjectSkillTime(item.DiscoveredAt),
 		CreatedAt:              formatProjectSkillTime(item.CreatedAt),
 		UpdatedAt:              formatProjectSkillTime(item.UpdatedAt),
+	}
+}
+
+func projectSkillsByID(items []projectskills.Skill) map[string]projectskills.Skill {
+	out := make(map[string]projectskills.Skill, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func projectSkillFromCairnline(item cairnline.ProjectSkill, native projectskills.Skill) projectskills.Skill {
+	return projectskills.Skill{
+		ID:                     item.ID,
+		ProjectID:              item.ProjectID,
+		Title:                  item.Title,
+		Description:            item.Description,
+		Path:                   item.Path,
+		RootID:                 item.RootID,
+		Format:                 item.Format,
+		SuggestedTools:         append([]string(nil), native.SuggestedTools...),
+		RequiredPermissions:    native.RequiredPermissions,
+		Enabled:                item.Enabled,
+		Status:                 item.Status,
+		TrustLabel:             item.TrustLabel,
+		SourceContextSourceIDs: append([]string(nil), item.SourceRefs...),
+		Warnings:               append([]string(nil), item.Warnings...),
+		DiscoveredAt:           item.DiscoveredAt,
+		CreatedAt:              item.CreatedAt,
+		UpdatedAt:              item.UpdatedAt,
 	}
 }
 

--- a/internal/api/handler_project_skills_test.go
+++ b/internal/api/handler_project_skills_test.go
@@ -7,10 +7,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
 )
 
 func TestProjectSkillsAPI_DiscoverListAndPatch(t *testing.T) {
@@ -136,6 +139,238 @@ func TestProjectSkillsAPI_DiscoverReportsConflicts(t *testing.T) {
 	}
 }
 
+func TestProjectSkillsAPI_ListUsesCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_skills_cairnline",
+		Name: "Skills Cairnline",
+		Roots: []projects.Root{{
+			ID:     "root_skills_cairnline",
+			Path:   t.TempDir(),
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_agents",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Path:    "AGENTS.md",
+			Enabled: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	tools := true
+	writes := false
+	if _, err := handler.projectSkills.UpsertDiscovered(t.Context(), "proj_skills_cairnline", []projectskills.Skill{{
+		ID:          "backend",
+		ProjectID:   "proj_skills_cairnline",
+		Title:       "Backend",
+		Description: "Build backend changes.",
+		Path:        ".agents/skills/backend/SKILL.md",
+		RootID:      "root_skills_cairnline",
+		Format:      projectskills.FormatSkillMD,
+		Enabled:     true,
+		Status:      projectskills.StatusAvailable,
+		TrustLabel:  projectskills.TrustWorkspaceSkill,
+		SuggestedTools: []string{
+			"git.diff",
+		},
+		RequiredPermissions: projectskills.RequiredPermissions{
+			Tools:  &tools,
+			Writes: &writes,
+		},
+		SourceContextSourceIDs: []string{"ctx_agents"},
+		Warnings:               []string{"metadata-only skill"},
+	}}); err != nil {
+		t.Fatalf("Upsert skills: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_skills_cairnline/skills", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listed ProjectSkillsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	backend := projectSkillResponseFor(listed.Data, "backend")
+	if backend == nil {
+		t.Fatalf("listed skills = %+v, want backend skill", listed.Data)
+	}
+	if backend.ReadBackend != "cairnline" || backend.Path != ".agents/skills/backend/SKILL.md" || backend.RootID != "root_skills_cairnline" || backend.TrustLabel != projectskills.TrustWorkspaceSkill {
+		t.Fatalf("backend skill = %+v, want Cairnline-projected portable metadata", *backend)
+	}
+	if len(backend.SourceContextSourceIDs) != 1 || backend.SourceContextSourceIDs[0] != "ctx_agents" || len(backend.Warnings) != 1 || backend.Warnings[0] != "metadata-only skill" {
+		t.Fatalf("backend provenance = sources %+v warnings %+v, want Cairnline-projected source refs and warnings", backend.SourceContextSourceIDs, backend.Warnings)
+	}
+	if len(backend.SuggestedTools) != 1 || backend.SuggestedTools[0] != "git.diff" {
+		t.Fatalf("backend suggested tools = %+v, want Hecate snapshot enrichment", backend.SuggestedTools)
+	}
+	if backend.RequiredPermissions == nil || backend.RequiredPermissions.Tools == nil || !*backend.RequiredPermissions.Tools || backend.RequiredPermissions.Writes == nil || *backend.RequiredPermissions.Writes {
+		t.Fatalf("backend required permissions = %+v, want Hecate snapshot enrichment", backend.RequiredPermissions)
+	}
+
+	nativeSkills, err := handler.projectSkills.List(t.Context(), "proj_skills_cairnline")
+	if err != nil {
+		t.Fatalf("List native skills: %v", err)
+	}
+	assertProjectSkillsProjectionParity(t, renderProjectSkills(nativeSkills, "hecate"), listed.Data)
+}
+
+func TestProjectSkillsAPI_MirrorsMutationsToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	root := t.TempDir()
+	writeProjectSkillAPITestFile(t, root, ".agents/skills/backend/SKILL.md", `---
+name: Backend
+description: Build backend changes.
+---
+`)
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_skills_mirror",
+		Name: "Skills Mirror",
+		Roots: []projects.Root{{
+			ID:     "root_skills_mirror",
+			Path:   root,
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_agents",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Path:    "AGENTS.md",
+			Enabled: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	discoverRec := httptest.NewRecorder()
+	server.ServeHTTP(discoverRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_skills_mirror/skills/discover", nil))
+	if discoverRec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", discoverRec.Code, discoverRec.Body.String())
+	}
+	mirrored := getMirroredCairnlineProjectSkillForTest(t, handler, "proj_skills_mirror", "backend")
+	if mirrored.Title != "Backend" || mirrored.Path != ".agents/skills/backend/SKILL.md" || !mirrored.Enabled || mirrored.Status != projectskills.StatusAvailable {
+		t.Fatalf("mirrored discovered skill = %+v, want available Backend skill", mirrored)
+	}
+	if mirrored.TrustLabel != projectskills.TrustWorkspaceSkill {
+		t.Fatalf("mirrored trust label = %q, want workspace skill", mirrored.TrustLabel)
+	}
+
+	patchRec := httptest.NewRecorder()
+	server.ServeHTTP(patchRec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/proj_skills_mirror/skills/backend", projectSkillAPITestJSONBody(t, map[string]any{
+		"enabled":     false,
+		"title":       "Backend Owner",
+		"description": "Operator-reviewed backend guidance.",
+		"trust_label": "operator_curated_skill",
+	})))
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s, want 200", patchRec.Code, patchRec.Body.String())
+	}
+	mirrored = getMirroredCairnlineProjectSkillForTest(t, handler, "proj_skills_mirror", "backend")
+	if mirrored.Enabled || mirrored.Title != "Backend Owner" || mirrored.Description != "Operator-reviewed backend guidance." || mirrored.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("mirrored patched skill = %+v, want operator-curated disabled skill", mirrored)
+	}
+}
+
+func TestProjectSkillsAPI_MirrorRefreshesSkillSourceRefsOnRediscovery(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	root := t.TempDir()
+	writeProjectSkillAPITestFile(t, root, "docs-ai/skills/backend/SKILL.md", "# Backend\n")
+	writeProjectSkillAPITestFile(t, root, "AGENTS.md", "Use docs-ai/skills/backend/SKILL.md.\n")
+	writeProjectSkillAPITestFile(t, root, "CLAUDE.md", "Use docs-ai/skills/backend/SKILL.md.\n")
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_skills_refs",
+		Name: "Skill Source Refs",
+		Roots: []projects.Root{{
+			ID:     "root_skills_refs",
+			Path:   root,
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_agents",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Path:    "AGENTS.md",
+			Enabled: true,
+			Format:  "agents_md",
+			Metadata: map[string]string{
+				"root_id": "root_skills_refs",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	discoverRec := httptest.NewRecorder()
+	server.ServeHTTP(discoverRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_skills_refs/skills/discover", nil))
+	if discoverRec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", discoverRec.Code, discoverRec.Body.String())
+	}
+	mirrored := getMirroredCairnlineProjectSkillForTest(t, handler, project.ID, "backend")
+	if !stringSliceContains(mirrored.SourceRefs, "ctx_agents") {
+		t.Fatalf("initial mirrored source refs = %+v, want ctx_agents", mirrored.SourceRefs)
+	}
+
+	patchRec := httptest.NewRecorder()
+	server.ServeHTTP(patchRec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/proj_skills_refs/skills/backend", projectSkillAPITestJSONBody(t, map[string]any{
+		"enabled":     false,
+		"title":       "Backend Owner",
+		"description": "Operator-reviewed backend guidance.",
+		"trust_label": "operator_curated_skill",
+	})))
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s, want 200", patchRec.Code, patchRec.Body.String())
+	}
+	if _, err := handler.projects.Update(t.Context(), project.ID, func(project *projects.Project) {
+		project.ContextSources = []projects.ContextSource{{
+			ID:      "ctx_claude",
+			Kind:    "workspace_instruction",
+			Title:   "CLAUDE.md",
+			Path:    "CLAUDE.md",
+			Enabled: true,
+			Format:  "claude_md",
+			Metadata: map[string]string{
+				"root_id": "root_skills_refs",
+			},
+		}}
+	}); err != nil {
+		t.Fatalf("Update project context sources: %v", err)
+	}
+
+	rediscoverRec := httptest.NewRecorder()
+	server.ServeHTTP(rediscoverRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_skills_refs/skills/discover", nil))
+	if rediscoverRec.Code != http.StatusOK {
+		t.Fatalf("rediscover status = %d body=%s, want 200", rediscoverRec.Code, rediscoverRec.Body.String())
+	}
+	mirrored = getMirroredCairnlineProjectSkillForTest(t, handler, project.ID, "backend")
+	if mirrored.Enabled || mirrored.Title != "Backend Owner" || mirrored.Description != "Operator-reviewed backend guidance." || mirrored.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("rediscovered mirrored skill = %+v, want operator overrides preserved", mirrored)
+	}
+	if !stringSliceContains(mirrored.SourceRefs, "ctx_claude") || stringSliceContains(mirrored.SourceRefs, "ctx_agents") {
+		t.Fatalf("rediscovered mirrored source refs = %+v, want ctx_claude only", mirrored.SourceRefs)
+	}
+}
+
 func projectSkillResponseHas(items []ProjectSkillResponseItem, id string, enabled bool, trustLabel string) bool {
 	for _, item := range items {
 		if item.ID == id && item.Enabled == enabled && item.TrustLabel == trustLabel {
@@ -154,6 +389,28 @@ func projectSkillResponseFor(items []ProjectSkillResponseItem, id string) *Proje
 	return nil
 }
 
+func assertProjectSkillsProjectionParity(t *testing.T, hecate, cairnline []ProjectSkillResponseItem) {
+	t.Helper()
+	if len(hecate) != len(cairnline) {
+		t.Fatalf("skill projection count = hecate:%d cairnline:%d", len(hecate), len(cairnline))
+	}
+	normalizedHecate := append([]ProjectSkillResponseItem(nil), hecate...)
+	normalizedCairnline := append([]ProjectSkillResponseItem(nil), cairnline...)
+	for idx := range normalizedHecate {
+		if normalizedHecate[idx].ReadBackend != "hecate" {
+			t.Fatalf("hecate skill[%d] read_backend = %q, want hecate", idx, normalizedHecate[idx].ReadBackend)
+		}
+		if normalizedCairnline[idx].ReadBackend != "cairnline" {
+			t.Fatalf("cairnline skill[%d] read_backend = %q, want cairnline", idx, normalizedCairnline[idx].ReadBackend)
+		}
+		normalizedHecate[idx].ReadBackend = ""
+		normalizedCairnline[idx].ReadBackend = ""
+	}
+	if !reflect.DeepEqual(normalizedHecate, normalizedCairnline) {
+		t.Fatalf("skill projection mismatch\nhecate:   %+v\ncairnline: %+v", normalizedHecate, normalizedCairnline)
+	}
+}
+
 func projectSkillAPITestJSONBody(t *testing.T, payload any) *bytes.Reader {
 	t.Helper()
 	raw, err := json.Marshal(payload)
@@ -161,6 +418,20 @@ func projectSkillAPITestJSONBody(t *testing.T, payload any) *bytes.Reader {
 		t.Fatalf("marshal payload: %v", err)
 	}
 	return bytes.NewReader(raw)
+}
+
+func getMirroredCairnlineProjectSkillForTest(t *testing.T, handler *Handler, projectID, skillID string) cairnline.ProjectSkill {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	skill, err := service.GetProjectSkill(t.Context(), projectID, skillID)
+	if err != nil {
+		t.Fatalf("GetProjectSkill(%q, %q): %v", projectID, skillID, err)
+	}
+	return skill
 }
 
 func writeProjectSkillAPITestFile(t *testing.T, root, rel, body string) {

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -160,6 +160,7 @@ type ProjectWorkRoleResponse struct {
 	DefaultAgentProfile string   `json:"default_agent_profile,omitempty"`
 	SkillIDs            []string `json:"skill_ids,omitempty"`
 	BuiltIn             bool     `json:"built_in"`
+	ReadBackend         string   `json:"read_backend,omitempty"`
 	CreatedAt           string   `json:"created_at,omitempty"`
 	UpdatedAt           string   `json:"updated_at,omitempty"`
 }
@@ -268,6 +269,7 @@ type ProjectWorkArtifactResponse struct {
 	ID                     string `json:"id"`
 	ProjectID              string `json:"project_id"`
 	WorkItemID             string `json:"work_item_id"`
+	ReadBackend            string `json:"read_backend,omitempty"`
 	AssignmentID           string `json:"assignment_id,omitempty"`
 	Kind                   string `json:"kind"`
 	Title                  string `json:"title,omitempty"`
@@ -300,6 +302,7 @@ type ProjectHandoffResponse struct {
 	ID                    string   `json:"id"`
 	ProjectID             string   `json:"project_id"`
 	WorkItemID            string   `json:"work_item_id"`
+	ReadBackend           string   `json:"read_backend,omitempty"`
 	SourceAssignmentID    string   `json:"source_assignment_id,omitempty"`
 	SourceRunID           string   `json:"source_run_id,omitempty"`
 	SourceChatSessionID   string   `json:"source_chat_session_id,omitempty"`
@@ -340,14 +343,10 @@ func (h *Handler) HandleProjectWorkRoles(w http.ResponseWriter, r *http.Request)
 	if !h.requireProject(w, r, projectID) {
 		return
 	}
-	roles, err := h.projectWork.ListRoles(r.Context(), projectID)
+	data, err := h.renderProjectWorkRoles(r.Context(), projectID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
-	}
-	data := make([]ProjectWorkRoleResponse, 0, len(roles))
-	for _, role := range roles {
-		data = append(data, renderProjectWorkRole(role))
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkRolesResponse{Object: "project_roles", Data: data})
 }
@@ -375,6 +374,7 @@ func (h *Handler) HandleCreateProjectWorkRole(w http.ResponseWriter, r *http.Req
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectRoleByIDToCairnline(r.Context(), "project_role_create", projectID, role)
 	WriteJSON(w, http.StatusCreated, ProjectWorkRoleEnvelope{Object: "project_role", Data: renderProjectWorkRole(role)})
 }
 
@@ -400,6 +400,7 @@ func (h *Handler) HandleUpdateProjectWorkRole(w http.ResponseWriter, r *http.Req
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectRoleByIDToCairnline(r.Context(), "project_role_update", projectID, role)
 	WriteJSON(w, http.StatusOK, ProjectWorkRoleEnvelope{Object: "project_role", Data: renderProjectWorkRole(role)})
 }
 
@@ -408,8 +409,12 @@ func (h *Handler) HandleDeleteProjectWorkRole(w http.ResponseWriter, r *http.Req
 	if !h.requireProject(w, r, projectID) {
 		return
 	}
+	role, roleLoaded := h.projectWorkRoleForCairnlineMirror(r.Context(), "project_role_delete", projectID, r.PathValue("role_id"))
 	if err := h.projectWorkApplication().DeleteRole(r.Context(), projectID, r.PathValue("role_id")); !writeProjectWorkError(w, err) {
 		return
+	}
+	if roleLoaded {
+		h.mirrorProjectRoleDeleteToCairnline(r.Context(), "project_role_delete", role)
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -452,6 +457,7 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectWorkItemByIDToCairnline(r.Context(), "project_work_item_create", projectID, item)
 	projected, err := h.renderProjectedProjectWorkItem(r.Context(), item)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -521,6 +527,7 @@ func (h *Handler) HandleUpdateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectWorkItemByIDToCairnline(r.Context(), "project_work_item_update", projectID, item)
 	projected, err := h.renderProjectedProjectWorkItem(r.Context(), item)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -537,6 +544,7 @@ func (h *Handler) HandleDeleteProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if err := h.projectWorkApplication().DeleteWorkItem(r.Context(), projectID, r.PathValue("work_item_id")); !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectWorkItemDeleteToCairnline(r.Context(), "project_work_item_delete", projectID, r.PathValue("work_item_id"))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -603,6 +611,7 @@ func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectAssignmentToCairnline(r.Context(), "project_assignment_create", item)
 	projected, err := h.renderProjectedProjectWorkAssignment(r.Context(), item)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -649,6 +658,7 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectAssignmentToCairnline(r.Context(), "project_assignment_update", item)
 	projected, err := h.renderProjectedProjectWorkAssignment(r.Context(), item)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -667,6 +677,7 @@ func (h *Handler) HandleDeleteProjectWorkAssignment(w http.ResponseWriter, r *ht
 	if err := h.projectWorkApplication().DeleteAssignment(r.Context(), projectID, workItemID, assignmentID); !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectAssignmentDeleteToCairnline(r.Context(), "project_assignment_delete", projectID, assignmentID)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -743,14 +754,9 @@ func (h *Handler) HandleProjectWorkArtifacts(w http.ResponseWriter, r *http.Requ
 	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
-	items, err := h.projectWork.ListArtifacts(r.Context(), projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: workItemID})
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	data, err := h.renderProjectWorkArtifacts(r.Context(), projectID, workItemID)
+	if !writeProjectWorkError(w, err) {
 		return
-	}
-	data := make([]ProjectWorkArtifactResponse, 0, len(items))
-	for _, item := range items {
-		data = append(data, renderProjectWorkArtifact(item))
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkArtifactsResponse{Object: "project_collaboration_artifacts", Data: data})
 }
@@ -785,6 +791,7 @@ func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectArtifactToCairnline(r.Context(), "project_artifact_create", item)
 	WriteJSON(w, http.StatusCreated, ProjectWorkArtifactEnvelope{Object: "project_collaboration_artifact", Data: renderProjectWorkArtifact(item)})
 }
 
@@ -798,13 +805,9 @@ func (h *Handler) HandleProjectHandoffs(w http.ResponseWriter, r *http.Request) 
 		WorkItemID: strings.TrimSpace(r.URL.Query().Get("work_item_id")),
 		Status:     strings.TrimSpace(r.URL.Query().Get("status")),
 	}
-	items, err := h.projectWork.ListHandoffs(r.Context(), filter)
+	data, err := h.renderProjectHandoffs(r.Context(), filter)
 	if !writeProjectWorkError(w, err) {
 		return
-	}
-	data := make([]ProjectHandoffResponse, 0, len(items))
-	for _, item := range items {
-		data = append(data, renderProjectHandoff(item))
 	}
 	WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
 }
@@ -815,17 +818,13 @@ func (h *Handler) HandleProjectWorkItemHandoffs(w http.ResponseWriter, r *http.R
 	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
-	items, err := h.projectWork.ListHandoffs(r.Context(), projectwork.HandoffFilter{
+	data, err := h.renderProjectHandoffs(r.Context(), projectwork.HandoffFilter{
 		ProjectID:  projectID,
 		WorkItemID: workItemID,
 		Status:     strings.TrimSpace(r.URL.Query().Get("status")),
 	})
 	if !writeProjectWorkError(w, err) {
 		return
-	}
-	data := make([]ProjectHandoffResponse, 0, len(items))
-	for _, item := range items {
-		data = append(data, renderProjectHandoff(item))
 	}
 	WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
 }
@@ -863,6 +862,7 @@ func (h *Handler) HandleCreateProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_create", item)
 	WriteJSON(w, http.StatusCreated, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
 }
 
@@ -899,6 +899,7 @@ func (h *Handler) HandleUpdateProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_update", item)
 	WriteJSON(w, http.StatusOK, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
 }
 
@@ -919,6 +920,7 @@ func (h *Handler) HandleUpdateProjectHandoffStatus(w http.ResponseWriter, r *htt
 	if !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_status_update", item)
 	WriteJSON(w, http.StatusOK, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
 }
 
@@ -932,6 +934,7 @@ func (h *Handler) HandleDeleteProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if err := h.projectWorkApplication().DeleteHandoff(r.Context(), projectID, workItemID, handoffID); !writeProjectWorkError(w, err) {
 		return
 	}
+	h.mirrorProjectHandoffDeleteToCairnline(r.Context(), "project_handoff_delete", projectID, workItemID, handoffID)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -3,12 +3,130 @@ package api
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
+
+func (h *Handler) renderProjectWorkArtifacts(ctx context.Context, projectID, workItemID string) ([]ProjectWorkArtifactResponse, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectWorkArtifacts(ctx, projectID, workItemID)
+	}
+	items, err := h.projectWork.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		return nil, err
+	}
+	data := make([]ProjectWorkArtifactResponse, 0, len(items))
+	for _, item := range items {
+		projected := renderProjectWorkArtifact(item)
+		projected.ReadBackend = "hecate"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineProjectWorkArtifacts(ctx context.Context, projectID, workItemID string) ([]ProjectWorkArtifactResponse, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := cairnlineProjectWorkArtifacts(ctx, service, snapshot.Project.ID, workItemID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return nil, projectwork.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	data := make([]ProjectWorkArtifactResponse, 0, len(items))
+	for _, item := range items {
+		projected := renderProjectWorkArtifact(item)
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectHandoffs(ctx, filter)
+	}
+	items, err := h.projectWork.ListHandoffs(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]ProjectHandoffResponse, 0, len(items))
+	for _, item := range items {
+		projected := renderProjectHandoff(item)
+		projected.ReadBackend = "hecate"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, filter.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := cairnlineProjectHandoffs(ctx, service, snapshot.Project.ID, strings.TrimSpace(filter.WorkItemID), strings.TrimSpace(filter.Status))
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return nil, projectwork.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	data := make([]ProjectHandoffResponse, 0, len(items))
+	for _, item := range items {
+		projected := renderProjectHandoff(item)
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderProjectWorkRoles(ctx context.Context, projectID string) ([]ProjectWorkRoleResponse, error) {
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjectWorkRoles(ctx, projectID)
+	}
+	roles, err := h.projectWork.ListRoles(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]ProjectWorkRoleResponse, 0, len(roles))
+	for _, role := range roles {
+		projected := renderProjectWorkRole(role)
+		projected.ReadBackend = "hecate"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineProjectWorkRoles(ctx context.Context, projectID string) ([]ProjectWorkRoleResponse, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	roles, err := service.ListRoles(ctx, snapshot.Project.ID)
+	if err != nil {
+		return nil, err
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+	nativeByID := projectWorkRolesByID(snapshot.Roles)
+	executionProfilesByID := cairnlineExecutionProfilesByID(executionProfiles)
+	data := make([]ProjectWorkRoleResponse, 0, len(roles))
+	for _, role := range roles {
+		projected := renderProjectWorkRole(projectWorkRoleFromCairnline(role, executionProfilesByID, nativeByID[role.ID]))
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
 
 func (h *Handler) renderProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
 	if h.projectReadRoutesUseCairnlineReadModel() {
@@ -82,6 +200,87 @@ func (h *Handler) renderCairnlineProjectWorkItem(ctx context.Context, projectID,
 		return projected, nil
 	}
 	return ProjectWorkItemResponse{}, projectwork.ErrNotFound
+}
+
+func cairnlineProjectWorkArtifacts(ctx context.Context, service *cairnline.Service, projectID, workItemID string) ([]projectwork.CollaborationArtifact, error) {
+	artifacts, err := service.ListArtifacts(ctx, projectID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	evidence, err := service.ListEvidence(ctx, projectID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	reviews, err := service.ListReviews(ctx, projectID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]projectwork.CollaborationArtifact, 0, len(artifacts)+len(evidence)+len(reviews))
+	for _, item := range artifacts {
+		out = append(out, projectWorkArtifactFromCairnline(item))
+	}
+	for _, item := range evidence {
+		out = append(out, projectHealthEvidenceFromCairnline(item))
+	}
+	for _, item := range reviews {
+		out = append(out, projectHealthReviewFromCairnline(item))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.Before(out[j].CreatedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+func projectWorkArtifactFromCairnline(item cairnline.Artifact) projectwork.CollaborationArtifact {
+	return projectwork.CollaborationArtifact{
+		ID:           item.ID,
+		ProjectID:    item.ProjectID,
+		WorkItemID:   item.WorkItemID,
+		AssignmentID: item.AssignmentID,
+		Kind:         item.Kind,
+		Title:        item.Title,
+		Body:         item.Body,
+		AuthorRoleID: item.AuthorRoleID,
+		CreatedAt:    item.CreatedAt,
+		UpdatedAt:    item.UpdatedAt,
+	}
+}
+
+func cairnlineProjectHandoffs(ctx context.Context, service *cairnline.Service, projectID, workItemID, status string) ([]projectwork.Handoff, error) {
+	workItems, err := service.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]projectwork.Handoff, 0)
+	for _, item := range workItems {
+		if workItemID != "" && item.ID != workItemID {
+			continue
+		}
+		handoffs, err := service.ListHandoffs(ctx, projectID, item.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, handoff := range handoffs {
+			projected := projectHealthHandoffFromCairnline(handoff)
+			if status != "" && projected.Status != status {
+				continue
+			}
+			out = append(out, projected)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].UpdatedAt.Equal(out[j].UpdatedAt) {
+			return out[i].UpdatedAt.After(out[j].UpdatedAt)
+		}
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.After(out[j].CreatedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
 }
 
 func (h *Handler) renderCairnlineProjectWorkAssignments(ctx context.Context, projectID, workItemID string) ([]ProjectWorkAssignmentResponse, error) {
@@ -167,6 +366,41 @@ func projectWorkAssignmentsByID(items []projectwork.Assignment) map[string]proje
 	return out
 }
 
+func projectWorkRolesByID(items []projectwork.AgentRoleProfile) map[string]projectwork.AgentRoleProfile {
+	out := make(map[string]projectwork.AgentRoleProfile, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func cairnlineExecutionProfilesByID(items []cairnline.ExecutionProfile) map[string]cairnline.ExecutionProfile {
+	out := make(map[string]cairnline.ExecutionProfile, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func projectWorkRoleFromCairnline(item cairnline.Role, executionProfiles map[string]cairnline.ExecutionProfile, native projectwork.AgentRoleProfile) projectwork.AgentRoleProfile {
+	executionProfile := executionProfiles[item.DefaultExecutionProfileID]
+	return projectwork.AgentRoleProfile{
+		ID:                  item.ID,
+		ProjectID:           item.ProjectID,
+		Name:                item.Name,
+		Description:         item.Description,
+		Instructions:        item.Instructions,
+		DefaultDriverKind:   projectWorkAssignmentDriverFromCairnline(item.DefaultExecutionMode),
+		DefaultProvider:     executionProfile.ProviderHint,
+		DefaultModel:        executionProfile.ModelHint,
+		DefaultAgentProfile: item.DefaultProfileID,
+		SkillIDs:            append([]string(nil), item.DefaultSkillIDs...),
+		BuiltIn:             native.BuiltIn,
+		CreatedAt:           native.CreatedAt,
+		UpdatedAt:           native.UpdatedAt,
+	}
+}
+
 func projectWorkAssignmentFromCairnline(item cairnline.Assignment) projectwork.Assignment {
 	return projectwork.Assignment{
 		ID:         item.ID,
@@ -219,7 +453,7 @@ func renderCairnlineProjectWorkItemReadiness(readiness cairnline.WorkItemCloseou
 		Status:                       readiness.Status,
 		Title:                        readiness.Title,
 		Detail:                       readiness.Detail,
-		Blockers:                     append([]string(nil), readiness.Blockers...),
+		Blockers:                     renderCairnlineProjectWorkItemReadinessBlockers(readiness.Blockers),
 		Warnings:                     append([]string(nil), readiness.Warnings...),
 		AssignmentCount:              readiness.AssignmentCount,
 		CompletedAssignments:         readiness.CompletedAssignments,
@@ -240,11 +474,36 @@ func renderCairnlineProjectWorkItemReviewFollowUps(items []cairnline.ReviewFollo
 			ArtifactID:           item.ArtifactID,
 			Title:                item.Title,
 			Status:               item.Status,
-			Blocker:              item.Blocker,
+			Blocker:              renderCairnlineProjectWorkItemReadinessBlocker(item.Blocker),
 			ReviewedAssignmentID: item.ReviewedAssignmentID,
 			ReviewVerdict:        item.ReviewVerdict,
 			ReviewRisk:           item.ReviewRisk,
 		})
 	}
 	return out
+}
+
+func renderCairnlineProjectWorkItemReadinessBlockers(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, renderCairnlineProjectWorkItemReadinessBlocker(value))
+	}
+	return out
+}
+
+func renderCairnlineProjectWorkItemReadinessBlocker(value string) string {
+	// Cairnline's portable handoff state is "open"; Hecate's Projects API has
+	// historically exposed the same unresolved state as "pending".
+	switch value {
+	case "handoff is open":
+		return "handoff is pending"
+	case "handoffs are open":
+		return "handoffs are pending"
+	}
+	value = strings.ReplaceAll(value, "handoff is open", "handoff is pending")
+	value = strings.ReplaceAll(value, "handoffs are open", "handoffs are pending")
+	return strings.ReplaceAll(value, " has an open handoff", " has a pending handoff")
 }

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -11,19 +11,23 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/chatcontext"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -38,6 +42,7 @@ func newProjectWorkTestServer() (*Handler, http.Handler) {
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
 	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
 	return handler, NewServer(quietLogger(), handler)
 }
 
@@ -45,6 +50,31 @@ func newProjectWorkTestServerWithProviders(items ...providers.Provider) (*Handle
 	handler := newTestAPIHandlerWithSettings(quietLogger(), items, config.Config{}, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
 	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectWorkCairnlineReadTestServer() (*Handler, http.Handler) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectWorkCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
 	return handler, NewServer(quietLogger(), handler)
 }
 
@@ -486,6 +516,256 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineMirrorTestServer(t)
+	project := createProjectForWorkTest(t, server)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/roles", bytes.NewReader([]byte(`{
+		"id":"role_release",
+		"name":"Release captain",
+		"description":"Coordinates release work.",
+		"instructions":"Keep release notes current.",
+		"default_driver_kind":"external_agent",
+		"default_provider":"anthropic",
+		"default_model":"claude-sonnet-4",
+		"default_agent_profile":"safe_external_review",
+		"skill_ids":["release"]
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create role status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirroredRole := getMirroredCairnlineRoleForTest(t, handler, project.Data.ID, "role_release")
+	if mirroredRole.Name != "Release captain" || mirroredRole.DefaultProfileID != "safe_external_review" || mirroredRole.DefaultExecutionMode != "external_adapter" {
+		t.Fatalf("mirrored role = %+v, want release captain defaults", mirroredRole)
+	}
+	if len(mirroredRole.DefaultSkillIDs) != 1 || mirroredRole.DefaultSkillIDs[0] != "release" {
+		t.Fatalf("mirrored role skill ids = %+v, want release", mirroredRole.DefaultSkillIDs)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirroredRole.DefaultExecutionProfileID, "anthropic", "claude-sonnet-4")
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/roles/role_release", bytes.NewReader([]byte(`{
+		"name":"Release owner",
+		"default_model":"claude-opus-4",
+		"skill_ids":["release","qa"]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update role status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	mirroredRole = getMirroredCairnlineRoleForTest(t, handler, project.Data.ID, "role_release")
+	if mirroredRole.Name != "Release owner" || !containsString(mirroredRole.DefaultSkillIDs, "release") || !containsString(mirroredRole.DefaultSkillIDs, "qa") {
+		t.Fatalf("mirrored updated role = %+v, want renamed role with two skills", mirroredRole)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirroredRole.DefaultExecutionProfileID, "anthropic", "claude-opus-4")
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items", bytes.NewReader([]byte(`{
+		"id":"work_release",
+		"title":"Prepare release",
+		"brief":"Coordinate the release checklist.",
+		"priority":"high",
+		"owner_role_id":"role_release",
+		"reviewer_role_ids":["role_release"]
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create work item status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirroredWork := getMirroredCairnlineWorkItemForTest(t, handler, project.Data.ID, "work_release")
+	if mirroredWork.Title != "Prepare release" || mirroredWork.Priority != "high" || mirroredWork.OwnerRoleID != "role_release" || len(mirroredWork.ReviewerRoleIDs) != 1 {
+		t.Fatalf("mirrored work item = %+v, want release-owned high-priority work", mirroredWork)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release", bytes.NewReader([]byte(`{
+		"title":"Prepare release notes",
+		"status":"ready",
+		"reviewer_role_ids":[]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update work item status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	mirroredWork = getMirroredCairnlineWorkItemForTest(t, handler, project.Data.ID, "work_release")
+	if mirroredWork.Title != "Prepare release notes" || mirroredWork.Status != projectwork.WorkItemStatusReady || len(mirroredWork.ReviewerRoleIDs) != 0 {
+		t.Fatalf("mirrored updated work item = %+v, want ready release notes without reviewers", mirroredWork)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/assignments", bytes.NewReader([]byte(`{
+		"id":"asgn_release",
+		"role_id":"role_release",
+		"driver_kind":"external_agent",
+		"status":"queued",
+		"execution_ref":{"kind":"task_run","task_id":"task_release","run_id":"run_release","context_snapshot_id":"ctx_release"}
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create assignment status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirroredAssignment := getMirroredCairnlineAssignmentForTest(t, handler, project.Data.ID, "asgn_release")
+	if mirroredAssignment.Status != cairnline.AssignmentQueued || mirroredAssignment.RoleID != "role_release" || mirroredAssignment.WorkItemID != "work_release" || mirroredAssignment.ProfileID != "safe_external_review" {
+		t.Fatalf("mirrored assignment = %+v, want queued release assignment metadata", mirroredAssignment)
+	}
+	if mirroredAssignment.ExecutionMode != cairnline.ExecutionExternalAdapter || mirroredAssignment.DesiredAgent.Kind != cairnline.DesiredAgentAny || mirroredAssignment.ContextSnapshotID != "ctx_release" {
+		t.Fatalf("mirrored assignment execution = %+v, want external adapter context snapshot", mirroredAssignment)
+	}
+	if len(mirroredAssignment.DesiredAgent.SkillIDs) != 2 || !containsString(mirroredAssignment.DesiredAgent.SkillIDs, "release") || !containsString(mirroredAssignment.DesiredAgent.SkillIDs, "qa") {
+		t.Fatalf("mirrored assignment desired skills = %+v, want role skill ids", mirroredAssignment.DesiredAgent.SkillIDs)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/artifacts", bytes.NewReader([]byte(`{
+		"id":"art_release_decision",
+		"assignment_id":"asgn_release",
+		"kind":"decision_note",
+		"title":"Release decision",
+		"body":"Ship after the release checklist is complete.",
+		"author_role_id":"role_release"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create decision artifact status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirroredArtifact := getMirroredCairnlineArtifactForTest(t, handler, project.Data.ID, "work_release", "art_release_decision")
+	if mirroredArtifact.Kind != projectwork.ArtifactKindDecisionNote || mirroredArtifact.AssignmentID != "asgn_release" || mirroredArtifact.AuthorRoleID != "role_release" {
+		t.Fatalf("mirrored artifact = %+v, want release decision metadata", mirroredArtifact)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/artifacts", bytes.NewReader([]byte(`{
+		"id":"art_release_evidence",
+		"assignment_id":"asgn_release",
+		"kind":"evidence_link",
+		"title":"Release checklist",
+		"body":"Checklist output was reviewed.",
+		"evidence_url":"https://example.invalid/release/checklist",
+		"evidence_trust_label":"operator_provided"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create evidence artifact status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirroredEvidence := getMirroredCairnlineEvidenceForTest(t, handler, project.Data.ID, "work_release", "art_release_evidence")
+	if mirroredEvidence.AssignmentID != "asgn_release" || mirroredEvidence.Locator != "https://example.invalid/release/checklist" || mirroredEvidence.TrustLabel != cairnline.EvidenceTrustOperator {
+		t.Fatalf("mirrored evidence = %+v, want release checklist evidence metadata", mirroredEvidence)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/artifacts", bytes.NewReader([]byte(`{
+		"id":"art_release_review",
+		"assignment_id":"asgn_release",
+		"reviewed_assignment_id":"asgn_release",
+		"kind":"review",
+		"title":"Release review",
+		"body":"Release assignment is ready.",
+		"author_role_id":"role_release",
+		"review_verdict":"approved",
+		"review_risk":"low"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create review artifact status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirroredReview := getMirroredCairnlineReviewForTest(t, handler, project.Data.ID, "work_release", "art_release_review")
+	if mirroredReview.AssignmentID != "asgn_release" || mirroredReview.ReviewerRoleID != "role_release" || mirroredReview.Verdict != cairnline.ReviewVerdictPass || mirroredReview.Risk != cairnline.ReviewRiskLow {
+		t.Fatalf("mirrored review = %+v, want approved release review metadata", mirroredReview)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/handoffs", bytes.NewReader([]byte(`{
+		"id":"handoff_release",
+		"source_assignment_id":"asgn_release",
+		"target_role_id":"role_release",
+		"target_assignment_id":"asgn_release",
+		"target_work_item_id":"work_release",
+		"title":"Release handoff",
+		"summary":"Ready for release owner follow-through.",
+		"recommended_next_action":"Publish the release notes.",
+		"created_by_role_id":"role_release"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create handoff status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirroredHandoff := getMirroredCairnlineHandoffForTest(t, handler, project.Data.ID, "work_release", "handoff_release")
+	if mirroredHandoff.Status != cairnline.HandoffStatusOpen || mirroredHandoff.SourceAssignmentID != "asgn_release" || mirroredHandoff.TargetAssignmentID != "asgn_release" || mirroredHandoff.ToRoleID != "role_release" {
+		t.Fatalf("mirrored handoff = %+v, want open release handoff metadata", mirroredHandoff)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/handoffs/handoff_release/status", bytes.NewReader([]byte(`{"status":"accepted"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("accept handoff status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	mirroredHandoff = getMirroredCairnlineHandoffForTest(t, handler, project.Data.ID, "work_release", "handoff_release")
+	if mirroredHandoff.Status != cairnline.HandoffStatusAccepted {
+		t.Fatalf("mirrored accepted handoff = %+v, want accepted", mirroredHandoff)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/handoffs/handoff_release", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete handoff status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	if _, err := service.GetHandoff(t.Context(), project.Data.ID, "work_release", "handoff_release"); !errors.Is(err, cairnline.ErrNotFound) {
+		store.Close()
+		t.Fatalf("deleted mirrored handoff error = %v, want ErrNotFound", err)
+	}
+	store.Close()
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/assignments/asgn_release", bytes.NewReader([]byte(`{
+		"status":"completed",
+		"execution_ref":{"kind":"chat_session","chat_session_id":"chat_release","message_id":"msg_release"}
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	mirroredAssignment = getMirroredCairnlineAssignmentForTest(t, handler, project.Data.ID, "asgn_release")
+	if mirroredAssignment.Status != cairnline.AssignmentCompleted || mirroredAssignment.ExecutionRef != "chat_release" {
+		t.Fatalf("mirrored completed assignment = %+v, want completed chat execution ref", mirroredAssignment)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release/assignments/asgn_release", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete assignment status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+	service, store, err = cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	if _, err := service.GetAssignment(t.Context(), project.Data.ID, "asgn_release"); !errors.Is(err, cairnline.ErrNotFound) {
+		store.Close()
+		t.Fatalf("deleted mirrored assignment error = %v, want ErrNotFound", err)
+	}
+	store.Close()
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_release", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete work item status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+	service, store, err = cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	if _, err := service.GetWorkItem(t.Context(), project.Data.ID, "work_release"); !errors.Is(err, cairnline.ErrNotFound) {
+		store.Close()
+		t.Fatalf("deleted mirrored work item error = %v, want ErrNotFound", err)
+	}
+	store.Close()
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+project.Data.ID+"/roles/role_release", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete role status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+	if role := mirroredCairnlineRoleForTest(t, handler, project.Data.ID, "role_release"); role != nil {
+		t.Fatalf("mirrored deleted role = %+v, want absent", *role)
+	}
+}
+
 func TestProjectWorkAPI_CreateHandoffGeneratesOpaqueHandoffID(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectWorkTestServer()
@@ -876,6 +1156,39 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentMirrorsResultToCairnline(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineMirrorTestServer(t)
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: workspace,
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	if ref.RunID == "" || ref.ContextSnapshotID == "" {
+		t.Fatalf("assignment execution_ref = %+v, want run and context snapshot links", ref)
+	}
+
+	stored := getStoredProjectWorkAssignmentForTest(t, handler, "proj_start", "work_start", "asgn_start")
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_start", "asgn_start")
+	if mirrored.Status != cairnlinebridge.AssignmentStatus(stored.Status) || mirrored.ExecutionMode != cairnline.ExecutionOrchestrated {
+		t.Fatalf("mirrored assignment status/mode = %q/%q, want %q/orchestrated", mirrored.Status, mirrored.ExecutionMode, cairnlinebridge.AssignmentStatus(stored.Status))
+	}
+	if mirrored.ExecutionRef != stored.ExecutionRef.RunID || mirrored.ContextSnapshotID != stored.ExecutionRef.ContextSnapshotID {
+		t.Fatalf("mirrored assignment execution = ref %q context %q, want %q/%q", mirrored.ExecutionRef, mirrored.ContextSnapshotID, stored.ExecutionRef.RunID, stored.ExecutionRef.ContextSnapshotID)
+	}
+}
+
 func TestProjectWorkAPI_PreflightAssignmentReturnsLaunchContextWithoutSideEffects(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -1015,6 +1328,42 @@ func TestProjectWorkAPI_PreflightAndStartShareNativeLaunchPlan(t *testing.T) {
 			task.RequestedProvider, task.RequestedModel, task.ExecutionProfile, task.WorkingDirectory,
 			preflight.Data.Provider, preflight.Data.Model, preflight.Data.ExecutionProfile, preflight.Data.Workspace)
 	}
+}
+
+func TestProjectWorkAPI_PreflightAndStartIncludeCairnlineLaunchPacketEvidenceWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineReadTestServer()
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: workspace,
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	client := newAPITestClient(t, server)
+	preflight := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/preflight", "")
+	if preflight.Data.ExecutionMode != chat.ExecutionModeHecateTask || preflight.Data.Provider != "anthropic" || preflight.Data.Model != "claude-sonnet-4" {
+		t.Fatalf("Cairnline preflight launch shape = %q/%q/%q, want native task launch hints", preflight.Data.ExecutionMode, preflight.Data.Provider, preflight.Data.Model)
+	}
+	if preflight.Data.ExecutionProfile != "coding_agent" || preflight.Data.Workspace != workspace {
+		t.Fatalf("Cairnline preflight profile/workspace = %q/%q, want coding_agent/%q", preflight.Data.ExecutionProfile, preflight.Data.Workspace, workspace)
+	}
+	if preflight.Data.Refs == nil || preflight.Data.Refs.ProjectID != "proj_start" || preflight.Data.Refs.WorkItemID != "work_start" || preflight.Data.Refs.AssignmentID != "asgn_start" || preflight.Data.Refs.RoleID != "role_backend" {
+		t.Fatalf("Cairnline preflight refs = %+v, want project/work/assignment/role refs", preflight.Data.Refs)
+	}
+	assertCairnlineLaunchPacketEvidenceForTest(t, preflight.Data)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	started := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
+	assertCairnlineLaunchPacketEvidenceForTest(t, started.Data)
 }
 
 func TestProjectWorkAPI_PreflightAndStartSnapshotModelReadiness(t *testing.T) {
@@ -1891,10 +2240,62 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 	}
 }
 
+func TestProjectWorkAPI_StartExternalAgentAssignmentMirrorsResultToCairnline(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineMirrorTestServer(t)
+	runner := &fakeAgentChatRunner{nativeSessionID: "native_project_external"}
+	handler.SetAgentChatRunner(runner)
+	workspace := t.TempDir()
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           workspace,
+		Driver:              projectwork.AssignmentDriverExternalAgent,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                  "prof_external",
+		Name:                "External implementer",
+		Surface:             agentprofiles.SurfaceExternalAgent,
+		ExecutionProfile:    "external_implementation",
+		ExternalAgentKind:   "codex",
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
+	}); err != nil {
+		t.Fatalf("Create external profile: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.DefaultAgentProfile = "prof_external"
+	}); err != nil {
+		t.Fatalf("Update role profile: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start external assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	if ref.ChatSessionID == "" || ref.ContextSnapshotID == "" {
+		t.Fatalf("assignment execution_ref = %+v, want linked session and context snapshot", ref)
+	}
+
+	stored := getStoredProjectWorkAssignmentForTest(t, handler, "proj_start", "work_start", "asgn_start")
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_start", "asgn_start")
+	if mirrored.Status != cairnlinebridge.AssignmentStatus(stored.Status) || mirrored.ExecutionMode != cairnline.ExecutionExternalAdapter {
+		t.Fatalf("mirrored assignment status/mode = %q/%q, want %q/external_adapter", mirrored.Status, mirrored.ExecutionMode, cairnlinebridge.AssignmentStatus(stored.Status))
+	}
+	if mirrored.ExecutionRef != stored.ExecutionRef.ChatSessionID || mirrored.ContextSnapshotID != stored.ExecutionRef.ContextSnapshotID {
+		t.Fatalf("mirrored assignment execution = ref %q context %q, want %q/%q", mirrored.ExecutionRef, mirrored.ContextSnapshotID, stored.ExecutionRef.ChatSessionID, stored.ExecutionRef.ContextSnapshotID)
+	}
+}
+
 func TestProjectWorkAPI_ExternalAgentChatTurnReconcilesAssignmentStatus(t *testing.T) {
 	t.Parallel()
 
-	handler, server := newProjectWorkTestServer()
+	handler, server := newProjectWorkCairnlineMirrorTestServer(t)
 	handler.SetAgentChatRunner(&fakeAgentChatRunner{output: "implementation complete"})
 	ctx := t.Context()
 	workspace := t.TempDir()
@@ -1956,6 +2357,10 @@ func TestProjectWorkAPI_ExternalAgentChatTurnReconcilesAssignmentStatus(t *testi
 	}
 	if assignments[0].Status != projectwork.AssignmentStatusCompleted || assignments[0].ExecutionRef.MessageID == "" || assignments[0].ExecutionRef.Status != projectwork.AssignmentStatusCompleted {
 		t.Fatalf("stored assignment = %+v, want reconciled completed chat assignment", assignments[0])
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_chat_reconcile", "asgn_chat_reconcile")
+	if mirrored.Status != cairnline.AssignmentCompleted || mirrored.ExecutionRef != "chat_project_reconcile" {
+		t.Fatalf("mirrored assignment = %+v, want completed chat-session execution ref", mirrored)
 	}
 }
 
@@ -2822,6 +3227,36 @@ func TestProjectWorkAPI_StartAssignmentPreservesTaskLinkWhenStartFails(t *testin
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentFailureMirrorsResultToCairnline(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineMirrorTestServer(t)
+	failingRunner := orchestrator.NewRunner(quietLogger(), nil, nil, orchestrator.Config{})
+	t.Cleanup(func() { _ = failingRunner.Shutdown(t.Context()) })
+	handler.taskRunner = failingRunner
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("start failure status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	stored := getStoredProjectWorkAssignmentForTest(t, handler, "proj_start", "work_start", "asgn_start")
+	if stored.Status != projectwork.AssignmentStatusFailed || stored.ExecutionRef.TaskID == "" {
+		t.Fatalf("stored assignment = %+v, want failed assignment with preserved task ref", stored)
+	}
+
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_start", "asgn_start")
+	if mirrored.Status != cairnline.AssignmentFailed || mirrored.ExecutionMode != cairnline.ExecutionOrchestrated {
+		t.Fatalf("mirrored assignment status/mode = %q/%q, want failed/orchestrated", mirrored.Status, mirrored.ExecutionMode)
+	}
+	if mirrored.ExecutionRef != stored.ExecutionRef.TaskID || mirrored.ContextSnapshotID != "" {
+		t.Fatalf("mirrored assignment execution = ref %q context %q, want failed task ref %q and no context snapshot", mirrored.ExecutionRef, mirrored.ContextSnapshotID, stored.ExecutionRef.TaskID)
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentClearsClaimWhenTaskCreateFails(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()
@@ -3105,6 +3540,122 @@ func TestProjectWorkAPI_ProjectActivityCairnlineConfiguredUsesReadModel(t *testi
 	}
 }
 
+func TestProjectWorkAPI_ProjectActivityCairnlineMatchesHecate(t *testing.T) {
+	t.Parallel()
+	hecateHandler, hecateServer := newProjectWorkProjectionTestServer(t, "memory")
+	seedProjectWorkProjectionTest(t, hecateHandler)
+	hecateHandler.agentChat = failingChatGetStore{Store: hecateHandler.agentChat, failingID: "chat_external_error"}
+	cairnlineHandler, cairnlineServer := newProjectWorkCairnlineReadTestServer()
+	seedProjectWorkProjectionTest(t, cairnlineHandler)
+	cairnlineHandler.agentChat = failingChatGetStore{Store: cairnlineHandler.agentChat, failingID: "chat_external_error"}
+
+	hecate := mustRequestJSON[ProjectActivityEnvelope](newAPITestClient(t, hecateServer), http.MethodGet, "/hecate/v1/projects/proj_projection/activity", "")
+	cairnline := mustRequestJSON[ProjectActivityEnvelope](newAPITestClient(t, cairnlineServer), http.MethodGet, "/hecate/v1/projects/proj_projection/activity", "")
+	if hecate.Data.ReadBackend != "hecate" {
+		t.Fatalf("Hecate activity read_backend = %q, want hecate", hecate.Data.ReadBackend)
+	}
+	if cairnline.Data.ReadBackend != "cairnline" {
+		t.Fatalf("Cairnline activity read_backend = %q, want cairnline", cairnline.Data.ReadBackend)
+	}
+
+	hecateData := normalizeProjectActivityForParity(hecate.Data)
+	cairnlineData := normalizeProjectActivityForParity(cairnline.Data)
+	if !reflect.DeepEqual(hecateData, cairnlineData) {
+		t.Fatalf("activity mismatch: %s", projectActivityParityMismatch(hecateData, cairnlineData))
+	}
+}
+
+func normalizeProjectActivityForParity(item ProjectActivityDataResponse) ProjectActivityDataResponse {
+	item.ReadBackend = ""
+	normalizeProjectActivityItemsForParity(item.Recent)
+	normalizeProjectActivityItemsForParity(item.Buckets.Active)
+	normalizeProjectActivityItemsForParity(item.Buckets.Blocked)
+	normalizeProjectActivityItemsForParity(item.Buckets.Completed)
+	normalizeProjectActivityItemsForParity(item.Buckets.Recent)
+	return item
+}
+
+func normalizeProjectActivityItemsForParity(items []ProjectActivityItemResponse) {
+	for idx := range items {
+		items[idx].UpdatedAt = ""
+		items[idx].Role.ReadBackend = ""
+		items[idx].Role.CreatedAt = ""
+		items[idx].Role.UpdatedAt = ""
+		normalizeProjectWorkAssignmentResponseForParity(&items[idx].Assignment)
+		for artifactIdx := range items[idx].RecentArtifacts {
+			items[idx].RecentArtifacts[artifactIdx].ReadBackend = ""
+			items[idx].RecentArtifacts[artifactIdx].CreatedAt = ""
+			items[idx].RecentArtifacts[artifactIdx].UpdatedAt = ""
+		}
+		for handoffIdx := range items[idx].RecentHandoffs {
+			items[idx].RecentHandoffs[handoffIdx].ReadBackend = ""
+			items[idx].RecentHandoffs[handoffIdx].CreatedAt = ""
+			items[idx].RecentHandoffs[handoffIdx].UpdatedAt = ""
+			items[idx].RecentHandoffs[handoffIdx].StatusChangedAt = ""
+		}
+	}
+}
+
+func normalizeProjectWorkAssignmentResponseForParity(item *ProjectWorkAssignmentResponse) {
+	item.ReadBackend = ""
+	item.CreatedAt = ""
+	item.UpdatedAt = ""
+	item.StartedAt = ""
+	item.CompletedAt = ""
+	if item.Execution != nil {
+		item.Execution.StartedAt = ""
+		item.Execution.FinishedAt = ""
+	}
+}
+
+func projectActivityParityMismatch(left, right ProjectActivityDataResponse) string {
+	if left.ProjectID != right.ProjectID {
+		return fmt.Sprintf("project_id %q != %q", left.ProjectID, right.ProjectID)
+	}
+	if !reflect.DeepEqual(left.Summary, right.Summary) {
+		return fmt.Sprintf("summary %+v != %+v", left.Summary, right.Summary)
+	}
+	if message := projectActivityItemsParityMismatch("recent", left.Recent, right.Recent); message != "" {
+		return message
+	}
+	if message := projectActivityItemsParityMismatch("active", left.Buckets.Active, right.Buckets.Active); message != "" {
+		return message
+	}
+	if message := projectActivityItemsParityMismatch("blocked", left.Buckets.Blocked, right.Buckets.Blocked); message != "" {
+		return message
+	}
+	if message := projectActivityItemsParityMismatch("completed", left.Buckets.Completed, right.Buckets.Completed); message != "" {
+		return message
+	}
+	if message := projectActivityItemsParityMismatch("bucket_recent", left.Buckets.Recent, right.Buckets.Recent); message != "" {
+		return message
+	}
+	return fmt.Sprintf("\nHecate:   %+v\nCairnline: %+v", left, right)
+}
+
+func projectActivityItemsParityMismatch(name string, left, right []ProjectActivityItemResponse) string {
+	if !reflect.DeepEqual(projectActivityIDsForParity(left), projectActivityIDsForParity(right)) {
+		return fmt.Sprintf("%s IDs %v != %v", name, projectActivityIDsForParity(left), projectActivityIDsForParity(right))
+	}
+	for idx := range left {
+		if reflect.DeepEqual(left[idx], right[idx]) {
+			continue
+		}
+		leftJSON, _ := json.Marshal(left[idx])
+		rightJSON, _ := json.Marshal(right[idx])
+		return fmt.Sprintf("%s item %q differs\nHecate:   %s\nCairnline: %s", name, left[idx].ID, leftJSON, rightJSON)
+	}
+	return ""
+}
+
+func projectActivityIDsForParity(items []ProjectActivityItemResponse) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.ID)
+	}
+	return out
+}
+
 func TestProjectWorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{
@@ -3131,6 +3682,24 @@ func TestProjectWorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel(t *t
 	}
 
 	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/roles", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list roles status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var roles ProjectWorkRolesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &roles); err != nil {
+		t.Fatalf("decode roles: %v", err)
+	}
+	projectionRole := findProjectWorkRoleForTest(t, roles.Data, "role_projection")
+	if projectionRole.ReadBackend != "cairnline" || projectionRole.DefaultProvider != "openai" || projectionRole.DefaultModel != "gpt-5" || projectionRole.DefaultAgentProfile != "implementation" {
+		t.Fatalf("projection role = %+v, want Cairnline role read with Hecate execution defaults", projectionRole)
+	}
+	builtInRole := findProjectWorkRoleForTest(t, roles.Data, "product_manager")
+	if builtInRole.ReadBackend != "cairnline" || !builtInRole.BuiltIn {
+		t.Fatalf("built-in role = %+v, want Cairnline role read preserving built-in flag", builtInRole)
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("list work items status = %d body=%s, want 200", rec.Code, rec.Body.String())
@@ -3184,6 +3753,31 @@ func TestProjectWorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel(t *t
 	}
 
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_not_started/assignments/asgn_not_started/context", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assignment context status = %d body=%s, want Cairnline read-model packet", rec.Code, rec.Body.String())
+	}
+	var packetResp ChatContextPacketResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &packetResp); err != nil {
+		t.Fatalf("decode assignment context: %v", err)
+	}
+	if packetResp.Data.ID != "cairnline_assignment_context_asgn_not_started" || packetResp.Data.ExecutionMode != "orchestrated" {
+		t.Fatalf("assignment context id/mode = %q/%q, want deterministic Cairnline orchestrated packet", packetResp.Data.ID, packetResp.Data.ExecutionMode)
+	}
+	if packetResp.Data.Refs == nil || packetResp.Data.Refs.ProjectID != "proj_projection" || packetResp.Data.Refs.WorkItemID != "work_not_started" || packetResp.Data.Refs.AssignmentID != "asgn_not_started" || packetResp.Data.Refs.RoleID != "role_projection" {
+		t.Fatalf("assignment context refs = %+v, want project/work/assignment/role refs", packetResp.Data.Refs)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "cairnline.assignment_launch_packet"); item == nil || item.Section != contextSectionRuntime || item.Included || item.Metadata["read_backend"] != "cairnline" {
+		t.Fatalf("Cairnline runtime item = %+v, want inspect-only runtime preview metadata", item)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "asgn_not_started"); item == nil || item.Section != contextSectionProjectWork || !item.Included {
+		t.Fatalf("Cairnline assignment item = %+v, want included project_work assignment metadata", item)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "art_work_not_started"); item == nil || item.Section != contextSectionProjectWork || item.Included {
+		t.Fatalf("Cairnline artifact item = %+v, want inspect-only work-item artifact metadata", item)
+	}
+
+	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_needs_evidence/readiness", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
@@ -3204,6 +3798,208 @@ func TestProjectWorkAPI_ProjectWorkItemReadsCairnlineConfiguredUseReadModel(t *t
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("missing work item status = %d body=%s, want 404", rec.Code, rec.Body.String())
 	}
+}
+
+func TestProjectWorkAPI_ProjectWorkItemReadinessCairnlineMatchesHecate(t *testing.T) {
+	t.Parallel()
+	hecateHandler, hecateServer := newProjectWorkProjectionTestServer(t, "memory")
+	seedProjectWorkProjectionTest(t, hecateHandler)
+	cairnlineHandler, cairnlineServer := newProjectWorkCairnlineReadTestServer()
+	seedProjectWorkProjectionTest(t, cairnlineHandler)
+
+	hecateClient := newAPITestClient(t, hecateServer)
+	cairnlineClient := newAPITestClient(t, cairnlineServer)
+	for _, workID := range []string{
+		"work_running",
+		"work_queued",
+		"work_awaiting",
+		"work_completed",
+		"work_failed",
+		"work_cancelled",
+		"work_missing",
+		"work_run_only",
+		"work_manual_terminal",
+		"work_external_chat",
+		"work_mixed",
+		"work_not_started",
+	} {
+		workID := workID
+		t.Run(workID, func(t *testing.T) {
+			hecate := mustRequestJSON[ProjectWorkItemReadinessEnvelope](hecateClient, http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/"+workID+"/readiness", "")
+			cairnline := mustRequestJSON[ProjectWorkItemReadinessEnvelope](cairnlineClient, http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/"+workID+"/readiness", "")
+			if hecate.Data.ReadBackend != "hecate" {
+				t.Fatalf("Hecate readiness read_backend = %q, want hecate", hecate.Data.ReadBackend)
+			}
+			if cairnline.Data.ReadBackend != "cairnline" {
+				t.Fatalf("Cairnline readiness read_backend = %q, want cairnline", cairnline.Data.ReadBackend)
+			}
+
+			hecateData := normalizeProjectWorkItemReadinessForParity(hecate.Data)
+			cairnlineData := normalizeProjectWorkItemReadinessForParity(cairnline.Data)
+			if !reflect.DeepEqual(hecateData, cairnlineData) {
+				t.Fatalf("readiness mismatch for %s\nHecate:   %+v\nCairnline: %+v", workID, hecateData, cairnlineData)
+			}
+		})
+	}
+}
+
+func normalizeProjectWorkItemReadinessForParity(item ProjectWorkItemReadinessResponse) ProjectWorkItemReadinessResponse {
+	item.ReadBackend = ""
+	if len(item.Blockers) == 0 {
+		item.Blockers = nil
+	}
+	if len(item.Warnings) == 0 {
+		item.Warnings = nil
+	}
+	if len(item.ReviewFollowUpArtifactIDs) == 0 {
+		item.ReviewFollowUpArtifactIDs = nil
+	}
+	if len(item.ReviewFollowUps) == 0 {
+		item.ReviewFollowUps = nil
+	}
+	if len(item.MissingEvidenceAssignmentIDs) == 0 {
+		item.MissingEvidenceAssignmentIDs = nil
+	}
+	return item
+}
+
+func TestProjectWorkAPI_ProjectArtifactsAndHandoffsCairnlineConfiguredUseReadModel(t *testing.T) {
+	t.Parallel()
+	nativeHandler, nativeServer := newProjectWorkTestServer()
+	seedProjectWorkProjectionTest(t, nativeHandler)
+	seedProjectWorkArtifactsAndHandoffsReadModelTest(t, nativeHandler)
+	cairnlineHandler, cairnlineServer := newProjectWorkCairnlineReadTestServer()
+	seedProjectWorkProjectionTest(t, cairnlineHandler)
+	seedProjectWorkArtifactsAndHandoffsReadModelTest(t, cairnlineHandler)
+
+	nativeArtifacts := mustRequestJSON[ProjectWorkArtifactsResponse](newAPITestClient(t, nativeServer), http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_completed/artifacts", "")
+	cairnlineArtifacts := mustRequestJSON[ProjectWorkArtifactsResponse](newAPITestClient(t, cairnlineServer), http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_completed/artifacts", "")
+	assertProjectWorkArtifactsParity(t, nativeArtifacts.Data, cairnlineArtifacts.Data)
+
+	decision := findProjectWorkArtifactForTest(t, cairnlineArtifacts.Data, "art_completion_decision")
+	if decision.ReadBackend != "cairnline" || decision.Kind != projectwork.ArtifactKindDecisionNote || decision.AuthorRoleID != "role_projection" || decision.Body != "Keep the completed assignment as the closeout record." {
+		t.Fatalf("decision artifact = %+v, want Cairnline-backed generic artifact", decision)
+	}
+	handoffArtifact := findProjectWorkArtifactForTest(t, cairnlineArtifacts.Data, "art_asgn_completed")
+	if handoffArtifact.ReadBackend != "cairnline" || handoffArtifact.Kind != projectwork.ArtifactKindHandoff || handoffArtifact.Body != "Ready for review." {
+		t.Fatalf("handoff artifact = %+v, want Cairnline-backed generic handoff artifact", handoffArtifact)
+	}
+	evidence := findProjectWorkArtifactForTest(t, cairnlineArtifacts.Data, "art_completion_evidence")
+	if evidence.ReadBackend != "cairnline" || evidence.Kind != projectwork.ArtifactKindEvidenceLink || evidence.EvidenceURL != "https://example.invalid/evidence/completion" || evidence.EvidenceTrustLabel != projectwork.EvidenceTrustOperatorProvided {
+		t.Fatalf("evidence artifact = %+v, want Cairnline-backed evidence metadata", evidence)
+	}
+	review := findProjectWorkArtifactForTest(t, cairnlineArtifacts.Data, "art_completion_review")
+	if review.ReadBackend != "cairnline" || review.Kind != projectwork.ArtifactKindReview || review.ReviewedAssignmentID != "asgn_completed" || review.ReviewVerdict != projectwork.ReviewVerdictApproved || review.ReviewRisk != projectwork.ReviewRiskLow || review.ReviewFollowUpRequired {
+		t.Fatalf("review artifact = %+v, want Cairnline-backed review metadata", review)
+	}
+
+	nativeWorkHandoffs := mustRequestJSON[ProjectHandoffsResponse](newAPITestClient(t, nativeServer), http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_completed/handoffs", "")
+	cairnlineWorkHandoffs := mustRequestJSON[ProjectHandoffsResponse](newAPITestClient(t, cairnlineServer), http.MethodGet, "/hecate/v1/projects/proj_projection/work-items/work_completed/handoffs", "")
+	assertProjectHandoffsParity(t, nativeWorkHandoffs.Data, cairnlineWorkHandoffs.Data)
+	handoff := findProjectHandoffForTest(t, cairnlineWorkHandoffs.Data, "handoff_review_followup")
+	if handoff.ReadBackend != "cairnline" || handoff.TargetAssignmentID != "asgn_queued" || handoff.TargetWorkItemID != "work_queued" || handoff.Status != projectwork.HandoffStatusPending {
+		t.Fatalf("work-item handoff = %+v, want Cairnline-backed handoff metadata", handoff)
+	}
+
+	nativeProjectHandoffs := mustRequestJSON[ProjectHandoffsResponse](newAPITestClient(t, nativeServer), http.MethodGet, "/hecate/v1/projects/proj_projection/handoffs?work_item_id=work_completed&status=pending", "")
+	cairnlineProjectHandoffs := mustRequestJSON[ProjectHandoffsResponse](newAPITestClient(t, cairnlineServer), http.MethodGet, "/hecate/v1/projects/proj_projection/handoffs?work_item_id=work_completed&status=pending", "")
+	assertProjectHandoffsParity(t, nativeProjectHandoffs.Data, cairnlineProjectHandoffs.Data)
+	if len(cairnlineProjectHandoffs.Data) != 1 || cairnlineProjectHandoffs.Data[0].ID != "handoff_review_followup" || cairnlineProjectHandoffs.Data[0].ReadBackend != "cairnline" {
+		t.Fatalf("project handoffs = %+v, want filtered Cairnline-backed handoff", cairnlineProjectHandoffs.Data)
+	}
+}
+
+func seedProjectWorkArtifactsAndHandoffsReadModelTest(t *testing.T, handler *Handler) {
+	t.Helper()
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:           "art_completion_decision",
+		ProjectID:    "proj_projection",
+		WorkItemID:   "work_completed",
+		AssignmentID: "asgn_completed",
+		Kind:         projectwork.ArtifactKindDecisionNote,
+		Title:        "Completion decision",
+		Body:         "Keep the completed assignment as the closeout record.",
+		AuthorRoleID: "role_projection",
+		CreatedAt:    time.Date(2026, 6, 3, 12, 3, 30, 0, time.UTC),
+		UpdatedAt:    time.Date(2026, 6, 3, 12, 3, 30, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateArtifact(decision): %v", err)
+	}
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:                 "art_completion_evidence",
+		ProjectID:          "proj_projection",
+		WorkItemID:         "work_completed",
+		AssignmentID:       "asgn_completed",
+		Kind:               projectwork.ArtifactKindEvidenceLink,
+		Title:              "Completion evidence",
+		Body:               "Focused test output was captured.",
+		EvidenceURL:        "https://example.invalid/evidence/completion",
+		EvidenceTrustLabel: projectwork.EvidenceTrustOperatorProvided,
+		CreatedAt:          time.Date(2026, 6, 3, 12, 4, 30, 0, time.UTC),
+		UpdatedAt:          time.Date(2026, 6, 3, 12, 4, 30, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateArtifact(evidence): %v", err)
+	}
+	if _, err := handler.projectWork.CreateArtifact(t.Context(), projectwork.CollaborationArtifact{
+		ID:                     "art_completion_review",
+		ProjectID:              "proj_projection",
+		WorkItemID:             "work_completed",
+		AssignmentID:           "asgn_completed",
+		ReviewedAssignmentID:   "asgn_completed",
+		Kind:                   projectwork.ArtifactKindReview,
+		Title:                  "Completion review",
+		Body:                   "Verdict: approved.",
+		AuthorRoleID:           "role_projection",
+		ReviewVerdict:          projectwork.ReviewVerdictApproved,
+		ReviewRisk:             projectwork.ReviewRiskLow,
+		ReviewFollowUpRequired: false,
+		CreatedAt:              time.Date(2026, 6, 3, 12, 5, 30, 0, time.UTC),
+		UpdatedAt:              time.Date(2026, 6, 3, 12, 5, 30, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateArtifact(review): %v", err)
+	}
+}
+
+func assertProjectWorkArtifactsParity(t *testing.T, hecate, cairnline []ProjectWorkArtifactResponse) {
+	t.Helper()
+	normalizedHecate := normalizeProjectWorkArtifactsForParity(t, hecate, "hecate")
+	normalizedCairnline := normalizeProjectWorkArtifactsForParity(t, cairnline, "cairnline")
+	if !reflect.DeepEqual(normalizedHecate, normalizedCairnline) {
+		t.Fatalf("project work artifacts mismatch\nHecate:   %+v\nCairnline: %+v", normalizedHecate, normalizedCairnline)
+	}
+}
+
+func normalizeProjectWorkArtifactsForParity(t *testing.T, items []ProjectWorkArtifactResponse, backend string) []ProjectWorkArtifactResponse {
+	t.Helper()
+	out := append([]ProjectWorkArtifactResponse(nil), items...)
+	for index := range out {
+		if out[index].ReadBackend != backend {
+			t.Fatalf("%s artifact[%d] read_backend = %q, want %s", backend, index, out[index].ReadBackend, backend)
+		}
+		out[index].ReadBackend = ""
+	}
+	return out
+}
+
+func assertProjectHandoffsParity(t *testing.T, hecate, cairnline []ProjectHandoffResponse) {
+	t.Helper()
+	normalizedHecate := normalizeProjectHandoffsForParity(t, hecate, "hecate")
+	normalizedCairnline := normalizeProjectHandoffsForParity(t, cairnline, "cairnline")
+	if !reflect.DeepEqual(normalizedHecate, normalizedCairnline) {
+		t.Fatalf("project handoffs mismatch\nHecate:   %+v\nCairnline: %+v", normalizedHecate, normalizedCairnline)
+	}
+}
+
+func normalizeProjectHandoffsForParity(t *testing.T, items []ProjectHandoffResponse, backend string) []ProjectHandoffResponse {
+	t.Helper()
+	out := append([]ProjectHandoffResponse(nil), items...)
+	for index := range out {
+		if out[index].ReadBackend != backend {
+			t.Fatalf("%s handoff[%d] read_backend = %q, want %s", backend, index, out[index].ReadBackend, backend)
+		}
+		out[index].ReadBackend = ""
+	}
+	return out
 }
 
 func TestProjectWorkAPI_ProjectActivityShowsFreshQueuedAssignments(t *testing.T) {
@@ -3421,7 +4217,15 @@ func seedProjectWorkProjectionTest(t *testing.T, handler *Handler) {
 	if _, err := handler.projects.Create(ctx, projects.Project{ID: "proj_projection", Name: "Projection"}); err != nil {
 		t.Fatalf("Create project: %v", err)
 	}
-	if _, err := handler.projectWork.CreateRole(ctx, projectwork.AgentRoleProfile{ID: "role_projection", ProjectID: "proj_projection", Name: "Projection engineer"}); err != nil {
+	if _, err := handler.projectWork.CreateRole(ctx, projectwork.AgentRoleProfile{
+		ID:                  "role_projection",
+		ProjectID:           "proj_projection",
+		Name:                "Projection engineer",
+		DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
+		DefaultProvider:     "openai",
+		DefaultModel:        "gpt-5",
+		DefaultAgentProfile: "implementation",
+	}); err != nil {
 		t.Fatalf("CreateRole: %v", err)
 	}
 
@@ -3635,6 +4439,7 @@ func seedProjectWorkExternalChatProjectionCase(t *testing.T, handler *Handler) {
 func seedProjectWorkRunOnlyProjectionCase(t *testing.T, handler *Handler) {
 	t.Helper()
 	ctx := t.Context()
+	createdAt := time.Date(2026, 6, 3, 11, 57, 0, 0, time.UTC)
 	if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
 		ID:        "work_run_only",
 		ProjectID: "proj_projection",
@@ -3654,6 +4459,8 @@ func seedProjectWorkRunOnlyProjectionCase(t *testing.T, handler *Handler) {
 			Kind:  projectwork.AssignmentExecutionKindTaskRun,
 			RunID: "run_without_task",
 		},
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
 	}); err != nil {
 		t.Fatalf("CreateAssignment(asgn_run_only): %v", err)
 	}
@@ -3699,21 +4506,6 @@ func seedProjectWorkNotStartedProjectionCase(t *testing.T, handler *Handler) {
 func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assignmentID, assignmentStatus, runStatus string, runStartedAt, runFinishedAt, assignmentUpdated time.Time, lastError string, approvalPending, missing bool) {
 	t.Helper()
 	ctx := t.Context()
-	if _, ok, err := handler.projectWork.GetWorkItem(ctx, "proj_projection", workID); err != nil {
-		t.Fatalf("GetWorkItem(%s): %v", workID, err)
-	} else if !ok {
-		if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
-			ID:        workID,
-			ProjectID: "proj_projection",
-			Title:     workID,
-			Status:    projectwork.WorkItemStatusReady,
-		}); err != nil {
-			t.Fatalf("CreateWorkItem(%s): %v", workID, err)
-		}
-	}
-
-	taskID := "task_" + assignmentID
-	runID := "run_" + assignmentID
 	if assignmentStatus == "" {
 		assignmentStatus = projectwork.AssignmentStatusQueued
 	}
@@ -3723,6 +4515,23 @@ func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assig
 			assignmentUpdated = time.Date(2026, 6, 3, 11, 59, 0, 0, time.UTC)
 		}
 	}
+	if _, ok, err := handler.projectWork.GetWorkItem(ctx, "proj_projection", workID); err != nil {
+		t.Fatalf("GetWorkItem(%s): %v", workID, err)
+	} else if !ok {
+		if _, err := handler.projectWork.CreateWorkItem(ctx, projectwork.WorkItem{
+			ID:        workID,
+			ProjectID: "proj_projection",
+			Title:     workID,
+			Status:    projectwork.WorkItemStatusReady,
+			CreatedAt: assignmentUpdated,
+			UpdatedAt: assignmentUpdated,
+		}); err != nil {
+			t.Fatalf("CreateWorkItem(%s): %v", workID, err)
+		}
+	}
+
+	taskID := "task_" + assignmentID
+	runID := "run_" + assignmentID
 	if _, err := handler.projectWork.CreateAssignment(ctx, projectwork.Assignment{
 		ID:         assignmentID,
 		ProjectID:  "proj_projection",
@@ -3808,6 +4617,7 @@ func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assig
 			RecommendedNextAction: "Review the queued follow-up assignment.",
 			CreatedAt:             runFinishedAt.Add(2 * time.Minute),
 			UpdatedAt:             runFinishedAt.Add(2 * time.Minute),
+			StatusChangedAt:       runFinishedAt.Add(2 * time.Minute),
 		}); err != nil {
 			t.Fatalf("CreateHandoff(%s): %v", assignmentID, err)
 		}
@@ -3840,6 +4650,42 @@ func assignmentExecutionRefForTest(t *testing.T, assignment ProjectWorkAssignmen
 		t.Fatalf("assignment %q execution_ref is nil", assignment.ID)
 	}
 	return *assignment.ExecutionRef
+}
+
+func assertCairnlineLaunchPacketEvidenceForTest(t *testing.T, packet ChatContextPacketItem) {
+	t.Helper()
+	item := findRenderedContextItemByKind(packet, "cairnline_launch_packet")
+	if item == nil || item.Section != contextSectionRuntime || item.Included {
+		t.Fatalf("Cairnline launch packet item = %+v, want inspect-only runtime evidence", item)
+	}
+	if item.Origin != "cairnline.assignment_launch_packet" || item.InclusionReason != cairnlineAssignmentLaunchEvidenceReason {
+		t.Fatalf("Cairnline launch packet origin/reason = %q/%q, want replacement-readiness evidence", item.Origin, item.InclusionReason)
+	}
+	for _, want := range []string{
+		"Ready: true",
+		"Assignment: asgn_start",
+		"Execution mode: orchestrated",
+		"Root: root_start",
+		"Skills: 0; artifacts: 0; evidence: 0; reviews: 0; handoffs: 0; memory: 0; memory candidates: 0",
+	} {
+		if !strings.Contains(item.Body, want) {
+			t.Fatalf("Cairnline launch packet body = %q, want %q", item.Body, want)
+		}
+	}
+	for key, want := range map[string]string{
+		"read_backend":   "cairnline",
+		"ready":          "true",
+		"project_id":     "proj_start",
+		"work_item_id":   "work_start",
+		"assignment_id":  "asgn_start",
+		"role_id":        "role_backend",
+		"root_id":        "root_start",
+		"execution_mode": "orchestrated",
+	} {
+		if item.Metadata[key] != want {
+			t.Fatalf("Cairnline launch packet metadata[%q] = %q, want %q in %+v", key, item.Metadata[key], want, item.Metadata)
+		}
+	}
 }
 
 func assertProjectWorkStatusForTest(t *testing.T, server http.Handler, workID, want string) {
@@ -4000,6 +4846,28 @@ func findProjectWorkItemForTest(t *testing.T, items []ProjectWorkItemResponse, w
 	return ProjectWorkItemResponse{}
 }
 
+func findProjectWorkArtifactForTest(t *testing.T, items []ProjectWorkArtifactResponse, artifactID string) ProjectWorkArtifactResponse {
+	t.Helper()
+	for _, item := range items {
+		if item.ID == artifactID {
+			return item
+		}
+	}
+	t.Fatalf("artifact %s not found in %+v", artifactID, items)
+	return ProjectWorkArtifactResponse{}
+}
+
+func findProjectHandoffForTest(t *testing.T, items []ProjectHandoffResponse, handoffID string) ProjectHandoffResponse {
+	t.Helper()
+	for _, item := range items {
+		if item.ID == handoffID {
+			return item
+		}
+	}
+	t.Fatalf("handoff %s not found in %+v", handoffID, items)
+	return ProjectHandoffResponse{}
+}
+
 func allProjectActivityItemsForTest(data ProjectActivityDataResponse) []ProjectActivityItemResponse {
 	items := make([]ProjectActivityItemResponse, 0, len(data.Buckets.Active)+len(data.Buckets.Blocked)+len(data.Buckets.Completed)+len(data.Buckets.Recent)+len(data.Recent))
 	items = append(items, data.Buckets.Active...)
@@ -4031,6 +4899,137 @@ func createProjectForWorkTest(t *testing.T, server http.Handler) ProjectResponse
 	return project
 }
 
+func getMirroredCairnlineRoleForTest(t *testing.T, handler *Handler, projectID, roleID string) cairnline.Role {
+	t.Helper()
+	role := mirroredCairnlineRoleForTest(t, handler, projectID, roleID)
+	if role == nil {
+		t.Fatalf("mirrored role %q not found", roleID)
+	}
+	return *role
+}
+
+func mirroredCairnlineRoleForTest(t *testing.T, handler *Handler, projectID, roleID string) *cairnline.Role {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	roles, err := service.ListRoles(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("ListRoles(%q): %v", projectID, err)
+	}
+	for _, role := range roles {
+		if role.ID == roleID {
+			found := role
+			return &found
+		}
+	}
+	return nil
+}
+
+func getMirroredCairnlineWorkItemForTest(t *testing.T, handler *Handler, projectID, workItemID string) cairnline.WorkItem {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	item, err := service.GetWorkItem(t.Context(), projectID, workItemID)
+	if err != nil {
+		t.Fatalf("GetWorkItem(%q, %q): %v", projectID, workItemID, err)
+	}
+	return item
+}
+
+func getMirroredCairnlineAssignmentForTest(t *testing.T, handler *Handler, projectID, assignmentID string) cairnline.Assignment {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	item, err := service.GetAssignment(t.Context(), projectID, assignmentID)
+	if err != nil {
+		t.Fatalf("GetAssignment(%q, %q): %v", projectID, assignmentID, err)
+	}
+	return item
+}
+
+func getStoredProjectWorkAssignmentForTest(t *testing.T, handler *Handler, projectID, workItemID, assignmentID string) projectwork.Assignment {
+	t.Helper()
+	assignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{
+		ProjectID:  projectID,
+		WorkItemID: workItemID,
+	})
+	if err != nil {
+		t.Fatalf("ListAssignments(%q, %q): %v", projectID, workItemID, err)
+	}
+	for _, assignment := range assignments {
+		if assignment.ID == assignmentID {
+			return assignment
+		}
+	}
+	t.Fatalf("assignment %q not found in %+v", assignmentID, assignments)
+	return projectwork.Assignment{}
+}
+
+func getMirroredCairnlineArtifactForTest(t *testing.T, handler *Handler, projectID, workItemID, artifactID string) cairnline.Artifact {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	item, err := service.GetArtifact(t.Context(), projectID, workItemID, artifactID)
+	if err != nil {
+		t.Fatalf("GetArtifact(%q, %q, %q): %v", projectID, workItemID, artifactID, err)
+	}
+	return item
+}
+
+func getMirroredCairnlineEvidenceForTest(t *testing.T, handler *Handler, projectID, workItemID, evidenceID string) cairnline.Evidence {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	item, err := service.GetEvidence(t.Context(), projectID, workItemID, evidenceID)
+	if err != nil {
+		t.Fatalf("GetEvidence(%q, %q, %q): %v", projectID, workItemID, evidenceID, err)
+	}
+	return item
+}
+
+func getMirroredCairnlineReviewForTest(t *testing.T, handler *Handler, projectID, workItemID, reviewID string) cairnline.Review {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	item, err := service.GetReview(t.Context(), projectID, workItemID, reviewID)
+	if err != nil {
+		t.Fatalf("GetReview(%q, %q, %q): %v", projectID, workItemID, reviewID, err)
+	}
+	return item
+}
+
+func getMirroredCairnlineHandoffForTest(t *testing.T, handler *Handler, projectID, workItemID, handoffID string) cairnline.Handoff {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	item, err := service.GetHandoff(t.Context(), projectID, workItemID, handoffID)
+	if err != nil {
+		t.Fatalf("GetHandoff(%q, %q, %q): %v", projectID, workItemID, handoffID, err)
+	}
+	return item
+}
+
 func projectWorkRoleExists(roles []ProjectWorkRoleResponse, id string, builtIn bool) bool {
 	for _, role := range roles {
 		if role.ID == id && role.BuiltIn == builtIn {
@@ -4038,6 +5037,17 @@ func projectWorkRoleExists(roles []ProjectWorkRoleResponse, id string, builtIn b
 		}
 	}
 	return false
+}
+
+func findProjectWorkRoleForTest(t *testing.T, roles []ProjectWorkRoleResponse, id string) ProjectWorkRoleResponse {
+	t.Helper()
+	for _, role := range roles {
+		if role.ID == id {
+			return role
+		}
+	}
+	t.Fatalf("role %q not found in %+v", id, roles)
+	return ProjectWorkRoleResponse{}
 }
 
 func projectWorkRoleExistsStore(roles []projectwork.AgentRoleProfile, id string, builtIn bool) bool {

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/projectapp"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -69,14 +70,10 @@ type updateProjectRequest struct {
 }
 
 func (h *Handler) HandleProjects(w http.ResponseWriter, r *http.Request) {
-	items, err := h.projects.List(r.Context())
+	data, err := h.renderProjects(r.Context())
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
-	}
-	data := make([]ProjectResponseItem, 0, len(items))
-	for _, item := range items {
-		data = append(data, renderProject(item))
 	}
 	WriteJSON(w, http.StatusOK, ProjectsResponse{Object: "projects", Data: data})
 }
@@ -122,20 +119,21 @@ func (h *Handler) HandleCreateProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectIdentityToCairnline(r.Context(), "project_create", project)
 	WriteJSON(w, http.StatusCreated, ProjectResponse{Object: "project", Data: renderProject(project)})
 }
 
 func (h *Handler) HandleProject(w http.ResponseWriter, r *http.Request) {
-	project, ok, err := h.projects.Get(r.Context(), r.PathValue("id"))
+	project, err := h.renderProject(r.Context(), r.PathValue("id"))
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if !ok {
+	if project == nil {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
+	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: *project})
 }
 
 func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
@@ -271,6 +269,7 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectIdentityToCairnline(r.Context(), "project_update", project)
 	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
 }
 
@@ -288,7 +287,7 @@ func (h *Handler) HandleCreateProjectRoot(w http.ResponseWriter, r *http.Request
 		root.ID = newOpaqueTaskResourceID("root")
 	}
 	project, _, err := h.projectApplication().CreateRoot(r.Context(), r.PathValue("id"), root)
-	writeProjectRootMutationResponse(w, http.StatusCreated, project, err)
+	h.writeProjectRootMutationResponse(r.Context(), w, http.StatusCreated, project, err)
 }
 
 func (h *Handler) HandleUpdateProjectRoot(w http.ResponseWriter, r *http.Request) {
@@ -302,12 +301,12 @@ func (h *Handler) HandleUpdateProjectRoot(w http.ResponseWriter, r *http.Request
 		return
 	}
 	project, _, err := h.projectApplication().UpdateRoot(r.Context(), r.PathValue("id"), r.PathValue("root_id"), root)
-	writeProjectRootMutationResponse(w, http.StatusOK, project, err)
+	h.writeProjectRootMutationResponse(r.Context(), w, http.StatusOK, project, err)
 }
 
 func (h *Handler) HandleDeleteProjectRoot(w http.ResponseWriter, r *http.Request) {
 	project, _, err := h.projectApplication().DeleteRoot(r.Context(), r.PathValue("id"), r.PathValue("root_id"))
-	writeProjectRootMutationResponse(w, http.StatusOK, project, err)
+	h.writeProjectRootMutationResponse(r.Context(), w, http.StatusOK, project, err)
 }
 
 func (h *Handler) HandleCreateProjectContextSource(w http.ResponseWriter, r *http.Request) {
@@ -324,7 +323,7 @@ func (h *Handler) HandleCreateProjectContextSource(w http.ResponseWriter, r *htt
 		source.ID = newOpaqueTaskResourceID("ctxsrc")
 	}
 	project, _, err := h.projectApplication().CreateContextSource(r.Context(), r.PathValue("id"), source)
-	writeProjectContextSourceMutationResponse(w, http.StatusCreated, project, err)
+	h.writeProjectContextSourceMutationResponse(r.Context(), w, http.StatusCreated, project, err)
 }
 
 func (h *Handler) HandleUpdateProjectContextSource(w http.ResponseWriter, r *http.Request) {
@@ -338,12 +337,12 @@ func (h *Handler) HandleUpdateProjectContextSource(w http.ResponseWriter, r *htt
 		return
 	}
 	project, _, err := h.projectApplication().UpdateContextSource(r.Context(), r.PathValue("id"), r.PathValue("source_id"), source)
-	writeProjectContextSourceMutationResponse(w, http.StatusOK, project, err)
+	h.writeProjectContextSourceMutationResponse(r.Context(), w, http.StatusOK, project, err)
 }
 
 func (h *Handler) HandleDeleteProjectContextSource(w http.ResponseWriter, r *http.Request) {
 	project, _, err := h.projectApplication().DeleteContextSource(r.Context(), r.PathValue("id"), r.PathValue("source_id"))
-	writeProjectContextSourceMutationResponse(w, http.StatusOK, project, err)
+	h.writeProjectContextSourceMutationResponse(r.Context(), w, http.StatusOK, project, err)
 }
 
 func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
@@ -360,10 +359,11 @@ func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectDeleteToCairnline(r.Context(), "project_delete", result.Project)
 	WriteJSON(w, http.StatusOK, ProjectDeleteResponse{Object: "project_delete", Data: renderProjectDeleteResult(result)})
 }
 
-func writeProjectRootMutationResponse(w http.ResponseWriter, status int, project projects.Project, err error) {
+func (h *Handler) writeProjectRootMutationResponse(ctx context.Context, w http.ResponseWriter, status int, project projects.Project, err error) {
 	if errors.Is(err, projectapp.ErrProjectNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
@@ -384,10 +384,11 @@ func writeProjectRootMutationResponse(w http.ResponseWriter, status int, project
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectIdentityToCairnline(ctx, "project_root_mutation", project)
 	WriteJSON(w, status, ProjectResponse{Object: "project", Data: renderProject(project)})
 }
 
-func writeProjectContextSourceMutationResponse(w http.ResponseWriter, status int, project projects.Project, err error) {
+func (h *Handler) writeProjectContextSourceMutationResponse(ctx context.Context, w http.ResponseWriter, status int, project projects.Project, err error) {
 	if errors.Is(err, projectapp.ErrProjectNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
@@ -408,6 +409,7 @@ func writeProjectContextSourceMutationResponse(w http.ResponseWriter, status int
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	h.mirrorProjectIdentityToCairnline(ctx, "project_context_source_mutation", project)
 	WriteJSON(w, status, ProjectResponse{Object: "project", Data: renderProject(project)})
 }
 
@@ -583,7 +585,72 @@ func parseProjectTime(value string) (time.Time, error) {
 	return parsed.UTC(), nil
 }
 
+func (h *Handler) renderProjects(ctx context.Context) ([]ProjectResponseItem, error) {
+	items, err := h.projects.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		return h.renderCairnlineProjects(ctx, items)
+	}
+	data := make([]ProjectResponseItem, 0, len(items))
+	for _, item := range items {
+		data = append(data, renderProject(item))
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineProjects(ctx context.Context, nativeProjects []projects.Project) ([]ProjectResponseItem, error) {
+	data := make([]ProjectResponseItem, 0, len(nativeProjects))
+	for _, native := range nativeProjects {
+		project, err := h.renderCairnlineProject(ctx, native)
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, project)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderProject(ctx context.Context, projectID string) (*ProjectResponseItem, error) {
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil || !ok {
+		return nil, err
+	}
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		rendered, err := h.renderCairnlineProject(ctx, project)
+		if err != nil {
+			return nil, err
+		}
+		return &rendered, nil
+	}
+	rendered := renderProject(project)
+	return &rendered, nil
+}
+
+func (h *Handler) renderCairnlineProject(ctx context.Context, native projects.Project) (ProjectResponseItem, error) {
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, native.ID)
+	if err != nil {
+		return ProjectResponseItem{}, err
+	}
+	project, err := service.GetProject(ctx, snapshot.Project.ID)
+	if err != nil {
+		return ProjectResponseItem{}, err
+	}
+	executionProfile, err := cairnlineExecutionProfileByID(ctx, service, project.DefaultExecutionProfileID)
+	if err != nil {
+		return ProjectResponseItem{}, err
+	}
+	rendered := renderProject(projectFromCairnline(project, executionProfile, native))
+	rendered.ReadBackend = "cairnline"
+	return rendered, nil
+}
+
 func renderProject(project projects.Project) ProjectResponseItem {
+	return renderProjectWithBackend(project, "hecate")
+}
+
+func renderProjectWithBackend(project projects.Project, readBackend string) ProjectResponseItem {
 	roots := make([]ProjectRootResponseItem, 0, len(project.Roots))
 	for _, root := range project.Roots {
 		roots = append(roots, ProjectRootResponseItem{
@@ -616,6 +683,7 @@ func renderProject(project projects.Project) ProjectResponseItem {
 	}
 	return ProjectResponseItem{
 		ID:                       project.ID,
+		ReadBackend:              readBackend,
 		Name:                     project.Name,
 		Description:              project.Description,
 		Roots:                    roots,
@@ -632,6 +700,140 @@ func renderProject(project projects.Project) ProjectResponseItem {
 		UpdatedAt:                formatOptionalTime(project.UpdatedAt),
 		LastOpenedAt:             formatOptionalTime(project.LastOpenedAt),
 	}
+}
+
+func projectFromCairnline(item cairnline.Project, executionProfile *cairnline.ExecutionProfile, native projects.Project) projects.Project {
+	project := projects.Project{
+		ID:                       item.ID,
+		Name:                     item.Name,
+		Description:              item.Description,
+		Roots:                    projectRootsFromCairnline(item.Roots, native.Roots),
+		ContextSources:           projectContextSourcesFromCairnline(item.ContextSources),
+		DefaultRootID:            item.DefaultRootID,
+		DefaultProvider:          native.DefaultProvider,
+		DefaultModel:             native.DefaultModel,
+		DefaultAgentProfile:      firstNonEmpty(item.DefaultProfileID, native.DefaultAgentProfile),
+		DefaultToolsEnabled:      cloneBool(native.DefaultToolsEnabled),
+		DefaultWorkspaceMode:     native.DefaultWorkspaceMode,
+		DefaultSystemPrompt:      native.DefaultSystemPrompt,
+		DefaultCompactToolOutput: cloneBool(native.DefaultCompactToolOutput),
+		CreatedAt:                native.CreatedAt,
+		UpdatedAt:                native.UpdatedAt,
+		LastOpenedAt:             native.LastOpenedAt,
+	}
+	if executionProfile != nil {
+		project.DefaultProvider = strings.TrimSpace(executionProfile.ProviderHint)
+		project.DefaultModel = strings.TrimSpace(executionProfile.ModelHint)
+		project.DefaultToolsEnabled = boolFromCairnlinePolicy(executionProfile.ToolsPolicy)
+		project.DefaultWorkspaceMode = stringFromCairnlineAdapterOption(executionProfile.AdapterOptions, "workspace_mode")
+		project.DefaultSystemPrompt = stringFromCairnlineAdapterOption(executionProfile.AdapterOptions, "system_prompt")
+		project.DefaultCompactToolOutput = boolFromCairnlineAdapterOption(executionProfile.AdapterOptions, "compact_tool_output")
+	}
+	return project
+}
+
+func cairnlineExecutionProfileByID(ctx context.Context, service *cairnline.Service, id string) (*cairnline.ExecutionProfile, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, nil
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range executionProfiles {
+		if item.ID != id {
+			continue
+		}
+		found := item
+		return &found, nil
+	}
+	return nil, nil
+}
+
+func boolFromCairnlinePolicy(policy string) *bool {
+	switch strings.TrimSpace(policy) {
+	case "allow":
+		value := true
+		return &value
+	case "block":
+		value := false
+		return &value
+	default:
+		return nil
+	}
+}
+
+func stringFromCairnlineAdapterOption(options map[string]any, key string) string {
+	value, ok := options[key]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+func boolFromCairnlineAdapterOption(options map[string]any, key string) *bool {
+	value, ok := options[key]
+	if !ok {
+		return nil
+	}
+	flag, ok := value.(bool)
+	if !ok {
+		return nil
+	}
+	return &flag
+}
+
+func projectRootsFromCairnline(items []cairnline.Root, native []projects.Root) []projects.Root {
+	nativeByID := projectRootsByID(native)
+	out := make([]projects.Root, 0, len(items))
+	for _, item := range items {
+		prior := nativeByID[item.ID]
+		out = append(out, projects.Root{
+			ID:        item.ID,
+			Path:      item.Path,
+			Kind:      item.Kind,
+			GitRemote: item.GitRemote,
+			GitBranch: item.GitBranch,
+			Active:    item.Active,
+			CreatedAt: prior.CreatedAt,
+			UpdatedAt: prior.UpdatedAt,
+		})
+	}
+	return out
+}
+
+func projectRootsByID(items []projects.Root) map[string]projects.Root {
+	out := make(map[string]projects.Root, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
+func projectContextSourcesFromCairnline(items []cairnline.Source) []projects.ContextSource {
+	out := make([]projects.ContextSource, 0, len(items))
+	for _, item := range items {
+		out = append(out, projects.ContextSource{
+			ID:             item.ID,
+			Kind:           item.Kind,
+			Title:          item.Title,
+			Path:           item.Locator,
+			Enabled:        item.Enabled,
+			Format:         item.Format,
+			Scope:          item.Scope,
+			TrustLabel:     item.TrustLabel,
+			SourceCategory: item.SourceCategory,
+			Metadata:       cloneProjectContextMetadata(item.Metadata),
+			CreatedAt:      item.CreatedAt,
+			UpdatedAt:      item.UpdatedAt,
+		})
+	}
+	return out
 }
 
 func renderProjectDeleteResult(result projectapp.DeleteProjectResult) ProjectDeleteResponseItem {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -3,12 +3,15 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -17,6 +20,35 @@ import (
 func newProjectsTestServer() http.Handler {
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
+	return NewServer(quietLogger(), handler)
+}
+
+func newProjectsCairnlineReadTestServer() http.Handler {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	return NewServer(quietLogger(), handler)
+}
+
+func newProjectsCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newSeededProjectsTestServer(t *testing.T, cfg config.Config, project projects.Project) http.Handler {
+	t.Helper()
+	handler := NewHandler(cfg, quietLogger(), nil, nil, nil, nil)
+	store := projects.NewMemoryStore()
+	if _, err := store.Create(t.Context(), project); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	handler.SetProjectStore(store)
 	return NewServer(quietLogger(), handler)
 }
 
@@ -118,6 +150,386 @@ func TestProjectsAPI_CRUD(t *testing.T) {
 		deleted.Data.ProjectName != "Renamed" {
 		t.Fatalf("delete response = %+v, want project id/name", deleted)
 	}
+}
+
+func TestProjectsAPI_ReadsUseCairnlineReadModelWhenConfigured(t *testing.T) {
+	t.Parallel()
+	server := newProjectsCairnlineReadTestServer()
+
+	createBody := []byte(`{
+		"name":"Cairnline Project",
+		"description":"project identity read projection",
+		"roots":[{"id":"root_main","path":"/tmp/cairnline-project","kind":"git","git_remote":"git@example.com:hecate/hecate.git","git_branch":"main"}],
+		"context_sources":[{
+			"id":"ctx_agents",
+			"kind":"workspace_instruction",
+			"title":"AGENTS.md",
+			"path":"AGENTS.md",
+			"enabled":true,
+			"format":"agents_md",
+			"scope":"workspace",
+			"trust_label":"workspace_guidance",
+			"source_category":"instructions",
+			"metadata":{"root_id":"root_main"}
+		}],
+		"default_provider":"openai",
+		"default_model":"gpt-5",
+		"default_agent_profile":"architecture",
+		"default_tools_enabled":false,
+		"default_workspace_mode":"worktree",
+		"default_system_prompt":"Stay crisp.",
+		"default_compact_tool_output":true
+	}`)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader(createBody)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Data.ReadBackend != "hecate" {
+		t.Fatalf("created read_backend = %q, want hecate mutation response", created.Data.ReadBackend)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+created.Data.ID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var fetched ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &fetched); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	assertCairnlineProjectProjectionForTest(t, fetched.Data, created.Data.ID)
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listed ProjectsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed.Data) != 1 {
+		t.Fatalf("listed projects = %+v, want one project", listed.Data)
+	}
+	assertCairnlineProjectProjectionForTest(t, listed.Data[0], created.Data.ID)
+}
+
+func TestProjectsAPI_CairnlineReadsMatchHecateProjectProjection(t *testing.T) {
+	t.Parallel()
+
+	project := projectReadParityFixture()
+	hecateServer := newSeededProjectsTestServer(t, config.Config{}, project)
+	cairnlineServer := newSeededProjectsTestServer(t, config.Config{
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, project)
+
+	hecateDetail := getProjectForTest(t, hecateServer, project.ID)
+	cairnlineDetail := getProjectForTest(t, cairnlineServer, project.ID)
+	assertProjectProjectionParity(t, hecateDetail, cairnlineDetail, "detail")
+
+	hecateList := listProjectsForTest(t, hecateServer)
+	cairnlineList := listProjectsForTest(t, cairnlineServer)
+	if len(hecateList) != 1 || len(cairnlineList) != 1 {
+		t.Fatalf("project list counts = hecate:%d cairnline:%d, want one each", len(hecateList), len(cairnlineList))
+	}
+	assertProjectProjectionParity(t, hecateList[0], cairnlineList[0], "list")
+}
+
+func TestProjectsAPI_MirrorsIdentityMutationsToCairnlineWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineMirrorTestServer(t)
+
+	createBody := []byte(`{
+		"name":"Mirror Project",
+		"description":"project identity mirror",
+		"roots":[{"id":"root_main","path":"/workspace/main","kind":"git","git_branch":"main"}],
+		"context_sources":[{"id":"ctx_agents","path":"AGENTS.md","kind":"workspace_instruction","title":"AGENTS.md"}],
+		"default_provider":"openai",
+		"default_model":"gpt-5"
+	}`)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader(createBody)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.ID != created.Data.ID || mirrored.Name != "Mirror Project" || mirrored.DefaultRootID != "root_main" {
+		t.Fatalf("mirrored project = %+v, want created project identity", mirrored)
+	}
+	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" || mirrored.Roots[0].Path != "/workspace/main" {
+		t.Fatalf("mirrored roots = %+v, want root_main", mirrored.Roots)
+	}
+	if len(mirrored.ContextSources) != 1 || mirrored.ContextSources[0].ID != "ctx_agents" || mirrored.ContextSources[0].Locator != "AGENTS.md" {
+		t.Fatalf("mirrored context sources = %+v, want AGENTS.md source", mirrored.ContextSources)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "openai", "gpt-5")
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
+		"name":"Mirrored Rename",
+		"default_model":"gpt-5.1"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.Name != "Mirrored Rename" {
+		t.Fatalf("mirrored name = %q, want patched name", mirrored.Name)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "openai", "gpt-5.1")
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+created.Data.ID+"/roots", bytes.NewReader([]byte(`{
+		"id":"root_worktree",
+		"path":"/workspace/.worktrees/feature",
+		"kind":"git_worktree",
+		"git_branch":"feature/mirror"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create root status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if len(mirrored.Roots) != 2 || mirrored.Roots[1].ID != "root_worktree" || mirrored.Roots[1].GitBranch != "feature/mirror" {
+		t.Fatalf("mirrored roots after create = %+v, want worktree root", mirrored.Roots)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+created.Data.ID+"/context-sources", bytes.NewReader([]byte(`{
+		"id":"ctx_design",
+		"path":"docs/design/accepted/projects.md",
+		"kind":"doc",
+		"title":"Projects"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create source status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if len(mirrored.ContextSources) != 2 || mirrored.ContextSources[1].ID != "ctx_design" || mirrored.ContextSources[1].Locator != "docs/design/accepted/projects.md" {
+		t.Fatalf("mirrored context sources after create = %+v, want design source", mirrored.ContextSources)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+created.Data.ID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror after delete: %v", err)
+	}
+	defer store.Close()
+	if _, err := service.GetProject(t.Context(), created.Data.ID); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("mirrored deleted project error = %v, want ErrNotFound", err)
+	}
+}
+
+func assertCairnlineProjectProjectionForTest(t *testing.T, project ProjectResponseItem, projectID string) {
+	t.Helper()
+	if project.ID != projectID || project.ReadBackend != "cairnline" {
+		t.Fatalf("project = %+v, want Cairnline-backed project %s", project, projectID)
+	}
+	if project.DefaultProvider != "openai" || project.DefaultModel != "gpt-5" || project.DefaultAgentProfile != "architecture" || project.DefaultWorkspaceMode != "worktree" || project.DefaultSystemPrompt != "Stay crisp." {
+		t.Fatalf("project defaults = %+v, want Cairnline-projected defaults", project)
+	}
+	if project.DefaultToolsEnabled == nil || *project.DefaultToolsEnabled {
+		t.Fatalf("default_tools_enabled = %v, want false from Cairnline execution profile", project.DefaultToolsEnabled)
+	}
+	if project.DefaultCompactToolOutput == nil || !*project.DefaultCompactToolOutput {
+		t.Fatalf("default_compact_tool_output = %v, want true from Cairnline execution profile", project.DefaultCompactToolOutput)
+	}
+	if len(project.Roots) != 1 || project.Roots[0].ID != "root_main" || project.Roots[0].Path != "/tmp/cairnline-project" || project.Roots[0].Kind != "git" || project.Roots[0].GitBranch != "main" {
+		t.Fatalf("project roots = %+v, want Cairnline-projected root metadata", project.Roots)
+	}
+	if project.DefaultRootID != "root_main" {
+		t.Fatalf("default_root_id = %q, want root_main", project.DefaultRootID)
+	}
+	if len(project.ContextSources) != 1 {
+		t.Fatalf("context sources = %+v, want one source", project.ContextSources)
+	}
+	source := project.ContextSources[0]
+	if source.ID != "ctx_agents" || source.Kind != "workspace_instruction" || source.Path != "AGENTS.md" || source.Format != "agents_md" || source.TrustLabel != "workspace_guidance" {
+		t.Fatalf("context source = %+v, want Cairnline-projected source metadata", source)
+	}
+	if source.Metadata["root_id"] != "root_main" {
+		t.Fatalf("context source metadata = %+v, want root_id", source.Metadata)
+	}
+}
+
+func projectReadParityFixture() projects.Project {
+	toolsEnabled := true
+	compactToolOutput := true
+	createdAt := time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 6, 11, 10, 30, 0, 0, time.UTC)
+	lastOpenedAt := time.Date(2026, 6, 12, 15, 45, 0, 0, time.UTC)
+	rootCreatedAt := time.Date(2026, 6, 10, 9, 5, 0, 0, time.UTC)
+	rootUpdatedAt := time.Date(2026, 6, 10, 9, 10, 0, 0, time.UTC)
+	sourceCreatedAt := time.Date(2026, 6, 10, 9, 15, 0, 0, time.UTC)
+	sourceUpdatedAt := time.Date(2026, 6, 10, 9, 20, 0, 0, time.UTC)
+	return projects.Project{
+		ID:                       "proj_cairnline_parity",
+		Name:                     "Cairnline parity",
+		Description:              "portable project identity projection",
+		DefaultRootID:            "root_main",
+		DefaultProvider:          "openai",
+		DefaultModel:             "gpt-5",
+		DefaultAgentProfile:      "architecture",
+		DefaultToolsEnabled:      &toolsEnabled,
+		DefaultWorkspaceMode:     "worktree",
+		DefaultSystemPrompt:      "Stay crisp.",
+		DefaultCompactToolOutput: &compactToolOutput,
+		CreatedAt:                createdAt,
+		UpdatedAt:                updatedAt,
+		LastOpenedAt:             lastOpenedAt,
+		Roots: []projects.Root{
+			{
+				ID:        "root_main",
+				Path:      "/workspace/hecate",
+				Kind:      "git",
+				GitRemote: "git@example.com:hecate/hecate.git",
+				GitBranch: "main",
+				Active:    true,
+				CreatedAt: rootCreatedAt,
+				UpdatedAt: rootUpdatedAt,
+			},
+			{
+				ID:        "root_feature",
+				Path:      "/workspace/hecate/.worktrees/feature",
+				Kind:      "git_worktree",
+				GitBranch: "feature/cairnline",
+				Active:    false,
+				CreatedAt: rootCreatedAt.Add(time.Minute),
+				UpdatedAt: rootUpdatedAt.Add(time.Minute),
+			},
+		},
+		ContextSources: []projects.ContextSource{
+			{
+				ID:             "ctx_agents",
+				Kind:           "workspace_instruction",
+				Title:          "AGENTS.md",
+				Path:           "AGENTS.md",
+				Enabled:        true,
+				Format:         "agents_md",
+				Scope:          "workspace",
+				TrustLabel:     "workspace_guidance",
+				SourceCategory: "instructions",
+				Metadata: map[string]string{
+					"root_id": "root_main",
+					"scope":   "workspace",
+				},
+				CreatedAt: sourceCreatedAt,
+				UpdatedAt: sourceUpdatedAt,
+			},
+			{
+				ID:             "ctx_design",
+				Kind:           "doc",
+				Title:          "Projects design",
+				Path:           "docs/design/accepted/projects.md",
+				Enabled:        false,
+				Format:         "markdown",
+				Scope:          "project",
+				TrustLabel:     "operator_guidance",
+				SourceCategory: "design",
+				Metadata: map[string]string{
+					"root_id": "root_main",
+				},
+				CreatedAt: sourceCreatedAt.Add(time.Minute),
+				UpdatedAt: sourceUpdatedAt.Add(time.Minute),
+			},
+		},
+	}
+}
+
+func getProjectForTest(t *testing.T, server http.Handler, projectID string) ProjectResponseItem {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get project status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode project response: %v", err)
+	}
+	return response.Data
+}
+
+func listProjectsForTest(t *testing.T, server http.Handler) []ProjectResponseItem {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list projects status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode projects response: %v", err)
+	}
+	return response.Data
+}
+
+func assertProjectProjectionParity(t *testing.T, hecate, cairnline ProjectResponseItem, label string) {
+	t.Helper()
+	if hecate.ReadBackend != "hecate" {
+		t.Fatalf("%s hecate read_backend = %q, want hecate", label, hecate.ReadBackend)
+	}
+	if cairnline.ReadBackend != "cairnline" {
+		t.Fatalf("%s cairnline read_backend = %q, want cairnline", label, cairnline.ReadBackend)
+	}
+	hecate.ReadBackend = ""
+	cairnline.ReadBackend = ""
+	if !reflect.DeepEqual(hecate, cairnline) {
+		t.Fatalf("%s project projection mismatch\nhecate:   %+v\ncairnline: %+v", label, hecate, cairnline)
+	}
+}
+
+func getMirroredCairnlineProjectForTest(t *testing.T, handler *Handler, projectID string) cairnline.Project {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	project, err := service.GetProject(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("GetProject(%q): %v", projectID, err)
+	}
+	return project
+}
+
+func assertMirroredExecutionProfileForTest(t *testing.T, handler *Handler, profileID, provider, model string) {
+	t.Helper()
+	if profileID == "" {
+		t.Fatalf("mirrored project missing default execution profile id")
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	profiles, err := service.ListExecutionProfiles(t.Context())
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles(): %v", err)
+	}
+	for _, profile := range profiles {
+		if profile.ID != profileID {
+			continue
+		}
+		if profile.ProviderHint != provider || profile.ModelHint != model {
+			t.Fatalf("execution profile = %+v, want provider/model %s/%s", profile, provider, model)
+		}
+		return
+	}
+	t.Fatalf("execution profile %q not found in %+v", profileID, profiles)
 }
 
 func TestProjectsAPI_Validation(t *testing.T) {

--- a/internal/api/handler_system_reset.go
+++ b/internal/api/handler_system_reset.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -102,6 +103,12 @@ func (h *Handler) resetSystemData(ctx context.Context) (SystemResetDataResponseI
 		return stats, err
 	}
 	stats.DatabaseRowsDeleted = rowsDeleted
+
+	cairnlineMirrorDeleted, err := h.resetCairnlineMirrorDatabase()
+	if err != nil {
+		return stats, err
+	}
+	stats.CairnlineMirrorFilesDeleted = cairnlineMirrorDeleted
 
 	return stats, nil
 }
@@ -226,6 +233,24 @@ func (h *Handler) resetTasks(ctx context.Context) (int, error) {
 			return deleted, fmt.Errorf("%w: task %q has an active run; cancel it first", errSystemResetConflict, task.ID)
 		}
 		if err := h.taskStore.DeleteTask(ctx, task.ID); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+func (h *Handler) resetCairnlineMirrorDatabase() (int, error) {
+	if h == nil {
+		return 0, nil
+	}
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	deleted := 0
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if err := os.Remove(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return deleted, err
 		}
 		deleted++

--- a/internal/api/handler_system_reset_test.go
+++ b/internal/api/handler_system_reset_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -215,6 +216,46 @@ func TestSystemResetDataRejectsNonLoopbackClients(t *testing.T) {
 	server.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSystemResetDataRemovesEmbeddedCairnlineMirrorDatabase(t *testing.T) {
+	t.Parallel()
+	logger := quietLogger()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, logger, nil, controlplane.NewMemoryStore(), taskstate.NewMemoryStore(), nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	server := NewServer(logger, handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"Mirror reset"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create project status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(handler.cairnlineEmbeddedDatabasePath()); err != nil {
+		t.Fatalf("stat Cairnline mirror before reset: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/system/reset-data", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	server.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var reset SystemResetDataResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &reset); err != nil {
+		t.Fatalf("decode reset response: %v", err)
+	}
+	if reset.Data.CairnlineMirrorFilesDeleted == 0 {
+		t.Fatalf("cairnline mirror databases deleted = 0, want embedded mirror files removed; stats=%+v", reset.Data)
+	}
+	for _, path := range []string{handler.cairnlineEmbeddedDatabasePath(), handler.cairnlineEmbeddedDatabasePath() + "-wal", handler.cairnlineEmbeddedDatabasePath() + "-shm"} {
+		if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
+			t.Fatalf("stat %s after reset error = %v, want not exist", path, err)
+		}
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -297,17 +297,88 @@ type ProjectCairnlineExportResponse struct {
 }
 
 type ProjectCairnlineExportResponseItem struct {
-	ProjectID            string `json:"project_id"`
-	DatabasePath         string `json:"database_path"`
-	AgentProfileCount    int    `json:"agent_profile_count"`
-	SkillCount           int    `json:"skill_count"`
-	RoleCount            int    `json:"role_count"`
-	WorkItemCount        int    `json:"work_item_count"`
-	AssignmentCount      int    `json:"assignment_count"`
-	ArtifactCount        int    `json:"artifact_count"`
-	HandoffCount         int    `json:"handoff_count"`
-	MemoryEntryCount     int    `json:"memory_entry_count"`
-	MemoryCandidateCount int    `json:"memory_candidate_count"`
+	ProjectID              string `json:"project_id"`
+	DatabasePath           string `json:"database_path"`
+	RootCount              int    `json:"root_count"`
+	ContextSourceCount     int    `json:"context_source_count"`
+	AgentProfileCount      int    `json:"agent_profile_count"`
+	ExecutionProfileCount  int    `json:"execution_profile_count"`
+	SkillCount             int    `json:"skill_count"`
+	RoleCount              int    `json:"role_count"`
+	WorkItemCount          int    `json:"work_item_count"`
+	AssignmentCount        int    `json:"assignment_count"`
+	ArtifactCount          int    `json:"artifact_count"`
+	HandoffCount           int    `json:"handoff_count"`
+	MemoryEntryCount       int    `json:"memory_entry_count"`
+	MemoryCandidateCount   int    `json:"memory_candidate_count"`
+	AssistantProposalCount int    `json:"assistant_proposal_count"`
+}
+
+type ProjectCairnlineSyncResponse struct {
+	Object string                           `json:"object"`
+	Data   ProjectCairnlineSyncResponseItem `json:"data"`
+}
+
+type ProjectCairnlineSyncResponseItem struct {
+	DatabasePath       string                              `json:"database_path"`
+	Match              bool                                `json:"match"`
+	Differences        []ProjectCairnlineParityDifference  `json:"differences,omitempty"`
+	IDDifferences      []ProjectCairnlineIDDifference      `json:"id_differences,omitempty"`
+	ContentDifferences []ProjectCairnlineContentDifference `json:"content_differences,omitempty"`
+	Hecate             ProjectCairnlineSyncCounts          `json:"hecate"`
+	Cairnline          ProjectCairnlineSyncCounts          `json:"cairnline"`
+	Authoritative      bool                                `json:"authoritative"`
+}
+
+type ProjectCairnlineSyncCounts struct {
+	Projects           int `json:"projects"`
+	Roots              int `json:"roots"`
+	ContextSources     int `json:"context_sources"`
+	AgentProfiles      int `json:"agent_profiles"`
+	ExecutionProfiles  int `json:"execution_profiles"`
+	Skills             int `json:"skills"`
+	Roles              int `json:"roles"`
+	WorkItems          int `json:"work_items"`
+	Assignments        int `json:"assignments"`
+	Artifacts          int `json:"artifacts"`
+	Handoffs           int `json:"handoffs"`
+	MemoryEntries      int `json:"memory_entries"`
+	MemoryCandidates   int `json:"memory_candidates"`
+	AssistantProposals int `json:"assistant_proposals"`
+	LaunchPackets      int `json:"launch_packets"`
+	LaunchWarnings     int `json:"launch_warnings"`
+	LaunchErrors       int `json:"launch_errors"`
+}
+
+type ProjectCairnlineSyncIDSets struct {
+	Projects           []string `json:"projects,omitempty"`
+	Roots              []string `json:"roots,omitempty"`
+	ContextSources     []string `json:"context_sources,omitempty"`
+	AgentProfiles      []string `json:"agent_profiles,omitempty"`
+	ExecutionProfiles  []string `json:"execution_profiles,omitempty"`
+	Skills             []string `json:"skills,omitempty"`
+	Roles              []string `json:"roles,omitempty"`
+	WorkItems          []string `json:"work_items,omitempty"`
+	Assignments        []string `json:"assignments,omitempty"`
+	Artifacts          []string `json:"artifacts,omitempty"`
+	Handoffs           []string `json:"handoffs,omitempty"`
+	MemoryEntries      []string `json:"memory_entries,omitempty"`
+	MemoryCandidates   []string `json:"memory_candidates,omitempty"`
+	AssistantProposals []string `json:"assistant_proposals,omitempty"`
+	LaunchPackets      []string `json:"launch_packets,omitempty"`
+}
+
+type ProjectCairnlineIDDifference struct {
+	Path      string   `json:"path"`
+	Hecate    []string `json:"hecate"`
+	Cairnline []string `json:"cairnline"`
+}
+
+type ProjectCairnlineContentDifference struct {
+	Path      string `json:"path"`
+	ID        string `json:"id"`
+	Hecate    string `json:"hecate_digest"`
+	Cairnline string `json:"cairnline_digest"`
 }
 
 type ProjectCairnlineReadModelResponse struct {
@@ -316,18 +387,30 @@ type ProjectCairnlineReadModelResponse struct {
 }
 
 type ProjectCairnlineReadModelResponseItem struct {
-	ProjectID            string                           `json:"project_id"`
-	AgentProfileCount    int                              `json:"agent_profile_count"`
-	SkillCount           int                              `json:"skill_count"`
-	RoleCount            int                              `json:"role_count"`
-	WorkItemCount        int                              `json:"work_item_count"`
-	AssignmentCount      int                              `json:"assignment_count"`
-	ArtifactCount        int                              `json:"artifact_count"`
-	HandoffCount         int                              `json:"handoff_count"`
-	MemoryEntryCount     int                              `json:"memory_entry_count"`
-	MemoryCandidateCount int                              `json:"memory_candidate_count"`
-	Operations           cairnline.ProjectOperationsBrief `json:"operations"`
-	Activity             cairnline.ProjectActivity        `json:"activity"`
+	ProjectID                string                              `json:"project_id"`
+	RootCount                int                                 `json:"root_count"`
+	ContextSourceCount       int                                 `json:"context_source_count"`
+	AgentProfileCount        int                                 `json:"agent_profile_count"`
+	ExecutionProfileCount    int                                 `json:"execution_profile_count"`
+	SkillCount               int                                 `json:"skill_count"`
+	RoleCount                int                                 `json:"role_count"`
+	WorkItemCount            int                                 `json:"work_item_count"`
+	AssignmentCount          int                                 `json:"assignment_count"`
+	ArtifactCount            int                                 `json:"artifact_count"`
+	HandoffCount             int                                 `json:"handoff_count"`
+	MemoryEntryCount         int                                 `json:"memory_entry_count"`
+	MemoryCandidateCount     int                                 `json:"memory_candidate_count"`
+	AssistantProposalCount   int                                 `json:"assistant_proposal_count"`
+	LaunchPacketCount        int                                 `json:"launch_packet_count"`
+	LaunchPacketWarningCount int                                 `json:"launch_packet_warning_count"`
+	LaunchPacketErrors       []ProjectCairnlineLaunchPacketError `json:"launch_packet_errors,omitempty"`
+	Operations               cairnline.ProjectOperationsBrief    `json:"operations"`
+	Activity                 cairnline.ProjectActivity           `json:"activity"`
+}
+
+type ProjectCairnlineLaunchPacketError struct {
+	AssignmentID string `json:"assignment_id"`
+	Error        string `json:"error"`
 }
 
 type ProjectCairnlineParityReportResponse struct {
@@ -344,8 +427,26 @@ type ProjectCairnlineParityReportResponseItem struct {
 }
 
 type ProjectCairnlineParitySnapshot struct {
-	Activity   ProjectCairnlineActivityParityCounts   `json:"activity"`
-	Operations ProjectCairnlineOperationsParityCounts `json:"operations"`
+	Graph         ProjectCairnlineGraphParityCounts        `json:"graph"`
+	Activity      ProjectCairnlineActivityParityCounts     `json:"activity"`
+	Operations    ProjectCairnlineOperationsParityCounts   `json:"operations"`
+	Assistant     ProjectCairnlineAssistantParityCounts    `json:"assistant"`
+	LaunchPackets ProjectCairnlineLaunchPacketParityCounts `json:"launch_packets"`
+}
+
+type ProjectCairnlineGraphParityCounts struct {
+	Roots             int `json:"roots"`
+	ContextSources    int `json:"context_sources"`
+	AgentProfiles     int `json:"agent_profiles"`
+	ExecutionProfiles int `json:"execution_profiles"`
+	Skills            int `json:"skills"`
+	Roles             int `json:"roles"`
+	WorkItems         int `json:"work_items"`
+	Assignments       int `json:"assignments"`
+	Artifacts         int `json:"artifacts"`
+	Handoffs          int `json:"handoffs"`
+	MemoryEntries     int `json:"memory_entries"`
+	MemoryCandidates  int `json:"memory_candidates"`
 }
 
 type ProjectCairnlineActivityParityCounts struct {
@@ -360,6 +461,16 @@ type ProjectCairnlineActivityParityCounts struct {
 type ProjectCairnlineOperationsParityCounts struct {
 	PendingMemoryCandidates int `json:"pending_memory_candidates"`
 	OpenHandoffs            int `json:"open_handoffs"`
+}
+
+type ProjectCairnlineAssistantParityCounts struct {
+	Proposals int `json:"proposals"`
+}
+
+type ProjectCairnlineLaunchPacketParityCounts struct {
+	Assignments int `json:"assignments"`
+	Warnings    int `json:"warnings"`
+	Errors      int `json:"errors"`
 }
 
 type ProjectCairnlineParityDifference struct {
@@ -381,10 +492,14 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineAuthoritative  bool     `json:"cairnline_authoritative"`
 	ReadModelSwitchReady    bool     `json:"read_model_switch_ready"`
 	WriteAdapterReady       bool     `json:"write_adapter_ready"`
+	ReadRoutes              []string `json:"read_routes,omitempty"`
+	WriteAdapterSeams       []string `json:"write_adapter_seams,omitempty"`
+	WriteAdapterGaps        []string `json:"write_adapter_gaps,omitempty"`
 	Status                  string   `json:"status"`
 	Detail                  string   `json:"detail"`
 	Warnings                []string `json:"warnings,omitempty"`
 	ReplacementReadinessURL string   `json:"replacement_readiness_url,omitempty"`
+	SyncReadinessURL        string   `json:"sync_readiness_url,omitempty"`
 }
 
 type AgentProfileResponse struct {
@@ -461,6 +576,7 @@ type UpdateAgentProfileRequest struct {
 
 type ProjectResponseItem struct {
 	ID                       string                             `json:"id"`
+	ReadBackend              string                             `json:"read_backend,omitempty"`
 	Name                     string                             `json:"name"`
 	Description              string                             `json:"description,omitempty"`
 	Roots                    []ProjectRootResponseItem          `json:"roots"`
@@ -517,6 +633,7 @@ type ProjectSkillResponse struct {
 type ProjectSkillResponseItem struct {
 	ID                     string                                       `json:"id"`
 	ProjectID              string                                       `json:"project_id"`
+	ReadBackend            string                                       `json:"read_backend,omitempty"`
 	Title                  string                                       `json:"title"`
 	Description            string                                       `json:"description,omitempty"`
 	Path                   string                                       `json:"path,omitempty"`
@@ -645,17 +762,18 @@ type ProjectMemoryCandidateListResponse struct {
 }
 
 type ProjectMemoryResponseItem struct {
-	ID         string `json:"id"`
-	Scope      string `json:"scope"`
-	ProjectID  string `json:"project_id"`
-	Title      string `json:"title"`
-	Body       string `json:"body"`
-	TrustLabel string `json:"trust_label"`
-	SourceKind string `json:"source_kind"`
-	SourceID   string `json:"source_id,omitempty"`
-	Enabled    bool   `json:"enabled"`
-	CreatedAt  string `json:"created_at"`
-	UpdatedAt  string `json:"updated_at"`
+	ID          string `json:"id"`
+	Scope       string `json:"scope"`
+	ProjectID   string `json:"project_id"`
+	ReadBackend string `json:"read_backend,omitempty"`
+	Title       string `json:"title"`
+	Body        string `json:"body"`
+	TrustLabel  string `json:"trust_label"`
+	SourceKind  string `json:"source_kind"`
+	SourceID    string `json:"source_id,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
 }
 
 type ProjectMemoryCandidateSourceRefResponseItem struct {
@@ -668,6 +786,7 @@ type ProjectMemoryCandidateSourceRefResponseItem struct {
 type ProjectMemoryCandidateResponseItem struct {
 	ID                  string                                        `json:"id"`
 	ProjectID           string                                        `json:"project_id"`
+	ReadBackend         string                                        `json:"read_backend,omitempty"`
 	Title               string                                        `json:"title"`
 	Body                string                                        `json:"body"`
 	SuggestedKind       string                                        `json:"suggested_kind,omitempty"`
@@ -1488,6 +1607,7 @@ type SystemResetDataResponseItem struct {
 	PolicyRulesDeleted               int `json:"policy_rules_deleted"`
 	AgentApprovalGrantsDeleted       int `json:"agent_approval_grants_deleted"`
 	DatabaseRowsDeleted              int `json:"database_rows_deleted"`
+	CairnlineMirrorFilesDeleted      int `json:"cairnline_mirror_files_deleted"`
 }
 
 type UsageSummaryResponseItem struct {

--- a/internal/api/project_assistant_agent_tool.go
+++ b/internal/api/project_assistant_agent_tool.go
@@ -35,7 +35,7 @@ func (h *Handler) DraftProjectProposal(ctx context.Context, input orchestrator.P
 		}
 	}
 
-	proposal, err := h.projectAssistantApplication().Draft(ctx, projectassistantapp.DraftCommand{
+	proposal, err := h.projectAssistantDraft(ctx, projectassistantapp.DraftCommand{
 		ProjectID:  projectID,
 		WorkItemID: input.WorkItemID,
 		Request:    request,

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -22,6 +22,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/system/reset-data"},
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/cairnline/export"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -82,6 +82,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/cairnline/export", handler.HandleExportProjectToCairnline)

--- a/internal/cairnlinebridge/assistant.go
+++ b/internal/cairnlinebridge/assistant.go
@@ -1,0 +1,1029 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func UpsertAssistantProposalRecord(ctx context.Context, service *cairnline.Service, record projectassistant.ProposalRecord) (cairnline.AssistantProposalRecord, bool, error) {
+	if service == nil {
+		return cairnline.AssistantProposalRecord{}, false, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item, ok := AssistantProposalRecord(record)
+	if !ok {
+		return cairnline.AssistantProposalRecord{}, false, nil
+	}
+	imported, err := service.ImportAssistantProposalRecord(ctx, item)
+	return imported, true, err
+}
+
+func AssistantProposalRecord(record projectassistant.ProposalRecord) (cairnline.AssistantProposalRecord, bool) {
+	actions := make([]cairnline.AssistantAction, 0, len(record.Proposal.Actions))
+	for _, action := range record.Proposal.Actions {
+		item, ok := AssistantAction(action)
+		if !ok {
+			continue
+		}
+		actions = append(actions, item)
+	}
+	if len(actions) == 0 {
+		return cairnline.AssistantProposalRecord{}, false
+	}
+	latestResult := AssistantApplyResultPtr(record.LatestResult)
+	attempts := make([]cairnline.AssistantApplyAttempt, 0, len(record.ApplyAttempts))
+	for _, attempt := range record.ApplyAttempts {
+		attempts = append(attempts, AssistantApplyAttempt(attempt))
+	}
+	return cairnline.AssistantProposalRecord{
+		ID:        strings.TrimSpace(record.ID),
+		ProjectID: strings.TrimSpace(record.ProjectID),
+		Source:    AssistantProposalSource(record.Source),
+		SourceID:  strings.TrimSpace(record.SourceID),
+		Proposal: cairnline.AssistantProposal{
+			ID:                   strings.TrimSpace(record.Proposal.ID),
+			ProjectID:            strings.TrimSpace(record.ProjectID),
+			Title:                strings.TrimSpace(record.Proposal.Title),
+			Summary:              strings.TrimSpace(record.Proposal.Summary),
+			Warnings:             compactStrings(record.Proposal.Warnings),
+			Source:               AssistantProposalSource(record.Source),
+			RequiresConfirmation: record.Proposal.RequiresConfirmation,
+			Actions:              actions,
+			CreatedAt:            record.CreatedAt,
+		},
+		Status:        AssistantProposalStatus(record.Status),
+		LatestResult:  latestResult,
+		ApplyAttempts: attempts,
+		CreatedAt:     record.CreatedAt,
+		UpdatedAt:     record.UpdatedAt,
+		AppliedAt:     record.AppliedAt,
+	}, true
+}
+
+func ProjectAssistantProposalRecord(record cairnline.AssistantProposalRecord) (projectassistant.ProposalRecord, bool) {
+	actions := make([]projectassistant.Action, 0, len(record.Proposal.Actions))
+	for _, action := range record.Proposal.Actions {
+		item, ok := ProjectAssistantAction(action)
+		if !ok {
+			continue
+		}
+		actions = append(actions, item)
+	}
+	if len(actions) == 0 {
+		return projectassistant.ProposalRecord{}, false
+	}
+	latestResult := ProjectAssistantApplyResultPtr(record.LatestResult)
+	attempts := make([]projectassistant.ApplyAttempt, 0, len(record.ApplyAttempts))
+	for _, attempt := range record.ApplyAttempts {
+		attempts = append(attempts, ProjectAssistantApplyAttempt(attempt))
+	}
+	return projectassistant.ProposalRecord{
+		ID:        strings.TrimSpace(record.ID),
+		ProjectID: strings.TrimSpace(record.ProjectID),
+		Source:    ProjectAssistantProposalSource(record.Source),
+		SourceID:  strings.TrimSpace(record.SourceID),
+		Proposal: projectassistant.Proposal{
+			ID:                   strings.TrimSpace(record.Proposal.ID),
+			Title:                strings.TrimSpace(record.Proposal.Title),
+			Summary:              strings.TrimSpace(record.Proposal.Summary),
+			Actions:              actions,
+			Warnings:             compactStrings(record.Proposal.Warnings),
+			RequiresConfirmation: record.Proposal.RequiresConfirmation,
+		},
+		Status:        ProjectAssistantProposalStatus(record.Status),
+		LatestResult:  latestResult,
+		ApplyAttempts: attempts,
+		CreatedAt:     record.CreatedAt,
+		UpdatedAt:     record.UpdatedAt,
+		AppliedAt:     record.AppliedAt,
+	}, true
+}
+
+func AssistantAction(action projectassistant.Action) (cairnline.AssistantAction, bool) {
+	item := cairnline.AssistantAction{
+		Kind:    AssistantActionKind(action.Kind),
+		Summary: strings.TrimSpace(action.Reason),
+		Target:  AssistantTarget(action.Target),
+	}
+	if item.Kind == "" {
+		return cairnline.AssistantAction{}, false
+	}
+	switch strings.TrimSpace(action.Kind) {
+	case projectassistant.ActionCreateProject:
+		patch, ok := decodeAssistantPatch[assistantProjectPatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		item.Project = assistantProject(patch)
+	case projectassistant.ActionUpdateProject:
+		projectID := firstNonEmpty(targetValue(action.Target, "project_id"), targetValue(action.Target, "id"))
+		if projectID == "" {
+			return cairnline.AssistantAction{}, false
+		}
+		patch, ok := decodeAssistantPatch[assistantUpdateProjectPatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		item.Project = &cairnline.Project{
+			ID:          projectID,
+			Name:        pointerValue(patch.Name),
+			Description: pointerValue(patch.Description),
+		}
+	case projectassistant.ActionAttachProjectRoot:
+		patch, ok := decodeAssistantPatch[assistantRootPatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		if item.Target.ProjectID == "" {
+			return cairnline.AssistantAction{}, false
+		}
+		root := assistantRoot(patch)
+		item.Root = &root
+	case projectassistant.ActionRemoveProjectRoot:
+		if item.Target.ProjectID == "" || item.Target.RootID == "" {
+			return cairnline.AssistantAction{}, false
+		}
+	case projectassistant.ActionSetProjectDefaults:
+		projectID := firstNonEmpty(targetValue(action.Target, "project_id"), targetValue(action.Target, "id"))
+		if projectID == "" {
+			return cairnline.AssistantAction{}, false
+		}
+		patch, ok := decodeAssistantPatch[assistantDefaultsPatch](action.Patch)
+		if !ok || patch.DefaultRootID == nil {
+			return cairnline.AssistantAction{}, false
+		}
+		item.Project = &cairnline.Project{
+			ID:            projectID,
+			DefaultRootID: strings.TrimSpace(*patch.DefaultRootID),
+		}
+	case projectassistant.ActionCreateRole:
+		patch, ok := decodeAssistantPatch[assistantRolePatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		projectID := firstNonEmpty(strings.TrimSpace(patch.ProjectID), targetValue(action.Target, "project_id"))
+		item.Role = &cairnline.Role{
+			ID:                   strings.TrimSpace(patch.ID),
+			ProjectID:            projectID,
+			Name:                 strings.TrimSpace(patch.Name),
+			Description:          strings.TrimSpace(patch.Description),
+			Instructions:         strings.TrimSpace(patch.Instructions),
+			DefaultProfileID:     strings.TrimSpace(patch.DefaultAgentProfile),
+			DefaultSkillIDs:      compactStrings(patch.SkillIDs),
+			DefaultExecutionMode: ExecutionMode(patch.DefaultDriverKind),
+		}
+	case projectassistant.ActionCreateWorkItem:
+		patch, ok := decodeAssistantPatch[assistantWorkItemPatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		projectID := firstNonEmpty(strings.TrimSpace(patch.ProjectID), targetValue(action.Target, "project_id"))
+		item.WorkItem = &cairnline.WorkItem{
+			ID:              strings.TrimSpace(patch.ID),
+			ProjectID:       projectID,
+			Title:           strings.TrimSpace(patch.Title),
+			Brief:           strings.TrimSpace(patch.Brief),
+			Status:          WorkItemStatus(patch.Status),
+			Priority:        strings.TrimSpace(patch.Priority),
+			OwnerRoleID:     strings.TrimSpace(patch.OwnerRoleID),
+			ReviewerRoleIDs: compactStrings(patch.ReviewerRoleIDs),
+			RootID:          strings.TrimSpace(patch.RootID),
+		}
+	case projectassistant.ActionUpdateWorkItem:
+		projectID := targetValue(action.Target, "project_id")
+		workItemID := targetValue(action.Target, "work_item_id")
+		if projectID == "" || workItemID == "" {
+			return cairnline.AssistantAction{}, false
+		}
+		patch, ok := decodeAssistantPatch[assistantUpdateWorkItemPatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		item.WorkItem = &cairnline.WorkItem{
+			ID:              workItemID,
+			ProjectID:       projectID,
+			Title:           pointerValue(patch.Title),
+			Brief:           pointerValue(patch.Brief),
+			Status:          WorkItemStatus(pointerValue(patch.Status)),
+			Priority:        pointerValue(patch.Priority),
+			OwnerRoleID:     pointerValue(patch.OwnerRoleID),
+			ReviewerRoleIDs: compactStrings(patch.ReviewerRoleIDs),
+		}
+	case projectassistant.ActionCreateAssignment:
+		patch, ok := decodeAssistantPatch[assistantAssignmentPatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		projectID := firstNonEmpty(strings.TrimSpace(patch.ProjectID), targetValue(action.Target, "project_id"))
+		item.Assignment = &cairnline.Assignment{
+			ID:            strings.TrimSpace(patch.ID),
+			ProjectID:     projectID,
+			WorkItemID:    strings.TrimSpace(patch.WorkItemID),
+			RoleID:        strings.TrimSpace(patch.RoleID),
+			RootID:        strings.TrimSpace(patch.RootID),
+			ExecutionMode: ExecutionMode(patch.DriverKind),
+			Status:        cairnline.AssignmentQueued,
+			DesiredAgent: cairnline.DesiredAgent{
+				Kind: DesiredAgentKind(patch.DriverKind),
+			},
+		}
+	case projectassistant.ActionCreateHandoff:
+		patch, ok := decodeAssistantPatch[assistantHandoffPatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		projectID := firstNonEmpty(strings.TrimSpace(patch.ProjectID), targetValue(action.Target, "project_id"))
+		item.Handoff = &cairnline.Handoff{
+			ID:                    strings.TrimSpace(patch.ID),
+			ProjectID:             projectID,
+			WorkItemID:            strings.TrimSpace(patch.WorkItemID),
+			SourceAssignmentID:    strings.TrimSpace(patch.SourceAssignmentID),
+			SourceRunID:           strings.TrimSpace(patch.SourceRunID),
+			SourceChatSessionID:   strings.TrimSpace(patch.SourceChatSessionID),
+			SourceMessageID:       strings.TrimSpace(patch.SourceMessageID),
+			FromRoleID:            strings.TrimSpace(patch.CreatedByRoleID),
+			ToRoleID:              strings.TrimSpace(patch.TargetRoleID),
+			TargetAssignmentID:    strings.TrimSpace(patch.TargetAssignmentID),
+			TargetWorkItemID:      strings.TrimSpace(patch.TargetWorkItemID),
+			Title:                 strings.TrimSpace(patch.Title),
+			Body:                  strings.TrimSpace(patch.Summary),
+			RecommendedNextAction: strings.TrimSpace(patch.RecommendedNextAction),
+			LinkedArtifactIDs:     compactStrings(patch.LinkedArtifactIDs),
+			LinkedMemoryIDs:       compactStrings(patch.LinkedMemoryIDs),
+			ContextRefs:           compactStrings(patch.ContextRefs),
+			Status:                HandoffStatus(patch.Status),
+			ProvenanceKind:        strings.TrimSpace(patch.ProvenanceKind),
+			TrustLabel:            strings.TrimSpace(patch.TrustLabel),
+		}
+	case projectassistant.ActionUpdateHandoff:
+		projectID := targetValue(action.Target, "project_id")
+		workItemID := targetValue(action.Target, "work_item_id")
+		handoffID := targetValue(action.Target, "handoff_id")
+		if projectID == "" || workItemID == "" || handoffID == "" {
+			return cairnline.AssistantAction{}, false
+		}
+		patch, ok := decodeAssistantPatch[assistantUpdateHandoffPatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		item.Handoff = &cairnline.Handoff{
+			ID:                 handoffID,
+			ProjectID:          projectID,
+			WorkItemID:         workItemID,
+			TargetAssignmentID: pointerValue(patch.TargetAssignmentID),
+			ToRoleID:           pointerValue(patch.TargetRoleID),
+			Status:             HandoffStatus(pointerValue(patch.Status)),
+		}
+	case projectassistant.ActionCreateMemoryCandidate:
+		patch, ok := decodeAssistantPatch[assistantMemoryCandidatePatch](action.Patch)
+		if !ok {
+			return cairnline.AssistantAction{}, false
+		}
+		projectID := firstNonEmpty(strings.TrimSpace(patch.ProjectID), targetValue(action.Target, "project_id"))
+		item.MemoryCandidate = &cairnline.MemoryCandidate{
+			ID:                  strings.TrimSpace(patch.ID),
+			ProjectID:           projectID,
+			Title:               strings.TrimSpace(patch.Title),
+			Body:                strings.TrimSpace(patch.Body),
+			SuggestedKind:       strings.TrimSpace(patch.SuggestedKind),
+			SuggestedTrustLabel: strings.TrimSpace(patch.SuggestedTrustLabel),
+			SuggestedSourceKind: strings.TrimSpace(patch.SuggestedSourceKind),
+			SuggestedSourceID:   strings.TrimSpace(patch.SuggestedSourceID),
+			SourceRefs:          MemoryCandidateSourceRefs(patch.SourceRefs),
+			Status:              cairnline.MemoryCandidatePending,
+		}
+	default:
+		return cairnline.AssistantAction{}, false
+	}
+	return item, true
+}
+
+func ProjectAssistantAction(action cairnline.AssistantAction) (projectassistant.Action, bool) {
+	item := projectassistant.Action{
+		Kind:   ProjectAssistantActionKind(action.Kind),
+		Target: ProjectAssistantTarget(action.Target),
+		Reason: strings.TrimSpace(firstNonEmpty(action.Summary, action.Title)),
+	}
+	if item.Kind == "" {
+		return projectassistant.Action{}, false
+	}
+	var patch json.RawMessage
+	var ok bool
+	switch strings.TrimSpace(action.Kind) {
+	case cairnline.AssistantActionCreateProject:
+		if action.Project == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(assistantProjectPatch{
+			ID:          strings.TrimSpace(action.Project.ID),
+			Name:        strings.TrimSpace(action.Project.Name),
+			Description: strings.TrimSpace(action.Project.Description),
+			Roots:       projectAssistantRootPatches(action.Project.Roots),
+		})
+	case cairnline.AssistantActionUpdateProject:
+		if action.Project == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(assistantUpdateProjectPatch{
+			Name:        stringPtrIfNotEmpty(action.Project.Name),
+			Description: stringPtrIfNotEmpty(action.Project.Description),
+		})
+	case cairnline.AssistantActionAttachProjectRoot:
+		if action.Root == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(projectAssistantRootPatch(*action.Root))
+	case cairnline.AssistantActionRemoveProjectRoot:
+		ok = true
+	case cairnline.AssistantActionSetProjectDefaults:
+		if action.Project == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(assistantDefaultsPatch{
+			DefaultRootID: stringPtrIfNotEmpty(action.Project.DefaultRootID),
+		})
+	case cairnline.AssistantActionCreateRole:
+		if action.Role == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(assistantRolePatch{
+			ID:                  strings.TrimSpace(action.Role.ID),
+			ProjectID:           strings.TrimSpace(action.Role.ProjectID),
+			Name:                strings.TrimSpace(action.Role.Name),
+			Description:         strings.TrimSpace(action.Role.Description),
+			Instructions:        strings.TrimSpace(action.Role.Instructions),
+			DefaultDriverKind:   DriverKind(action.Role.DefaultExecutionMode),
+			DefaultAgentProfile: strings.TrimSpace(action.Role.DefaultProfileID),
+			SkillIDs:            compactStrings(action.Role.DefaultSkillIDs),
+		})
+	case cairnline.AssistantActionCreateWorkItem:
+		if action.WorkItem == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(assistantWorkItemPatch{
+			ID:              strings.TrimSpace(action.WorkItem.ID),
+			ProjectID:       strings.TrimSpace(action.WorkItem.ProjectID),
+			Title:           strings.TrimSpace(action.WorkItem.Title),
+			Brief:           strings.TrimSpace(action.WorkItem.Brief),
+			Status:          projectWorkItemStatus(action.WorkItem.Status),
+			Priority:        strings.TrimSpace(action.WorkItem.Priority),
+			OwnerRoleID:     strings.TrimSpace(action.WorkItem.OwnerRoleID),
+			ReviewerRoleIDs: compactStrings(action.WorkItem.ReviewerRoleIDs),
+			RootID:          strings.TrimSpace(action.WorkItem.RootID),
+		})
+	case cairnline.AssistantActionUpdateWorkItem:
+		if action.WorkItem == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(assistantUpdateWorkItemPatch{
+			Title:           stringPtrIfNotEmpty(action.WorkItem.Title),
+			Brief:           stringPtrIfNotEmpty(action.WorkItem.Brief),
+			Status:          stringPtrIfNotEmpty(projectWorkItemStatus(action.WorkItem.Status)),
+			Priority:        stringPtrIfNotEmpty(action.WorkItem.Priority),
+			OwnerRoleID:     stringPtrIfNotEmpty(action.WorkItem.OwnerRoleID),
+			ReviewerRoleIDs: compactStrings(action.WorkItem.ReviewerRoleIDs),
+		})
+	case cairnline.AssistantActionCreateAssignment:
+		if action.Assignment == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(assistantAssignmentPatch{
+			ID:         strings.TrimSpace(action.Assignment.ID),
+			ProjectID:  strings.TrimSpace(action.Assignment.ProjectID),
+			WorkItemID: strings.TrimSpace(action.Assignment.WorkItemID),
+			RoleID:     strings.TrimSpace(action.Assignment.RoleID),
+			RootID:     strings.TrimSpace(action.Assignment.RootID),
+			DriverKind: DriverKind(action.Assignment.ExecutionMode),
+		})
+	case cairnline.AssistantActionCreateHandoff:
+		if action.Handoff == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(projectAssistantHandoffPatch(*action.Handoff))
+	case cairnline.AssistantActionUpdateHandoff:
+		if action.Handoff == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(assistantUpdateHandoffPatch{
+			TargetAssignmentID: stringPtrIfNotEmpty(action.Handoff.TargetAssignmentID),
+			TargetRoleID:       stringPtrIfNotEmpty(action.Handoff.ToRoleID),
+			Status:             stringPtrIfNotEmpty(projectHandoffStatus(action.Handoff.Status)),
+		})
+	case cairnline.AssistantActionCreateMemoryCandidate:
+		if action.MemoryCandidate == nil {
+			return projectassistant.Action{}, false
+		}
+		patch, ok = projectAssistantRawPatch(projectAssistantMemoryCandidatePatch(*action.MemoryCandidate))
+	default:
+		return projectassistant.Action{}, false
+	}
+	if !ok {
+		return projectassistant.Action{}, false
+	}
+	item.Patch = patch
+	return item, true
+}
+
+func AssistantProposalSource(source string) string {
+	switch strings.TrimSpace(source) {
+	case projectassistant.ProposalSourceAPI:
+		return cairnline.AssistantProposalSourceAPI
+	default:
+		return cairnline.AssistantProposalSourceAssistant
+	}
+}
+
+func ProjectAssistantProposalSource(source string) string {
+	switch strings.TrimSpace(source) {
+	case cairnline.AssistantProposalSourceAPI:
+		return projectassistant.ProposalSourceAPI
+	default:
+		return projectassistant.ProposalSourceDraft
+	}
+}
+
+func AssistantProposalStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case projectassistant.ProposalStatusProposed, projectassistant.ProposalStatusApplying:
+		return strings.TrimSpace(status)
+	case projectassistant.ApplyStatusApplied:
+		return cairnline.AssistantProposalStatusApplied
+	case projectassistant.ApplyStatusPartialDueToRuntimeFailure:
+		return cairnline.AssistantProposalStatusPartial
+	case projectassistant.ApplyStatusBlockedBeforeApply:
+		return cairnline.AssistantProposalStatusRejected
+	default:
+		return cairnline.AssistantProposalStatusProposed
+	}
+}
+
+func ProjectAssistantProposalStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case cairnline.AssistantProposalStatusApplied:
+		return projectassistant.ApplyStatusApplied
+	case cairnline.AssistantProposalStatusPartial:
+		return projectassistant.ApplyStatusPartialDueToRuntimeFailure
+	case cairnline.AssistantProposalStatusRejected, cairnline.AssistantProposalStatusNeedsConfirm:
+		return projectassistant.ApplyStatusBlockedBeforeApply
+	default:
+		return projectassistant.ProposalStatusProposed
+	}
+}
+
+func AssistantApplyStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case projectassistant.ApplyStatusApplied:
+		return cairnline.AssistantApplyStatusApplied
+	case projectassistant.ApplyStatusPartialDueToRuntimeFailure:
+		return cairnline.AssistantApplyStatusPartial
+	case projectassistant.ApplyStatusBlockedBeforeApply:
+		return cairnline.AssistantApplyStatusRejected
+	default:
+		return firstNonEmpty(strings.TrimSpace(status), cairnline.AssistantApplyStatusRejected)
+	}
+}
+
+func ProjectAssistantApplyStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case cairnline.AssistantApplyStatusApplied:
+		return projectassistant.ApplyStatusApplied
+	case cairnline.AssistantApplyStatusPartial:
+		return projectassistant.ApplyStatusPartialDueToRuntimeFailure
+	case cairnline.AssistantApplyStatusRejected, cairnline.AssistantApplyStatusNeedsConfirm:
+		return projectassistant.ApplyStatusBlockedBeforeApply
+	default:
+		return projectassistant.ApplyStatusBlockedBeforeApply
+	}
+}
+
+func AssistantActionKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case projectassistant.ActionCreateProject:
+		return cairnline.AssistantActionCreateProject
+	case projectassistant.ActionUpdateProject:
+		return cairnline.AssistantActionUpdateProject
+	case projectassistant.ActionAttachProjectRoot:
+		return cairnline.AssistantActionAttachProjectRoot
+	case projectassistant.ActionRemoveProjectRoot:
+		return cairnline.AssistantActionRemoveProjectRoot
+	case projectassistant.ActionSetProjectDefaults:
+		return cairnline.AssistantActionSetProjectDefaults
+	case projectassistant.ActionCreateRole:
+		return cairnline.AssistantActionCreateRole
+	case projectassistant.ActionCreateWorkItem:
+		return cairnline.AssistantActionCreateWorkItem
+	case projectassistant.ActionUpdateWorkItem:
+		return cairnline.AssistantActionUpdateWorkItem
+	case projectassistant.ActionCreateAssignment:
+		return cairnline.AssistantActionCreateAssignment
+	case projectassistant.ActionCreateHandoff:
+		return cairnline.AssistantActionCreateHandoff
+	case projectassistant.ActionUpdateHandoff:
+		return cairnline.AssistantActionUpdateHandoff
+	case projectassistant.ActionCreateMemoryCandidate:
+		return cairnline.AssistantActionCreateMemoryCandidate
+	default:
+		return ""
+	}
+}
+
+func ProjectAssistantActionKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case cairnline.AssistantActionCreateProject:
+		return projectassistant.ActionCreateProject
+	case cairnline.AssistantActionUpdateProject:
+		return projectassistant.ActionUpdateProject
+	case cairnline.AssistantActionAttachProjectRoot:
+		return projectassistant.ActionAttachProjectRoot
+	case cairnline.AssistantActionRemoveProjectRoot:
+		return projectassistant.ActionRemoveProjectRoot
+	case cairnline.AssistantActionSetProjectDefaults:
+		return projectassistant.ActionSetProjectDefaults
+	case cairnline.AssistantActionCreateRole:
+		return projectassistant.ActionCreateRole
+	case cairnline.AssistantActionCreateWorkItem:
+		return projectassistant.ActionCreateWorkItem
+	case cairnline.AssistantActionUpdateWorkItem:
+		return projectassistant.ActionUpdateWorkItem
+	case cairnline.AssistantActionCreateAssignment:
+		return projectassistant.ActionCreateAssignment
+	case cairnline.AssistantActionCreateHandoff:
+		return projectassistant.ActionCreateHandoff
+	case cairnline.AssistantActionUpdateHandoff:
+		return projectassistant.ActionUpdateHandoff
+	case cairnline.AssistantActionCreateMemoryCandidate:
+		return projectassistant.ActionCreateMemoryCandidate
+	default:
+		return ""
+	}
+}
+
+func AssistantApplyResultPtr(result *projectassistant.ApplyResult) *cairnline.AssistantApplyResult {
+	if result == nil {
+		return nil
+	}
+	out := AssistantApplyResult(*result)
+	return &out
+}
+
+func AssistantApplyResult(result projectassistant.ApplyResult) cairnline.AssistantApplyResult {
+	actions := make([]cairnline.AssistantActionResult, 0, len(result.Actions))
+	for _, action := range result.Actions {
+		actions = append(actions, AssistantActionResult(action))
+	}
+	return cairnline.AssistantApplyResult{
+		ProposalID:         strings.TrimSpace(result.ProposalID),
+		Status:             AssistantApplyStatus(result.Status),
+		Applied:            result.Applied,
+		TotalActionCount:   result.TotalActionCount,
+		AppliedActionCount: result.CommittedActionCount,
+		FailedActionIndex:  result.FailedActionIndex,
+		Actions:            actions,
+	}
+}
+
+func ProjectAssistantApplyResultPtr(result *cairnline.AssistantApplyResult) *projectassistant.ApplyResult {
+	if result == nil {
+		return nil
+	}
+	out := ProjectAssistantApplyResult(*result)
+	return &out
+}
+
+func ProjectAssistantApplyResult(result cairnline.AssistantApplyResult) projectassistant.ApplyResult {
+	actions := make([]projectassistant.ActionResult, 0, len(result.Actions))
+	for _, action := range result.Actions {
+		actions = append(actions, ProjectAssistantActionResult(action))
+	}
+	return projectassistant.ApplyResult{
+		ProposalID:           strings.TrimSpace(result.ProposalID),
+		Status:               ProjectAssistantApplyStatus(result.Status),
+		Applied:              result.Applied,
+		Actions:              actions,
+		TotalActionCount:     result.TotalActionCount,
+		CommittedActionCount: result.AppliedActionCount,
+		FailedActionIndex:    result.FailedActionIndex,
+		ResumeActionIndex:    result.AppliedActionCount,
+	}
+}
+
+func AssistantApplyAttempt(attempt projectassistant.ApplyAttempt) cairnline.AssistantApplyAttempt {
+	result := AssistantApplyResult(attempt.Result)
+	result.Confirmed = attempt.Confirmed
+	return cairnline.AssistantApplyAttempt{
+		ID:           strings.TrimSpace(attempt.ID),
+		ProposalID:   strings.TrimSpace(attempt.ProposalID),
+		Status:       AssistantApplyStatus(attempt.Status),
+		Confirmed:    attempt.Confirmed,
+		Result:       result,
+		ErrorMessage: strings.TrimSpace(firstNonEmpty(attempt.ErrorMessage, attempt.ErrorType)),
+		CreatedAt:    attempt.CreatedAt,
+	}
+}
+
+func ProjectAssistantApplyAttempt(attempt cairnline.AssistantApplyAttempt) projectassistant.ApplyAttempt {
+	return projectassistant.ApplyAttempt{
+		ID:           strings.TrimSpace(attempt.ID),
+		ProposalID:   strings.TrimSpace(attempt.ProposalID),
+		Status:       ProjectAssistantApplyStatus(attempt.Status),
+		Confirmed:    attempt.Confirmed,
+		Result:       ProjectAssistantApplyResult(attempt.Result),
+		ErrorMessage: strings.TrimSpace(attempt.ErrorMessage),
+		CreatedAt:    attempt.CreatedAt,
+	}
+}
+
+func AssistantActionResult(result projectassistant.ActionResult) cairnline.AssistantActionResult {
+	return cairnline.AssistantActionResult{
+		Kind:              AssistantActionKind(result.Kind),
+		Status:            cairnline.AssistantApplyStatusApplied,
+		ProjectID:         result.Data["project_id"],
+		RootID:            result.Data["root_id"],
+		RoleID:            result.Data["role_id"],
+		WorkItemID:        result.Data["work_item_id"],
+		AssignmentID:      result.Data["assignment_id"],
+		ArtifactID:        result.Data["artifact_id"],
+		HandoffID:         result.Data["handoff_id"],
+		MemoryCandidateID: firstNonEmpty(result.Data["memory_candidate_id"], result.Data["candidate_id"]),
+	}
+}
+
+func ProjectAssistantActionResult(result cairnline.AssistantActionResult) projectassistant.ActionResult {
+	data := map[string]string{}
+	add := func(key, value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			data[key] = value
+		}
+	}
+	add("project_id", result.ProjectID)
+	add("root_id", result.RootID)
+	add("role_id", result.RoleID)
+	add("work_item_id", result.WorkItemID)
+	add("assignment_id", result.AssignmentID)
+	add("artifact_id", result.ArtifactID)
+	add("handoff_id", result.HandoffID)
+	add("memory_candidate_id", result.MemoryCandidateID)
+	return projectassistant.ActionResult{
+		Kind: ProjectAssistantActionKind(result.Kind),
+		ID: firstNonEmpty(
+			result.ProjectID,
+			result.RootID,
+			result.RoleID,
+			result.WorkItemID,
+			result.AssignmentID,
+			result.ArtifactID,
+			result.HandoffID,
+			result.MemoryCandidateID,
+		),
+		Data: data,
+	}
+}
+
+func AssistantTarget(target map[string]string) cairnline.AssistantTarget {
+	return cairnline.AssistantTarget{
+		ProjectID:    targetValue(target, "project_id"),
+		RootID:       targetValue(target, "root_id"),
+		RoleID:       targetValue(target, "role_id"),
+		WorkItemID:   targetValue(target, "work_item_id"),
+		AssignmentID: targetValue(target, "assignment_id"),
+		ArtifactID:   targetValue(target, "artifact_id"),
+		HandoffID:    targetValue(target, "handoff_id"),
+	}
+}
+
+func ProjectAssistantTarget(target cairnline.AssistantTarget) map[string]string {
+	out := map[string]string{}
+	add := func(key, value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			out[key] = value
+		}
+	}
+	add("project_id", target.ProjectID)
+	add("root_id", target.RootID)
+	add("role_id", target.RoleID)
+	add("work_item_id", target.WorkItemID)
+	add("assignment_id", target.AssignmentID)
+	add("artifact_id", target.ArtifactID)
+	add("handoff_id", target.HandoffID)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func WorkItemStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case projectwork.WorkItemStatusDone:
+		return cairnline.WorkStatusDone
+	case "":
+		return cairnline.WorkStatusReady
+	default:
+		return strings.TrimSpace(status)
+	}
+}
+
+func DriverKind(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case cairnline.ExecutionOrchestrated:
+		return projectwork.AssignmentDriverHecateTask
+	case cairnline.ExecutionExternalAdapter:
+		return projectwork.AssignmentDriverExternalAgent
+	default:
+		return ""
+	}
+}
+
+func projectWorkItemStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case cairnline.WorkStatusDone:
+		return projectwork.WorkItemStatusDone
+	case cairnline.WorkStatusReady, "":
+		return projectwork.WorkItemStatusReady
+	default:
+		return strings.TrimSpace(status)
+	}
+}
+
+func projectHandoffStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case cairnline.HandoffStatusAccepted:
+		return projectwork.HandoffStatusAccepted
+	case cairnline.HandoffStatusSuperseded:
+		return projectwork.HandoffStatusSuperseded
+	case cairnline.HandoffStatusDismissed:
+		return projectwork.HandoffStatusDismissed
+	default:
+		return projectwork.HandoffStatusPending
+	}
+}
+
+func assistantProject(patch assistantProjectPatch) *cairnline.Project {
+	roots := assistantRoots(patch.Roots)
+	if workspacePath := strings.TrimSpace(patch.WorkspacePath); workspacePath != "" && len(roots) == 0 {
+		roots = []cairnline.Root{{
+			Path:   workspacePath,
+			Kind:   strings.TrimSpace(patch.WorkspaceKind),
+			Active: true,
+		}}
+	}
+	return &cairnline.Project{
+		ID:          strings.TrimSpace(patch.ID),
+		Name:        strings.TrimSpace(patch.Name),
+		Description: strings.TrimSpace(patch.Description),
+		Roots:       roots,
+	}
+}
+
+func assistantRoots(items []assistantRootPatch) []cairnline.Root {
+	roots := make([]cairnline.Root, 0, len(items))
+	for _, item := range items {
+		roots = append(roots, assistantRoot(item))
+	}
+	return roots
+}
+
+func assistantRoot(item assistantRootPatch) cairnline.Root {
+	active := true
+	if item.Active != nil {
+		active = *item.Active
+	}
+	return cairnline.Root{
+		ID:        strings.TrimSpace(item.ID),
+		Path:      strings.TrimSpace(item.Path),
+		Kind:      strings.TrimSpace(item.Kind),
+		GitRemote: strings.TrimSpace(item.GitRemote),
+		GitBranch: strings.TrimSpace(item.GitBranch),
+		Active:    active,
+	}
+}
+
+func projectAssistantRootPatches(items []cairnline.Root) []assistantRootPatch {
+	roots := make([]assistantRootPatch, 0, len(items))
+	for _, item := range items {
+		roots = append(roots, projectAssistantRootPatch(item))
+	}
+	return roots
+}
+
+func projectAssistantRootPatch(item cairnline.Root) assistantRootPatch {
+	return assistantRootPatch{
+		ID:        strings.TrimSpace(item.ID),
+		Path:      strings.TrimSpace(item.Path),
+		Kind:      strings.TrimSpace(item.Kind),
+		GitRemote: strings.TrimSpace(item.GitRemote),
+		GitBranch: strings.TrimSpace(item.GitBranch),
+		Active:    boolPtr(item.Active),
+	}
+}
+
+func projectAssistantHandoffPatch(item cairnline.Handoff) assistantHandoffPatch {
+	return assistantHandoffPatch{
+		ID:                    strings.TrimSpace(item.ID),
+		ProjectID:             strings.TrimSpace(item.ProjectID),
+		WorkItemID:            strings.TrimSpace(item.WorkItemID),
+		SourceAssignmentID:    strings.TrimSpace(item.SourceAssignmentID),
+		SourceRunID:           strings.TrimSpace(item.SourceRunID),
+		SourceChatSessionID:   strings.TrimSpace(item.SourceChatSessionID),
+		SourceMessageID:       strings.TrimSpace(item.SourceMessageID),
+		TargetRoleID:          strings.TrimSpace(item.ToRoleID),
+		TargetAssignmentID:    strings.TrimSpace(item.TargetAssignmentID),
+		TargetWorkItemID:      strings.TrimSpace(item.TargetWorkItemID),
+		Title:                 strings.TrimSpace(item.Title),
+		Summary:               strings.TrimSpace(item.Body),
+		RecommendedNextAction: strings.TrimSpace(item.RecommendedNextAction),
+		LinkedArtifactIDs:     compactStrings(item.LinkedArtifactIDs),
+		LinkedMemoryIDs:       compactStrings(item.LinkedMemoryIDs),
+		ContextRefs:           compactStrings(item.ContextRefs),
+		Status:                projectHandoffStatus(item.Status),
+		ProvenanceKind:        strings.TrimSpace(item.ProvenanceKind),
+		TrustLabel:            strings.TrimSpace(item.TrustLabel),
+		CreatedByRoleID:       strings.TrimSpace(item.FromRoleID),
+	}
+}
+
+func projectAssistantMemoryCandidatePatch(item cairnline.MemoryCandidate) assistantMemoryCandidatePatch {
+	return assistantMemoryCandidatePatch{
+		ID:                  strings.TrimSpace(item.ID),
+		ProjectID:           strings.TrimSpace(item.ProjectID),
+		Title:               strings.TrimSpace(item.Title),
+		Body:                strings.TrimSpace(item.Body),
+		SuggestedKind:       strings.TrimSpace(item.SuggestedKind),
+		SuggestedTrustLabel: strings.TrimSpace(item.SuggestedTrustLabel),
+		SuggestedSourceKind: strings.TrimSpace(item.SuggestedSourceKind),
+		SuggestedSourceID:   strings.TrimSpace(item.SuggestedSourceID),
+		SourceRefs:          projectAssistantMemoryCandidateSourceRefs(item.SourceRefs),
+	}
+}
+
+func projectAssistantMemoryCandidateSourceRefs(items []cairnline.MemoryCandidateSourceRef) []memory.CandidateSourceRef {
+	refs := make([]memory.CandidateSourceRef, 0, len(items))
+	for _, item := range items {
+		refs = append(refs, memory.CandidateSourceRef{
+			Kind:  strings.TrimSpace(item.Kind),
+			ID:    strings.TrimSpace(item.ID),
+			Title: strings.TrimSpace(item.Title),
+			URL:   strings.TrimSpace(item.URL),
+		})
+	}
+	return refs
+}
+
+func decodeAssistantPatch[T any](payload json.RawMessage) (T, bool) {
+	var out T
+	if len(payload) == 0 {
+		return out, true
+	}
+	if err := json.Unmarshal(payload, &out); err != nil {
+		return out, false
+	}
+	return out, true
+}
+
+func targetValue(target map[string]string, key string) string {
+	if len(target) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(target[key])
+}
+
+func pointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func projectAssistantRawPatch(value any) (json.RawMessage, bool) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	return payload, true
+}
+
+func stringPtrIfNotEmpty(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+type assistantProjectPatch struct {
+	ID            string               `json:"id,omitempty"`
+	Name          string               `json:"name,omitempty"`
+	Description   string               `json:"description,omitempty"`
+	WorkspacePath string               `json:"workspace_path,omitempty"`
+	WorkspaceKind string               `json:"workspace_kind,omitempty"`
+	Roots         []assistantRootPatch `json:"roots,omitempty"`
+}
+
+type assistantUpdateProjectPatch struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+type assistantRootPatch struct {
+	ID        string `json:"id,omitempty"`
+	Path      string `json:"path,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	GitRemote string `json:"git_remote,omitempty"`
+	GitBranch string `json:"git_branch,omitempty"`
+	Active    *bool  `json:"active,omitempty"`
+}
+
+type assistantDefaultsPatch struct {
+	DefaultRootID *string `json:"default_root_id,omitempty"`
+}
+
+type assistantRolePatch struct {
+	ID                  string   `json:"id,omitempty"`
+	ProjectID           string   `json:"project_id,omitempty"`
+	Name                string   `json:"name,omitempty"`
+	Description         string   `json:"description,omitempty"`
+	Instructions        string   `json:"instructions,omitempty"`
+	DefaultDriverKind   string   `json:"default_driver_kind,omitempty"`
+	DefaultAgentProfile string   `json:"default_agent_profile,omitempty"`
+	SkillIDs            []string `json:"skill_ids,omitempty"`
+}
+
+type assistantWorkItemPatch struct {
+	ID              string   `json:"id,omitempty"`
+	ProjectID       string   `json:"project_id,omitempty"`
+	Title           string   `json:"title,omitempty"`
+	Brief           string   `json:"brief,omitempty"`
+	Status          string   `json:"status,omitempty"`
+	Priority        string   `json:"priority,omitempty"`
+	OwnerRoleID     string   `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
+	RootID          string   `json:"root_id,omitempty"`
+}
+
+type assistantUpdateWorkItemPatch struct {
+	Title           *string  `json:"title,omitempty"`
+	Brief           *string  `json:"brief,omitempty"`
+	Status          *string  `json:"status,omitempty"`
+	Priority        *string  `json:"priority,omitempty"`
+	OwnerRoleID     *string  `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
+}
+
+type assistantAssignmentPatch struct {
+	ID         string `json:"id,omitempty"`
+	ProjectID  string `json:"project_id,omitempty"`
+	WorkItemID string `json:"work_item_id,omitempty"`
+	RoleID     string `json:"role_id,omitempty"`
+	RootID     string `json:"root_id,omitempty"`
+	DriverKind string `json:"driver_kind,omitempty"`
+}
+
+type assistantHandoffPatch struct {
+	ID                    string   `json:"id,omitempty"`
+	ProjectID             string   `json:"project_id,omitempty"`
+	WorkItemID            string   `json:"work_item_id,omitempty"`
+	SourceAssignmentID    string   `json:"source_assignment_id,omitempty"`
+	SourceRunID           string   `json:"source_run_id,omitempty"`
+	SourceChatSessionID   string   `json:"source_chat_session_id,omitempty"`
+	SourceMessageID       string   `json:"source_message_id,omitempty"`
+	TargetRoleID          string   `json:"target_role_id,omitempty"`
+	TargetAssignmentID    string   `json:"target_assignment_id,omitempty"`
+	TargetWorkItemID      string   `json:"target_work_item_id,omitempty"`
+	Title                 string   `json:"title,omitempty"`
+	Summary               string   `json:"summary,omitempty"`
+	RecommendedNextAction string   `json:"recommended_next_action,omitempty"`
+	LinkedArtifactIDs     []string `json:"linked_artifact_ids,omitempty"`
+	LinkedMemoryIDs       []string `json:"linked_memory_ids,omitempty"`
+	ContextRefs           []string `json:"context_refs,omitempty"`
+	Status                string   `json:"status,omitempty"`
+	ProvenanceKind        string   `json:"provenance_kind,omitempty"`
+	TrustLabel            string   `json:"trust_label,omitempty"`
+	CreatedByRoleID       string   `json:"created_by_role_id,omitempty"`
+}
+
+type assistantUpdateHandoffPatch struct {
+	TargetAssignmentID *string `json:"target_assignment_id,omitempty"`
+	TargetRoleID       *string `json:"target_role_id,omitempty"`
+	Status             *string `json:"status,omitempty"`
+}
+
+type assistantMemoryCandidatePatch struct {
+	ID                  string                      `json:"id,omitempty"`
+	ProjectID           string                      `json:"project_id,omitempty"`
+	Title               string                      `json:"title,omitempty"`
+	Body                string                      `json:"body,omitempty"`
+	SuggestedKind       string                      `json:"suggested_kind,omitempty"`
+	SuggestedTrustLabel string                      `json:"suggested_trust_label,omitempty"`
+	SuggestedSourceKind string                      `json:"suggested_source_kind,omitempty"`
+	SuggestedSourceID   string                      `json:"suggested_source_id,omitempty"`
+	SourceRefs          []memory.CandidateSourceRef `json:"source_refs,omitempty"`
+}

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -13,43 +13,58 @@ import (
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 type Snapshot struct {
-	Project          projects.Project
-	AgentProfiles    []agentprofiles.Profile
-	Skills           []projectskills.Skill
-	Roles            []projectwork.AgentRoleProfile
-	WorkItems        []projectwork.WorkItem
-	Assignments      []projectwork.Assignment
-	Artifacts        []projectwork.CollaborationArtifact
-	Handoffs         []projectwork.Handoff
-	MemoryEntries    []memory.Entry
-	MemoryCandidates []memory.Candidate
+	Project            projects.Project
+	AgentProfiles      []agentprofiles.Profile
+	Skills             []projectskills.Skill
+	Roles              []projectwork.AgentRoleProfile
+	WorkItems          []projectwork.WorkItem
+	Assignments        []projectwork.Assignment
+	Artifacts          []projectwork.CollaborationArtifact
+	Handoffs           []projectwork.Handoff
+	MemoryEntries      []memory.Entry
+	MemoryCandidates   []memory.Candidate
+	AssistantProposals []projectassistant.ProposalRecord
+}
+
+func SnapshotExecutionProfileCount(snapshot Snapshot) int {
+	ids := map[string]struct{}{}
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		ids[id] = struct{}{}
+	}
+	if executionProfile, ok := ProjectExecutionProfile(snapshot.Project); ok {
+		add(executionProfile.ID)
+	}
+	for _, profile := range snapshot.AgentProfiles {
+		add(ExecutionProfile(profile).ID)
+	}
+	for _, role := range snapshot.Roles {
+		executionProfile, ok := RoleExecutionProfile(role)
+		if !ok {
+			continue
+		}
+		add(executionProfile.ID)
+	}
+	return len(ids)
 }
 
 func Seed(ctx context.Context, service *cairnline.Service, snapshot Snapshot) error {
+	return SeedSnapshots(ctx, service, []Snapshot{snapshot})
+}
+
+func seedProjectScopedSnapshot(ctx context.Context, service *cairnline.Service, snapshot Snapshot, profilesByID map[string]agentprofiles.Profile) error {
 	if _, err := service.CreateProject(ctx, Project(snapshot.Project)); err != nil {
 		return err
-	}
-	profilesByID := make(map[string]agentprofiles.Profile, len(snapshot.AgentProfiles))
-	executionProfileIDs := make(map[string]struct{}, len(snapshot.AgentProfiles))
-	for _, profile := range snapshot.AgentProfiles {
-		profilesByID[profile.ID] = profile
-		if _, err := service.CreateAgentProfile(ctx, AgentProfile(profile)); err != nil {
-			return err
-		}
-		executionProfile := ExecutionProfile(profile)
-		if _, ok := executionProfileIDs[executionProfile.ID]; ok {
-			continue
-		}
-		executionProfileIDs[executionProfile.ID] = struct{}{}
-		if _, err := service.CreateExecutionProfile(ctx, executionProfile); err != nil {
-			return err
-		}
 	}
 	for _, skill := range snapshot.Skills {
 		if _, err := service.CreateProjectSkill(ctx, ProjectSkill(skill)); err != nil {
@@ -80,6 +95,12 @@ func Seed(ctx context.Context, service *cairnline.Service, snapshot Snapshot) er
 		}
 	}
 	for _, artifact := range snapshot.Artifacts {
+		if item, ok := Artifact(artifact); ok {
+			if _, err := service.CreateArtifact(ctx, item); err != nil {
+				return err
+			}
+			continue
+		}
 		if item, ok := Evidence(artifact); ok {
 			if _, err := service.CreateEvidence(ctx, item); err != nil {
 				return err
@@ -98,35 +119,52 @@ func Seed(ctx context.Context, service *cairnline.Service, snapshot Snapshot) er
 		}
 	}
 	for _, entry := range snapshot.MemoryEntries {
-		if _, err := service.CreateMemoryEntry(ctx, MemoryEntry(entry)); err != nil {
+		if _, err := UpsertMemoryEntry(ctx, service, entry); err != nil {
 			return err
 		}
 	}
 	for _, candidate := range snapshot.MemoryCandidates {
-		item := MemoryCandidate(candidate)
-		created, err := service.CreateMemoryCandidate(ctx, item)
-		if err != nil {
+		if _, err := UpsertMemoryCandidate(ctx, service, candidate); err != nil {
 			return err
 		}
-		if created.Status != item.Status || created.StatusReason != item.StatusReason || created.PromotedMemoryID != item.PromotedMemoryID {
-			if _, err := service.UpdateMemoryCandidate(ctx, item); err != nil {
-				return err
-			}
+	}
+	for _, proposal := range snapshot.AssistantProposals {
+		item, ok := AssistantProposalRecord(proposal)
+		if !ok {
+			continue
+		}
+		if _, err := service.ImportAssistantProposalRecord(ctx, item); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
+func createExecutionProfileOnce(ctx context.Context, service *cairnline.Service, seen map[string]struct{}, profile cairnline.ExecutionProfile) error {
+	id := strings.TrimSpace(profile.ID)
+	if id == "" {
+		return nil
+	}
+	if _, ok := seen[id]; ok {
+		return nil
+	}
+	seen[id] = struct{}{}
+	_, err := service.CreateExecutionProfile(ctx, profile)
+	return err
+}
+
 func Project(project projects.Project) cairnline.Project {
 	return cairnline.Project{
-		ID:             strings.TrimSpace(project.ID),
-		Name:           strings.TrimSpace(project.Name),
-		Description:    strings.TrimSpace(project.Description),
-		Roots:          Roots(project.Roots),
-		DefaultRootID:  strings.TrimSpace(project.DefaultRootID),
-		ContextSources: Sources(project.ContextSources),
-		CreatedAt:      project.CreatedAt,
-		UpdatedAt:      project.UpdatedAt,
+		ID:                        strings.TrimSpace(project.ID),
+		Name:                      strings.TrimSpace(project.Name),
+		Description:               strings.TrimSpace(project.Description),
+		Roots:                     Roots(project.Roots),
+		DefaultRootID:             strings.TrimSpace(project.DefaultRootID),
+		DefaultProfileID:          strings.TrimSpace(project.DefaultAgentProfile),
+		DefaultExecutionProfileID: projectExecutionProfileID(project),
+		ContextSources:            Sources(project.ContextSources),
+		CreatedAt:                 project.CreatedAt,
+		UpdatedAt:                 project.UpdatedAt,
 	}
 }
 
@@ -198,35 +236,81 @@ func ExecutionProfile(profile agentprofiles.Profile) cairnline.ExecutionProfile 
 	}
 }
 
+func ProjectExecutionProfile(project projects.Project) (cairnline.ExecutionProfile, bool) {
+	provider := strings.TrimSpace(project.DefaultProvider)
+	model := strings.TrimSpace(project.DefaultModel)
+	toolsPolicy := optionalBoolPolicy(project.DefaultToolsEnabled)
+	adapterOptions := projectExecutionAdapterOptions(project)
+	if provider == "" && model == "" && toolsPolicy == "" && len(adapterOptions) == 0 {
+		return cairnline.ExecutionProfile{}, false
+	}
+	id := projectExecutionProfileIDValue(project)
+	if id == "" {
+		return cairnline.ExecutionProfile{}, false
+	}
+	return cairnline.ExecutionProfile{
+		ID:             id,
+		Name:           firstNonEmpty(strings.TrimSpace(project.Name), strings.TrimSpace(project.ID), "Project") + " execution defaults",
+		Description:    "Hecate project-level execution defaults.",
+		AgentKind:      "hecate",
+		ModelHint:      model,
+		ProviderHint:   provider,
+		ToolsPolicy:    toolsPolicy,
+		AdapterOptions: adapterOptions,
+		CreatedAt:      project.CreatedAt,
+		UpdatedAt:      project.UpdatedAt,
+	}, true
+}
+
+func RoleExecutionProfile(role projectwork.AgentRoleProfile) (cairnline.ExecutionProfile, bool) {
+	provider := strings.TrimSpace(role.DefaultProvider)
+	model := strings.TrimSpace(role.DefaultModel)
+	if provider == "" && model == "" {
+		return cairnline.ExecutionProfile{}, false
+	}
+	return cairnline.ExecutionProfile{
+		ID:           roleExecutionProfileID(role),
+		Name:         firstNonEmpty(strings.TrimSpace(role.Name), strings.TrimSpace(role.ID)) + " execution defaults",
+		Description:  "Hecate role-level execution defaults.",
+		AgentKind:    DesiredAgentKind(role.DefaultDriverKind),
+		ModelHint:    model,
+		ProviderHint: provider,
+		CreatedAt:    role.CreatedAt,
+		UpdatedAt:    role.UpdatedAt,
+	}, true
+}
+
 func ProjectSkill(skill projectskills.Skill) cairnline.ProjectSkill {
 	return cairnline.ProjectSkill{
-		ID:          strings.TrimSpace(skill.ID),
-		ProjectID:   strings.TrimSpace(skill.ProjectID),
-		Title:       strings.TrimSpace(skill.Title),
-		Description: strings.TrimSpace(skill.Description),
-		Path:        strings.TrimSpace(skill.Path),
-		RootID:      strings.TrimSpace(skill.RootID),
-		Format:      strings.TrimSpace(skill.Format),
-		Enabled:     skill.Enabled,
-		Status:      strings.TrimSpace(skill.Status),
-		TrustLabel:  strings.TrimSpace(skill.TrustLabel),
-		SourceRefs:  compactStrings(skill.SourceContextSourceIDs),
-		Warnings:    compactStrings(skill.Warnings),
-		CreatedAt:   skill.CreatedAt,
-		UpdatedAt:   skill.UpdatedAt,
+		ID:           strings.TrimSpace(skill.ID),
+		ProjectID:    strings.TrimSpace(skill.ProjectID),
+		Title:        strings.TrimSpace(skill.Title),
+		Description:  strings.TrimSpace(skill.Description),
+		Path:         strings.TrimSpace(skill.Path),
+		RootID:       strings.TrimSpace(skill.RootID),
+		Format:       strings.TrimSpace(skill.Format),
+		Enabled:      skill.Enabled,
+		Status:       strings.TrimSpace(skill.Status),
+		TrustLabel:   strings.TrimSpace(skill.TrustLabel),
+		SourceRefs:   compactStrings(skill.SourceContextSourceIDs),
+		Warnings:     compactStrings(skill.Warnings),
+		DiscoveredAt: skill.DiscoveredAt,
+		CreatedAt:    skill.CreatedAt,
+		UpdatedAt:    skill.UpdatedAt,
 	}
 }
 
 func Role(role projectwork.AgentRoleProfile) cairnline.Role {
 	return cairnline.Role{
-		ID:                   strings.TrimSpace(role.ID),
-		ProjectID:            strings.TrimSpace(role.ProjectID),
-		Name:                 strings.TrimSpace(role.Name),
-		Description:          strings.TrimSpace(role.Description),
-		Instructions:         strings.TrimSpace(role.Instructions),
-		DefaultProfileID:     strings.TrimSpace(role.DefaultAgentProfile),
-		DefaultSkillIDs:      compactStrings(role.SkillIDs),
-		DefaultExecutionMode: ExecutionMode(role.DefaultDriverKind),
+		ID:                        strings.TrimSpace(role.ID),
+		ProjectID:                 strings.TrimSpace(role.ProjectID),
+		Name:                      strings.TrimSpace(role.Name),
+		Description:               strings.TrimSpace(role.Description),
+		Instructions:              strings.TrimSpace(role.Instructions),
+		DefaultProfileID:          strings.TrimSpace(role.DefaultAgentProfile),
+		DefaultExecutionProfileID: roleExecutionProfileID(role),
+		DefaultSkillIDs:           compactStrings(role.SkillIDs),
+		DefaultExecutionMode:      ExecutionMode(role.DefaultDriverKind),
 	}
 }
 
@@ -254,7 +338,7 @@ func Assignment(assignment projectwork.Assignment, role projectwork.AgentRolePro
 		RoleID:             strings.TrimSpace(assignment.RoleID),
 		RootID:             strings.TrimSpace(assignment.RootID),
 		ProfileID:          strings.TrimSpace(role.DefaultAgentProfile),
-		ExecutionProfileID: firstNonEmpty(strings.TrimSpace(profile.ExecutionProfile), strings.TrimSpace(profile.ID)),
+		ExecutionProfileID: firstNonEmpty(roleExecutionProfileID(role), strings.TrimSpace(profile.ExecutionProfile), strings.TrimSpace(profile.ID)),
 		ExecutionMode:      ExecutionMode(assignment.DriverKind),
 		Status:             AssignmentStatus(assignment.Status),
 		DesiredAgent: cairnline.DesiredAgent{
@@ -266,6 +350,25 @@ func Assignment(assignment projectwork.Assignment, role projectwork.AgentRolePro
 		CreatedAt:         assignment.CreatedAt,
 		UpdatedAt:         assignment.UpdatedAt,
 	}
+}
+
+func Artifact(artifact projectwork.CollaborationArtifact) (cairnline.Artifact, bool) {
+	switch strings.TrimSpace(artifact.Kind) {
+	case projectwork.ArtifactKindEvidenceLink, projectwork.ArtifactKindReview:
+		return cairnline.Artifact{}, false
+	}
+	return cairnline.Artifact{
+		ID:           strings.TrimSpace(artifact.ID),
+		ProjectID:    strings.TrimSpace(artifact.ProjectID),
+		WorkItemID:   strings.TrimSpace(artifact.WorkItemID),
+		AssignmentID: strings.TrimSpace(artifact.AssignmentID),
+		Kind:         strings.TrimSpace(artifact.Kind),
+		Title:        strings.TrimSpace(artifact.Title),
+		Body:         strings.TrimSpace(artifact.Body),
+		AuthorRoleID: strings.TrimSpace(artifact.AuthorRoleID),
+		CreatedAt:    artifact.CreatedAt,
+		UpdatedAt:    artifact.UpdatedAt,
+	}, true
 }
 
 func Evidence(artifact projectwork.CollaborationArtifact) (cairnline.Evidence, bool) {
@@ -473,13 +576,26 @@ func syncAssignmentStatus(ctx context.Context, service *cairnline.Service, assig
 	case cairnline.AssignmentQueued:
 		return nil
 	case cairnline.AssignmentRunning, cairnline.AssignmentReview:
-		if _, err := service.ClaimAssignment(ctx, assignment.ProjectID, assignment.ID, claimedBy(assignment)); err != nil {
+		current, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
+		if err != nil {
 			return err
 		}
-		_, err := service.UpdateAssignmentStatus(ctx, assignment.ProjectID, assignment.ID, assignment.Status, assignment.ExecutionRef)
+		if current.Status == cairnline.AssignmentQueued {
+			if _, err := service.ClaimAssignment(ctx, assignment.ProjectID, assignment.ID, claimedBy(assignment)); err != nil {
+				return err
+			}
+		}
+		_, err = service.UpdateAssignmentStatus(ctx, assignment.ProjectID, assignment.ID, assignment.Status, assignment.ExecutionRef)
 		return err
 	case cairnline.AssignmentCompleted, cairnline.AssignmentFailed, cairnline.AssignmentCancelled:
-		_, err := service.CompleteAssignment(ctx, assignment.ProjectID, assignment.ID, assignment.Status, assignment.ExecutionRef)
+		current, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
+		if err != nil {
+			return err
+		}
+		if current.Status == assignment.Status {
+			return nil
+		}
+		_, err = service.CompleteAssignment(ctx, assignment.ProjectID, assignment.ID, assignment.Status, assignment.ExecutionRef)
 		return err
 	default:
 		return nil
@@ -507,6 +623,60 @@ func executionAgentKind(profile agentprofiles.Profile) string {
 	}
 }
 
+func roleExecutionProfileID(role projectwork.AgentRoleProfile) string {
+	if strings.TrimSpace(role.DefaultProvider) == "" && strings.TrimSpace(role.DefaultModel) == "" {
+		return ""
+	}
+	return roleExecutionProfileIDValue(role)
+}
+
+func roleExecutionProfileIDValue(role projectwork.AgentRoleProfile) string {
+	projectID := safeCairnlineIDPart(role.ProjectID)
+	roleID := safeCairnlineIDPart(role.ID)
+	if roleID == "" {
+		return ""
+	}
+	return "role_exec_" + firstNonEmpty(projectID, "project") + "_" + roleID
+}
+
+func projectExecutionProfileID(project projects.Project) string {
+	if strings.TrimSpace(project.DefaultProvider) == "" &&
+		strings.TrimSpace(project.DefaultModel) == "" &&
+		optionalBoolPolicy(project.DefaultToolsEnabled) == "" &&
+		len(projectExecutionAdapterOptions(project)) == 0 {
+		return ""
+	}
+	return projectExecutionProfileIDValue(project)
+}
+
+func projectExecutionProfileIDValue(project projects.Project) string {
+	projectID := safeCairnlineIDPart(project.ID)
+	if projectID == "" {
+		return ""
+	}
+	return "project_exec_" + projectID
+}
+
+func safeCairnlineIDPart(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			builder.WriteRune(r)
+		default:
+			builder.WriteByte('_')
+		}
+	}
+	return strings.Trim(builder.String(), "_")
+}
+
 func assignmentExecutionRef(ref projectwork.AssignmentExecutionRef) string {
 	return firstNonEmpty(
 		strings.TrimSpace(ref.RunID),
@@ -521,6 +691,30 @@ func boolPolicy(value bool) string {
 		return "allow"
 	}
 	return "block"
+}
+
+func optionalBoolPolicy(value *bool) string {
+	if value == nil {
+		return ""
+	}
+	return boolPolicy(*value)
+}
+
+func projectExecutionAdapterOptions(project projects.Project) map[string]any {
+	out := make(map[string]any)
+	if value := strings.TrimSpace(project.DefaultWorkspaceMode); value != "" {
+		out["workspace_mode"] = value
+	}
+	if value := strings.TrimSpace(project.DefaultSystemPrompt); value != "" {
+		out["system_prompt"] = value
+	}
+	if project.DefaultCompactToolOutput != nil {
+		out["compact_tool_output"] = *project.DefaultCompactToolOutput
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func compactStrings(items []string) []string {

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -2,6 +2,8 @@ package cairnlinebridge
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -9,6 +11,7 @@ import (
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -24,6 +27,9 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if err := Seed(ctx, service, snapshot); err != nil {
 		t.Fatalf("Seed() error = %v", err)
 	}
+	if got := SnapshotExecutionProfileCount(snapshot); got != 3 {
+		t.Fatalf("SnapshotExecutionProfileCount() = %d, want project, agent-profile, and role execution profiles", got)
+	}
 
 	packet, err := service.AssignmentLaunchPacket(ctx, "proj_hecate", "asgn_bridge")
 	if err != nil {
@@ -31,6 +37,27 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	}
 	if packet.Project.ID != "proj_hecate" || packet.Project.DefaultRootID != "root_main" || packet.WorkItem.RootID != "root_main" {
 		t.Fatalf("packet project/work = %+v/%+v, want Hecate project with default root and root-scoped work", packet.Project, packet.WorkItem)
+	}
+	if packet.Project.DefaultProfileID != "bridge_implementation" || packet.Project.DefaultExecutionProfileID != projectExecutionProfileID(snapshot.Project) {
+		t.Fatalf("packet project defaults = %+v, want mapped project profile and execution defaults", packet.Project)
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() error = %v", err)
+	}
+	if len(executionProfiles) != SnapshotExecutionProfileCount(snapshot) {
+		t.Fatalf("execution profile count = %d, want %d", len(executionProfiles), SnapshotExecutionProfileCount(snapshot))
+	}
+	projectExecutionProfile := findCairnlineExecutionProfile(executionProfiles, projectExecutionProfileID(snapshot.Project))
+	if projectExecutionProfile == nil ||
+		projectExecutionProfile.AgentKind != "hecate" ||
+		projectExecutionProfile.ProviderHint != "ollama" ||
+		projectExecutionProfile.ModelHint != "qwen3-coder" ||
+		projectExecutionProfile.ToolsPolicy != "allow" ||
+		projectExecutionProfile.AdapterOptions["workspace_mode"] != "worktree" ||
+		projectExecutionProfile.AdapterOptions["system_prompt"] != "Stay crisp." ||
+		projectExecutionProfile.AdapterOptions["compact_tool_output"] != true {
+		t.Fatalf("project execution profile = %+v, want Hecate project-level execution defaults", projectExecutionProfile)
 	}
 	if len(packet.Project.ContextSources) != 1 {
 		t.Fatalf("packet project sources = %+v, want one context source", packet.Project.ContextSources)
@@ -42,17 +69,23 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if packet.Role == nil || packet.Role.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
 		t.Fatalf("packet role = %+v, want orchestrated role from Hecate task driver", packet.Role)
 	}
+	if packet.Role.DefaultExecutionProfileID != roleExecutionProfileID(snapshot.Roles[0]) {
+		t.Fatalf("packet role = %+v, want role execution-profile default", packet.Role)
+	}
 	if packet.Profile == nil || packet.Profile.ID != "bridge_implementation" || packet.Profile.MemoryPolicy != agentprofiles.MemoryInclude {
 		t.Fatalf("packet profile = %+v, want mapped Hecate agent profile", packet.Profile)
 	}
-	if packet.ExecutionProfile == nil || packet.ExecutionProfile.AgentKind != "hecate" || packet.ExecutionProfile.WritesPolicy != "allow" || packet.ExecutionProfile.NetworkPolicy != "block" {
-		t.Fatalf("packet execution profile = %+v, want mapped Hecate execution posture", packet.ExecutionProfile)
+	if packet.ExecutionProfile == nil || packet.ExecutionProfile.ID != roleExecutionProfileID(snapshot.Roles[0]) || packet.ExecutionProfile.AgentKind != "hecate" || packet.ExecutionProfile.ProviderHint != "openai" || packet.ExecutionProfile.ModelHint != "gpt-5" {
+		t.Fatalf("packet execution profile = %+v, want mapped Hecate role execution defaults", packet.ExecutionProfile)
 	}
 	if packet.Assignment.ExecutionMode != cairnline.ExecutionOrchestrated || packet.Assignment.RootID != "root_main" || packet.Assignment.ContextSnapshotID != "ctx_123" {
 		t.Fatalf("packet assignment = %+v, want orchestrated root-scoped assignment", packet.Assignment)
 	}
 	if len(packet.Skills) != 1 || packet.Skills[0].ID != "backend" || len(packet.Skills[0].SourceRefs) != 1 {
 		t.Fatalf("packet skills = %+v, want mapped backend skill with provenance", packet.Skills)
+	}
+	if len(packet.Artifacts) != 1 || packet.Artifacts[0].ID != "art_decision" || packet.Artifacts[0].Kind != projectwork.ArtifactKindDecisionNote || packet.Artifacts[0].AuthorRoleID != "bridge_developer" {
+		t.Fatalf("packet artifacts = %+v, want mapped generic collaboration artifact", packet.Artifacts)
 	}
 	if len(packet.Evidence) != 1 || packet.Evidence[0].ID != "art_evidence" || packet.Evidence[0].AssignmentID != "asgn_external" || packet.Evidence[0].Locator != "https://github.com/hecatehq/hecate/actions/runs/123" {
 		t.Fatalf("packet evidence = %+v, want mapped assignment-scoped evidence link", packet.Evidence)
@@ -74,6 +107,40 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	}
 	if len(packet.MemoryCandidates) != 1 || packet.MemoryCandidates[0].ID != "memcand_bridge" || packet.MemoryCandidates[0].SuggestedTrustLabel != memory.TrustLabelGenerated || packet.MemoryCandidates[0].SuggestedSourceID != "handoff_review" || len(packet.MemoryCandidates[0].SourceRefs) != 1 {
 		t.Fatalf("packet memory candidates = %+v, want mapped memory candidate provenance", packet.MemoryCandidates)
+	}
+	proposals, err := service.ListAssistantProposals(ctx, "proj_hecate")
+	if err != nil {
+		t.Fatalf("ListAssistantProposals() error = %v", err)
+	}
+	if len(proposals) != 1 || proposals[0].ID != "pa_bridge" || proposals[0].Status != cairnline.AssistantProposalStatusApplied || proposals[0].LatestResult == nil || len(proposals[0].ApplyAttempts) != 1 {
+		t.Fatalf("assistant proposals = %+v, want one imported portable applied proposal with attempt ledger", proposals)
+	}
+	if len(proposals[0].Proposal.Warnings) != 1 || proposals[0].Proposal.Warnings[0] != "Review generated follow-up scope before applying." {
+		t.Fatalf("assistant proposal warnings = %+v, want warning metadata preserved", proposals[0].Proposal.Warnings)
+	}
+	if len(proposals[0].Proposal.Actions) != 4 ||
+		proposals[0].Proposal.Actions[0].Kind != cairnline.AssistantActionAttachProjectRoot ||
+		proposals[0].Proposal.Actions[0].Root == nil ||
+		proposals[0].Proposal.Actions[0].Root.ID != "root_proposal" ||
+		proposals[0].Proposal.Actions[1].Kind != cairnline.AssistantActionSetProjectDefaults ||
+		proposals[0].Proposal.Actions[1].Project == nil ||
+		proposals[0].Proposal.Actions[1].Project.DefaultRootID != "root_proposal" ||
+		proposals[0].Proposal.Actions[2].Kind != cairnline.AssistantActionRemoveProjectRoot ||
+		proposals[0].Proposal.Actions[2].Target.RootID != "root_legacy" ||
+		proposals[0].Proposal.Actions[3].Kind != cairnline.AssistantActionCreateWorkItem ||
+		proposals[0].Proposal.Actions[3].WorkItem == nil ||
+		proposals[0].Proposal.Actions[3].WorkItem.ID != "work_from_proposal" {
+		t.Fatalf("assistant proposal actions = %+v, want mapped root/default and create-work-item actions", proposals[0].Proposal.Actions)
+	}
+	if proposals[0].LatestResult.TotalActionCount != 4 || len(proposals[0].LatestResult.Actions) != 4 || proposals[0].LatestResult.Actions[0].RootID != "root_proposal" || proposals[0].LatestResult.Actions[1].RootID != "root_proposal" || proposals[0].LatestResult.Actions[2].RootID != "root_legacy" {
+		t.Fatalf("assistant proposal latest result = %+v, want root action result refs", proposals[0].LatestResult)
+	}
+	workItems, err := service.ListWorkItems(ctx, "proj_hecate")
+	if err != nil {
+		t.Fatalf("ListWorkItems() error = %v", err)
+	}
+	if len(workItems) != len(snapshot.WorkItems) {
+		t.Fatalf("work item count after proposal import = %d, want %d; import must not replay proposal actions", len(workItems), len(snapshot.WorkItems))
 	}
 	readiness, err := service.WorkItemCloseoutReadiness(ctx, "proj_hecate", "work_bridge")
 	if err != nil {
@@ -126,6 +193,52 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	}
 }
 
+func TestAssistantProposalRecordProjectsCairnlineLedgerBackToHecate(t *testing.T) {
+	now := time.Date(2026, 6, 27, 13, 0, 0, 0, time.UTC)
+	source := bridgeAssistantProposalFixture(now)
+	imported, ok := AssistantProposalRecord(source)
+	if !ok {
+		t.Fatalf("AssistantProposalRecord() ok = false, want portable proposal fixture imported")
+	}
+	projected, ok := ProjectAssistantProposalRecord(imported)
+	if !ok {
+		t.Fatalf("ProjectAssistantProposalRecord() ok = false, want Cairnline proposal projected back to Hecate")
+	}
+	if projected.ID != source.ID || projected.ProjectID != source.ProjectID || projected.Status != projectassistant.ApplyStatusApplied || projected.LatestResult == nil || len(projected.ApplyAttempts) != 1 {
+		t.Fatalf("projected proposal = %+v, want applied Hecate proposal record with one attempt", projected)
+	}
+	if projected.LatestResult.CommittedActionCount != 4 || projected.LatestResult.ResumeActionIndex != 4 || len(projected.LatestResult.Actions) != 4 {
+		t.Fatalf("projected latest result = %+v, want Hecate apply progress counts", projected.LatestResult)
+	}
+	if len(projected.Proposal.Actions) != 4 {
+		t.Fatalf("projected actions = %+v, want four portable actions", projected.Proposal.Actions)
+	}
+	var attachRoot assistantRootPatch
+	if err := json.Unmarshal(projected.Proposal.Actions[0].Patch, &attachRoot); err != nil {
+		t.Fatalf("decode attach-root patch: %v", err)
+	}
+	if projected.Proposal.Actions[0].Kind != projectassistant.ActionAttachProjectRoot || attachRoot.ID != "root_proposal" || attachRoot.GitBranch != "proposal/root-actions" {
+		t.Fatalf("projected attach-root action = %+v patch %+v, want root action reconstructed", projected.Proposal.Actions[0], attachRoot)
+	}
+	var defaults assistantDefaultsPatch
+	if err := json.Unmarshal(projected.Proposal.Actions[1].Patch, &defaults); err != nil {
+		t.Fatalf("decode defaults patch: %v", err)
+	}
+	if defaults.DefaultRootID == nil || *defaults.DefaultRootID != "root_proposal" {
+		t.Fatalf("projected defaults patch = %+v, want default root id", defaults)
+	}
+	var work assistantWorkItemPatch
+	if err := json.Unmarshal(projected.Proposal.Actions[3].Patch, &work); err != nil {
+		t.Fatalf("decode work patch: %v", err)
+	}
+	if projected.Proposal.Actions[3].Kind != projectassistant.ActionCreateWorkItem || work.ID != "work_from_proposal" || work.RootID != "root_main" {
+		t.Fatalf("projected work action = %+v patch %+v, want create-work-item action reconstructed", projected.Proposal.Actions[3], work)
+	}
+	if projected.ApplyAttempts[0].Result.CommittedActionCount != 4 || projected.ApplyAttempts[0].Result.ResumeActionIndex != 4 {
+		t.Fatalf("projected apply attempt = %+v, want preserved Hecate apply progress", projected.ApplyAttempts[0])
+	}
+}
+
 func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
@@ -149,8 +262,8 @@ func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	if len(loaded.Skills) != len(snapshot.Skills) || len(loaded.WorkItems) != len(snapshot.WorkItems) || len(loaded.Assignments) != len(snapshot.Assignments) {
 		t.Fatalf("loaded counts skills=%d work=%d assignments=%d, want %d/%d/%d", len(loaded.Skills), len(loaded.WorkItems), len(loaded.Assignments), len(snapshot.Skills), len(snapshot.WorkItems), len(snapshot.Assignments))
 	}
-	if len(loaded.Artifacts) != len(snapshot.Artifacts) || len(loaded.Handoffs) != len(snapshot.Handoffs) || len(loaded.MemoryEntries) != len(snapshot.MemoryEntries) || len(loaded.MemoryCandidates) != len(snapshot.MemoryCandidates) {
-		t.Fatalf("loaded collaboration counts artifacts=%d handoffs=%d memory_entries=%d memory_candidates=%d, want %d/%d/%d/%d", len(loaded.Artifacts), len(loaded.Handoffs), len(loaded.MemoryEntries), len(loaded.MemoryCandidates), len(snapshot.Artifacts), len(snapshot.Handoffs), len(snapshot.MemoryEntries), len(snapshot.MemoryCandidates))
+	if len(loaded.Artifacts) != len(snapshot.Artifacts) || len(loaded.Handoffs) != len(snapshot.Handoffs) || len(loaded.MemoryEntries) != len(snapshot.MemoryEntries) || len(loaded.MemoryCandidates) != len(snapshot.MemoryCandidates) || len(loaded.AssistantProposals) != len(snapshot.AssistantProposals) {
+		t.Fatalf("loaded collaboration counts artifacts=%d handoffs=%d memory_entries=%d memory_candidates=%d proposals=%d, want %d/%d/%d/%d/%d", len(loaded.Artifacts), len(loaded.Handoffs), len(loaded.MemoryEntries), len(loaded.MemoryCandidates), len(loaded.AssistantProposals), len(snapshot.Artifacts), len(snapshot.Handoffs), len(snapshot.MemoryEntries), len(snapshot.MemoryCandidates), len(snapshot.AssistantProposals))
 	}
 
 	service := cairnline.NewMemoryService()
@@ -163,6 +276,16 @@ func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	}
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("loaded launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
+	}
+	proposals, err := service.ListAssistantProposals(ctx, snapshot.Project.ID)
+	if err != nil {
+		t.Fatalf("ListAssistantProposals() loaded snapshot error = %v", err)
+	}
+	if len(proposals) != 1 || proposals[0].ID != "pa_bridge" {
+		t.Fatalf("loaded assistant proposals = %+v, want portable proposal imported into Cairnline", proposals)
+	}
+	if len(proposals[0].Proposal.Warnings) != 1 || proposals[0].Proposal.Warnings[0] != "Review generated follow-up scope before applying." {
+		t.Fatalf("loaded assistant proposal warnings = %+v, want preserved warnings", proposals[0].Proposal.Warnings)
 	}
 }
 
@@ -211,6 +334,1003 @@ func TestProjectOperationsBriefFromStores(t *testing.T) {
 	}
 }
 
+func TestUpsertProjectMirrorsProjectRootAndContextSourceMutations(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 10, 0, 0, 0, time.UTC)
+
+	project := projects.Project{
+		ID:                   "proj_write",
+		Name:                 "Write Adapter",
+		Description:          "Prove project writes can land in Cairnline.",
+		DefaultProvider:      "openai",
+		DefaultModel:         "gpt-5",
+		DefaultAgentProfile:  "implementation",
+		DefaultToolsEnabled:  boolPtrForTest(true),
+		DefaultWorkspaceMode: "worktree",
+		Roots: []projects.Root{{
+			ID:        "root_main",
+			Path:      "/tmp/hecate-write",
+			Kind:      "git",
+			GitRemote: "https://github.com/hecatehq/hecate",
+			GitBranch: "main",
+			Active:    true,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}},
+		DefaultRootID: "root_main",
+		ContextSources: []projects.ContextSource{{
+			ID:             "ctx_agents",
+			Kind:           "workspace_instruction",
+			Title:          "AGENTS.md",
+			Path:           "AGENTS.md",
+			Enabled:        true,
+			Format:         "agents_md",
+			Scope:          "workspace",
+			TrustLabel:     "workspace_guidance",
+			SourceCategory: "workspace_guidance",
+			Metadata:       map[string]string{"root_id": "root_main"},
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	created, err := UpsertProject(ctx, service, project)
+	if err != nil {
+		t.Fatalf("UpsertProject(create) error = %v", err)
+	}
+	if created.ID != project.ID || created.DefaultRootID != "root_main" || created.DefaultProfileID != "implementation" || created.DefaultExecutionProfileID != projectExecutionProfileID(project) {
+		t.Fatalf("created project = %+v, want mapped Hecate project defaults", created)
+	}
+	if len(created.Roots) != 1 || created.Roots[0].Path != "/tmp/hecate-write" || created.Roots[0].GitBranch != "main" {
+		t.Fatalf("created roots = %+v, want portable root metadata", created.Roots)
+	}
+	if len(created.ContextSources) != 1 || created.ContextSources[0].Locator != "AGENTS.md" || created.ContextSources[0].Metadata["root_id"] != "root_main" {
+		t.Fatalf("created sources = %+v, want portable context-source metadata", created.ContextSources)
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() error = %v", err)
+	}
+	if profile := findCairnlineExecutionProfile(executionProfiles, projectExecutionProfileID(project)); profile == nil || profile.ProviderHint != "openai" || profile.ModelHint != "gpt-5" || profile.ToolsPolicy != "allow" || profile.AdapterOptions["workspace_mode"] != "worktree" {
+		t.Fatalf("project execution profile = %+v, want Hecate project execution defaults", profile)
+	}
+
+	project.Name = "Write Adapter Updated"
+	project.DefaultProvider = ""
+	project.DefaultModel = ""
+	project.DefaultToolsEnabled = nil
+	project.DefaultWorkspaceMode = ""
+	project.Roots = []projects.Root{{
+		ID:     "root_docs",
+		Path:   "/tmp/hecate-docs",
+		Kind:   "folder",
+		Active: true,
+	}}
+	project.DefaultRootID = "root_docs"
+	project.ContextSources = []projects.ContextSource{{
+		ID:             "ctx_readme",
+		Kind:           "workspace_instruction",
+		Title:          "README.md",
+		Path:           "README.md",
+		Enabled:        false,
+		Format:         "markdown",
+		Scope:          "workspace",
+		TrustLabel:     "workspace_guidance",
+		SourceCategory: "workspace_guidance",
+	}}
+
+	updated, err := UpsertProject(ctx, service, project)
+	if err != nil {
+		t.Fatalf("UpsertProject(update) error = %v", err)
+	}
+	if updated.Name != "Write Adapter Updated" || updated.DefaultRootID != "root_docs" || updated.DefaultExecutionProfileID != "" {
+		t.Fatalf("updated project = %+v, want updated project and removed execution default", updated)
+	}
+	if len(updated.Roots) != 1 || updated.Roots[0].ID != "root_docs" {
+		t.Fatalf("updated roots = %+v, want replaced root set", updated.Roots)
+	}
+	if len(updated.ContextSources) != 1 || updated.ContextSources[0].ID != "ctx_readme" || updated.ContextSources[0].Enabled {
+		t.Fatalf("updated sources = %+v, want replaced source set", updated.ContextSources)
+	}
+	executionProfiles, err = service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() after update error = %v", err)
+	}
+	if profile := findCairnlineExecutionProfile(executionProfiles, projectExecutionProfileIDValue(project)); profile != nil {
+		t.Fatalf("project execution profile = %+v, want removed after project defaults cleared", profile)
+	}
+}
+
+func TestDeleteProjectRemovesProjectAndProjectExecutionProfile(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	project := projects.Project{
+		ID:              "proj_delete",
+		Name:            "Delete Adapter",
+		DefaultProvider: "openai",
+		DefaultModel:    "gpt-5",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   "/tmp/hecate-delete",
+			Active: true,
+		}},
+		DefaultRootID: "root_main",
+	}
+	if _, err := UpsertProject(ctx, service, project); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+	if err := DeleteProject(ctx, service, project); err != nil {
+		t.Fatalf("DeleteProject() error = %v", err)
+	}
+	if _, err := service.GetProject(ctx, project.ID); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("GetProject() error = %v, want cairnline.ErrNotFound", err)
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() error = %v", err)
+	}
+	if profile := findCairnlineExecutionProfile(executionProfiles, projectExecutionProfileIDValue(project)); profile != nil {
+		t.Fatalf("project execution profile = %+v, want deleted with project", profile)
+	}
+}
+
+func TestUpsertAgentProfileMirrorsProfileAndExecutionPosture(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 11, 15, 0, 0, time.UTC)
+	profile := agentprofiles.Profile{
+		ID:                  "safe_external_review",
+		Name:                "Safe external review",
+		Description:         "Reviews external-agent work.",
+		Instructions:        "Inspect evidence before approval.",
+		Surface:             agentprofiles.SurfaceExternalAgent,
+		ProviderHint:        "anthropic",
+		ModelHint:           "claude-sonnet-4",
+		ExecutionProfile:    "review_runtime",
+		ToolsEnabled:        true,
+		WritesAllowed:       false,
+		NetworkAllowed:      false,
+		ApprovalPolicy:      agentprofiles.ApprovalRequire,
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		SkillIDs:            []string{"review", "review"},
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+
+	created, err := UpsertAgentProfile(ctx, service, profile)
+	if err != nil {
+		t.Fatalf("UpsertAgentProfile(create) error = %v", err)
+	}
+	if created.ID != "safe_external_review" || created.MemoryPolicy != agentprofiles.MemoryVisibleOnly || len(created.SkillIDs) != 1 || created.SkillIDs[0] != "review" {
+		t.Fatalf("created profile = %+v, want compacted profile metadata", created)
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() error = %v", err)
+	}
+	if execution := findCairnlineExecutionProfile(executionProfiles, "review_runtime"); execution == nil || execution.AgentKind != cairnline.DesiredAgentAny || execution.ProviderHint != "anthropic" || execution.ModelHint != "claude-sonnet-4" || execution.ToolsPolicy != "allow" || execution.WritesPolicy != "block" {
+		t.Fatalf("execution profile = %+v, want profile posture", execution)
+	}
+
+	profile.Name = "External review"
+	profile.ModelHint = "claude-opus-4"
+	updated, err := UpsertAgentProfile(ctx, service, profile)
+	if err != nil {
+		t.Fatalf("UpsertAgentProfile(update) error = %v", err)
+	}
+	if updated.Name != "External review" {
+		t.Fatalf("updated profile = %+v, want renamed profile", updated)
+	}
+	executionProfiles, err = service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() after update error = %v", err)
+	}
+	if execution := findCairnlineExecutionProfile(executionProfiles, "review_runtime"); execution == nil || execution.ModelHint != "claude-opus-4" {
+		t.Fatalf("execution profile after update = %+v, want updated model hint", execution)
+	}
+}
+
+func TestUpsertRoleMirrorsRoleAndExecutionDefaults(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 11, 30, 0, 0, time.UTC)
+	if _, err := UpsertProject(ctx, service, projects.Project{ID: "proj_roles", Name: "Role Adapter"}); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+	profile := agentprofiles.Profile{
+		ID:                  "implementation",
+		Name:                "Implementation",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ProviderHint:        "openai",
+		ModelHint:           "gpt-5",
+		ToolsEnabled:        true,
+		WritesAllowed:       true,
+		NetworkAllowed:      false,
+		ApprovalPolicy:      agentprofiles.ApprovalRequire,
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	if _, err := service.CreateAgentProfile(ctx, AgentProfile(profile)); err != nil {
+		t.Fatalf("CreateAgentProfile() error = %v", err)
+	}
+
+	role := projectwork.AgentRoleProfile{
+		ID:                  "developer",
+		ProjectID:           "proj_roles",
+		Name:                "Developer",
+		Description:         "Implements scoped changes.",
+		Instructions:        "Keep changes small.",
+		DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
+		DefaultProvider:     "openai",
+		DefaultModel:        "gpt-5",
+		DefaultAgentProfile: "implementation",
+		SkillIDs:            []string{"backend", "backend"},
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+
+	created, err := UpsertRole(ctx, service, role)
+	if err != nil {
+		t.Fatalf("UpsertRole(create) error = %v", err)
+	}
+	if created.ID != "developer" || created.DefaultProfileID != "implementation" || created.DefaultExecutionProfileID != roleExecutionProfileID(role) || created.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
+		t.Fatalf("created role = %+v, want mapped role defaults", created)
+	}
+	if len(created.DefaultSkillIDs) != 1 || created.DefaultSkillIDs[0] != "backend" {
+		t.Fatalf("created role skill ids = %+v, want compacted backend skill", created.DefaultSkillIDs)
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() error = %v", err)
+	}
+	if profile := findCairnlineExecutionProfile(executionProfiles, roleExecutionProfileID(role)); profile == nil || profile.AgentKind != "hecate" || profile.ProviderHint != "openai" || profile.ModelHint != "gpt-5" {
+		t.Fatalf("role execution profile = %+v, want role-level execution defaults", profile)
+	}
+
+	role.Name = "Developer Updated"
+	role.DefaultProvider = ""
+	role.DefaultModel = ""
+	role.SkillIDs = []string{"frontend"}
+	updated, err := UpsertRole(ctx, service, role)
+	if err != nil {
+		t.Fatalf("UpsertRole(update) error = %v", err)
+	}
+	if updated.Name != "Developer Updated" || updated.DefaultExecutionProfileID != "" || len(updated.DefaultSkillIDs) != 1 || updated.DefaultSkillIDs[0] != "frontend" {
+		t.Fatalf("updated role = %+v, want updated role and removed execution default", updated)
+	}
+	executionProfiles, err = service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() after update error = %v", err)
+	}
+	if profile := findCairnlineExecutionProfile(executionProfiles, roleExecutionProfileIDValue(role)); profile != nil {
+		t.Fatalf("role execution profile = %+v, want removed after role defaults cleared", profile)
+	}
+
+	if err := DeleteRole(ctx, service, role); err != nil {
+		t.Fatalf("DeleteRole() error = %v", err)
+	}
+	roles, err := service.ListRoles(ctx, "proj_roles")
+	if err != nil {
+		t.Fatalf("ListRoles() error = %v", err)
+	}
+	if len(roles) != 0 {
+		t.Fatalf("roles after delete = %+v, want empty", roles)
+	}
+}
+
+func TestUpsertWorkItemMirrorsWorkItemMutations(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	project := projects.Project{
+		ID:   "proj_work_items",
+		Name: "Work Adapter",
+		Roots: []projects.Root{
+			{ID: "root_main", Path: "/tmp/hecate-work", Kind: "git", Active: true},
+			{ID: "root_docs", Path: "/tmp/hecate-docs", Kind: "folder", Active: true},
+		},
+		DefaultRootID: "root_main",
+	}
+	if _, err := UpsertProject(ctx, service, project); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+	item := projectwork.WorkItem{
+		ID:              "work_docs",
+		ProjectID:       "proj_work_items",
+		Title:           "Document adapter",
+		Brief:           "Write the bridge docs.",
+		Status:          projectwork.WorkItemStatusBacklog,
+		Priority:        "high",
+		OwnerRoleID:     "writer",
+		RootID:          "root_main",
+		ReviewerRoleIDs: []string{"reviewer", "reviewer"},
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	created, err := UpsertWorkItem(ctx, service, item)
+	if err != nil {
+		t.Fatalf("UpsertWorkItem(create) error = %v", err)
+	}
+	if created.ID != item.ID || created.Status != projectwork.WorkItemStatusBacklog || created.Priority != "high" || created.RootID != "root_main" || len(created.ReviewerRoleIDs) != 1 || created.ReviewerRoleIDs[0] != "reviewer" {
+		t.Fatalf("created work item = %+v, want mapped Hecate work item metadata", created)
+	}
+
+	item.Title = "Document adapter updated"
+	item.Status = projectwork.WorkItemStatusReady
+	item.Priority = "normal"
+	item.RootID = "root_docs"
+	item.ReviewerRoleIDs = []string{"reviewer"}
+	updated, err := UpsertWorkItem(ctx, service, item)
+	if err != nil {
+		t.Fatalf("UpsertWorkItem(update) error = %v", err)
+	}
+	if updated.Title != "Document adapter updated" || updated.Status != projectwork.WorkItemStatusReady || updated.RootID != "root_docs" || len(updated.ReviewerRoleIDs) != 1 {
+		t.Fatalf("updated work item = %+v, want updated work item metadata", updated)
+	}
+
+	if err := DeleteWorkItem(ctx, service, item.ProjectID, item.ID); err != nil {
+		t.Fatalf("DeleteWorkItem() error = %v", err)
+	}
+	if _, err := service.GetWorkItem(ctx, item.ProjectID, item.ID); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("GetWorkItem() error = %v, want cairnline.ErrNotFound", err)
+	}
+}
+
+func TestUpsertAssignmentCreatesAndSyncsLifecycle(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 12, 30, 0, 0, time.UTC)
+	project := projects.Project{
+		ID:   "proj_assignments",
+		Name: "Assignment Adapter",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   "/tmp/hecate-assignment",
+			Kind:   "git",
+			Active: true,
+		}},
+		DefaultRootID: "root_main",
+	}
+	if _, err := UpsertProject(ctx, service, project); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+	profile := agentprofiles.Profile{
+		ID:                  "implementation",
+		Name:                "Implementation",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ProviderHint:        "openai",
+		ModelHint:           "gpt-5",
+		ToolsEnabled:        true,
+		WritesAllowed:       true,
+		ApprovalPolicy:      agentprofiles.ApprovalRequire,
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	if _, err := service.CreateAgentProfile(ctx, AgentProfile(profile)); err != nil {
+		t.Fatalf("CreateAgentProfile() error = %v", err)
+	}
+	if _, err := service.CreateExecutionProfile(ctx, ExecutionProfile(profile)); err != nil {
+		t.Fatalf("CreateExecutionProfile(profile) error = %v", err)
+	}
+	role := projectwork.AgentRoleProfile{
+		ID:                  "developer",
+		ProjectID:           project.ID,
+		Name:                "Developer",
+		DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
+		DefaultProvider:     "openai",
+		DefaultModel:        "gpt-5",
+		DefaultAgentProfile: profile.ID,
+		SkillIDs:            []string{"backend"},
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	if _, err := UpsertRole(ctx, service, role); err != nil {
+		t.Fatalf("UpsertRole() error = %v", err)
+	}
+	workItem := projectwork.WorkItem{
+		ID:        "work_bridge",
+		ProjectID: project.ID,
+		Title:     "Bridge assignments",
+		Status:    projectwork.WorkItemStatusReady,
+		RootID:    "root_main",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if _, err := UpsertWorkItem(ctx, service, workItem); err != nil {
+		t.Fatalf("UpsertWorkItem() error = %v", err)
+	}
+	assignment := projectwork.Assignment{
+		ID:         "asgn_bridge",
+		ProjectID:  project.ID,
+		WorkItemID: workItem.ID,
+		RoleID:     role.ID,
+		RootID:     "root_main",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusQueued,
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			ContextSnapshotID: "ctx_queued",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	queued, err := UpsertAssignment(ctx, service, assignment, role, profile)
+	if err != nil {
+		t.Fatalf("UpsertAssignment(queued) error = %v", err)
+	}
+	if queued.Status != cairnline.AssignmentQueued || queued.ProfileID != profile.ID || queued.ExecutionProfileID != roleExecutionProfileID(role) || queued.ExecutionMode != cairnline.ExecutionOrchestrated || queued.ContextSnapshotID != "ctx_queued" {
+		t.Fatalf("queued assignment = %+v, want created orchestrated assignment metadata", queued)
+	}
+	if queued.DesiredAgent.Kind != "hecate" || len(queued.DesiredAgent.SkillIDs) != 1 || queued.DesiredAgent.SkillIDs[0] != "backend" {
+		t.Fatalf("queued desired agent = %+v, want Hecate desired agent with role skill ids", queued.DesiredAgent)
+	}
+
+	followUpWork := projectwork.WorkItem{
+		ID:        "work_followup",
+		ProjectID: project.ID,
+		Title:     "Follow up assignments",
+		Status:    projectwork.WorkItemStatusReady,
+		RootID:    "root_main",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if _, err := UpsertWorkItem(ctx, service, followUpWork); err != nil {
+		t.Fatalf("UpsertWorkItem(follow up) error = %v", err)
+	}
+	externalRole := projectwork.AgentRoleProfile{
+		ID:                  "external_reviewer",
+		ProjectID:           project.ID,
+		Name:                "External Reviewer",
+		DefaultDriverKind:   projectwork.AssignmentDriverExternalAgent,
+		DefaultAgentProfile: profile.ID,
+		SkillIDs:            []string{"review", "review"},
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	if _, err := UpsertRole(ctx, service, externalRole); err != nil {
+		t.Fatalf("UpsertRole(external reviewer) error = %v", err)
+	}
+	assignment.WorkItemID = followUpWork.ID
+	assignment.RoleID = externalRole.ID
+	assignment.DriverKind = projectwork.AssignmentDriverExternalAgent
+	assignment.ExecutionRef = projectwork.AssignmentExecutionRef{ContextSnapshotID: "ctx_updated"}
+	updatedQueued, err := UpsertAssignment(ctx, service, assignment, externalRole, profile)
+	if err != nil {
+		t.Fatalf("UpsertAssignment(update queued metadata) error = %v", err)
+	}
+	if updatedQueued.Status != cairnline.AssignmentQueued || updatedQueued.WorkItemID != followUpWork.ID || updatedQueued.RoleID != externalRole.ID || updatedQueued.ExecutionMode != cairnline.ExecutionExternalAdapter || updatedQueued.ContextSnapshotID != "ctx_updated" {
+		t.Fatalf("updated queued assignment = %+v, want retargeted queued assignment metadata", updatedQueued)
+	}
+	if !updatedQueued.CreatedAt.Equal(queued.CreatedAt) {
+		t.Fatalf("updated queued created_at = %s, want preserved %s", updatedQueued.CreatedAt, queued.CreatedAt)
+	}
+	if updatedQueued.DesiredAgent.Kind != cairnline.DesiredAgentAny || len(updatedQueued.DesiredAgent.SkillIDs) != 1 || updatedQueued.DesiredAgent.SkillIDs[0] != "review" {
+		t.Fatalf("updated queued desired agent = %+v, want external role skill metadata", updatedQueued.DesiredAgent)
+	}
+
+	assignment.Status = projectwork.AssignmentStatusRunning
+	assignment.ExecutionRef = projectwork.AssignmentExecutionRef{TaskID: "task_1", RunID: "run_1", ContextSnapshotID: "ctx_running"}
+	running, err := UpsertAssignment(ctx, service, assignment, externalRole, profile)
+	if err != nil {
+		t.Fatalf("UpsertAssignment(running) error = %v", err)
+	}
+	if running.Status != cairnline.AssignmentRunning || running.ClaimedBy != "external_adapter" || running.ExecutionRef != "run_1" || running.WorkItemID != followUpWork.ID || running.RoleID != externalRole.ID {
+		t.Fatalf("running assignment = %+v, want claimed running assignment", running)
+	}
+	if _, err := UpsertAssignment(ctx, service, assignment, externalRole, profile); err != nil {
+		t.Fatalf("UpsertAssignment(running idempotent) error = %v", err)
+	}
+
+	assignment.Status = projectwork.AssignmentStatusCompleted
+	completed, err := UpsertAssignment(ctx, service, assignment, externalRole, profile)
+	if err != nil {
+		t.Fatalf("UpsertAssignment(completed) error = %v", err)
+	}
+	if completed.Status != cairnline.AssignmentCompleted || completed.ExecutionRef != "run_1" {
+		t.Fatalf("completed assignment = %+v, want completed assignment with execution ref", completed)
+	}
+	if _, err := UpsertAssignment(ctx, service, assignment, externalRole, profile); err != nil {
+		t.Fatalf("UpsertAssignment(completed idempotent) error = %v", err)
+	}
+
+	if err := DeleteAssignment(ctx, service, assignment.ProjectID, assignment.ID); err != nil {
+		t.Fatalf("DeleteAssignment() error = %v", err)
+	}
+	if _, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("GetAssignment() error = %v, want cairnline.ErrNotFound", err)
+	}
+}
+
+func TestRecordCollaborationArtifactsAndUpsertHandoff(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 13, 0, 0, 0, time.UTC)
+	project := projects.Project{
+		ID:   "proj_collab",
+		Name: "Collaboration Adapter",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   "/tmp/hecate-collab",
+			Kind:   "git",
+			Active: true,
+		}},
+		DefaultRootID: "root_main",
+	}
+	if _, err := UpsertProject(ctx, service, project); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+	profile := agentprofiles.Profile{
+		ID:                  "implementation",
+		Name:                "Implementation",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ToolsEnabled:        true,
+		WritesAllowed:       true,
+		ApprovalPolicy:      agentprofiles.ApprovalRequire,
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	if _, err := service.CreateAgentProfile(ctx, AgentProfile(profile)); err != nil {
+		t.Fatalf("CreateAgentProfile() error = %v", err)
+	}
+	if _, err := service.CreateExecutionProfile(ctx, ExecutionProfile(profile)); err != nil {
+		t.Fatalf("CreateExecutionProfile(profile) error = %v", err)
+	}
+	role := projectwork.AgentRoleProfile{
+		ID:                  "developer",
+		ProjectID:           project.ID,
+		Name:                "Developer",
+		DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
+		DefaultAgentProfile: profile.ID,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	if _, err := UpsertRole(ctx, service, role); err != nil {
+		t.Fatalf("UpsertRole() error = %v", err)
+	}
+	workItem := projectwork.WorkItem{
+		ID:        "work_collab",
+		ProjectID: project.ID,
+		Title:     "Record collaboration",
+		Status:    projectwork.WorkItemStatusReady,
+		RootID:    "root_main",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if _, err := UpsertWorkItem(ctx, service, workItem); err != nil {
+		t.Fatalf("UpsertWorkItem() error = %v", err)
+	}
+	assignment := projectwork.Assignment{
+		ID:         "asgn_collab",
+		ProjectID:  project.ID,
+		WorkItemID: workItem.ID,
+		RoleID:     role.ID,
+		RootID:     "root_main",
+		DriverKind: projectwork.AssignmentDriverHecateTask,
+		Status:     projectwork.AssignmentStatusQueued,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if _, err := UpsertAssignment(ctx, service, assignment, role, profile); err != nil {
+		t.Fatalf("UpsertAssignment() error = %v", err)
+	}
+
+	generic := projectwork.CollaborationArtifact{
+		ID:           "art_decision",
+		ProjectID:    project.ID,
+		WorkItemID:   workItem.ID,
+		AssignmentID: assignment.ID,
+		Kind:         projectwork.ArtifactKindDecisionNote,
+		Title:        "Decision",
+		Body:         "Keep the bridge seams non-authoritative.",
+		AuthorRoleID: role.ID,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	recordedArtifact, err := RecordArtifact(ctx, service, generic)
+	if err != nil {
+		t.Fatalf("RecordArtifact() error = %v", err)
+	}
+	if recordedArtifact.ID != generic.ID || recordedArtifact.AssignmentID != assignment.ID || recordedArtifact.AuthorRoleID != role.ID || recordedArtifact.Body != generic.Body {
+		t.Fatalf("recorded artifact = %+v, want generic collaboration artifact metadata", recordedArtifact)
+	}
+	generic.Body = "Replay should not mutate create-only artifacts."
+	replayedArtifact, err := RecordArtifact(ctx, service, generic)
+	if err != nil {
+		t.Fatalf("RecordArtifact(replay) error = %v", err)
+	}
+	if replayedArtifact.Body != recordedArtifact.Body {
+		t.Fatalf("replayed artifact body = %q, want original create-only body %q", replayedArtifact.Body, recordedArtifact.Body)
+	}
+
+	evidenceArtifact := projectwork.CollaborationArtifact{
+		ID:                 "art_evidence",
+		ProjectID:          project.ID,
+		WorkItemID:         workItem.ID,
+		AssignmentID:       assignment.ID,
+		Kind:               projectwork.ArtifactKindEvidenceLink,
+		Title:              "CI run",
+		Body:               "Tests passed.",
+		EvidenceURL:        "https://github.com/hecatehq/hecate/actions/runs/42",
+		EvidenceTrustLabel: projectwork.EvidenceTrustOperatorProvided,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	evidence, err := RecordEvidence(ctx, service, evidenceArtifact)
+	if err != nil {
+		t.Fatalf("RecordEvidence() error = %v", err)
+	}
+	if evidence.ID != "art_evidence" || evidence.AssignmentID != assignment.ID || evidence.Locator != evidenceArtifact.EvidenceURL || evidence.TrustLabel != projectwork.EvidenceTrustOperatorProvided {
+		t.Fatalf("recorded evidence = %+v, want evidence link metadata", evidence)
+	}
+
+	reviewArtifact := projectwork.CollaborationArtifact{
+		ID:                   "art_review",
+		ProjectID:            project.ID,
+		WorkItemID:           workItem.ID,
+		AssignmentID:         assignment.ID,
+		Kind:                 projectwork.ArtifactKindReview,
+		Title:                "Review",
+		Body:                 "Needs one follow-up.",
+		AuthorRoleID:         role.ID,
+		ReviewedAssignmentID: assignment.ID,
+		ReviewVerdict:        projectwork.ReviewVerdictChangesRequested,
+		ReviewRisk:           projectwork.ReviewRiskHigh,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	review, err := RecordReview(ctx, service, reviewArtifact)
+	if err != nil {
+		t.Fatalf("RecordReview() error = %v", err)
+	}
+	if review.ID != "art_review" || review.AssignmentID != assignment.ID || review.ReviewerRoleID != role.ID || review.Verdict != cairnline.ReviewVerdictConcerns || review.Risk != cairnline.ReviewRiskHigh {
+		t.Fatalf("recorded review = %+v, want reduced review metadata", review)
+	}
+
+	handoff := projectwork.Handoff{
+		ID:                    "handoff_review",
+		ProjectID:             project.ID,
+		WorkItemID:            workItem.ID,
+		SourceAssignmentID:    assignment.ID,
+		SourceRunID:           "run_collab",
+		TargetRoleID:          role.ID,
+		Title:                 "Review follow-up",
+		Summary:               "Please address the review concern.",
+		RecommendedNextAction: "Create a follow-up assignment.",
+		LinkedArtifactIDs:     []string{"art_review", "art_review"},
+		ContextRefs:           []string{"ctx_1"},
+		Status:                projectwork.HandoffStatusPending,
+		ProvenanceKind:        "operator",
+		TrustLabel:            "operator_reviewed",
+		CreatedByRoleID:       role.ID,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}
+	createdHandoff, err := UpsertHandoff(ctx, service, handoff)
+	if err != nil {
+		t.Fatalf("UpsertHandoff(create) error = %v", err)
+	}
+	if createdHandoff.ID != handoff.ID || createdHandoff.SourceAssignmentID != assignment.ID || createdHandoff.FromRoleID != role.ID || createdHandoff.ToRoleID != role.ID || len(createdHandoff.LinkedArtifactIDs) != 1 || createdHandoff.Status != cairnline.HandoffStatusOpen {
+		t.Fatalf("created handoff = %+v, want mapped handoff metadata", createdHandoff)
+	}
+
+	handoff.Status = projectwork.HandoffStatusAccepted
+	handoff.TargetAssignmentID = assignment.ID
+	handoff.TargetWorkItemID = workItem.ID
+	handoff.Summary = "Accepted follow-up."
+	updatedHandoff, err := UpsertHandoff(ctx, service, handoff)
+	if err != nil {
+		t.Fatalf("UpsertHandoff(update) error = %v", err)
+	}
+	if updatedHandoff.Status != cairnline.HandoffStatusAccepted || updatedHandoff.TargetAssignmentID != assignment.ID || updatedHandoff.TargetWorkItemID != workItem.ID || updatedHandoff.Body != "Accepted follow-up." {
+		t.Fatalf("updated handoff = %+v, want accepted handoff update", updatedHandoff)
+	}
+
+	if err := DeleteHandoff(ctx, service, handoff.ProjectID, handoff.WorkItemID, handoff.ID); err != nil {
+		t.Fatalf("DeleteHandoff() error = %v", err)
+	}
+	if _, err := service.GetHandoff(ctx, handoff.ProjectID, handoff.WorkItemID, handoff.ID); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("GetHandoff() error = %v, want cairnline.ErrNotFound", err)
+	}
+}
+
+func TestUpsertProjectSkillMirrorsSkillMetadata(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 11, 0, 0, 0, time.UTC)
+	if _, err := UpsertProject(ctx, service, projects.Project{
+		ID:   "proj_skills",
+		Name: "Skill Adapter",
+	}); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+
+	skill := projectskills.Skill{
+		ID:                     "backend",
+		ProjectID:              "proj_skills",
+		Title:                  "Backend",
+		Description:            "Server implementation guidance.",
+		Path:                   ".agents/skills/backend/SKILL.md",
+		RootID:                 "root_main",
+		Format:                 projectskills.FormatSkillMD,
+		Enabled:                false,
+		Status:                 projectskills.StatusAvailable,
+		TrustLabel:             projectskills.TrustWorkspaceSkill,
+		SourceContextSourceIDs: []string{"ctx_agents"},
+		Warnings:               []string{"Review before use."},
+		DiscoveredAt:           now,
+		CreatedAt:              now.Add(-time.Hour),
+		UpdatedAt:              now,
+	}
+
+	created, err := UpsertProjectSkill(ctx, service, skill)
+	if err != nil {
+		t.Fatalf("UpsertProjectSkill(create) error = %v", err)
+	}
+	if created.ID != "backend" || created.ProjectID != "proj_skills" || created.Title != "Backend" || created.Path != ".agents/skills/backend/SKILL.md" || created.RootID != "root_main" {
+		t.Fatalf("created skill = %+v, want portable skill metadata", created)
+	}
+	if created.Enabled {
+		t.Fatalf("created skill enabled = true, want disabled operator override preserved")
+	}
+	if created.Status != cairnline.SkillStatusAvailable || created.TrustLabel != cairnline.SkillTrustWorkspace || len(created.SourceRefs) != 1 || created.SourceRefs[0] != "ctx_agents" || len(created.Warnings) != 1 {
+		t.Fatalf("created skill = %+v, want status/trust/provenance/warnings", created)
+	}
+
+	skill.Title = "Backend Lead"
+	skill.Description = "Operator edited description."
+	skill.Enabled = true
+	skill.Status = projectskills.StatusConflict
+	skill.TrustLabel = "operator_curated_skill"
+	skill.Warnings = []string{"Duplicate skill id."}
+	updated, err := UpsertProjectSkill(ctx, service, skill)
+	if err != nil {
+		t.Fatalf("UpsertProjectSkill(update) error = %v", err)
+	}
+	if updated.Title != "Backend Lead" || updated.Description != "Operator edited description." || !updated.Enabled || updated.Status != cairnline.SkillStatusConflict || updated.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("updated skill = %+v, want operator-edited metadata", updated)
+	}
+	if updated.CreatedAt.IsZero() || !updated.DiscoveredAt.Equal(now) {
+		t.Fatalf("updated skill times = created %s discovered %s, want preserved created and Hecate discovered time", updated.CreatedAt, updated.DiscoveredAt)
+	}
+}
+
+func TestUpsertProjectSkillsMirrorsBatch(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	if _, err := UpsertProject(ctx, service, projects.Project{
+		ID:   "proj_skill_batch",
+		Name: "Skill Batch",
+	}); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+	written, err := UpsertProjectSkills(ctx, service, []projectskills.Skill{
+		{
+			ID:        "backend",
+			ProjectID: "proj_skill_batch",
+			Title:     "Backend",
+			Path:      ".agents/skills/backend/SKILL.md",
+			Format:    projectskills.FormatSkillMD,
+			Enabled:   true,
+			Status:    projectskills.StatusAvailable,
+		},
+		{
+			ID:        "frontend",
+			ProjectID: "proj_skill_batch",
+			Title:     "Frontend",
+			Path:      ".agents/skills/frontend/SKILL.md",
+			Format:    projectskills.FormatSkillMD,
+			Enabled:   true,
+			Status:    projectskills.StatusAvailable,
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpsertProjectSkills() error = %v", err)
+	}
+	if len(written) != 2 {
+		t.Fatalf("written skills = %+v, want two upserted skills", written)
+	}
+	items, err := service.ListProjectSkills(ctx, "proj_skill_batch")
+	if err != nil {
+		t.Fatalf("ListProjectSkills() error = %v", err)
+	}
+	if len(items) != 2 || findCairnlineProjectSkill(items, "backend") == nil || findCairnlineProjectSkill(items, "frontend") == nil {
+		t.Fatalf("project skills = %+v, want backend and frontend", items)
+	}
+}
+
+func TestUpsertMemoryEntryMirrorsMemoryMetadata(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	if _, err := UpsertProject(ctx, service, projects.Project{
+		ID:   "proj_memory",
+		Name: "Memory Adapter",
+	}); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+
+	entry := memory.Entry{
+		ID:         "mem_backend",
+		Scope:      memory.ScopeProject,
+		ProjectID:  "proj_memory",
+		Title:      "Backend Memory",
+		Body:       "Prefer bounded bridge seams before route switches.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		SourceID:   "operator_note",
+		Enabled:    false,
+	}
+	created, err := UpsertMemoryEntry(ctx, service, entry)
+	if err != nil {
+		t.Fatalf("UpsertMemoryEntry(create) error = %v", err)
+	}
+	if created.ID != "mem_backend" || created.ProjectID != "proj_memory" || created.Title != "Backend Memory" || created.Body != entry.Body || created.TrustLabel != memory.TrustLabelOperatorMemory || created.SourceKind != memory.SourceKindOperator || created.SourceID != "operator_note" {
+		t.Fatalf("created memory = %+v, want Hecate memory metadata", created)
+	}
+	if created.Enabled {
+		t.Fatalf("created memory enabled = true, want disabled Hecate memory preserved")
+	}
+
+	entry.Title = "Backend Memory Updated"
+	entry.Body = "Now routed through the reusable memory seam."
+	entry.Enabled = true
+	entry.SourceKind = "handoff"
+	entry.SourceID = "handoff_1"
+	updated, err := UpsertMemoryEntry(ctx, service, entry)
+	if err != nil {
+		t.Fatalf("UpsertMemoryEntry(update) error = %v", err)
+	}
+	if updated.Title != "Backend Memory Updated" || updated.Body != entry.Body || !updated.Enabled || updated.SourceKind != "handoff" || updated.SourceID != "handoff_1" {
+		t.Fatalf("updated memory = %+v, want updated Hecate memory metadata", updated)
+	}
+	if err := DeleteMemoryEntry(ctx, service, "proj_memory", "mem_backend"); err != nil {
+		t.Fatalf("DeleteMemoryEntry() error = %v", err)
+	}
+	if _, err := service.GetMemoryEntry(ctx, "proj_memory", "mem_backend"); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("GetMemoryEntry() error = %v, want cairnline.ErrNotFound", err)
+	}
+}
+
+func TestUpsertMemoryCandidateMirrorsResolvedState(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	if _, err := UpsertProject(ctx, service, projects.Project{
+		ID:   "proj_memory_candidates",
+		Name: "Memory Candidate Adapter",
+	}); err != nil {
+		t.Fatalf("UpsertProject() error = %v", err)
+	}
+	if _, err := UpsertMemoryEntry(ctx, service, memory.Entry{
+		ID:         "mem_promoted",
+		Scope:      memory.ScopeProject,
+		ProjectID:  "proj_memory_candidates",
+		Title:      "Promoted Memory",
+		Body:       "Use the promoted entry id generated by Hecate.",
+		TrustLabel: memory.TrustLabelGenerated,
+		SourceKind: "handoff",
+		SourceID:   "handoff_memory",
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("UpsertMemoryEntry(promoted) error = %v", err)
+	}
+
+	candidate := memory.Candidate{
+		ID:                  "memcand_promoted",
+		ProjectID:           "proj_memory_candidates",
+		Title:               "Candidate",
+		Body:                "Candidate body.",
+		SuggestedKind:       "project_pattern",
+		SuggestedTrustLabel: memory.TrustLabelGenerated,
+		SuggestedSourceKind: "handoff",
+		SuggestedSourceID:   "handoff_memory",
+		SourceRefs: []memory.CandidateSourceRef{{
+			Kind:  "handoff",
+			ID:    "handoff_memory",
+			Title: "Memory handoff",
+			URL:   "https://example.test/handoff",
+		}},
+		Status:           memory.CandidateStatusPromoted,
+		PromotedMemoryID: "mem_promoted",
+	}
+	created, err := UpsertMemoryCandidate(ctx, service, candidate)
+	if err != nil {
+		t.Fatalf("UpsertMemoryCandidate(create promoted) error = %v", err)
+	}
+	if created.Status != cairnline.MemoryCandidatePromoted || created.PromotedMemoryID != "mem_promoted" || created.SuggestedKind != "project_pattern" || created.SuggestedTrustLabel != memory.TrustLabelGenerated || len(created.SourceRefs) != 1 || created.SourceRefs[0].ID != "handoff_memory" {
+		t.Fatalf("created candidate = %+v, want promoted Hecate candidate metadata", created)
+	}
+
+	candidate.Status = memory.CandidateStatusRejected
+	candidate.StatusReason = "Too speculative"
+	candidate.PromotedMemoryID = ""
+	updated, err := UpsertMemoryCandidate(ctx, service, candidate)
+	if err != nil {
+		t.Fatalf("UpsertMemoryCandidate(update rejected) error = %v", err)
+	}
+	if updated.Status != cairnline.MemoryCandidateRejected || updated.StatusReason != "Too speculative" || updated.PromotedMemoryID != "" {
+		t.Fatalf("updated candidate = %+v, want rejected Hecate candidate state", updated)
+	}
+	if err := DeleteMemoryCandidate(ctx, service, "proj_memory_candidates", "memcand_promoted"); err != nil {
+		t.Fatalf("DeleteMemoryCandidate() error = %v", err)
+	}
+	if _, err := service.GetMemoryCandidate(ctx, "proj_memory_candidates", "memcand_promoted"); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("GetMemoryCandidate() error = %v, want cairnline.ErrNotFound", err)
+	}
+}
+
+func TestSeedSnapshotsMirrorsMultipleProjectsWithSharedProfiles(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	sharedProfile := agentprofiles.Profile{
+		ID:                  "shared_architect",
+		Name:                "Shared architect",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ModelHint:           "gpt-5",
+		ProviderHint:        "openai",
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	snapshots := []Snapshot{{
+		Project: projects.Project{
+			ID:                  "proj_one",
+			Name:                "One",
+			DefaultAgentProfile: "shared_architect",
+			DefaultProvider:     "openai",
+			DefaultModel:        "gpt-5",
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		},
+		AgentProfiles: []agentprofiles.Profile{sharedProfile},
+	}, {
+		Project: projects.Project{
+			ID:                  "proj_two",
+			Name:                "Two",
+			DefaultAgentProfile: "shared_architect",
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		},
+		AgentProfiles: []agentprofiles.Profile{sharedProfile},
+	}}
+
+	if err := SeedSnapshots(ctx, service, snapshots); err != nil {
+		t.Fatalf("SeedSnapshots() error = %v", err)
+	}
+	projects, err := service.ListProjects(ctx)
+	if err != nil {
+		t.Fatalf("ListProjects() error = %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("projects = %+v, want two seeded projects", projects)
+	}
+	profiles, err := service.ListAgentProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListAgentProfiles() error = %v", err)
+	}
+	if len(profiles) != 1 || profiles[0].ID != "shared_architect" {
+		t.Fatalf("profiles = %+v, want shared profile inserted once", profiles)
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutionProfiles() error = %v", err)
+	}
+	if len(executionProfiles) != 2 {
+		t.Fatalf("execution profiles = %+v, want shared agent profile plus project execution defaults", executionProfiles)
+	}
+}
+
 func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
@@ -247,6 +1367,16 @@ func TestSeedProjectFromStoresPersistsToCairnlineSQLite(t *testing.T) {
 	}
 	if len(packet.Evidence) != 1 || len(packet.Reviews) != 1 || len(packet.Handoffs) != 1 || len(packet.Memory) != 1 || len(packet.MemoryCandidates) != 1 {
 		t.Fatalf("reopened launch packet collaboration counts evidence=%d reviews=%d handoffs=%d memory_entries=%d memory_candidates=%d, want all one", len(packet.Evidence), len(packet.Reviews), len(packet.Handoffs), len(packet.Memory), len(packet.MemoryCandidates))
+	}
+	proposals, err := reopened.ListAssistantProposals(ctx, snapshot.Project.ID)
+	if err != nil {
+		t.Fatalf("reopened ListAssistantProposals() error = %v", err)
+	}
+	if len(proposals) != 1 || proposals[0].ID != "pa_bridge" || proposals[0].Status != cairnline.AssistantProposalStatusApplied || proposals[0].LatestResult == nil || len(proposals[0].ApplyAttempts) != 1 || proposals[0].AppliedAt == nil {
+		t.Fatalf("reopened assistant proposals = %+v, want persisted imported proposal ledger", proposals)
+	}
+	if len(proposals[0].Proposal.Warnings) != 1 || proposals[0].Proposal.Warnings[0] != "Review generated follow-up scope before applying." {
+		t.Fatalf("reopened assistant proposal warnings = %+v, want persisted warnings", proposals[0].Proposal.Warnings)
 	}
 	if packet.Evidence[0].AssignmentID != "asgn_external" {
 		t.Fatalf("reopened evidence = %+v, want persisted assignment-scoped evidence", packet.Evidence[0])
@@ -297,11 +1427,20 @@ func TestExecutionModeMapsHecateDrivers(t *testing.T) {
 }
 
 func bridgeSnapshotFixture(now time.Time) Snapshot {
+	defaultToolsEnabled := true
+	defaultCompactOutput := true
 	return Snapshot{
 		Project: projects.Project{
-			ID:          "proj_hecate",
-			Name:        "Hecate",
-			Description: "Local AI operations console.",
+			ID:                       "proj_hecate",
+			Name:                     "Hecate",
+			Description:              "Local AI operations console.",
+			DefaultProvider:          "ollama",
+			DefaultModel:             "qwen3-coder",
+			DefaultAgentProfile:      "bridge_implementation",
+			DefaultToolsEnabled:      &defaultToolsEnabled,
+			DefaultWorkspaceMode:     "worktree",
+			DefaultSystemPrompt:      "Stay crisp.",
+			DefaultCompactToolOutput: &defaultCompactOutput,
 			Roots: []projects.Root{{
 				ID:        "root_main",
 				Path:      "/Users/alice/dev/hecate",
@@ -368,6 +1507,8 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			Description:         "Implements backend and shared behavior.",
 			Instructions:        "Keep handlers thin.",
 			DefaultDriverKind:   projectwork.AssignmentDriverHecateTask,
+			DefaultProvider:     "openai",
+			DefaultModel:        "gpt-5",
 			DefaultAgentProfile: "bridge_implementation",
 			SkillIDs:            []string{"backend", "backend"},
 			CreatedAt:           now,
@@ -425,6 +1566,17 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			UpdatedAt: now,
 		}},
 		Artifacts: []projectwork.CollaborationArtifact{{
+			ID:           "art_decision",
+			ProjectID:    "proj_hecate",
+			WorkItemID:   "work_bridge",
+			AssignmentID: "asgn_bridge",
+			Kind:         projectwork.ArtifactKindDecisionNote,
+			Title:        "Bridge decision",
+			Body:         "Keep generic collaboration artifacts portable.",
+			AuthorRoleID: "bridge_developer",
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}, {
 			ID:                 "art_evidence",
 			ProjectID:          "proj_hecate",
 			WorkItemID:         "work_bridge",
@@ -518,7 +1670,151 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			CreatedAt:           now,
 			UpdatedAt:           now,
 		}},
+		AssistantProposals: []projectassistant.ProposalRecord{
+			bridgeAssistantProposalFixture(now),
+			bridgeHecateOnlyProposalFixture(now),
+		},
 	}
+}
+
+func bridgeAssistantProposalFixture(now time.Time) projectassistant.ProposalRecord {
+	appliedAt := now.Add(2 * time.Minute)
+	result := projectassistant.ApplyResult{
+		ProposalID:           "pa_bridge",
+		Status:               projectassistant.ApplyStatusApplied,
+		Applied:              true,
+		TotalActionCount:     4,
+		CommittedActionCount: 4,
+		Actions: []projectassistant.ActionResult{{
+			Kind: projectassistant.ActionAttachProjectRoot,
+			ID:   "root_proposal",
+			Data: map[string]string{
+				"project_id": "proj_hecate",
+				"root_id":    "root_proposal",
+			},
+		}, {
+			Kind: projectassistant.ActionSetProjectDefaults,
+			ID:   "proj_hecate",
+			Data: map[string]string{
+				"project_id": "proj_hecate",
+				"root_id":    "root_proposal",
+			},
+		}, {
+			Kind: projectassistant.ActionRemoveProjectRoot,
+			ID:   "root_legacy",
+			Data: map[string]string{
+				"project_id": "proj_hecate",
+				"root_id":    "root_legacy",
+			},
+		}, {
+			Kind: projectassistant.ActionCreateWorkItem,
+			ID:   "work_from_proposal",
+			Data: map[string]string{
+				"project_id":   "proj_hecate",
+				"work_item_id": "work_from_proposal",
+			},
+		}},
+	}
+	return projectassistant.ProposalRecord{
+		ID:        "pa_bridge",
+		ProjectID: "proj_hecate",
+		Source:    projectassistant.ProposalSourceDraft,
+		SourceID:  "deterministic",
+		Proposal: projectassistant.Proposal{
+			ID:      "pa_bridge",
+			Title:   "Create follow-up work",
+			Summary: "Queue one portable follow-up work item.",
+			Warnings: []string{
+				"Review generated follow-up scope before applying.",
+			},
+			Actions: []projectassistant.Action{{
+				Kind:   projectassistant.ActionAttachProjectRoot,
+				Target: map[string]string{"project_id": "proj_hecate"},
+				Patch: bridgeRawPatch(map[string]any{
+					"id":         "root_proposal",
+					"path":       "/Users/alice/dev/hecate-proposal",
+					"kind":       "git_worktree",
+					"git_branch": "proposal/root-actions",
+					"active":     true,
+				}),
+				Reason: "Attach a proposed worktree root.",
+			}, {
+				Kind:   projectassistant.ActionSetProjectDefaults,
+				Target: map[string]string{"project_id": "proj_hecate"},
+				Patch: bridgeRawPatch(map[string]any{
+					"default_root_id": "root_proposal",
+					"default_model":   "qwen3-coder",
+				}),
+				Reason: "Make the proposed root the default portable root.",
+			}, {
+				Kind:   projectassistant.ActionRemoveProjectRoot,
+				Target: map[string]string{"project_id": "proj_hecate", "root_id": "root_legacy"},
+				Reason: "Remove an obsolete root.",
+			}, {
+				Kind:   projectassistant.ActionCreateWorkItem,
+				Target: map[string]string{"project_id": "proj_hecate"},
+				Patch: bridgeRawPatch(map[string]any{
+					"id":            "work_from_proposal",
+					"project_id":    "proj_hecate",
+					"title":         "Follow up bridge export",
+					"brief":         "Verify assistant proposal ledger import.",
+					"status":        projectwork.WorkItemStatusReady,
+					"priority":      "normal",
+					"owner_role_id": "bridge_developer",
+					"root_id":       "root_main",
+				}),
+				Reason: "Capture a reviewable follow-up.",
+			}},
+			RequiresConfirmation: true,
+			TraceID:              "trace_bridge",
+		},
+		Status:       projectassistant.ApplyStatusApplied,
+		LatestResult: &result,
+		ApplyAttempts: []projectassistant.ApplyAttempt{{
+			ID:         "paatt_bridge",
+			ProposalID: "pa_bridge",
+			Status:     projectassistant.ApplyStatusApplied,
+			Confirmed:  true,
+			Result:     result,
+			CreatedAt:  appliedAt,
+		}},
+		CreatedAt: appliedAt.Add(-time.Minute),
+		UpdatedAt: appliedAt,
+		AppliedAt: &appliedAt,
+	}
+}
+
+func bridgeHecateOnlyProposalFixture(now time.Time) projectassistant.ProposalRecord {
+	return projectassistant.ProposalRecord{
+		ID:        "pa_hecate_defaults",
+		ProjectID: "proj_hecate",
+		Source:    projectassistant.ProposalSourceBootstrap,
+		SourceID:  "bootstrap",
+		Proposal: projectassistant.Proposal{
+			ID:      "pa_hecate_defaults",
+			Title:   "Set Hecate defaults",
+			Summary: "Hecate-only project default updates are not portable Cairnline actions.",
+			Actions: []projectassistant.Action{{
+				Kind:   projectassistant.ActionSetProjectDefaults,
+				Target: map[string]string{"project_id": "proj_hecate"},
+				Patch: bridgeRawPatch(map[string]any{
+					"default_model": "qwen3-coder",
+				}),
+			}},
+			RequiresConfirmation: true,
+		},
+		Status:    projectassistant.ProposalStatusProposed,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func bridgeRawPatch(value any) json.RawMessage {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return payload
 }
 
 func bridgeMemorySources() SnapshotSources {
@@ -530,6 +1826,7 @@ func bridgeMemorySources() SnapshotSources {
 		Work:             projectwork.NewMemoryStore(),
 		Memory:           memoryStore,
 		MemoryCandidates: memoryStore,
+		Proposals:        projectassistant.NewMemoryProposalStore(),
 	}
 }
 
@@ -581,6 +1878,19 @@ func seedHecateSources(t *testing.T, ctx context.Context, sources SnapshotSource
 			t.Fatalf("Create memory candidate %q: %v", candidate.ID, err)
 		}
 	}
+	for _, proposal := range snapshot.AssistantProposals {
+		record := proposal
+		attempts := append([]projectassistant.ApplyAttempt(nil), record.ApplyAttempts...)
+		record.ApplyAttempts = nil
+		if _, err := sources.Proposals.UpsertProposal(ctx, record); err != nil {
+			t.Fatalf("Upsert proposal %q: %v", proposal.ID, err)
+		}
+		for _, attempt := range attempts {
+			if _, err := sources.Proposals.RecordApplyAttempt(ctx, attempt); err != nil {
+				t.Fatalf("Record proposal attempt %q: %v", attempt.ID, err)
+			}
+		}
+	}
 }
 
 func hasAgentProfile(profiles []agentprofiles.Profile, id string) bool {
@@ -608,6 +1918,28 @@ func findCairnlineMemoryCandidate(candidates []cairnline.MemoryCandidate, id str
 		}
 	}
 	return nil
+}
+
+func findCairnlineExecutionProfile(profiles []cairnline.ExecutionProfile, id string) *cairnline.ExecutionProfile {
+	for idx := range profiles {
+		if profiles[idx].ID == id {
+			return &profiles[idx]
+		}
+	}
+	return nil
+}
+
+func findCairnlineProjectSkill(skills []cairnline.ProjectSkill, id string) *cairnline.ProjectSkill {
+	for idx := range skills {
+		if skills[idx].ID == id {
+			return &skills[idx]
+		}
+	}
+	return nil
+}
+
+func boolPtrForTest(value bool) *bool {
+	return &value
 }
 
 func hasCairnlineOperation(items []cairnline.ProjectOperationItem, kind, workItemID, refID string) bool {

--- a/internal/cairnlinebridge/collaboration_write.go
+++ b/internal/cairnlinebridge/collaboration_write.go
@@ -1,0 +1,89 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+// RecordArtifact creates a generic Cairnline artifact when it is missing. The
+// Hecate and Cairnline public contracts are both create/list for artifacts, so
+// this helper intentionally returns the existing row instead of pretending
+// artifact metadata can be updated.
+func RecordArtifact(ctx context.Context, service *cairnline.Service, artifact projectwork.CollaborationArtifact) (cairnline.Artifact, error) {
+	if service == nil {
+		return cairnline.Artifact{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item, ok := Artifact(artifact)
+	if !ok {
+		return cairnline.Artifact{}, errors.Join(cairnline.ErrInvalid, errors.New("artifact kind is not a generic artifact"))
+	}
+	if _, err := service.GetArtifact(ctx, item.ProjectID, item.WorkItemID, item.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Artifact{}, err
+		}
+		return service.CreateArtifact(ctx, item)
+	}
+	return service.GetArtifact(ctx, item.ProjectID, item.WorkItemID, item.ID)
+}
+
+func RecordEvidence(ctx context.Context, service *cairnline.Service, artifact projectwork.CollaborationArtifact) (cairnline.Evidence, error) {
+	if service == nil {
+		return cairnline.Evidence{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item, ok := Evidence(artifact)
+	if !ok {
+		return cairnline.Evidence{}, errors.Join(cairnline.ErrInvalid, errors.New("artifact kind is not evidence"))
+	}
+	if _, err := service.GetEvidence(ctx, item.ProjectID, item.WorkItemID, item.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Evidence{}, err
+		}
+		return service.CreateEvidence(ctx, item)
+	}
+	return service.GetEvidence(ctx, item.ProjectID, item.WorkItemID, item.ID)
+}
+
+func RecordReview(ctx context.Context, service *cairnline.Service, artifact projectwork.CollaborationArtifact) (cairnline.Review, error) {
+	if service == nil {
+		return cairnline.Review{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item, ok := Review(artifact)
+	if !ok {
+		return cairnline.Review{}, errors.Join(cairnline.ErrInvalid, errors.New("artifact kind is not review"))
+	}
+	if _, err := service.GetReview(ctx, item.ProjectID, item.WorkItemID, item.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Review{}, err
+		}
+		return service.CreateReview(ctx, item)
+	}
+	return service.GetReview(ctx, item.ProjectID, item.WorkItemID, item.ID)
+}
+
+func UpsertHandoff(ctx context.Context, service *cairnline.Service, handoff projectwork.Handoff) (cairnline.Handoff, error) {
+	if service == nil {
+		return cairnline.Handoff{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := Handoff(handoff)
+	if strings.TrimSpace(item.ID) == "" {
+		return cairnline.Handoff{}, errors.Join(cairnline.ErrInvalid, errors.New("handoff id is required"))
+	}
+	if _, err := service.GetHandoff(ctx, item.ProjectID, item.WorkItemID, item.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Handoff{}, err
+		}
+		return service.CreateHandoff(ctx, item)
+	}
+	return service.UpdateHandoff(ctx, item)
+}
+
+func DeleteHandoff(ctx context.Context, service *cairnline.Service, projectID, workItemID, id string) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	return service.DeleteHandoff(ctx, projectID, workItemID, id)
+}

--- a/internal/cairnlinebridge/memory_write.go
+++ b/internal/cairnlinebridge/memory_write.go
@@ -1,0 +1,71 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/memory"
+)
+
+func UpsertMemoryEntry(ctx context.Context, service *cairnline.Service, entry memory.Entry) (cairnline.MemoryEntry, error) {
+	if service == nil {
+		return cairnline.MemoryEntry{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := MemoryEntry(entry)
+	if _, err := service.GetMemoryEntry(ctx, item.ProjectID, item.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.MemoryEntry{}, err
+		}
+		created, err := service.CreateMemoryEntry(ctx, item)
+		if err != nil {
+			return cairnline.MemoryEntry{}, err
+		}
+		if created.Enabled == item.Enabled {
+			return created, nil
+		}
+		return service.UpdateMemoryEntry(ctx, item)
+	}
+	return service.UpdateMemoryEntry(ctx, item)
+}
+
+func DeleteMemoryEntry(ctx context.Context, service *cairnline.Service, projectID, id string) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	return service.DeleteMemoryEntry(ctx, projectID, id)
+}
+
+func UpsertMemoryCandidate(ctx context.Context, service *cairnline.Service, candidate memory.Candidate) (cairnline.MemoryCandidate, error) {
+	if service == nil {
+		return cairnline.MemoryCandidate{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := MemoryCandidate(candidate)
+	if _, err := service.GetMemoryCandidate(ctx, item.ProjectID, item.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.MemoryCandidate{}, err
+		}
+		created, err := service.CreateMemoryCandidate(ctx, item)
+		if err != nil {
+			return cairnline.MemoryCandidate{}, err
+		}
+		if memoryCandidateStateMatches(created, item) {
+			return created, nil
+		}
+		return service.UpdateMemoryCandidate(ctx, item)
+	}
+	return service.UpdateMemoryCandidate(ctx, item)
+}
+
+func DeleteMemoryCandidate(ctx context.Context, service *cairnline.Service, projectID, id string) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	return service.DeleteMemoryCandidate(ctx, projectID, id)
+}
+
+func memoryCandidateStateMatches(left, right cairnline.MemoryCandidate) bool {
+	return left.Status == right.Status &&
+		left.StatusReason == right.StatusReason &&
+		left.PromotedMemoryID == right.PromotedMemoryID
+}

--- a/internal/cairnlinebridge/profile_write.go
+++ b/internal/cairnlinebridge/profile_write.go
@@ -1,0 +1,48 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+)
+
+// UpsertAgentProfile mirrors a Hecate agent profile plus its execution-profile
+// posture into Cairnline. It is metadata/config only; it does not grant tools or
+// launch any runtime.
+func UpsertAgentProfile(ctx context.Context, service *cairnline.Service, profile agentprofiles.Profile) (cairnline.AgentProfile, error) {
+	if service == nil {
+		return cairnline.AgentProfile{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := AgentProfile(profile)
+	if strings.TrimSpace(item.ID) == "" {
+		return cairnline.AgentProfile{}, errors.Join(cairnline.ErrInvalid, errors.New("agent profile id is required"))
+	}
+	if err := upsertExecutionProfile(ctx, service, ExecutionProfile(profile)); err != nil {
+		return cairnline.AgentProfile{}, err
+	}
+	written, err := service.UpdateAgentProfile(ctx, item)
+	if err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.AgentProfile{}, err
+		}
+		return service.CreateAgentProfile(ctx, item)
+	}
+	return written, nil
+}
+
+// DeleteAgentProfile removes only the portable profile metadata. Execution
+// profiles are intentionally left in place because Hecate profiles may share
+// the same execution_profile hint.
+func DeleteAgentProfile(ctx context.Context, service *cairnline.Service, id string) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.Join(cairnline.ErrInvalid, errors.New("agent profile id is required"))
+	}
+	return service.DeleteAgentProfile(ctx, id)
+}

--- a/internal/cairnlinebridge/project_write.go
+++ b/internal/cairnlinebridge/project_write.go
@@ -1,0 +1,92 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+// UpsertProject is the first non-authoritative Cairnline write-adapter seam for
+// Hecate project identity plus embedded root/context-source state. Live Hecate
+// routes still write Hecate stores; this function proves the portable service
+// can accept the same mutation shape before authority moves.
+func UpsertProject(ctx context.Context, service *cairnline.Service, project projects.Project) (cairnline.Project, error) {
+	if service == nil {
+		return cairnline.Project{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := Project(project)
+	if strings.TrimSpace(item.ID) == "" {
+		return cairnline.Project{}, errors.Join(cairnline.ErrInvalid, errors.New("project id is required"))
+	}
+	if executionProfile, ok := ProjectExecutionProfile(project); ok {
+		if err := upsertExecutionProfile(ctx, service, executionProfile); err != nil {
+			return cairnline.Project{}, err
+		}
+	}
+	staleExecutionProfileID := ""
+	if item.DefaultExecutionProfileID == "" {
+		staleExecutionProfileID = projectExecutionProfileIDValue(project)
+	}
+	var written cairnline.Project
+	if _, err := service.GetProject(ctx, item.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Project{}, err
+		}
+		created, err := service.CreateProject(ctx, item)
+		if err != nil {
+			return cairnline.Project{}, err
+		}
+		written = created
+	} else {
+		updated, err := service.UpdateProject(ctx, item)
+		if err != nil {
+			return cairnline.Project{}, err
+		}
+		written = updated
+	}
+	if staleExecutionProfileID != "" {
+		if err := service.DeleteExecutionProfile(ctx, staleExecutionProfileID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Project{}, err
+		}
+	}
+	return written, nil
+}
+
+// DeleteProject removes the portable project record and the deterministic
+// project-level execution profile generated from Hecate project defaults. Other
+// project-scoped execution profiles, such as role defaults, are intentionally
+// left for the later role/work write-adapter slice that owns those records.
+func DeleteProject(ctx context.Context, service *cairnline.Service, project projects.Project) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	projectID := strings.TrimSpace(project.ID)
+	if projectID == "" {
+		return errors.Join(cairnline.ErrInvalid, errors.New("project id is required"))
+	}
+	if err := service.DeleteProject(ctx, projectID); err != nil {
+		return err
+	}
+	executionProfileID := projectExecutionProfileIDValue(project)
+	if executionProfileID == "" {
+		return nil
+	}
+	if err := service.DeleteExecutionProfile(ctx, executionProfileID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
+func upsertExecutionProfile(ctx context.Context, service *cairnline.Service, profile cairnline.ExecutionProfile) error {
+	if _, err := service.UpdateExecutionProfile(ctx, profile); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		_, err = service.CreateExecutionProfile(ctx, profile)
+		return err
+	}
+	return nil
+}

--- a/internal/cairnlinebridge/skill_write.go
+++ b/internal/cairnlinebridge/skill_write.go
@@ -1,0 +1,45 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/projectskills"
+)
+
+// UpsertProjectSkill mirrors Hecate project-skill metadata into Cairnline
+// without loading or executing SKILL.md bodies. It covers the current
+// Hecate/Cairnline mutation shape: discovery records plus operator edits.
+func UpsertProjectSkill(ctx context.Context, service *cairnline.Service, skill projectskills.Skill) (cairnline.ProjectSkill, error) {
+	if service == nil {
+		return cairnline.ProjectSkill{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := ProjectSkill(skill)
+	if _, err := service.GetProjectSkill(ctx, item.ProjectID, item.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.ProjectSkill{}, err
+		}
+		created, err := service.CreateProjectSkill(ctx, item)
+		if err != nil {
+			return cairnline.ProjectSkill{}, err
+		}
+		if created.Enabled == item.Enabled {
+			return created, nil
+		}
+		return service.UpdateProjectSkill(ctx, item)
+	}
+	return service.UpdateProjectSkill(ctx, item)
+}
+
+func UpsertProjectSkills(ctx context.Context, service *cairnline.Service, skills []projectskills.Skill) ([]cairnline.ProjectSkill, error) {
+	out := make([]cairnline.ProjectSkill, 0, len(skills))
+	for _, skill := range skills {
+		written, err := UpsertProjectSkill(ctx, service, skill)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, written)
+	}
+	return out, nil
+}

--- a/internal/cairnlinebridge/snapshot.go
+++ b/internal/cairnlinebridge/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -22,6 +23,77 @@ type SnapshotSources struct {
 	Work             projectwork.Store
 	Memory           memory.Store
 	MemoryCandidates memory.CandidateStore
+	Proposals        projectassistant.ProposalStore
+}
+
+func LoadSnapshots(ctx context.Context, sources SnapshotSources) ([]Snapshot, error) {
+	if sources.Projects == nil {
+		return nil, errors.Join(ErrSourceNotConfigured, errors.New("projects store is required"))
+	}
+	projects, err := sources.Projects.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	snapshots := make([]Snapshot, 0, len(projects))
+	for _, project := range projects {
+		snapshot, err := LoadSnapshot(ctx, sources, project.ID)
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	return snapshots, nil
+}
+
+func SeedSnapshots(ctx context.Context, service *cairnline.Service, snapshots []Snapshot) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	profilesByID := map[string]agentprofiles.Profile{}
+	executionProfileIDs := map[string]struct{}{}
+	for _, snapshot := range snapshots {
+		if executionProfile, ok := ProjectExecutionProfile(snapshot.Project); ok {
+			if err := createExecutionProfileOnce(ctx, service, executionProfileIDs, executionProfile); err != nil {
+				return err
+			}
+		}
+		for _, profile := range snapshot.AgentProfiles {
+			if _, seen := profilesByID[profile.ID]; seen {
+				continue
+			}
+			profilesByID[profile.ID] = profile
+		}
+	}
+	createdProfiles := map[string]struct{}{}
+	for _, snapshot := range snapshots {
+		for _, profile := range snapshot.AgentProfiles {
+			if _, seen := createdProfiles[profile.ID]; seen {
+				continue
+			}
+			createdProfiles[profile.ID] = struct{}{}
+			if _, err := service.CreateAgentProfile(ctx, AgentProfile(profile)); err != nil {
+				return err
+			}
+			if err := createExecutionProfileOnce(ctx, service, executionProfileIDs, ExecutionProfile(profile)); err != nil {
+				return err
+			}
+		}
+	}
+	for _, snapshot := range snapshots {
+		for _, role := range snapshot.Roles {
+			executionProfile, ok := RoleExecutionProfile(role)
+			if !ok {
+				continue
+			}
+			if err := createExecutionProfileOnce(ctx, service, executionProfileIDs, executionProfile); err != nil {
+				return err
+			}
+		}
+		if err := seedProjectScopedSnapshot(ctx, service, snapshot, profilesByID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func SeedProjectFromStores(ctx context.Context, service *cairnline.Service, sources SnapshotSources, projectID string) (Snapshot, error) {
@@ -32,7 +104,7 @@ func SeedProjectFromStores(ctx context.Context, service *cairnline.Service, sour
 	if err != nil {
 		return Snapshot{}, err
 	}
-	if err := Seed(ctx, service, snapshot); err != nil {
+	if err := SeedSnapshots(ctx, service, []Snapshot{snapshot}); err != nil {
 		return Snapshot{}, err
 	}
 	return snapshot, nil
@@ -132,16 +204,24 @@ func LoadSnapshot(ctx context.Context, sources SnapshotSources, projectID string
 			return Snapshot{}, err
 		}
 	}
+	var assistantProposals []projectassistant.ProposalRecord
+	if sources.Proposals != nil {
+		assistantProposals, err = sources.Proposals.ListProposals(ctx, projectID)
+		if err != nil {
+			return Snapshot{}, err
+		}
+	}
 	return Snapshot{
-		Project:          project,
-		AgentProfiles:    profiles,
-		Skills:           skills,
-		Roles:            roles,
-		WorkItems:        workItems,
-		Assignments:      assignments,
-		Artifacts:        artifacts,
-		Handoffs:         handoffs,
-		MemoryEntries:    memoryEntries,
-		MemoryCandidates: memoryCandidates,
+		Project:            project,
+		AgentProfiles:      profiles,
+		Skills:             skills,
+		Roles:              roles,
+		WorkItems:          workItems,
+		Assignments:        assignments,
+		Artifacts:          artifacts,
+		Handoffs:           handoffs,
+		MemoryEntries:      memoryEntries,
+		MemoryCandidates:   memoryCandidates,
+		AssistantProposals: assistantProposals,
 	}, nil
 }

--- a/internal/cairnlinebridge/work_write.go
+++ b/internal/cairnlinebridge/work_write.go
@@ -1,0 +1,133 @@
+package cairnlinebridge
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+// UpsertRole mirrors a Hecate project role into Cairnline without making the
+// Cairnline record authoritative for live Hecate routes.
+func UpsertRole(ctx context.Context, service *cairnline.Service, role projectwork.AgentRoleProfile) (cairnline.Role, error) {
+	if service == nil {
+		return cairnline.Role{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := Role(role)
+	if strings.TrimSpace(item.ID) == "" {
+		return cairnline.Role{}, errors.Join(cairnline.ErrInvalid, errors.New("role id is required"))
+	}
+	if executionProfile, ok := RoleExecutionProfile(role); ok {
+		if err := upsertExecutionProfile(ctx, service, executionProfile); err != nil {
+			return cairnline.Role{}, err
+		}
+	}
+	staleExecutionProfileID := ""
+	if item.DefaultExecutionProfileID == "" {
+		staleExecutionProfileID = roleExecutionProfileIDValue(role)
+	}
+	written, err := service.UpdateRole(ctx, item)
+	if err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Role{}, err
+		}
+		written, err = service.CreateRole(ctx, item)
+		if err != nil {
+			return cairnline.Role{}, err
+		}
+	}
+	if staleExecutionProfileID != "" {
+		if err := service.DeleteExecutionProfile(ctx, staleExecutionProfileID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Role{}, err
+		}
+	}
+	return written, nil
+}
+
+func DeleteRole(ctx context.Context, service *cairnline.Service, role projectwork.AgentRoleProfile) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	projectID := strings.TrimSpace(role.ProjectID)
+	roleID := strings.TrimSpace(role.ID)
+	if projectID == "" || roleID == "" {
+		return errors.Join(cairnline.ErrInvalid, errors.New("role project_id and id are required"))
+	}
+	if err := service.DeleteRole(ctx, projectID, roleID); err != nil {
+		return err
+	}
+	if executionProfileID := roleExecutionProfileIDValue(role); executionProfileID != "" {
+		if err := service.DeleteExecutionProfile(ctx, executionProfileID); err != nil && !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+	}
+	return nil
+}
+
+func UpsertWorkItem(ctx context.Context, service *cairnline.Service, item projectwork.WorkItem) (cairnline.WorkItem, error) {
+	if service == nil {
+		return cairnline.WorkItem{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	mapped := WorkItem(item)
+	if strings.TrimSpace(mapped.ID) == "" {
+		return cairnline.WorkItem{}, errors.Join(cairnline.ErrInvalid, errors.New("work item id is required"))
+	}
+	if _, err := service.GetWorkItem(ctx, mapped.ProjectID, mapped.ID); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.WorkItem{}, err
+		}
+		return service.CreateWorkItem(ctx, mapped)
+	}
+	return service.UpdateWorkItem(ctx, mapped)
+}
+
+func DeleteWorkItem(ctx context.Context, service *cairnline.Service, projectID, id string) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	return service.DeleteWorkItem(ctx, projectID, id)
+}
+
+// UpsertAssignment creates or updates a Cairnline assignment and then syncs the
+// Hecate assignment lifecycle state through the portable claim/status/complete
+// methods. Existing rows are first updated with their current Cairnline status
+// so metadata parity does not bypass lifecycle transition semantics.
+func UpsertAssignment(ctx context.Context, service *cairnline.Service, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, profile agentprofiles.Profile) (cairnline.Assignment, error) {
+	if service == nil {
+		return cairnline.Assignment{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := Assignment(assignment, role, profile)
+	if strings.TrimSpace(item.ID) == "" {
+		return cairnline.Assignment{}, errors.Join(cairnline.ErrInvalid, errors.New("assignment id is required"))
+	}
+	existing, err := service.GetAssignment(ctx, item.ProjectID, item.ID)
+	if err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.Assignment{}, err
+		}
+		if _, err := service.CreateAssignment(ctx, item); err != nil {
+			return cairnline.Assignment{}, err
+		}
+	} else {
+		metadata := item
+		metadata.Status = existing.Status
+		metadata.ClaimedBy = existing.ClaimedBy
+		if _, err := service.UpdateAssignment(ctx, metadata); err != nil {
+			return cairnline.Assignment{}, err
+		}
+	}
+	if err := syncAssignmentStatus(ctx, service, item); err != nil {
+		return cairnline.Assignment{}, err
+	}
+	return service.GetAssignment(ctx, item.ProjectID, item.ID)
+}
+
+func DeleteAssignment(ctx context.Context, service *cairnline.Service, projectID, id string) error {
+	if service == nil {
+		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	return service.DeleteAssignment(ctx, projectID, id)
+}

--- a/internal/projectassistant/context.go
+++ b/internal/projectassistant/context.go
@@ -24,6 +24,7 @@ const (
 )
 
 type DraftContext struct {
+	ReadBackend      string                   `json:"read_backend,omitempty"`
 	Project          ProjectContext           `json:"project"`
 	Request          string                   `json:"request"`
 	SelectedWork     *WorkItemContext         `json:"selected_work,omitempty"`

--- a/internal/projectassistant/proposal_store.go
+++ b/internal/projectassistant/proposal_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ const (
 type ProposalStore interface {
 	Backend() string
 	UpsertProposal(ctx context.Context, record ProposalRecord) (ProposalRecord, error)
+	ListProposals(ctx context.Context, projectID string) ([]ProposalRecord, error)
 	GetProposal(ctx context.Context, id string) (ProposalRecord, bool, error)
 	UpdateProposalApplyState(ctx context.Context, proposalID string, result ApplyResult) (ProposalRecord, error)
 	RecordApplyAttempt(ctx context.Context, attempt ApplyAttempt) (ProposalRecord, error)
@@ -108,6 +110,22 @@ func (s *MemoryProposalStore) GetProposal(_ context.Context, id string) (Proposa
 		return ProposalRecord{}, false, nil
 	}
 	return s.proposalWithAttemptsLocked(id), true, nil
+}
+
+func (s *MemoryProposalStore) ListProposals(_ context.Context, projectID string) ([]ProposalRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	projectID = strings.TrimSpace(projectID)
+	records := make([]ProposalRecord, 0, len(s.proposals))
+	for id, record := range s.proposals {
+		if projectID != "" && strings.TrimSpace(record.ProjectID) != projectID {
+			continue
+		}
+		records = append(records, s.proposalWithAttemptsLocked(id))
+	}
+	sortProposalRecords(records)
+	return records, nil
 }
 
 func (s *MemoryProposalStore) UpdateProposalApplyState(_ context.Context, proposalID string, result ApplyResult) (ProposalRecord, error) {
@@ -304,6 +322,15 @@ func cloneProposalRecord(record ProposalRecord) ProposalRecord {
 	record.ApplyAttempts = cloneApplyAttempts(record.ApplyAttempts)
 	record.AppliedAt = cloneTimePtr(record.AppliedAt)
 	return record
+}
+
+func sortProposalRecords(records []ProposalRecord) {
+	slices.SortFunc(records, func(a, b ProposalRecord) int {
+		if cmp := b.UpdatedAt.Compare(a.UpdatedAt); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
 }
 
 func cloneProposal(proposal Proposal) Proposal {

--- a/internal/projectassistant/proposal_store_sql.go
+++ b/internal/projectassistant/proposal_store_sql.go
@@ -124,6 +124,42 @@ func (s *SQLProposalStore) GetProposal(ctx context.Context, id string) (Proposal
 	return cloneProposalRecord(record), true, nil
 }
 
+func (s *SQLProposalStore) ListProposals(ctx context.Context, projectID string) ([]ProposalRecord, error) {
+	query := fmt.Sprintf(`
+SELECT id, project_id, source, source_id, proposal, fingerprint, status, latest_result,
+	created_at, updated_at, applied_at
+FROM %s`, s.proposals)
+	var args []any
+	projectID = strings.TrimSpace(projectID)
+	if projectID != "" {
+		query += ` WHERE project_id = ?`
+		args = append(args, projectID)
+	}
+	query += ` ORDER BY updated_at DESC, id ASC`
+	rows, err := s.client.DB().QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var records []ProposalRecord
+	for rows.Next() {
+		record, err := scanProposalRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		attempts, err := s.listAttempts(ctx, record.ID)
+		if err != nil {
+			return nil, err
+		}
+		record.ApplyAttempts = attempts
+		records = append(records, cloneProposalRecord(record))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
 func (s *SQLProposalStore) UpdateProposalApplyState(ctx context.Context, proposalID string, result ApplyResult) (ProposalRecord, error) {
 	proposalID = strings.TrimSpace(proposalID)
 	record, ok, err := s.getProposalOnly(ctx, proposalID)

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/hecatehq/hecate/internal/chat"
@@ -112,6 +113,64 @@ func TestService_ProposeStoresProposalRecordAcrossStores(t *testing.T) {
 			}
 			if record.Fingerprint == "" {
 				t.Fatalf("fingerprint is empty")
+			}
+		})
+	}
+}
+
+func TestProposalStore_ListProposalsFiltersOrdersAndHydratesAttempts(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			oldTime := time.Date(2024, 6, 27, 9, 0, 0, 0, time.UTC)
+			newTime := oldTime.Add(time.Hour)
+
+			oldRecord := proposalStoreTestRecord(t, "pa_old", "proj_alpha", oldTime)
+			newRecord := proposalStoreTestRecord(t, "pa_new", "proj_alpha", newTime)
+			otherRecord := proposalStoreTestRecord(t, "pa_other", "proj_beta", newTime.Add(time.Minute))
+			for _, record := range []ProposalRecord{oldRecord, newRecord, otherRecord} {
+				if _, err := fixture.proposals.UpsertProposal(ctx, record); err != nil {
+					t.Fatalf("UpsertProposal(%s): %v", record.ID, err)
+				}
+			}
+			attemptResult := ApplyResult{
+				ProposalID:           newRecord.ID,
+				Status:               ApplyStatusBlockedBeforeApply,
+				Applied:              false,
+				TotalActionCount:     1,
+				CommittedActionCount: 0,
+			}
+			if _, err := fixture.proposals.RecordApplyAttempt(ctx, ApplyAttempt{
+				ID:           "paatt_new",
+				ProposalID:   newRecord.ID,
+				Status:       ApplyStatusBlockedBeforeApply,
+				Confirmed:    false,
+				Result:       attemptResult,
+				ErrorMessage: "confirmation required",
+				CreatedAt:    newTime.Add(time.Minute),
+			}); err != nil {
+				t.Fatalf("RecordApplyAttempt: %v", err)
+			}
+
+			alpha, err := fixture.proposals.ListProposals(ctx, "proj_alpha")
+			if err != nil {
+				t.Fatalf("ListProposals(project): %v", err)
+			}
+			if len(alpha) != 2 || alpha[0].ID != "pa_new" || alpha[1].ID != "pa_old" {
+				t.Fatalf("project list ids = %+v, want pa_new then pa_old", proposalRecordIDs(alpha))
+			}
+			if alpha[0].LatestResult == nil || alpha[0].LatestResult.Status != ApplyStatusBlockedBeforeApply || len(alpha[0].ApplyAttempts) != 1 || alpha[0].ApplyAttempts[0].ID != "paatt_new" {
+				t.Fatalf("new record = %+v, want hydrated latest result and attempt", alpha[0])
+			}
+			all, err := fixture.proposals.ListProposals(ctx, "")
+			if err != nil {
+				t.Fatalf("ListProposals(all): %v", err)
+			}
+			if len(all) != 3 {
+				t.Fatalf("all list len = %d, want 3", len(all))
 			}
 		})
 	}
@@ -2386,6 +2445,40 @@ func rawPatchMap(t *testing.T, payload json.RawMessage) map[string]string {
 		t.Fatalf("decode patch: %v", err)
 	}
 	return decoded
+}
+
+func proposalStoreTestRecord(t *testing.T, id, projectID string, updatedAt time.Time) ProposalRecord {
+	t.Helper()
+	return ProposalRecord{
+		ID:        id,
+		ProjectID: projectID,
+		Source:    ProposalSourceAPI,
+		Status:    ProposalStatusProposed,
+		Proposal: Proposal{
+			ID:      id,
+			Title:   "Stored proposal " + id,
+			Summary: "Used by proposal store listing tests.",
+			Actions: []Action{{
+				Kind:   ActionCreateWorkItem,
+				Target: map[string]string{"project_id": projectID},
+				Patch: rawPatch(t, map[string]string{
+					"project_id": projectID,
+					"title":      "Work " + id,
+				}),
+			}},
+			RequiresConfirmation: true,
+		},
+		CreatedAt: updatedAt.Add(-time.Minute),
+		UpdatedAt: updatedAt,
+	}
+}
+
+func proposalRecordIDs(records []ProposalRecord) []string {
+	out := make([]string, 0, len(records))
+	for _, record := range records {
+		out = append(out, record.ID)
+	}
+	return out
 }
 
 func contextRoleExists(roles []RoleContext, id string) bool {

--- a/internal/projectwork/store.go
+++ b/internal/projectwork/store.go
@@ -51,6 +51,7 @@ const (
 	ReviewRiskHigh    = "high"
 	ReviewRiskUnknown = "unknown"
 
+	EvidenceSourceExternal        = "external"
 	EvidenceTrustOperatorProvided = "operator_provided"
 
 	HandoffStatusPending    = "pending"
@@ -922,7 +923,7 @@ func normalizeArtifact(item CollaborationArtifact, now time.Time) CollaborationA
 		item.EvidenceTrustLabel = ""
 	} else {
 		if item.EvidenceSourceKind == "" {
-			item.EvidenceSourceKind = "external"
+			item.EvidenceSourceKind = EvidenceSourceExternal
 		}
 		if item.EvidenceTrustLabel == "" {
 			item.EvidenceTrustLabel = EvidenceTrustOperatorProvided

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -208,13 +208,18 @@ describe("SettingsView maintenance cleanup", () => {
       object: "system_reset",
       data: {
         projects_deleted: 1,
+        project_skills_deleted: 1,
+        project_work_rows_deleted: 2,
+        project_assistant_proposals_deleted: 1,
         plugins_deleted: 1,
+        agent_profiles_deleted: 1,
         chat_sessions_deleted: 2,
         tasks_deleted: 1,
         providers_deleted: 1,
         policy_rules_deleted: 1,
         agent_approval_grants_deleted: 1,
         database_rows_deleted: 3,
+        cairnline_mirror_files_deleted: 1,
       },
     });
     const loadDashboard = vi.fn(async () => undefined);

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -145,23 +145,33 @@ export function SettingsView() {
 
 function resetSummary(data: {
   projects_deleted: number;
+  project_skills_deleted?: number;
+  project_work_rows_deleted?: number;
+  project_assistant_proposals_deleted?: number;
   plugins_deleted?: number;
+  agent_profiles_deleted?: number;
   chat_sessions_deleted: number;
   tasks_deleted: number;
   providers_deleted: number;
   policy_rules_deleted: number;
   agent_approval_grants_deleted: number;
   database_rows_deleted: number;
+  cairnline_mirror_files_deleted?: number;
 }): string {
   const total =
     data.projects_deleted +
+    (data.project_skills_deleted ?? 0) +
+    (data.project_work_rows_deleted ?? 0) +
+    (data.project_assistant_proposals_deleted ?? 0) +
     (data.plugins_deleted ?? 0) +
+    (data.agent_profiles_deleted ?? 0) +
     data.chat_sessions_deleted +
     data.tasks_deleted +
     data.providers_deleted +
     data.policy_rules_deleted +
     data.agent_approval_grants_deleted +
-    data.database_rows_deleted;
+    data.database_rows_deleted +
+    (data.cairnline_mirror_files_deleted ?? 0);
   if (total === 0) return "Local data was already clean.";
   return `Reset local data. Removed ${total} item${total === 1 ? "" : "s"}.`;
 }

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -633,6 +633,7 @@ export type ProjectAssignmentLaunchReadinessRecord = {
   project_id: string;
   work_item_id: string;
   assignment_id: string;
+  read_backend?: "hecate" | "cairnline" | (string & {});
   generated_at: string;
   ready: boolean;
   status: "blocked" | "ready" | (string & {});

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -110,6 +110,7 @@ export type SystemResetDataResponse = {
     projects_deleted: number;
     project_skills_deleted?: number;
     project_work_rows_deleted?: number;
+    project_assistant_proposals_deleted?: number;
     plugins_deleted?: number;
     agent_profiles_deleted?: number;
     chat_sessions_deleted: number;
@@ -118,5 +119,6 @@ export type SystemResetDataResponse = {
     policy_rules_deleted: number;
     agent_approval_grants_deleted: number;
     database_rows_deleted: number;
+    cairnline_mirror_files_deleted?: number;
   };
 };


### PR DESCRIPTION
## Summary
- expand the Cairnline read adapter across Projects list/detail, setup, health, skills, memory, work, assignments, artifacts, handoffs, activity, closeout, operations, and Project Assistant reads
- add non-authoritative live mirror seams for project identity, profiles, skills, roles, work items, assignments, collaboration, handoffs, memory, memory candidates, assistant proposal ledger/apply side effects, start results, and linked-chat reconciliation
- pin Hecate to Cairnline 3ad8b2b and add regression coverage for refreshed skill discovery provenance
- document the current bridge status, read routes, proof seams, and remaining authority/migration gaps

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -count=1 ./internal/api -run 'TestProjectSkillsAPI_(MirrorsMutationsToCairnlineWhenConfigured|MirrorRefreshesSkillSourceRefsOnRediscovery|ListUsesCairnlineReadModelWhenConfigured)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -count=1 ./internal/api ./internal/cairnlinebridge ./internal/projectassistant ./internal/projectwork
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -count=1 ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- cd ui && bun run typecheck
- cd ui && bun run test
- git diff --check

## Notes
- Hecate remains authoritative; Cairnline mirrors and read routes are replacement-readiness evidence only.
- Remaining replacement blockers are live write authority, migration/rollback, security review for roots/worktrees/source locators, and real dogfood on Cairnline-backed project coordination.