### PR TITLE
test: cover strict Cairnline sync route reads

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -309,8 +309,9 @@ after these gates are met:
   move.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha; the embedded Cairnline sync database proves a
-  durable all-project seed with count-level, ID-set, record-content, and stable
-  launch-packet content parity before it becomes a write path.
+  durable all-project seed with count-level, ID-set, record-content, stable
+  launch-packet content parity, and strict embedded configured-route smoke
+  before it becomes a write path.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -413,7 +413,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   authoritative write adapter exists. The sync response compares aggregate
   Hecate snapshot counts, normalized record ID sets, and semantic
   record-content digests with the embedded database and reports count-level,
-  ID-set, and content-digest differences.
+  ID-set, and content-digest differences. Hecate also uses strict embedded
+  configured-route smoke tests after sync to prove normal project/detail,
+  work-item, activity, and operations reads can run from that synced database.
 - After V0 stabilizes, Hecate may embed the portable core as its Projects
   backend or talk to the MCP server as a separate local coordination process.
 - Hecate remains the richer cockpit and orchestrator for supervised Hecate

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -427,6 +427,29 @@ func TestProjectCairnlineSyncAPI_WritesDurableAllProjectsSQLiteDB(t *testing.T) 
 	if contentDigests["launch_packets"][launchPacketID] == "" {
 		t.Fatalf("launch packet content digests = %+v, want digest for %s", contentDigests["launch_packets"], launchPacketID)
 	}
+
+	handler.config.Projects.CoordinationBackend = "cairnline"
+	handler.config.Projects.CairnlineReadSource = "embedded"
+
+	detail := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+firstProject.Data.ID, "")
+	if detail.Data.ReadBackend != "cairnline" || detail.Data.ID != firstProject.Data.ID || len(detail.Data.Roots) != 1 {
+		t.Fatalf("strict embedded project detail = %+v, want synced Cairnline-backed rooted project", detail.Data)
+	}
+	workItems := mustRequestJSONStatus[ProjectWorkItemsResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+firstProject.Data.ID+"/work-items", "")
+	if len(workItems.Data) != 1 || workItems.Data[0].ID != work.Data.ID || workItems.Data[0].ReadBackend != "cairnline" || len(workItems.Data[0].Assignments) != 1 || workItems.Data[0].Assignments[0].ID != assignment.Data.ID || workItems.Data[0].Assignments[0].ReadBackend != "cairnline" {
+		t.Fatalf("strict embedded work items = %+v, want synced Cairnline-backed work item and assignment", workItems.Data)
+	}
+	activity := mustRequestJSONStatus[ProjectActivityEnvelope](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+firstProject.Data.ID+"/activity", "")
+	if activity.Data.ReadBackend != "cairnline" || activity.Data.Summary.WorkItemCount != 1 || activity.Data.Summary.AssignmentCount != 1 || activity.Data.Summary.BlockedCount != 1 || len(activity.Data.Buckets.Blocked) != 1 || activity.Data.Buckets.Blocked[0].Assignment.ID != assignment.Data.ID {
+		t.Fatalf("strict embedded activity = %+v, want synced Cairnline-backed queued assignment activity", activity.Data)
+	}
+	operations := mustRequestJSONStatus[ProjectOperationsBriefEnvelope](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+firstProject.Data.ID+"/operations/brief", "")
+	if operations.Data.ReadBackend != "cairnline" || operations.Data.Summary.ItemCount == 0 || operations.Data.Summary.AvailableItemCount == 0 || operations.Data.Summary.PendingMemoryCandidateCount != 0 {
+		t.Fatalf("strict embedded operations = %+v, want synced Cairnline-backed operations brief", operations.Data)
+	}
+	if len(operations.Data.Items) == 0 || operations.Data.Items[0].Assignment == nil || operations.Data.Items[0].Assignment.ID != assignment.Data.ID {
+		t.Fatalf("strict embedded operations items = %+v, want queued assignment action from synced Cairnline DB", operations.Data.Items)
+	}
 }
 
 func TestProjectCairnlineMirrorParityAPI_MissingDatabaseDoesNotCreateMirror(t *testing.T) {


### PR DESCRIPTION
## Summary

- Extend the all-project Cairnline sync test to flip into strict embedded read mode after sync.
- Verify normal project detail, work-item, activity, and operations routes can read from the synced embedded Cairnline database.
- Update the Cairnline design docs to record strict embedded configured-route smoke as part of migration rehearsal evidence.

## Validation

- `git diff --check`
- `just agent-docs-check`
- `GOCACHE="$PWD/.gocache" go vet ./internal/api`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCairnlineSyncAPI_WritesDurableAllProjectsSQLiteDB'`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`