### PR TITLE
feat: mirror project metadata through Cairnline

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -164,10 +164,10 @@ and same-ID/wrong-field drift are visible. It reports count-level, ID-set, and
 content-digest differences. It is not a dual-write path and does not make
 Cairnline authoritative.
 When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is configured, live
-project identity, root create/update/delete/discovery/worktree-creation,
+project identity, metadata, root create/update/delete/discovery/worktree-creation,
 context-source create/update/delete/discovery, and project-default mutations
-still commit to Hecate stores first, then best-effort mirror the portable
-identity shape into the embedded Cairnline database. This mirror is
+still commit to Hecate stores first, then best-effort mirror into the embedded
+Cairnline database through their identity/metadata/root/source/default seams. This mirror is
 replacement-readiness evidence only: Hecate remains authoritative and mirror
 failures are logged.
 Project skill discovery and metadata updates follow the same non-authoritative
@@ -220,7 +220,9 @@ progress, and completion methods. These seams prove the Cairnline service can
 accept Hecate's project/root/source, skill, role, work-item, assignment,
 collaboration, handoff, and memory mutation shapes, but live API routes still
 write Hecate stores first. Live mirror seams reported as
-`project-identity-live-mirror` cover project identity create/update/delete;
+`project-identity-live-mirror` cover project create/delete and full project
+root/source array replacement patches; `project-metadata-live-mirror` covers
+project name/description metadata updates without replacing roots or sources;
 `project-roots-live-mirror` covers direct root create/update/delete, root
 discovery, and worktree-root creation mutations through Cairnline's root-level
 API; `project-context-sources-live-mirror` covers direct context-source

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -371,11 +371,11 @@ records before applying Hecate runtime checks.
 Assignment preflight/start context packets may include inspect-only Cairnline
 launch-packet evidence for replacement review, but Hecate still owns dispatch,
 task/external agent supervision, approvals, and assignment mutation. Project
-identity, root create/update/delete/discovery/worktree-creation,
+identity, metadata, root create/update/delete/discovery/worktree-creation,
 context-source create/update/delete/discovery, and default mutations still
 write Hecate stores first and then best-effort mirror into the embedded
-Cairnline database through their identity/root/source/default seams; this is
-replacement-readiness evidence, not write authority.
+Cairnline database through their identity/metadata/root/source/default seams;
+this is replacement-readiness evidence, not write authority.
 Project skill discovery and
 metadata updates also best-effort mirror metadata-only skill records after the
 Hecate store commit; the mirror does not load or execute skill bodies. Project
@@ -400,7 +400,8 @@ assignment metadata upsert/delete, assignment-start result and linked-chat
 reconciliation sync, memory, memory-candidate, create-only collaboration
 artifact/evidence/review, and handoff shapes. Backend status reports those
 proof seams separately from the live-route `write_adapter_gaps`; only
-`project-identity-live-mirror`, `project-roots-live-mirror`,
+`project-identity-live-mirror`, `project-metadata-live-mirror`,
+`project-roots-live-mirror`,
 `project-context-sources-live-mirror`, `project-defaults-live-mirror`,
 `agent-profiles-live-mirror`, `project-skills-live-mirror`,
 `project-roles-live-mirror`, `project-work-items-live-mirror`,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2232,10 +2232,12 @@ agent profiles, skills, roles, work items, assignment metadata upsert/delete plu
 lifecycle-status sync, create-if-missing generic artifacts/evidence/reviews,
 handoffs, memory entries, memory candidates, Project Assistant proposal-ledger
 import, and all-project sync rehearsal. The
-`project-identity-live-mirror` seam means project create/update/delete still
-commit to Hecate stores first, then best-effort mirror the portable project
-identity shape into the embedded Cairnline database when Cairnline is
-configured.
+`project-identity-live-mirror` seam means project create/delete and full project
+root/source array replacement patches still commit to Hecate stores first, then
+best-effort mirror the portable project identity shape into the embedded
+Cairnline database when Cairnline is configured. `project-metadata-live-mirror`
+uses Cairnline's project-metadata seam for project name/description updates
+without replacing mirrored roots or sources.
 `project-roots-live-mirror` uses Cairnline's root-level API for direct root
 mutations, root discovery, and worktree-root creation after Hecate commits.
 `project-context-sources-live-mirror` uses Cairnline's source-level
@@ -2317,6 +2319,7 @@ Example response:
       "project-roots-live-mirror",
       "context-sources",
       "project-context-sources-live-mirror",
+      "project-metadata-live-mirror",
       "project-defaults",
       "project-defaults-live-mirror",
       "project-identity-live-mirror",
@@ -2369,7 +2372,8 @@ Example response:
     "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
     "warnings": [
       "Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
-      "Project identity still writes Hecate-native stores first, then best-effort mirrors portable project identity into the embedded Cairnline database.",
+      "Project create/delete and root/source array replacement still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database.",
+      "Project metadata updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata seam.",
       "Root create/update/delete, root discovery, and worktree-root creation mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API.",
       "Direct context-source create/update/delete and discovery mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's source-level API.",
       "Default-only project updates still write Hecate-native stores first, then best-effort mirror portable launch defaults through Cairnline's project-defaults seam.",

--- a/internal/api/handler_project_cairnline_mirror.go
+++ b/internal/api/handler_project_cairnline_mirror.go
@@ -30,6 +30,12 @@ func (h *Handler) mirrorProjectDefaultsToCairnline(ctx context.Context, operatio
 	}
 }
 
+func (h *Handler) mirrorProjectMetadataToCairnline(ctx context.Context, operation string, project projects.Project) {
+	if err := h.writeProjectMetadataToCairnline(ctx, project); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+	}
+}
+
 func (h *Handler) mirrorProjectDeleteToCairnline(ctx context.Context, operation string, project projects.Project) {
 	if err := h.deleteProjectIdentityFromCairnline(ctx, project); err != nil {
 		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
@@ -404,6 +410,13 @@ func (h *Handler) writeProjectIdentityToCairnline(ctx context.Context, project p
 func (h *Handler) writeProjectDefaultsToCairnline(ctx context.Context, project projects.Project) error {
 	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
 		_, err := cairnlinebridge.UpsertProjectDefaults(ctx, service, project)
+		return err
+	})
+}
+
+func (h *Handler) writeProjectMetadataToCairnline(ctx context.Context, project projects.Project) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		_, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project)
 		return err
 	})
 }

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -34,6 +34,7 @@ var projectCairnlineWriteAdapterSeamNames = []string{
 	"project-roots-live-mirror",
 	"context-sources",
 	"project-context-sources-live-mirror",
+	"project-metadata-live-mirror",
 	"project-defaults",
 	"project-defaults-live-mirror",
 	"project-identity-live-mirror",
@@ -120,7 +121,8 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
 			response.Warnings = []string{
 				"Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
-				"Project identity still writes Hecate-native stores first, then best-effort mirrors portable project identity into the embedded Cairnline database.",
+				"Project create/delete and root/source array replacement still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database.",
+				"Project metadata updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata seam.",
 				"Root create/update/delete, root discovery, and worktree-root creation mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API.",
 				"Direct context-source create/update/delete and discovery mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's source-level API.",
 				"Default-only project updates still write Hecate-native stores first, then best-effort mirror portable launch defaults through Cairnline's project-defaults seam.",

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -269,23 +269,25 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if projectUpdateTouchesOnlyPortableDefaults(req) {
-		h.mirrorProjectDefaultsToCairnline(r.Context(), "project_defaults_update", project)
-	} else {
+	if projectUpdateTouchesRootOrSourceState(req) {
 		h.mirrorProjectIdentityToCairnline(r.Context(), "project_update", project)
+	} else {
+		if projectUpdateTouchesPortableMetadata(req) {
+			h.mirrorProjectMetadataToCairnline(r.Context(), "project_metadata_update", project)
+		}
+		if projectUpdateTouchesPortableDefaults(req) {
+			h.mirrorProjectDefaultsToCairnline(r.Context(), "project_defaults_update", project)
+		}
 	}
 	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
 }
 
-func projectUpdateTouchesOnlyPortableDefaults(req updateProjectRequest) bool {
-	if !projectUpdateTouchesPortableDefaults(req) {
-		return false
-	}
-	return req.Name == nil &&
-		req.Description == nil &&
-		req.Roots == nil &&
-		req.ContextSources == nil &&
-		req.LastOpenedAt == nil
+func projectUpdateTouchesRootOrSourceState(req updateProjectRequest) bool {
+	return req.Roots != nil || req.ContextSources != nil
+}
+
+func projectUpdateTouchesPortableMetadata(req updateProjectRequest) bool {
+	return req.Name != nil || req.Description != nil
 }
 
 func projectUpdateTouchesPortableDefaults(req updateProjectRequest) bool {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -406,28 +406,7 @@ func TestProjectsAPI_DefaultOnlyPatchMirrorsDefaultsWithoutReplacingCairnlineSta
 		t.Fatalf("decode create response: %v", err)
 	}
 
-	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
-	if err != nil {
-		t.Fatalf("open Cairnline mirror: %v", err)
-	}
-	if _, _, err := service.CreateRoot(t.Context(), created.Data.ID, cairnline.Root{
-		ID:     "root_cairnline_only",
-		Path:   "/workspace/cairnline-only",
-		Kind:   "folder",
-		Active: true,
-	}); err != nil {
-		t.Fatalf("CreateRoot(cairnline-only): %v", err)
-	}
-	if _, _, err := service.CreateContextSource(t.Context(), created.Data.ID, cairnline.Source{
-		ID:      "ctx_cairnline_only",
-		Kind:    "operator_note",
-		Title:   "Cairnline-only source",
-		Locator: "cairnline://source",
-		Enabled: true,
-	}); err != nil {
-		t.Fatalf("CreateContextSource(cairnline-only): %v", err)
-	}
-	store.Close()
+	seedCairnlineOnlyProjectGraphForTest(t, handler, created.Data.ID)
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
@@ -441,6 +420,55 @@ func TestProjectsAPI_DefaultOnlyPatchMirrorsDefaultsWithoutReplacingCairnlineSta
 		t.Fatalf("defaults update status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.DefaultProfileID != "architecture" {
+		t.Fatalf("mirrored default profile = %q, want architecture", mirrored.DefaultProfileID)
+	}
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_cairnline_only") == nil {
+		t.Fatalf("mirrored roots = %+v, want Cairnline-only root preserved", mirrored.Roots)
+	}
+	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
+		t.Fatalf("mirrored context sources = %+v, want Cairnline-only source preserved", mirrored.ContextSources)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "anthropic", "claude-sonnet-4-5")
+}
+
+func TestProjectsAPI_MetadataPatchMirrorsMetadataWithoutReplacingCairnlineState(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineMirrorTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Metadata Mirror",
+		"description":"Before",
+		"roots":[{"id":"root_main","path":"/workspace/main","kind":"git"}],
+		"context_sources":[{"id":"ctx_agents","path":"AGENTS.md","kind":"workspace_instruction","title":"AGENTS.md"}],
+		"default_provider":"openai",
+		"default_model":"gpt-5"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	seedCairnlineOnlyProjectGraphForTest(t, handler, created.Data.ID)
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
+		"name":"Metadata Mirror Renamed",
+		"description":"After",
+		"default_provider":"anthropic",
+		"default_model":"claude-sonnet-4-5",
+		"default_agent_profile":"architecture"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("metadata update status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.Name != "Metadata Mirror Renamed" || mirrored.Description != "After" {
+		t.Fatalf("mirrored metadata = %+v, want renamed project with updated description", mirrored)
+	}
 	if mirrored.DefaultProfileID != "architecture" {
 		t.Fatalf("mirrored default profile = %q, want architecture", mirrored.DefaultProfileID)
 	}
@@ -668,6 +696,32 @@ func assertMirroredExecutionProfileForTest(t *testing.T, handler *Handler, profi
 		return
 	}
 	t.Fatalf("execution profile %q not found in %+v", profileID, profiles)
+}
+
+func seedCairnlineOnlyProjectGraphForTest(t *testing.T, handler *Handler, projectID string) {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	if _, _, err := service.CreateRoot(t.Context(), projectID, cairnline.Root{
+		ID:     "root_cairnline_only",
+		Path:   "/workspace/cairnline-only",
+		Kind:   "folder",
+		Active: true,
+	}); err != nil {
+		t.Fatalf("CreateRoot(cairnline-only): %v", err)
+	}
+	if _, _, err := service.CreateContextSource(t.Context(), projectID, cairnline.Source{
+		ID:      "ctx_cairnline_only",
+		Kind:    "operator_note",
+		Title:   "Cairnline-only source",
+		Locator: "cairnline://source",
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("CreateContextSource(cairnline-only): %v", err)
+	}
 }
 
 func TestProjectsAPI_Validation(t *testing.T) {

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -543,6 +543,71 @@ func TestUpsertProjectDefaultsPreservesRootAndSourceState(t *testing.T) {
 	}
 }
 
+func TestUpsertProjectMetadataPreservesRootAndSourceState(t *testing.T) {
+	ctx := context.Background()
+	service := cairnline.NewMemoryService()
+	now := time.Date(2026, 6, 27, 11, 30, 0, 0, time.UTC)
+
+	project := projects.Project{
+		ID:          "proj_metadata",
+		Name:        "Metadata Adapter",
+		Description: "Before",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   "/tmp/hecate-metadata",
+			Kind:   "git",
+			Active: true,
+		}},
+		DefaultRootID: "root_main",
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_agents",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Path:    "AGENTS.md",
+			Enabled: true,
+		}},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if _, err := UpsertProject(ctx, service, project); err != nil {
+		t.Fatalf("UpsertProject(create) error = %v", err)
+	}
+	if _, _, err := service.CreateRoot(ctx, project.ID, cairnline.Root{
+		ID:     "root_cairnline_only",
+		Path:   "/tmp/hecate-metadata-cairnline-only",
+		Kind:   "folder",
+		Active: true,
+	}); err != nil {
+		t.Fatalf("CreateRoot(cairnline-only) error = %v", err)
+	}
+	if _, _, err := service.CreateContextSource(ctx, project.ID, cairnline.Source{
+		ID:      "ctx_cairnline_only",
+		Kind:    "operator_note",
+		Title:   "Cairnline-only source",
+		Locator: "cairnline://source",
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("CreateContextSource(cairnline-only) error = %v", err)
+	}
+
+	project.Name = "Metadata Adapter Updated"
+	project.Description = "After"
+	project.UpdatedAt = now.Add(time.Minute)
+	updated, err := UpsertProjectMetadata(ctx, service, project)
+	if err != nil {
+		t.Fatalf("UpsertProjectMetadata(update) error = %v", err)
+	}
+	if updated.Name != "Metadata Adapter Updated" || updated.Description != "After" {
+		t.Fatalf("updated project = %+v, want updated metadata", updated)
+	}
+	if findCairnlineRoot(updated.Roots, "root_cairnline_only") == nil {
+		t.Fatalf("updated roots = %+v, want Cairnline-only root preserved", updated.Roots)
+	}
+	if findCairnlineSource(updated.ContextSources, "ctx_cairnline_only") == nil {
+		t.Fatalf("updated sources = %+v, want Cairnline-only source preserved", updated.ContextSources)
+	}
+}
+
 func TestUpsertContextSourceMirrorsSingleSourceMutations(t *testing.T) {
 	ctx := context.Background()
 	service := cairnline.NewMemoryService()

--- a/internal/cairnlinebridge/project_write.go
+++ b/internal/cairnlinebridge/project_write.go
@@ -100,6 +100,36 @@ func UpsertProjectDefaults(ctx context.Context, service *cairnline.Service, proj
 	return updated, nil
 }
 
+// UpsertProjectMetadata mirrors portable project identity metadata without
+// replacing Cairnline-owned root/context-source state. Missing projects fall
+// back to the full bootstrap write so out-of-order mirrors still converge.
+func UpsertProjectMetadata(ctx context.Context, service *cairnline.Service, project projects.Project) (cairnline.Project, error) {
+	if service == nil {
+		return cairnline.Project{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
+	}
+	item := Project(project)
+	if strings.TrimSpace(item.ID) == "" {
+		return cairnline.Project{}, errors.Join(cairnline.ErrInvalid, errors.New("project id is required"))
+	}
+	existing, err := service.GetProject(ctx, item.ID)
+	if err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return UpsertProject(ctx, service, project)
+		}
+		return cairnline.Project{}, err
+	}
+	existing.Name = item.Name
+	existing.Description = item.Description
+	updated, err := service.UpdateProject(ctx, existing)
+	if err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return UpsertProject(ctx, service, project)
+		}
+		return cairnline.Project{}, err
+	}
+	return updated, nil
+}
+
 // DeleteProject removes the portable project record and the deterministic
 // project-level execution profile generated from Hecate project defaults. Other
 // project-scoped execution profiles, such as role defaults, are intentionally


### PR DESCRIPTION
## Summary
- add a Cairnline project-metadata mirror seam for name/description updates
- route safe project PATCH shapes through metadata/default mirrors instead of broad project replacement
- preserve broad identity mirroring for create/delete and root/source array replacement patches
- add bridge and API regression tests proving Cairnline-only roots/sources survive metadata/default PATCHes
- update backend status and docs for the new project-metadata live mirror

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge -run 'TestUpsertProject(Metadata|Defaults)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectsAPI_(DefaultOnlyPatch|MetadataPatch|MirrorsToCairnline|ProjectCoordinationBackendStatus)|TestProjectCoordinationBackendStatus'
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...