### PR TITLE
fix: honor strict Cairnline assistant proposal reads

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -127,12 +127,14 @@ assignment-context, launch-readiness, assignment-preflight, artifact-list,
 handoff-list, Project Assistant context and proposal reads, closeout readiness,
 and operations brief can use the Cairnline read model for portable setup/work
 state. Configured read routes prefer the embedded Cairnline mirror database
-when it already contains the requested project; if the mirror database or
-project row is missing, they fall back to the snapshot-seeded in-memory bridge
-projection. `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot` forces that
-snapshot-seeded bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`
-requires the embedded mirror database and project row so replacement-readiness
-gaps fail loudly during dogfood. Activity, work-item list/detail,
+when it already contains the requested project or proposal record; if the
+mirror database, project row, or proposal record is missing, they fall back to
+the snapshot-seeded in-memory bridge projection.
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot` forces that snapshot-seeded
+bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
+mirror database and requested project row or proposal record so
+replacement-readiness gaps fail loudly during dogfood. Activity, work-item
+list/detail,
 assignment-list, and operations brief reads render work items, assignments,
 roles, artifacts, and handoffs from the Cairnline service records, then overlay
 Hecate-only runtime refs/timestamps where Hecate still owns execution.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -372,14 +372,14 @@ Assignment preflight/start context packets may include inspect-only Cairnline
 launch-packet evidence for replacement review, but Hecate still owns dispatch,
 task/external agent supervision, approvals, and assignment mutation. Project
 reads backed by the Cairnline read model prefer the embedded Cairnline mirror
-database when that database already contains the requested project; if the
-mirror database or project row is missing, they fall back to the snapshot-seeded
-in-memory bridge projection. Set
+database when that database already contains the requested project or proposal
+record; if the mirror database, project row, or proposal record is missing,
+they fall back to the snapshot-seeded in-memory bridge projection. Set
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot` to force the snapshot-seeded
 bridge, or `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` to make configured
 read routes require a populated
 `{HECATE_DATA_DIR}/cairnline/embedded/projects.db` and fail loudly when the
-mirror database or project row is missing; run
+mirror database, project row, or proposal record is missing; run
 `POST /hecate/v1/projects/cairnline/sync` first when dogfooding strict embedded
 reads. Activity, work-item list/detail, assignment-list, and operations brief
 reads render the work graph from Cairnline service records and overlay

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -467,12 +467,13 @@ sequenceDiagram
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. The default `auto` prefers
   the embedded mirror database under
   `{HECATE_DATA_DIR}/cairnline/embedded/projects.db` when it already contains
-  the requested project and otherwise falls back to the snapshot-seeded
-  in-memory bridge. `snapshot` always uses the snapshot-seeded bridge.
+  the requested project or proposal record and otherwise falls back to the
+  snapshot-seeded in-memory bridge. `snapshot` always uses the snapshot-seeded bridge.
   `embedded` is a strict replacement-readiness dogfood mode: configured read
   routes require a populated embedded mirror database and fail if the database
-  or project row is missing. Run `POST /hecate/v1/projects/cairnline/sync`
-  first when testing strict embedded reads.
+  or requested project row/proposal record is missing. Run
+  `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
+  reads.
 - `HECATE_POSTGRES_URL=postgres://...` or `DATABASE_URL=postgres://...` is
   required when `HECATE_BACKEND=postgres`. Optional Postgres knobs:
   `HECATE_POSTGRES_TABLE_PREFIX`, `HECATE_POSTGRES_MAX_OPEN_CONNS`, and
@@ -2237,8 +2238,9 @@ configured read routes still load Hecate snapshots as bridge scaffolding, but
 their Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the
-snapshot-seeded bridge, and `embedded` requires the mirror database/project row
-to exist so replacement-readiness gaps fail loudly.
+snapshot-seeded bridge, and `embedded` requires the mirror database and
+requested project row or proposal record to exist so replacement-readiness gaps
+fail loudly.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
@@ -2391,10 +2393,10 @@ Example response:
       "migration-cutover"
     ],
     "status": "cairnline_read_routes_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Configured read routes prefer the embedded mirror database when it already contains the requested project; otherwise they fall back to the snapshot-seeded in-memory bridge projection. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Configured read routes prefer the embedded mirror database when it already contains the requested project or proposal record; otherwise they fall back to the snapshot-seeded in-memory bridge projection. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
     "warnings": [
       "Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
-      "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection.",
+      "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project or proposal record, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection.",
       "Project create/delete still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database.",
       "Project metadata updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata seam.",
       "Root create/update/delete, root list replacement, root discovery, and worktree-root creation mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API.",
@@ -4519,6 +4521,10 @@ includes `read_backend` (`hecate` or `cairnline`). Under
 from the Cairnline read model. Draft generation uses that same
 Cairnline-projected context so preview and proposal assembly do not drift,
 while proposal ledger writes and apply authority remain Hecate-owned.
+`GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
+Cairnline read source as the other read routes; strict embedded mode reads the
+proposal record from the embedded mirror instead of falling back to the native
+proposal store.
 The projection keeps Hecate-owned compatibility details such as native snapshot
 timestamps and Hecate-only metadata where the current UI/model context depends
 on them; Cairnline supplies the portable project graph, not final write

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -234,6 +234,20 @@ func (h *Handler) HandleProjectAssistantProposal(w http.ResponseWriter, r *http.
 }
 
 func (h *Handler) cairnlineProjectAssistantProposal(ctx context.Context, id string) (projectassistant.ProposalRecord, bool, error) {
+	strictEmbedded := h.requiresEmbeddedCairnlineProjectReads()
+	if h.prefersEmbeddedCairnlineProjectReads() {
+		_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+		if err == nil {
+			defer store.Close()
+			record, ok, err := cairnlineProjectAssistantProposalFromService(ctx, service, id)
+			if err != nil || ok || strictEmbedded {
+				return record, ok, err
+			}
+		} else if strictEmbedded || !errors.Is(err, cairnline.ErrNotFound) {
+			return projectassistant.ProposalRecord{}, false, err
+		}
+	}
+
 	snapshots, err := cairnlinebridge.LoadSnapshots(ctx, h.cairnlineSnapshotSources())
 	if err != nil {
 		return projectassistant.ProposalRecord{}, false, err
@@ -242,6 +256,10 @@ func (h *Handler) cairnlineProjectAssistantProposal(ctx context.Context, id stri
 	if err := cairnlinebridge.SeedSnapshots(ctx, service, snapshots); err != nil {
 		return projectassistant.ProposalRecord{}, false, err
 	}
+	return cairnlineProjectAssistantProposalFromService(ctx, service, id)
+}
+
+func cairnlineProjectAssistantProposalFromService(ctx context.Context, service *cairnline.Service, id string) (projectassistant.ProposalRecord, bool, error) {
 	item, err := service.GetAssistantProposal(ctx, id)
 	if errors.Is(err, cairnline.ErrNotFound) {
 		return projectassistant.ProposalRecord{}, false, nil

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -918,6 +918,38 @@ func TestProjectAssistantAPI_MirrorsProposalLedgerToCairnlineWhenConfigured(t *t
 	}
 }
 
+func TestProjectAssistantAPI_ProposalRouteUsesStrictEmbeddedReadSource(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	client := newAPITestClient(t, server)
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", `{
+		"name":"Strict Embedded Assistant"
+	}`)
+
+	drafted := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/draft", projectJourneyJSON(t, map[string]any{
+		"project_id": project.Data.ID,
+		"request":    "Capture the first reviewable work item.",
+	}))
+	if drafted.Data.ID == "" || len(drafted.Data.Actions) == 0 {
+		t.Fatalf("drafted proposal = %+v, want mirrored proposal with at least one action", drafted.Data)
+	}
+	mirroredDraft := getMirroredCairnlineAssistantProposalForTest(t, handler, drafted.Data.ID)
+	if mirroredDraft.ProjectID != project.Data.ID || mirroredDraft.Status != cairnline.AssistantProposalStatusProposed {
+		t.Fatalf("mirrored draft = %+v, want proposed embedded proposal for project %s", mirroredDraft, project.Data.ID)
+	}
+
+	handler.config.Projects.CairnlineReadSource = "embedded"
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
+	if _, ok, err := handler.projectAssistantProposals.GetProposal(t.Context(), drafted.Data.ID); err != nil || ok {
+		t.Fatalf("native proposal store = ok %v err %v, want cleared store before strict embedded read", ok, err)
+	}
+
+	record := mustRequestJSON[projectAssistantProposalRecordResponse](client, http.MethodGet, "/hecate/v1/project-assistant/proposals/"+drafted.Data.ID, "")
+	if record.Data.ID != drafted.Data.ID || record.Data.ProjectID != project.Data.ID || record.Data.Status != projectassistant.ProposalStatusProposed || len(record.Data.Proposal.Actions) != len(drafted.Data.Actions) {
+		t.Fatalf("proposal record = %+v, want strict embedded Cairnline-projected proposal", record.Data)
+	}
+}
+
 func TestProjectAssistantAPI_ApplyMirrorsCoordinationGraphToCairnlineWhenConfigured(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -164,22 +164,22 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 func projectCairnlineReadSourceDetail(source string) string {
 	switch source {
 	case "embedded":
-		return "Configured read routes require the embedded mirror database and requested project row; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
+		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
-		return "Configured read routes prefer the embedded mirror database when it already contains the requested project; otherwise they fall back to the snapshot-seeded in-memory bridge projection."
+		return "Configured read routes prefer the embedded mirror database when it already contains the requested project or proposal record; otherwise they fall back to the snapshot-seeded in-memory bridge projection."
 	}
 }
 
 func projectCairnlineReadSourceWarning(source string) string {
 	switch source {
 	case "embedded":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database or project row is missing."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project or proposal record, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection."
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `GET /hecate/v1/project-assistant/proposals/{id}` honor the configured Cairnline read source
- in strict embedded mode, read proposal records from the embedded mirror instead of falling back to the native proposal store
- add a regression test that clears the native proposal ledger before reading the mirrored record
- update backend-status wording and operator/runtime/design docs for project/proposal-record strict read-source behavior

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_(ProposalRouteUsesStrictEmbeddedReadSource|DraftCairnlineMatchesHecate|MirrorsProposalLedgerToCairnlineWhenConfigured)|TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady'\n- git diff --check\n- just agent-docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n- just docs-format-check\n- just docs-check\n\nNote: a sandboxed package test hit the expected httptest loopback bind restriction; the escalated rerun above passed.