### PR TITLE
Add Cairnline project memory authority

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -157,6 +157,12 @@ assignment. Hecate stores remain authoritative, Hecate-specific runtime
 enrichment and setup/action wording remain in Hecate, and the Cairnline-backed
 operations brief uses Cairnline activity/service rows plus Hecate cockpit action
 helpers so operator-facing actions stay parity-checked with the native route.
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is the first
+disabled-by-default Cairnline write-authority dogfood switch. When enabled,
+accepted project memory entry create/update/delete commits to embedded
+Cairnline first, then best-effort shadows the entry into Hecate-native memory
+stores for compatibility. Memory candidates and candidate promotion/rejection
+remain Hecate-owned.
 Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results are best-effort mirrored for replacement evidence, and
 other live Projects reads/writes still use the Hecate-native API.
@@ -216,11 +222,13 @@ Hecate commits them. Linked external-agent chat reconciliation also mirrors the
 committed assignment status/ref when Hecate updates the linked assignment from a
 chat session. Collaboration artifact creation, including generic artifacts,
 evidence links, and reviews, and handoff create/update/delete routes also mirror
-portable collaboration metadata after Hecate commits. Project memory entry and
-memory-candidate create/update/resolve
-routes mirror accepted memory and reviewable candidate state after Hecate
-commits, including disabled state, provenance, status reason, and promoted
-memory references. Global agent-profile create/update/delete routes also
+portable collaboration metadata after Hecate commits. Accepted project memory
+entries can be switched to Cairnline-first authority with
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory`; otherwise they
+mirror after Hecate commits. Memory-candidate create/update/resolve routes still
+mirror reviewable candidate state after Hecate commits, including disabled
+state, provenance, status reason, and promoted memory references. Global
+agent-profile create/update/delete routes also
 mirror portable profile metadata and execution posture after Hecate commits;
 the delete mirror removes only the profile record because execution-profile
 posture can be shared. Project Assistant draft/propose/apply routes mirror the

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -161,8 +161,9 @@ helpers so operator-facing actions stay parity-checked with the native route.
 disabled-by-default Cairnline write-authority dogfood switch. When enabled,
 accepted project memory entry create/update/delete commits to embedded
 Cairnline first, then best-effort shadows the entry into Hecate-native memory
-stores for compatibility. Memory candidates and candidate promotion/rejection
-remain Hecate-owned.
+stores for compatibility. Adding `memory-candidates` to that setting makes
+memory-candidate create/promote/reject Cairnline-first too; it requires
+`project-memory` because promotion creates accepted project memory.
 Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results are best-effort mirrored for replacement evidence, and
 other live Projects reads/writes still use the Hecate-native API.
@@ -225,9 +226,11 @@ evidence links, and reviews, and handoff create/update/delete routes also mirror
 portable collaboration metadata after Hecate commits. Accepted project memory
 entries can be switched to Cairnline-first authority with
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory`; otherwise they
-mirror after Hecate commits. Memory-candidate create/update/resolve routes still
-mirror reviewable candidate state after Hecate commits, including disabled
-state, provenance, status reason, and promoted memory references. Global
+mirror after Hecate commits. Memory-candidate create/promote/reject routes mirror
+reviewable candidate state after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory,memory-candidates` is
+enabled, in which case they commit to Cairnline first and then shadow candidate
+state and promoted memory references back into Hecate. Global
 agent-profile create/update/delete routes also
 mirror portable profile metadata and execution posture after Hecate commits;
 the delete mirror removes only the profile record because execution-profile

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -381,6 +381,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   tracked without parsing warning prose. These fields are diagnostic only:
   `replacement_ready=false` until read parity, strict embedded mirror probes,
   authoritative write switchpoints, and migration/rollback gates are ready.
+- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables Hecate's
+  first disabled-by-default Cairnline write-authority switchpoint: accepted
+  project memory entry create/update/delete commits to embedded Cairnline first
+  and then shadows back into Hecate-native memory stores. Memory candidates and
+  candidate promotion/rejection remain Hecate-owned.
 - Hecate has a non-authoritative bridge write seam for project identity,
   embedded roots, root discovery/worktree creation, direct root
   create/update/delete, context-source discovery, direct context-source
@@ -393,16 +398,18 @@ launch agents. Those remain explicit operator or orchestrator actions.
   create-if-missing generic artifact/evidence/review seams, handoff
   upsert/delete seams, plus accepted-memory and memory-candidate seams that
   preserve metadata, disabled state, provenance, resolved candidate state, and
-  Hecate-owned promoted memory IDs. The project identity/root
+  Hecate-owned promoted memory IDs. Accepted memory can additionally run as the
+  opt-in Cairnline-first switchpoint above. The project identity/root
   discovery/worktree-creation/context-source discovery seam, the root-level
   direct root mutation seam, the source-level direct context-source mutation
   seam, the global agent-profile seam, the
   metadata-only project-skill discovery/update seam, the
   role/work-item/assignment coordination seams, the assignment start/reconcile
   result seams, the collaboration artifact create seam, the handoff mutation
-  seam, and the accepted-memory and memory-candidate seams, plus the Project
-  Assistant proposal-ledger seam, are now wired as best-effort live mirrors into
-  the embedded Cairnline DB when the Cairnline backend is configured, but
+  seam, the memory-candidate seam, and accepted memory when its write-authority
+  switchpoint is disabled, plus the Project Assistant proposal-ledger seam, are
+  now wired as best-effort live mirrors into the embedded Cairnline DB when the
+  Cairnline backend is configured, but
   Hecate still commits first and remains authoritative. Role mirrors also seed
   referenced agent-profile metadata/execution posture when the profile store is
   available.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -384,8 +384,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables Hecate's
   first disabled-by-default Cairnline write-authority switchpoint: accepted
   project memory entry create/update/delete commits to embedded Cairnline first
-  and then shadows back into Hecate-native memory stores. Memory candidates and
-  candidate promotion/rejection remain Hecate-owned.
+  and then shadows back into Hecate-native memory stores.
+  `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory,memory-candidates`
+  also makes memory-candidate create/promote/reject Cairnline-first; the
+  `memory-candidates` switch requires `project-memory` because promotion creates
+  accepted project memory.
 - Hecate has a non-authoritative bridge write seam for project identity,
   embedded roots, root discovery/worktree creation, direct root
   create/update/delete, context-source discovery, direct context-source
@@ -398,8 +401,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   create-if-missing generic artifact/evidence/review seams, handoff
   upsert/delete seams, plus accepted-memory and memory-candidate seams that
   preserve metadata, disabled state, provenance, resolved candidate state, and
-  Hecate-owned promoted memory IDs. Accepted memory can additionally run as the
-  opt-in Cairnline-first switchpoint above. The project identity/root
+  promoted memory IDs. Accepted memory and memory-candidate review flows can
+  additionally run as the opt-in Cairnline-first switchpoints above. The project
+  identity/root
   discovery/worktree-creation/context-source discovery seam, the root-level
   direct root mutation seam, the source-level direct context-source mutation
   seam, the global agent-profile seam, the

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -392,11 +392,14 @@ Hecate stores first and then best-effort mirror into the embedded Cairnline
 database through their identity/metadata/root/source/default seams; this is
 replacement-readiness evidence, not write authority.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
-write-authority dogfood switch for accepted project memory entries only:
+write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then
 best-effort shadows the row into Hecate-native memory stores. The default is
-`none`; memory candidates, candidate promotion/rejection, and all other Projects
-mutations remain Hecate-owned.
+`none`. `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory,memory-candidates`
+also makes memory-candidate create/promote/reject Cairnline-first; the
+`memory-candidates` switch requires `project-memory` because candidate promotion
+creates accepted project memory. All other Projects mutations remain
+Hecate-owned.
 Project skill discovery and
 metadata updates also best-effort mirror metadata-only skill records after the
 Hecate store commit; the mirror does not load or execute skill bodies. Project
@@ -410,8 +413,10 @@ create/update/delete mutations also best-effort mirror portable metadata after
 Hecate commits, but assignment start/dispatch remains Hecate-owned. Project
 memory entries mirror after Hecate commits unless the
 `project-memory` Cairnline write-authority switchpoint is enabled; memory
-candidates still best-effort mirror reviewable candidate state after Hecate
-commits. Project Assistant draft/propose/apply ledger mutations likewise
+candidates mirror after Hecate commits unless `project-memory,memory-candidates`
+is enabled, in which case candidate create/promote/reject commit to Cairnline
+first and then shadow back into Hecate. Project Assistant draft/propose/apply
+ledger mutations likewise
 best-effort mirror proposal records, apply attempts, and committed apply side
 effects after Hecate commits.
 Other live Projects reads/writes still use Hecate-native

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -391,6 +391,12 @@ context-source create/update/delete/discovery, and default mutations still write
 Hecate stores first and then best-effort mirror into the embedded Cairnline
 database through their identity/metadata/root/source/default seams; this is
 replacement-readiness evidence, not write authority.
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
+write-authority dogfood switch for accepted project memory entries only:
+create/update/delete commits to the embedded Cairnline database first and then
+best-effort shadows the row into Hecate-native memory stores. The default is
+`none`; memory candidates, candidate promotion/rejection, and all other Projects
+mutations remain Hecate-owned.
 Project skill discovery and
 metadata updates also best-effort mirror metadata-only skill records after the
 Hecate store commit; the mirror does not load or execute skill bodies. Project
@@ -402,8 +408,9 @@ create/update/delete, committed assignment-start results, linked-chat
 reconciliation, collaboration artifact creation, and handoff
 create/update/delete mutations also best-effort mirror portable metadata after
 Hecate commits, but assignment start/dispatch remains Hecate-owned. Project
-memory entry and memory-candidate mutations also
-best-effort mirror accepted memory and reviewable candidate state after Hecate
+memory entries mirror after Hecate commits unless the
+`project-memory` Cairnline write-authority switchpoint is enabled; memory
+candidates still best-effort mirror reviewable candidate state after Hecate
 commits. Project Assistant draft/propose/apply ledger mutations likewise
 best-effort mirror proposal records, apply attempts, and committed apply side
 effects after Hecate commits.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -474,6 +474,13 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads.
+- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory` controls
+  alpha Cairnline write-authority switchpoints while
+  `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. The default is `none`.
+  `project-memory` makes accepted project memory entry create/update/delete
+  commit to the embedded Cairnline database first and then best-effort shadow
+  the row back into Hecate-native memory stores. Memory candidates, candidate
+  promotion/rejection, and all other Projects mutations remain Hecate-owned.
 - `HECATE_POSTGRES_URL=postgres://...` or `DATABASE_URL=postgres://...` is
   required when `HECATE_BACKEND=postgres`. Optional Postgres knobs:
   `HECATE_POSTGRES_TABLE_PREFIX`, `HECATE_POSTGRES_MAX_OPEN_CONNS`, and
@@ -2222,18 +2229,24 @@ being built.
 
 `configured_backend` reflects `HECATE_PROJECTS_COORDINATION_BACKEND`.
 `cairnline_read_source` reflects `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`.
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables the first
+disabled-by-default write authority switchpoint: accepted project memory entries
+commit to embedded Cairnline first and are then shadowed back into Hecate-native
+memory stores. Memory candidates and candidate promotion/rejection are still
+Hecate-owned.
 `authoritative_backend` remains `hecate` until Hecate can run project read/write
 flows against Cairnline without UI-local fallback state. When
-`configured_backend=cairnline`, Hecate still commits live Projects writes to the
-current Hecate-native stores first. `read_model_switch_ready=true` means the
-Cairnline read adapter is wired well enough to project the full current Hecate
-project graph, including the Project Assistant proposal ledger. In that state,
-project list/detail reads, project setup readiness, project health, skills,
-memory entries, memory candidates, roles, work items, assignment lists,
-assignment context previews, assignment launch-readiness, assignment preflight,
-artifact lists, handoff lists, Project Assistant context/proposal reads,
-closeout readiness, activity inbox, and operations brief can be served from the
-Cairnline read model, while other live Projects reads still use Hecate. Those
+`configured_backend=cairnline`, Hecate still commits live Projects writes to
+the current Hecate-native stores first except for explicitly enabled
+write-authority switchpoints. `read_model_switch_ready=true` means the Cairnline
+read adapter is wired well enough to project the full current Hecate project
+graph, including the Project Assistant proposal ledger. In that state, project
+list/detail reads, project setup readiness, project health, skills, memory
+entries, memory candidates, roles, work items, assignment lists, assignment
+context previews, assignment launch-readiness, assignment preflight, artifact
+lists, handoff lists, Project Assistant context/proposal reads, closeout
+readiness, activity inbox, and operations brief can be served from the Cairnline
+read model, while other live Projects reads still use Hecate. Those
 configured read routes still load Hecate snapshots as bridge scaffolding, but
 their Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
@@ -2253,8 +2266,9 @@ ready. `replacement_gates` reports those high-level gates as structured
 checklist items so clients do not need to parse warning prose.
 `write_switchpoints` maps each live mutation family to the current authority,
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`, or
-`missing_authoritative_switchpoint`), the related mirror seams, and whether that
-family still blocks replacement.
+`missing_authoritative_switchpoint`; `authoritative_opt_in` for enabled alpha
+write-authority switchpoints), the related mirror seams, and whether that family
+still blocks replacement.
 Non-authoritative bridge seams currently cover project/root/source/defaults,
 agent profiles, skills, roles, work items, assignment metadata upsert/delete plus
 lifecycle-status sync, create-if-missing generic artifacts/evidence/reviews,
@@ -2295,9 +2309,11 @@ external-agent chat reconciliation. `project-collaboration-live-mirror` mirrors
 collaboration artifact creation, including generic artifacts, evidence links,
 and reviews, and `project-handoffs-live-mirror` mirrors handoff
 create/update/delete mutations after Hecate commits. `project-memory-live-mirror`
-mirrors accepted project memory entries and `project-memory-candidates-live-mirror`
-mirrors reviewable candidate state after Hecate commits, including
-promoted/rejected status and promoted memory references.
+mirrors accepted project memory entries after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` makes accepted memory
+Cairnline-first. `project-memory-candidates-live-mirror` mirrors reviewable
+candidate state after Hecate commits, including promoted/rejected status and
+promoted memory references.
 `project-assistant-proposal-ledger-live-mirror`
 mirrors Project Assistant draft/propose/apply proposal records and apply-attempt
 history after Hecate commits. `project-assistant-apply-side-effects-live-mirror`

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -474,13 +474,17 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads.
-- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory` controls
-  alpha Cairnline write-authority switchpoints while
+- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates`
+  controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. The default is `none`.
   `project-memory` makes accepted project memory entry create/update/delete
   commit to the embedded Cairnline database first and then best-effort shadow
-  the row back into Hecate-native memory stores. Memory candidates, candidate
-  promotion/rejection, and all other Projects mutations remain Hecate-owned.
+  the row back into Hecate-native memory stores. `memory-candidates` requires
+  `project-memory`; together they make reviewable memory-candidate
+  create/promote/reject mutations Cairnline-first too, with candidate promotion
+  creating accepted memory through Cairnline before shadowing the candidate and
+  promoted memory row back into Hecate-native stores. All other Projects
+  mutations remain Hecate-owned.
 - `HECATE_POSTGRES_URL=postgres://...` or `DATABASE_URL=postgres://...` is
   required when `HECATE_BACKEND=postgres`. Optional Postgres knobs:
   `HECATE_POSTGRES_TABLE_PREFIX`, `HECATE_POSTGRES_MAX_OPEN_CONNS`, and
@@ -2232,8 +2236,9 @@ being built.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables the first
 disabled-by-default write authority switchpoint: accepted project memory entries
 commit to embedded Cairnline first and are then shadowed back into Hecate-native
-memory stores. Memory candidates and candidate promotion/rejection are still
-Hecate-owned.
+memory stores. Adding `memory-candidates` to that comma-separated setting makes
+candidate create/promote/reject Cairnline-first as well; it requires
+`project-memory` because candidate promotion creates accepted project memory.
 `authoritative_backend` remains `hecate` until Hecate can run project read/write
 flows against Cairnline without UI-local fallback state. When
 `configured_backend=cairnline`, Hecate still commits live Projects writes to
@@ -2312,8 +2317,10 @@ create/update/delete mutations after Hecate commits. `project-memory-live-mirror
 mirrors accepted project memory entries after Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` makes accepted memory
 Cairnline-first. `project-memory-candidates-live-mirror` mirrors reviewable
-candidate state after Hecate commits, including promoted/rejected status and
-promoted memory references.
+candidate state after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory,memory-candidates`
+makes candidate create/promote/reject Cairnline-first, including promoted or
+rejected status and promoted memory references.
 `project-assistant-proposal-ledger-live-mirror`
 mirrors Project Assistant draft/propose/apply proposal records and apply-attempt
 history after Hecate commits. `project-assistant-apply-side-effects-live-mirror`

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -367,8 +367,12 @@ func projectReplacementGateStatus(ready bool) string {
 func projectCairnlineWriteAdapterGapsSnapshot(writeAuthority []string) []string {
 	out := make([]string, 0, len(projectCairnlineWriteAdapterGapNames))
 	projectMemoryAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory")
+	memoryCandidatesAuthoritative := projectMemoryAuthoritative && projectCairnlineWriteAuthorityEnabled(writeAuthority, "memory-candidates")
 	for _, item := range projectCairnlineWriteAdapterGapNames {
 		if projectMemoryAuthoritative && item == "memory" {
+			continue
+		}
+		if memoryCandidatesAuthoritative && item == "memory-candidates" {
 			continue
 		}
 		out = append(out, item)
@@ -379,6 +383,7 @@ func projectCairnlineWriteAdapterGapsSnapshot(writeAuthority []string) []string 
 func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []ProjectCoordinationBackendWriteSwitchpoint {
 	out := make([]ProjectCoordinationBackendWriteSwitchpoint, 0, len(projectCairnlineWriteSwitchpoints))
 	projectMemoryAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory")
+	memoryCandidatesAuthoritative := projectMemoryAuthoritative && projectCairnlineWriteAuthorityEnabled(writeAuthority, "memory-candidates")
 	for _, item := range projectCairnlineWriteSwitchpoints {
 		if projectMemoryAuthoritative && item.Name == "project-memory" {
 			item.CurrentAuthority = "cairnline"
@@ -387,6 +392,14 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.BlocksAuthority = false
 			item.Gap = ""
 			item.Detail = "Accepted project memory entry mutations commit to the embedded Cairnline database first, then best-effort shadow durable memory state back into Hecate-native stores for compatibility."
+		}
+		if memoryCandidatesAuthoritative && item.Name == "memory-candidates" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Project memory-candidate create, promote, and reject mutations commit to the embedded Cairnline database first, then best-effort shadow review state and promoted-memory references back into Hecate-native stores for compatibility."
 		}
 		item.Seams = append([]string(nil), item.Seams...)
 		out = append(out, item)
@@ -405,6 +418,9 @@ func projectCairnlineWriteAuthorityEnabled(items []string, name string) bool {
 }
 
 func projectCairnlineProjectMemoryWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory") && projectCairnlineWriteAuthorityEnabled(writeAuthority, "memory-candidates") {
+		return "Accepted project memory entry and memory-candidate mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores; candidate promotion also creates accepted memory through Cairnline."
+	}
 	if projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory") {
 		return "Accepted project memory entry mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores; memory-candidate mutations still write Hecate-native stores first, then mirror reviewable candidate state into Cairnline."
 	}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -1,6 +1,9 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
@@ -282,9 +285,10 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 	switch configured {
 	case "cairnline":
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
+		writeAuthority := h.config.ProjectsCairnlineWriteAuthority()
 		response.WriteAdapterSeams = append([]string(nil), projectCairnlineWriteAdapterSeamNames...)
-		response.WriteAdapterGaps = append([]string(nil), projectCairnlineWriteAdapterGapNames...)
-		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot()
+		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsSnapshot(writeAuthority)
+		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(writeAuthority)
 		response.ReplacementGates = projectCairnlineReplacementGates(readReady)
 		response.ReadModelSwitchReady = readReady
 		if readReady {
@@ -304,7 +308,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 				"Project role and work-item mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline.",
 				"Project assignment create/update/delete mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results.",
 				"Project collaboration artifact creation and handoff mutations still write Hecate-native stores first, then best-effort mirror portable collaboration metadata into Cairnline.",
-				"Project memory entry and memory-candidate mutations still write Hecate-native stores first, then best-effort mirror accepted memory and reviewable candidate state into Cairnline.",
+				projectCairnlineProjectMemoryWriteWarning(writeAuthority),
 				"Project Assistant proposal draft/propose/apply ledger mutations still write Hecate-native stores first, then best-effort mirror proposal records plus committed apply side effects into Cairnline.",
 				"Other project mutation routes still write only Hecate-native stores.",
 				"Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready.",
@@ -360,13 +364,51 @@ func projectReplacementGateStatus(ready bool) string {
 	return "blocked"
 }
 
-func projectCairnlineWriteSwitchpointsSnapshot() []ProjectCoordinationBackendWriteSwitchpoint {
+func projectCairnlineWriteAdapterGapsSnapshot(writeAuthority []string) []string {
+	out := make([]string, 0, len(projectCairnlineWriteAdapterGapNames))
+	projectMemoryAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory")
+	for _, item := range projectCairnlineWriteAdapterGapNames {
+		if projectMemoryAuthoritative && item == "memory" {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []ProjectCoordinationBackendWriteSwitchpoint {
 	out := make([]ProjectCoordinationBackendWriteSwitchpoint, 0, len(projectCairnlineWriteSwitchpoints))
+	projectMemoryAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory")
 	for _, item := range projectCairnlineWriteSwitchpoints {
+		if projectMemoryAuthoritative && item.Name == "project-memory" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Accepted project memory entry mutations commit to the embedded Cairnline database first, then best-effort shadow durable memory state back into Hecate-native stores for compatibility."
+		}
 		item.Seams = append([]string(nil), item.Seams...)
 		out = append(out, item)
 	}
 	return out
+}
+
+func projectCairnlineWriteAuthorityEnabled(items []string, name string) bool {
+	name = strings.TrimSpace(name)
+	for _, item := range items {
+		if item == name {
+			return true
+		}
+	}
+	return false
+}
+
+func projectCairnlineProjectMemoryWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory") {
+		return "Accepted project memory entry mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores; memory-candidate mutations still write Hecate-native stores first, then mirror reviewable candidate state into Cairnline."
+	}
+	return "Project memory entry and memory-candidate mutations still write Hecate-native stores first, then best-effort mirror accepted memory and reviewable candidate state into Cairnline."
 }
 
 func projectCairnlineReadSourceDetail(source string) string {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -162,6 +162,34 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectMemoryAuthorityConfigu
 	}
 }
 
+func TestProjectCoordinationBackendStatus_CairnlineProjectMemoryCandidateAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-memory,memory-candidates",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "memory") || containsString(status.WriteAdapterGaps, "memory-candidates") {
+		t.Fatalf("write gaps = %+v, want memory and memory-candidates removed for opt-in Cairnline authority", status.WriteAdapterGaps)
+	}
+	for _, name := range []string{"project-memory", "memory-candidates"} {
+		point := findWriteSwitchpoint(status.WriteSwitchpoints, name)
+		if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+			t.Fatalf("%s switchpoint = %+v, want opt-in Cairnline authority", name, point)
+		}
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	if !strings.Contains(strings.Join(status.Warnings, "\n"), "candidate promotion also creates accepted memory through Cairnline") {
+		t.Fatalf("warnings = %+v, want memory-candidate authority warning", status.Warnings)
+	}
+}
+
 func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	cfg := config.Config{

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -130,6 +130,38 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	}
 }
 
+func TestProjectCoordinationBackendStatus_CairnlineProjectMemoryAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-memory",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if status.ConfiguredBackend != "cairnline" || status.AuthoritativeBackend != "hecate" || !status.ReadModelSwitchReady || status.ReplacementReady {
+		t.Fatalf("status = %+v, want Cairnline read routes ready, partial write authority, and no full replacement readiness", status)
+	}
+	if containsString(status.WriteAdapterGaps, "memory") {
+		t.Fatalf("write gaps = %+v, want accepted project memory removed while memory-candidates still block", status.WriteAdapterGaps)
+	}
+	if !containsString(status.WriteAdapterGaps, "memory-candidates") {
+		t.Fatalf("write gaps = %+v, want memory-candidates to remain blocking", status.WriteAdapterGaps)
+	}
+	point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-memory")
+	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("project-memory switchpoint = %+v, want opt-in Cairnline authority", point)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "blocked" {
+		t.Fatalf("write-authority gate = %+v, want full replacement still blocked", gate)
+	}
+	if !strings.Contains(strings.Join(status.Warnings, "\n"), "Accepted project memory entry mutations are opt-in Cairnline-authoritative") {
+		t.Fatalf("warnings = %+v, want project-memory authority warning", status.Warnings)
+	}
+}
+
 func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	cfg := config.Config{

--- a/internal/api/handler_project_memory.go
+++ b/internal/api/handler_project_memory.go
@@ -174,6 +174,15 @@ func (h *Handler) HandleCreateProjectMemoryCandidate(w http.ResponseWriter, r *h
 		SourceRefs:          candidateSourceRefsFromRequest(req.SourceRefs),
 		Status:              memory.CandidateStatusPending,
 	}
+	if h.projectMemoryCandidatesWriteUseCairnlineAuthority() {
+		created, err := h.createProjectMemoryCandidateWithCairnlineAuthority(r.Context(), projectID, candidate)
+		if writeProjectMemoryMutationError(w, err, "project memory candidate not found") {
+			return
+		}
+		h.shadowProjectMemoryCandidateToHecate(r.Context(), "project_memory_candidate_authority_create_shadow", created)
+		WriteJSON(w, http.StatusCreated, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(created, "cairnline")})
+		return
+	}
 	created, err := candidateStore.CreateCandidate(r.Context(), candidate)
 	if errors.Is(err, memory.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
@@ -205,6 +214,16 @@ func (h *Handler) HandlePromoteProjectMemoryCandidate(w http.ResponseWriter, r *
 		return
 	}
 	candidateID := r.PathValue("candidate_id")
+	if h.projectMemoryCandidatesWriteUseCairnlineAuthority() {
+		updated, promotedEntry, err := h.promoteProjectMemoryCandidateWithCairnlineAuthority(r.Context(), projectID, candidateID, req)
+		if writeProjectMemoryMutationError(w, err, "project memory candidate not found") {
+			return
+		}
+		h.shadowProjectMemoryEntryToHecate(r.Context(), "project_memory_candidate_authority_promote_entry_shadow", promotedEntry)
+		h.shadowProjectMemoryCandidateToHecate(r.Context(), "project_memory_candidate_authority_promote_shadow", updated)
+		WriteJSON(w, http.StatusOK, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(updated, "cairnline")})
+		return
+	}
 	candidate, ok, err := candidateStore.GetCandidate(r.Context(), projectID, candidateID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -284,6 +303,15 @@ func (h *Handler) HandleRejectProjectMemoryCandidate(w http.ResponseWriter, r *h
 		return
 	}
 	candidateID := r.PathValue("candidate_id")
+	if h.projectMemoryCandidatesWriteUseCairnlineAuthority() {
+		updated, err := h.rejectProjectMemoryCandidateWithCairnlineAuthority(r.Context(), projectID, candidateID, req.Reason)
+		if writeProjectMemoryMutationError(w, err, "project memory candidate not found") {
+			return
+		}
+		h.shadowProjectMemoryCandidateToHecate(r.Context(), "project_memory_candidate_authority_reject_shadow", updated)
+		WriteJSON(w, http.StatusOK, ProjectMemoryCandidateResponse{Object: "project_memory_candidate", Data: renderProjectMemoryCandidate(updated, "cairnline")})
+		return
+	}
 	candidate, ok, err := candidateStore.GetCandidate(r.Context(), projectID, candidateID)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())

--- a/internal/api/handler_project_memory.go
+++ b/internal/api/handler_project_memory.go
@@ -102,6 +102,16 @@ func (h *Handler) HandleCreateProjectMemoryEntry(w http.ResponseWriter, r *http.
 		SourceID:   req.SourceID,
 		Enabled:    enabled,
 	}
+	entry = normalizeProjectMemoryEntryForCairnlineAuthority(entry)
+	if h.projectMemoryWritesUseCairnlineAuthority() {
+		created, err := h.createProjectMemoryEntryWithCairnlineAuthority(r.Context(), projectID, entry)
+		if writeProjectMemoryMutationError(w, err, "project memory entry not found") {
+			return
+		}
+		h.shadowProjectMemoryEntryToHecate(r.Context(), "project_memory_authority_create_shadow", created)
+		WriteJSON(w, http.StatusCreated, ProjectMemoryResponse{Object: "project_memory_entry", Data: renderProjectMemory(created, "cairnline")})
+		return
+	}
 	created, err := h.memory.Create(r.Context(), entry)
 	if errors.Is(err, memory.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
@@ -316,25 +326,19 @@ func (h *Handler) HandleUpdateProjectMemoryEntry(w http.ResponseWriter, r *http.
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if h.projectMemoryWritesUseCairnlineAuthority() {
+		entry, err := h.updateProjectMemoryEntryWithCairnlineAuthority(r.Context(), projectID, r.PathValue("memory_id"), func(item *memory.Entry) {
+			applyProjectMemoryUpdate(item, req)
+		})
+		if writeProjectMemoryMutationError(w, err, "project memory entry not found") {
+			return
+		}
+		h.shadowProjectMemoryEntryToHecate(r.Context(), "project_memory_authority_update_shadow", entry)
+		WriteJSON(w, http.StatusOK, ProjectMemoryResponse{Object: "project_memory_entry", Data: renderProjectMemory(entry, "cairnline")})
+		return
+	}
 	entry, err := h.memory.Update(r.Context(), projectID, r.PathValue("memory_id"), func(item *memory.Entry) {
-		if req.Title != nil {
-			item.Title = *req.Title
-		}
-		if req.Body != nil {
-			item.Body = *req.Body
-		}
-		if req.TrustLabel != nil {
-			item.TrustLabel = *req.TrustLabel
-		}
-		if req.SourceKind != nil {
-			item.SourceKind = *req.SourceKind
-		}
-		if req.SourceID != nil {
-			item.SourceID = *req.SourceID
-		}
-		if req.Enabled != nil {
-			item.Enabled = *req.Enabled
-		}
+		applyProjectMemoryUpdate(item, req)
 	})
 	if errors.Is(err, memory.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project memory entry not found")
@@ -358,6 +362,15 @@ func (h *Handler) HandleDeleteProjectMemoryEntry(w http.ResponseWriter, r *http.
 		return
 	}
 	if !h.requireProjectMemoryStore(w) {
+		return
+	}
+	if h.projectMemoryWritesUseCairnlineAuthority() {
+		err := h.deleteProjectMemoryEntryWithCairnlineAuthority(r.Context(), projectID, r.PathValue("memory_id"))
+		if writeProjectMemoryMutationError(w, err, "project memory entry not found") {
+			return
+		}
+		h.shadowProjectMemoryEntryDeleteToHecate(r.Context(), "project_memory_authority_delete_shadow", projectID, r.PathValue("memory_id"))
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	err := h.memory.Delete(r.Context(), projectID, r.PathValue("memory_id"))

--- a/internal/api/handler_project_memory_authority.go
+++ b/internal/api/handler_project_memory_authority.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/memory"
+)
+
+func applyProjectMemoryUpdate(item *memory.Entry, req updateProjectMemoryRequest) {
+	if req.Title != nil {
+		item.Title = *req.Title
+	}
+	if req.Body != nil {
+		item.Body = *req.Body
+	}
+	if req.TrustLabel != nil {
+		item.TrustLabel = *req.TrustLabel
+	}
+	if req.SourceKind != nil {
+		item.SourceKind = *req.SourceKind
+	}
+	if req.SourceID != nil {
+		item.SourceID = *req.SourceID
+	}
+	if req.Enabled != nil {
+		item.Enabled = *req.Enabled
+	}
+}
+
+func (h *Handler) projectMemoryWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled("project-memory")
+}
+
+func (h *Handler) createProjectMemoryEntryWithCairnlineAuthority(ctx context.Context, projectID string, entry memory.Entry) (memory.Entry, error) {
+	var created cairnline.MemoryEntry
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.seedProjectMetadataForCairnlineMemoryAuthority(ctx, service, projectID); err != nil {
+			return err
+		}
+		item, err := service.CreateMemoryEntry(ctx, cairnlinebridge.MemoryEntry(entry))
+		if err != nil {
+			return err
+		}
+		if item.Enabled != entry.Enabled {
+			item.Enabled = entry.Enabled
+			item, err = service.UpdateMemoryEntry(ctx, item)
+			if err != nil {
+				return err
+			}
+		}
+		created = item
+		return nil
+	})
+	if err != nil {
+		return memory.Entry{}, err
+	}
+	return projectMemoryFromCairnline(created), nil
+}
+
+func (h *Handler) updateProjectMemoryEntryWithCairnlineAuthority(ctx context.Context, projectID, memoryID string, update func(*memory.Entry)) (memory.Entry, error) {
+	var updated cairnline.MemoryEntry
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := service.GetMemoryEntry(ctx, projectID, memoryID)
+		if err != nil {
+			return err
+		}
+		entry := projectMemoryFromCairnline(existing)
+		if update != nil {
+			update(&entry)
+		}
+		entry = normalizeProjectMemoryEntryForCairnlineAuthority(entry)
+		entry.UpdatedAt = time.Time{}
+		item, err := service.UpdateMemoryEntry(ctx, cairnlinebridge.MemoryEntry(entry))
+		if err != nil {
+			return err
+		}
+		updated = item
+		return nil
+	})
+	if err != nil {
+		return memory.Entry{}, err
+	}
+	return projectMemoryFromCairnline(updated), nil
+}
+
+func (h *Handler) deleteProjectMemoryEntryWithCairnlineAuthority(ctx context.Context, projectID, memoryID string) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		return service.DeleteMemoryEntry(ctx, projectID, memoryID)
+	})
+}
+
+func (h *Handler) seedProjectMetadataForCairnlineMemoryAuthority(ctx context.Context, service *cairnline.Service, projectID string) error {
+	project, ok := h.projectForCairnlineMirror(ctx, "project_memory_authority", projectID)
+	if !ok {
+		return errors.Join(cairnline.ErrNotFound, errors.New("project not found for Cairnline memory authority"))
+	}
+	_, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project)
+	return err
+}
+
+func normalizeProjectMemoryEntryForCairnlineAuthority(entry memory.Entry) memory.Entry {
+	entry.ID = strings.TrimSpace(entry.ID)
+	entry.Scope = strings.TrimSpace(entry.Scope)
+	if entry.Scope == "" {
+		entry.Scope = memory.ScopeProject
+	}
+	entry.ProjectID = strings.TrimSpace(entry.ProjectID)
+	entry.Title = strings.TrimSpace(entry.Title)
+	entry.Body = strings.TrimSpace(entry.Body)
+	entry.TrustLabel = strings.TrimSpace(entry.TrustLabel)
+	if entry.TrustLabel == "" {
+		entry.TrustLabel = memory.TrustLabelOperatorMemory
+	}
+	entry.SourceKind = strings.TrimSpace(entry.SourceKind)
+	if entry.SourceKind == "" {
+		entry.SourceKind = memory.SourceKindOperator
+	}
+	entry.SourceID = strings.TrimSpace(entry.SourceID)
+	return entry
+}
+
+func (h *Handler) shadowProjectMemoryEntryToHecate(ctx context.Context, operation string, entry memory.Entry) {
+	if h == nil || h.memory == nil {
+		return
+	}
+	if err := h.memory.Delete(ctx, entry.ProjectID, entry.ID); err != nil && !errors.Is(err, memory.ErrNotFound) {
+		h.logProjectMemoryShadowError(ctx, operation, entry.ProjectID, entry.ID, err)
+		return
+	}
+	if _, err := h.memory.Create(ctx, entry); err != nil {
+		h.logProjectMemoryShadowError(ctx, operation, entry.ProjectID, entry.ID, err)
+	}
+}
+
+func (h *Handler) shadowProjectMemoryEntryDeleteToHecate(ctx context.Context, operation, projectID, memoryID string) {
+	if h == nil || h.memory == nil {
+		return
+	}
+	if err := h.memory.Delete(ctx, projectID, memoryID); err != nil && !errors.Is(err, memory.ErrNotFound) {
+		h.logProjectMemoryShadowError(ctx, operation, projectID, memoryID, err)
+	}
+}
+
+func (h *Handler) logProjectMemoryShadowError(ctx context.Context, operation, projectID, memoryID string, err error) {
+	if err == nil {
+		return
+	}
+	if h == nil {
+		return
+	}
+	logger := h.logger
+	if logger == nil {
+		return
+	}
+	logger.WarnContext(ctx, "project memory Hecate shadow failed", "operation", operation, "project_id", projectID, "memory_id", memoryID, "error", err)
+}
+
+func writeProjectMemoryMutationError(w http.ResponseWriter, err error, notFoundMessage string) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, memory.ErrInvalid) || errors.Is(err, cairnline.ErrInvalid) {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return true
+	}
+	if errors.Is(err, memory.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, notFoundMessage)
+		return true
+	}
+	if errors.Is(err, memory.ErrAlreadyExists) || errors.Is(err, memory.ErrConflict) || errors.Is(err, cairnline.ErrConflict) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+		return true
+	}
+	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	return true
+}

--- a/internal/api/handler_project_memory_authority.go
+++ b/internal/api/handler_project_memory_authority.go
@@ -175,7 +175,7 @@ func writeProjectMemoryMutationError(w http.ResponseWriter, err error, notFoundM
 		WriteError(w, http.StatusNotFound, errCodeNotFound, notFoundMessage)
 		return true
 	}
-	if errors.Is(err, memory.ErrAlreadyExists) || errors.Is(err, memory.ErrConflict) || errors.Is(err, cairnline.ErrConflict) {
+	if errors.Is(err, memory.ErrAlreadyExists) || errors.Is(err, memory.ErrConflict) || errors.Is(err, cairnline.ErrDuplicate) || errors.Is(err, cairnline.ErrConflict) {
 		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
 		return true
 	}

--- a/internal/api/handler_project_memory_authority.go
+++ b/internal/api/handler_project_memory_authority.go
@@ -131,11 +131,24 @@ func (h *Handler) shadowProjectMemoryEntryToHecate(ctx context.Context, operatio
 	if h == nil || h.memory == nil {
 		return
 	}
-	if err := h.memory.Delete(ctx, entry.ProjectID, entry.ID); err != nil && !errors.Is(err, memory.ErrNotFound) {
+	if _, ok, err := h.memory.Get(ctx, entry.ProjectID, entry.ID); err != nil {
 		h.logProjectMemoryShadowError(ctx, operation, entry.ProjectID, entry.ID, err)
 		return
+	} else if ok {
+		_, err := h.memory.Update(ctx, entry.ProjectID, entry.ID, func(item *memory.Entry) {
+			item.Title = entry.Title
+			item.Body = entry.Body
+			item.TrustLabel = entry.TrustLabel
+			item.SourceKind = entry.SourceKind
+			item.SourceID = entry.SourceID
+			item.Enabled = entry.Enabled
+		})
+		if err != nil {
+			h.logProjectMemoryShadowError(ctx, operation, entry.ProjectID, entry.ID, err)
+		}
+		return
 	}
-	if _, err := h.memory.Create(ctx, entry); err != nil {
+	if _, err := h.memory.Create(ctx, entry); err != nil && !errors.Is(err, memory.ErrAlreadyExists) {
 		h.logProjectMemoryShadowError(ctx, operation, entry.ProjectID, entry.ID, err)
 	}
 }

--- a/internal/api/handler_project_memory_candidate_authority.go
+++ b/internal/api/handler_project_memory_candidate_authority.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/memory"
+)
+
+func (h *Handler) projectMemoryCandidatesWriteUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled("project-memory") &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled("memory-candidates")
+}
+
+func (h *Handler) createProjectMemoryCandidateWithCairnlineAuthority(ctx context.Context, projectID string, candidate memory.Candidate) (memory.Candidate, error) {
+	var created cairnline.MemoryCandidate
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.seedProjectMetadataForCairnlineMemoryAuthority(ctx, service, projectID); err != nil {
+			return err
+		}
+		item, err := service.CreateMemoryCandidate(ctx, cairnlinebridge.MemoryCandidate(normalizeProjectMemoryCandidateForCairnlineAuthority(candidate)))
+		if err != nil {
+			return err
+		}
+		created = item
+		return nil
+	})
+	if err != nil {
+		return memory.Candidate{}, err
+	}
+	return projectMemoryCandidateFromCairnline(created), nil
+}
+
+func (h *Handler) promoteProjectMemoryCandidateWithCairnlineAuthority(ctx context.Context, projectID, candidateID string, req promoteProjectMemoryCandidateRequest) (memory.Candidate, memory.Entry, error) {
+	var updated cairnline.MemoryCandidate
+	var promoted cairnline.MemoryEntry
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.seedProjectMetadataForCairnlineMemoryAuthority(ctx, service, projectID); err != nil {
+			return err
+		}
+		candidate, entry, err := service.PromoteMemoryCandidate(ctx, cairnline.MemoryCandidatePromotion{
+			ProjectID:   projectID,
+			CandidateID: candidateID,
+			Title:       req.Title,
+			Body:        req.Body,
+			TrustLabel:  req.TrustLabel,
+			SourceKind:  req.SourceKind,
+			SourceID:    req.SourceID,
+			Enabled:     req.Enabled,
+		})
+		if err != nil {
+			return err
+		}
+		updated = candidate
+		promoted = entry
+		return nil
+	})
+	if err != nil {
+		return memory.Candidate{}, memory.Entry{}, err
+	}
+	return projectMemoryCandidateFromCairnline(updated), projectMemoryFromCairnline(promoted), nil
+}
+
+func (h *Handler) rejectProjectMemoryCandidateWithCairnlineAuthority(ctx context.Context, projectID, candidateID, reason string) (memory.Candidate, error) {
+	var updated cairnline.MemoryCandidate
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.seedProjectMetadataForCairnlineMemoryAuthority(ctx, service, projectID); err != nil {
+			return err
+		}
+		item, err := service.RejectMemoryCandidate(ctx, projectID, candidateID, reason)
+		if err != nil {
+			return err
+		}
+		updated = item
+		return nil
+	})
+	if err != nil {
+		return memory.Candidate{}, err
+	}
+	return projectMemoryCandidateFromCairnline(updated), nil
+}
+
+func normalizeProjectMemoryCandidateForCairnlineAuthority(candidate memory.Candidate) memory.Candidate {
+	candidate.ID = strings.TrimSpace(candidate.ID)
+	candidate.ProjectID = strings.TrimSpace(candidate.ProjectID)
+	candidate.Title = strings.TrimSpace(candidate.Title)
+	candidate.Body = strings.TrimSpace(candidate.Body)
+	candidate.SuggestedKind = strings.TrimSpace(candidate.SuggestedKind)
+	candidate.SuggestedTrustLabel = strings.TrimSpace(candidate.SuggestedTrustLabel)
+	if candidate.SuggestedTrustLabel == "" {
+		candidate.SuggestedTrustLabel = memory.TrustLabelGenerated
+	}
+	candidate.SuggestedSourceKind = strings.TrimSpace(candidate.SuggestedSourceKind)
+	if candidate.SuggestedSourceKind == "" {
+		candidate.SuggestedSourceKind = memory.SourceKindGenerated
+	}
+	candidate.SuggestedSourceID = strings.TrimSpace(candidate.SuggestedSourceID)
+	candidate.Status = strings.TrimSpace(candidate.Status)
+	if candidate.Status == "" {
+		candidate.Status = memory.CandidateStatusPending
+	}
+	candidate.StatusReason = strings.TrimSpace(candidate.StatusReason)
+	candidate.PromotedMemoryID = strings.TrimSpace(candidate.PromotedMemoryID)
+	return candidate
+}
+
+func (h *Handler) shadowProjectMemoryCandidateToHecate(ctx context.Context, operation string, candidate memory.Candidate) {
+	if h == nil || h.memoryCandidates == nil {
+		return
+	}
+	if _, ok, err := h.memoryCandidates.GetCandidate(ctx, candidate.ProjectID, candidate.ID); err != nil {
+		h.logProjectMemoryCandidateShadowError(ctx, operation, candidate.ProjectID, candidate.ID, err)
+		return
+	} else if ok {
+		_, err := h.memoryCandidates.UpdateCandidate(ctx, candidate.ProjectID, candidate.ID, func(item *memory.Candidate) {
+			item.Title = candidate.Title
+			item.Body = candidate.Body
+			item.SuggestedKind = candidate.SuggestedKind
+			item.SuggestedTrustLabel = candidate.SuggestedTrustLabel
+			item.SuggestedSourceKind = candidate.SuggestedSourceKind
+			item.SuggestedSourceID = candidate.SuggestedSourceID
+			item.SourceRefs = append([]memory.CandidateSourceRef(nil), candidate.SourceRefs...)
+			item.Status = candidate.Status
+			item.StatusReason = candidate.StatusReason
+			item.PromotedMemoryID = candidate.PromotedMemoryID
+		})
+		if err != nil {
+			h.logProjectMemoryCandidateShadowError(ctx, operation, candidate.ProjectID, candidate.ID, err)
+		}
+		return
+	}
+	if _, err := h.memoryCandidates.CreateCandidate(ctx, candidate); err != nil && !errors.Is(err, memory.ErrAlreadyExists) {
+		h.logProjectMemoryCandidateShadowError(ctx, operation, candidate.ProjectID, candidate.ID, err)
+	}
+}
+
+func (h *Handler) logProjectMemoryCandidateShadowError(ctx context.Context, operation, projectID, candidateID string, err error) {
+	if err == nil || h == nil || h.logger == nil {
+		return
+	}
+	h.logger.WarnContext(ctx, "project memory candidate Hecate shadow failed", "operation", operation, "project_id", projectID, "candidate_id", candidateID, "error", err)
+}

--- a/internal/api/handler_project_memory_test.go
+++ b/internal/api/handler_project_memory_test.go
@@ -480,6 +480,46 @@ func TestProjectMemoryAPI_CairnlineWriteAuthorityCommitsAcceptedMemoryFirst(t *t
 	}
 }
 
+func TestShadowProjectMemoryEntryToHecateUpdatesExistingShadowInPlace(t *testing.T) {
+	t.Parallel()
+	store := &existingProjectMemoryShadowStore{
+		entry: memory.Entry{
+			ID:         "mem_existing",
+			Scope:      memory.ScopeProject,
+			ProjectID:  "proj_existing",
+			Title:      "Old title",
+			Body:       "Old body",
+			TrustLabel: memory.TrustLabelOperatorMemory,
+			SourceKind: memory.SourceKindOperator,
+			SourceID:   "old_source",
+			Enabled:    false,
+		},
+	}
+	handler := &Handler{memory: store}
+
+	handler.shadowProjectMemoryEntryToHecate(t.Context(), "test_shadow_update", memory.Entry{
+		ID:         "mem_existing",
+		Scope:      memory.ScopeProject,
+		ProjectID:  "proj_existing",
+		Title:      "New title",
+		Body:       "New body",
+		TrustLabel: memory.TrustLabelGenerated,
+		SourceKind: "handoff",
+		SourceID:   "handoff_1",
+		Enabled:    true,
+	})
+
+	if store.deleted || store.created {
+		t.Fatalf("shadow calls delete=%v create=%v, want update in place", store.deleted, store.created)
+	}
+	if !store.updated {
+		t.Fatal("shadow did not update existing entry")
+	}
+	if got := store.entry; got.Title != "New title" || got.Body != "New body" || got.TrustLabel != memory.TrustLabelGenerated || got.SourceKind != "handoff" || got.SourceID != "handoff_1" || !got.Enabled {
+		t.Fatalf("shadow entry = %+v, want updated fields", got)
+	}
+}
+
 func TestProjectMemoryAPI_CairnlineWriteAuthorityCommitsMemoryCandidatesFirst(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectMemoryCairnlineCandidateAuthorityTestServer(t)
@@ -1087,5 +1127,46 @@ func (conflictMemoryStore) Delete(context.Context, string, string) error {
 }
 
 func (conflictMemoryStore) DeleteByProjectID(context.Context, string) (int, error) {
+	return 0, nil
+}
+
+type existingProjectMemoryShadowStore struct {
+	entry   memory.Entry
+	created bool
+	updated bool
+	deleted bool
+}
+
+func (s *existingProjectMemoryShadowStore) Backend() string {
+	return "memory"
+}
+
+func (s *existingProjectMemoryShadowStore) Create(context.Context, memory.Entry) (memory.Entry, error) {
+	s.created = true
+	return memory.Entry{}, errors.New("create should not be called for existing shadows")
+}
+
+func (s *existingProjectMemoryShadowStore) Get(context.Context, string, string) (memory.Entry, bool, error) {
+	return s.entry, true, nil
+}
+
+func (s *existingProjectMemoryShadowStore) List(context.Context, memory.Filter) ([]memory.Entry, error) {
+	return nil, nil
+}
+
+func (s *existingProjectMemoryShadowStore) Update(_ context.Context, _ string, _ string, update func(*memory.Entry)) (memory.Entry, error) {
+	s.updated = true
+	if update != nil {
+		update(&s.entry)
+	}
+	return s.entry, nil
+}
+
+func (s *existingProjectMemoryShadowStore) Delete(context.Context, string, string) error {
+	s.deleted = true
+	return nil
+}
+
+func (s *existingProjectMemoryShadowStore) DeleteByProjectID(context.Context, string) (int, error) {
 	return 0, nil
 }

--- a/internal/api/handler_project_memory_test.go
+++ b/internal/api/handler_project_memory_test.go
@@ -50,6 +50,20 @@ func newProjectMemoryCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Han
 	return handler, NewServer(quietLogger(), handler)
 }
 
+func newProjectMemoryCairnlineAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: "project-memory",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
 func TestProjectMemoryAPI_CRUD(t *testing.T) {
 	t.Parallel()
 	server := newProjectMemoryTestServer()
@@ -384,6 +398,71 @@ func TestProjectMemoryAPI_MirrorsMutationsToCairnlineWhenConfigured(t *testing.T
 	mirroredRejected := getMirroredCairnlineMemoryCandidateForTest(t, handler, projectID, rejected.Data.ID)
 	if mirroredRejected.Status != cairnline.MemoryCandidateRejected || mirroredRejected.StatusReason != "Not durable project guidance" || mirroredRejected.PromotedMemoryID != "" {
 		t.Fatalf("mirrored rejected candidate = %+v, want rejected reason without promoted memory", mirroredRejected)
+	}
+}
+
+func TestProjectMemoryAPI_CairnlineWriteAuthorityCommitsAcceptedMemoryFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectMemoryCairnlineAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	project := createMemoryTestProject(t, server, "Memory Authority")
+	projectID := project.Data.ID
+
+	created := mustRequestJSONStatus[ProjectMemoryResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory", `{
+		"title":"Authority note",
+		"body":"Accepted memory can be Cairnline-authoritative.",
+		"enabled":false
+	}`)
+	if created.Data.ReadBackend != "cairnline" || created.Data.TrustLabel != memory.TrustLabelOperatorMemory || created.Data.SourceKind != memory.SourceKindOperator || created.Data.Enabled {
+		t.Fatalf("created memory = %+v, want disabled Cairnline-backed operator memory with normalized source", created.Data)
+	}
+	mirroredMemory := getMirroredCairnlineMemoryEntryForTest(t, handler, projectID, created.Data.ID)
+	if mirroredMemory.Title != "Authority note" || mirroredMemory.SourceKind != memory.SourceKindOperator || mirroredMemory.Enabled {
+		t.Fatalf("Cairnline memory = %+v, want authoritative disabled normalized entry", mirroredMemory)
+	}
+	shadow, ok, err := handler.memory.Get(t.Context(), projectID, created.Data.ID)
+	if err != nil || !ok {
+		t.Fatalf("native shadow memory ok=%v error=%v, want present", ok, err)
+	}
+	if shadow.Title != created.Data.Title || shadow.SourceKind != memory.SourceKindOperator || shadow.Enabled {
+		t.Fatalf("native shadow memory = %+v, want created Cairnline entry shadowed", shadow)
+	}
+
+	updated := mustRequestJSON[ProjectMemoryResponse](client, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/memory/"+created.Data.ID, `{
+		"title":"Authority note updated",
+		"body":"Shadow Hecate after Cairnline commits.",
+		"trust_label":"generated_summary",
+		"source_kind":"handoff",
+		"source_id":"handoff_1",
+		"enabled":true
+	}`)
+	if updated.Data.ReadBackend != "cairnline" || updated.Data.Title != "Authority note updated" || updated.Data.TrustLabel != memory.TrustLabelGenerated || updated.Data.SourceKind != "handoff" || !updated.Data.Enabled {
+		t.Fatalf("updated memory = %+v, want Cairnline-backed patched entry", updated.Data)
+	}
+	mirroredMemory = getMirroredCairnlineMemoryEntryForTest(t, handler, projectID, created.Data.ID)
+	if mirroredMemory.Title != "Authority note updated" || mirroredMemory.Body != "Shadow Hecate after Cairnline commits." || mirroredMemory.SourceKind != "handoff" || mirroredMemory.SourceID != "handoff_1" || !mirroredMemory.Enabled {
+		t.Fatalf("updated Cairnline memory = %+v, want patched authoritative entry", mirroredMemory)
+	}
+	shadow, ok, err = handler.memory.Get(t.Context(), projectID, created.Data.ID)
+	if err != nil || !ok {
+		t.Fatalf("updated native shadow memory ok=%v error=%v, want present", ok, err)
+	}
+	if shadow.Title != updated.Data.Title || shadow.Body != updated.Data.Body || shadow.TrustLabel != updated.Data.TrustLabel || shadow.SourceKind != updated.Data.SourceKind || shadow.SourceID != updated.Data.SourceID || shadow.Enabled != updated.Data.Enabled {
+		t.Fatalf("updated native shadow memory = %+v, want updated Cairnline entry shadowed", shadow)
+	}
+
+	candidate := mustRequestJSONStatus[ProjectMemoryCandidateResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates", `{
+		"title":"Candidate remains Hecate-owned",
+		"body":"Candidates are a separate authority switchpoint."
+	}`)
+	if candidate.Data.ReadBackend != "hecate" {
+		t.Fatalf("candidate read backend = %q, want hecate while only accepted memory is Cairnline-authoritative", candidate.Data.ReadBackend)
+	}
+
+	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/memory/"+created.Data.ID, "")
+	assertCairnlineMemoryEntryMissingForTest(t, handler, projectID, created.Data.ID)
+	if _, ok, err := handler.memory.Get(t.Context(), projectID, created.Data.ID); err != nil || ok {
+		t.Fatalf("deleted native shadow ok=%v error=%v, want missing", ok, err)
 	}
 }
 

--- a/internal/api/handler_project_memory_test.go
+++ b/internal/api/handler_project_memory_test.go
@@ -64,6 +64,20 @@ func newProjectMemoryCairnlineAuthorityTestServer(t *testing.T) (*Handler, http.
 	return handler, NewServer(quietLogger(), handler)
 }
 
+func newProjectMemoryCairnlineCandidateAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: "project-memory,memory-candidates",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
 func TestProjectMemoryAPI_CRUD(t *testing.T) {
 	t.Parallel()
 	server := newProjectMemoryTestServer()
@@ -463,6 +477,84 @@ func TestProjectMemoryAPI_CairnlineWriteAuthorityCommitsAcceptedMemoryFirst(t *t
 	assertCairnlineMemoryEntryMissingForTest(t, handler, projectID, created.Data.ID)
 	if _, ok, err := handler.memory.Get(t.Context(), projectID, created.Data.ID); err != nil || ok {
 		t.Fatalf("deleted native shadow ok=%v error=%v, want missing", ok, err)
+	}
+}
+
+func TestProjectMemoryAPI_CairnlineWriteAuthorityCommitsMemoryCandidatesFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectMemoryCairnlineCandidateAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	project := createMemoryTestProject(t, server, "Memory Candidate Authority")
+	projectID := project.Data.ID
+
+	rejectCandidate := mustRequestJSONStatus[ProjectMemoryCandidateResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates", `{
+		"title":"Generated maybe",
+		"body":"Reviewable candidates can be Cairnline-authoritative.",
+		"source_refs":[{"kind":"handoff","id":"hand_1","title":"Handoff"}]
+	}`)
+	if rejectCandidate.Data.ReadBackend != "cairnline" || rejectCandidate.Data.SuggestedTrustLabel != memory.TrustLabelGenerated || rejectCandidate.Data.SuggestedSourceKind != memory.SourceKindGenerated || len(rejectCandidate.Data.SourceRefs) != 1 {
+		t.Fatalf("created candidate = %+v, want Cairnline-backed normalized candidate with source ref", rejectCandidate.Data)
+	}
+	mirroredCandidate := getMirroredCairnlineMemoryCandidateForTest(t, handler, projectID, rejectCandidate.Data.ID)
+	if mirroredCandidate.Status != cairnline.MemoryCandidatePending || mirroredCandidate.Title != "Generated maybe" {
+		t.Fatalf("Cairnline candidate = %+v, want pending authoritative candidate", mirroredCandidate)
+	}
+	shadowCandidate, ok, err := handler.memoryCandidates.GetCandidate(t.Context(), projectID, rejectCandidate.Data.ID)
+	if err != nil || !ok {
+		t.Fatalf("native candidate shadow ok=%v error=%v, want present", ok, err)
+	}
+	if shadowCandidate.ID != rejectCandidate.Data.ID || shadowCandidate.Title != rejectCandidate.Data.Title || shadowCandidate.Status != memory.CandidateStatusPending {
+		t.Fatalf("native candidate shadow = %+v, want shadowed pending candidate", shadowCandidate)
+	}
+
+	rejected := mustRequestJSON[ProjectMemoryCandidateResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates/"+rejectCandidate.Data.ID+"/reject", `{"reason":"Too speculative"}`)
+	if rejected.Data.ReadBackend != "cairnline" || rejected.Data.Status != memory.CandidateStatusRejected || rejected.Data.StatusReason != "Too speculative" {
+		t.Fatalf("rejected candidate = %+v, want Cairnline-backed rejected state", rejected.Data)
+	}
+	mirroredCandidate = getMirroredCairnlineMemoryCandidateForTest(t, handler, projectID, rejectCandidate.Data.ID)
+	if mirroredCandidate.Status != cairnline.MemoryCandidateRejected || mirroredCandidate.StatusReason != "Too speculative" {
+		t.Fatalf("Cairnline rejected candidate = %+v, want rejected reason", mirroredCandidate)
+	}
+	shadowCandidate, ok, err = handler.memoryCandidates.GetCandidate(t.Context(), projectID, rejectCandidate.Data.ID)
+	if err != nil || !ok || shadowCandidate.Status != memory.CandidateStatusRejected || shadowCandidate.StatusReason != "Too speculative" {
+		t.Fatalf("native rejected candidate shadow = %+v ok=%v error=%v, want rejected shadow", shadowCandidate, ok, err)
+	}
+
+	promoteCandidate := mustRequestJSONStatus[ProjectMemoryCandidateResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates", `{
+		"title":"Generated lesson",
+		"body":"Capture durable lessons after review.",
+		"suggested_kind":"lesson",
+		"suggested_trust_label":"generated_summary",
+		"suggested_source_kind":"artifact",
+		"suggested_source_id":"art_1"
+	}`)
+	promoted := mustRequestJSON[ProjectMemoryCandidateResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates/"+promoteCandidate.Data.ID+"/promote", `{
+		"title":"Reviewed lesson",
+		"body":"Capture durable lessons after operator review.",
+		"trust_label":"operator_memory",
+		"source_kind":"operator",
+		"source_id":"art_1",
+		"enabled":true
+	}`)
+	if promoted.Data.ReadBackend != "cairnline" || promoted.Data.Status != memory.CandidateStatusPromoted || promoted.Data.PromotedMemoryID == "" {
+		t.Fatalf("promoted candidate = %+v, want Cairnline-backed promoted state", promoted.Data)
+	}
+	mirroredMemory := getMirroredCairnlineMemoryEntryForTest(t, handler, projectID, promoted.Data.PromotedMemoryID)
+	if mirroredMemory.Title != "Reviewed lesson" || mirroredMemory.Body != "Capture durable lessons after operator review." || mirroredMemory.TrustLabel != memory.TrustLabelOperatorMemory || mirroredMemory.SourceKind != memory.SourceKindOperator {
+		t.Fatalf("Cairnline promoted memory = %+v, want reviewed operator memory", mirroredMemory)
+	}
+	shadowMemory, ok, err := handler.memory.Get(t.Context(), projectID, promoted.Data.PromotedMemoryID)
+	if err != nil || !ok || shadowMemory.Title != "Reviewed lesson" || shadowMemory.TrustLabel != memory.TrustLabelOperatorMemory {
+		t.Fatalf("native promoted memory shadow = %+v ok=%v error=%v, want promoted memory shadow", shadowMemory, ok, err)
+	}
+	shadowCandidate, ok, err = handler.memoryCandidates.GetCandidate(t.Context(), projectID, promoteCandidate.Data.ID)
+	if err != nil || !ok || shadowCandidate.Status != memory.CandidateStatusPromoted || shadowCandidate.PromotedMemoryID != promoted.Data.PromotedMemoryID {
+		t.Fatalf("native promoted candidate shadow = %+v ok=%v error=%v, want promoted candidate shadow", shadowCandidate, ok, err)
+	}
+
+	retried := mustRequestJSON[ProjectMemoryCandidateResponse](client, http.MethodPost, "/hecate/v1/projects/"+projectID+"/memory/candidates/"+promoteCandidate.Data.ID+"/promote", `{}`)
+	if retried.Data.PromotedMemoryID != promoted.Data.PromotedMemoryID {
+		t.Fatalf("repeat promote id = %q, want %q", retried.Data.PromotedMemoryID, promoted.Data.PromotedMemoryID)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -587,7 +587,10 @@ func (c Config) Validate() error {
 	validateBackend("HECATE_PROJECTS_COORDINATION_BACKEND", c.ProjectsCoordinationBackend(), "hecate", "cairnline")
 	validateBackend("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", c.ProjectsCairnlineReadSource(), "auto", "snapshot", "embedded")
 	for _, item := range c.ProjectsCairnlineWriteAuthority() {
-		validateBackend("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", item, "project-memory")
+		validateBackend("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", item, "project-memory", "memory-candidates")
+	}
+	if c.ProjectsCairnlineWriteAuthorityEnabled("memory-candidates") && !c.ProjectsCairnlineWriteAuthorityEnabled("project-memory") {
+		errs = append(errs, errors.New("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=memory-candidates requires project-memory because candidate promotion creates accepted project memory"))
 	}
 	if postgresRequired(c) && strings.TrimSpace(c.Postgres.DatabaseURL) == "" {
 		errs = append(errs, errors.New("HECATE_POSTGRES_URL or DATABASE_URL is required when HECATE_BACKEND=postgres"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,9 +226,10 @@ type ChatConfig struct {
 }
 
 type ProjectsConfig struct {
-	Backend             string
-	CoordinationBackend string
-	CairnlineReadSource string
+	Backend                 string
+	CoordinationBackend     string
+	CairnlineReadSource     string
+	CairnlineWriteAuthority string
 }
 
 func (c Config) ProjectsCoordinationBackend() string {
@@ -237,6 +238,23 @@ func (c Config) ProjectsCoordinationBackend() string {
 
 func (c Config) ProjectsCairnlineReadSource() string {
 	return normalizeProjectsCairnlineReadSource(c.Projects.CairnlineReadSource)
+}
+
+func (c Config) ProjectsCairnlineWriteAuthority() []string {
+	return normalizeProjectsCairnlineWriteAuthority(c.Projects.CairnlineWriteAuthority)
+}
+
+func (c Config) ProjectsCairnlineWriteAuthorityEnabled(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return false
+	}
+	for _, item := range c.ProjectsCairnlineWriteAuthority() {
+		if item == name {
+			return true
+		}
+	}
+	return false
 }
 
 type OTelSignalConfig struct {
@@ -479,9 +497,10 @@ func LoadFromEnv() Config {
 			SessionsBackend: storageBackend,
 		},
 		Projects: ProjectsConfig{
-			Backend:             storageBackend,
-			CoordinationBackend: strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_COORDINATION_BACKEND", "hecate"))),
-			CairnlineReadSource: strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "auto"))),
+			Backend:                 storageBackend,
+			CoordinationBackend:     strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_COORDINATION_BACKEND", "hecate"))),
+			CairnlineReadSource:     strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "auto"))),
+			CairnlineWriteAuthority: getEnv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", "none"),
 		},
 		OTel: loadOTelFromEnv(),
 		Governor: GovernorConfig{
@@ -567,6 +586,9 @@ func (c Config) Validate() error {
 	}
 	validateBackend("HECATE_PROJECTS_COORDINATION_BACKEND", c.ProjectsCoordinationBackend(), "hecate", "cairnline")
 	validateBackend("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", c.ProjectsCairnlineReadSource(), "auto", "snapshot", "embedded")
+	for _, item := range c.ProjectsCairnlineWriteAuthority() {
+		validateBackend("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", item, "project-memory")
+	}
 	if postgresRequired(c) && strings.TrimSpace(c.Postgres.DatabaseURL) == "" {
 		errs = append(errs, errors.New("HECATE_POSTGRES_URL or DATABASE_URL is required when HECATE_BACKEND=postgres"))
 	}
@@ -1156,6 +1178,28 @@ func normalizeProjectsCairnlineReadSource(value string) string {
 		return "auto"
 	}
 	return value
+}
+
+func normalizeProjectsCairnlineWriteAuthority(value string) []string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" || value == "none" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part == "" || part == "none" {
+			continue
+		}
+		if _, exists := seen[part]; exists {
+			continue
+		}
+		seen[part] = struct{}{}
+		out = append(out, part)
+	}
+	return out
 }
 
 func normalizeValues(values []string) []string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -473,16 +473,19 @@ func TestLoadFromEnvProjectsCairnlineWriteAuthority(t *testing.T) {
 		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-memory) = true, want false by default")
 	}
 
-	t.Setenv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", " Project-Memory, none, project-memory ")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", " Project-Memory, none, memory-candidates, project-memory ")
 	cfg = LoadFromEnv()
-	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 1 || got[0] != "project-memory" {
-		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want [project-memory]", got)
+	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 2 || got[0] != "project-memory" || got[1] != "memory-candidates" {
+		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want [project-memory memory-candidates]", got)
 	}
 	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-memory") {
 		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-memory) = false, want true")
 	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("memory-candidates") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(memory-candidates) = false, want true")
+	}
 	if err := cfg.Validate(); err != nil {
-		t.Fatalf("Validate() error = %v, want nil for project-memory Cairnline write authority opt-in", err)
+		t.Fatalf("Validate() error = %v, want nil for project memory and candidate Cairnline write authority opt-ins", err)
 	}
 }
 
@@ -522,6 +525,19 @@ func TestValidateRejectsInvalidProjectsCairnlineWriteAuthority(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY") {
 		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", err)
+	}
+}
+
+func TestValidateRejectsProjectsCairnlineMemoryCandidateAuthorityWithoutAcceptedMemory(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Projects.CairnlineWriteAuthority = "memory-candidates"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want memory-candidates dependency error")
+	}
+	if !strings.Contains(err.Error(), "memory-candidates requires project-memory") {
+		t.Fatalf("Validate() error = %q, want memory-candidates project-memory dependency", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -464,6 +464,28 @@ func TestLoadFromEnvProjectsCairnlineReadSource(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvProjectsCairnlineWriteAuthority(t *testing.T) {
+	cfg := LoadFromEnv()
+	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 0 {
+		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want empty default", got)
+	}
+	if cfg.ProjectsCairnlineWriteAuthorityEnabled("project-memory") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-memory) = true, want false by default")
+	}
+
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", " Project-Memory, none, project-memory ")
+	cfg = LoadFromEnv()
+	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 1 || got[0] != "project-memory" {
+		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want [project-memory]", got)
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-memory") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-memory) = false, want true")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil for project-memory Cairnline write authority opt-in", err)
+	}
+}
+
 func TestValidateRejectsInvalidProjectsCoordinationBackend(t *testing.T) {
 	cfg := LoadFromEnv()
 	cfg.Projects.CoordinationBackend = "cairnline_shadow"
@@ -487,6 +509,19 @@ func TestValidateRejectsInvalidProjectsCairnlineReadSource(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE") {
 		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", err)
+	}
+}
+
+func TestValidateRejectsInvalidProjectsCairnlineWriteAuthority(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Projects.CairnlineWriteAuthority = "project-memory,assignments"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid projects Cairnline write authority error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY") {
+		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates`
- make accepted project memory create/update/delete commit to embedded Cairnline first when `project-memory` is enabled, then shadow back to Hecate memory stores
- make memory-candidate create/promote/reject commit to embedded Cairnline first when both `project-memory` and `memory-candidates` are enabled, then shadow candidate state and promoted memory back to Hecate stores
- keep `memory-candidates` dependent on `project-memory` because candidate promotion creates accepted memory
- expose the partial authority switchpoints through backend-status and update runtime/operator/design docs

## Tests
- `GOCACHE="$PWD/.gocache" go test ./internal/config ./internal/api -run 'Test(LoadFromEnvProjects|ValidateRejectsInvalidProjects|ProjectCoordinationBackendStatus|ProjectMemoryAPI_)'`\n- `just agent-docs-check`\n- `GOCACHE="$PWD/.gocache" go test ./...`\n- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`