### PR TITLE
test: add Cairnline collaboration route parity

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -164,12 +164,13 @@ mirror can serve project projections directly.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
 differences for raw graph counts including execution-profile defaults,
-rendered work-item route shape including embedded assignments, activity,
-rendered cockpit operations including action-kind counts, and the Project
-Assistant proposal ledger, plus portable launch-packet coverage, so import
-coverage, work-item projection drift, bucket/status semantics,
-operator-action drift, portable ledger coverage, and assignment packet coverage
-can be fixed before any backend switch.
+rendered work-item route shape including embedded assignments, collaboration
+artifact/handoff route shape including artifact-kind and handoff-status counts,
+activity, rendered cockpit operations including action-kind counts, and the
+Project Assistant proposal ledger, plus portable launch-packet coverage, so
+import coverage, work-item projection drift, review/evidence/handoff projection
+drift, bucket/status semantics, operator-action drift, portable ledger coverage,
+and assignment packet coverage can be fixed before any backend switch.
 `GET /hecate/v1/projects/{id}/cairnline/embedded-parity-report` performs the
 same cockpit comparison against the existing embedded Cairnline mirror database
 instead of the snapshot-seeded in-memory service. It is the stricter live-read

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -367,8 +367,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   does not make assignment-start Cairnline-backed.
 - The Hecate parity report compares raw graph counts, derived activity and
   operations counts, rendered work-item route shape including embedded
-  assignments, Project Assistant proposal-ledger counts, and launch-packet
-  coverage before any backend switch.
+  assignments, collaboration artifact/handoff route-shape counts, Project
+  Assistant proposal-ledger counts, and launch-packet coverage before any
+  backend switch.
 - The Hecate backend-status endpoint exposes the live Cairnline read-route
   coverage, non-authoritative bridge write seams, and remaining live-route
   write-adapter gap families as structured fields, so replacement readiness can

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -428,7 +428,8 @@ activity, and launch-packet projections directly from the existing embedded
 mirror database without seeding from Hecate stores; `GET
 /hecate/v1/projects/{id}/cairnline/embedded-parity-report` compares that live
 mirror read model with Hecate's native cockpit projections, including rendered
-work-item route shape with embedded assignments; and
+work-item route shape with embedded assignments plus collaboration
+artifact/handoff route-shape counts; and
 `POST /hecate/v1/projects/cairnline/sync` remains the explicit all-project
 rebuild/rehearsal action.
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2495,7 +2495,8 @@ Example response:
 
 Local-only experimental bridge endpoint. It loads the same in-memory Cairnline
 read model as `/cairnline/read-model`, renders Hecate's native project activity
-and operations brief, then compares raw graph counts, shared derived counts, and
+and operations brief, then compares raw graph counts, rendered work-item route
+shape, collaboration artifact/handoff route shape, shared derived counts, and
 assignment launch-packet coverage.
 
 This endpoint is a replacement-readiness report, not a backend switch. A
@@ -2531,6 +2532,24 @@ Example response:
         "handoffs": 1,
         "memory_entries": 3,
         "memory_candidates": 2
+      },
+      "work_items": {
+        "items": 1,
+        "embedded_assignments": 1,
+        "unassigned_items": 0
+      },
+      "collaboration": {
+        "artifacts": 4,
+        "handoffs": 1,
+        "artifact_kind_counts": {
+          "decision_note": 1,
+          "evidence_link": 1,
+          "handoff": 1,
+          "review": 1
+        },
+        "handoff_status_counts": {
+          "pending": 1
+        }
       },
       "activity": {
         "work_items": 1,
@@ -2580,6 +2599,24 @@ Example response:
         "memory_entries": 3,
         "memory_candidates": 2
       },
+      "work_items": {
+        "items": 1,
+        "embedded_assignments": 1,
+        "unassigned_items": 0
+      },
+      "collaboration": {
+        "artifacts": 4,
+        "handoffs": 1,
+        "artifact_kind_counts": {
+          "decision_note": 1,
+          "evidence_link": 1,
+          "handoff": 1,
+          "review": 1
+        },
+        "handoff_status_counts": {
+          "pending": 1
+        }
+      },
       "activity": {
         "work_items": 1,
         "assignments": 1,
@@ -2627,10 +2664,11 @@ Unlike `/cairnline/parity-report`, this endpoint does not use the
 snapshot-seeded in-memory service for the Cairnline side. It opens the existing
 embedded SQLite mirror database, reads portable graph/activity/launch-packet
 state from that database, and renders the Cairnline operations brief through
-Hecate's cockpit adapter so operation/action-kind counts can be compared with
-the native operator surface. A missing mirror database or a project absent from
-the mirror returns `404`; the endpoint does not create, seed, or repair the
-database.
+Hecate's cockpit adapter so work-item route shape, collaboration
+artifact/handoff route shape, and operation/action-kind counts can be compared
+with the native operator surface. A missing mirror database or a project absent
+from the mirror returns `404`; the endpoint does not create, seed, or repair
+the database.
 
 Use this endpoint as the stricter read-side replacement-readiness check: a
 matching report shows that the live embedded mirror can serve the same

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -228,6 +228,16 @@ func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	nativeCollaboration, err := h.nativeProjectCollaborationParityCounts(r.Context(), projectID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	cairnlineCollaboration, err := cairnlineProjectCollaborationParityCountsFromService(r.Context(), service, snapshot.Project.ID)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	nativeActivity, err := h.renderNativeProjectActivity(r.Context(), projectID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -248,7 +258,7 @@ func (h *Handler) HandleProjectCairnlineParityReport(w http.ResponseWriter, r *h
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	report := projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeWorkItems, nativeActivity, nativeOperations, cairnlineWorkItems, cairnlineOperations, nativeAssistantProposals, readModel)
+	report := projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeWorkItems, nativeCollaboration, nativeActivity, nativeOperations, cairnlineWorkItems, cairnlineCollaboration, cairnlineOperations, nativeAssistantProposals, readModel)
 	WriteJSON(w, http.StatusOK, ProjectCairnlineParityReportResponse{
 		Object: "project_cairnline_parity_report",
 		Data:   report,
@@ -321,6 +331,14 @@ func (h *Handler) projectCairnlineEmbeddedParityReport(ctx context.Context, proj
 	if err != nil {
 		return ProjectCairnlineParityReportResponseItem{}, err
 	}
+	nativeCollaboration, err := h.nativeProjectCollaborationParityCounts(ctx, projectID)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
+	cairnlineCollaboration, err := cairnlineProjectCollaborationParityCountsFromService(ctx, service, projectID)
+	if err != nil {
+		return ProjectCairnlineParityReportResponseItem{}, err
+	}
 	nativeActivity, err := h.renderNativeProjectActivity(ctx, projectID)
 	if err != nil {
 		return ProjectCairnlineParityReportResponseItem{}, err
@@ -337,7 +355,7 @@ func (h *Handler) projectCairnlineEmbeddedParityReport(ctx context.Context, proj
 	if err != nil {
 		return ProjectCairnlineParityReportResponseItem{}, err
 	}
-	return projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeWorkItems, nativeActivity, nativeOperations, cairnlineWorkItems, cairnlineOperations, nativeAssistantProposals, readModel), nil
+	return projectCairnlineParityReport(projectID, projectCairnlineSnapshotGraphCounts(snapshot), nativeWorkItems, nativeCollaboration, nativeActivity, nativeOperations, cairnlineWorkItems, cairnlineCollaboration, cairnlineOperations, nativeAssistantProposals, readModel), nil
 }
 
 func (h *Handler) openCairnlineEmbeddedService(ctx context.Context) (string, *cairnline.Service, *cairnline.SQLiteStore, error) {
@@ -1377,10 +1395,13 @@ func (h *Handler) nativeProjectAssistantProposalCount(ctx context.Context, proje
 	return len(proposals), nil
 }
 
-func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnlineGraphParityCounts, nativeWorkItems []ProjectWorkItemResponse, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, cairnlineWorkItems []ProjectWorkItemResponse, cairnlineOperations ProjectOperationsBriefResponse, nativeAssistantProposals int, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
+func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnlineGraphParityCounts, nativeWorkItems []ProjectWorkItemResponse, nativeCollaboration ProjectCairnlineCollaborationParityCounts, nativeActivity ProjectActivityDataResponse, nativeOperations ProjectOperationsBriefResponse, cairnlineWorkItems []ProjectWorkItemResponse, cairnlineCollaboration ProjectCairnlineCollaborationParityCounts, cairnlineOperations ProjectOperationsBriefResponse, nativeAssistantProposals int, readModel ProjectCairnlineReadModelResponseItem) ProjectCairnlineParityReportResponseItem {
+	nativeCollaboration = normalizeProjectCairnlineCollaborationParityCounts(nativeCollaboration)
+	cairnlineCollaboration = normalizeProjectCairnlineCollaborationParityCounts(cairnlineCollaboration)
 	hecate := ProjectCairnlineParitySnapshot{
-		Graph:     nativeGraph,
-		WorkItems: projectCairnlineWorkItemParityCounts(nativeWorkItems),
+		Graph:         nativeGraph,
+		WorkItems:     projectCairnlineWorkItemParityCounts(nativeWorkItems),
+		Collaboration: nativeCollaboration,
 		Activity: ProjectCairnlineActivityParityCounts{
 			WorkItems:   nativeActivity.Summary.WorkItemCount,
 			Assignments: nativeActivity.Summary.AssignmentCount,
@@ -1414,7 +1435,8 @@ func projectCairnlineParityReport(projectID string, nativeGraph ProjectCairnline
 			MemoryEntries:     readModel.MemoryEntryCount,
 			MemoryCandidates:  readModel.MemoryCandidateCount,
 		},
-		WorkItems: projectCairnlineWorkItemParityCounts(cairnlineWorkItems),
+		WorkItems:     projectCairnlineWorkItemParityCounts(cairnlineWorkItems),
+		Collaboration: cairnlineCollaboration,
 		Activity: ProjectCairnlineActivityParityCounts{
 			WorkItems:   readModel.WorkItemCount,
 			Assignments: readModel.Activity.Counts.Assignments,
@@ -1459,6 +1481,86 @@ func projectCairnlineWorkItemParityCounts(items []ProjectWorkItemResponse) Proje
 	return counts
 }
 
+func normalizeProjectCairnlineCollaborationParityCounts(counts ProjectCairnlineCollaborationParityCounts) ProjectCairnlineCollaborationParityCounts {
+	if counts.ArtifactKindCounts == nil {
+		counts.ArtifactKindCounts = map[string]int{}
+	}
+	if counts.HandoffStatusCounts == nil {
+		counts.HandoffStatusCounts = map[string]int{}
+	}
+	return counts
+}
+
+func (h *Handler) nativeProjectCollaborationParityCounts(ctx context.Context, projectID string) (ProjectCairnlineCollaborationParityCounts, error) {
+	artifacts, err := h.projectWork.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID})
+	if err != nil {
+		return ProjectCairnlineCollaborationParityCounts{}, err
+	}
+	handoffs, err := h.projectWork.ListHandoffs(ctx, projectwork.HandoffFilter{ProjectID: projectID})
+	if err != nil {
+		return ProjectCairnlineCollaborationParityCounts{}, err
+	}
+	renderedArtifacts := make([]ProjectWorkArtifactResponse, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		renderedArtifacts = append(renderedArtifacts, renderProjectWorkArtifact(artifact))
+	}
+	renderedHandoffs := make([]ProjectHandoffResponse, 0, len(handoffs))
+	for _, handoff := range handoffs {
+		renderedHandoffs = append(renderedHandoffs, renderProjectHandoff(handoff))
+	}
+	return projectCairnlineCollaborationParityCounts(renderedArtifacts, renderedHandoffs), nil
+}
+
+func cairnlineProjectCollaborationParityCountsFromService(ctx context.Context, service *cairnline.Service, projectID string) (ProjectCairnlineCollaborationParityCounts, error) {
+	workItems, err := service.ListWorkItems(ctx, projectID)
+	if err != nil {
+		return ProjectCairnlineCollaborationParityCounts{}, err
+	}
+	var renderedArtifacts []ProjectWorkArtifactResponse
+	for _, workItem := range workItems {
+		artifacts, err := cairnlineProjectWorkArtifacts(ctx, service, projectID, workItem.ID)
+		if err != nil {
+			return ProjectCairnlineCollaborationParityCounts{}, err
+		}
+		for _, artifact := range artifacts {
+			renderedArtifacts = append(renderedArtifacts, renderProjectWorkArtifact(artifact))
+		}
+	}
+	handoffs, err := cairnlineProjectHandoffs(ctx, service, projectID, "", "")
+	if err != nil {
+		return ProjectCairnlineCollaborationParityCounts{}, err
+	}
+	renderedHandoffs := make([]ProjectHandoffResponse, 0, len(handoffs))
+	for _, handoff := range handoffs {
+		renderedHandoffs = append(renderedHandoffs, renderProjectHandoff(handoff))
+	}
+	return projectCairnlineCollaborationParityCounts(renderedArtifacts, renderedHandoffs), nil
+}
+
+func projectCairnlineCollaborationParityCounts(artifacts []ProjectWorkArtifactResponse, handoffs []ProjectHandoffResponse) ProjectCairnlineCollaborationParityCounts {
+	counts := ProjectCairnlineCollaborationParityCounts{
+		Artifacts:           len(artifacts),
+		Handoffs:            len(handoffs),
+		ArtifactKindCounts:  map[string]int{},
+		HandoffStatusCounts: map[string]int{},
+	}
+	for _, item := range artifacts {
+		kind := strings.TrimSpace(item.Kind)
+		if kind == "" {
+			continue
+		}
+		counts.ArtifactKindCounts[kind]++
+	}
+	for _, item := range handoffs {
+		status := strings.TrimSpace(item.Status)
+		if status == "" {
+			continue
+		}
+		counts.HandoffStatusCounts[status]++
+	}
+	return counts
+}
+
 func projectCairnlineOperationsParityCounts(operations ProjectOperationsBriefResponse) ProjectCairnlineOperationsParityCounts {
 	counts := ProjectCairnlineOperationsParityCounts{
 		ItemCount:               operations.Summary.ItemCount,
@@ -1499,6 +1601,10 @@ func projectCairnlineParityDifferences(hecate, cairnline ProjectCairnlineParityS
 	differences = appendProjectCairnlineParityDifference(differences, "work_items.items", hecate.WorkItems.Items, cairnline.WorkItems.Items)
 	differences = appendProjectCairnlineParityDifference(differences, "work_items.embedded_assignments", hecate.WorkItems.EmbeddedAssignments, cairnline.WorkItems.EmbeddedAssignments)
 	differences = appendProjectCairnlineParityDifference(differences, "work_items.unassigned_items", hecate.WorkItems.UnassignedItems, cairnline.WorkItems.UnassignedItems)
+	differences = appendProjectCairnlineParityDifference(differences, "collaboration.artifacts", hecate.Collaboration.Artifacts, cairnline.Collaboration.Artifacts)
+	differences = appendProjectCairnlineParityDifference(differences, "collaboration.handoffs", hecate.Collaboration.Handoffs, cairnline.Collaboration.Handoffs)
+	differences = appendProjectCairnlineParityMapDifferences(differences, "collaboration.artifact_kind_counts", hecate.Collaboration.ArtifactKindCounts, cairnline.Collaboration.ArtifactKindCounts)
+	differences = appendProjectCairnlineParityMapDifferences(differences, "collaboration.handoff_status_counts", hecate.Collaboration.HandoffStatusCounts, cairnline.Collaboration.HandoffStatusCounts)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.work_items", hecate.Activity.WorkItems, cairnline.Activity.WorkItems)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.assignments", hecate.Activity.Assignments, cairnline.Activity.Assignments)
 	differences = appendProjectCairnlineParityDifference(differences, "activity.active", hecate.Activity.Active, cairnline.Activity.Active)

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -223,6 +223,12 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if parity.Data.Hecate.Graph.Roots != 1 || parity.Data.Cairnline.Graph.Roots != 1 || parity.Data.Hecate.Graph.ExecutionProfiles != readModel.Data.ExecutionProfileCount || parity.Data.Cairnline.Graph.ExecutionProfiles != readModel.Data.ExecutionProfileCount || parity.Data.Hecate.Graph.Artifacts != 2 || parity.Data.Cairnline.Graph.Artifacts != 2 || parity.Data.Hecate.Graph.MemoryEntries != 1 || parity.Data.Cairnline.Graph.MemoryEntries != 1 {
 		t.Fatalf("parity graph counts = hecate %+v cairnline %+v, want matching portable graph counts", parity.Data.Hecate.Graph, parity.Data.Cairnline.Graph)
 	}
+	if parity.Data.Hecate.Collaboration.Artifacts != 2 || parity.Data.Cairnline.Collaboration.Artifacts != 2 || parity.Data.Hecate.Collaboration.Handoffs != 1 || parity.Data.Cairnline.Collaboration.Handoffs != 1 {
+		t.Fatalf("parity collaboration counts = hecate %+v cairnline %+v, want matching review/evidence/handoff route counts", parity.Data.Hecate.Collaboration, parity.Data.Cairnline.Collaboration)
+	}
+	if parity.Data.Hecate.Collaboration.ArtifactKindCounts[projectwork.ArtifactKindReview] != 1 || parity.Data.Cairnline.Collaboration.ArtifactKindCounts[projectwork.ArtifactKindReview] != 1 || parity.Data.Hecate.Collaboration.ArtifactKindCounts[projectwork.ArtifactKindEvidenceLink] != 1 || parity.Data.Cairnline.Collaboration.ArtifactKindCounts[projectwork.ArtifactKindEvidenceLink] != 1 || parity.Data.Hecate.Collaboration.HandoffStatusCounts[projectwork.HandoffStatusPending] != 1 || parity.Data.Cairnline.Collaboration.HandoffStatusCounts[projectwork.HandoffStatusPending] != 1 {
+		t.Fatalf("parity collaboration kind/status counts = hecate %+v cairnline %+v, want matching review/evidence/pending handoff route shape", parity.Data.Hecate.Collaboration, parity.Data.Cairnline.Collaboration)
+	}
 	if parity.Data.Hecate.Operations.PendingMemoryCandidates != 1 || parity.Data.Cairnline.Operations.PendingMemoryCandidates != 1 || parity.Data.Hecate.Operations.OpenHandoffs != 1 || parity.Data.Cairnline.Operations.OpenHandoffs != 1 {
 		t.Fatalf("parity operations counts = hecate %+v cairnline %+v, want matching memory and handoff counts", parity.Data.Hecate.Operations, parity.Data.Cairnline.Operations)
 	}
@@ -700,6 +706,9 @@ func TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
 	if embeddedParity.Data.Hecate.Graph.Assignments != 1 || embeddedParity.Data.Cairnline.Graph.Assignments != 1 || embeddedParity.Data.Hecate.Activity.Blocked != 1 || embeddedParity.Data.Cairnline.Activity.Blocked != 1 || embeddedParity.Data.Hecate.LaunchPackets.Assignments != 1 || embeddedParity.Data.Cairnline.LaunchPackets.Assignments != 1 {
 		t.Fatalf("embedded parity snapshots = hecate %+v cairnline %+v, want matching representative assignment graph/activity/launch coverage", embeddedParity.Data.Hecate, embeddedParity.Data.Cairnline)
 	}
+	if embeddedParity.Data.Hecate.Collaboration.Artifacts != 2 || embeddedParity.Data.Cairnline.Collaboration.Artifacts != 2 || embeddedParity.Data.Hecate.Collaboration.Handoffs != 1 || embeddedParity.Data.Cairnline.Collaboration.Handoffs != 1 || embeddedParity.Data.Hecate.Collaboration.ArtifactKindCounts[projectwork.ArtifactKindReview] != 1 || embeddedParity.Data.Cairnline.Collaboration.ArtifactKindCounts[projectwork.ArtifactKindReview] != 1 || embeddedParity.Data.Hecate.Collaboration.HandoffStatusCounts[projectwork.HandoffStatusPending] != 1 || embeddedParity.Data.Cairnline.Collaboration.HandoffStatusCounts[projectwork.HandoffStatusPending] != 1 {
+		t.Fatalf("embedded collaboration route counts = hecate %+v cairnline %+v, want matching representative review/evidence/handoff route shape", embeddedParity.Data.Hecate.Collaboration, embeddedParity.Data.Cairnline.Collaboration)
+	}
 	if embeddedParity.Data.Hecate.Operations.KindCounts["start_queued_assignment"] != 1 || embeddedParity.Data.Cairnline.Operations.KindCounts["start_queued_assignment"] != 1 {
 		t.Fatalf("embedded operations kind counts = hecate %+v cairnline %+v, want adapter-rendered queued assignment action parity", embeddedParity.Data.Hecate.Operations.KindCounts, embeddedParity.Data.Cairnline.Operations.KindCounts)
 	}
@@ -815,7 +824,7 @@ func TestProjectCairnlineContentDigestIgnoresVolatileTimestamps(t *testing.T) {
 }
 
 func TestProjectCairnlineParityReport_IncludesAssistantProposalDifferences(t *testing.T) {
-	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, nil, ProjectOperationsBriefResponse{}, 2, ProjectCairnlineReadModelResponseItem{
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectCairnlineCollaborationParityCounts{}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, nil, ProjectCairnlineCollaborationParityCounts{}, ProjectOperationsBriefResponse{}, 2, ProjectCairnlineReadModelResponseItem{
 		AssistantProposalCount: 1,
 	})
 	if report.Match {
@@ -835,7 +844,7 @@ func TestProjectCairnlineParityReport_IncludesGraphCountDifferences(t *testing.T
 		ContextSources:    2,
 		ExecutionProfiles: 4,
 		Artifacts:         3,
-	}, nil, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, nil, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
+	}, nil, ProjectCairnlineCollaborationParityCounts{}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, nil, ProjectCairnlineCollaborationParityCounts{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
 		RootCount:             1,
 		ContextSourceCount:    1,
 		ExecutionProfileCount: 3,
@@ -864,7 +873,7 @@ func TestProjectCairnlineParityReport_IncludesWorkItemRouteProjectionDifferences
 		{ID: "work_1", Assignments: []ProjectWorkAssignmentResponse{{ID: "asgn_1"}}},
 		{ID: "work_2"},
 	}
-	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nativeWorkItems, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, cairnlineWorkItems, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{})
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nativeWorkItems, ProjectCairnlineCollaborationParityCounts{}, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, cairnlineWorkItems, ProjectCairnlineCollaborationParityCounts{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{})
 	if report.Match {
 		t.Fatalf("parity report match = true, want work-item route projection mismatch")
 	}
@@ -879,10 +888,52 @@ func TestProjectCairnlineParityReport_IncludesWorkItemRouteProjectionDifferences
 	}
 }
 
+func TestProjectCairnlineParityReport_IncludesCollaborationRouteProjectionDifferences(t *testing.T) {
+	nativeCollaboration := projectCairnlineCollaborationParityCounts(
+		[]ProjectWorkArtifactResponse{
+			{ID: "art_decision", Kind: projectwork.ArtifactKindDecisionNote},
+			{ID: "art_evidence", Kind: projectwork.ArtifactKindEvidenceLink},
+			{ID: "art_review", Kind: projectwork.ArtifactKindReview},
+		},
+		[]ProjectHandoffResponse{
+			{ID: "handoff_pending", Status: projectwork.HandoffStatusPending},
+			{ID: "handoff_accepted", Status: projectwork.HandoffStatusAccepted},
+		},
+	)
+	cairnlineCollaboration := projectCairnlineCollaborationParityCounts(
+		[]ProjectWorkArtifactResponse{
+			{ID: "art_decision", Kind: projectwork.ArtifactKindDecisionNote},
+			{ID: "art_review", Kind: projectwork.ArtifactKindReview},
+		},
+		[]ProjectHandoffResponse{
+			{ID: "handoff_pending", Status: projectwork.HandoffStatusPending},
+		},
+	)
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, nativeCollaboration, ProjectActivityDataResponse{}, ProjectOperationsBriefResponse{}, nil, cairnlineCollaboration, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{})
+	if report.Match {
+		t.Fatalf("parity report match = true, want collaboration route projection mismatch")
+	}
+	if report.Hecate.Collaboration.Artifacts != 3 || report.Cairnline.Collaboration.Artifacts != 2 || report.Hecate.Collaboration.Handoffs != 2 || report.Cairnline.Collaboration.Handoffs != 1 {
+		t.Fatalf("collaboration parity counts = hecate %+v cairnline %+v, want artifact and handoff count drift", report.Hecate.Collaboration, report.Cairnline.Collaboration)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "collaboration.artifacts", 3, 2) {
+		t.Fatalf("parity differences = %+v, want collaboration.artifacts 3/2", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "collaboration.handoffs", 2, 1) {
+		t.Fatalf("parity differences = %+v, want collaboration.handoffs 2/1", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "collaboration.artifact_kind_counts.evidence_link", 1, 0) {
+		t.Fatalf("parity differences = %+v, want collaboration.artifact_kind_counts.evidence_link 1/0", report.Differences)
+	}
+	if !hasProjectCairnlineParityDifference(report.Differences, "collaboration.handoff_status_counts.accepted", 1, 0) {
+		t.Fatalf("parity differences = %+v, want collaboration.handoff_status_counts.accepted 1/0", report.Differences)
+	}
+}
+
 func TestProjectCairnlineParityReport_IncludesLaunchPacketCoverageDifferences(t *testing.T) {
-	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectActivityDataResponse{
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectCairnlineCollaborationParityCounts{}, ProjectActivityDataResponse{
 		Summary: ProjectActivitySummaryResponse{AssignmentCount: 2},
-	}, ProjectOperationsBriefResponse{}, nil, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
+	}, ProjectOperationsBriefResponse{}, nil, ProjectCairnlineCollaborationParityCounts{}, ProjectOperationsBriefResponse{}, 0, ProjectCairnlineReadModelResponseItem{
 		LaunchPacketCount:        1,
 		LaunchPacketWarningCount: 2,
 		LaunchPacketErrors: []ProjectCairnlineLaunchPacketError{{
@@ -934,7 +985,7 @@ func TestProjectCairnlineParityReport_IncludesOperationsDifferences(t *testing.T
 			{Kind: "start_queued_assignment"},
 		},
 	}
-	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectActivityDataResponse{}, nativeOperations, nil, cairnlineOperations, 0, ProjectCairnlineReadModelResponseItem{})
+	report := projectCairnlineParityReport("proj_parity", ProjectCairnlineGraphParityCounts{}, nil, ProjectCairnlineCollaborationParityCounts{}, ProjectActivityDataResponse{}, nativeOperations, nil, ProjectCairnlineCollaborationParityCounts{}, cairnlineOperations, 0, ProjectCairnlineReadModelResponseItem{})
 	if report.Match {
 		t.Fatalf("parity report match = true, want operations mismatch")
 	}

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -432,12 +432,13 @@ type ProjectCairnlineParityReportResponseItem struct {
 }
 
 type ProjectCairnlineParitySnapshot struct {
-	Graph         ProjectCairnlineGraphParityCounts        `json:"graph"`
-	WorkItems     ProjectCairnlineWorkItemParityCounts     `json:"work_items"`
-	Activity      ProjectCairnlineActivityParityCounts     `json:"activity"`
-	Operations    ProjectCairnlineOperationsParityCounts   `json:"operations"`
-	Assistant     ProjectCairnlineAssistantParityCounts    `json:"assistant"`
-	LaunchPackets ProjectCairnlineLaunchPacketParityCounts `json:"launch_packets"`
+	Graph         ProjectCairnlineGraphParityCounts         `json:"graph"`
+	WorkItems     ProjectCairnlineWorkItemParityCounts      `json:"work_items"`
+	Collaboration ProjectCairnlineCollaborationParityCounts `json:"collaboration"`
+	Activity      ProjectCairnlineActivityParityCounts      `json:"activity"`
+	Operations    ProjectCairnlineOperationsParityCounts    `json:"operations"`
+	Assistant     ProjectCairnlineAssistantParityCounts     `json:"assistant"`
+	LaunchPackets ProjectCairnlineLaunchPacketParityCounts  `json:"launch_packets"`
 }
 
 type ProjectCairnlineGraphParityCounts struct {
@@ -468,6 +469,13 @@ type ProjectCairnlineWorkItemParityCounts struct {
 	Items               int `json:"items"`
 	EmbeddedAssignments int `json:"embedded_assignments"`
 	UnassignedItems     int `json:"unassigned_items"`
+}
+
+type ProjectCairnlineCollaborationParityCounts struct {
+	Artifacts           int            `json:"artifacts"`
+	Handoffs            int            `json:"handoffs"`
+	ArtifactKindCounts  map[string]int `json:"artifact_kind_counts"`
+	HandoffStatusCounts map[string]int `json:"handoff_status_counts"`
 }
 
 type ProjectCairnlineOperationsParityCounts struct {


### PR DESCRIPTION
## Summary
- add collaboration artifact/handoff route-shape counts to Cairnline parity snapshots
- compare artifact-kind and handoff-status drift in parity reports
- update Cairnline readiness docs and runtime API response example

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline(ExportAPI|MirrorParityAPI|ParityReport)|TestProjectWorkAPI_ProjectArtifactsAndHandoffsCairnlineConfiguredUseReadModel'
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...