### PR TITLE
feat: add embedded Cairnline read-model probe

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -146,6 +146,12 @@ other live Projects reads/writes still use the Hecate-native API.
 `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
 Cairnline service from the current Hecate stores and returns the portable
 operations brief and activity projection without writing files.
+`GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` opens the
+existing embedded Cairnline mirror database and returns the same portable
+operations brief, activity projection, and launch-packet coverage without
+loading Hecate stores, creating the database, or repairing drift. It is the
+stricter read-side replacement-readiness probe because it verifies the live
+mirror can serve project projections directly.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
 differences for raw graph counts including execution-profile defaults,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -415,6 +415,9 @@ proof seams separately from the live-route `write_adapter_gaps`; only
 and all remain non-authoritative. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
+`GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,
+activity, and launch-packet projections directly from the existing embedded
+mirror database without seeding from Hecate stores; and
 `POST /hecate/v1/projects/cairnline/sync` remains the explicit all-project
 rebuild/rehearsal action.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2391,6 +2391,7 @@ Example response:
       "Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready."
     ],
     "replacement_readiness_url": "/hecate/v1/projects/{id}/cairnline/read-model",
+    "embedded_read_model_url": "/hecate/v1/projects/{id}/cairnline/embedded-read-model",
     "sync_readiness_url": "/hecate/v1/projects/cairnline/sync",
     "mirror_parity_url": "/hecate/v1/projects/cairnline/mirror-parity"
   }
@@ -2427,6 +2428,7 @@ Example response:
   "object": "project_cairnline_read_model",
   "data": {
     "project_id": "proj_...",
+    "read_source": "snapshot_seeded_memory",
     "root_count": 1,
     "context_source_count": 2,
     "agent_profile_count": 4,
@@ -2600,6 +2602,57 @@ Example response:
         "errors": 0
       }
     }
+  }
+}
+```
+
+### `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model`
+
+Local-only experimental bridge endpoint. It opens the existing embedded
+Cairnline mirror database at:
+
+```text
+{HECATE_DATA_DIR}/cairnline/embedded/projects.db
+```
+
+and returns the same portable read projections as
+`/hecate/v1/projects/{id}/cairnline/read-model`, but directly from that live
+mirror database. It does not load Hecate's authoritative stores, seed an
+in-memory service, create the database, repair drift, or make Cairnline
+authoritative. A missing mirror database or a project that is not present in
+the mirror returns `404`.
+
+This endpoint is stricter replacement-readiness evidence than the
+snapshot-seeded read-model endpoint: it proves the embedded Cairnline DB that
+live mirror writes maintain can serve operations, activity, and assignment
+launch-packet projections on its own.
+
+Example response:
+
+```json
+{
+  "object": "project_cairnline_embedded_read_model",
+  "data": {
+    "project_id": "proj_...",
+    "read_source": "embedded_cairnline",
+    "database_path": "/Users/alice/Library/Application Support/hecate/cairnline/embedded/projects.db",
+    "root_count": 1,
+    "context_source_count": 2,
+    "agent_profile_count": 4,
+    "execution_profile_count": 5,
+    "skill_count": 3,
+    "role_count": 6,
+    "work_item_count": 2,
+    "assignment_count": 5,
+    "artifact_count": 4,
+    "handoff_count": 1,
+    "memory_entry_count": 3,
+    "memory_candidate_count": 2,
+    "assistant_proposal_count": 1,
+    "launch_packet_count": 5,
+    "launch_packet_warning_count": 0,
+    "operations": {},
+    "activity": {}
   }
 }
 ```

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -180,6 +180,23 @@ func (h *Handler) HandleProjectCairnlineReadModel(w http.ResponseWriter, r *http
 	})
 }
 
+func (h *Handler) HandleProjectCairnlineEmbeddedReadModel(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("id"))
+	readModel, err := h.projectCairnlineEmbeddedReadModel(r.Context(), projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "embedded Cairnline read model not found")
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineReadModelResponse{
+		Object: "project_cairnline_embedded_read_model",
+		Data:   readModel,
+	})
+}
+
 func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("id"))
 	snapshot, err := cairnlinebridge.LoadSnapshot(r.Context(), h.cairnlineSnapshotSources(), projectID)
@@ -234,30 +251,59 @@ func (h *Handler) projectCairnlineReadModel(ctx context.Context, projectID strin
 	return projectCairnlineReadModelFromSnapshot(ctx, snapshot)
 }
 
+func (h *Handler) projectCairnlineEmbeddedReadModel(ctx context.Context, projectID string) (ProjectCairnlineReadModelResponseItem, error) {
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return ProjectCairnlineReadModelResponseItem{}, errors.Join(cairnline.ErrNotFound, errors.New("embedded Cairnline mirror database not found"))
+		}
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	service, store, err := cairnline.NewSQLiteService(ctx, dbPath)
+	if err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	defer store.Close()
+	return projectCairnlineReadModelFromService(ctx, service, projectID, "embedded_cairnline", dbPath)
+}
+
 func projectCairnlineReadModelFromSnapshot(ctx context.Context, snapshot cairnlinebridge.Snapshot) (ProjectCairnlineReadModelResponseItem, error) {
 	service := cairnline.NewMemoryService()
 	if err := cairnlinebridge.Seed(ctx, service, snapshot); err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
-	graph, err := projectCairnlineServiceGraphCounts(ctx, service, snapshot.Project.ID)
+	return projectCairnlineReadModelFromService(ctx, service, snapshot.Project.ID, "snapshot_seeded_memory", "")
+}
+
+func projectCairnlineReadModelFromService(ctx context.Context, service *cairnline.Service, projectID, readSource, dbPath string) (ProjectCairnlineReadModelResponseItem, error) {
+	project, err := service.GetProject(ctx, projectID)
 	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
-	assistantProposals, err := service.ListAssistantProposals(ctx, snapshot.Project.ID)
+	graph, err := projectCairnlineServiceGraphCounts(ctx, service, project.ID)
 	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
-	operations, err := service.ProjectOperationsBrief(ctx, snapshot.Project.ID)
+	assistantProposals, err := service.ListAssistantProposals(ctx, project.ID)
 	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
-	activity, err := service.ProjectActivity(ctx, snapshot.Project.ID)
+	operations, err := service.ProjectOperationsBrief(ctx, project.ID)
 	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
-	launchPackets := projectCairnlineLaunchPacketSummary(ctx, service, snapshot)
+	activity, err := service.ProjectActivity(ctx, project.ID)
+	if err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
+	launchPackets, err := projectCairnlineServiceLaunchPacketSummary(ctx, service, project.ID)
+	if err != nil {
+		return ProjectCairnlineReadModelResponseItem{}, err
+	}
 	return ProjectCairnlineReadModelResponseItem{
-		ProjectID:                snapshot.Project.ID,
+		ProjectID:                project.ID,
+		ReadSource:               readSource,
+		DatabasePath:             dbPath,
 		RootCount:                graph.Roots,
 		ContextSourceCount:       graph.ContextSources,
 		AgentProfileCount:        graph.AgentProfiles,
@@ -1200,19 +1246,17 @@ type projectCairnlineLaunchPacketSummaryData struct {
 	Errors       []ProjectCairnlineLaunchPacketError
 }
 
-func projectCairnlineLaunchPacketSummary(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) projectCairnlineLaunchPacketSummaryData {
+func projectCairnlineServiceLaunchPacketSummary(ctx context.Context, service *cairnline.Service, projectID string) (projectCairnlineLaunchPacketSummaryData, error) {
 	var summary projectCairnlineLaunchPacketSummaryData
 	if service == nil {
-		for _, assignment := range snapshot.Assignments {
-			summary.Errors = append(summary.Errors, ProjectCairnlineLaunchPacketError{
-				AssignmentID: assignment.ID,
-				Error:        "cairnline service is not configured",
-			})
-		}
-		return summary
+		return summary, errors.New("cairnline service is not configured")
 	}
-	for _, assignment := range snapshot.Assignments {
-		packet, err := service.AssignmentLaunchPacket(ctx, snapshot.Project.ID, assignment.ID)
+	assignments, err := service.ListAssignments(ctx, projectID)
+	if err != nil {
+		return summary, err
+	}
+	for _, assignment := range assignments {
+		packet, err := service.AssignmentLaunchPacket(ctx, projectID, assignment.ID)
 		if err != nil {
 			summary.Errors = append(summary.Errors, ProjectCairnlineLaunchPacketError{
 				AssignmentID: assignment.ID,
@@ -1223,7 +1267,7 @@ func projectCairnlineLaunchPacketSummary(ctx context.Context, service *cairnline
 		summary.Count++
 		summary.WarningCount += len(packet.Warnings)
 	}
-	return summary
+	return summary, nil
 }
 
 func (h *Handler) nativeProjectAssistantProposalCount(ctx context.Context, projectID string) (int, error) {

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -186,6 +186,9 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if readModel.Object != "project_cairnline_read_model" || readModel.Data.ProjectID != projectID {
 		t.Fatalf("read model envelope = %+v, want project_cairnline_read_model for project", readModel)
 	}
+	if readModel.Data.ReadSource != "snapshot_seeded_memory" || readModel.Data.DatabasePath != "" {
+		t.Fatalf("read model source = %q path %q, want snapshot-seeded memory without a database path", readModel.Data.ReadSource, readModel.Data.DatabasePath)
+	}
 	if readModel.Data.RootCount != 1 || readModel.Data.ContextSourceCount != 0 || readModel.Data.WorkItemCount != 1 || readModel.Data.AssignmentCount != 1 || readModel.Data.ArtifactCount != 2 || readModel.Data.HandoffCount != 1 || readModel.Data.MemoryEntryCount != 1 || readModel.Data.MemoryCandidateCount != 1 || readModel.Data.AssistantProposalCount != 1 || readModel.Data.LaunchPacketCount != 1 {
 		t.Fatalf("read model counts = %+v, want bridged project counts", readModel.Data)
 	}
@@ -452,6 +455,26 @@ func TestProjectCairnlineMirrorParityAPI_MissingDatabaseDoesNotCreateMirror(t *t
 	}
 }
 
+func TestProjectCairnlineEmbeddedReadModelAPI_MissingDatabaseDoesNotCreateMirror(t *testing.T) {
+	dataDir := t.TempDir()
+	handler := NewHandler(config.Config{Server: config.ServerConfig{DataDir: dataDir}}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Embedded Read Model Missing DB",
+	}))
+	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/cairnline/embedded-read-model", "")
+	if _, err := os.Stat(handler.cairnlineEmbeddedDatabasePath()); !os.IsNotExist(err) {
+		t.Fatalf("mirror DB stat error = %v, want embedded read-model probe to avoid creating the DB", err)
+	}
+}
+
 func TestProjectCairnlineMirrorParityAPI_ReportsLiveMirrorMatch(t *testing.T) {
 	dataDir := t.TempDir()
 	handler := NewHandler(config.Config{
@@ -641,6 +664,26 @@ func TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
 		response.Data.Hecate.ExecutionProfiles == 0 || response.Data.Cairnline.ExecutionProfiles != response.Data.Hecate.ExecutionProfiles ||
 		response.Data.Hecate.Roles == 0 || response.Data.Cairnline.Roles != response.Data.Hecate.Roles {
 		t.Fatalf("profile/role mirror counts = hecate %+v cairnline %+v, want built-in and custom coordination metadata parity", response.Data.Hecate, response.Data.Cairnline)
+	}
+
+	readModel := mustRequestJSONStatus[ProjectCairnlineReadModelResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/cairnline/embedded-read-model", "")
+	if readModel.Object != "project_cairnline_embedded_read_model" || readModel.Data.ProjectID != projectID {
+		t.Fatalf("embedded read model envelope = %+v, want direct embedded Cairnline read model for project", readModel)
+	}
+	if readModel.Data.ReadSource != "embedded_cairnline" || readModel.Data.DatabasePath != handler.cairnlineEmbeddedDatabasePath() || !filepath.IsAbs(readModel.Data.DatabasePath) {
+		t.Fatalf("embedded read model source = %q path %q, want embedded Cairnline database path", readModel.Data.ReadSource, readModel.Data.DatabasePath)
+	}
+	if readModel.Data.ContextSourceCount != 1 || readModel.Data.SkillCount != 1 || readModel.Data.WorkItemCount != 1 || readModel.Data.AssignmentCount != 1 || readModel.Data.ArtifactCount != 2 || readModel.Data.HandoffCount != 1 || readModel.Data.MemoryEntryCount != 1 || readModel.Data.MemoryCandidateCount != 1 || readModel.Data.LaunchPacketCount != 1 {
+		t.Fatalf("embedded read model counts = %+v, want representative live mirror graph", readModel.Data)
+	}
+	if readModel.Data.LaunchPacketWarningCount != 0 || len(readModel.Data.LaunchPacketErrors) != 0 {
+		t.Fatalf("embedded launch packet summary = warnings %d errors %+v, want clean portable packet coverage", readModel.Data.LaunchPacketWarningCount, readModel.Data.LaunchPacketErrors)
+	}
+	if readModel.Data.Operations.Status != cairnline.ProjectOperationsStatusAttention || readModel.Data.Operations.Counts.BlockedAssignments != 1 || readModel.Data.Operations.Counts.PendingMemoryCandidates != 1 || readModel.Data.Operations.Counts.OpenHandoffs != 1 {
+		t.Fatalf("embedded operations = %+v, want blocked assignment, pending memory, and open handoff from live mirror", readModel.Data.Operations)
+	}
+	if readModel.Data.Activity.Counts.Assignments != 1 || readModel.Data.Activity.Counts.Blocked != 1 || readModel.Data.Activity.Counts.Queued != 1 || len(readModel.Data.Activity.Buckets.Blocked) != 1 || readModel.Data.Activity.Buckets.Blocked[0].AssignmentID != assignment.Data.ID {
+		t.Fatalf("embedded activity = %+v, want blocked queued assignment from live mirror", readModel.Data.Activity)
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -3,6 +3,7 @@ package api
 import "net/http"
 
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
+const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
 const projectCoordinationBackendMirrorParityURL = "/hecate/v1/projects/cairnline/mirror-parity"
 
@@ -108,6 +109,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineAuthoritative:  false,
 		WriteAdapterReady:       false,
 		ReplacementReadinessURL: projectCoordinationBackendReadinessURL,
+		EmbeddedReadModelURL:    projectCoordinationBackendEmbeddedReadModelURL,
 		SyncReadinessURL:        projectCoordinationBackendSyncReadinessURL,
 		MirrorParityURL:         projectCoordinationBackendMirrorParityURL,
 	}

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -88,6 +88,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if status.SyncReadinessURL != projectCoordinationBackendSyncReadinessURL {
 		t.Fatalf("sync readiness URL = %q, want %q", status.SyncReadinessURL, projectCoordinationBackendSyncReadinessURL)
 	}
+	if status.EmbeddedReadModelURL != projectCoordinationBackendEmbeddedReadModelURL {
+		t.Fatalf("embedded read-model URL = %q, want %q", status.EmbeddedReadModelURL, projectCoordinationBackendEmbeddedReadModelURL)
+	}
 	if status.MirrorParityURL != projectCoordinationBackendMirrorParityURL {
 		t.Fatalf("mirror parity URL = %q, want %q", status.MirrorParityURL, projectCoordinationBackendMirrorParityURL)
 	}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -603,6 +603,7 @@ func TestRemoteRuntimeLocalEndpointGuardMiddleware(t *testing.T) {
 		{name: "blocks mcp probe", enabled: true, method: http.MethodPost, path: "/hecate/v1/mcp/probe", want: http.StatusForbidden},
 		{name: "blocks mcp registry discovery", enabled: true, method: http.MethodGet, path: "/hecate/v1/mcp/registry/servers", want: http.StatusForbidden},
 		{name: "blocks local provider discovery", enabled: true, method: http.MethodGet, path: "/hecate/v1/settings/providers/local-discovery", want: http.StatusForbidden},
+		{name: "blocks embedded cairnline read model", enabled: true, method: http.MethodGet, path: "/hecate/v1/projects/proj_123/cairnline/embedded-read-model", want: http.StatusForbidden},
 		{name: "blocks adapter authenticate", enabled: true, method: http.MethodPost, path: "/hecate/v1/agent-adapters/codex/authenticate", want: http.StatusForbidden},
 		{name: "blocks unclassified hecate endpoint", enabled: true, method: http.MethodPost, path: "/hecate/v1/future-local-only", want: http.StatusForbidden},
 		{name: "allows normal endpoint", enabled: true, method: http.MethodGet, path: "/hecate/v1/whoami", want: http.StatusNoContent},

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -389,6 +389,8 @@ type ProjectCairnlineReadModelResponse struct {
 
 type ProjectCairnlineReadModelResponseItem struct {
 	ProjectID                string                              `json:"project_id"`
+	ReadSource               string                              `json:"read_source,omitempty"`
+	DatabasePath             string                              `json:"database_path,omitempty"`
 	RootCount                int                                 `json:"root_count"`
 	ContextSourceCount       int                                 `json:"context_source_count"`
 	AgentProfileCount        int                                 `json:"agent_profile_count"`
@@ -508,6 +510,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	Detail                  string   `json:"detail"`
 	Warnings                []string `json:"warnings,omitempty"`
 	ReplacementReadinessURL string   `json:"replacement_readiness_url,omitempty"`
+	EmbeddedReadModelURL    string   `json:"embedded_read_model_url,omitempty"`
 	SyncReadinessURL        string   `json:"sync_readiness_url,omitempty"`
 	MirrorParityURL         string   `json:"mirror_parity_url,omitempty"`
 }

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -26,6 +26,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/embedded-read-model"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/cairnline/export"},
 	{method: http.MethodPost, path: "/hecate/v1/mcp/probe"},
 	{method: http.MethodGet, path: "/hecate/v1/mcp/registry/servers"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -86,6 +86,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/embedded-read-model", handler.HandleProjectCairnlineEmbeddedReadModel)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/cairnline/export", handler.HandleExportProjectToCairnline)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots", handler.HandleCreateProjectRoot)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots/discover", handler.HandleDiscoverProjectRoots)


### PR DESCRIPTION
## Summary
- add a local-only embedded Cairnline read-model probe that reads the existing mirror SQLite DB directly
- expose the probe URL in project coordination backend status and keep it blocked in remote runtime mode
- document the difference between snapshot-seeded read readiness and direct embedded mirror read readiness

## Verification
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline(EmbeddedReadModel|MirrorParity|Sync|Export)|TestProjectCoordinationBackendStatus|TestRemoteRuntime'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...

Note: the first sandboxed race run was blocked by localhost listener permissions in an existing httptest server; the same command passed with normal local permissions.