### PR TITLE
feat: add embedded Cairnline parity report

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -159,6 +159,11 @@ activity, rendered cockpit operations including action-kind counts, and the
 Project Assistant proposal ledger, plus portable launch-packet coverage, so
 import coverage, bucket/status semantics, operator-action drift, portable ledger
 coverage, and assignment packet coverage can be fixed before any backend switch.
+`GET /hecate/v1/projects/{id}/cairnline/embedded-parity-report` performs the
+same cockpit comparison against the existing embedded Cairnline mirror database
+instead of the snapshot-seeded in-memory service. It is the stricter live-read
+replacement probe: a match means the current mirror DB can serve the same
+operator-facing project projection counts for that project.
 `POST /hecate/v1/projects/cairnline/sync` writes a refreshable embedded
 Cairnline SQLite database for the full Hecate Projects graph under Hecate's
 data directory. It is a deterministic migration rehearsal and durable service

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -417,7 +417,9 @@ and all remain non-authoritative. `GET
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,
 activity, and launch-packet projections directly from the existing embedded
-mirror database without seeding from Hecate stores; and
+mirror database without seeding from Hecate stores; `GET
+/hecate/v1/projects/{id}/cairnline/embedded-parity-report` compares that live
+mirror read model with Hecate's native cockpit projections; and
 `POST /hecate/v1/projects/cairnline/sync` remains the explicit all-project
 rebuild/rehearsal action.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2392,6 +2392,7 @@ Example response:
     ],
     "replacement_readiness_url": "/hecate/v1/projects/{id}/cairnline/read-model",
     "embedded_read_model_url": "/hecate/v1/projects/{id}/cairnline/embedded-read-model",
+    "embedded_parity_report_url": "/hecate/v1/projects/{id}/cairnline/embedded-parity-report",
     "sync_readiness_url": "/hecate/v1/projects/cairnline/sync",
     "mirror_parity_url": "/hecate/v1/projects/cairnline/mirror-parity"
   }
@@ -2498,6 +2499,10 @@ Cairnline portable model and Hecate cockpit model still differ on at least one
 count, semantic bucket, or portable launch-packet coverage check that should be
 reviewed before Cairnline becomes authoritative.
 
+Use this endpoint to verify snapshot import/translation coverage. Use
+`/hecate/v1/projects/{id}/cairnline/embedded-parity-report` to verify the live
+embedded mirror database can serve the same read projections directly.
+
 Example response:
 
 ```json
@@ -2505,6 +2510,7 @@ Example response:
   "object": "project_cairnline_parity_report",
   "data": {
     "project_id": "proj_...",
+    "read_source": "snapshot_seeded_memory",
     "match": true,
     "hecate": {
       "graph": {
@@ -2605,6 +2611,30 @@ Example response:
   }
 }
 ```
+
+### `GET /hecate/v1/projects/{id}/cairnline/embedded-parity-report`
+
+Local-only experimental bridge endpoint. It compares Hecate's native project
+activity and operations brief with the direct embedded Cairnline mirror read
+model from `/hecate/v1/projects/{id}/cairnline/embedded-read-model`.
+
+Unlike `/cairnline/parity-report`, this endpoint does not use the
+snapshot-seeded in-memory service for the Cairnline side. It opens the existing
+embedded SQLite mirror database, reads portable graph/activity/launch-packet
+state from that database, and renders the Cairnline operations brief through
+Hecate's cockpit adapter so operation/action-kind counts can be compared with
+the native operator surface. A missing mirror database or a project absent from
+the mirror returns `404`; the endpoint does not create, seed, or repair the
+database.
+
+Use this endpoint as the stricter read-side replacement-readiness check: a
+matching report shows that the live embedded mirror can serve the same
+operator-facing project projections for that project. It still does not make
+Cairnline authoritative.
+
+The response shape matches `/cairnline/parity-report`, except `object` is
+`project_cairnline_embedded_parity_report`, `read_source` is
+`embedded_cairnline`, and `database_path` points at the embedded mirror DB.
 
 ### `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model`
 

--- a/internal/api/handler_project_activity_cairnline.go
+++ b/internal/api/handler_project_activity_cairnline.go
@@ -3,12 +3,22 @@ package api
 import (
 	"context"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 func (h *Handler) renderCairnlineProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
-	activity, snapshot, err := cairnlinebridge.ProjectActivityFromStores(ctx, h.cairnlineSnapshotSources(), projectID)
+	service, snapshot, err := h.cairnlineProjectWorkService(ctx, projectID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	return h.renderCairnlineProjectActivityFromService(ctx, service, snapshot)
+}
+
+func (h *Handler) renderCairnlineProjectActivityFromService(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) (ProjectActivityDataResponse, error) {
+	projectID := snapshot.Project.ID
+	activity, err := service.ProjectActivity(ctx, projectID)
 	if err != nil {
 		return ProjectActivityDataResponse{}, err
 	}

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -240,6 +240,27 @@ func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *h
 	})
 }
 
+func (h *Handler) HandleProjectCairnlineEmbeddedParityReport(w http.ResponseWriter, r *http.Request) {
+	projectID := strings.TrimSpace(r.PathValue("id"))
+	report, err := h.projectCairnlineEmbeddedParityReport(r.Context(), projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	if errors.Is(err, cairnline.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "embedded Cairnline parity report not found")
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineParityReportResponse{
+		Object: "project_cairnline_embedded_parity_report",
+		Data:   report,
+	})
+}
+
 func (h *Handler) projectCairnlineReadModel(ctx context.Context, projectID string) (ProjectCairnlineReadModelResponseItem, error) {
 	snapshot, err := cairnlinebridge.LoadSnapshot(ctx, h.cairnlineSnapshotSources(), projectID)
 	if errors.Is(err, projects.ErrNotFound) {
@@ -252,19 +273,63 @@ func (h *Handler) projectCairnlineReadModel(ctx context.Context, projectID strin
 }
 
 func (h *Handler) projectCairnlineEmbeddedReadModel(ctx context.Context, projectID string) (ProjectCairnlineReadModelResponseItem, error) {
-	dbPath := h.cairnlineEmbeddedDatabasePath()
-	if _, err := os.Stat(dbPath); err != nil {
-		if os.IsNotExist(err) {
-			return ProjectCairnlineReadModelResponseItem{}, errors.Join(cairnline.ErrNotFound, errors.New("embedded Cairnline mirror database not found"))
-		}
-		return ProjectCairnlineReadModelResponseItem{}, err
-	}
-	service, store, err := cairnline.NewSQLiteService(ctx, dbPath)
+	dbPath, service, store, err := h.openCairnlineEmbeddedService(ctx)
 	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
 	defer store.Close()
 	return projectCairnlineReadModelFromService(ctx, service, projectID, "embedded_cairnline", dbPath)
+}
+
+func (h *Handler) projectCairnlineEmbeddedParityReport(ctx context.Context, projectID string) (ProjectCairnlineParityReportResponseItem, error) {
+	snapshot, err := cairnlinebridge.LoadSnapshot(ctx, h.cairnlineSnapshotSources(), projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	dbPath, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	defer store.Close()
+	readModel, err := projectCairnlineReadModelFromService(ctx, service, projectID, "embedded_cairnline", dbPath)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	nativeActivity, err := h.renderNativeProjectActivity(ctx, projectID)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	nativeOperations, err := h.renderNativeProjectOperationsBriefByID(ctx, projectID)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	cairnlineOperations, err := h.renderCairnlineProjectOperationsBriefFromService(ctx, snapshot.Project, service, snapshot)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	nativeAssistantProposals, err := h.nativeProjectAssistantProposalCount(ctx, projectID)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	return projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeActivity, nativeOperations, cairnlineOperations, nativeAssistantProposals, readModel), nil
+}
+
+func (h *Handler) openCairnlineEmbeddedService(ctx context.Context) (string, *cairnline.Service, *cairnline.SQLiteStore, error) {
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil, nil, errors.Join(cairnline.ErrNotFound, errors.New("embedded Cairnline mirror database not found"))
+		}
+		return "", nil, nil, err
+	}
+	service, store, err := cairnline.NewSQLiteService(ctx, dbPath)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return dbPath, service, store, nil
 }
 
 func projectCairnlineReadModelFromSnapshot(ctx context.Context, snapshot cairnlinebridge.Snapshot) (ProjectCairnlineReadModelResponseItem, error) {
@@ -1337,11 +1402,13 @@ func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnline
 	}
 	differences := projectCairnlineParityDifferences(hecate, cairnline)
 	return ProjectCairnlineParityReportResponseItem{
-		ProjectID:   projectID,
-		Match:       len(differences) == 0,
-		Differences: differences,
-		Hecate:      hecate,
-		Cairnline:   cairnline,
+		ProjectID:    projectID,
+		ReadSource:   readModel.ReadSource,
+		DatabasePath: readModel.DatabasePath,
+		Match:        len(differences) == 0,
+		Differences:  differences,
+		Hecate:       hecate,
+		Cairnline:    cairnline,
 	}
 }
 

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -470,6 +470,7 @@ func TestProjectCairnlineEmbeddedReadModelAPI_MissingDatabaseDoesNotCreateMirror
 		"name": "Embedded Read Model Missing DB",
 	}))
 	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/cairnline/embedded-read-model", "")
+	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/cairnline/embedded-parity-report", "")
 	if _, err := os.Stat(handler.cairnlineEmbeddedDatabasePath()); !os.IsNotExist(err) {
 		t.Fatalf("mirror DB stat error = %v, want embedded read-model probe to avoid creating the DB", err)
 	}
@@ -684,6 +685,23 @@ func TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
 	}
 	if readModel.Data.Activity.Counts.Assignments != 1 || readModel.Data.Activity.Counts.Blocked != 1 || readModel.Data.Activity.Counts.Queued != 1 || len(readModel.Data.Activity.Buckets.Blocked) != 1 || readModel.Data.Activity.Buckets.Blocked[0].AssignmentID != assignment.Data.ID {
 		t.Fatalf("embedded activity = %+v, want blocked queued assignment from live mirror", readModel.Data.Activity)
+	}
+
+	embeddedParity := mustRequestJSONStatus[ProjectCairnlineParityReportResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/cairnline/embedded-parity-report", "")
+	if embeddedParity.Object != "project_cairnline_embedded_parity_report" || embeddedParity.Data.ProjectID != projectID {
+		t.Fatalf("embedded parity envelope = %+v, want project_cairnline_embedded_parity_report for project", embeddedParity)
+	}
+	if embeddedParity.Data.ReadSource != "embedded_cairnline" || embeddedParity.Data.DatabasePath != handler.cairnlineEmbeddedDatabasePath() || !filepath.IsAbs(embeddedParity.Data.DatabasePath) {
+		t.Fatalf("embedded parity source = %q path %q, want embedded Cairnline database path", embeddedParity.Data.ReadSource, embeddedParity.Data.DatabasePath)
+	}
+	if !embeddedParity.Data.Match || len(embeddedParity.Data.Differences) != 0 {
+		t.Fatalf("embedded parity = match %v differences %+v, want direct live mirror projections to match native cockpit", embeddedParity.Data.Match, embeddedParity.Data.Differences)
+	}
+	if embeddedParity.Data.Hecate.Graph.Assignments != 1 || embeddedParity.Data.Cairnline.Graph.Assignments != 1 || embeddedParity.Data.Hecate.Activity.Blocked != 1 || embeddedParity.Data.Cairnline.Activity.Blocked != 1 || embeddedParity.Data.Hecate.LaunchPackets.Assignments != 1 || embeddedParity.Data.Cairnline.LaunchPackets.Assignments != 1 {
+		t.Fatalf("embedded parity snapshots = hecate %+v cairnline %+v, want matching representative assignment graph/activity/launch coverage", embeddedParity.Data.Hecate, embeddedParity.Data.Cairnline)
+	}
+	if embeddedParity.Data.Hecate.Operations.KindCounts["start_queued_assignment"] != 1 || embeddedParity.Data.Cairnline.Operations.KindCounts["start_queued_assignment"] != 1 {
+		t.Fatalf("embedded operations kind counts = hecate %+v cairnline %+v, want adapter-rendered queued assignment action parity", embeddedParity.Data.Hecate.Operations.KindCounts, embeddedParity.Data.Cairnline.Operations.KindCounts)
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -4,6 +4,7 @@ import "net/http"
 
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
+const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
 const projectCoordinationBackendMirrorParityURL = "/hecate/v1/projects/cairnline/mirror-parity"
 
@@ -110,6 +111,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		WriteAdapterReady:       false,
 		ReplacementReadinessURL: projectCoordinationBackendReadinessURL,
 		EmbeddedReadModelURL:    projectCoordinationBackendEmbeddedReadModelURL,
+		EmbeddedParityReportURL: projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:        projectCoordinationBackendSyncReadinessURL,
 		MirrorParityURL:         projectCoordinationBackendMirrorParityURL,
 	}

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -91,6 +91,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if status.EmbeddedReadModelURL != projectCoordinationBackendEmbeddedReadModelURL {
 		t.Fatalf("embedded read-model URL = %q, want %q", status.EmbeddedReadModelURL, projectCoordinationBackendEmbeddedReadModelURL)
 	}
+	if status.EmbeddedParityReportURL != projectCoordinationBackendEmbeddedParityReportURL {
+		t.Fatalf("embedded parity report URL = %q, want %q", status.EmbeddedParityReportURL, projectCoordinationBackendEmbeddedParityReportURL)
+	}
 	if status.MirrorParityURL != projectCoordinationBackendMirrorParityURL {
 		t.Fatalf("mirror parity URL = %q, want %q", status.MirrorParityURL, projectCoordinationBackendMirrorParityURL)
 	}

--- a/internal/api/handler_project_operations_cairnline.go
+++ b/internal/api/handler_project_operations_cairnline.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
@@ -23,7 +24,11 @@ func (h *Handler) renderCairnlineProjectOperationsBrief(ctx context.Context, pro
 	if err != nil {
 		return ProjectOperationsBriefResponse{}, err
 	}
-	activity, err := h.renderCairnlineProjectActivity(ctx, project.ID)
+	return h.renderCairnlineProjectOperationsBriefFromService(ctx, project, service, snapshot)
+}
+
+func (h *Handler) renderCairnlineProjectOperationsBriefFromService(ctx context.Context, project projects.Project, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) (ProjectOperationsBriefResponse, error) {
+	activity, err := h.renderCairnlineProjectActivityFromService(ctx, service, snapshot)
 	if err != nil {
 		return ProjectOperationsBriefResponse{}, err
 	}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -604,6 +604,7 @@ func TestRemoteRuntimeLocalEndpointGuardMiddleware(t *testing.T) {
 		{name: "blocks mcp registry discovery", enabled: true, method: http.MethodGet, path: "/hecate/v1/mcp/registry/servers", want: http.StatusForbidden},
 		{name: "blocks local provider discovery", enabled: true, method: http.MethodGet, path: "/hecate/v1/settings/providers/local-discovery", want: http.StatusForbidden},
 		{name: "blocks embedded cairnline read model", enabled: true, method: http.MethodGet, path: "/hecate/v1/projects/proj_123/cairnline/embedded-read-model", want: http.StatusForbidden},
+		{name: "blocks embedded cairnline parity report", enabled: true, method: http.MethodGet, path: "/hecate/v1/projects/proj_123/cairnline/embedded-parity-report", want: http.StatusForbidden},
 		{name: "blocks adapter authenticate", enabled: true, method: http.MethodPost, path: "/hecate/v1/agent-adapters/codex/authenticate", want: http.StatusForbidden},
 		{name: "blocks unclassified hecate endpoint", enabled: true, method: http.MethodPost, path: "/hecate/v1/future-local-only", want: http.StatusForbidden},
 		{name: "allows normal endpoint", enabled: true, method: http.MethodGet, path: "/hecate/v1/whoami", want: http.StatusNoContent},

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -422,11 +422,13 @@ type ProjectCairnlineParityReportResponse struct {
 }
 
 type ProjectCairnlineParityReportResponseItem struct {
-	ProjectID   string                             `json:"project_id"`
-	Match       bool                               `json:"match"`
-	Differences []ProjectCairnlineParityDifference `json:"differences,omitempty"`
-	Hecate      ProjectCairnlineParitySnapshot     `json:"hecate"`
-	Cairnline   ProjectCairnlineParitySnapshot     `json:"cairnline"`
+	ProjectID    string                             `json:"project_id"`
+	ReadSource   string                             `json:"read_source,omitempty"`
+	DatabasePath string                             `json:"database_path,omitempty"`
+	Match        bool                               `json:"match"`
+	Differences  []ProjectCairnlineParityDifference `json:"differences,omitempty"`
+	Hecate       ProjectCairnlineParitySnapshot     `json:"hecate"`
+	Cairnline    ProjectCairnlineParitySnapshot     `json:"cairnline"`
 }
 
 type ProjectCairnlineParitySnapshot struct {
@@ -511,6 +513,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	Warnings                []string `json:"warnings,omitempty"`
 	ReplacementReadinessURL string   `json:"replacement_readiness_url,omitempty"`
 	EmbeddedReadModelURL    string   `json:"embedded_read_model_url,omitempty"`
+	EmbeddedParityReportURL string   `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL        string   `json:"sync_readiness_url,omitempty"`
 	MirrorParityURL         string   `json:"mirror_parity_url,omitempty"`
 }

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -27,6 +27,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/embedded-read-model"},
+	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/{id}/cairnline/export"},
 	{method: http.MethodPost, path: "/hecate/v1/mcp/probe"},
 	{method: http.MethodGet, path: "/hecate/v1/mcp/registry/servers"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -87,6 +87,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/embedded-read-model", handler.HandleProjectCairnlineEmbeddedReadModel)
+	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/embedded-parity-report", handler.HandleProjectCairnlineEmbeddedParityReport)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/cairnline/export", handler.HandleExportProjectToCairnline)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots", handler.HandleCreateProjectRoot)
 	mux.HandleFunc("POST /hecate/v1/projects/{id}/roots/discover", handler.HandleDiscoverProjectRoots)


### PR DESCRIPTION
## Summary
- add a local-only embedded Cairnline parity report endpoint that compares Hecate native cockpit projections with the existing embedded mirror DB
- factor Cairnline-backed activity and operations rendering so the same cockpit adapter can render from either snapshot-seeded memory or embedded SQLite
- expose the endpoint in backend status, keep it remote-runtime local-only, and document the stricter live-read replacement-readiness check

## Verification
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline(EmbeddedReadModel|MirrorParity|ParityReport|Sync|Export)|TestProjectCoordinationBackendStatus|TestRemoteRuntime|TestProjectOperations'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...