### PR TITLE
feat: expand Cairnline operations parity

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -149,10 +149,10 @@ operations brief and activity projection without writing files.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
 differences for raw graph counts including execution-profile defaults,
-activity, operations, and the Project Assistant proposal ledger, plus portable
-launch-packet coverage, so import coverage, bucket/status semantics, portable
-ledger coverage, and assignment packet coverage can be fixed before any backend
-switch.
+activity, rendered cockpit operations including action-kind counts, and the
+Project Assistant proposal ledger, plus portable launch-packet coverage, so
+import coverage, bucket/status semantics, operator-action drift, portable ledger
+coverage, and assignment packet coverage can be fixed before any backend switch.
 `POST /hecate/v1/projects/cairnline/sync` writes a refreshable embedded
 Cairnline SQLite database for the full Hecate Projects graph under Hecate's
 data directory. It is a deterministic migration rehearsal and durable service

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2508,8 +2508,20 @@ Example response:
         "recent": 1
       },
       "operations": {
+        "item_count": 3,
+        "available_item_count": 3,
+        "omitted_item_count": 0,
+        "item_limit": 8,
+        "high_count": 1,
+        "medium_count": 2,
+        "low_count": 0,
         "pending_memory_candidates": 1,
-        "open_handoffs": 1
+        "open_handoffs": 1,
+        "kind_counts": {
+          "review_memory_candidates": 1,
+          "review_pending_handoff": 1,
+          "start_queued_assignment": 1
+        }
       },
       "assistant": {
         "proposals": 1
@@ -2544,8 +2556,20 @@ Example response:
         "recent": 1
       },
       "operations": {
+        "item_count": 3,
+        "available_item_count": 3,
+        "omitted_item_count": 0,
+        "item_limit": 8,
+        "high_count": 1,
+        "medium_count": 2,
+        "low_count": 0,
         "pending_memory_candidates": 1,
-        "open_handoffs": 1
+        "open_handoffs": 1,
+        "kind_counts": {
+          "review_memory_candidates": 1,
+          "review_pending_handoff": 1,
+          "start_queued_assignment": 1
+        }
       },
       "assistant": {
         "proposals": 1

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -195,12 +195,17 @@ func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	cairnlineOperations, err := h.renderCairnlineProjectOperationsBrief(r.Context(), snapshot.Project)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	nativeAssistantProposals, err := h.nativeProjectAssistantProposalCount(r.Context(), projectID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	report := projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeActivity, nativeOperations, nativeAssistantProposals, readModel)
+	report := projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeActivity, nativeOperations, cairnlineOperations, nativeAssistantProposals, readModel)
 	WriteJSON(w, http.StatusOK, ProjectCairnlineParityReportResponse{
 		Object: "project_cairnline_parity_report",
 		Data:   report,
@@ -1149,7 +1154,7 @@ func (h *Handler) nativeProjectAssistantProposalCount(ctx context.Context, proje
 	return len(proposals), nil
 }
 
-func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnlineGraphParityCounts, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, nativeAssistantProposals int, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
+func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnlineGraphParityCounts, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, cairnlineOperations ProjectOperationsBriefResponse, nativeAssistantProposals int, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
 	hecate := ProjectCairnlineParitySnapshot{
 		Graph: nativeGraph,
 		Activity: ProjectCairnlineActivityParityCounts{
@@ -1160,10 +1165,7 @@ func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnline
 			Completed:   nativeActivity.Summary.CompletedCount,
 			Recent:      nativeActivity.Summary.RecentCount,
 		},
-		Operations: ProjectCairnlineOperationsParityCounts{
-			PendingMemoryCandidates: nativeOperations.Summary.PendingMemoryCandidateCount,
-			OpenHandoffs:            nativeOperations.Summary.PendingHandoffCount,
-		},
+		Operations: projectCairnlineOperationsParityCounts(nativeOperations),
 		Assistant: ProjectCairnlineAssistantParityCounts{
 			Proposals: nativeAssistantProposals,
 		},
@@ -1196,10 +1198,7 @@ func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnline
 			Completed:   readModel.Activity.Counts.Completed,
 			Recent:      len(readModel.Activity.Buckets.Recent),
 		},
-		Operations: ProjectCairnlineOperationsParityCounts{
-			PendingMemoryCandidates: readModel.Operations.Counts.PendingMemoryCandidates,
-			OpenHandoffs:            readModel.Operations.Counts.OpenHandoffs,
-		},
+		Operations: projectCairnlineOperationsParityCounts(cairnlineOperations),
 		Assistant: ProjectCairnlineAssistantParityCounts{
 			Proposals: readModel.AssistantProposalCount,
 		},
@@ -1217,6 +1216,29 @@ func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnline
 		Hecate:      hecate,
 		Cairnline:   cairnline,
 	}
+}
+
+func projectCairnlineOperationsParityCounts(operations ProjectOperationsBriefResponse) ProjectCairnlineOperationsParityCounts {
+	counts := ProjectCairnlineOperationsParityCounts{
+		ItemCount:               operations.Summary.ItemCount,
+		AvailableItemCount:      operations.Summary.AvailableItemCount,
+		OmittedItemCount:        operations.Summary.OmittedItemCount,
+		ItemLimit:               operations.Summary.ItemLimit,
+		HighCount:               operations.Summary.HighCount,
+		MediumCount:             operations.Summary.MediumCount,
+		LowCount:                operations.Summary.LowCount,
+		PendingMemoryCandidates: operations.Summary.PendingMemoryCandidateCount,
+		OpenHandoffs:            operations.Summary.PendingHandoffCount,
+		KindCounts:              map[string]int{},
+	}
+	for _, item := range operations.Items {
+		kind := strings.TrimSpace(item.Kind)
+		if kind == "" {
+			continue
+		}
+		counts.KindCounts[kind]++
+	}
+	return counts
 }
 
 func projectCairnlineParityDifferences(hecate, cairnline ProjectCairnlineParitySnapshot) []ProjectCairnlineParityDifference {
@@ -1239,12 +1261,39 @@ func projectCairnlineParityDifferences(hecate, cairnline ProjectCairnlineParityS
 	differences = appendProjectCairnlineParityDifference(differences, "activity.blocked", hecate.Activity.Blocked, cairnline.Activity.Blocked)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.completed", hecate.Activity.Completed, cairnline.Activity.Completed)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.recent", hecate.Activity.Recent, cairnline.Activity.Recent)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.item_count", hecate.Operations.ItemCount, cairnline.Operations.ItemCount)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.available_item_count", hecate.Operations.AvailableItemCount, cairnline.Operations.AvailableItemCount)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.omitted_item_count", hecate.Operations.OmittedItemCount, cairnline.Operations.OmittedItemCount)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.item_limit", hecate.Operations.ItemLimit, cairnline.Operations.ItemLimit)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.high_count", hecate.Operations.HighCount, cairnline.Operations.HighCount)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.medium_count", hecate.Operations.MediumCount, cairnline.Operations.MediumCount)
+	differences = appendProjectCairnlineParityDifference(differences, "operations.low_count", hecate.Operations.LowCount, cairnline.Operations.LowCount)
 	differences = appendProjectCairnlineParityDifference(differences, "operations.pending_memory_candidates", hecate.Operations.PendingMemoryCandidates, cairnline.Operations.PendingMemoryCandidates)
 	differences = appendProjectCairnlineParityDifference(differences, "operations.open_handoffs", hecate.Operations.OpenHandoffs, cairnline.Operations.OpenHandoffs)
+	differences = appendProjectCairnlineParityMapDifferences(differences, "operations.kind_counts", hecate.Operations.KindCounts, cairnline.Operations.KindCounts)
 	differences = appendProjectCairnlineParityDifference(differences, "assistant.proposals", hecate.Assistant.Proposals, cairnline.Assistant.Proposals)
 	differences = appendProjectCairnlineParityDifference(differences, "launch_packets.assignments", hecate.LaunchPackets.Assignments, cairnline.LaunchPackets.Assignments)
 	differences = appendProjectCairnlineParityDifference(differences, "launch_packets.warnings", hecate.LaunchPackets.Warnings, cairnline.LaunchPackets.Warnings)
 	differences = appendProjectCairnlineParityDifference(differences, "launch_packets.errors", hecate.LaunchPackets.Errors, cairnline.LaunchPackets.Errors)
+	return differences
+}
+
+func appendProjectCairnlineParityMapDifferences(differences []ProjectCairnlineParityDifference, prefix string, hecate, cairnline map[string]int) []ProjectCairnlineParityDifference {
+	keys := make(map[string]struct{}, len(hecate)+len(cairnline))
+	for key := range hecate {
+		keys[key] = struct{}{}
+	}
+	for key := range cairnline {
+		keys[key] = struct{}{}
+	}
+	ordered := make([]string, 0, len(keys))
+	for key := range keys {
+		ordered = append(ordered, key)
+	}
+	sort.Strings(ordered)
+	for _, key := range ordered {
+		differences = appendProjectCairnlineParityDifference(differences, prefix+"."+key, hecate[key], cairnline[key])
+	}
 	return differences
 }
 

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -223,6 +223,14 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if parity.Data.Hecate.Operations.PendingMemoryCandidates != 1 || parity.Data.Cairnline.Operations.PendingMemoryCandidates != 1 || parity.Data.Hecate.Operations.OpenHandoffs != 1 || parity.Data.Cairnline.Operations.OpenHandoffs != 1 {
 		t.Fatalf("parity operations counts = hecate %+v cairnline %+v, want matching memory and handoff counts", parity.Data.Hecate.Operations, parity.Data.Cairnline.Operations)
 	}
+	if parity.Data.Hecate.Operations.ItemCount == 0 || parity.Data.Hecate.Operations.ItemCount != parity.Data.Cairnline.Operations.ItemCount || parity.Data.Hecate.Operations.AvailableItemCount != parity.Data.Cairnline.Operations.AvailableItemCount || parity.Data.Hecate.Operations.ItemLimit != parity.Data.Cairnline.Operations.ItemLimit {
+		t.Fatalf("parity operations summary = hecate %+v cairnline %+v, want matching rendered operations brief counts", parity.Data.Hecate.Operations, parity.Data.Cairnline.Operations)
+	}
+	for _, kind := range []string{"start_queued_assignment", "review_memory_candidates", "review_pending_handoff"} {
+		if parity.Data.Hecate.Operations.KindCounts[kind] != 1 || parity.Data.Cairnline.Operations.KindCounts[kind] != 1 {
+			t.Fatalf("parity operations kind_counts[%s] = hecate %d cairnline %d, want 1/1", kind, parity.Data.Hecate.Operations.KindCounts[kind], parity.Data.Cairnline.Operations.KindCounts[kind])
+		}
+	}
 	if parity.Data.Hecate.Assistant.Proposals != 1 || parity.Data.Cairnline.Assistant.Proposals != 1 {
 		t.Fatalf("parity assistant counts = hecate %+v cairnline %+v, want matching assistant proposal ledger counts", parity.Data.Hecate.Assistant, parity.Data.Cairnline.Assistant)
 	}
@@ -505,7 +513,7 @@ func TestProjectCairnlineContentDigestIgnoresVolatileTimestamps(t *testing.T) {
 }
 
 func TestProjectCairnlineParityReport_IncludesAssistantProposalDifferences(t *testing.T) {
-	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, 2, ProjectCairnlineReadModelResponseItem{
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, ProjectOperationsBriefResponse{}, 2, ProjectCairnlineReadModelResponseItem{
 		AssistantProposalCount: 1,
 	})
 	if report.Match {
@@ -525,7 +533,7 @@ func TestProjectCairnlineParityReport_IncludesGraphCountDifferences(t *testing.T
 		ContextSources:    2,
 		ExecutionProfiles: 4,
 		Artifacts:         3,
-	}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
+	}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
 		RootCount:             1,
 		ContextSourceCount:    1,
 		ExecutionProfileCount: 3,
@@ -548,7 +556,7 @@ func TestProjectCairnlineParityReport_IncludesGraphCountDifferences(t *testing.T
 func TestProjectCairnlineParityReport_IncludesLaunchPacketCoverageDifferences(t *testing.T) {
 	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{
 		Summary: ProjectActivitySummaryResponse{AssignmentCount: 2},
-	}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
+	}, ProjectOperationsBriefResponse{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
 		LaunchPacketCount:        1,
 		LaunchPacketWarningCount: 2,
 		LaunchPacketErrors: []ProjectCairnlineLaunchPacketError{{
@@ -570,6 +578,51 @@ func TestProjectCairnlineParityReport_IncludesLaunchPacketCoverageDifferences(t 
 	}
 	if !hasProjectCairnlineParityDifference(report.Differences, "launch_packets.errors", 0, 1) {
 		t.Fatalf("parity differences = %+v, want launch_packets.errors 0/1", report.Differences)
+	}
+}
+
+func TestProjectCairnlineParityReport_IncludesOperationsDifferences(t *testing.T) {
+	nativeOperations := ProjectOperationsBriefResponse{
+		Summary: ProjectOperationsBriefSummaryResponse{
+			ItemCount:                   2,
+			AvailableItemCount:          2,
+			ItemLimit:                   projectOperationsBriefItemLimit,
+			HighCount:                   1,
+			MediumCount:                 1,
+			PendingMemoryCandidateCount: 1,
+		},
+		Items: []ProjectOperationsBriefItemResponse{
+			{Kind: "start_queued_assignment"},
+			{Kind: "review_memory_candidates"},
+		},
+	}
+	cairnlineOperations := ProjectOperationsBriefResponse{
+		Summary: ProjectOperationsBriefSummaryResponse{
+			ItemCount:                   1,
+			AvailableItemCount:          1,
+			ItemLimit:                   projectOperationsBriefItemLimit,
+			HighCount:                   1,
+			PendingMemoryCandidateCount: 0,
+		},
+		Items: []ProjectOperationsBriefItemResponse{
+			{Kind: "start_queued_assignment"},
+		},
+	}
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{}, nativeOperations, cairnlineOperations, 0, ProjectCairnlineReadModelResponseItem{})
+	if report.Match {
+		t.Fatalf("parity report match = true, want operations mismatch")
+	}
+	if report.Hecate.Operations.ItemCount != 2 || report.Cairnline.Operations.ItemCount != 1 || report.Hecate.Operations.KindCounts["review_memory_candidates"] != 1 || report.Cairnline.Operations.KindCounts["review_memory_candidates"] != 0 {
+		t.Fatalf("operations parity counts = hecate %+v cairnline %+v, want rendered brief counts and kind counts", report.Hecate.Operations, report.Cairnline.Operations)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "operations.item_count", 2, 1) {
+		t.Fatalf("parity differences = %+v, want operations.item_count 2/1", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "operations.pending_memory_candidates", 1, 0) {
+		t.Fatalf("parity differences = %+v, want operations.pending_memory_candidates 1/0", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "operations.kind_counts.review_memory_candidates", 1, 0) {
+		t.Fatalf("parity differences = %+v, want operations.kind_counts.review_memory_candidates 1/0", report.Differences)
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -459,8 +459,16 @@ type ProjectCairnlineActivityParityCounts struct {
 }
 
 type ProjectCairnlineOperationsParityCounts struct {
-	PendingMemoryCandidates int `json:"pending_memory_candidates"`
-	OpenHandoffs            int `json:"open_handoffs"`
+	ItemCount               int            `json:"item_count"`
+	AvailableItemCount      int            `json:"available_item_count"`
+	OmittedItemCount        int            `json:"omitted_item_count"`
+	ItemLimit               int            `json:"item_limit"`
+	HighCount               int            `json:"high_count"`
+	MediumCount             int            `json:"medium_count"`
+	LowCount                int            `json:"low_count"`
+	PendingMemoryCandidates int            `json:"pending_memory_candidates"`
+	OpenHandoffs            int            `json:"open_handoffs"`
+	KindCounts              map[string]int `json:"kind_counts"`
 }
 
 type ProjectCairnlineAssistantParityCounts struct {


### PR DESCRIPTION
## Summary
- compare rendered Hecate and Cairnline operations-brief summaries in the Cairnline parity report
- add operation action-kind counts to expose cockpit drift such as missing queued-assignment or handoff actions
- update parity-report docs and replacement-readiness notes

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- go vet ./internal/api
- just docs-check
- go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...