### PR TITLE
feat: add Cairnline live mirror parity check

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -412,7 +412,11 @@ proof seams separately from the live-route `write_adapter_gaps`; only
 `project-memory-live-mirror`, and `project-memory-candidates-live-mirror`, plus
 `project-assistant-proposal-ledger-live-mirror` and
 `project-assistant-apply-side-effects-live-mirror` are wired to live mutations,
-and all remain non-authoritative.
+and all remain non-authoritative. `GET
+/hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
+mirror database with Hecate's current stores without creating or repairing it;
+`POST /hecate/v1/projects/cairnline/sync` remains the explicit all-project
+rebuild/rehearsal action.
 
 Deployment-specific notes:
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2276,7 +2276,10 @@ history after Hecate commits. `project-assistant-apply-side-effects-live-mirror`
 mirrors committed apply side effects after Hecate commits. Assignment-start
 dispatch and other non-mirrored live mutation routes still write only
 Hecate-native stores.
-`sync_readiness_url` points at the all-project embedded SQLite rehearsal sync.
+`mirror_parity_url` points at a read-only check that compares Hecate's current
+project stores with the existing embedded Cairnline mirror database without
+creating or repairing it. `sync_readiness_url` points at the all-project
+embedded SQLite rehearsal sync, which replaces that database from Hecate stores.
 
 Example response:
 
@@ -2388,7 +2391,8 @@ Example response:
       "Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready."
     ],
     "replacement_readiness_url": "/hecate/v1/projects/{id}/cairnline/read-model",
-    "sync_readiness_url": "/hecate/v1/projects/cairnline/sync"
+    "sync_readiness_url": "/hecate/v1/projects/cairnline/sync",
+    "mirror_parity_url": "/hecate/v1/projects/cairnline/mirror-parity"
   }
 }
 ```
@@ -2600,6 +2604,30 @@ Example response:
 }
 ```
 
+### `GET /hecate/v1/projects/cairnline/mirror-parity`
+
+Local-only experimental bridge endpoint. It loads every project from Hecate's
+authoritative Projects stores and compares that snapshot with the existing
+embedded Cairnline mirror database at:
+
+```text
+{HECATE_DATA_DIR}/cairnline/embedded/projects.db
+```
+
+Unlike `POST /hecate/v1/projects/cairnline/sync`, this endpoint is read-only:
+it does not create the database, repair drift, or make Cairnline authoritative.
+It exists to prove that live best-effort mirror writes have kept the embedded
+Cairnline graph aligned with Hecate. `database_exists=false` means no live
+mirror database is present; the endpoint still reports Hecate-side counts and
+ID differences without creating files. `match=false` means the existing mirror
+has count, record-ID, semantic-content, or launch-packet drift. Built-in agent
+profiles and built-in project roles are included in the comparison because
+Hecate's replacement read model exposes them as durable portable coordination
+metadata.
+
+The response shape matches the sync response, except `object` is
+`project_cairnline_mirror_parity` and `database_exists` may be `false`.
+
 ### `POST /hecate/v1/projects/cairnline/sync`
 
 Local-only experimental bridge endpoint. It loads every project from Hecate's
@@ -2639,6 +2667,7 @@ Example response:
   "object": "project_cairnline_sync",
   "data": {
     "database_path": "/Users/alice/.hecate/cairnline/embedded/projects.db",
+    "database_exists": true,
     "match": true,
     "hecate": {
       "projects": 2,

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -47,43 +47,50 @@ func (h *Handler) HandleSyncProjectsToCairnline(w http.ResponseWriter, r *http.R
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	hecateCounts := projectCairnlineSnapshotAllCounts(snapshots)
-	cairnlineCounts, err := projectCairnlineServiceAllCounts(r.Context(), service)
+	item, err := projectCairnlineServiceParity(r.Context(), dbPath, true, snapshots, service)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	differences := projectCairnlineSyncDifferences(hecateCounts, cairnlineCounts)
-	hecateIDs := projectCairnlineSnapshotAllIDSets(snapshots)
-	cairnlineIDs, err := projectCairnlineServiceAllIDSets(r.Context(), service)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	idDifferences := projectCairnlineSyncIDDifferences(hecateIDs, cairnlineIDs)
-	hecateContent, err := projectCairnlineSnapshotAllContentDigests(r.Context(), snapshots)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	cairnlineContent, err := projectCairnlineServiceAllContentDigests(r.Context(), service)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	contentDifferences := projectCairnlineSyncContentDifferences(hecateContent, cairnlineContent)
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSyncResponse{
 		Object: "project_cairnline_sync",
-		Data: ProjectCairnlineSyncResponseItem{
-			DatabasePath:       dbPath,
-			Match:              len(differences) == 0 && len(idDifferences) == 0 && len(contentDifferences) == 0,
-			Differences:        differences,
-			IDDifferences:      idDifferences,
-			ContentDifferences: contentDifferences,
-			Hecate:             hecateCounts,
-			Cairnline:          cairnlineCounts,
-			Authoritative:      false,
-		},
+		Data:   item,
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineMirrorParity(w http.ResponseWriter, r *http.Request) {
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	snapshots, err := cairnlinebridge.LoadSnapshots(r.Context(), h.cairnlineSnapshotSources())
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		if !os.IsNotExist(err) {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		item := projectCairnlineMissingMirrorParity(dbPath, snapshots)
+		WriteJSON(w, http.StatusOK, ProjectCairnlineSyncResponse{
+			Object: "project_cairnline_mirror_parity",
+			Data:   item,
+		})
+		return
+	}
+	service, store, err := cairnline.NewSQLiteService(r.Context(), dbPath)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	defer store.Close()
+	item, err := projectCairnlineServiceParity(r.Context(), dbPath, true, snapshots, service)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSyncResponse{
+		Object: "project_cairnline_mirror_parity",
+		Data:   item,
 	})
 }
 
@@ -270,6 +277,61 @@ func projectCairnlineReadModelFromSnapshot(ctx context.Context, snapshot cairnli
 		Operations:               operations,
 		Activity:                 activity,
 	}, nil
+}
+
+func projectCairnlineServiceParity(ctx context.Context, dbPath string, databaseExists bool, snapshots []cairnlinebridge.Snapshot, service *cairnline.Service) (ProjectCairnlineSyncResponseItem, error) {
+	hecateCounts := projectCairnlineSnapshotAllCounts(snapshots)
+	cairnlineCounts, err := projectCairnlineServiceAllCounts(ctx, service)
+	if err != nil {
+		return ProjectCairnlineSyncResponseItem{}, err
+	}
+	differences := projectCairnlineSyncDifferences(hecateCounts, cairnlineCounts)
+	hecateIDs := projectCairnlineSnapshotAllIDSets(snapshots)
+	cairnlineIDs, err := projectCairnlineServiceAllIDSets(ctx, service)
+	if err != nil {
+		return ProjectCairnlineSyncResponseItem{}, err
+	}
+	idDifferences := projectCairnlineSyncIDDifferences(hecateIDs, cairnlineIDs)
+	hecateContent, err := projectCairnlineSnapshotAllContentDigests(ctx, snapshots)
+	if err != nil {
+		return ProjectCairnlineSyncResponseItem{}, err
+	}
+	cairnlineContent, err := projectCairnlineServiceAllContentDigests(ctx, service)
+	if err != nil {
+		return ProjectCairnlineSyncResponseItem{}, err
+	}
+	contentDifferences := projectCairnlineSyncContentDifferences(hecateContent, cairnlineContent)
+	return ProjectCairnlineSyncResponseItem{
+		DatabasePath:       dbPath,
+		DatabaseExists:     databaseExists,
+		Match:              len(differences) == 0 && len(idDifferences) == 0 && len(contentDifferences) == 0,
+		Differences:        differences,
+		IDDifferences:      idDifferences,
+		ContentDifferences: contentDifferences,
+		Hecate:             hecateCounts,
+		Cairnline:          cairnlineCounts,
+		Authoritative:      false,
+	}, nil
+}
+
+func projectCairnlineMissingMirrorParity(dbPath string, snapshots []cairnlinebridge.Snapshot) ProjectCairnlineSyncResponseItem {
+	hecateCounts := projectCairnlineSnapshotAllCounts(snapshots)
+	cairnlineCounts := ProjectCairnlineSyncCounts{}
+	hecateIDs := projectCairnlineSnapshotAllIDSets(snapshots)
+	cairnlineIDs := ProjectCairnlineSyncIDSets{}
+	differences := projectCairnlineSyncDifferences(hecateCounts, cairnlineCounts)
+	idDifferences := projectCairnlineSyncIDDifferences(hecateIDs, cairnlineIDs)
+	return ProjectCairnlineSyncResponseItem{
+		DatabasePath:       dbPath,
+		DatabaseExists:     false,
+		Match:              false,
+		Differences:        differences,
+		IDDifferences:      idDifferences,
+		ContentDifferences: nil,
+		Hecate:             hecateCounts,
+		Cairnline:          cairnlineCounts,
+		Authoritative:      false,
+	}
 }
 
 func projectCairnlineSnapshotGraphCounts(snapshot cairnlinebridge.Snapshot) ProjectCairnlineGraphParityCounts {

--- a/internal/api/handler_project_cairnline_mirror.go
+++ b/internal/api/handler_project_cairnline_mirror.go
@@ -456,8 +456,10 @@ func projectAssistantActionResultValue(result projectassistant.ActionResult, key
 
 func (h *Handler) writeProjectIdentityToCairnline(ctx context.Context, project projects.Project) error {
 	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
-		_, err := cairnlinebridge.UpsertProject(ctx, service, project)
-		return err
+		if _, err := cairnlinebridge.UpsertProject(ctx, service, project); err != nil {
+			return err
+		}
+		return h.seedProjectRolesToCairnline(ctx, service, project.ID)
 	})
 }
 
@@ -558,6 +560,15 @@ func (h *Handler) writeRoleAgentProfileToCairnline(ctx context.Context, service 
 	}
 	if !ok {
 		return agentprofiles.Profile{}, nil
+	}
+	executionProfileID := strings.TrimSpace(cairnlinebridge.ExecutionProfile(profile).ID)
+	exists, err := cairnlineExecutionProfileIDExists(ctx, service, executionProfileID)
+	if err != nil {
+		return agentprofiles.Profile{}, err
+	}
+	if exists {
+		_, err = upsertCairnlineAgentProfileMetadata(ctx, service, profile)
+		return profile, err
 	}
 	_, err = cairnlinebridge.UpsertAgentProfile(ctx, service, profile)
 	return profile, err
@@ -841,7 +852,81 @@ func (h *Handler) withCairnlineEmbeddedMirrorService(ctx context.Context, fn fun
 		return err
 	}
 	defer store.Close()
+	if err := h.seedAgentProfilesToCairnline(ctx, service); err != nil {
+		return err
+	}
 	return fn(service)
+}
+
+func (h *Handler) seedAgentProfilesToCairnline(ctx context.Context, service *cairnline.Service) error {
+	if h == nil || h.agentProfiles == nil || service == nil {
+		return nil
+	}
+	profiles, err := h.agentProfiles.List(ctx)
+	if err != nil {
+		return err
+	}
+	seenExecutionProfiles := map[string]struct{}{}
+	for _, profile := range profiles {
+		executionProfileID := strings.TrimSpace(cairnlinebridge.ExecutionProfile(profile).ID)
+		if _, seen := seenExecutionProfiles[executionProfileID]; seen {
+			if _, err := upsertCairnlineAgentProfileMetadata(ctx, service, profile); err != nil {
+				return err
+			}
+			continue
+		}
+		seenExecutionProfiles[executionProfileID] = struct{}{}
+		if _, err := cairnlinebridge.UpsertAgentProfile(ctx, service, profile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertCairnlineAgentProfileMetadata(ctx context.Context, service *cairnline.Service, profile agentprofiles.Profile) (cairnline.AgentProfile, error) {
+	item := cairnlinebridge.AgentProfile(profile)
+	written, err := service.UpdateAgentProfile(ctx, item)
+	if err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return cairnline.AgentProfile{}, err
+		}
+		return service.CreateAgentProfile(ctx, item)
+	}
+	return written, nil
+}
+
+func cairnlineExecutionProfileIDExists(ctx context.Context, service *cairnline.Service, id string) (bool, error) {
+	id = strings.TrimSpace(id)
+	if service == nil || id == "" {
+		return false, nil
+	}
+	profiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.ID) == id {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (h *Handler) seedProjectRolesToCairnline(ctx context.Context, service *cairnline.Service, projectID string) error {
+	projectID = strings.TrimSpace(projectID)
+	if h == nil || h.projectWork == nil || service == nil || projectID == "" {
+		return nil
+	}
+	roles, err := h.projectWork.ListRoles(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, role := range roles {
+		if err := h.writeProjectRoleRecordToCairnline(ctx, service, role); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (h *Handler) logCairnlineMirrorError(ctx context.Context, operation, projectID string, err error) {

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -420,6 +420,70 @@ func TestProjectCairnlineSyncAPI_WritesDurableAllProjectsSQLiteDB(t *testing.T) 
 	}
 }
 
+func TestProjectCairnlineMirrorParityAPI_MissingDatabaseDoesNotCreateMirror(t *testing.T) {
+	dataDir := t.TempDir()
+	handler := NewHandler(config.Config{Server: config.ServerConfig{DataDir: dataDir}}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Mirror Parity Missing DB",
+	}))
+	response := mustRequestJSONStatus[ProjectCairnlineSyncResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/cairnline/mirror-parity", "")
+	if response.Object != "project_cairnline_mirror_parity" {
+		t.Fatalf("object = %q, want project_cairnline_mirror_parity", response.Object)
+	}
+	if response.Data.DatabaseExists || response.Data.Match {
+		t.Fatalf("mirror parity = %+v, want missing database and no match", response.Data)
+	}
+	if response.Data.Hecate.Projects != 1 || response.Data.Cairnline.Projects != 0 {
+		t.Fatalf("mirror parity counts = hecate %+v cairnline %+v, want one Hecate project and empty mirror", response.Data.Hecate, response.Data.Cairnline)
+	}
+	if !hasProjectCairnlineIDDifference(response.Data.IDDifferences, "projects", []string{project.Data.ID}, nil) {
+		t.Fatalf("id differences = %+v, want missing project id", response.Data.IDDifferences)
+	}
+	if _, err := os.Stat(handler.cairnlineEmbeddedDatabasePath()); !os.IsNotExist(err) {
+		t.Fatalf("mirror DB stat error = %v, want read-only parity check to avoid creating the DB", err)
+	}
+}
+
+func TestProjectCairnlineMirrorParityAPI_ReportsLiveMirrorMatch(t *testing.T) {
+	dataDir := t.TempDir()
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: dataDir},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Live Mirror Parity",
+	}))
+	response := mustRequestJSONStatus[ProjectCairnlineSyncResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/cairnline/mirror-parity", "")
+	if response.Object != "project_cairnline_mirror_parity" {
+		t.Fatalf("object = %q, want project_cairnline_mirror_parity", response.Object)
+	}
+	if !response.Data.DatabaseExists || !response.Data.Match || response.Data.Authoritative {
+		t.Fatalf("mirror parity = %+v, want existing non-authoritative mirror with exact parity", response.Data)
+	}
+	if len(response.Data.Differences) != 0 || len(response.Data.IDDifferences) != 0 || len(response.Data.ContentDifferences) != 0 {
+		t.Fatalf("mirror parity differences = %+v id %+v content %+v, want none", response.Data.Differences, response.Data.IDDifferences, response.Data.ContentDifferences)
+	}
+	if response.Data.Hecate.AgentProfiles == 0 || response.Data.Cairnline.AgentProfiles != response.Data.Hecate.AgentProfiles {
+		t.Fatalf("agent profile mirror counts = hecate %+v cairnline %+v, want built-in profiles seeded into the live mirror", response.Data.Hecate, response.Data.Cairnline)
+	}
+}
+
 func TestProjectCairnlineSyncDifferences(t *testing.T) {
 	differences := projectCairnlineSyncDifferences(ProjectCairnlineSyncCounts{
 		Projects:          2,

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -4,6 +4,7 @@ import "net/http"
 
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
+const projectCoordinationBackendMirrorParityURL = "/hecate/v1/projects/cairnline/mirror-parity"
 
 var projectCairnlineReadRouteNames = []string{
 	"project-list",
@@ -108,6 +109,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		WriteAdapterReady:       false,
 		ReplacementReadinessURL: projectCoordinationBackendReadinessURL,
 		SyncReadinessURL:        projectCoordinationBackendSyncReadinessURL,
+		MirrorParityURL:         projectCoordinationBackendMirrorParityURL,
 	}
 	switch configured {
 	case "cairnline":

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -88,6 +88,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if status.SyncReadinessURL != projectCoordinationBackendSyncReadinessURL {
 		t.Fatalf("sync readiness URL = %q, want %q", status.SyncReadinessURL, projectCoordinationBackendSyncReadinessURL)
 	}
+	if status.MirrorParityURL != projectCoordinationBackendMirrorParityURL {
+		t.Fatalf("mirror parity URL = %q, want %q", status.MirrorParityURL, projectCoordinationBackendMirrorParityURL)
+	}
 }
 
 func TestProjectCoordinationBackendStatusRoute(t *testing.T) {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -664,8 +664,15 @@ func TestProjectChildMirrorsPreserveCairnlineProjectGraph(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListRoles: %v", err)
 	}
-	if len(roles) != 1 || roles[0].ID != role.ID {
-		t.Fatalf("mirrored roles = %+v, want architect role", roles)
+	foundRole := false
+	for _, mirroredRole := range roles {
+		if mirroredRole.ID == role.ID {
+			foundRole = true
+			break
+		}
+	}
+	if !foundRole {
+		t.Fatalf("mirrored roles = %+v, want architect role preserved", roles)
 	}
 	if _, err := service.GetWorkItem(t.Context(), project.ID, workItem.ID); err != nil {
 		t.Fatalf("GetWorkItem: %v", err)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -321,6 +321,7 @@ type ProjectCairnlineSyncResponse struct {
 
 type ProjectCairnlineSyncResponseItem struct {
 	DatabasePath       string                              `json:"database_path"`
+	DatabaseExists     bool                                `json:"database_exists"`
 	Match              bool                                `json:"match"`
 	Differences        []ProjectCairnlineParityDifference  `json:"differences,omitempty"`
 	IDDifferences      []ProjectCairnlineIDDifference      `json:"id_differences,omitempty"`
@@ -508,6 +509,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	Warnings                []string `json:"warnings,omitempty"`
 	ReplacementReadinessURL string   `json:"replacement_readiness_url,omitempty"`
 	SyncReadinessURL        string   `json:"sync_readiness_url,omitempty"`
+	MirrorParityURL         string   `json:"mirror_parity_url,omitempty"`
 }
 
 type AgentProfileResponse struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -22,6 +22,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/system/reset-data"},
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/cairnline/mirror-parity"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -82,6 +82,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}", handler.HandleProject)
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
+	mux.HandleFunc("GET /hecate/v1/projects/cairnline/mirror-parity", handler.HandleProjectCairnlineMirrorParity)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)


### PR DESCRIPTION
## Summary

- add a local-only read-only Cairnline mirror parity endpoint for checking live embedded mirror drift without creating or repairing the database
- expose the mirror parity URL from project backend status and document the response shape
- seed built-in/current agent profiles and built-in project roles into live mirror writes so live parity matches the replacement-readiness snapshot graph
- keep role dependency mirroring from rewriting existing shared execution-profile posture

## Validation

- GOCACHE="$PWD/.gocache" go test ./internal/api
- GOCACHE="$PWD/.gocache" go vet ./internal/api
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...
- just agent-docs-check
- git diff --check