### PR TITLE
test: smoke strict Cairnline read routes

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -311,6 +311,8 @@ after these gates are met:
   rolled back during alpha; the embedded Cairnline sync database proves a
   durable all-project seed with count-level, ID-set, record-content, stable
   launch-packet content parity, and strict embedded configured-route smoke
+  across representative project, setup, health, skill, memory, role, work,
+  collaboration, assistant-context, activity, and operations route families
   before it becomes a write path.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -414,8 +414,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   Hecate snapshot counts, normalized record ID sets, and semantic
   record-content digests with the embedded database and reports count-level,
   ID-set, and content-digest differences. Hecate also uses strict embedded
-  configured-route smoke tests after sync to prove normal project/detail,
-  work-item, activity, and operations reads can run from that synced database.
+  configured-route smoke tests after sync and live-mirror parity to prove normal
+  project, setup, health, skill, memory, role, work, collaboration, assistant
+  context, activity, and operations reads can run from the embedded database.
 - After V0 stabilizes, Hecate may embed the portable core as its Projects
   backend or talk to the MCP server as a separate local coordination process.
 - Hecate remains the richer cockpit and orchestrator for supervised Hecate

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -734,6 +735,39 @@ func TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
 	}
 	if embeddedParity.Data.Hecate.Operations.KindCounts["start_queued_assignment"] != 1 || embeddedParity.Data.Cairnline.Operations.KindCounts["start_queued_assignment"] != 1 {
 		t.Fatalf("embedded operations kind counts = hecate %+v cairnline %+v, want adapter-rendered queued assignment action parity", embeddedParity.Data.Hecate.Operations.KindCounts, embeddedParity.Data.Cairnline.Operations.KindCounts)
+	}
+
+	handler.config.Projects.CairnlineReadSource = "embedded"
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects", "", "project list")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID, "", "project detail")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/setup-readiness", "", "setup readiness")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/health", "", "health")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/skills", "", "skills")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/memory", "", "memory")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/memory/candidates", "", "memory candidates")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/roles", "", "roles")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items", "", "work items")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID, "", "work item detail")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/readiness", "", "closeout readiness")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments", "", "assignment list")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments/"+assignment.Data.ID+"/context", "", "assignment context")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments/"+assignment.Data.ID+"/launch-readiness", "", "launch readiness")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/artifacts", "", "artifact list")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/handoffs", "", "handoff list")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/activity", "", "activity")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/operations/brief", "", "operations brief")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodPost, "/hecate/v1/project-assistant/context", projectJourneyJSON(t, map[string]any{
+		"project_id":   projectID,
+		"work_item_id": work.Data.ID,
+		"request":      "Inspect strict embedded Cairnline context.",
+	}), "project assistant context")
+}
+
+func assertStrictEmbeddedCairnlineReadBackend(t *testing.T, client apiTestClient, method, path, body, label string) {
+	t.Helper()
+	recorder := client.mustRequestStatus(http.StatusOK, method, path, body)
+	if !strings.Contains(recorder.Body.String(), `"read_backend":"cairnline"`) {
+		t.Fatalf("%s response = %s, want strict embedded configured read route to expose Cairnline read_backend", label, recorder.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- expand the representative Cairnline live mirror journey to switch into strict embedded read mode after parity passes
- smoke normal configured read routes across project, setup, health, skills, memory, roles, work, collaboration, assistant context, activity, and operations families
- update Cairnline readiness docs to describe the broader strict embedded route coverage

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
- git diff --check
- just agent-docs-check
- GOCACHE="$PWD/.gocache" go vet ./internal/api
- GOCACHE="$PWD/.gocache" go test ./internal/api
- GOCACHE="$PWD/.gocache" go test ./...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...

Note: the first sandboxed broad Go test attempt hit the expected httptest loopback bind restriction; the escalated reruns above passed.