### PR TITLE
feat: expose Cairnline replacement readiness gates

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -117,7 +117,10 @@ endpoints. `GET /hecate/v1/projects/backend-status` reports the configured
 coordination backend, whether the Cairnline read adapter can project the full
 current Hecate project graph, the live read-route families currently projected
 from Cairnline, the remaining write-adapter gap families, and whether Cairnline
-is actually authoritative.
+is actually authoritative. It also reports `replacement_ready`,
+`replacement_gates`, and `write_switchpoints` so operator tools can distinguish
+ready read routes from strict embedded probe work, non-authoritative live
+mirrors, still-Hecate-owned dispatch, and missing migration/rollback authority.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 it reports `cairnline_read_routes_ready`, and the live project activity inbox

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -376,8 +376,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   backend switch.
 - The Hecate backend-status endpoint exposes the live Cairnline read-route
   coverage, non-authoritative bridge write seams, and remaining live-route
-  write-adapter gap families as structured fields, so replacement readiness can
-  be tracked without parsing warning prose.
+  write-adapter gap families as structured fields, plus explicit
+  `replacement_gates` and `write_switchpoints`, so replacement readiness can be
+  tracked without parsing warning prose. These fields are diagnostic only:
+  `replacement_ready=false` until read parity, strict embedded mirror probes,
+  authoritative write switchpoints, and migration/rollback gates are ready.
 - Hecate has a non-authoritative bridge write seam for project identity,
   embedded roots, root discovery/worktree creation, direct root
   create/update/delete, context-source discovery, direct context-source

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -427,7 +427,10 @@ proof seams separately from the live-route `write_adapter_gaps`; only
 `project-memory-live-mirror`, and `project-memory-candidates-live-mirror`, plus
 `project-assistant-proposal-ledger-live-mirror` and
 `project-assistant-apply-side-effects-live-mirror` are wired to live mutations,
-and all remain non-authoritative. `GET
+and all remain non-authoritative. It also reports `replacement_ready`,
+`replacement_gates`, and `write_switchpoints` so operators can see the exact
+read-route, strict-embedded-probe, write-authority, and migration blockers
+without parsing warning prose. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2247,6 +2247,14 @@ Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
 can write Cairnline-shaped records during tests or local sync rehearsals;
 `write_adapter_gaps` lists mutation families whose live Hecate routes are not
 Cairnline-backed yet and therefore still block authority switch.
+`replacement_ready` stays `false` until read parity, strict embedded mirror
+probes, write-authority switchpoints, and migration/rollback gates are all
+ready. `replacement_gates` reports those high-level gates as structured
+checklist items so clients do not need to parse warning prose.
+`write_switchpoints` maps each live mutation family to the current authority,
+the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`, or
+`missing_authoritative_switchpoint`), the related mirror seams, and whether that
+family still blocks replacement.
 Non-authoritative bridge seams currently cover project/root/source/defaults,
 agent profiles, skills, roles, work items, assignment metadata upsert/delete plus
 lifecycle-status sync, create-if-missing generic artifacts/evidence/reviews,
@@ -2301,7 +2309,7 @@ project stores with the existing embedded Cairnline mirror database without
 creating or repairing it. `sync_readiness_url` points at the all-project
 embedded SQLite rehearsal sync, which replaces that database from Hecate stores.
 
-Example response:
+Example response, with `write_switchpoints` shortened for readability:
 
 ```json
 {
@@ -2315,6 +2323,7 @@ Example response:
     "cairnline_authoritative": false,
     "read_model_switch_ready": true,
     "write_adapter_ready": false,
+    "replacement_ready": false,
     "read_routes": [
       "project-list",
       "project-detail",
@@ -2391,6 +2400,63 @@ Example response:
       "handoffs",
       "project-assistant-proposals",
       "migration-cutover"
+    ],
+    "replacement_gates": [
+      {
+        "id": "read-routes",
+        "ready": true,
+        "status": "ready",
+        "detail": "Configured live project read families can be served from Cairnline's projected read model."
+      },
+      {
+        "id": "strict-embedded-read-smoke",
+        "ready": false,
+        "status": "operator_probe_required",
+        "detail": "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate."
+      },
+      {
+        "id": "write-authority-switchpoints",
+        "ready": false,
+        "status": "blocked",
+        "detail": "Live mutation routes still commit to Hecate-native stores first; Cairnline mirrors are replacement evidence, not write authority."
+      },
+      {
+        "id": "migration-and-rollback",
+        "ready": false,
+        "status": "blocked",
+        "detail": "No migration cutover, rollback, or authoritative Cairnline storage switch exists yet."
+      }
+    ],
+    "write_switchpoints": [
+      {
+        "name": "project-memory",
+        "current_authority": "hecate",
+        "cairnline_state": "live_mirror_non_authoritative",
+        "live_mirror": true,
+        "blocks_authority": true,
+        "seams": ["project-memory-live-mirror"],
+        "gap": "memory",
+        "detail": "Accepted project memory mutations still commit to Hecate first, then mirror durable memory state into Cairnline."
+      },
+      {
+        "name": "assignment-start-dispatch",
+        "current_authority": "hecate",
+        "cairnline_state": "result_mirror_only",
+        "live_mirror": true,
+        "blocks_authority": true,
+        "seams": ["project-assignment-start-result-live-mirror"],
+        "gap": "assignment-start",
+        "detail": "Assignment start still dispatches through Hecate runtime/task/external-agent authority; Cairnline receives only committed start results and cleanup/conflict states."
+      },
+      {
+        "name": "migration-cutover",
+        "current_authority": "hecate",
+        "cairnline_state": "missing_authoritative_switchpoint",
+        "live_mirror": false,
+        "blocks_authority": true,
+        "gap": "migration-cutover",
+        "detail": "No import/export cutover, rollback, or authoritative Cairnline storage switch exists yet."
+      }
     ],
     "status": "cairnline_read_routes_ready",
     "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Configured read routes prefer the embedded mirror database when it already contains the requested project or proposal record; otherwise they fall back to the snapshot-seeded in-memory bridge projection. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -88,6 +88,167 @@ var projectCairnlineWriteAdapterGapNames = []string{
 	"migration-cutover",
 }
 
+var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchpoint{
+	{
+		Name:             "project-identity",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-identity-live-mirror"},
+		Gap:              "projects",
+		Detail:           "Project create/delete still commit to Hecate stores first, then best-effort mirror portable identity records into the embedded Cairnline database.",
+	},
+	{
+		Name:             "project-metadata-defaults",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-metadata-live-mirror", "project-defaults-live-mirror"},
+		Gap:              "projects",
+		Detail:           "Project metadata and default posture mutations still commit to Hecate first, then mirror through Cairnline metadata/default seams.",
+	},
+	{
+		Name:             "roots-and-worktrees",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-roots-live-mirror"},
+		Gap:              "roots",
+		Detail:           "Root create/update/delete, root discovery, root list replacement, and worktree-root creation still commit to Hecate first, then mirror through Cairnline root APIs.",
+	},
+	{
+		Name:             "context-sources",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-context-sources-live-mirror"},
+		Gap:              "context-sources",
+		Detail:           "Context-source discovery and direct source mutations still commit to Hecate first, then mirror through Cairnline source APIs.",
+	},
+	{
+		Name:             "agent-profiles",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"agent-profiles-live-mirror"},
+		Gap:              "agent-profiles",
+		Detail:           "Global agent-profile CRUD still commits to Hecate first, then mirrors portable profile metadata and execution posture into Cairnline.",
+	},
+	{
+		Name:             "skills",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-skills-live-mirror"},
+		Gap:              "skills",
+		Detail:           "Project skill discovery/update still commits metadata to Hecate first, then mirrors metadata-only skill records into Cairnline.",
+	},
+	{
+		Name:             "roles",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-roles-live-mirror"},
+		Gap:              "roles",
+		Detail:           "Role mutations still commit to Hecate first, then mirror coordination metadata and referenced portable profile posture into Cairnline.",
+	},
+	{
+		Name:             "work-items",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-work-items-live-mirror"},
+		Gap:              "work-items",
+		Detail:           "Work-item create/update/delete still commit to Hecate first, then mirror portable coordination metadata into Cairnline.",
+	},
+	{
+		Name:             "assignments",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-assignments-live-mirror", "project-assignment-chat-reconcile-live-mirror"},
+		Gap:              "assignments",
+		Detail:           "Assignment create/update/delete and linked-chat reconciliation still commit to Hecate first, then mirror portable metadata/status into Cairnline.",
+	},
+	{
+		Name:             "assignment-start-dispatch",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "result_mirror_only",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-assignment-start-result-live-mirror"},
+		Gap:              "assignment-start",
+		Detail:           "Assignment start still dispatches through Hecate runtime/task/external-agent authority; Cairnline receives only committed start results and cleanup/conflict states.",
+	},
+	{
+		Name:             "collaboration-artifacts",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-collaboration-live-mirror"},
+		Gap:              "artifacts",
+		Detail:           "Generic artifact, evidence, and review creation still commits to Hecate first, then mirrors portable collaboration metadata into Cairnline.",
+	},
+	{
+		Name:             "handoffs",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-handoffs-live-mirror"},
+		Gap:              "handoffs",
+		Detail:           "Handoff create/update/delete still commits to Hecate first, then mirrors portable handoff metadata into Cairnline.",
+	},
+	{
+		Name:             "project-memory",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-memory-live-mirror"},
+		Gap:              "memory",
+		Detail:           "Accepted project memory mutations still commit to Hecate first, then mirror durable memory state into Cairnline.",
+	},
+	{
+		Name:             "memory-candidates",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-memory-candidates-live-mirror"},
+		Gap:              "memory-candidates",
+		Detail:           "Memory-candidate create/promote/reject/delete still commits to Hecate first, then mirrors review state and promoted-memory references into Cairnline.",
+	},
+	{
+		Name:             "project-assistant-proposals",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "live_mirror_non_authoritative",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-assistant-proposal-ledger-live-mirror", "project-assistant-apply-side-effects-live-mirror"},
+		Gap:              "project-assistant-proposals",
+		Detail:           "Project Assistant draft/propose/apply records and committed side effects still commit to Hecate first, then mirror into the portable proposal ledger.",
+	},
+	{
+		Name:             "migration-cutover",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "missing_authoritative_switchpoint",
+		BlocksAuthority:  true,
+		Gap:              "migration-cutover",
+		Detail:           "No import/export cutover, rollback, or authoritative Cairnline storage switch exists yet.",
+	},
+}
+
 func (h *Handler) HandleProjectCoordinationBackendStatus(w http.ResponseWriter, r *http.Request) {
 	WriteJSON(w, http.StatusOK, ProjectCoordinationBackendStatusEnvelope{
 		Object: "project_coordination_backend_status",
@@ -123,6 +284,8 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
 		response.WriteAdapterSeams = append([]string(nil), projectCairnlineWriteAdapterSeamNames...)
 		response.WriteAdapterGaps = append([]string(nil), projectCairnlineWriteAdapterGapNames...)
+		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot()
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady)
 		response.ReadModelSwitchReady = readReady
 		if readReady {
 			response.ReadRoutes = append([]string(nil), projectCairnlineReadRouteNames...)
@@ -159,6 +322,51 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.Detail = "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks."
 	}
 	return response
+}
+
+func projectCairnlineReplacementGates(readRoutesReady bool) []ProjectCoordinationBackendReplacementGate {
+	return []ProjectCoordinationBackendReplacementGate{
+		{
+			ID:     "read-routes",
+			Ready:  readRoutesReady,
+			Status: projectReplacementGateStatus(readRoutesReady),
+			Detail: "Configured live project read families can be served from Cairnline's projected read model.",
+		},
+		{
+			ID:     "strict-embedded-read-smoke",
+			Ready:  false,
+			Status: "operator_probe_required",
+			Detail: "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
+		},
+		{
+			ID:     "write-authority-switchpoints",
+			Ready:  false,
+			Status: "blocked",
+			Detail: "Live mutation routes still commit to Hecate-native stores first; Cairnline mirrors are replacement evidence, not write authority.",
+		},
+		{
+			ID:     "migration-and-rollback",
+			Ready:  false,
+			Status: "blocked",
+			Detail: "No migration cutover, rollback, or authoritative Cairnline storage switch exists yet.",
+		},
+	}
+}
+
+func projectReplacementGateStatus(ready bool) string {
+	if ready {
+		return "ready"
+	}
+	return "blocked"
+}
+
+func projectCairnlineWriteSwitchpointsSnapshot() []ProjectCoordinationBackendWriteSwitchpoint {
+	out := make([]ProjectCoordinationBackendWriteSwitchpoint, 0, len(projectCairnlineWriteSwitchpoints))
+	for _, item := range projectCairnlineWriteSwitchpoints {
+		item.Seams = append([]string(nil), item.Seams...)
+		out = append(out, item)
+	}
+	return out
 }
 
 func projectCairnlineReadSourceDetail(source string) string {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -24,10 +24,10 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineReadSource != "auto" {
 		t.Fatalf("cairnline read source = %q, want auto", status.CairnlineReadSource)
 	}
-	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || len(status.Warnings) != 0 {
+	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
-	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 {
+	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 || len(status.ReplacementGates) != 0 || len(status.WriteSwitchpoints) != 0 {
 		t.Fatalf("status = %+v, want no Cairnline route/seam/gap lists until Cairnline is configured", status)
 	}
 }
@@ -44,7 +44,7 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || status.Status != "cairnline_configured_read_adapter_missing_sources" {
 		t.Fatalf("status = %+v, want configured Cairnline with missing read-adapter sources", status)
 	}
-	if status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || len(status.Warnings) == 0 {
+	if status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) == 0 {
 		t.Fatalf("status = %+v, want read adapter missing-source warnings", status)
 	}
 	if !strings.Contains(strings.Join(status.Warnings, "\n"), "project assistant proposal store") {
@@ -58,6 +58,15 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	}
 	if !containsString(status.WriteAdapterSeams, "projects") || !containsString(status.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(status.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(status.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(status.WriteAdapterSeams, "agent-profiles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(status.WriteAdapterSeams, "assignments") || !containsString(status.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(status.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(status.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(status.WriteAdapterSeams, "sync-rehearsal") {
 		t.Fatalf("write seams = %+v, want structured non-authoritative write-adapter seam coverage", status.WriteAdapterSeams)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "read-routes"); gate == nil || gate.Ready || gate.Status != "blocked" {
+		t.Fatalf("read-routes gate = %+v, want blocked when read adapter sources are missing", gate)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "blocked" {
+		t.Fatalf("write-authority gate = %+v, want blocking gate", gate)
+	}
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "result_mirror_only" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "assignment-start" {
+		t.Fatalf("assignment-start switchpoint = %+v, want Hecate-owned result mirror blocker", point)
 	}
 }
 
@@ -77,7 +86,7 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if status.CairnlineReadSource != "embedded" {
 		t.Fatalf("cairnline read source = %q, want embedded", status.CairnlineReadSource)
 	}
-	if status.CairnlineAuthoritative || !status.ReadModelSwitchReady || status.WriteAdapterReady {
+	if status.CairnlineAuthoritative || !status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
 		t.Fatalf("status = %+v, want read adapter ready but Hecate still authoritative", status)
 	}
 	if len(status.Warnings) == 0 {
@@ -94,6 +103,18 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	}
 	if !containsString(status.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(status.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(status.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(status.WriteAdapterSeams, "agent-profiles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(status.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(status.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(status.WriteAdapterSeams, "assignment-status") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-import") || !containsString(status.WriteAdapterSeams, "memory-candidates") {
 		t.Fatalf("write seams = %+v, want structured non-authoritative write-adapter seam coverage", status.WriteAdapterSeams)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "read-routes"); gate == nil || !gate.Ready || gate.Status != "ready" {
+		t.Fatalf("read-routes gate = %+v, want ready gate", gate)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "strict-embedded-read-smoke"); gate == nil || gate.Ready || gate.Status != "operator_probe_required" {
+		t.Fatalf("strict embedded gate = %+v, want operator probe gate", gate)
+	}
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-memory"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "live_mirror_non_authoritative" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "memory" {
+		t.Fatalf("project-memory switchpoint = %+v, want Hecate-owned live mirror blocker", point)
+	}
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "missing_authoritative_switchpoint" || point.LiveMirror || !point.BlocksAuthority || point.Gap != "migration-cutover" {
+		t.Fatalf("migration switchpoint = %+v, want missing authoritative switchpoint blocker", point)
 	}
 	if status.SyncReadinessURL != projectCoordinationBackendSyncReadinessURL {
 		t.Fatalf("sync readiness URL = %q, want %q", status.SyncReadinessURL, projectCoordinationBackendSyncReadinessURL)
@@ -138,6 +159,12 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if !containsString(response.Data.ReadRoutes, "project-detail") || !containsString(response.Data.ReadRoutes, "launch-readiness") || !containsString(response.Data.ReadRoutes, "assignment-preflight") || !containsString(response.Data.ReadRoutes, "project-assistant-context") || !containsString(response.Data.ReadRoutes, "project-assistant-proposal") || !containsString(response.Data.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "handoffs") || !containsString(response.Data.WriteAdapterGaps, "memory-candidates") {
 		t.Fatalf("response routes/seams/gaps = %+v / %+v / %+v, want structured readiness details", response.Data.ReadRoutes, response.Data.WriteAdapterSeams, response.Data.WriteAdapterGaps)
 	}
+	if response.Data.ReplacementReady {
+		t.Fatalf("response replacement_ready = true, want false until write authority and migration gates are ready")
+	}
+	if findReplacementGate(response.Data.ReplacementGates, "write-authority-switchpoints") == nil || findWriteSwitchpoint(response.Data.WriteSwitchpoints, "project-assistant-proposals") == nil {
+		t.Fatalf("response gates/switchpoints = %+v / %+v, want structured replacement blockers", response.Data.ReplacementGates, response.Data.WriteSwitchpoints)
+	}
 }
 
 func containsString(items []string, want string) bool {
@@ -147,4 +174,22 @@ func containsString(items []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func findReplacementGate(items []ProjectCoordinationBackendReplacementGate, id string) *ProjectCoordinationBackendReplacementGate {
+	for idx := range items {
+		if items[idx].ID == id {
+			return &items[idx]
+		}
+	}
+	return nil
+}
+
+func findWriteSwitchpoint(items []ProjectCoordinationBackendWriteSwitchpoint, name string) *ProjectCoordinationBackendWriteSwitchpoint {
+	for idx := range items {
+		if items[idx].Name == name {
+			return &items[idx]
+		}
+	}
+	return nil
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -513,25 +513,46 @@ type ProjectCoordinationBackendStatusEnvelope struct {
 }
 
 type ProjectCoordinationBackendStatusResponse struct {
-	ConfiguredBackend       string   `json:"configured_backend"`
-	AuthoritativeBackend    string   `json:"authoritative_backend"`
-	StorageBackend          string   `json:"storage_backend"`
-	CairnlineReadSource     string   `json:"cairnline_read_source,omitempty"`
-	CairnlineBridgeReady    bool     `json:"cairnline_bridge_ready"`
-	CairnlineAuthoritative  bool     `json:"cairnline_authoritative"`
-	ReadModelSwitchReady    bool     `json:"read_model_switch_ready"`
-	WriteAdapterReady       bool     `json:"write_adapter_ready"`
-	ReadRoutes              []string `json:"read_routes,omitempty"`
-	WriteAdapterSeams       []string `json:"write_adapter_seams,omitempty"`
-	WriteAdapterGaps        []string `json:"write_adapter_gaps,omitempty"`
-	Status                  string   `json:"status"`
-	Detail                  string   `json:"detail"`
-	Warnings                []string `json:"warnings,omitempty"`
-	ReplacementReadinessURL string   `json:"replacement_readiness_url,omitempty"`
-	EmbeddedReadModelURL    string   `json:"embedded_read_model_url,omitempty"`
-	EmbeddedParityReportURL string   `json:"embedded_parity_report_url,omitempty"`
-	SyncReadinessURL        string   `json:"sync_readiness_url,omitempty"`
-	MirrorParityURL         string   `json:"mirror_parity_url,omitempty"`
+	ConfiguredBackend       string                                       `json:"configured_backend"`
+	AuthoritativeBackend    string                                       `json:"authoritative_backend"`
+	StorageBackend          string                                       `json:"storage_backend"`
+	CairnlineReadSource     string                                       `json:"cairnline_read_source,omitempty"`
+	CairnlineBridgeReady    bool                                         `json:"cairnline_bridge_ready"`
+	CairnlineAuthoritative  bool                                         `json:"cairnline_authoritative"`
+	ReadModelSwitchReady    bool                                         `json:"read_model_switch_ready"`
+	WriteAdapterReady       bool                                         `json:"write_adapter_ready"`
+	ReplacementReady        bool                                         `json:"replacement_ready"`
+	ReadRoutes              []string                                     `json:"read_routes,omitempty"`
+	WriteAdapterSeams       []string                                     `json:"write_adapter_seams,omitempty"`
+	WriteAdapterGaps        []string                                     `json:"write_adapter_gaps,omitempty"`
+	ReplacementGates        []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
+	WriteSwitchpoints       []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
+	Status                  string                                       `json:"status"`
+	Detail                  string                                       `json:"detail"`
+	Warnings                []string                                     `json:"warnings,omitempty"`
+	ReplacementReadinessURL string                                       `json:"replacement_readiness_url,omitempty"`
+	EmbeddedReadModelURL    string                                       `json:"embedded_read_model_url,omitempty"`
+	EmbeddedParityReportURL string                                       `json:"embedded_parity_report_url,omitempty"`
+	SyncReadinessURL        string                                       `json:"sync_readiness_url,omitempty"`
+	MirrorParityURL         string                                       `json:"mirror_parity_url,omitempty"`
+}
+
+type ProjectCoordinationBackendReplacementGate struct {
+	ID     string `json:"id"`
+	Ready  bool   `json:"ready"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+type ProjectCoordinationBackendWriteSwitchpoint struct {
+	Name             string   `json:"name"`
+	CurrentAuthority string   `json:"current_authority"`
+	CairnlineState   string   `json:"cairnline_state"`
+	LiveMirror       bool     `json:"live_mirror"`
+	BlocksAuthority  bool     `json:"blocks_authority"`
+	Seams            []string `json:"seams,omitempty"`
+	Gap              string   `json:"gap,omitempty"`
+	Detail           string   `json:"detail"`
 }
 
 type AgentProfileResponse struct {


### PR DESCRIPTION
## Summary
- add structured replacement gates and write switchpoints to project backend status
- keep existing read-route, seam, and gap fields compatible
- document the new readiness contract in runtime, operator, and design docs

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- just docs-check\n- just agent-docs-check\n- git diff --check\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n