### PR TITLE
chore: update Cairnline security boundary

### DIFF
--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -75,8 +75,11 @@ Hecate should replace its internal Projects stores with Cairnline only after:
 - Hecate has an adapter from Hecate task / External Agent execution records to
   Cairnline assignment coordination records.
 - Hecate can migrate or import/export existing local project state.
-- Workspace root, worktree, evidence-link, and source-locator boundaries have
-  a dedicated security review in the Cairnline API.
+- Workspace root, worktree, evidence-link, and source-locator boundaries keep a
+  documented security boundary in the Cairnline API. The current Cairnline
+  package documents that boundary and tests unsafe guidance-path rejection for
+  skill discovery; future local-read or locator-opening behavior needs the same
+  level of review before becoming authoritative.
 - At least one real Hecate project has been dogfooded end to end through
   Cairnline-backed coordination.
 - Hecate's Projects UI can consume Cairnline state without losing current

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -382,7 +382,8 @@ role and work-item mutations likewise mirror coordination metadata after Hecate
 commits. Role mirroring seeds referenced agent-profile metadata and execution
 posture when available, and global agent-profile CRUD now best-effort mirrors
 portable profile metadata and execution posture after Hecate commits. Assignment
-create/update/delete, collaboration artifact creation, and handoff
+create/update/delete, committed assignment-start results, linked-chat
+reconciliation, collaboration artifact creation, and handoff
 create/update/delete mutations also best-effort mirror portable metadata after
 Hecate commits, but assignment start/dispatch remains Hecate-owned. Project
 memory entry and memory-candidate mutations also
@@ -394,15 +395,18 @@ Other live Projects reads/writes still use Hecate-native
 stores until the remaining read routes, write adapter, and migration path are
 ready. Current bridge write experiments cover non-authoritative
 project/root/source/defaults, agent profiles, skills, roles, work items,
-assignment metadata upsert/delete plus lifecycle-status sync, memory,
-memory-candidate, create-only collaboration artifact/evidence/review, and
-handoff shapes. Backend status reports those proof seams separately from the
-live-route `write_adapter_gaps`; only `project-identity-live-mirror`,
+assignment metadata upsert/delete, assignment-start result and linked-chat
+reconciliation sync, memory, memory-candidate, create-only collaboration
+artifact/evidence/review, and handoff shapes. Backend status reports those
+proof seams separately from the live-route `write_adapter_gaps`; only
+`project-identity-live-mirror`,
 `agent-profiles-live-mirror`, `project-skills-live-mirror`,
 `project-roles-live-mirror`, `project-work-items-live-mirror`,
-`project-assignments-live-mirror`, `project-collaboration-live-mirror`,
-`project-handoffs-live-mirror`, `project-memory-live-mirror`, and
-`project-memory-candidates-live-mirror`, plus
+`project-assignments-live-mirror`,
+`project-assignment-start-result-live-mirror`,
+`project-assignment-chat-reconcile-live-mirror`,
+`project-collaboration-live-mirror`, `project-handoffs-live-mirror`,
+`project-memory-live-mirror`, and `project-memory-candidates-live-mirror`, plus
 `project-assistant-proposal-ledger-live-mirror` and
 `project-assistant-apply-side-effects-live-mirror` are wired to live mutations,
 and all remain non-authoritative.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260627233806-3ad8b2b37fac
+	github.com/hecatehq/cairnline v0.0.0-20260628001401-f95ef934fb42
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.0.0-20260627233806-3ad8b2b37fac h1:5mfPIBfJ/Kg1LJ2hOjHokuEdQbPerk6VhyhTSMEc9Ng=
-github.com/hecatehq/cairnline v0.0.0-20260627233806-3ad8b2b37fac/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260628001401-f95ef934fb42 h1:xIyZF4jn0paqPH7/HqhQhWrrMDMwRhWgA2srF1uCbxg=
+github.com/hecatehq/cairnline v0.0.0-20260628001401-f95ef934fb42/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/just/docs.just
+++ b/just/docs.just
@@ -23,7 +23,7 @@ check-mermaid:
 docs-env-check:
 	test -f docs/contributor/release.md
 	test -f docs/operator/known-limitations.md
-	! rg -n 'HECATE_POLICY_RULES_JSON|HECATE_PRICEBOOK_JSON|HECATE_PROVIDERS|HECATE_[A-Z0-9_]+_BACKEND|PROVIDER_[A-Z0-9_]+_(PROTOCOL|API_VERSION|TIMEOUT)' README.md docs .env.example internal/config e2e .github
+	! (rg -n 'HECATE_POLICY_RULES_JSON|HECATE_PRICEBOOK_JSON|HECATE_PROVIDERS|HECATE_[A-Z0-9_]+_BACKEND|PROVIDER_[A-Z0-9_]+_(PROTOCOL|API_VERSION|TIMEOUT)' README.md docs .env.example internal/config e2e .github | rg -v 'HECATE_PROJECTS_COORDINATION_BACKEND')
 
 # Run lychee against tracked markdown and .mdc files to catch broken relative
 # links. Mirrors the hard-fail half of the CI Links workflow; external URL


### PR DESCRIPTION
## Summary
- update Hecate to the Cairnline commit that documents security boundaries and tests unsafe guidance-path rejection
- mark the current Cairnline security-boundary review as covered while keeping future local-read/locator behavior gated
- align deployment docs with assignment start-result and linked-chat reconciliation mirror seams
- keep docs-env-check green by allowing the current HECATE_PROJECTS_COORDINATION_BACKEND flag while still banning removed backend env surfaces

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge ./internal/api (sandboxed run hit httptest port restrictions for internal/api; full run below passed)
- go test ./...
- go vet ./...
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...