### PR TITLE
feat: add strict Cairnline read source mode

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -129,10 +129,13 @@ and operations brief can use the Cairnline read model for portable setup/work
 state. Configured read routes prefer the embedded Cairnline mirror database
 when it already contains the requested project; if the mirror database or
 project row is missing, they fall back to the snapshot-seeded in-memory bridge
-projection. Activity, work-item list/detail, assignment-list, and operations
-brief reads render work items, assignments, roles, artifacts, and handoffs from
-the Cairnline service records, then overlay Hecate-only runtime refs/timestamps
-where Hecate still owns execution.
+projection. `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot` forces that
+snapshot-seeded bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`
+requires the embedded mirror database and project row so replacement-readiness
+gaps fail loudly during dogfood. Activity, work-item list/detail,
+assignment-list, and operations brief reads render work items, assignments,
+roles, artifacts, and handoffs from the Cairnline service records, then overlay
+Hecate-only runtime refs/timestamps where Hecate still owns execution.
 Project identity and some compatibility scaffolding still come from Hecate
 until Cairnline becomes authoritative. Project Assistant draft generation also
 uses the Cairnline-projected

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -347,7 +347,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   generic/evidence/review artifact lists, handoff lists, Project Assistant
   context/proposal reads, activity, closeout readiness, and operations brief
   reads from a Cairnline-seeded read model while Hecate stores remain
-  authoritative.
+  authoritative. `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto` prefers the
+  embedded mirror database when it already contains the requested project and
+  otherwise uses the snapshot-seeded bridge; `snapshot` forces the bridge; and
+  `embedded` requires a populated embedded mirror so read-route drift fails
+  loudly during replacement-readiness dogfood.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -374,10 +374,17 @@ task/external agent supervision, approvals, and assignment mutation. Project
 reads backed by the Cairnline read model prefer the embedded Cairnline mirror
 database when that database already contains the requested project; if the
 mirror database or project row is missing, they fall back to the snapshot-seeded
-in-memory bridge projection. Activity, work-item list/detail, assignment-list,
-and operations brief reads render the work graph from Cairnline service records
-and overlay Hecate-only runtime refs/timestamps while Hecate still owns
-execution. Project identity and some compatibility
+in-memory bridge projection. Set
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot` to force the snapshot-seeded
+bridge, or `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` to make configured
+read routes require a populated
+`{HECATE_DATA_DIR}/cairnline/embedded/projects.db` and fail loudly when the
+mirror database or project row is missing; run
+`POST /hecate/v1/projects/cairnline/sync` first when dogfooding strict embedded
+reads. Activity, work-item list/detail, assignment-list, and operations brief
+reads render the work graph from Cairnline service records and overlay
+Hecate-only runtime refs/timestamps while Hecate still owns execution. Project
+identity and some compatibility
 scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
 metadata, root create/update/delete/discovery/worktree-creation,
 context-source create/update/delete/discovery, and default mutations still write

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -462,6 +462,17 @@ sequenceDiagram
   authoritative until the feature-flagged Cairnline read/write adapter and
   migration path land. Use
   `GET /hecate/v1/projects/backend-status` to inspect the effective state.
+- `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
+  Cairnline service backing configured read routes use while
+  `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. The default `auto` prefers
+  the embedded mirror database under
+  `{HECATE_DATA_DIR}/cairnline/embedded/projects.db` when it already contains
+  the requested project and otherwise falls back to the snapshot-seeded
+  in-memory bridge. `snapshot` always uses the snapshot-seeded bridge.
+  `embedded` is a strict replacement-readiness dogfood mode: configured read
+  routes require a populated embedded mirror database and fail if the database
+  or project row is missing. Run `POST /hecate/v1/projects/cairnline/sync`
+  first when testing strict embedded reads.
 - `HECATE_POSTGRES_URL=postgres://...` or `DATABASE_URL=postgres://...` is
   required when `HECATE_BACKEND=postgres`. Optional Postgres knobs:
   `HECATE_POSTGRES_TABLE_PREFIX`, `HECATE_POSTGRES_MAX_OPEN_CONNS`, and
@@ -2209,6 +2220,7 @@ It exists to make the Cairnline replacement switch explicit while the adapter is
 being built.
 
 `configured_backend` reflects `HECATE_PROJECTS_COORDINATION_BACKEND`.
+`cairnline_read_source` reflects `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`.
 `authoritative_backend` remains `hecate` until Hecate can run project read/write
 flows against Cairnline without UI-local fallback state. When
 `configured_backend=cairnline`, Hecate still commits live Projects writes to the
@@ -2221,10 +2233,12 @@ assignment context previews, assignment launch-readiness, assignment preflight,
 artifact lists, handoff lists, Project Assistant context/proposal reads,
 closeout readiness, activity inbox, and operations brief can be served from the
 Cairnline read model, while other live Projects reads still use Hecate. Those
-configured read routes still use Hecate snapshots as bridge scaffolding, but
-their Cairnline service reads prefer the embedded mirror database when it
-already contains the requested project; if the mirror database or project row is
-missing, they fall back to the snapshot-seeded in-memory bridge projection.
+configured read routes still load Hecate snapshots as bridge scaffolding, but
+their Cairnline service read source is controlled by
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
+falls back to the snapshot-seeded bridge, `snapshot` always uses the
+snapshot-seeded bridge, and `embedded` requires the mirror database/project row
+to exist so replacement-readiness gaps fail loudly.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
@@ -2294,6 +2308,7 @@ Example response:
     "configured_backend": "cairnline",
     "authoritative_backend": "hecate",
     "storage_backend": "sqlite",
+    "cairnline_read_source": "auto",
     "cairnline_bridge_ready": true,
     "cairnline_authoritative": false,
     "read_model_switch_ready": true,
@@ -2376,10 +2391,10 @@ Example response:
       "migration-cutover"
     ],
     "status": "cairnline_read_routes_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. When the embedded mirror database contains the project, their Cairnline service reads use that live mirror; otherwise they fall back to the snapshot-seeded in-memory bridge. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Configured read routes prefer the embedded mirror database when it already contains the requested project; otherwise they fall back to the snapshot-seeded in-memory bridge projection. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
     "warnings": [
       "Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
-      "Configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection.",
+      "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection.",
       "Project create/delete still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database.",
       "Project metadata updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata seam.",
       "Root create/update/delete, root list replacement, root discovery, and worktree-root creation mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API.",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -98,14 +98,17 @@ func (h *Handler) HandleProjectCoordinationBackendStatus(w http.ResponseWriter, 
 func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendStatusResponse {
 	configured := "hecate"
 	storageBackend := ""
+	readSource := "auto"
 	if h != nil {
 		configured = h.config.ProjectsCoordinationBackend()
 		storageBackend = h.config.Projects.Backend
+		readSource = h.config.ProjectsCairnlineReadSource()
 	}
 	response := ProjectCoordinationBackendStatusResponse{
 		ConfiguredBackend:       configured,
 		AuthoritativeBackend:    "hecate",
 		StorageBackend:          storageBackend,
+		CairnlineReadSource:     readSource,
 		CairnlineBridgeReady:    true,
 		CairnlineAuthoritative:  false,
 		WriteAdapterReady:       false,
@@ -124,10 +127,10 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if readReady {
 			response.ReadRoutes = append([]string(nil), projectCairnlineReadRouteNames...)
 			response.Status = "cairnline_read_routes_ready"
-			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. When the embedded mirror database contains the project, their Cairnline service reads use that live mirror; otherwise they fall back to the snapshot-seeded in-memory bridge. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
+			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. " + projectCairnlineReadSourceDetail(readSource) + " Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready."
 			response.Warnings = []string{
 				"Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
-				"Configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection.",
+				projectCairnlineReadSourceWarning(readSource),
 				"Project create/delete still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database.",
 				"Project metadata updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata seam.",
 				"Root create/update/delete, root list replacement, root discovery, and worktree-root creation mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API.",
@@ -156,6 +159,28 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.Detail = "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks."
 	}
 	return response
+}
+
+func projectCairnlineReadSourceDetail(source string) string {
+	switch source {
+	case "embedded":
+		return "Configured read routes require the embedded mirror database and requested project row; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
+	case "snapshot":
+		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
+	default:
+		return "Configured read routes prefer the embedded mirror database when it already contains the requested project; otherwise they fall back to the snapshot-seeded in-memory bridge projection."
+	}
+}
+
+func projectCairnlineReadSourceWarning(source string) string {
+	switch source {
+	case "embedded":
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database or project row is missing."
+	case "snapshot":
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
+	default:
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection."
+	}
 }
 
 func (h *Handler) cairnlineReadModelReadiness() (bool, []string) {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -21,6 +21,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.ConfiguredBackend != "hecate" || status.AuthoritativeBackend != "hecate" || status.StorageBackend != "sqlite" {
 		t.Fatalf("status = %+v, want Hecate authoritative over sqlite project storage", status)
 	}
+	if status.CairnlineReadSource != "auto" {
+		t.Fatalf("cairnline read source = %q, want auto", status.CairnlineReadSource)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -63,6 +66,7 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 		Projects: config.ProjectsConfig{
 			Backend:             "sqlite",
 			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
 		},
 	}, quietLogger(), nil, nil, nil, nil)
 
@@ -70,11 +74,17 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_read_routes_ready" {
 		t.Fatalf("status = %+v, want configured Cairnline with read routes ready", status)
 	}
+	if status.CairnlineReadSource != "embedded" {
+		t.Fatalf("cairnline read source = %q, want embedded", status.CairnlineReadSource)
+	}
 	if status.CairnlineAuthoritative || !status.ReadModelSwitchReady || status.WriteAdapterReady {
 		t.Fatalf("status = %+v, want read adapter ready but Hecate still authoritative", status)
 	}
 	if len(status.Warnings) == 0 {
 		t.Fatalf("status = %+v, want write-adapter/migration warning", status)
+	}
+	if !strings.Contains(strings.Join(status.Warnings, "\n"), "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded") {
+		t.Fatalf("warnings = %+v, want embedded read-source warning", status.Warnings)
 	}
 	if !containsString(status.ReadRoutes, "project-list") || !containsString(status.ReadRoutes, "assignment-context") || !containsString(status.ReadRoutes, "launch-readiness") || !containsString(status.ReadRoutes, "assignment-preflight") || !containsString(status.ReadRoutes, "project-assistant-context") || !containsString(status.ReadRoutes, "project-assistant-proposal") || !containsString(status.ReadRoutes, "operations-brief") {
 		t.Fatalf("read routes = %+v, want structured Cairnline read-route coverage", status.ReadRoutes)

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -380,12 +380,13 @@ func (h *Handler) cairnlineProjectWorkView(ctx context.Context, projectID string
 	if err != nil {
 		return nil, err
 	}
+	strictEmbedded := h.requiresEmbeddedCairnlineProjectReads()
 	if h.prefersEmbeddedCairnlineProjectReads() {
 		_, service, store, err := h.openCairnlineEmbeddedService(ctx)
 		if err == nil {
 			if _, err := service.GetProject(ctx, snapshot.Project.ID); err != nil {
 				_ = store.Close()
-				if errors.Is(err, cairnline.ErrNotFound) {
+				if !strictEmbedded && errors.Is(err, cairnline.ErrNotFound) {
 					return h.cairnlineProjectWorkSeededView(ctx, snapshot)
 				}
 				return nil, err
@@ -396,17 +397,38 @@ func (h *Handler) cairnlineProjectWorkView(ctx context.Context, projectID string
 				close:    store.Close,
 			}, nil
 		}
-		if !errors.Is(err, cairnline.ErrNotFound) {
+		if strictEmbedded || !errors.Is(err, cairnline.ErrNotFound) {
 			return nil, err
 		}
 	}
 	return h.cairnlineProjectWorkSeededView(ctx, snapshot)
 }
 
-func (h *Handler) prefersEmbeddedCairnlineProjectReads() bool {
+func (h *Handler) cairnlineProjectReadSource() string {
+	if h == nil {
+		return "auto"
+	}
+	return h.config.ProjectsCairnlineReadSource()
+}
+
+func (h *Handler) requiresEmbeddedCairnlineProjectReads() bool {
 	return h != nil &&
 		h.config.ProjectsCoordinationBackend() == "cairnline" &&
-		strings.TrimSpace(h.config.Server.DataDir) != ""
+		h.cairnlineProjectReadSource() == "embedded"
+}
+
+func (h *Handler) prefersEmbeddedCairnlineProjectReads() bool {
+	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+		return false
+	}
+	switch h.cairnlineProjectReadSource() {
+	case "embedded":
+		return true
+	case "snapshot":
+		return false
+	default:
+		return strings.TrimSpace(h.config.Server.DataDir) != ""
+	}
 }
 
 func (h *Handler) cairnlineProjectWorkSeededView(ctx context.Context, snapshot cairnlinebridge.Snapshot) (*cairnlineProjectWorkView, error) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -78,6 +78,91 @@ func newProjectWorkCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handl
 	return handler, NewServer(quietLogger(), handler)
 }
 
+func newProjectWorkCairnlineReadSourceTestHandler(t *testing.T, source string) *Handler {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: source,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_read_source",
+		Name: "Read source",
+	}); err != nil {
+		t.Fatalf("create read-source project: %v", err)
+	}
+	return handler
+}
+
+func TestProjectWorkAPI_CairnlineReadSourceSnapshotUsesSeededBridge(t *testing.T) {
+	t.Parallel()
+	handler := newProjectWorkCairnlineReadSourceTestHandler(t, "snapshot")
+	if handler.prefersEmbeddedCairnlineProjectReads() {
+		t.Fatal("prefersEmbeddedCairnlineProjectReads() = true, want false for snapshot read source")
+	}
+
+	view, err := handler.cairnlineProjectWorkView(t.Context(), "proj_read_source")
+	if err != nil {
+		t.Fatalf("cairnlineProjectWorkView(snapshot) error = %v, want nil", err)
+	}
+	defer view.Close()
+	if _, err := view.service.GetProject(t.Context(), "proj_read_source"); err != nil {
+		t.Fatalf("GetProject from snapshot-seeded view error = %v, want nil", err)
+	}
+}
+
+func TestProjectWorkAPI_CairnlineReadSourceAutoFallsBackWhenMirrorMissing(t *testing.T) {
+	t.Parallel()
+	handler := newProjectWorkCairnlineReadSourceTestHandler(t, "auto")
+	if !handler.prefersEmbeddedCairnlineProjectReads() {
+		t.Fatal("prefersEmbeddedCairnlineProjectReads() = false, want true for auto read source with data dir")
+	}
+
+	view, err := handler.cairnlineProjectWorkView(t.Context(), "proj_read_source")
+	if err != nil {
+		t.Fatalf("cairnlineProjectWorkView(auto) error = %v, want nil fallback", err)
+	}
+	defer view.Close()
+	if _, err := view.service.GetProject(t.Context(), "proj_read_source"); err != nil {
+		t.Fatalf("GetProject from auto fallback view error = %v, want nil", err)
+	}
+}
+
+func TestProjectWorkAPI_CairnlineReadSourceEmbeddedRequiresMirror(t *testing.T) {
+	t.Parallel()
+	handler := newProjectWorkCairnlineReadSourceTestHandler(t, "embedded")
+	if !handler.requiresEmbeddedCairnlineProjectReads() {
+		t.Fatal("requiresEmbeddedCairnlineProjectReads() = false, want true for embedded read source")
+	}
+
+	if _, err := handler.cairnlineProjectWorkView(t.Context(), "proj_read_source"); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("cairnlineProjectWorkView(embedded missing db) error = %v, want ErrNotFound", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(handler.cairnlineEmbeddedDatabasePath()), 0o700); err != nil {
+		t.Fatalf("create embedded Cairnline mirror parent: %v", err)
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("create empty embedded Cairnline mirror: %v", err)
+	}
+	if _, err := service.ListProjects(t.Context()); err != nil {
+		store.Close()
+		t.Fatalf("ListProjects on empty embedded Cairnline mirror: %v", err)
+	}
+	store.Close()
+	if _, err := handler.cairnlineProjectWorkView(t.Context(), "proj_read_source"); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("cairnlineProjectWorkView(embedded missing project) error = %v, want ErrNotFound", err)
+	}
+}
+
 type launchContextContract struct {
 	Sections []string            `json:"sections"`
 	Fields   map[string][]string `json:"fields"`

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -516,6 +516,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	ConfiguredBackend       string   `json:"configured_backend"`
 	AuthoritativeBackend    string   `json:"authoritative_backend"`
 	StorageBackend          string   `json:"storage_backend"`
+	CairnlineReadSource     string   `json:"cairnline_read_source,omitempty"`
 	CairnlineBridgeReady    bool     `json:"cairnline_bridge_ready"`
 	CairnlineAuthoritative  bool     `json:"cairnline_authoritative"`
 	ReadModelSwitchReady    bool     `json:"read_model_switch_ready"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,10 +228,15 @@ type ChatConfig struct {
 type ProjectsConfig struct {
 	Backend             string
 	CoordinationBackend string
+	CairnlineReadSource string
 }
 
 func (c Config) ProjectsCoordinationBackend() string {
 	return normalizeProjectsCoordinationBackend(c.Projects.CoordinationBackend)
+}
+
+func (c Config) ProjectsCairnlineReadSource() string {
+	return normalizeProjectsCairnlineReadSource(c.Projects.CairnlineReadSource)
 }
 
 type OTelSignalConfig struct {
@@ -476,6 +481,7 @@ func LoadFromEnv() Config {
 		Projects: ProjectsConfig{
 			Backend:             storageBackend,
 			CoordinationBackend: strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_COORDINATION_BACKEND", "hecate"))),
+			CairnlineReadSource: strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "auto"))),
 		},
 		OTel: loadOTelFromEnv(),
 		Governor: GovernorConfig{
@@ -560,6 +566,7 @@ func (c Config) Validate() error {
 		validateBackend("HECATE_BACKEND", backend, "memory", "sqlite", "postgres")
 	}
 	validateBackend("HECATE_PROJECTS_COORDINATION_BACKEND", c.ProjectsCoordinationBackend(), "hecate", "cairnline")
+	validateBackend("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", c.ProjectsCairnlineReadSource(), "auto", "snapshot", "embedded")
 	if postgresRequired(c) && strings.TrimSpace(c.Postgres.DatabaseURL) == "" {
 		errs = append(errs, errors.New("HECATE_POSTGRES_URL or DATABASE_URL is required when HECATE_BACKEND=postgres"))
 	}
@@ -1139,6 +1146,14 @@ func normalizeProjectsCoordinationBackend(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
 	if value == "" {
 		return "hecate"
+	}
+	return value
+}
+
+func normalizeProjectsCairnlineReadSource(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "auto"
 	}
 	return value
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -448,6 +448,22 @@ func TestLoadFromEnvProjectsCoordinationBackend(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvProjectsCairnlineReadSource(t *testing.T) {
+	cfg := LoadFromEnv()
+	if got := cfg.ProjectsCairnlineReadSource(); got != "auto" {
+		t.Fatalf("ProjectsCairnlineReadSource() = %q, want auto", got)
+	}
+
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", " Embedded ")
+	cfg = LoadFromEnv()
+	if got := cfg.ProjectsCairnlineReadSource(); got != "embedded" {
+		t.Fatalf("ProjectsCairnlineReadSource() = %q, want embedded", got)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil for embedded Cairnline read source", err)
+	}
+}
+
 func TestValidateRejectsInvalidProjectsCoordinationBackend(t *testing.T) {
 	cfg := LoadFromEnv()
 	cfg.Projects.CoordinationBackend = "cairnline_shadow"
@@ -458,6 +474,19 @@ func TestValidateRejectsInvalidProjectsCoordinationBackend(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_PROJECTS_COORDINATION_BACKEND") {
 		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_COORDINATION_BACKEND", err)
+	}
+}
+
+func TestValidateRejectsInvalidProjectsCairnlineReadSource(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Projects.CairnlineReadSource = "live"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid projects Cairnline read source error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE") {
+		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` for Cairnline-backed Projects read routes.
- Keep `auto` on the existing embedded-mirror-then-snapshot fallback, add `snapshot` for deterministic bridge reads, and make `embedded` fail loudly when the mirror database or project row is missing.
- Surface `cairnline_read_source` in backend status and update runtime/operator/design docs.

## Validation

- `git diff --check`
- `GOCACHE="$PWD/.gocache" go vet ./internal/config ./internal/api`
- `GOCACHE="$PWD/.gocache" go test ./internal/config -run 'TestLoadFromEnvProjectsCairnlineReadSource|TestValidateRejectsInvalidProjectsCairnlineReadSource'`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_CairnlineReadSource|TestProjectCoordinationBackendStatus'`
- `just agent-docs-check`
- `GOCACHE="$PWD/.gocache" go test ./internal/config ./internal/api`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`