### PR TITLE
Read Cairnline work-item assignments from service rows

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -129,9 +129,10 @@ and operations brief can use the Cairnline read model for portable setup/work
 state. Configured read routes prefer the embedded Cairnline mirror database
 when it already contains the requested project; if the mirror database or
 project row is missing, they fall back to the snapshot-seeded in-memory bridge
-projection. Activity and operations render work items, assignments, roles,
-artifacts, and handoffs from the Cairnline service records, then overlay
-Hecate-only runtime refs/timestamps where Hecate still owns execution.
+projection. Activity, work-item list/detail, assignment-list, and operations
+brief reads render work items, assignments, roles, artifacts, and handoffs from
+the Cairnline service records, then overlay Hecate-only runtime refs/timestamps
+where Hecate still owns execution.
 Project identity and some compatibility scaffolding still come from Hecate
 until Cairnline becomes authoritative. Project Assistant draft generation also
 uses the Cairnline-projected

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -348,10 +348,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   context/proposal reads, activity, closeout readiness, and operations brief
   reads from a Cairnline-seeded read model while Hecate stores remain
   authoritative.
-- In configured Hecate embed mode, activity and operations now render work
-  items, assignments, roles, artifacts, and handoffs from Cairnline service
-  records, then overlay Hecate-only runtime refs/timestamps while Hecate still
-  owns execution. Project identity and some compatibility scaffolding remain
+- In configured Hecate embed mode, activity, work-item list/detail,
+  assignment-list, and operations brief reads now render work items,
+  assignments, roles, artifacts, and handoffs from Cairnline service records,
+  then overlay Hecate-only runtime refs/timestamps while Hecate still owns
+  execution. Project identity and some compatibility scaffolding remain
   Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -374,9 +374,10 @@ task/external agent supervision, approvals, and assignment mutation. Project
 reads backed by the Cairnline read model prefer the embedded Cairnline mirror
 database when that database already contains the requested project; if the
 mirror database or project row is missing, they fall back to the snapshot-seeded
-in-memory bridge projection. Activity and operations render the work graph from
-Cairnline service records and overlay Hecate-only runtime refs/timestamps while
-Hecate still owns execution. Project identity and some compatibility
+in-memory bridge projection. Activity, work-item list/detail, assignment-list,
+and operations brief reads render the work graph from Cairnline service records
+and overlay Hecate-only runtime refs/timestamps while Hecate still owns
+execution. Project identity and some compatibility
 scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
 metadata, root create/update/delete/discovery/worktree-creation,
 context-source create/update/delete/discovery, and default mutations still write

--- a/internal/api/handler_project_activity_cairnline.go
+++ b/internal/api/handler_project_activity_cairnline.go
@@ -48,7 +48,7 @@ func (h *Handler) renderCairnlineProjectActivityFromService(ctx context.Context,
 		return ProjectActivityDataResponse{}, err
 	}
 
-	workItems := projectActivityWorkItemsFromCairnline(cairnlineWorkItems, snapshot.WorkItems)
+	workItems := projectWorkItemsFromCairnlineWithNativeTimestamps(cairnlineWorkItems, snapshot.WorkItems)
 	assignments := projectWorkAssignmentsFromCairnline(cairnlineAssignments, snapshot.Assignments)
 	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
 	projectedWorkItems := make(map[string]ProjectWorkItemResponse, len(workItems))
@@ -125,24 +125,6 @@ func projectActivityCairnlineRolesByID(items []cairnline.Role, executionProfiles
 	nativeByID := projectWorkRolesByID(native)
 	for _, item := range items {
 		out[item.ID] = projectWorkRoleFromCairnline(item, executionProfilesByID, nativeByID[item.ID])
-	}
-	return out
-}
-
-func projectActivityWorkItemsFromCairnline(items []cairnline.WorkItem, native []projectwork.WorkItem) []projectwork.WorkItem {
-	nativeByID := projectWorkItemsByID(native)
-	out := make([]projectwork.WorkItem, 0, len(items))
-	for _, item := range items {
-		projected := projectWorkItemFromCairnline(item)
-		if nativeItem, ok := nativeByID[item.ID]; ok {
-			if !nativeItem.CreatedAt.IsZero() {
-				projected.CreatedAt = nativeItem.CreatedAt
-			}
-			if !nativeItem.UpdatedAt.IsZero() {
-				projected.UpdatedAt = nativeItem.UpdatedAt
-			}
-		}
-		out = append(out, projected)
 	}
 	return out
 }

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -551,16 +551,20 @@ func (h *Handler) HandleDeleteProjectWorkItem(w http.ResponseWriter, r *http.Req
 func (h *Handler) HandleProjectWorkAssignments(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
-	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
-		return
-	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		data, err := h.renderCairnlineProjectWorkAssignments(r.Context(), projectID, workItemID)
 		if err != nil {
+			if errors.Is(err, projectwork.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+				return
+			}
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
 		WriteJSON(w, http.StatusOK, ProjectWorkAssignmentsResponse{Object: "project_assignments", Data: data})
+		return
+	}
+	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
 	items, err := h.projectWork.ListAssignments(r.Context(), projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: workItemID})

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -167,10 +167,16 @@ func (h *Handler) renderCairnlineProjectWorkItems(ctx context.Context, projectID
 	if err != nil {
 		return nil, err
 	}
-	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(view.snapshot.Assignments)
+	cairnlineAssignments, err := view.service.ListAssignments(ctx, view.snapshot.Project.ID)
+	if err != nil {
+		return nil, err
+	}
+	workItems := projectWorkItemsFromCairnlineWithNativeTimestamps(items, view.snapshot.WorkItems)
+	assignments := projectWorkAssignmentsFromCairnline(cairnlineAssignments, view.snapshot.Assignments)
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
 	data := make([]ProjectWorkItemResponse, 0, len(items))
-	for _, item := range items {
-		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, projectWorkItemFromCairnline(item), assignmentsByWorkItem[item.ID])
+	for _, item := range workItems {
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
 		if err != nil {
 			return nil, err
 		}
@@ -191,12 +197,18 @@ func (h *Handler) renderCairnlineProjectWorkItem(ctx context.Context, projectID,
 	if err != nil {
 		return ProjectWorkItemResponse{}, err
 	}
-	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(view.snapshot.Assignments)
-	for _, item := range items {
+	cairnlineAssignments, err := view.service.ListAssignments(ctx, view.snapshot.Project.ID)
+	if err != nil {
+		return ProjectWorkItemResponse{}, err
+	}
+	workItems := projectWorkItemsFromCairnlineWithNativeTimestamps(items, view.snapshot.WorkItems)
+	assignments := projectWorkAssignmentsFromCairnline(cairnlineAssignments, view.snapshot.Assignments)
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	for _, item := range workItems {
 		if item.ID != workItemID {
 			continue
 		}
-		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, projectWorkItemFromCairnline(item), assignmentsByWorkItem[item.ID])
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
 		if err != nil {
 			return ProjectWorkItemResponse{}, err
 		}
@@ -294,19 +306,21 @@ func (h *Handler) renderCairnlineProjectWorkAssignments(ctx context.Context, pro
 		return nil, err
 	}
 	defer view.Close()
+	if _, err := view.service.GetWorkItem(ctx, view.snapshot.Project.ID, workItemID); err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return nil, projectwork.ErrNotFound
+		}
+		return nil, err
+	}
 	items, err := view.service.ListAssignments(ctx, view.snapshot.Project.ID)
 	if err != nil {
 		return nil, err
 	}
-	nativeByID := projectWorkAssignmentsByID(view.snapshot.Assignments)
+	assignments := projectWorkAssignmentsFromCairnline(items, view.snapshot.Assignments)
 	data := make([]ProjectWorkAssignmentResponse, 0, len(items))
-	for _, item := range items {
-		if strings.TrimSpace(item.WorkItemID) != workItemID {
+	for _, assignment := range assignments {
+		if strings.TrimSpace(assignment.WorkItemID) != workItemID {
 			continue
-		}
-		assignment := projectWorkAssignmentFromCairnline(item)
-		if native, ok := nativeByID[item.ID]; ok {
-			assignment = native
 		}
 		projected, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
 		if err != nil {
@@ -412,6 +426,24 @@ func projectWorkItemFromCairnline(item cairnline.WorkItem) projectwork.WorkItem 
 		CreatedAt:       item.CreatedAt,
 		UpdatedAt:       item.UpdatedAt,
 	}
+}
+
+func projectWorkItemsFromCairnlineWithNativeTimestamps(items []cairnline.WorkItem, native []projectwork.WorkItem) []projectwork.WorkItem {
+	nativeByID := projectWorkItemsByID(native)
+	out := make([]projectwork.WorkItem, 0, len(items))
+	for _, item := range items {
+		projected := projectWorkItemFromCairnline(item)
+		if nativeItem, ok := nativeByID[item.ID]; ok {
+			if !nativeItem.CreatedAt.IsZero() {
+				projected.CreatedAt = nativeItem.CreatedAt
+			}
+			if !nativeItem.UpdatedAt.IsZero() {
+				projected.UpdatedAt = nativeItem.UpdatedAt
+			}
+		}
+		out = append(out, projected)
+	}
+	return out
 }
 
 func projectWorkItemsByID(items []projectwork.WorkItem) map[string]projectwork.WorkItem {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -4101,6 +4101,25 @@ func TestProjectWorkAPI_ProjectActivityUsesEmbeddedCairnlineWorkGraph(t *testing
 	}
 
 	client := newAPITestClient(t, server)
+	listed := mustRequestJSON[ProjectWorkItemsResponse](client, http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items", "")
+	listedItem := findProjectWorkItemForTest(t, listed.Data, "work_mirror_only")
+	if listedItem.ReadBackend != "cairnline" || len(listedItem.Assignments) != 1 || listedItem.Assignments[0].ID != "asgn_mirror_only" {
+		t.Fatalf("listed work item = %+v, want Cairnline service assignment projection", listedItem)
+	}
+	if listedItem.Assignments[0].DriverKind != projectwork.AssignmentDriverHecateTask || listedItem.Assignments[0].ReadBackend != "cairnline" {
+		t.Fatalf("listed assignment = %+v, want projected Hecate task assignment from Cairnline service row", listedItem.Assignments[0])
+	}
+
+	detail := mustRequestJSON[ProjectWorkItemEnvelope](client, http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_mirror_only", "")
+	if detail.Data.ReadBackend != "cairnline" || len(detail.Data.Assignments) != 1 || detail.Data.Assignments[0].ID != "asgn_mirror_only" {
+		t.Fatalf("detail work item = %+v, want Cairnline service assignment projection", detail.Data)
+	}
+
+	assignments := mustRequestJSON[ProjectWorkAssignmentsResponse](client, http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/work-items/work_mirror_only/assignments", "")
+	if len(assignments.Data) != 1 || assignments.Data[0].ID != "asgn_mirror_only" || assignments.Data[0].ReadBackend != "cairnline" {
+		t.Fatalf("assignment list = %+v, want mirror-only Cairnline assignment", assignments.Data)
+	}
+
 	response := mustRequestJSON[ProjectActivityEnvelope](client, http.MethodGet, "/hecate/v1/projects/"+project.Data.ID+"/activity", "")
 	if response.Data.ReadBackend != "cairnline" {
 		t.Fatalf("activity read_backend = %q, want cairnline", response.Data.ReadBackend)


### PR DESCRIPTION
## Summary
- render Cairnline-backed work-item list/detail surfaces with assignment rows from the Cairnline service instead of snapshot-only assignment scaffolding
- make the Cairnline assignment-list route validate work-item existence through Cairnline and keep the existing 404 contract
- extend the mirror-only regression so list, detail, assignment-list, and activity all see Cairnline-only work graph rows
- update Projects/Cairnline docs to reflect the read-route coverage

## Verification
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_ProjectActivityUsesEmbeddedCairnlineWorkGraph|TestProjectWorkAPI_ProjectWorkCairnlineMatchesHecate|TestProjectWorkAPI_ProjectActivityCairnlineMatchesHecate|TestProjectOperationsBrief_CairnlineMatchesHecateProjectionGraph'
- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge
- just agent-docs-check
- GOCACHE="$PWD/.gocache" go test ./internal/api
- GOCACHE="$PWD/.gocache" go test ./...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...
- git diff --check