### PR TITLE
Add Cairnline work-item route parity

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -164,10 +164,12 @@ mirror can serve project projections directly.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
 differences for raw graph counts including execution-profile defaults,
-activity, rendered cockpit operations including action-kind counts, and the
-Project Assistant proposal ledger, plus portable launch-packet coverage, so
-import coverage, bucket/status semantics, operator-action drift, portable ledger
-coverage, and assignment packet coverage can be fixed before any backend switch.
+rendered work-item route shape including embedded assignments, activity,
+rendered cockpit operations including action-kind counts, and the Project
+Assistant proposal ledger, plus portable launch-packet coverage, so import
+coverage, work-item projection drift, bucket/status semantics,
+operator-action drift, portable ledger coverage, and assignment packet coverage
+can be fixed before any backend switch.
 `GET /hecate/v1/projects/{id}/cairnline/embedded-parity-report` performs the
 same cockpit comparison against the existing embedded Cairnline mirror database
 instead of the snapshot-seeded in-memory service. It is the stricter live-read

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -366,7 +366,8 @@ launch agents. Those remain explicit operator or orchestrator actions.
   mirror committed assignment-start results as replacement evidence, but this
   does not make assignment-start Cairnline-backed.
 - The Hecate parity report compares raw graph counts, derived activity and
-  operations counts, Project Assistant proposal-ledger counts, and launch-packet
+  operations counts, rendered work-item route shape including embedded
+  assignments, Project Assistant proposal-ledger counts, and launch-packet
   coverage before any backend switch.
 - The Hecate backend-status endpoint exposes the live Cairnline read-route
   coverage, non-authoritative bridge write seams, and remaining live-route

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -427,7 +427,8 @@ mirror database with Hecate's current stores without creating or repairing it;
 activity, and launch-packet projections directly from the existing embedded
 mirror database without seeding from Hecate stores; `GET
 /hecate/v1/projects/{id}/cairnline/embedded-parity-report` compares that live
-mirror read model with Hecate's native cockpit projections; and
+mirror read model with Hecate's native cockpit projections, including rendered
+work-item route shape with embedded assignments; and
 `POST /hecate/v1/projects/cairnline/sync` remains the explicit all-project
 rebuild/rehearsal action.
 

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -208,7 +208,22 @@ func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	readModel, err := projectCairnlineReadModelFromSnapshot(r.Context(), snapshot)
+	service, err := projectCairnlineServiceFromSnapshot(r.Context(), snapshot)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	readModel, err := projectCairnlineReadModelFromService(r.Context(), service, snapshot.Project.ID, "snapshot_seeded_memory", "")
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	nativeWorkItems, err := h.renderNativeProjectWorkItems(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	cairnlineWorkItems, err := h.renderCairnlineProjectWorkItemsFromService(r.Context(), service, snapshot)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
@@ -233,7 +248,7 @@ func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	report := projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeActivity, nativeOperations, cairnlineOperations, nativeAssistantProposals, readModel)
+	report := projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeWorkItems, nativeActivity, nativeOperations, cairnlineWorkItems, cairnlineOperations, nativeAssistantProposals, readModel)
 	WriteJSON(w, http.StatusOK, ProjectCairnlineParityReportResponse{
 		Object: "project_cairnline_parity_report",
 		Data:   report,
@@ -298,6 +313,14 @@ func (h *Handler) projectCairnlineEmbeddedParityReport(ctx context.Context, proj
 	if err != nil {
 		return ProjectCairnlineParityReportResponseItem{}, err
 	}
+	nativeWorkItems, err := h.renderNativeProjectWorkItems(ctx, projectID)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	cairnlineWorkItems, err := h.renderCairnlineProjectWorkItemsFromService(ctx, service, snapshot)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
 	nativeActivity, err := h.renderNativeProjectActivity(ctx, projectID)
 	if err != nil {
 		return ProjectCairnlineParityReportResponseItem{}, err
@@ -314,7 +337,7 @@ func (h *Handler) projectCairnlineEmbeddedParityReport(ctx context.Context, proj
 	if err != nil {
 		return ProjectCairnlineParityReportResponseItem{}, err
 	}
-	return projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeActivity, nativeOperations, cairnlineOperations, nativeAssistantProposals, readModel), nil
+	return projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeWorkItems, nativeActivity, nativeOperations, cairnlineWorkItems, cairnlineOperations, nativeAssistantProposals, readModel), nil
 }
 
 func (h *Handler) openCairnlineEmbeddedService(ctx context.Context) (string, *cairnline.Service, *cairnline.SQLiteStore, error) {
@@ -333,11 +356,19 @@ func (h *Handler) openCairnlineEmbeddedService(ctx context.Context) (string, *ca
 }
 
 func projectCairnlineReadModelFromSnapshot(ctx context.Context, snapshot cairnlinebridge.Snapshot) (ProjectCairnlineReadModelResponseItem, error) {
-	service := cairnline.NewMemoryService()
-	if err := cairnlinebridge.Seed(ctx, service, snapshot); err != nil {
+	service, err := projectCairnlineServiceFromSnapshot(ctx, snapshot)
+	if err != nil {
 		return ProjectCairnlineReadModelResponseItem{}, err
 	}
 	return projectCairnlineReadModelFromService(ctx, service, snapshot.Project.ID, "snapshot_seeded_memory", "")
+}
+
+func projectCairnlineServiceFromSnapshot(ctx context.Context, snapshot cairnlinebridge.Snapshot) (*cairnline.Service, error) {
+	service := cairnline.NewMemoryService()
+	if err := cairnlinebridge.Seed(ctx, service, snapshot); err != nil {
+		return nil, err
+	}
+	return service, nil
 }
 
 func projectCairnlineReadModelFromService(ctx context.Context, service *cairnline.Service, projectID, readSource, dbPath string) (ProjectCairnlineReadModelResponseItem, error) {
@@ -1346,9 +1377,10 @@ func (h *Handler) nativeProjectAssistantProposalCount(ctx context.Context, proje
 	return len(proposals), nil
 }
 
-func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnlineGraphParityCounts, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, cairnlineOperations ProjectOperationsBriefResponse, nativeAssistantProposals int, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
+func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnlineGraphParityCounts, nativeWorkItems []ProjectWorkItemResponse, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, cairnlineWorkItems []ProjectWorkItemResponse, cairnlineOperations ProjectOperationsBriefResponse, nativeAssistantProposals int, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
 	hecate := ProjectCairnlineParitySnapshot{
-		Graph: nativeGraph,
+		Graph:     nativeGraph,
+		WorkItems: projectCairnlineWorkItemParityCounts(nativeWorkItems),
 		Activity: ProjectCairnlineActivityParityCounts{
 			WorkItems:   nativeActivity.Summary.WorkItemCount,
 			Assignments: nativeActivity.Summary.AssignmentCount,
@@ -1382,6 +1414,7 @@ func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnline
 			MemoryEntries:     readModel.MemoryEntryCount,
 			MemoryCandidates:  readModel.MemoryCandidateCount,
 		},
+		WorkItems: projectCairnlineWorkItemParityCounts(cairnlineWorkItems),
 		Activity: ProjectCairnlineActivityParityCounts{
 			WorkItems:   readModel.WorkItemCount,
 			Assignments: readModel.Activity.Counts.Assignments,
@@ -1410,6 +1443,20 @@ func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnline
 		Hecate:       hecate,
 		Cairnline:    cairnline,
 	}
+}
+
+func projectCairnlineWorkItemParityCounts(items []ProjectWorkItemResponse) ProjectCairnlineWorkItemParityCounts {
+	counts := ProjectCairnlineWorkItemParityCounts{
+		Items: len(items),
+	}
+	for _, item := range items {
+		if len(item.Assignments) == 0 {
+			counts.UnassignedItems++
+			continue
+		}
+		counts.EmbeddedAssignments += len(item.Assignments)
+	}
+	return counts
 }
 
 func projectCairnlineOperationsParityCounts(operations ProjectOperationsBriefResponse) ProjectCairnlineOperationsParityCounts {
@@ -1449,6 +1496,9 @@ func projectCairnlineParityDifferences(hecate, cairnline ProjectCairnlineParityS
 	differences = appendProjectCairnlineParityDifference(differences, "graph.handoffs", hecate.Graph.Handoffs, cairnline.Graph.Handoffs)
 	differences = appendProjectCairnlineParityDifference(differences, "graph.memory_entries", hecate.Graph.MemoryEntries, cairnline.Graph.MemoryEntries)
 	differences = appendProjectCairnlineParityDifference(differences, "graph.memory_candidates", hecate.Graph.MemoryCandidates, cairnline.Graph.MemoryCandidates)
+	differences = appendProjectCairnlineParityDifference(differences, "work_items.items", hecate.WorkItems.Items, cairnline.WorkItems.Items)
+	differences = appendProjectCairnlineParityDifference(differences, "work_items.embedded_assignments", hecate.WorkItems.EmbeddedAssignments, cairnline.WorkItems.EmbeddedAssignments)
+	differences = appendProjectCairnlineParityDifference(differences, "work_items.unassigned_items", hecate.WorkItems.UnassignedItems, cairnline.WorkItems.UnassignedItems)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.work_items", hecate.Activity.WorkItems, cairnline.Activity.WorkItems)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.assignments", hecate.Activity.Assignments, cairnline.Activity.Assignments)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.active", hecate.Activity.Active, cairnline.Activity.Active)

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -815,7 +815,7 @@ func TestProjectCairnlineContentDigestIgnoresVolatileTimestamps(t *testing.T) {
 }
 
 func TestProjectCairnlineParityReport_IncludesAssistantProposalDifferences(t *testing.T) {
-	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, ProjectOperationsBriefResponse{}, 2, ProjectCairnlineReadModelResponseItem{
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, nil, ProjectOperationsBriefResponse{}, 2, ProjectCairnlineReadModelResponseItem{
 		AssistantProposalCount: 1,
 	})
 	if report.Match {
@@ -835,7 +835,7 @@ func TestProjectCairnlineParityReport_IncludesGraphCountDifferences(t *testing.T
 		ContextSources:    2,
 		ExecutionProfiles: 4,
 		Artifacts:         3,
-	}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
+	}, nil, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, nil, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
 		RootCount:             1,
 		ContextSourceCount:    1,
 		ExecutionProfileCount: 3,
@@ -855,10 +855,34 @@ func TestProjectCairnlineParityReport_IncludesGraphCountDifferences(t *testing.T
 	}
 }
 
+func TestProjectCairnlineParityReport_IncludesWorkItemRouteProjectionDifferences(t *testing.T) {
+	nativeWorkItems := []ProjectWorkItemResponse{
+		{ID: "work_1", Assignments: []ProjectWorkAssignmentResponse{{ID: "asgn_1"}, {ID: "asgn_2"}}},
+		{ID: "work_2"},
+	}
+	cairnlineWorkItems := []ProjectWorkItemResponse{
+		{ID: "work_1", Assignments: []ProjectWorkAssignmentResponse{{ID: "asgn_1"}}},
+		{ID: "work_2"},
+	}
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nativeWorkItems, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, cairnlineWorkItems, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{})
+	if report.Match {
+		t.Fatalf("parity report match = true, want work-item route projection mismatch")
+	}
+	if report.Hecate.WorkItems.Items != 2 || report.Hecate.WorkItems.EmbeddedAssignments != 2 || report.Hecate.WorkItems.UnassignedItems != 1 {
+		t.Fatalf("hecate work-item parity = %+v, want 2 items, 2 embedded assignments, 1 unassigned", report.Hecate.WorkItems)
+	}
+	if report.Cairnline.WorkItems.Items != 2 || report.Cairnline.WorkItems.EmbeddedAssignments != 1 || report.Cairnline.WorkItems.UnassignedItems != 1 {
+		t.Fatalf("cairnline work-item parity = %+v, want 2 items, 1 embedded assignment, 1 unassigned", report.Cairnline.WorkItems)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "work_items.embedded_assignments", 2, 1) {
+		t.Fatalf("parity differences = %+v, want work_items.embedded_assignments 2/1", report.Differences)
+	}
+}
+
 func TestProjectCairnlineParityReport_IncludesLaunchPacketCoverageDifferences(t *testing.T) {
-	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectActivityDataResponse{
 		Summary: ProjectActivitySummaryResponse{AssignmentCount: 2},
-	}, ProjectOperationsBriefResponse{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
+	}, ProjectOperationsBriefResponse{}, nil, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
 		LaunchPacketCount:        1,
 		LaunchPacketWarningCount: 2,
 		LaunchPacketErrors: []ProjectCairnlineLaunchPacketError{{
@@ -910,7 +934,7 @@ func TestProjectCairnlineParityReport_IncludesOperationsDifferences(t *testing.T
 			{Kind: "start_queued_assignment"},
 		},
 	}
-	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, ProjectActivityDataResponse{}, nativeOperations, cairnlineOperations, 0, ProjectCairnlineReadModelResponseItem{})
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectActivityDataResponse{}, nativeOperations, nil, cairnlineOperations, 0, ProjectCairnlineReadModelResponseItem{})
 	if report.Match {
 		t.Fatalf("parity report match = true, want operations mismatch")
 	}

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -135,6 +135,10 @@ func (h *Handler) renderProjectWorkItems(ctx context.Context, projectID string) 
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectWorkItems(ctx, projectID)
 	}
+	return h.renderNativeProjectWorkItems(ctx, projectID)
+}
+
+func (h *Handler) renderNativeProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
 	items, err := h.projectWork.ListWorkItems(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -163,16 +167,20 @@ func (h *Handler) renderCairnlineProjectWorkItems(ctx context.Context, projectID
 		return nil, err
 	}
 	defer view.Close()
-	items, err := view.service.ListWorkItems(ctx, view.snapshot.Project.ID)
+	return h.renderCairnlineProjectWorkItemsFromService(ctx, view.service, view.snapshot)
+}
+
+func (h *Handler) renderCairnlineProjectWorkItemsFromService(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) ([]ProjectWorkItemResponse, error) {
+	items, err := service.ListWorkItems(ctx, snapshot.Project.ID)
 	if err != nil {
 		return nil, err
 	}
-	cairnlineAssignments, err := view.service.ListAssignments(ctx, view.snapshot.Project.ID)
+	cairnlineAssignments, err := service.ListAssignments(ctx, snapshot.Project.ID)
 	if err != nil {
 		return nil, err
 	}
-	workItems := projectWorkItemsFromCairnlineWithNativeTimestamps(items, view.snapshot.WorkItems)
-	assignments := projectWorkAssignmentsFromCairnline(cairnlineAssignments, view.snapshot.Assignments)
+	workItems := projectWorkItemsFromCairnlineWithNativeTimestamps(items, snapshot.WorkItems)
+	assignments := projectWorkAssignmentsFromCairnline(cairnlineAssignments, snapshot.Assignments)
 	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
 	data := make([]ProjectWorkItemResponse, 0, len(items))
 	for _, item := range workItems {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -433,6 +433,7 @@ type ProjectCairnlineParityReportResponseItem struct {
 
 type ProjectCairnlineParitySnapshot struct {
 	Graph         ProjectCairnlineGraphParityCounts        `json:"graph"`
+	WorkItems     ProjectCairnlineWorkItemParityCounts     `json:"work_items"`
 	Activity      ProjectCairnlineActivityParityCounts     `json:"activity"`
 	Operations    ProjectCairnlineOperationsParityCounts   `json:"operations"`
 	Assistant     ProjectCairnlineAssistantParityCounts    `json:"assistant"`
@@ -461,6 +462,12 @@ type ProjectCairnlineActivityParityCounts struct {
 	Blocked     int `json:"blocked"`
 	Completed   int `json:"completed"`
 	Recent      int `json:"recent"`
+}
+
+type ProjectCairnlineWorkItemParityCounts struct {
+	Items               int `json:"items"`
+	EmbeddedAssignments int `json:"embedded_assignments"`
+	UnassignedItems     int `json:"unassigned_items"`
 }
 
 type ProjectCairnlineOperationsParityCounts struct {


### PR DESCRIPTION
## Summary
- add rendered work-item route counts to the Cairnline parity report, including embedded assignments and unassigned items
- reuse the same seeded Cairnline service for snapshot read-model and work-item route projection checks
- split native/service work-item render helpers so replacement evidence can compare the actual API-shaped projection
- update Cairnline replacement-readiness docs to mention work-item route-shape parity

## Verification
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCairnlineParityReport|TestProjectCairnlineMirrorParityAPI|TestProjectWorkAPI_ProjectActivityUsesEmbeddedCairnlineWorkGraph'
- just agent-docs-check
- git diff --check
- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/cairnlinebridge
- GOCACHE="$PWD/.gocache" go test ./internal/api
- GOCACHE="$PWD/.gocache" go test ./...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...