### PR TITLE
Read Cairnline activity from service rows

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -126,11 +126,15 @@ memory candidates, roles, work-item list/detail, assignment-list,
 assignment-context, launch-readiness, assignment-preflight, artifact-list,
 handoff-list, Project Assistant context and proposal reads, closeout readiness,
 and operations brief can use the Cairnline read model for portable setup/work
-state. Those configured read routes still use Hecate snapshots as bridge
-scaffolding, but their Cairnline service reads prefer the embedded Cairnline
-mirror database when it already contains the requested project; if the mirror
-database or project row is missing, they fall back to the snapshot-seeded
-in-memory bridge projection. Project Assistant draft generation also uses the Cairnline-projected
+state. Configured read routes prefer the embedded Cairnline mirror database
+when it already contains the requested project; if the mirror database or
+project row is missing, they fall back to the snapshot-seeded in-memory bridge
+projection. Activity and operations render work items, assignments, roles,
+artifacts, and handoffs from the Cairnline service records, then overlay
+Hecate-only runtime refs/timestamps where Hecate still owns execution.
+Project identity and some compatibility scaffolding still come from Hecate
+until Cairnline becomes authoritative. Project Assistant draft generation also
+uses the Cairnline-projected
 context so preview and proposal assembly stay aligned, while the proposal
 ledger and apply remain Hecate-owned. Project list/detail reconstruct default
 profile and execution posture from Cairnline project/execution-profile records
@@ -142,9 +146,9 @@ evidence so replacement reviews can compare Hecate's authoritative launch
 context with the portable launch packet Cairnline can build for the same
 assignment. Hecate stores remain authoritative, Hecate-specific runtime
 enrichment and setup/action wording remain in Hecate, and the Cairnline-backed
-operations brief assembles through Hecate's activity projection and cockpit
-action helpers so operator-facing actions stay parity-checked with the native
-route. Assignment-start is still a Hecate-native dispatch mutation, committed
+operations brief uses Cairnline activity/service rows plus Hecate cockpit action
+helpers so operator-facing actions stay parity-checked with the native route.
+Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results are best-effort mirrored for replacement evidence, and
 other live Projects reads/writes still use the Hecate-native API.
 `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -348,6 +348,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   context/proposal reads, activity, closeout readiness, and operations brief
   reads from a Cairnline-seeded read model while Hecate stores remain
   authoritative.
+- In configured Hecate embed mode, activity and operations now render work
+  items, assignments, roles, artifacts, and handoffs from Cairnline service
+  records, then overlay Hecate-only runtime refs/timestamps while Hecate still
+  owns execution. Project identity and some compatibility scaffolding remain
+  Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -371,16 +371,18 @@ records before applying Hecate runtime checks.
 Assignment preflight/start context packets may include inspect-only Cairnline
 launch-packet evidence for replacement review, but Hecate still owns dispatch,
 task/external agent supervision, approvals, and assignment mutation. Project
-reads backed by the Cairnline read model still use Hecate snapshots as bridge
-scaffolding, but their Cairnline service reads prefer the embedded Cairnline
-mirror database when that database already contains the requested project; if
-the mirror database or project row is missing, they fall back to the
-snapshot-seeded in-memory bridge projection.
-identity, metadata, root create/update/delete/discovery/worktree-creation,
-context-source create/update/delete/discovery, and default mutations still
-write Hecate stores first and then best-effort mirror into the embedded
-Cairnline database through their identity/metadata/root/source/default seams;
-this is replacement-readiness evidence, not write authority.
+reads backed by the Cairnline read model prefer the embedded Cairnline mirror
+database when that database already contains the requested project; if the
+mirror database or project row is missing, they fall back to the snapshot-seeded
+in-memory bridge projection. Activity and operations render the work graph from
+Cairnline service records and overlay Hecate-only runtime refs/timestamps while
+Hecate still owns execution. Project identity and some compatibility
+scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
+metadata, root create/update/delete/discovery/worktree-creation,
+context-source create/update/delete/discovery, and default mutations still write
+Hecate stores first and then best-effort mirror into the embedded Cairnline
+database through their identity/metadata/root/source/default seams; this is
+replacement-readiness evidence, not write authority.
 Project skill discovery and
 metadata updates also best-effort mirror metadata-only skill records after the
 Hecate store commit; the mirror does not load or execute skill bodies. Project

--- a/internal/api/handler_project_activity_cairnline.go
+++ b/internal/api/handler_project_activity_cairnline.go
@@ -23,10 +23,37 @@ func (h *Handler) renderCairnlineProjectActivityFromService(ctx context.Context,
 	if err != nil {
 		return ProjectActivityDataResponse{}, err
 	}
-	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(snapshot.Assignments)
-	projectedWorkItems := make(map[string]ProjectWorkItemResponse, len(snapshot.WorkItems))
-	projectedAssignments := make(map[string]ProjectWorkAssignmentResponse, len(snapshot.Assignments))
-	for _, item := range snapshot.WorkItems {
+	cairnlineWorkItems, err := service.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	cairnlineAssignments, err := service.ListAssignments(ctx, projectID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	cairnlineRoles, err := service.ListRoles(ctx, projectID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	artifacts, err := projectHealthCairnlineArtifacts(ctx, service, projectID, cairnlineWorkItems)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	handoffs, err := projectHealthCairnlineHandoffs(ctx, service, projectID, cairnlineWorkItems)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+
+	workItems := projectActivityWorkItemsFromCairnline(cairnlineWorkItems, snapshot.WorkItems)
+	assignments := projectWorkAssignmentsFromCairnline(cairnlineAssignments, snapshot.Assignments)
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	projectedWorkItems := make(map[string]ProjectWorkItemResponse, len(workItems))
+	projectedAssignments := make(map[string]ProjectWorkAssignmentResponse, len(assignments))
+	for _, item := range workItems {
 		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
 		if err != nil {
 			return ProjectActivityDataResponse{}, err
@@ -36,10 +63,10 @@ func (h *Handler) renderCairnlineProjectActivityFromService(ctx context.Context,
 			projectedAssignments[assignment.ID] = assignment
 		}
 	}
-	rolesByID := projectActivitySnapshotRolesByID(snapshot.Roles)
-	linkedChats := h.projectActivityLinkedChats(ctx, projectID, snapshot.Assignments)
-	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(snapshot.Artifacts)
-	handoffsByAssignment, handoffsByWorkItem := groupProjectActivityHandoffs(snapshot.Handoffs)
+	rolesByID := projectActivityCairnlineRolesByID(cairnlineRoles, executionProfiles, snapshot.Roles)
+	linkedChats := h.projectActivityLinkedChats(ctx, projectID, assignments)
+	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(artifacts)
+	handoffsByAssignment, handoffsByWorkItem := groupProjectActivityHandoffs(handoffs)
 
 	items := make([]ProjectActivityItemResponse, 0, len(activity.Items))
 	for _, item := range activity.Items {
@@ -69,7 +96,7 @@ func (h *Handler) renderCairnlineProjectActivityFromService(ctx context.Context,
 		ReadBackend: "cairnline",
 		Recent:      boundedProjectActivityItems(items, 20),
 	}
-	response.Summary.WorkItemCount = len(snapshot.WorkItems)
+	response.Summary.WorkItemCount = len(workItems)
 	response.Summary.AssignmentCount = activity.Counts.Assignments
 	for _, item := range items {
 		switch projectActivityBucket(item) {
@@ -92,10 +119,30 @@ func (h *Handler) renderCairnlineProjectActivityFromService(ctx context.Context,
 	return response, nil
 }
 
-func projectActivitySnapshotRolesByID(items []projectwork.AgentRoleProfile) map[string]projectwork.AgentRoleProfile {
+func projectActivityCairnlineRolesByID(items []cairnline.Role, executionProfiles []cairnline.ExecutionProfile, native []projectwork.AgentRoleProfile) map[string]projectwork.AgentRoleProfile {
 	out := make(map[string]projectwork.AgentRoleProfile, len(items))
+	executionProfilesByID := cairnlineExecutionProfilesByID(executionProfiles)
+	nativeByID := projectWorkRolesByID(native)
 	for _, item := range items {
-		out[item.ID] = item
+		out[item.ID] = projectWorkRoleFromCairnline(item, executionProfilesByID, nativeByID[item.ID])
+	}
+	return out
+}
+
+func projectActivityWorkItemsFromCairnline(items []cairnline.WorkItem, native []projectwork.WorkItem) []projectwork.WorkItem {
+	nativeByID := projectWorkItemsByID(native)
+	out := make([]projectwork.WorkItem, 0, len(items))
+	for _, item := range items {
+		projected := projectWorkItemFromCairnline(item)
+		if nativeItem, ok := nativeByID[item.ID]; ok {
+			if !nativeItem.CreatedAt.IsZero() {
+				projected.CreatedAt = nativeItem.CreatedAt
+			}
+			if !nativeItem.UpdatedAt.IsZero() {
+				projected.UpdatedAt = nativeItem.UpdatedAt
+			}
+		}
+		out = append(out, projected)
 	}
 	return out
 }

--- a/internal/api/handler_project_assistant_cairnline.go
+++ b/internal/api/handler_project_assistant_cairnline.go
@@ -184,14 +184,6 @@ func seedCairnlineProjectAssistantWork(ctx context.Context, store *projectwork.M
 	return nil
 }
 
-func projectWorkItemsByID(items []projectwork.WorkItem) map[string]projectwork.WorkItem {
-	out := make(map[string]projectwork.WorkItem, len(items))
-	for _, item := range items {
-		out[item.ID] = item
-	}
-	return out
-}
-
 func seedCairnlineProjectAssistantSkills(ctx context.Context, store *projectskills.MemoryStore, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) error {
 	projectID := snapshot.Project.ID
 	items, err := service.ListProjectSkills(ctx, projectID)

--- a/internal/api/handler_project_health_cairnline.go
+++ b/internal/api/handler_project_health_cairnline.go
@@ -105,20 +105,11 @@ func (h *Handler) renderCairnlineProjectHealth(ctx context.Context, projectID st
 func projectHealthCairnlineArtifacts(ctx context.Context, service *cairnline.Service, projectID string, workItems []cairnline.WorkItem) ([]projectwork.CollaborationArtifact, error) {
 	out := make([]projectwork.CollaborationArtifact, 0)
 	for _, workItem := range workItems {
-		evidence, err := service.ListEvidence(ctx, projectID, workItem.ID)
+		artifacts, err := cairnlineProjectWorkArtifacts(ctx, service, projectID, workItem.ID)
 		if err != nil {
 			return nil, err
 		}
-		for _, item := range evidence {
-			out = append(out, projectHealthEvidenceFromCairnline(item))
-		}
-		reviews, err := service.ListReviews(ctx, projectID, workItem.ID)
-		if err != nil {
-			return nil, err
-		}
-		for _, item := range reviews {
-			out = append(out, projectHealthReviewFromCairnline(item))
-		}
+		out = append(out, artifacts...)
 	}
 	return out, nil
 }
@@ -141,11 +132,24 @@ func projectWorkAssignmentsFromCairnline(items []cairnline.Assignment, native []
 	nativeByID := projectWorkAssignmentsByID(native)
 	out := make([]projectwork.Assignment, 0, len(items))
 	for _, item := range items {
+		projected := projectWorkAssignmentFromCairnline(item)
 		if nativeItem, ok := nativeByID[item.ID]; ok {
-			out = append(out, nativeItem)
-			continue
+			projected.ExecutionRef = nativeItem.ExecutionRef
+			projected.ContextPacket = append([]byte(nil), nativeItem.ContextPacket...)
+			if !nativeItem.CreatedAt.IsZero() {
+				projected.CreatedAt = nativeItem.CreatedAt
+			}
+			if !nativeItem.UpdatedAt.IsZero() {
+				projected.UpdatedAt = nativeItem.UpdatedAt
+			}
+			if !nativeItem.StartedAt.IsZero() {
+				projected.StartedAt = nativeItem.StartedAt
+			}
+			if !nativeItem.CompletedAt.IsZero() {
+				projected.CompletedAt = nativeItem.CompletedAt
+			}
 		}
-		out = append(out, projectWorkAssignmentFromCairnline(item))
+		out = append(out, projected)
 	}
 	return out
 }

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -414,6 +414,14 @@ func projectWorkItemFromCairnline(item cairnline.WorkItem) projectwork.WorkItem 
 	}
 }
 
+func projectWorkItemsByID(items []projectwork.WorkItem) map[string]projectwork.WorkItem {
+	out := make(map[string]projectwork.WorkItem, len(items))
+	for _, item := range items {
+		out[item.ID] = item
+	}
+	return out
+}
+
 func projectWorkAssignmentsByID(items []projectwork.Assignment) map[string]projectwork.Assignment {
 	out := make(map[string]projectwork.Assignment, len(items))
 	for _, item := range items {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -4054,6 +4054,66 @@ func TestProjectWorkAPI_ProjectActivityShowsFreshQueuedAssignments(t *testing.T)
 	}
 }
 
+func TestProjectWorkAPI_ProjectActivityUsesEmbeddedCairnlineWorkGraph(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineMirrorTestServer(t)
+	project := createProjectForWorkTest(t, server)
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	if _, err := service.CreateRole(t.Context(), cairnline.Role{
+		ID:                   "role_mirror_only",
+		ProjectID:            project.Data.ID,
+		Name:                 "Mirror-only role",
+		DefaultExecutionMode: cairnline.ExecutionOrchestrated,
+	}); err != nil {
+		t.Fatalf("CreateRole(role_mirror_only): %v", err)
+	}
+	if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+		ID:        "work_mirror_only",
+		ProjectID: project.Data.ID,
+		Title:     "Mirror-only work",
+		Status:    cairnline.WorkStatusReady,
+		Priority:  cairnline.PriorityNormal,
+	}); err != nil {
+		t.Fatalf("CreateWorkItem(work_mirror_only): %v", err)
+	}
+	if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+		ID:            "asgn_mirror_only",
+		ProjectID:     project.Data.ID,
+		WorkItemID:    "work_mirror_only",
+		RoleID:        "role_mirror_only",
+		ExecutionMode: cairnline.ExecutionOrchestrated,
+		Status:        cairnline.AssignmentQueued,
+	}); err != nil {
+		t.Fatalf("CreateAssignment(asgn_mirror_only): %v", err)
+	}
+
+	nativeWorkItems, err := handler.projectWork.ListWorkItems(t.Context(), project.Data.ID)
+	if err != nil {
+		t.Fatalf("ListWorkItems(native): %v", err)
+	}
+	if len(nativeWorkItems) != 0 {
+		t.Fatalf("native work items = %+v, want mirror-only graph to stay out of Hecate store", nativeWorkItems)
+	}
+
+	client := newAPITestClient(t, server)
+	response := mustRequestJSON[ProjectActivityEnvelope](client, http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/activity", "")
+	if response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("activity read_backend = %q, want cairnline", response.Data.ReadBackend)
+	}
+	if response.Data.Summary.WorkItemCount != 1 || response.Data.Summary.AssignmentCount != 1 || response.Data.Summary.BlockedCount != 1 {
+		t.Fatalf("activity summary = %+v, want mirror-only work and queued assignment counted", response.Data.Summary)
+	}
+	item := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asgn_mirror_only")
+	if item.WorkItem.ID != "work_mirror_only" || item.WorkItem.Title != "Mirror-only work" || item.Role.ID != "role_mirror_only" || item.Role.Name != "Mirror-only role" {
+		t.Fatalf("activity item = %+v, want Cairnline service work/role projection", item)
+	}
+}
+
 type failingCreateTaskStore struct {
 	taskstate.Store
 }


### PR DESCRIPTION
## Summary
- render configured Cairnline activity from Cairnline work/assignment/role/artifact/handoff service rows instead of snapshot work scaffolding
- keep Hecate runtime refs/timestamps as a compatibility overlay while execution remains Hecate-owned
- add a mirror-only activity regression and update Cairnline replacement-readiness docs

## Verification
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_ProjectActivity(ShowsFreshQueuedAssignments|UsesEmbeddedCairnlineWorkGraph|CairnlineConfiguredUsesReadModel|CairnlineMatchesHecate)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api ./internal/cairnlinebridge
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...