### PR TITLE
feat: compare Cairnline launch packet digests

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -158,10 +158,11 @@ Cairnline SQLite database for the full Hecate Projects graph under Hecate's
 data directory. It is a deterministic migration rehearsal and durable service
 boundary proof; the response compares Hecate snapshot counts with the written
 Cairnline database, including launch-packet coverage/warnings/errors, and also
-compares normalized record ID sets plus semantic record-content digests so
-same-count/different-record and same-ID/wrong-field drift are visible. It
-reports count-level, ID-set, and content-digest differences. It is not a
-dual-write path and does not make Cairnline authoritative.
+compares normalized record ID sets plus semantic record-content digests,
+including stable assignment launch-packet digests, so same-count/different-record
+and same-ID/wrong-field drift are visible. It reports count-level, ID-set, and
+content-digest differences. It is not a dual-write path and does not make
+Cairnline authoritative.
 When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is configured, live
 project identity, root create/update/delete/discovery/worktree-creation,
 context-source create/update/delete/discovery, and project-default mutations
@@ -274,8 +275,8 @@ after these gates are met:
   move.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha; the embedded Cairnline sync database proves a
-  durable all-project seed with count-level, ID-set, and content-digest parity
-  before it becomes a write path.
+  durable all-project seed with count-level, ID-set, record-content, and stable
+  launch-packet content parity before it becomes a write path.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2589,8 +2589,8 @@ Example response:
 Local-only experimental bridge endpoint. It loads every project from Hecate's
 authoritative Projects stores, writes a single refreshable embedded Cairnline
 SQLite database, then compares aggregate Hecate snapshot counts with aggregate
-counts, record ID sets, and semantic record-content digests read back from that
-database:
+counts, record ID sets, semantic record-content digests, and stable assignment
+launch-packet digests read back from that database:
 
 ```text
 {HECATE_DATA_DIR}/cairnline/embedded/projects.db
@@ -2607,12 +2607,14 @@ Projects reads or writes, and does not migrate Hecate's stores. It exists to
 prove Hecate can seed a durable all-project Cairnline database before the write
 adapter and migration path exist. `match: false` means the sync completed but
 the written database no longer mirrors the source graph and launch-packet
-coverage at the count, record-ID, or semantic-record-content level; see
+coverage/content at the count, record-ID, or semantic-record-content level; see
 `differences` for count mismatches, `id_differences` for same-family ID drift,
 and `content_differences` for same-path/same-ID records whose normalized
 Cairnline-shaped JSON digests differ. Content digests intentionally omit
 volatile write timestamps and do not expose raw project, memory, or artifact
-bodies in the response.
+bodies in the response. Launch-packet content digests compare packets that can
+be built on both sides; launch-packet coverage and build errors are reported by
+the count and ID-set checks.
 
 Example response:
 

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -61,7 +61,11 @@ func (h *Handler) HandleSyncProjectsToCairnline(w http.ResponseWriter, r *http.R
 		return
 	}
 	idDifferences := projectCairnlineSyncIDDifferences(hecateIDs, cairnlineIDs)
-	hecateContent := projectCairnlineSnapshotAllContentDigests(snapshots)
+	hecateContent, err := projectCairnlineSnapshotAllContentDigests(r.Context(), snapshots)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	cairnlineContent, err := projectCairnlineServiceAllContentDigests(r.Context(), service)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -691,8 +695,12 @@ func projectCairnlineServiceAllIDSets(ctx context.Context, service *cairnline.Se
 
 type projectCairnlineContentDigests map[string]map[string]string
 
-func projectCairnlineSnapshotAllContentDigests(snapshots []cairnlinebridge.Snapshot) projectCairnlineContentDigests {
+func projectCairnlineSnapshotAllContentDigests(ctx context.Context, snapshots []cairnlinebridge.Snapshot) (projectCairnlineContentDigests, error) {
 	digests := projectCairnlineContentDigests{}
+	service := cairnline.NewMemoryService()
+	if err := cairnlinebridge.SeedSnapshots(ctx, service, snapshots); err != nil {
+		return digests, err
+	}
 	executionProfileDigests := map[string]struct{}{}
 	addExecutionProfile := func(profile cairnline.ExecutionProfile) {
 		id := strings.TrimSpace(profile.ID)
@@ -751,6 +759,9 @@ func projectCairnlineSnapshotAllContentDigests(snapshots []cairnlinebridge.Snaps
 			profile := profileByID[role.DefaultAgentProfile]
 			item := cairnlinebridge.Assignment(assignment, role, profile)
 			digests.add("assignments", scopedCairnlineID(projectID, item.ID), item)
+			if packet, err := service.AssignmentLaunchPacket(ctx, projectID, item.ID); err == nil {
+				digests.add("launch_packets", scopedCairnlineID(projectID, item.ID), projectCairnlineStableLaunchPacket(packet))
+			}
 		}
 		for _, artifact := range snapshot.Artifacts {
 			if item, ok := cairnlinebridge.Artifact(artifact); ok {
@@ -785,7 +796,7 @@ func projectCairnlineSnapshotAllContentDigests(snapshots []cairnlinebridge.Snaps
 			digests.add("assistant_proposals", scopedCairnlineID(projectID, item.ID), item)
 		}
 	}
-	return digests
+	return digests, nil
 }
 
 func projectCairnlineServiceAllContentDigests(ctx context.Context, service *cairnline.Service) (projectCairnlineContentDigests, error) {
@@ -873,6 +884,9 @@ func projectCairnlineServiceAllContentDigests(ctx context.Context, service *cair
 		}
 		for _, assignment := range assignments {
 			digests.add("assignments", scopedCairnlineID(projectID, assignment.ID), assignment)
+			if packet, err := service.AssignmentLaunchPacket(ctx, projectID, assignment.ID); err == nil {
+				digests.add("launch_packets", scopedCairnlineID(projectID, assignment.ID), projectCairnlineStableLaunchPacket(packet))
+			}
 		}
 		memoryEntries, err := service.ListMemoryEntries(ctx, projectID, true)
 		if err != nil {
@@ -900,6 +914,13 @@ func projectCairnlineServiceAllContentDigests(ctx context.Context, service *cair
 		}
 	}
 	return digests, nil
+}
+
+func projectCairnlineStableLaunchPacket(packet cairnline.AssignmentLaunchPacket) cairnline.AssignmentLaunchPacket {
+	// Launch-packet coverage and build errors are reported by sync counts and
+	// ID sets; content digests only compare packets that build on both sides.
+	packet.ID = ""
+	return packet
 }
 
 func projectCairnlineSyncContentDifferences(hecate, cairnline projectCairnlineContentDigests) []ProjectCairnlineContentDifference {

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -410,6 +410,14 @@ func TestProjectCairnlineSyncAPI_WritesDurableAllProjectsSQLiteDB(t *testing.T) 
 	if packet.Project.ID != firstProject.Data.ID || packet.Assignment.ID != assignment.Data.ID || packet.Assignment.RootID != firstProject.Data.Roots[0].ID {
 		t.Fatalf("packet = %+v, want synced rooted assignment launch packet", packet)
 	}
+	contentDigests, err := projectCairnlineServiceAllContentDigests(t.Context(), service)
+	if err != nil {
+		t.Fatalf("projectCairnlineServiceAllContentDigests() error = %v", err)
+	}
+	launchPacketID := scopedCairnlineID(firstProject.Data.ID, assignment.Data.ID)
+	if contentDigests["launch_packets"][launchPacketID] == "" {
+		t.Fatalf("launch packet content digests = %+v, want digest for %s", contentDigests["launch_packets"], launchPacketID)
+	}
 }
 
 func TestProjectCairnlineSyncDifferences(t *testing.T) {
@@ -473,6 +481,9 @@ func TestProjectCairnlineSyncContentDifferences(t *testing.T) {
 			"proj_a": "digest-a",
 			"proj_b": "digest-b",
 		},
+		"launch_packets": map[string]string{
+			"proj_a/asgn_a": "launch-a",
+		},
 		"work_items": map[string]string{
 			"proj_a/work_a": "same",
 		},
@@ -481,15 +492,21 @@ func TestProjectCairnlineSyncContentDifferences(t *testing.T) {
 			"proj_a": "digest-c",
 			"proj_c": "digest-d",
 		},
+		"launch_packets": map[string]string{
+			"proj_a/asgn_a": "launch-b",
+		},
 		"work_items": map[string]string{
 			"proj_a/work_a": "same",
 		},
 	})
-	if len(differences) != 1 {
-		t.Fatalf("content differences = %+v, want only same-id project content mismatch", differences)
+	if len(differences) != 2 {
+		t.Fatalf("content differences = %+v, want same-id project and launch-packet content mismatches", differences)
 	}
 	if !hasProjectCairnlineContentDifference(differences, "projects", "proj_a", "digest-a", "digest-c") {
 		t.Fatalf("content differences = %+v, want projects/proj_a digest mismatch", differences)
+	}
+	if !hasProjectCairnlineContentDifference(differences, "launch_packets", "proj_a/asgn_a", "launch-a", "launch-b") {
+		t.Fatalf("content differences = %+v, want launch_packets/proj_a/asgn_a digest mismatch", differences)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add stable assignment launch-packet digests to the Cairnline sync content-digest rehearsal
- keep launch-packet build failures reported through existing coverage/count and ID-set checks instead of failing content digest comparison
- document launch-packet content parity in Projects and runtime API docs

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline(Sync|Content|Export)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- go vet ./internal/api
- go vet ./...
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...