### PR TITLE
feat(projects): advance Cairnline parity bridge

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -88,8 +88,9 @@ agent supervision, traces, and context-packet rendering.
 
 The current `internal/cairnlinebridge` package is a replacement-readiness proof.
 It can load Hecate project state from the current project/profile/skills/work
-stores, then seed a memory-backed or SQLite-backed Cairnline service from
-Hecate project-shaped records:
+stores, convert that graph into Cairnline's versioned portable snapshot
+contract, then import it into a memory-backed or SQLite-backed Cairnline
+service:
 
 - project identity, roots, default root, project default profile/execution
   posture references, and context-source provenance metadata including format,
@@ -97,13 +98,14 @@ Hecate project-shaped records:
 - agent profiles and project/role execution posture;
 - skills metadata, roles, work items, and root-scoped assignments;
 - assignment-scoped collaboration evidence links, reviews, handoffs with
-  source/target refs and linked artifacts/memory/context, accepted memory
-  entries, memory candidates with decision state, and portable Project
-  Assistant proposal ledger records with root/default-root actions, warnings,
-  apply results, and attempts.
+  source/target refs, status-transition timestamps, and linked
+  artifacts/memory/context, accepted memory entries, memory candidates with
+  decision state, and portable Project Assistant proposal ledger records with
+  root/default-root actions, warnings, apply results, and attempts.
 
 This bridge proves the portable Cairnline model can receive the core
-coordination graph and produce assignment launch packets with the expected
+coordination graph through the same embeddable snapshot API standalone
+Cairnline hosts use, and produce assignment launch packets with the expected
 metadata. The experimental read model also reports how many seeded assignments
 can produce a portable launch packet plus any packet warnings or
 per-assignment packet errors. It also exercises Cairnline's read-only closeout
@@ -145,9 +147,14 @@ Project identity and some compatibility scaffolding still come from Hecate
 until Cairnline becomes authoritative. Project Assistant draft generation also
 uses the Cairnline-projected
 context so preview and proposal assembly stay aligned, while the proposal
-ledger and apply remain Hecate-owned. Project list/detail reconstruct default
-profile and execution posture from Cairnline project/execution-profile records
-where available. Launch-readiness and assignment preflight read
+ledger remains Hecate-owned unless `project-assistant-proposals` is enabled.
+Confirmed Project Assistant apply routes role, work-item, assignment, and
+handoff actions through the same opt-in Cairnline authority switchpoints when
+those switchpoints are enabled; project/default/chat/memory/runtime side
+effects still keep apply as a mixed-authority replacement blocker.
+Project list/detail reconstruct default profile and execution posture from
+Cairnline project/execution-profile records where available. Launch-readiness
+and assignment preflight read
 project/work/assignment/role coordination records from Cairnline when
 configured, then apply Hecate runtime validation. Native assignment preflight
 and start context packets can append inspect-only `cairnline_launch_packet`
@@ -164,9 +171,63 @@ Cairnline first, then best-effort shadows the entry into Hecate-native memory
 stores for compatibility. Adding `memory-candidates` to that setting makes
 memory-candidate create/promote/reject Cairnline-first too; it requires
 `project-memory` because promotion creates accepted project memory.
+`project-metadata-defaults` is a scoped opt-in authority slice: project
+metadata/default-only PATCHes commit portable project metadata and launch
+defaults to embedded Cairnline first, then best-effort shadow Hecate's
+compatibility project row. Project create/delete, roots, context sources,
+last-opened-only updates, and mixed metadata/root/source replacement PATCHes
+remain Hecate-owned unless their separate switchpoints are enabled.
+`project-identity` is a scoped authority slice: project create/delete commits
+portable identity, initial roots, context sources, launch defaults, and project
+identity removal to embedded Cairnline first, then best-effort shadows Hecate's
+compatibility project row. Delete restores the Cairnline snapshot if Hecate
+compatibility cleanup fails.
+`project-roots` and `project-context-sources` are scoped partial authority
+slices: project root create/update/delete, root list replacement, root
+discovery-result replacement, context-source create/update/delete,
+context-source list replacement, and context-source discovery-result
+replacement can commit to embedded Cairnline first, then best-effort shadow
+Hecate's compatibility project row. Worktree-created root records also move
+with `project-roots`, but Hecate still performs root discovery scans and Git
+worktree creation side effects, so the worktree side-effect gap still blocks
+full cutover.
+`project-collaboration` is another opt-in authority slice: collaboration
+artifact creation and handoff create/update/status/delete commit to embedded
+Cairnline first, then best-effort shadow the portable records into Hecate-native
+project-work stores for compatibility. While that alpha switch is enabled,
+review artifacts must carry a supported verdict because Cairnline does not have
+a verdict-less review state and Hecate must not silently rewrite that shape.
+`project-skills` is a third opt-in authority slice: project skill discovery and
+metadata updates commit metadata-only skill records to embedded Cairnline first,
+then best-effort shadow the records into Hecate-native project-skill stores for
+compatibility. Skill bodies are still not loaded, injected, executed, or treated
+as permissions.
+`project-roles` is a fourth opt-in authority slice: role create/update/delete
+commits to embedded Cairnline first, preserves Hecate's built-in-role
+protection, then best-effort shadows portable role defaults into Hecate-native
+project-work stores for compatibility. Deleting a custom role preserves
+historical assignments that still carry the deleted `role_id`.
+`project-work-items` is a fifth opt-in authority slice: work-item
+create/update/delete commits to embedded Cairnline first, preserves Hecate's
+`backlog` default and closeout-readiness gate, then best-effort shadows the
+portable work item into Hecate-native project-work stores for compatibility.
+`project-assignments` is a sixth opt-in authority slice: assignment
+create/update/delete record mutations commit to embedded Cairnline first, then
+best-effort shadow portable assignment state into Hecate-native project-work
+stores for compatibility. Assignment start/dispatch remains Hecate-owned; only
+committed start results, pre-dispatch cleanup/conflict states, and linked-chat
+reconciliation updates are mirrored as replacement evidence.
+`project-assistant-proposals` is a seventh opt-in authority slice: Project
+Assistant draft/propose/apply-attempt ledger records commit to embedded
+Cairnline first, then best-effort shadow Hecate's proposal store for
+compatibility. Confirmed apply uses the enabled Cairnline authority seams for
+role, work-item, assignment, and handoff actions, but
+project/default/chat/memory/runtime side effects still keep Assistant apply as
+a mixed-authority replacement blocker.
 Assignment-start is still a Hecate-native dispatch mutation, committed
-assignment-start results are best-effort mirrored for replacement evidence, and
-other live Projects reads/writes still use the Hecate-native API.
+assignment-start results and cleanup/conflict states are best-effort mirrored
+for replacement evidence, and other live Projects reads/writes still use the
+Hecate-native API.
 `GET /hecate/v1/projects/{id}/cairnline/read-model` seeds an in-memory
 Cairnline service from the current Hecate stores and returns the portable
 operations brief and activity projection without writing files.
@@ -193,28 +254,55 @@ replacement probe: a match means the current mirror DB can serve the same
 operator-facing project projection counts for that project.
 `POST /hecate/v1/projects/cairnline/sync` writes a refreshable embedded
 Cairnline SQLite database for the full Hecate Projects graph under Hecate's
-data directory. It is a deterministic migration rehearsal and durable service
-boundary proof; the response compares Hecate snapshot counts with the written
-Cairnline database, including launch-packet coverage/warnings/errors, and also
-compares normalized record ID sets plus semantic record-content digests,
+data directory by importing Cairnline's native portable snapshot format. It is
+a deterministic migration rehearsal and durable service boundary proof; the
+response compares Hecate snapshot counts with the written Cairnline database,
+including launch-packet coverage/warnings/errors, and also compares normalized
+record ID sets plus semantic record-content digests,
 including stable assignment launch-packet digests, so same-count/different-record
 and same-ID/wrong-field drift are visible. It reports count-level, ID-set, and
 content-digest differences. It is not a dual-write path and does not make
-Cairnline authoritative.
+Cairnline authoritative. The response also includes a structured
+`migration_rehearsal` object with the snapshot import mode, Cairnline snapshot
+version, source authority, target database family, checklist status, rollback
+notes, and `cutover_ready=false`, making the migration boundary reviewable
+instead of implicit. For embedded sync and existing mirror-parity checks, that
+object also includes strict embedded smoke evidence: Hecate copies the current
+handler configuration, forces `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`
+and `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and exercises
+representative project read projections against the generated mirror database
+without mutating live configuration.
 When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is configured, live
-project identity, metadata, root create/update/delete/discovery/worktree-creation,
-context-source create/update/delete/discovery, and project-default mutations
-still commit to Hecate stores first, then best-effort mirror into the embedded
-Cairnline database through their identity/metadata/root/source/default seams. This mirror is
-replacement-readiness evidence only: Hecate remains authoritative and mirror
-failures are logged.
-Project skill discovery and metadata updates follow the same non-authoritative
-mirror pattern for metadata-only skill records; the mirror never loads, injects,
-or executes `SKILL.md` bodies.
+project identity, metadata/default, root, and context-source mutations still
+commit to Hecate stores first, then best-effort mirror into the embedded
+Cairnline database through their identity/metadata/root/source/default seams
+unless their explicit write-authority switchpoints are enabled. Project create
+and delete can be switched to Cairnline-first authority with
+`project-identity`. Root create/update/delete, context-source
+create/update/delete, and root/source list replacement can be switched to
+Cairnline-first authority with `project-roots` and
+`project-context-sources`; discovered context-source record replacement also
+moves with `project-context-sources`, while Hecate still performs the workspace
+scan for its operator UI. Discovered root record replacement also moves with
+`project-roots`, while Hecate still performs root discovery scans and
+Git worktree creation side effects; worktree-created root records commit
+Cairnline-first with `project-roots`. These mirrors and partial authority
+switches are replacement-readiness evidence: Hecate remains authoritative for
+the remaining gaps and mirror failures are logged.
+Project skill discovery and metadata updates follow the same mirror pattern for
+metadata-only skill records; by default they commit to Hecate first and then
+mirror to Cairnline. They can be switched to Cairnline-first authority with
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills`. Neither path loads,
+injects, or executes `SKILL.md` bodies.
 Project role and work-item create/update/delete routes also mirror coordination
 metadata into Cairnline after Hecate commits; when a mirrored role references
 an agent profile, the mirror also seeds that profile metadata and execution
-posture so the role can validate in Cairnline. Assignment create/update/delete
+posture so the role can validate in Cairnline. Role and work-item
+create/update/delete can be switched to Cairnline-first authority with
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-roles,project-work-items`.
+Project skill discovery/update can be switched to Cairnline-first authority with
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills`.
+Assignment create/update/delete
 routes mirror coordination metadata and lifecycle status after Hecate commits;
 assignment-start remains a Hecate-owned write gap because dispatch still carries
 runtime coupling that needs a narrower switch point, but successful start
@@ -223,7 +311,9 @@ Hecate commits them. Linked external-agent chat reconciliation also mirrors the
 committed assignment status/ref when Hecate updates the linked assignment from a
 chat session. Collaboration artifact creation, including generic artifacts,
 evidence links, and reviews, and handoff create/update/delete routes also mirror
-portable collaboration metadata after Hecate commits. Accepted project memory
+portable collaboration metadata after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-collaboration` makes those
+routes Cairnline-first. Accepted project memory
 entries can be switched to Cairnline-first authority with
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory`; otherwise they
 mirror after Hecate commits. Memory-candidate create/promote/reject routes mirror
@@ -231,16 +321,25 @@ reviewable candidate state after Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory,memory-candidates` is
 enabled, in which case they commit to Cairnline first and then shadow candidate
 state and promoted memory references back into Hecate. Global
-agent-profile create/update/delete routes also
-mirror portable profile metadata and execution posture after Hecate commits;
-the delete mirror removes only the profile record because execution-profile
-posture can be shared. Project Assistant draft/propose/apply routes mirror the
-proposal ledger and committed apply side effects after Hecate commits proposal
-records and apply attempts.
+agent-profile create/update/delete routes also mirror portable profile metadata
+and execution posture after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles` is enabled. With
+that opt-in switchpoint, agent-profile create/update/delete commits
+Cairnline's separate portable profile and execution-posture records first, then
+best-effort shadows Hecate's combined profile row back into Hecate-native stores
+for compatibility. The delete mirror removes only the profile record because
+execution-profile posture can be shared. Project Assistant draft/propose/apply
+routes mirror the proposal ledger and committed apply side effects after Hecate
+commits proposal records and apply attempts unless `project-assistant-proposals`
+is enabled, in which case the proposal ledger commits to Cairnline first while
+confirmed apply uses enabled role/work-item/assignment/handoff authority seams
+and still blocks replacement on the remaining project/default/chat/memory/runtime
+side effects.
 `POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
-SQLite export under Hecate's data directory. Both use the same bridge and are
-useful for inspecting replacement parity, but they are still proofs, not the
-live Projects backend.
+SQLite export under Hecate's data directory and returns the same
+`migration_rehearsal` evidence for the single-project database. Both sync and
+export use the same bridge and are useful for inspecting replacement parity,
+but they are still proofs, not the live Projects backend.
 
 The first non-authoritative write-adapter seams exist in `cairnlinebridge` for
 project identity, embedded roots, context sources, project defaults,
@@ -252,31 +351,48 @@ and project memory entry/candidate upserts and deletes. Create-if-missing seams
 exist for generic collaboration artifacts, evidence links, and reviews because
 Hecate and Cairnline both expose those as record/list contracts today; handoffs
 have upsert/delete coverage because they are mutable coordination records. The
-skill seam preserves operator-disabled state and discovered-at provenance while
-remaining metadata-only; it never loads, injects, or executes `SKILL.md` bodies.
+skill seam preserves operator-disabled state, discovered-at provenance,
+suggested tool names, and nullable permission hints while remaining
+metadata-only; it never loads, injects, or executes `SKILL.md` bodies.
 The memory seam preserves accepted-memory fields, disabled state, candidate
 provenance, and resolved candidate state including Hecate-owned promoted memory
 IDs. The assignment seam updates existing role/root/profile/driver/context
-metadata while preserving Cairnline lifecycle transitions through claim,
-progress, and completion methods. These seams prove the Cairnline service can
-accept Hecate's project/root/source, skill, role, work-item, assignment,
-collaboration, handoff, and memory mutation shapes, but live API routes still
-write Hecate stores first. Live mirror seams reported as
-`project-identity-live-mirror` covers project create/delete;
+metadata and mirrors Hecate-provided started/completed timestamps without
+manufacturing lifecycle times during import; Cairnline's own claim, progress,
+and completion methods remain the live MCP execution path. Evidence and review
+seams preserve source/provider/external IDs and exact review verdict/risk
+metadata, and handoff seams preserve status-transition timestamps. These seams
+prove the Cairnline service can accept Hecate's project/root/source, skill,
+role, work-item, assignment, collaboration, handoff, and memory mutation shapes,
+but live API routes still write Hecate stores first.
+Live mirror seams reported as
+`project-identity-live-mirror` covers project create/delete, and
+`project-identity` can make project create/delete Cairnline-authoritative with
+snapshot rollback for failed Hecate compatibility cleanup;
 `project-metadata-live-mirror` covers project name/description metadata updates
 without replacing roots or sources; `project-roots-live-mirror` covers direct
 root create/update/delete, root list replacement, root discovery, and
-worktree-root creation mutations through Cairnline's root-level API;
+worktree-created root record mutations through Cairnline's root-level API;
 `project-context-sources-live-mirror` covers direct context-source
-create/update/delete, context-source list replacement, and discovery mutations
-through Cairnline's source-level API;
+create/update/delete, context-source list replacement, and discovery-result
+replacement mutations through Cairnline's source-level API;
 `project-defaults-live-mirror` covers default-only project updates through
 Cairnline's project-defaults seam while preserving mirrored roots and context
-sources;
+sources; `project-metadata-defaults` can make metadata/default-only PATCHes
+Cairnline-authoritative while project identity and mixed metadata/root/source replacement
+updates remain Hecate-owned;
+`project-roots` and `project-context-sources` can make direct root/source CRUD
+Cairnline-authoritative with list replacement, while discovered context-source
+records also move with `project-context-sources` and discovered root records
+move with `project-roots`; worktree-created root records also move with
+`project-roots`, while Hecate still performs the root/workspace scans and Git
+worktree creation side effects;
 `agent-profiles-live-mirror` covers global
-agent-profile create/update/delete metadata; `project-skills-live-mirror`
-covers project skill discovery/update metadata; `project-roles-live-mirror`,
-`project-work-items-live-mirror`, `project-assignments-live-mirror`,
+agent-profile create/update/delete metadata and can be switched to Cairnline
+authority with `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles`;
+`project-skills-live-mirror` covers project skill discovery/update metadata;
+`project-roles-live-mirror`, `project-work-items-live-mirror`,
+`project-assignments-live-mirror`,
 `project-assignment-start-result-live-mirror`,
 `project-assignment-chat-reconcile-live-mirror`,
 `project-collaboration-live-mirror`, and `project-handoffs-live-mirror` cover
@@ -287,11 +403,36 @@ memory-candidate records; and
 `project-assistant-proposal-ledger-live-mirror` and
 `project-assistant-apply-side-effects-live-mirror` cover Project Assistant
 proposal records, apply-attempt history, and committed apply side effects before
-assignment-start/runtime handoff. None are write authority. Backend status
+assignment-start/runtime handoff. `project-assistant-proposals` can make the
+proposal ledger Cairnline-authoritative while confirmed apply uses enabled
+role/work-item/assignment/handoff authority seams and remains blocked on
+project/default/chat/memory/runtime side effects. `project-identity` can make project
+create/delete Cairnline-authoritative with snapshot rollback for failed Hecate
+compatibility cleanup;
+`project-metadata-defaults` can make
+metadata/default-only PATCHes Cairnline-authoritative; `project-roots` and
+`project-context-sources` can make direct root/source CRUD
+Cairnline-authoritative with list replacement while context-source discovery
+records move with `project-context-sources` and root discovery records move
+with `project-roots`; worktree-created root records also move with
+`project-roots`, leaving the root/workspace scans and Git worktree creation
+side effects Hecate-owned; `agent-profiles` can make
+global agent-profile create/update/delete Cairnline-authoritative while Hecate
+shadows its combined profile row for compatibility; `project-skills` can make
+project skill discovery/update Cairnline-authoritative; `project-roles` and
+`project-work-items` can make role and work-item create/update/delete
+Cairnline-authoritative; `project-assignments` can make assignment record
+create/update/delete Cairnline-authoritative while keeping assignment
+start/dispatch Hecate-owned; and `project-collaboration` can make the
+collaboration and handoff route family Cairnline-authoritative as opt-in
+dogfood switchpoints.
+Backend status
 reports these proofs as
 `write_adapter_seams`, while `write_adapter_gaps`
 remains the machine-readable live-route stop list until route switch points,
-atomic promotion semantics, and migration/rollback semantics are implemented.
+atomic promotion semantics, and authoritative cutover semantics are
+implemented. The snapshot import/export rehearsal and rollback notes exist, but
+they are evidence for a future cutover rather than a storage authority switch.
 
 Current read-model parity includes queued-assignment attention semantics:
 Hecate and Cairnline both count a queued assignment as blocked/attention rather
@@ -312,8 +453,11 @@ after these gates are met:
   lists, assignment context, launch-readiness, assignment preflight, artifact
   lists, handoff lists, Project Assistant context/proposal reads, closeout
   readiness, and operations brief. Draft generation may use the
-  Cairnline-projected context, but proposal ledger writes and apply authority
-  remain Hecate-owned while committed assistant side effects are mirrored as
+  Cairnline-projected context, and proposal ledger writes may become
+  Cairnline-authoritative with the `project-assistant-proposals` switchpoint.
+  Confirmed apply may use enabled role/work-item/assignment/handoff
+  Cairnline-authority seams, but project/default/chat/memory/runtime side
+  effects remain a mixed-authority replacement blocker and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative
   Cairnline launch-packet evidence, but assignment-start remains a Hecate-owned
@@ -325,11 +469,11 @@ after these gates are met:
   move.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha; the embedded Cairnline sync database proves a
-  durable all-project seed with count-level, ID-set, record-content, stable
-  launch-packet content parity, and strict embedded configured-route smoke
-  across representative project, setup, health, skill, memory, role, work,
-  collaboration, assistant-context, activity, and operations route families
-  before it becomes a write path.
+  durable all-project seed through Cairnline's native snapshot import with
+  count-level, ID-set, record-content, stable launch-packet content parity, and
+  strict embedded configured-route smoke across representative project, setup,
+  health, skill, memory, role, work, collaboration, assistant-context,
+  activity, and operations route families before it becomes a write path.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -388,9 +388,34 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory,memory-candidates`
   also makes memory-candidate create/promote/reject Cairnline-first; the
   `memory-candidates` switch requires `project-memory` because promotion creates
-  accepted project memory.
+  accepted project memory. Additional opt-in switchpoints can make
+  project create (`project-identity`), metadata/default-only project PATCHes
+  (`project-metadata-defaults`), direct root CRUD (`project-roots`),
+  direct context-source CRUD
+  (`project-context-sources`), collaboration/handoff routes
+  (`project-collaboration`), metadata-only skill discovery/update
+  (`project-skills`), role mutations (`project-roles`), work-item mutations
+  (`project-work-items`), assignment record mutations (`project-assignments`),
+  and global agent-profile mutations (`agent-profiles`) commit to Cairnline
+  first and then shadow back into Hecate-native compatibility stores.
+  Agent-profile authority writes
+  Cairnline's separate portable profile and execution-posture records before
+  shadowing Hecate's combined profile row. `project-identity` makes project
+  create/delete commit portable identity, initial roots, context sources,
+  launch defaults, and project identity removal to Cairnline first before
+  shadowing Hecate's compatibility project row. Delete restores the Cairnline
+  snapshot if Hecate compatibility cleanup fails. Git worktree creation side effects,
+  last-opened-only updates, mixed
+  metadata/root/source replacement PATCHes, and assignment start/dispatch
+  remain Hecate-owned until later cutover slices. Root and context-source list
+  replacement can move with the `project-roots` and `project-context-sources`
+  switchpoints. Discovered root record replacement can move with
+  `project-roots`, worktree-created root records can move with `project-roots`,
+  and discovered context-source record replacement can move with
+  `project-context-sources`, while Hecate still performs the Git/workspace
+  scans and Git worktree creation for its operator UI.
 - Hecate has a non-authoritative bridge write seam for project identity,
-  embedded roots, root discovery/worktree creation, direct root
+  embedded roots, root discovery/worktree-created root records, direct root
   create/update/delete, context-source discovery, direct context-source
   create/update/delete, project defaults, and project-level execution-profile
   cleanup. Hecate also has a non-authoritative project skill metadata upsert
@@ -401,8 +426,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   create-if-missing generic artifact/evidence/review seams, handoff
   upsert/delete seams, plus accepted-memory and memory-candidate seams that
   preserve metadata, disabled state, provenance, resolved candidate state, and
-  promoted memory IDs. Accepted memory and memory-candidate review flows can
-  additionally run as the opt-in Cairnline-first switchpoints above. The project
+  promoted memory IDs. Accepted memory, memory-candidate review,
+  collaboration/handoff, metadata-only skill discovery/update, global
+  agent-profile, role, work-item, and assignment-record flows can additionally
+  run as opt-in Cairnline-first switchpoints above. The project
   identity/root
   discovery/worktree-creation/context-source discovery seam, the root-level
   direct root mutation seam, the source-level direct context-source mutation
@@ -413,10 +440,14 @@ launch agents. Those remain explicit operator or orchestrator actions.
   seam, the memory-candidate seam, and accepted memory when its write-authority
   switchpoint is disabled, plus the Project Assistant proposal-ledger seam, are
   now wired as best-effort live mirrors into the embedded Cairnline DB when the
-  Cairnline backend is configured, but
-  Hecate still commits first and remains authoritative. Role mirrors also seed
-  referenced agent-profile metadata/execution posture when the profile store is
-  available.
+  Cairnline backend is configured. Hecate still commits first and remains
+  authoritative for any mutation family whose opt-in Cairnline write-authority
+  switchpoint is not enabled; Project Assistant confirmed apply uses enabled
+  role/work-item/assignment/handoff authority seams and remains a
+  mixed-authority blocker for project/default/chat/memory/runtime side effects
+  even when the proposal-ledger switchpoint is enabled. Role
+  mirrors also seed referenced agent-profile metadata/execution posture when the
+  profile store is available.
   Assignment-start dispatch is still a Hecate-owned write
   gap. Artifact/evidence/review update/delete semantics are absent because
   Hecate currently records those as immutable collaboration artifacts. Route

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -364,10 +364,14 @@ assignment-preflight, artifact-list, handoff-list, Project Assistant
 context/proposal reads, closeout readiness, activity inbox, and operations brief
 can be served from the Cairnline read model. Project Assistant draft generation
 also uses the Cairnline-projected context in this mode, while proposal ledger
-writes and apply authority remain Hecate-owned; committed assistant side
-effects are best-effort mirrored into Cairnline as replacement-readiness
-evidence. Launch-readiness and assignment preflight read Cairnline coordination
-records before applying Hecate runtime checks.
+writes remain Hecate-owned unless `project-assistant-proposals` is explicitly
+enabled. Confirmed Project Assistant apply routes role, work-item, assignment,
+and handoff actions through the same opt-in Cairnline authority switchpoints
+when those switchpoints are enabled; other apply side effects remain
+Hecate-owned and are best-effort mirrored into Cairnline as
+replacement-readiness evidence.
+Launch-readiness and assignment preflight read Cairnline coordination records
+before applying Hecate runtime checks.
 Assignment preflight/start context packets may include inspect-only Cairnline
 launch-packet evidence for replacement review, but Hecate still owns dispatch,
 task/external agent supervision, approvals, and assignment mutation. Project
@@ -384,13 +388,13 @@ mirror database, project row, or proposal record is missing; run
 reads. Activity, work-item list/detail, assignment-list, and operations brief
 reads render the work graph from Cairnline service records and overlay
 Hecate-only runtime refs/timestamps while Hecate still owns execution. Project
-identity and some compatibility
-scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
-metadata, root create/update/delete/discovery/worktree-creation,
-context-source create/update/delete/discovery, and default mutations still write
-Hecate stores first and then best-effort mirror into the embedded Cairnline
-database through their identity/metadata/root/source/default seams; this is
-replacement-readiness evidence, not write authority.
+identity and some compatibility scaffolding remain Hecate-owned until Cairnline
+becomes authoritative. Project identity, metadata/default, root, and
+context-source mutations still write Hecate stores first and then best-effort
+mirror into the embedded Cairnline database through their
+identity/metadata/root/source/default seams unless their explicit
+write-authority switchpoints are enabled; this is replacement-readiness
+evidence, not write authority.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then
@@ -399,26 +403,71 @@ best-effort shadows the row into Hecate-native memory stores. The default is
 also makes memory-candidate create/promote/reject Cairnline-first; the
 `memory-candidates` switch requires `project-memory` because candidate promotion
 creates accepted project memory. All other Projects mutations remain
-Hecate-owned.
+Hecate-owned unless one of the other alpha write-authority switchpoints is
+explicitly listed.
+Project metadata/default-only PATCHes also best-effort mirror after the Hecate
+store commit unless `project-metadata-defaults` is enabled, in which case those
+scoped updates commit portable metadata and launch defaults to Cairnline first
+and then shadow Hecate's compatibility project row. Project create/delete,
+roots, context sources, last-opened-only updates, and mixed metadata/root/source
+replacement PATCHes remain Hecate-owned unless their separate switchpoints are
+enabled.
+Project create also best-effort mirrors portable identity, initial roots,
+context sources, and launch defaults after the Hecate store commit unless
+`project-identity` is enabled, in which case create/delete commits to Cairnline
+first and then shadows Hecate's compatibility project row. Delete restores the
+Cairnline snapshot if Hecate compatibility cleanup fails.
+Project root create/update/delete and root list replacement mutations also
+best-effort mirror after the Hecate store commit unless `project-roots` is
+enabled, in which case those root mutations plus discovery-result replacement
+and worktree-created root record mutations commit to Cairnline first and then
+shadow Hecate's compatibility project row. Hecate still performs the root
+discovery scan and Git worktree creation side effect.
+Context-source create/update/delete and list replacement mutations likewise
+mirror after Hecate commits unless
+`project-context-sources` is enabled, in which case those source mutations
+plus discovery-result replacement commit to Cairnline first and then shadow
+Hecate's compatibility project row. Hecate still performs the workspace scan
+for its operator UI.
 Project skill discovery and
 metadata updates also best-effort mirror metadata-only skill records after the
-Hecate store commit; the mirror does not load or execute skill bodies. Project
-role and work-item mutations likewise mirror coordination metadata after Hecate
-commits. Role mirroring seeds referenced agent-profile metadata and execution
-posture when available, and global agent-profile CRUD now best-effort mirrors
-portable profile metadata and execution posture after Hecate commits. Assignment
-create/update/delete, committed assignment-start results, linked-chat
-reconciliation, collaboration artifact creation, and handoff
-create/update/delete mutations also best-effort mirror portable metadata after
-Hecate commits, but assignment start/dispatch remains Hecate-owned. Project
+Hecate store commit unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills` is enabled, in which
+case skill discovery/update commits metadata-only skill records to Cairnline
+first and then shadows them back into Hecate. Neither path loads, injects,
+executes, or grants permissions from skill bodies. Project role and work-item
+mutations likewise mirror coordination metadata after Hecate commits unless
+`project-roles` or `project-work-items` is enabled, respectively. Role mirroring
+seeds referenced agent-profile metadata and execution posture when available,
+and global agent-profile CRUD best-effort mirrors portable profile metadata and
+execution posture after Hecate commits unless `agent-profiles` is enabled, in
+which case profile create/update/delete commits Cairnline's separate portable
+profile and execution-posture records first and shadows Hecate's combined
+profile row back into Hecate for compatibility. Assignment create/update/delete
+mutations likewise mirror portable metadata after Hecate commits unless
+`project-assignments` is enabled, in which case assignment record mutations
+commit to Cairnline first and shadow back into Hecate. Committed
+assignment-start results, linked-chat reconciliation, collaboration artifact
+creation, and handoff create/update/delete mutations also best-effort mirror
+portable metadata after Hecate commits, but assignment start/dispatch remains
+Hecate-owned. Pre-dispatch cleanup and conflict states are mirrored back into
+Cairnline so replacement probes do not leave stale claimed assignment rows.
+Project
 memory entries mirror after Hecate commits unless the
 `project-memory` Cairnline write-authority switchpoint is enabled; memory
 candidates mirror after Hecate commits unless `project-memory,memory-candidates`
 is enabled, in which case candidate create/promote/reject commit to Cairnline
-first and then shadow back into Hecate. Project Assistant draft/propose/apply
-ledger mutations likewise
-best-effort mirror proposal records, apply attempts, and committed apply side
-effects after Hecate commits.
+first and then shadow back into Hecate. Collaboration artifact and handoff
+routes mirror after Hecate commits unless `project-collaboration` is enabled,
+in which case they commit to Cairnline first and shadow back into Hecate.
+Project Assistant draft/propose/apply
+ledger mutations likewise best-effort mirror proposal records and apply attempts
+after Hecate commits unless `project-assistant-proposals` is enabled, in which
+case the proposal ledger commits to Cairnline first and shadows Hecate's
+proposal store for compatibility. Confirmed apply uses the enabled Cairnline
+authority seams for role, work-item, assignment, and handoff actions, but
+project/default/chat/memory/runtime side effects still keep apply as a
+mixed-authority replacement blocker.
 Other live Projects reads/writes still use Hecate-native
 stores until the remaining read routes, write adapter, and migration path are
 ready. Current bridge write experiments cover non-authoritative
@@ -439,7 +488,11 @@ proof seams separately from the live-route `write_adapter_gaps`; only
 `project-memory-live-mirror`, and `project-memory-candidates-live-mirror`, plus
 `project-assistant-proposal-ledger-live-mirror` and
 `project-assistant-apply-side-effects-live-mirror` are wired to live mutations,
-and all remain non-authoritative. It also reports `replacement_ready`,
+and they are mirror-only unless their explicit Cairnline write-authority
+switchpoint is enabled; currently only the proposal-ledger switchpoint can be
+made Cairnline-authoritative, while apply side effects become mixed-authority
+only through the enabled role/work-item/assignment/handoff switchpoints. It
+also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operators can see the exact
 read-route, strict-embedded-probe, write-authority, and migration blockers
 without parsing warning prose. `GET

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -474,7 +474,7 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads.
-- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates`
+- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. The default is `none`.
   `project-memory` makes accepted project memory entry create/update/delete
@@ -483,8 +483,51 @@ sequenceDiagram
   `project-memory`; together they make reviewable memory-candidate
   create/promote/reject mutations Cairnline-first too, with candidate promotion
   creating accepted memory through Cairnline before shadowing the candidate and
-  promoted memory row back into Hecate-native stores. All other Projects
-  mutations remain Hecate-owned.
+  promoted memory row back into Hecate-native stores. `project-collaboration`
+  makes collaboration artifact creation plus handoff create/update/status/delete
+  mutations Cairnline-first, then best-effort shadows those portable records
+  back into Hecate-native stores. `project-skills` makes project skill
+  discovery/update mutations Cairnline-first for metadata-only skill records,
+  then best-effort shadows those records back into Hecate-native project-skill
+  stores; it still does not load, inject, execute, or grant permissions from
+  `SKILL.md` bodies. `project-roles` makes custom role
+  create/update/delete mutations Cairnline-first, preserves built-in role
+  protection, and keeps historical assignments that still reference deleted
+  role ids. `project-work-items` makes work-item
+  create/update/delete mutations Cairnline-first, while preserving Hecate's
+  `backlog` default and closeout-readiness gate before shadowing the resulting
+  work item back into Hecate-native project-work stores. `project-assignments`
+  makes assignment create/update/delete record mutations Cairnline-first, then
+  shadows portable assignment state back into Hecate-native project-work stores
+  for compatibility. Assignment start/dispatch remains Hecate-owned; only
+  committed start results, pre-dispatch cleanup/conflict states, and linked-chat
+  reconciliation updates are mirrored as replacement evidence. `agent-profiles`
+  makes global agent-profile
+  create/update/delete Cairnline-first, writing Cairnline's separate portable
+  profile and execution-posture records before shadowing Hecate's combined
+  profile row. `project-metadata-defaults` makes project metadata/default-only
+  PATCHes Cairnline-first, then shadows Hecate's compatibility project row;
+  project create/delete, roots, context sources, last-opened-only updates, and
+  mixed metadata/root/source replacement PATCHes remain Hecate-owned.
+  `project-assistant-proposals` makes Project Assistant draft/propose/apply-attempt
+  ledger records Cairnline-first, then best-effort shadows Hecate's proposal
+  store for compatibility. Confirmed Project Assistant apply uses enabled
+  role/work-item/assignment/handoff authority seams and still blocks replacement
+  on the remaining project/default/chat/memory/runtime side effects.
+  `project-roots` makes project root create/update/delete plus root list
+  replacement plus discovery-result replacement and worktree-created root
+  record mutations Cairnline-first, then shadows Hecate's compatibility project
+  row; Hecate still performs the root discovery scan and Git worktree creation
+  side effect.
+  `project-context-sources` makes context-source create/update/delete plus
+  context-source list replacement and discovery-result replacement
+  Cairnline-first, then shadows Hecate's compatibility project row; Hecate
+  still performs the workspace scan for its operator UI.
+  `project-identity` makes project create/delete commit portable identity,
+  initial roots, context sources, launch defaults, and project identity removal
+  to Cairnline first, then best-effort shadows Hecate's compatibility project
+  row. Delete restores the Cairnline snapshot if Hecate compatibility cleanup
+  fails. All other Projects mutations remain Hecate-owned.
 - `HECATE_POSTGRES_URL=postgres://...` or `DATABASE_URL=postgres://...` is
   required when `HECATE_BACKEND=postgres`. Optional Postgres knobs:
   `HECATE_POSTGRES_TABLE_PREFIX`, `HECATE_POSTGRES_MAX_OPEN_CONNS`, and
@@ -2239,6 +2282,42 @@ commit to embedded Cairnline first and are then shadowed back into Hecate-native
 memory stores. Adding `memory-candidates` to that comma-separated setting makes
 candidate create/promote/reject Cairnline-first as well; it requires
 `project-memory` because candidate promotion creates accepted project memory.
+Adding `project-collaboration` makes generic collaboration artifact, evidence,
+review, and handoff mutations Cairnline-first, then shadows the portable records
+back into Hecate-native project-work stores for compatibility. In that alpha
+authority mode, review artifacts must include a supported `review_verdict` so
+Hecate never silently converts a verdict-less Hecate review into a Cairnline
+review with different semantics. Adding `project-skills` makes project skill
+discovery/update Cairnline-first for metadata-only skill records, then shadows
+those records back into Hecate-native project-skill stores without loading,
+injecting, executing, or granting permissions from `SKILL.md` bodies. Adding
+`project-roles` makes role
+create/update/delete mutations Cairnline-first, then shadows portable role
+defaults back into Hecate-native project-work stores. Role delete preserves
+historical assignments that still carry the deleted `role_id`. Adding
+`project-work-items` makes work-item
+create/update/delete mutations Cairnline-first, then shadows the portable record
+back into Hecate-native project-work stores. It preserves Hecate's `backlog`
+create default and closeout-readiness gate.
+Adding `agent-profiles` makes global agent-profile create/update/delete
+Cairnline-first, writing Cairnline's separate portable profile and
+execution-posture records before shadowing Hecate's combined profile row.
+Adding `project-metadata-defaults` makes project metadata/default-only PATCHes
+Cairnline-first, then shadows Hecate's compatibility project row; project
+create/delete, roots, context sources, last-opened-only updates, and mixed
+root/source replacement PATCHes remain Hecate-owned.
+Adding `project-roots` makes project root create/update/delete plus root list
+replacement, discovery-result replacement, and worktree-created root record
+mutations Cairnline-first, then shadows the compatibility project row. Hecate
+still performs the root discovery scan and Git worktree creation side effect.
+Adding `project-context-sources` makes context-source create/update/delete plus
+context-source list replacement and discovery-result replacement
+Cairnline-first, then shadows the compatibility project row. Hecate still
+performs the workspace scan for its operator UI.
+Adding `project-identity` makes project create/delete Cairnline-first for
+portable identity, initial roots, context sources, launch defaults, and project
+identity removal, then shadows the compatibility project row. Delete restores
+the Cairnline snapshot if Hecate compatibility cleanup fails.
 `authoritative_backend` remains `hecate` until Hecate can run project read/write
 flows against Cairnline without UI-local fallback state. When
 `configured_backend=cairnline`, Hecate still commits live Projects writes to
@@ -2270,42 +2349,77 @@ probes, write-authority switchpoints, and migration/rollback gates are all
 ready. `replacement_gates` reports those high-level gates as structured
 checklist items so clients do not need to parse warning prose.
 `write_switchpoints` maps each live mutation family to the current authority,
-the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`, or
-`missing_authoritative_switchpoint`; `authoritative_opt_in` for enabled alpha
-write-authority switchpoints), the related mirror seams, and whether that family
-still blocks replacement.
+the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
+`snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled
+alpha write-authority switchpoints, or `partial_authoritative_opt_in` when only
+some routes in a family have moved), the related mirror seams, and whether that
+family still blocks replacement.
 Non-authoritative bridge seams currently cover project/root/source/defaults,
 agent profiles, skills, roles, work items, assignment metadata upsert/delete plus
 lifecycle-status sync, create-if-missing generic artifacts/evidence/reviews,
 handoffs, memory entries, memory candidates, Project Assistant proposal-ledger
 import, and all-project sync rehearsal. The
-`project-identity-live-mirror` seam means project create/delete still commit to
-Hecate stores first, then best-effort mirror the portable project identity shape
-into the embedded Cairnline database when Cairnline is configured.
+`project-identity-live-mirror` seam means project create/delete normally commit
+to Hecate stores first, then best-effort mirror the portable project identity
+shape into the embedded Cairnline database when Cairnline is configured.
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-identity` makes project
+create/delete Cairnline-first for portable identity, initial roots, context
+sources, launch defaults, and project identity removal; delete restores the
+Cairnline snapshot if Hecate compatibility cleanup fails.
 `project-metadata-live-mirror` uses Cairnline's project-metadata seam for
-project name/description updates without replacing mirrored roots or sources.
+project name/description updates without replacing mirrored roots or sources;
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-metadata-defaults` makes
+metadata/default-only PATCHes Cairnline-first while mixed metadata/root/source
+replacement PATCHes stay Hecate-owned.
 `project-roots-live-mirror` uses Cairnline's root-level API for direct root
-mutations, full root-list replacement, root discovery, and worktree-root
-creation after Hecate commits.
+mutations, full root-list replacement, root discovery, and worktree-created
+root record mirroring after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-roots` makes root
+create/update/delete, root list replacement, discovery-result replacement, and
+worktree-created root record mutations Cairnline-first; Hecate still performs
+the root discovery scan and Git worktree creation side effect in that partial
+authority mode.
 `project-context-sources-live-mirror` uses Cairnline's source-level
 API for direct context-source mutations, full context-source-list replacement,
-and context-source discovery after Hecate commits. `project-defaults-live-mirror` uses Cairnline's
-project-defaults seam for default-only project updates after Hecate commits,
-preserving existing mirrored roots and context sources. None of these mirrors is
-write authority.
-`project-skills-live-mirror` similarly mirrors metadata-only
-project skill discovery/update records after Hecate commits; it does not load,
-inject, or execute `SKILL.md` bodies. `agent-profiles-live-mirror` mirrors
+and context-source discovery after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-context-sources` makes
+context-source create/update/delete, list replacement, and discovery-result
+replacement Cairnline-first; Hecate still performs the workspace scan for its
+operator UI in that authority mode.
+`project-defaults-live-mirror`
+uses Cairnline's project-defaults seam for default-only project updates after
+Hecate commits, preserving existing mirrored roots and context sources unless
+`project-metadata-defaults` is enabled for scoped metadata/default-only PATCHes.
+`project-skills-live-mirror` mirrors metadata-only
+project skill discovery/update records after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills` makes those mutations
+Cairnline-first; it does not load, inject, or execute `SKILL.md` bodies, and
+preserves suggested tool names plus nullable permission hints as inspectable
+metadata only. `agent-profiles-live-mirror` mirrors
 global agent-profile create/update/delete metadata and execution posture after
-Hecate commits; delete removes only the portable profile record because
+Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles` is enabled. With
+that opt-in switchpoint, agent-profile create/update/delete commits
+Cairnline's separate portable profile and execution-posture records first, then
+best-effort shadows Hecate's combined profile row back into Hecate-native stores
+for compatibility; delete removes only the portable profile record because
 execution-profile posture can be shared. `project-roles-live-mirror` and
 `project-work-items-live-mirror` mirror role/work-item coordination metadata
 after Hecate commits. Role mirroring also seeds the referenced agent profile and
 execution posture when the profile store is available, so Cairnline role
 validation can pass without requiring a full sync first.
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-roles,project-work-items`
+makes role and work-item create/update/delete Cairnline-first and then shadows
+Hecate-native compatibility rows.
 `project-assignments-live-mirror` mirrors assignment create/update/delete
-coordination metadata and lifecycle status after Hecate commits. Mirror failures
-are logged. `project-assignment-start-result-live-mirror` best-effort mirrors
+coordination metadata, lifecycle status, and Hecate-provided
+started/completed timestamps after Hecate commits without manufacturing missing
+times during import unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assignments` makes assignment
+record create/update/delete mutations Cairnline-first and then shadows portable
+assignment state back into Hecate-native project-work stores. Mirror failures
+are logged.
+`project-assignment-start-result-live-mirror` best-effort mirrors
 committed assignment-start results after Hecate-owned dispatch completes or
 returns a committed cleanup/conflict state; it is replacement evidence, not
 runtime write authority. `project-assignment-chat-reconcile-live-mirror`
@@ -2313,7 +2427,9 @@ best-effort mirrors assignment status/ref updates committed by linked
 external-agent chat reconciliation. `project-collaboration-live-mirror` mirrors
 collaboration artifact creation, including generic artifacts, evidence links,
 and reviews, and `project-handoffs-live-mirror` mirrors handoff
-create/update/delete mutations after Hecate commits. `project-memory-live-mirror`
+create/update/delete mutations and status-transition timestamps after Hecate
+commits unless `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-collaboration`
+makes those collaboration routes Cairnline-first. `project-memory-live-mirror`
 mirrors accepted project memory entries after Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` makes accepted memory
 Cairnline-first. `project-memory-candidates-live-mirror` mirrors reviewable
@@ -2323,10 +2439,13 @@ makes candidate create/promote/reject Cairnline-first, including promoted or
 rejected status and promoted memory references.
 `project-assistant-proposal-ledger-live-mirror`
 mirrors Project Assistant draft/propose/apply proposal records and apply-attempt
-history after Hecate commits. `project-assistant-apply-side-effects-live-mirror`
+history after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` makes
+those ledger records Cairnline-first. `project-assistant-apply-side-effects-live-mirror`
 mirrors committed apply side effects after Hecate commits. Assignment-start
-dispatch and other non-mirrored live mutation routes still write only
-Hecate-native stores.
+dispatch still writes Hecate-native runtime stores first, while committed
+results and cleanup/conflict states mirror to Cairnline. Other non-mirrored live
+mutation routes still write only Hecate-native stores.
 `mirror_parity_url` points at a read-only check that compares Hecate's current
 project stores with the existing embedded Cairnline mirror database without
 creating or repairing it. `sync_readiness_url` points at the all-project
@@ -2422,6 +2541,7 @@ Example response, with `write_switchpoints` shortened for readability:
       "artifacts",
       "handoffs",
       "project-assistant-proposals",
+      "project-assistant-apply-side-effects",
       "migration-cutover"
     ],
     "replacement_gates": [
@@ -2446,8 +2566,8 @@ Example response, with `write_switchpoints` shortened for readability:
       {
         "id": "migration-and-rollback",
         "ready": false,
-        "status": "blocked",
-        "detail": "No migration cutover, rollback, or authoritative Cairnline storage switch exists yet."
+        "status": "rehearsal_available",
+        "detail": "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet."
       }
     ],
     "write_switchpoints": [
@@ -2474,11 +2594,12 @@ Example response, with `write_switchpoints` shortened for readability:
       {
         "name": "migration-cutover",
         "current_authority": "hecate",
-        "cairnline_state": "missing_authoritative_switchpoint",
+        "cairnline_state": "snapshot_import_rehearsal_available",
         "live_mirror": false,
         "blocks_authority": true,
+        "seams": ["sync-rehearsal"],
         "gap": "migration-cutover",
-        "detail": "No import/export cutover, rollback, or authoritative Cairnline storage switch exists yet."
+        "detail": "Snapshot import/export rehearsal and rollback notes exist, but no authoritative Cairnline storage cutover switch exists yet."
       }
     ],
     "status": "cairnline_read_routes_ready",
@@ -2487,17 +2608,17 @@ Example response, with `write_switchpoints` shortened for readability:
       "Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
       "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project or proposal record, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection.",
       "Project create/delete still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database.",
-      "Project metadata updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata seam.",
-      "Root create/update/delete, root list replacement, root discovery, and worktree-root creation mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API.",
+      "Project metadata/default updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata and project-defaults seams.",
+      "Root create/update/delete, root list replacement, root discovery, and worktree-created root record mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API; Hecate owns the Git worktree creation side effect.",
       "Direct context-source create/update/delete, context-source list replacement, and discovery mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's source-level API.",
-      "Default-only project updates still write Hecate-native stores first, then best-effort mirror portable launch defaults through Cairnline's project-defaults seam.",
       "Agent profile create/update/delete mutations still write Hecate-native stores first, then best-effort mirror portable profile metadata and execution posture into Cairnline.",
       "Project skill discovery and metadata updates still write Hecate-native stores first, then best-effort mirror metadata-only skill records into Cairnline.",
-      "Project role and work-item mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline.",
+      "Project role and work-item mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline unless project-roles or project-work-items write authority is explicitly enabled.",
       "Project assignment create/update/delete mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results.",
       "Project collaboration artifact creation and handoff mutations still write Hecate-native stores first, then best-effort mirror portable collaboration metadata into Cairnline.",
       "Project memory entry and memory-candidate mutations still write Hecate-native stores first, then best-effort mirror accepted memory and reviewable candidate state into Cairnline.",
-      "Project Assistant proposal draft/propose/apply ledger mutations still write Hecate-native stores first, then best-effort mirror proposal records plus committed apply side effects into Cairnline.",
+      "Project Assistant proposal draft/propose/apply-attempt ledger mutations still write Hecate-native stores first, then best-effort mirror proposal records into Cairnline.",
+      "Project Assistant confirmed apply side effects still execute through Hecate-owned mutation services, then best-effort mirror committed results into Cairnline.",
       "Other project mutation routes still write only Hecate-native stores.",
       "Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready."
     ],
@@ -2858,15 +2979,19 @@ Hecate's replacement read model exposes them as durable portable coordination
 metadata.
 
 The response shape matches the sync response, except `object` is
-`project_cairnline_mirror_parity` and `database_exists` may be `false`.
+`project_cairnline_mirror_parity`, `database_exists` may be `false`, and
+`migration_rehearsal.status` is `verified` for an exact existing mirror,
+`drift_detected` for a mismatched existing mirror, or `not_run` when no mirror
+database exists.
 
 ### `POST /hecate/v1/projects/cairnline/sync`
 
 Local-only experimental bridge endpoint. It loads every project from Hecate's
-authoritative Projects stores, writes a single refreshable embedded Cairnline
-SQLite database, then compares aggregate Hecate snapshot counts with aggregate
-counts, record ID sets, semantic record-content digests, and stable assignment
-launch-packet digests read back from that database:
+authoritative Projects stores, converts them into Cairnline's versioned
+portable snapshot contract, imports that snapshot into a single refreshable
+embedded Cairnline SQLite database, then compares aggregate Hecate snapshot
+counts with aggregate counts, record ID sets, semantic record-content digests,
+and stable assignment launch-packet digests read back from that database:
 
 ```text
 {HECATE_DATA_DIR}/cairnline/embedded/projects.db
@@ -2891,6 +3016,20 @@ volatile write timestamps and do not expose raw project, memory, or artifact
 bodies in the response. Launch-packet content digests compare packets that can
 be built on both sides; launch-packet coverage and build errors are reported by
 the count and ID-set checks.
+
+The response also includes `migration_rehearsal`, a structured checklist for
+the replacement-readiness rehearsal. It records the operation
+(`embedded_sync`), import mode (`cairnline_snapshot_import`), Cairnline snapshot
+version, source authority (`hecate_authoritative_stores`), target database
+family, whether the target was refreshed, and rollback notes. `cutover_ready`
+is always `false` in this release: Hecate stores remain authoritative, and the
+generated SQLite database is evidence for future migration rather than a source
+of truth. Sync and mirror-parity responses also include
+`migration_rehearsal.embedded_smoke` when an embedded Cairnline database was
+available. That smoke forces Hecate's read adapter to `cairnline + embedded`
+for representative project read routes (project detail, setup readiness,
+health, work items, activity, operations brief, and read model) without
+mutating live configuration.
 
 Example response:
 
@@ -2939,7 +3078,60 @@ Example response:
       "launch_warnings": 0,
       "launch_errors": 0
     },
-    "authoritative": false
+    "authoritative": false,
+    "migration_rehearsal": {
+      "operation": "embedded_sync",
+      "import_mode": "cairnline_snapshot_import",
+      "snapshot_version": 1,
+      "source_authority": "hecate_authoritative_stores",
+      "target": "embedded_cairnline_sqlite",
+      "refreshes_target": true,
+      "authoritative": false,
+      "cutover_ready": false,
+      "status": "rehearsed",
+      "checklist": [
+        {
+          "id": "load-hecate-stores",
+          "status": "complete",
+          "detail": "Loaded Hecate's authoritative project, profile, work, skill, memory, and assistant stores."
+        },
+        {
+          "id": "native-snapshot-import",
+          "status": "complete",
+          "detail": "Imported through Cairnline's versioned snapshot contract."
+        },
+        {
+          "id": "parity-check",
+          "status": "complete",
+          "detail": "Compared counts, IDs, launch packets, and content digests where available."
+        },
+        {
+          "id": "strict-embedded-read-smoke",
+          "status": "complete",
+          "detail": "Set Hecate to the embedded Cairnline read source and exercise Projects routes before any cutover."
+        },
+        {
+          "id": "authoritative-switchpoint",
+          "status": "blocked",
+          "detail": "No write authority has moved to Cairnline yet."
+        }
+      ],
+      "rollback": [
+        "Hecate stores remain authoritative; do not treat the generated Cairnline database as source of truth.",
+        "Rollback the rehearsal by deleting the generated Cairnline SQLite database files under the reported database path.",
+        "Keep or restore HECATE_PROJECTS_COORDINATION_BACKEND=hecate until write switchpoints and cutover are implemented."
+      ],
+      "embedded_smoke": {
+        "status": "passed",
+        "project_count": 2,
+        "checked_project_ids": ["proj_a", "proj_b"],
+        "read_route_checks": 14,
+        "read_model_count": 2,
+        "launch_packet_count": 5,
+        "launch_packet_warning_count": 0,
+        "launch_packet_error_count": 0
+      }
+    }
   }
 }
 ```
@@ -2948,8 +3140,9 @@ Example response:
 
 Local-only experimental bridge endpoint. It loads the selected project from
 Hecate's authoritative Projects stores and writes a refreshable Cairnline SQLite
-export that preserves roots, `default_root_id`, and context-source provenance
-metadata plus portable Project Assistant proposal ledger records at:
+export through Cairnline's native snapshot import. The export preserves roots,
+`default_root_id`, context-source provenance metadata, and portable Project
+Assistant proposal ledger records at:
 
 ```text
 {HECATE_DATA_DIR}/cairnline/projects/{safe_project_id}.db
@@ -2963,7 +3156,10 @@ missing project does not wipe an existing export.
 This endpoint is an interoperability and replacement-readiness proof only. It
 does not make Cairnline authoritative, does not proxy live Projects reads or
 writes, and does not migrate Hecate's stores. Response counts are read back
-from the written Cairnline database, not copied from the Hecate snapshot.
+from the written Cairnline database, not copied from the Hecate snapshot. The
+response includes the same `migration_rehearsal` object as the all-project sync
+response, with `operation: "project_export"` and
+`target: "project_cairnline_sqlite_export"`.
 
 Example response:
 
@@ -2985,7 +3181,55 @@ Example response:
     "handoff_count": 1,
     "memory_entry_count": 3,
     "memory_candidate_count": 2,
-    "assistant_proposal_count": 1
+    "assistant_proposal_count": 1,
+    "migration_rehearsal": {
+      "operation": "project_export",
+      "import_mode": "cairnline_snapshot_import",
+      "snapshot_version": 1,
+      "source_authority": "hecate_authoritative_stores",
+      "target": "project_cairnline_sqlite_export",
+      "refreshes_target": true,
+      "authoritative": false,
+      "cutover_ready": false,
+      "status": "exported",
+      "checklist": [
+        {
+          "id": "load-hecate-stores",
+          "status": "complete",
+          "detail": "Loaded Hecate's authoritative project, profile, work, skill, memory, and assistant stores."
+        },
+        {
+          "id": "native-snapshot-import",
+          "status": "complete",
+          "detail": "Imported through Cairnline's versioned snapshot contract."
+        },
+        {
+          "id": "parity-check",
+          "status": "complete",
+          "detail": "Compared counts, IDs, launch packets, and content digests where available."
+        },
+        {
+          "id": "strict-embedded-read-smoke",
+          "status": "operator_required",
+          "detail": "Set Hecate to the embedded Cairnline read source and exercise Projects routes before any cutover."
+        },
+        {
+          "id": "rollback-plan",
+          "status": "documented",
+          "detail": "Hecate remains authoritative; rollback is deleting the generated Cairnline SQLite files or switching reads back to Hecate."
+        },
+        {
+          "id": "authoritative-switchpoint",
+          "status": "blocked",
+          "detail": "No write authority has moved to Cairnline yet."
+        }
+      ],
+      "rollback": [
+        "Hecate stores remain authoritative; do not treat the generated Cairnline database as source of truth.",
+        "Rollback the rehearsal by deleting the generated Cairnline SQLite database files under the reported database path.",
+        "Keep or restore HECATE_PROJECTS_COORDINATION_BACKEND=hecate until write switchpoints and cutover are implemented."
+      ]
+    }
   }
 }
 ```
@@ -4520,7 +4764,9 @@ metadata:
 - `reviewed_assignment_id` — optional assignment being reviewed. When supplied
   it must refer to an assignment on the same work item.
 - `review_verdict` — optional `approved`, `changes_requested`, `blocked`, or
-  `risk`.
+  `risk`. Required when
+  `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-collaboration` is enabled,
+  because the Cairnline review record has no verdict-less state.
 - `review_risk` — optional `low`, `medium`, `high`, or `unknown`.
 - `review_follow_up_required` — optional boolean used by Projects attention
   surfaces.
@@ -4609,7 +4855,11 @@ includes `read_backend` (`hecate` or `cairnline`). Under
 `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`, this context packet is built
 from the Cairnline read model. Draft generation uses that same
 Cairnline-projected context so preview and proposal assembly do not drift,
-while proposal ledger writes and apply authority remain Hecate-owned.
+while proposal ledger writes remain Hecate-owned unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
+enabled. Confirmed apply uses enabled role/work-item/assignment/handoff
+Cairnline-authority seams and still blocks replacement on the remaining
+project/default/chat/memory/runtime side effects.
 `GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
 Cairnline read source as the other read routes; strict embedded mode reads the
 proposal record from the embedded mirror instead of falling back to the native

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260628020051-1b14ca2ad675
+	github.com/hecatehq/cairnline v0.0.0-20260629024923-2e83ea36ee1c
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.0.0-20260628020051-1b14ca2ad675 h1:byI7eBnHZX3utNrjmJqNFfsDiDUydTWYvdJGwVEpFbE=
-github.com/hecatehq/cairnline v0.0.0-20260628020051-1b14ca2ad675/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260629024923-2e83ea36ee1c h1:xgf0Ztd2L6jtDxEfTWnu6j2dIm2pf3eXE0H8wrTsL2E=
+github.com/hecatehq/cairnline v0.0.0-20260629024923-2e83ea36ee1c/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -99,11 +99,12 @@ func (h *Handler) projectAssistantApplication() *projectassistantapp.Application
 			Projects:         h.projects,
 			Chats:            h.agentChat,
 			Work:             h.projectWork,
+			WorkAuthority:    h.projectAssistantWorkAuthorityForApplication(),
 			WorkApplication:  h.projectWorkApplication(),
 			ProjectSkills:    h.projectSkills,
 			Memory:           h.memory,
 			MemoryCandidates: h.memoryCandidates,
-			Proposals:        h.projectAssistantProposals,
+			Proposals:        h.projectAssistantProposalStoreForApplication(),
 			LLM:              gatewayAgentLLMClient{service: h.service},
 			IDGenerator:      newOpaqueTaskResourceID,
 		})

--- a/internal/api/handler_agent_profile_authority.go
+++ b/internal/api/handler_agent_profile_authority.go
@@ -1,0 +1,334 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+)
+
+const projectCairnlineWriteAuthorityAgentProfiles = "agent-profiles"
+
+func (h *Handler) agentProfileWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityAgentProfiles)
+}
+
+func (h *Handler) createAgentProfileWithCairnlineAuthority(ctx context.Context, profile agentprofiles.Profile) (agentprofiles.Profile, error) {
+	profile = normalizeAgentProfileForCairnlineAuthority(profile)
+	if err := validateAgentProfileForCairnlineAuthority(profile); err != nil {
+		return agentprofiles.Profile{}, err
+	}
+	var recorded agentprofiles.Profile
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		written, err := cairnlinebridge.UpsertAgentProfile(ctx, service, profile)
+		if err != nil {
+			return err
+		}
+		recorded = profile
+		recorded.CreatedAt = written.CreatedAt
+		recorded.UpdatedAt = written.UpdatedAt
+		return nil
+	})
+	if err != nil {
+		return agentprofiles.Profile{}, agentProfileCairnlineAuthorityError(err)
+	}
+	if shadowed, ok := h.shadowAgentProfileToHecate(ctx, "agent_profile_cairnline_authority_create", recorded); ok {
+		recorded = shadowed
+	}
+	return recorded, nil
+}
+
+func (h *Handler) updateAgentProfileWithCairnlineAuthority(ctx context.Context, profileID string, req UpdateAgentProfileRequest) (agentprofiles.Profile, error) {
+	profileID = strings.TrimSpace(profileID)
+	if agentprofiles.IsBuiltInProfileID(profileID) {
+		return agentprofiles.Profile{}, agentprofiles.ErrBuiltIn
+	}
+	var recorded agentprofiles.Profile
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := h.loadAgentProfileForCairnlineAuthority(ctx, service, profileID)
+		if err != nil {
+			return err
+		}
+		applyAgentProfileUpdate(&existing, req)
+		existing = normalizeAgentProfileForCairnlineAuthority(existing)
+		if err := validateAgentProfileForCairnlineAuthority(existing); err != nil {
+			return err
+		}
+		written, err := cairnlinebridge.UpsertAgentProfile(ctx, service, existing)
+		if err != nil {
+			return err
+		}
+		recorded = existing
+		recorded.CreatedAt = written.CreatedAt
+		recorded.UpdatedAt = written.UpdatedAt
+		return nil
+	})
+	if err != nil {
+		return agentprofiles.Profile{}, agentProfileCairnlineAuthorityError(err)
+	}
+	if shadowed, ok := h.shadowAgentProfileToHecate(ctx, "agent_profile_cairnline_authority_update", recorded); ok {
+		recorded = shadowed
+	}
+	return recorded, nil
+}
+
+func (h *Handler) deleteAgentProfileWithCairnlineAuthority(ctx context.Context, profileID string) error {
+	profileID = strings.TrimSpace(profileID)
+	if agentprofiles.IsBuiltInProfileID(profileID) {
+		return agentprofiles.ErrBuiltIn
+	}
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := getCairnlineAgentProfileForAuthority(ctx, service, profileID); err != nil {
+			return err
+		}
+		return cairnlinebridge.DeleteAgentProfile(ctx, service, profileID)
+	})
+	if err != nil {
+		return agentProfileCairnlineAuthorityError(err)
+	}
+	h.shadowAgentProfileDeleteToHecate(ctx, "agent_profile_cairnline_authority_delete", profileID)
+	return nil
+}
+
+func (h *Handler) loadAgentProfileForCairnlineAuthority(ctx context.Context, service *cairnline.Service, profileID string) (agentprofiles.Profile, error) {
+	if h != nil && h.agentProfiles != nil {
+		if profile, ok, err := h.agentProfiles.Get(ctx, profileID); err != nil {
+			return agentprofiles.Profile{}, err
+		} else if ok {
+			if profile.BuiltIn {
+				return agentprofiles.Profile{}, agentprofiles.ErrBuiltIn
+			}
+			return profile, nil
+		}
+	}
+	profile, err := getCairnlineAgentProfileForAuthority(ctx, service, profileID)
+	if err != nil {
+		return agentprofiles.Profile{}, err
+	}
+	execution := cairnline.ExecutionProfile{}
+	if profile.ID != "" {
+		execution = getCairnlineExecutionProfileForAgentProfileAuthority(ctx, service, profile.ID)
+	}
+	return agentProfileFromCairnlineAuthority(profile, execution), nil
+}
+
+func getCairnlineAgentProfileForAuthority(ctx context.Context, service *cairnline.Service, profileID string) (cairnline.AgentProfile, error) {
+	profiles, err := service.ListAgentProfiles(ctx)
+	if err != nil {
+		return cairnline.AgentProfile{}, err
+	}
+	profileID = strings.TrimSpace(profileID)
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.ID) == profileID {
+			return profile, nil
+		}
+	}
+	return cairnline.AgentProfile{}, cairnline.ErrNotFound
+}
+
+func getCairnlineExecutionProfileForAgentProfileAuthority(ctx context.Context, service *cairnline.Service, profileID string) cairnline.ExecutionProfile {
+	profiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return cairnline.ExecutionProfile{}
+	}
+	profileID = strings.TrimSpace(profileID)
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.ID) == profileID {
+			return profile
+		}
+	}
+	return cairnline.ExecutionProfile{}
+}
+
+func agentProfileFromCairnlineAuthority(profile cairnline.AgentProfile, execution cairnline.ExecutionProfile) agentprofiles.Profile {
+	return normalizeAgentProfileForCairnlineAuthority(agentprofiles.Profile{
+		ID:                   profile.ID,
+		Name:                 profile.Name,
+		Description:          profile.Description,
+		Instructions:         profile.Instructions,
+		Surface:              agentProfileSurfaceFromExecutionAgentKind(execution.AgentKind),
+		ProviderHint:         execution.ProviderHint,
+		ModelHint:            execution.ModelHint,
+		ExecutionProfile:     execution.ID,
+		ToolsEnabled:         execution.ToolsPolicy == "allow",
+		WritesAllowed:        execution.WritesPolicy == "allow",
+		NetworkAllowed:       execution.NetworkPolicy == "allow",
+		ApprovalPolicy:       firstNonEmptyString(execution.ApprovalPolicy, agentprofiles.ApprovalInherit),
+		ProjectMemoryPolicy:  firstNonEmptyString(profile.MemoryPolicy, agentprofiles.MemoryInherit),
+		ContextSourcePolicy:  firstNonEmptyString(profile.SourcePolicy, agentprofiles.ContextInherit),
+		SkillIDs:             append([]string(nil), profile.SkillIDs...),
+		ExternalAgentKind:    agentProfileExternalAgentKindFromExecution(execution),
+		ExternalAgentOptions: stringAgentProfileAdapterOptions(execution.AdapterOptions),
+		CreatedAt:            profile.CreatedAt,
+		UpdatedAt:            profile.UpdatedAt,
+	})
+}
+
+func normalizeAgentProfileForCairnlineAuthority(profile agentprofiles.Profile) agentprofiles.Profile {
+	profile.ID = strings.TrimSpace(profile.ID)
+	profile.Name = strings.TrimSpace(profile.Name)
+	profile.Description = strings.TrimSpace(profile.Description)
+	profile.Instructions = strings.TrimSpace(profile.Instructions)
+	profile.Surface = strings.TrimSpace(profile.Surface)
+	profile.ProviderHint = strings.TrimSpace(profile.ProviderHint)
+	profile.ModelHint = strings.TrimSpace(profile.ModelHint)
+	profile.ExecutionProfile = strings.TrimSpace(profile.ExecutionProfile)
+	profile.ApprovalPolicy = strings.TrimSpace(profile.ApprovalPolicy)
+	profile.ProjectMemoryPolicy = strings.TrimSpace(profile.ProjectMemoryPolicy)
+	profile.ContextSourcePolicy = strings.TrimSpace(profile.ContextSourcePolicy)
+	profile.ExternalAgentKind = strings.TrimSpace(profile.ExternalAgentKind)
+	if profile.Surface == "" {
+		profile.Surface = agentprofiles.SurfaceAny
+	}
+	if profile.ApprovalPolicy == "" {
+		profile.ApprovalPolicy = agentprofiles.ApprovalInherit
+	}
+	if profile.ProjectMemoryPolicy == "" {
+		profile.ProjectMemoryPolicy = agentprofiles.MemoryInherit
+	}
+	if profile.ContextSourcePolicy == "" {
+		profile.ContextSourcePolicy = agentprofiles.ContextInherit
+	}
+	profile.SkillIDs = compactProjectWorkAuthorityStrings(profile.SkillIDs)
+	profile.ExternalAgentOptions = normalizeAgentProfileAuthorityOptions(profile.ExternalAgentOptions)
+	return profile
+}
+
+func validateAgentProfileForCairnlineAuthority(profile agentprofiles.Profile) error {
+	if profile.ID == "" || profile.Name == "" {
+		return agentprofiles.ErrInvalid
+	}
+	if agentprofiles.IsBuiltInProfileID(profile.ID) || profile.BuiltIn {
+		return agentprofiles.ErrBuiltIn
+	}
+	if !oneOfAgentProfileAuthority(profile.Surface, agentprofiles.SurfaceAny, agentprofiles.SurfaceHecateChat, agentprofiles.SurfaceHecateTask, agentprofiles.SurfaceExternalAgent) {
+		return agentprofiles.ErrInvalid
+	}
+	if !oneOfAgentProfileAuthority(profile.ApprovalPolicy, agentprofiles.ApprovalInherit, agentprofiles.ApprovalRequire, agentprofiles.ApprovalBlock, agentprofiles.ApprovalAllow) {
+		return agentprofiles.ErrInvalid
+	}
+	if !oneOfAgentProfileAuthority(profile.ProjectMemoryPolicy, agentprofiles.MemoryInherit, agentprofiles.MemoryInclude, agentprofiles.MemoryVisibleOnly, agentprofiles.MemoryExclude) {
+		return agentprofiles.ErrInvalid
+	}
+	if !oneOfAgentProfileAuthority(profile.ContextSourcePolicy, agentprofiles.ContextInherit, agentprofiles.ContextIncludeEnabled, agentprofiles.ContextVisibleOnly, agentprofiles.ContextExclude) {
+		return agentprofiles.ErrInvalid
+	}
+	return nil
+}
+
+func normalizeAgentProfileAuthorityOptions(options map[string]string) map[string]string {
+	if len(options) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(options))
+	for key, value := range options {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func oneOfAgentProfileAuthority(value string, allowed ...string) bool {
+	for _, item := range allowed {
+		if value == item {
+			return true
+		}
+	}
+	return false
+}
+
+func agentProfileSurfaceFromExecutionAgentKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case "hecate":
+		return agentprofiles.SurfaceHecateTask
+	case "":
+		return agentprofiles.SurfaceAny
+	default:
+		return agentprofiles.SurfaceExternalAgent
+	}
+}
+
+func agentProfileExternalAgentKindFromExecution(profile cairnline.ExecutionProfile) string {
+	switch strings.TrimSpace(profile.AgentKind) {
+	case "", "hecate", cairnline.DesiredAgentAny:
+		return ""
+	default:
+		return strings.TrimSpace(profile.AgentKind)
+	}
+}
+
+func stringAgentProfileAdapterOptions(options map[string]any) map[string]string {
+	if len(options) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(options))
+	for key, value := range options {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if text, ok := value.(string); ok && strings.TrimSpace(text) != "" {
+			out[key] = strings.TrimSpace(text)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func agentProfileCairnlineAuthorityError(err error) error {
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return errors.Join(agentprofiles.ErrNotFound, err)
+	}
+	if errors.Is(err, cairnline.ErrInvalid) {
+		return errors.Join(agentprofiles.ErrInvalid, err)
+	}
+	return err
+}
+
+func (h *Handler) shadowAgentProfileToHecate(ctx context.Context, operation string, profile agentprofiles.Profile) (agentprofiles.Profile, bool) {
+	if h == nil || h.agentProfiles == nil {
+		return profile, false
+	}
+	if existing, ok, err := h.agentProfiles.Get(ctx, profile.ID); err != nil {
+		h.logCairnlineAgentProfileMirrorError(ctx, operation, profile.ID, err)
+		return profile, false
+	} else if ok && !existing.BuiltIn {
+		updated, err := h.agentProfiles.Update(ctx, profile.ID, func(item *agentprofiles.Profile) {
+			*item = profile
+		})
+		if err != nil {
+			h.logCairnlineAgentProfileMirrorError(ctx, operation, profile.ID, err)
+			return profile, false
+		}
+		return updated, true
+	}
+	created, err := h.agentProfiles.Create(ctx, profile)
+	if err != nil {
+		h.logCairnlineAgentProfileMirrorError(ctx, operation, profile.ID, err)
+		return profile, false
+	}
+	return created, true
+}
+
+func (h *Handler) shadowAgentProfileDeleteToHecate(ctx context.Context, operation, profileID string) {
+	if h == nil || h.agentProfiles == nil {
+		return
+	}
+	if err := h.agentProfiles.Delete(ctx, profileID); err != nil && !errors.Is(err, agentprofiles.ErrNotFound) {
+		h.logCairnlineAgentProfileMirrorError(ctx, operation, profileID, err)
+	}
+}

--- a/internal/api/handler_agent_profiles.go
+++ b/internal/api/handler_agent_profiles.go
@@ -29,6 +29,23 @@ func (h *Handler) HandleCreateAgentProfile(w http.ResponseWriter, r *http.Reques
 	if profile.ID == "" {
 		profile.ID = newOpaqueTaskResourceID("prof")
 	}
+	if h.agentProfileWritesUseCairnlineAuthority() {
+		created, err := h.createAgentProfileWithCairnlineAuthority(r.Context(), profile)
+		if errors.Is(err, agentprofiles.ErrInvalid) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid agent profile")
+			return
+		}
+		if errors.Is(err, agentprofiles.ErrBuiltIn) {
+			WriteError(w, http.StatusConflict, errCodeConflict, "built-in agent profile cannot be created")
+			return
+		}
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusCreated, AgentProfileResponse{Object: "agent_profile", Data: renderAgentProfile(created)})
+		return
+	}
 	profile, err := h.agentProfiles.Create(r.Context(), profile)
 	if errors.Is(err, agentprofiles.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid agent profile")
@@ -64,6 +81,27 @@ func (h *Handler) HandleUpdateAgentProfile(w http.ResponseWriter, r *http.Reques
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if h.agentProfileWritesUseCairnlineAuthority() {
+		profile, err := h.updateAgentProfileWithCairnlineAuthority(r.Context(), r.PathValue("id"), req)
+		if errors.Is(err, agentprofiles.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
+			return
+		}
+		if errors.Is(err, agentprofiles.ErrBuiltIn) {
+			WriteError(w, http.StatusConflict, errCodeConflict, "built-in agent profile cannot be updated")
+			return
+		}
+		if errors.Is(err, agentprofiles.ErrInvalid) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "invalid agent profile")
+			return
+		}
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusOK, AgentProfileResponse{Object: "agent_profile", Data: renderAgentProfile(profile)})
+		return
+	}
 	profile, err := h.agentProfiles.Update(r.Context(), r.PathValue("id"), func(item *agentprofiles.Profile) {
 		applyAgentProfileUpdate(item, req)
 	})
@@ -89,6 +127,20 @@ func (h *Handler) HandleUpdateAgentProfile(w http.ResponseWriter, r *http.Reques
 
 func (h *Handler) HandleDeleteAgentProfile(w http.ResponseWriter, r *http.Request) {
 	profileID := r.PathValue("id")
+	if h.agentProfileWritesUseCairnlineAuthority() {
+		if err := h.deleteAgentProfileWithCairnlineAuthority(r.Context(), profileID); errors.Is(err, agentprofiles.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
+			return
+		} else if errors.Is(err, agentprofiles.ErrBuiltIn) {
+			WriteError(w, http.StatusConflict, errCodeConflict, "built-in agent profile cannot be deleted")
+			return
+		} else if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 	if err := h.agentProfiles.Delete(r.Context(), profileID); errors.Is(err, agentprofiles.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent profile not found")
 		return

--- a/internal/api/handler_agent_profiles_test.go
+++ b/internal/api/handler_agent_profiles_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/config"
 )
 
@@ -22,6 +24,18 @@ func newAgentProfilesCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Han
 	handler := NewHandler(config.Config{
 		Server:   config.ServerConfig{DataDir: t.TempDir()},
 		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newAgentProfilesCairnlineAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityAgentProfiles,
+		},
 	}, quietLogger(), nil, nil, nil, nil)
 	return handler, NewServer(quietLogger(), handler)
 }
@@ -162,6 +176,114 @@ func TestAgentProfilesAPI_MirrorsMutationsToCairnlineWhenConfigured(t *testing.T
 	}
 }
 
+func TestAgentProfilesAPI_CairnlineWriteAuthorityCommitsProfilesFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newAgentProfilesCairnlineAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-profiles", bytes.NewReader([]byte(`{
+		"id":"prof_bad",
+		"name":"Bad",
+		"surface":"terminal"
+	}`))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("create bad enum status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(handler.cairnlineEmbeddedDatabasePath()); !os.IsNotExist(err) {
+		t.Fatalf("Cairnline database stat after invalid create error = %v, want database not created", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-profiles", bytes.NewReader([]byte(`{
+		"id":"prof_authority",
+		"name":"Authority profile",
+		"description":"Cairnline owns this profile.",
+		"instructions":"Keep profile metadata portable.",
+		"surface":"external_agent",
+		"provider_hint":"anthropic",
+		"model_hint":"claude-sonnet-4",
+		"execution_profile":"prof_authority_exec",
+		"tools_enabled":true,
+		"writes_allowed":true,
+		"network_allowed":false,
+		"approval_policy":"require",
+		"project_memory_policy":"include",
+		"context_source_policy":"include_enabled",
+		"skill_ids":["review","review","release"],
+		"external_agent_kind":"codex",
+		"external_agent_options":{"effort":"high"}
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created AgentProfileResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Data.ID != "prof_authority" || created.Data.Surface != agentprofiles.SurfaceExternalAgent || !created.Data.ToolsEnabled || !created.Data.WritesAllowed || len(created.Data.SkillIDs) != 2 {
+		t.Fatalf("created profile = %+v, want normalized Hecate-compatible response", created.Data)
+	}
+	profile := getMirroredCairnlineAgentProfileForTest(t, handler, "prof_authority")
+	if profile.Name != "Authority profile" || profile.MemoryPolicy != "include" || profile.SourcePolicy != "include_enabled" || !stringSliceContains(profile.SkillIDs, "release") {
+		t.Fatalf("Cairnline profile = %+v, want authority metadata", profile)
+	}
+	execution := getMirroredCairnlineExecutionProfileForTest(t, handler, "prof_authority_exec")
+	if execution.AgentKind != "codex" || execution.ProviderHint != "anthropic" || execution.ModelHint != "claude-sonnet-4" || execution.ToolsPolicy != "allow" || execution.WritesPolicy != "allow" || execution.NetworkPolicy != "block" || execution.AdapterOptions["effort"] != "high" {
+		t.Fatalf("Cairnline execution profile = %+v, want authority execution posture", execution)
+	}
+	if shadow, ok, err := handler.agentProfiles.Get(t.Context(), "prof_authority"); err != nil || !ok || shadow.ExternalAgentKind != "codex" || shadow.ExecutionProfile != "prof_authority_exec" {
+		t.Fatalf("Hecate shadow profile = %+v ok=%v err=%v, want compatibility row", shadow, ok, err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/agent-profiles/prof_authority", bytes.NewReader([]byte(`{
+		"name":"Updated authority profile",
+		"model_hint":"claude-opus-4",
+		"writes_allowed":false,
+		"skill_ids":["review"]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var updated AgentProfileResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode patch response: %v", err)
+	}
+	if updated.Data.Name != "Updated authority profile" || updated.Data.ModelHint != "claude-opus-4" || updated.Data.WritesAllowed || len(updated.Data.SkillIDs) != 1 || updated.Data.SkillIDs[0] != "review" {
+		t.Fatalf("updated profile = %+v, want patched response", updated.Data)
+	}
+	profile = getMirroredCairnlineAgentProfileForTest(t, handler, "prof_authority")
+	if profile.Name != "Updated authority profile" || !stringSliceContains(profile.SkillIDs, "review") || stringSliceContains(profile.SkillIDs, "release") {
+		t.Fatalf("updated Cairnline profile = %+v, want patched metadata", profile)
+	}
+	execution = getMirroredCairnlineExecutionProfileForTest(t, handler, "prof_authority_exec")
+	if execution.ModelHint != "claude-opus-4" || execution.WritesPolicy != "block" {
+		t.Fatalf("updated Cairnline execution profile = %+v, want patched execution posture", execution)
+	}
+	if shadow, ok, err := handler.agentProfiles.Get(t.Context(), "prof_authority"); err != nil || !ok || shadow.Name != "Updated authority profile" || shadow.WritesAllowed {
+		t.Fatalf("updated Hecate shadow profile = %+v ok=%v err=%v, want patched compatibility row", shadow, ok, err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/agent-profiles/prof_authority", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d body=%s, want 204", rec.Code, rec.Body.String())
+	}
+	assertCairnlineAgentProfileMissingForTest(t, handler, "prof_authority")
+	if _, ok, err := handler.agentProfiles.Get(t.Context(), "prof_authority"); err != nil || ok {
+		t.Fatalf("Hecate shadow after delete ok=%v err=%v, want missing", ok, err)
+	}
+	if !cairnlineExecutionProfileIDExistsForTest(t, handler, "prof_authority_exec") {
+		t.Fatalf("delete should leave portable execution profile posture in place")
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/agent-profiles/prof_authority", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("delete missing status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestAgentProfilesAPI_BuiltInProfilesAreReadOnly(t *testing.T) {
 	t.Parallel()
 	server := newAgentProfilesTestServer()
@@ -289,6 +411,20 @@ func assertCairnlineAgentProfileMissingForTest(t *testing.T, handler *Handler, i
 
 func cairnlineExecutionProfileIDExistsForTest(t *testing.T, handler *Handler, id string) bool {
 	t.Helper()
+	return getMirroredCairnlineExecutionProfileForTestOrNil(t, handler, id) != nil
+}
+
+func getMirroredCairnlineExecutionProfileForTest(t *testing.T, handler *Handler, id string) cairnline.ExecutionProfile {
+	t.Helper()
+	item := getMirroredCairnlineExecutionProfileForTestOrNil(t, handler, id)
+	if item == nil {
+		t.Fatalf("mirrored Cairnline execution profile %q not found", id)
+	}
+	return *item
+}
+
+func getMirroredCairnlineExecutionProfileForTestOrNil(t *testing.T, handler *Handler, id string) *cairnline.ExecutionProfile {
+	t.Helper()
 	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
 	if err != nil {
 		t.Fatalf("open Cairnline mirror: %v", err)
@@ -300,10 +436,11 @@ func cairnlineExecutionProfileIDExistsForTest(t *testing.T, handler *Handler, id
 	}
 	for _, item := range items {
 		if item.ID == id {
-			return true
+			found := item
+			return &found
 		}
 	}
-	return false
+	return nil
 }
 
 func stringSliceContains(items []string, value string) bool {

--- a/internal/api/handler_project_assignment_authority.go
+++ b/internal/api/handler_project_assignment_authority.go
@@ -1,0 +1,329 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
+)
+
+const projectCairnlineWriteAuthorityProjectAssignments = "project-assignments"
+
+func (h *Handler) projectAssignmentWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectAssignments)
+}
+
+func (h *Handler) createProjectWorkAssignmentWithCairnlineAuthority(ctx context.Context, projectID, workItemID string, cmd projectworkapp.CreateAssignmentCommand) (projectwork.Assignment, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projectwork.Assignment{}, err
+	}
+	assignment := projectwork.Assignment{
+		ID:           firstNonEmptyString(strings.TrimSpace(cmd.ID), newOpaqueTaskResourceID("asgn")),
+		ProjectID:    projectID,
+		WorkItemID:   workItemID,
+		RoleID:       strings.TrimSpace(cmd.RoleID),
+		RootID:       strings.TrimSpace(cmd.RootID),
+		DriverKind:   strings.TrimSpace(cmd.DriverKind),
+		Status:       strings.TrimSpace(cmd.Status),
+		ExecutionRef: cmd.ExecutionRef,
+		StartedAt:    cmd.StartedAt,
+		CompletedAt:  cmd.CompletedAt,
+	}
+	if err := validateProjectAssignmentForCairnlineAuthority(assignment); err != nil {
+		return projectwork.Assignment{}, err
+	}
+	var recorded projectwork.Assignment
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		role, profile, err := h.seedProjectAssignmentDependenciesForCairnlineAuthority(ctx, service, project, assignment)
+		if err != nil {
+			return err
+		}
+		assignment.DriverKind = resolvedProjectAssignmentDriverKind(assignment.DriverKind, role.DefaultDriverKind)
+		written, err := cairnlinebridge.UpsertAssignment(ctx, service, assignment, role, profile)
+		if err != nil {
+			return err
+		}
+		recorded = projectWorkAssignmentFromCairnlineAuthority(written, assignment)
+		return nil
+	})
+	if err != nil {
+		return projectwork.Assignment{}, err
+	}
+	h.shadowProjectAssignmentToHecate(ctx, "project_assignment_cairnline_authority_create", recorded)
+	return recorded, nil
+}
+
+func (h *Handler) updateProjectWorkAssignmentWithCairnlineAuthority(ctx context.Context, projectID, workItemID, assignmentID string, cmd projectworkapp.UpdateAssignmentCommand) (projectwork.Assignment, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projectwork.Assignment{}, err
+	}
+	var recorded projectwork.Assignment
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := service.GetAssignment(ctx, projectID, assignmentID)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(existing.WorkItemID) != strings.TrimSpace(workItemID) {
+			return cairnline.ErrNotFound
+		}
+		assignment := projectWorkAssignmentFromCairnline(existing)
+		if shadow, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID); err != nil {
+			return err
+		} else if ok {
+			assignment.ExecutionRef = shadow.ExecutionRef
+		}
+		applyProjectAssignmentUpdate(&assignment, cmd)
+		if err := validateProjectAssignmentForCairnlineAuthority(assignment); err != nil {
+			return err
+		}
+		role, profile, err := h.seedProjectAssignmentDependenciesForCairnlineAuthority(ctx, service, project, assignment)
+		if err != nil {
+			return err
+		}
+		written, err := cairnlinebridge.UpsertAssignment(ctx, service, assignment, role, profile)
+		if err != nil {
+			return err
+		}
+		recorded = projectWorkAssignmentFromCairnlineAuthority(written, assignment)
+		return nil
+	})
+	if err != nil {
+		return projectwork.Assignment{}, err
+	}
+	h.shadowProjectAssignmentToHecate(ctx, "project_assignment_cairnline_authority_update", recorded)
+	return recorded, nil
+}
+
+func (h *Handler) deleteProjectWorkAssignmentWithCairnlineAuthority(ctx context.Context, projectID, workItemID, assignmentID string) error {
+	var deleted projectwork.Assignment
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := service.GetAssignment(ctx, projectID, assignmentID)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(existing.WorkItemID) != strings.TrimSpace(workItemID) {
+			return cairnline.ErrNotFound
+		}
+		deleted = projectWorkAssignmentFromCairnline(existing)
+		return cairnlinebridge.DeleteAssignment(ctx, service, projectID, assignmentID)
+	})
+	if err != nil {
+		return err
+	}
+	h.shadowProjectAssignmentDeleteToHecate(ctx, "project_assignment_cairnline_authority_delete", deleted.ProjectID, deleted.WorkItemID, deleted.ID)
+	return nil
+}
+
+func (h *Handler) seedProjectAssignmentDependenciesForCairnlineAuthority(ctx context.Context, service *cairnline.Service, project projects.Project, assignment projectwork.Assignment) (projectwork.AgentRoleProfile, agentprofiles.Profile, error) {
+	if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	}
+	workItem, err := h.projectWorkItemForCairnlineAssignmentAuthority(ctx, service, assignment.ProjectID, assignment.WorkItemID)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	}
+	if err := h.seedProjectWorkItemDependenciesForCairnlineAuthority(ctx, service, project, workItem); err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	}
+	if err := h.seedProjectAssignmentRootForCairnlineAuthority(ctx, service, project, assignment.RootID); err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	}
+	role, profile, err := h.projectRoleForCairnlineAssignmentAuthority(ctx, service, assignment.ProjectID, assignment.RoleID)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	}
+	return role, profile, nil
+}
+
+func (h *Handler) projectWorkItemForCairnlineAssignmentAuthority(ctx context.Context, service *cairnline.Service, projectID, workItemID string) (projectwork.WorkItem, error) {
+	if h != nil && h.projectWork != nil {
+		if item, ok, err := h.projectWork.GetWorkItem(ctx, projectID, workItemID); err != nil {
+			return projectwork.WorkItem{}, err
+		} else if ok {
+			return item, nil
+		}
+	}
+	item, err := service.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return projectwork.WorkItem{}, err
+	}
+	return projectWorkItemFromCairnline(item), nil
+}
+
+func (h *Handler) projectRoleForCairnlineAssignmentAuthority(ctx context.Context, service *cairnline.Service, projectID, roleID string) (projectwork.AgentRoleProfile, agentprofiles.Profile, error) {
+	if role, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, projectID, roleID); err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	} else if ok {
+		profile, err := h.writeRoleAgentProfileToCairnline(ctx, service, role)
+		if err != nil {
+			return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+		}
+		if _, err := cairnlinebridge.UpsertRole(ctx, service, role); err != nil {
+			return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+		}
+		return role, profile, nil
+	}
+	role, err := getCairnlineProjectRoleForAuthority(ctx, service, projectID, roleID)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	}
+	native, err := h.projectWorkRoleFromCairnlineAuthority(ctx, service, role, projectwork.AgentRoleProfile{})
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	}
+	return native, agentprofiles.Profile{}, nil
+}
+
+func resolvedProjectAssignmentDriverKind(driverKind, roleDefault string) string {
+	return firstNonEmptyString(
+		strings.TrimSpace(driverKind),
+		strings.TrimSpace(roleDefault),
+		projectwork.AssignmentDriverHecateTask,
+	)
+}
+
+func (h *Handler) seedProjectAssignmentRootForCairnlineAuthority(ctx context.Context, service *cairnline.Service, project projects.Project, rootID string) error {
+	rootID = strings.TrimSpace(rootID)
+	if rootID == "" {
+		return nil
+	}
+	root, ok := projectRootForCairnlineMirror(project, rootID)
+	if !ok {
+		return errors.Join(cairnline.ErrNotFound, errors.New("project root not found for Cairnline assignment authority"))
+	}
+	_, err := cairnlinebridge.UpsertRoot(ctx, service, project, root)
+	return err
+}
+
+func applyProjectAssignmentUpdate(item *projectwork.Assignment, cmd projectworkapp.UpdateAssignmentCommand) {
+	if item == nil {
+		return
+	}
+	if cmd.RoleID != nil {
+		item.RoleID = *cmd.RoleID
+	}
+	if cmd.RootID != nil {
+		item.RootID = *cmd.RootID
+	}
+	if cmd.DriverKind != nil {
+		item.DriverKind = *cmd.DriverKind
+	}
+	if cmd.Status != nil {
+		item.Status = *cmd.Status
+	}
+	if cmd.ExecutionRef != nil {
+		item.ExecutionRef = *cmd.ExecutionRef
+	}
+	if cmd.StartedAt != nil {
+		item.StartedAt = *cmd.StartedAt
+	}
+	if cmd.CompletedAt != nil {
+		item.CompletedAt = *cmd.CompletedAt
+	}
+}
+
+func projectWorkAssignmentFromCairnlineAuthority(item cairnline.Assignment, native projectwork.Assignment) projectwork.Assignment {
+	out := projectWorkAssignmentFromCairnline(item)
+	if ref := projectwork.NormalizeAssignmentExecutionRef(native.ExecutionRef); !projectAssignmentExecutionRefEmpty(ref) {
+		out.ExecutionRef = ref
+	}
+	if out.ExecutionRef.ContextSnapshotID == "" {
+		out.ExecutionRef.ContextSnapshotID = strings.TrimSpace(item.ContextSnapshotID)
+	}
+	return out
+}
+
+func projectAssignmentExecutionRefEmpty(ref projectwork.AssignmentExecutionRef) bool {
+	return ref.Kind == "" &&
+		ref.TaskID == "" &&
+		ref.RunID == "" &&
+		ref.ChatSessionID == "" &&
+		ref.MessageID == "" &&
+		ref.ContextSnapshotID == "" &&
+		ref.Status == "" &&
+		ref.PendingApprovalCount == 0 &&
+		ref.TraceID == "" &&
+		!ref.Missing
+}
+
+func (h *Handler) shadowProjectAssignmentToHecate(ctx context.Context, operation string, assignment projectwork.Assignment) {
+	if h == nil || h.projectWork == nil {
+		return
+	}
+	if _, err := h.projectWork.CreateAssignment(ctx, assignment); err == nil {
+		return
+	} else if !errors.Is(err, projectwork.ErrDuplicate) {
+		h.logCairnlineMirrorError(ctx, operation, assignment.ProjectID, err)
+		return
+	}
+	_, err := h.projectWork.UpdateAssignment(ctx, assignment.ProjectID, assignment.ID, func(item *projectwork.Assignment) {
+		item.WorkItemID = assignment.WorkItemID
+		item.RoleID = assignment.RoleID
+		item.RootID = assignment.RootID
+		item.DriverKind = assignment.DriverKind
+		item.Status = assignment.Status
+		item.ExecutionRef = assignment.ExecutionRef
+		item.StartedAt = assignment.StartedAt
+		item.CompletedAt = assignment.CompletedAt
+	})
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, assignment.ProjectID, err)
+	}
+}
+
+func (h *Handler) shadowProjectAssignmentDeleteToHecate(ctx context.Context, operation, projectID, workItemID, assignmentID string) {
+	if h == nil || h.projectWork == nil {
+		return
+	}
+	if err := h.projectWork.DeleteAssignment(ctx, projectID, workItemID, assignmentID); err != nil && !errors.Is(err, projectwork.ErrNotFound) {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
+	}
+}
+
+func validateProjectAssignmentForCairnlineAuthority(assignment projectwork.Assignment) error {
+	if strings.TrimSpace(assignment.ProjectID) == "" {
+		return fmt.Errorf("%w: project_id is required", projectwork.ErrInvalid)
+	}
+	if strings.TrimSpace(assignment.WorkItemID) == "" {
+		return fmt.Errorf("%w: work_item_id is required", projectwork.ErrInvalid)
+	}
+	if strings.TrimSpace(assignment.RoleID) == "" {
+		return fmt.Errorf("%w: role_id is required", projectwork.ErrInvalid)
+	}
+	if driverKind := strings.TrimSpace(assignment.DriverKind); driverKind != "" && !validProjectAssignmentDriverKindForCairnlineAuthority(driverKind) {
+		return fmt.Errorf("%w: unsupported assignment driver_kind %q", projectwork.ErrInvalid, driverKind)
+	}
+	if status := strings.TrimSpace(assignment.Status); status != "" && !validProjectAssignmentStatusForCairnlineAuthority(status) {
+		return fmt.Errorf("%w: unsupported assignment status %q", projectwork.ErrInvalid, status)
+	}
+	return nil
+}
+
+func validProjectAssignmentDriverKindForCairnlineAuthority(kind string) bool {
+	switch kind {
+	case projectwork.AssignmentDriverHecateTask, projectwork.AssignmentDriverExternalAgent:
+		return true
+	default:
+		return false
+	}
+}
+
+func validProjectAssignmentStatusForCairnlineAuthority(status string) bool {
+	switch status {
+	case projectwork.AssignmentStatusQueued, projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval, projectwork.AssignmentStatusCompleted, projectwork.AssignmentStatusFailed, projectwork.AssignmentStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/api/handler_project_assistant_apply_authority.go
+++ b/internal/api/handler_project_assistant_apply_authority.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
+)
+
+type projectAssistantWorkAuthority struct {
+	handler *Handler
+}
+
+func (h *Handler) projectAssistantWorkAuthorityForApplication() projectassistant.WorkAuthority {
+	if h == nil {
+		return nil
+	}
+	return projectAssistantWorkAuthority{handler: h}
+}
+
+func (authority projectAssistantWorkAuthority) CreateRole(ctx context.Context, projectID string, cmd projectassistant.WorkRoleCommand) (projectwork.AgentRoleProfile, error) {
+	h := authority.handler
+	if h == nil {
+		return projectwork.AgentRoleProfile{}, projectassistant.ErrStoreNotConfigured
+	}
+	appCmd := projectworkapp.CreateRoleCommand{
+		ID:                  cmd.ID,
+		Name:                cmd.Name,
+		Description:         cmd.Description,
+		Instructions:        cmd.Instructions,
+		DefaultDriverKind:   cmd.DefaultDriverKind,
+		DefaultProvider:     cmd.DefaultProvider,
+		DefaultModel:        cmd.DefaultModel,
+		DefaultAgentProfile: cmd.DefaultAgentProfile,
+		SkillIDs:            append([]string(nil), cmd.SkillIDs...),
+	}
+	var (
+		role projectwork.AgentRoleProfile
+		err  error
+	)
+	if h.projectRoleWritesUseCairnlineAuthority() {
+		role, err = h.createProjectWorkRoleWithCairnlineAuthority(ctx, projectID, appCmd)
+	} else {
+		role, err = h.projectWorkApplication().CreateRole(ctx, projectID, appCmd)
+	}
+	return role, projectAssistantApplyWorkError(err)
+}
+
+func (authority projectAssistantWorkAuthority) CreateWorkItem(ctx context.Context, projectID string, cmd projectassistant.WorkItemCommand) (projectwork.WorkItem, error) {
+	h := authority.handler
+	if h == nil {
+		return projectwork.WorkItem{}, projectassistant.ErrStoreNotConfigured
+	}
+	appCmd := projectworkapp.CreateWorkItemCommand{
+		ID:              cmd.ID,
+		Title:           cmd.Title,
+		Brief:           cmd.Brief,
+		Status:          cmd.Status,
+		Priority:        cmd.Priority,
+		OwnerRoleID:     cmd.OwnerRoleID,
+		ReviewerRoleIDs: append([]string(nil), cmd.ReviewerRoleIDs...),
+	}
+	var (
+		item projectwork.WorkItem
+		err  error
+	)
+	if h.projectWorkItemWritesUseCairnlineAuthority() {
+		item, err = h.createProjectWorkItemWithCairnlineAuthority(ctx, projectID, appCmd)
+	} else {
+		item, err = h.projectWorkApplication().CreateWorkItem(ctx, projectID, appCmd)
+	}
+	return item, projectAssistantApplyWorkError(err)
+}
+
+func (authority projectAssistantWorkAuthority) UpdateWorkItem(ctx context.Context, projectID, workItemID string, cmd projectassistant.WorkItemUpdateCommand) (projectwork.WorkItem, error) {
+	h := authority.handler
+	if h == nil {
+		return projectwork.WorkItem{}, projectassistant.ErrStoreNotConfigured
+	}
+	appCmd := projectworkapp.UpdateWorkItemCommand{
+		Title:       cmd.Title,
+		Brief:       cmd.Brief,
+		Status:      cmd.Status,
+		Priority:    cmd.Priority,
+		OwnerRoleID: cmd.OwnerRoleID,
+	}
+	if cmd.ReviewerRoleIDs != nil {
+		reviewerRoleIDs := append([]string(nil), *cmd.ReviewerRoleIDs...)
+		appCmd.ReviewerRoleIDs = &reviewerRoleIDs
+	}
+	var (
+		item projectwork.WorkItem
+		err  error
+	)
+	if h.projectWorkItemWritesUseCairnlineAuthority() {
+		item, err = h.updateProjectWorkItemWithCairnlineAuthority(ctx, projectID, workItemID, appCmd)
+	} else {
+		item, err = h.projectWorkApplication().UpdateWorkItem(ctx, projectID, workItemID, appCmd)
+	}
+	return item, projectAssistantApplyWorkError(err)
+}
+
+func (authority projectAssistantWorkAuthority) CreateAssignment(ctx context.Context, projectID, workItemID string, cmd projectassistant.WorkAssignmentCommand) (projectwork.Assignment, error) {
+	h := authority.handler
+	if h == nil {
+		return projectwork.Assignment{}, projectassistant.ErrStoreNotConfigured
+	}
+	appCmd := projectworkapp.CreateAssignmentCommand{
+		ID:         cmd.ID,
+		RoleID:     cmd.RoleID,
+		RootID:     cmd.RootID,
+		DriverKind: cmd.DriverKind,
+		Status:     cmd.Status,
+	}
+	var (
+		assignment projectwork.Assignment
+		err        error
+	)
+	if h.projectAssignmentWritesUseCairnlineAuthority() {
+		assignment, err = h.createProjectWorkAssignmentWithCairnlineAuthority(ctx, projectID, workItemID, appCmd)
+	} else {
+		assignment, err = h.projectWorkApplication().CreateAssignment(ctx, projectID, workItemID, appCmd)
+	}
+	return assignment, projectAssistantApplyWorkError(err)
+}
+
+func (authority projectAssistantWorkAuthority) CreateHandoff(ctx context.Context, projectID, workItemID string, cmd projectassistant.WorkHandoffCommand) (projectwork.Handoff, error) {
+	h := authority.handler
+	if h == nil {
+		return projectwork.Handoff{}, projectassistant.ErrStoreNotConfigured
+	}
+	appCmd := projectworkapp.CreateHandoffCommand{
+		ID:                    cmd.ID,
+		SourceAssignmentID:    cmd.SourceAssignmentID,
+		SourceRunID:           cmd.SourceRunID,
+		SourceChatSessionID:   cmd.SourceChatSessionID,
+		SourceMessageID:       cmd.SourceMessageID,
+		TargetRoleID:          cmd.TargetRoleID,
+		TargetAssignmentID:    cmd.TargetAssignmentID,
+		TargetWorkItemID:      cmd.TargetWorkItemID,
+		Title:                 cmd.Title,
+		Summary:               cmd.Summary,
+		RecommendedNextAction: cmd.RecommendedNextAction,
+		LinkedArtifactIDs:     append([]string(nil), cmd.LinkedArtifactIDs...),
+		LinkedMemoryIDs:       append([]string(nil), cmd.LinkedMemoryIDs...),
+		ContextRefs:           append([]string(nil), cmd.ContextRefs...),
+		Status:                cmd.Status,
+		ProvenanceKind:        cmd.ProvenanceKind,
+		TrustLabel:            cmd.TrustLabel,
+		CreatedByRoleID:       cmd.CreatedByRoleID,
+	}
+	var (
+		handoff projectwork.Handoff
+		err     error
+	)
+	if h.projectCollaborationWritesUseCairnlineAuthority() {
+		handoff, err = h.createProjectHandoffWithCairnlineAuthority(ctx, projectID, workItemID, appCmd)
+	} else {
+		handoff, err = h.projectWorkApplication().CreateHandoff(ctx, projectID, workItemID, appCmd)
+	}
+	return handoff, projectAssistantApplyWorkError(err)
+}
+
+func (authority projectAssistantWorkAuthority) UpdateHandoff(ctx context.Context, projectID, workItemID, handoffID string, cmd projectassistant.WorkHandoffUpdateCommand) (projectwork.Handoff, error) {
+	h := authority.handler
+	if h == nil {
+		return projectwork.Handoff{}, projectassistant.ErrStoreNotConfigured
+	}
+	appCmd := projectworkapp.UpdateHandoffCommand{
+		TargetAssignmentID: cmd.TargetAssignmentID,
+		TargetRoleID:       cmd.TargetRoleID,
+		Status:             cmd.Status,
+	}
+	var (
+		handoff projectwork.Handoff
+		err     error
+	)
+	if h.projectCollaborationWritesUseCairnlineAuthority() {
+		handoff, err = h.updateProjectHandoffWithCairnlineAuthority(ctx, projectID, workItemID, handoffID, appCmd)
+	} else {
+		handoff, err = h.projectWorkApplication().UpdateHandoff(ctx, projectID, workItemID, handoffID, appCmd)
+	}
+	return handoff, projectAssistantApplyWorkError(err)
+}
+
+func projectAssistantApplyWorkError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, projectworkapp.ErrWorkItemCloseoutBlocked) {
+		return fmt.Errorf("%w: %w", projectassistant.ErrConflict, err)
+	}
+	return err
+}

--- a/internal/api/handler_project_assistant_authority.go
+++ b/internal/api/handler_project_assistant_authority.go
@@ -1,0 +1,300 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projectassistant"
+)
+
+const projectCairnlineWriteAuthorityProjectAssistantProposals = "project-assistant-proposals"
+
+func (h *Handler) projectAssistantProposalWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectAssistantProposals)
+}
+
+func (h *Handler) projectAssistantProposalStoreForApplication() projectassistant.ProposalStore {
+	if h == nil {
+		return nil
+	}
+	if h.projectAssistantProposalWritesUseCairnlineAuthority() {
+		return cairnlineProjectAssistantProposalAuthorityStore{
+			handler: h,
+			shadow:  h.projectAssistantProposals,
+		}
+	}
+	return h.projectAssistantProposals
+}
+
+type cairnlineProjectAssistantProposalAuthorityStore struct {
+	handler *Handler
+	shadow  projectassistant.ProposalStore
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) Backend() string {
+	shadowBackend := "unconfigured"
+	if s.shadow != nil {
+		shadowBackend = s.shadow.Backend()
+	}
+	return "cairnline+" + shadowBackend
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) UpsertProposal(ctx context.Context, record projectassistant.ProposalRecord) (projectassistant.ProposalRecord, error) {
+	written, err := s.writeRecord(ctx, record)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, projectAssistantCairnlineAuthorityError(err)
+	}
+	shadowed, ok := s.shadowProposalRecord(ctx, "project_assistant_proposal_cairnline_authority_upsert", written)
+	if ok {
+		return shadowed, nil
+	}
+	return normalizeProjectAssistantProposalRecordForAuthority(written)
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) ListProposals(ctx context.Context, projectID string) ([]projectassistant.ProposalRecord, error) {
+	if s.handler == nil {
+		return nil, projectassistant.ErrStoreNotConfigured
+	}
+	projectID = strings.TrimSpace(projectID)
+	var records []projectassistant.ProposalRecord
+	err := s.handler.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		items, err := service.ListAssistantProposals(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		records = make([]projectassistant.ProposalRecord, 0, len(items))
+		for _, item := range items {
+			record, ok := cairnlinebridge.ProjectAssistantProposalRecord(item)
+			if !ok {
+				continue
+			}
+			record, err = normalizeProjectAssistantProposalRecordForAuthority(record)
+			if err != nil {
+				return err
+			}
+			records = append(records, record)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, projectAssistantCairnlineAuthorityError(err)
+	}
+	return records, nil
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) GetProposal(ctx context.Context, id string) (projectassistant.ProposalRecord, bool, error) {
+	record, ok, err := s.getRecord(ctx, id)
+	if err != nil || !ok {
+		return projectassistant.ProposalRecord{}, ok, err
+	}
+	shadowed, shadowOK := s.shadowProposalRecord(ctx, "project_assistant_proposal_cairnline_authority_get", record)
+	if shadowOK {
+		return shadowed, true, nil
+	}
+	record, err = normalizeProjectAssistantProposalRecordForAuthority(record)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, false, err
+	}
+	return record, true, nil
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) UpdateProposalApplyState(ctx context.Context, proposalID string, result projectassistant.ApplyResult) (projectassistant.ProposalRecord, error) {
+	record, ok, err := s.GetProposal(ctx, proposalID)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, err
+	}
+	if !ok {
+		return projectassistant.ProposalRecord{}, projectassistant.ErrNotFound
+	}
+	record = projectAssistantProposalRecordWithApplyResult(record, result)
+	written, err := s.writeRecord(ctx, record)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, projectAssistantCairnlineAuthorityError(err)
+	}
+	if s.shadow != nil {
+		if shadowed, err := s.shadow.UpdateProposalApplyState(ctx, proposalID, result); err == nil {
+			return shadowed, nil
+		} else if s.handler != nil {
+			s.handler.logCairnlineMirrorError(ctx, "project_assistant_proposal_cairnline_authority_shadow_apply_state", record.ProjectID, err)
+		}
+	}
+	return normalizeProjectAssistantProposalRecordForAuthority(written)
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) RecordApplyAttempt(ctx context.Context, attempt projectassistant.ApplyAttempt) (projectassistant.ProposalRecord, error) {
+	proposalID := strings.TrimSpace(firstNonEmpty(attempt.ProposalID, attempt.Result.ProposalID))
+	if proposalID == "" {
+		return projectassistant.ProposalRecord{}, fmt.Errorf("%w: apply attempt proposal_id is required", projectassistant.ErrInvalid)
+	}
+	attempt.ProposalID = proposalID
+	if attempt.Result.ProposalID == "" {
+		attempt.Result.ProposalID = proposalID
+	}
+	record, ok, err := s.GetProposal(ctx, proposalID)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, err
+	}
+	if !ok {
+		return projectassistant.ProposalRecord{}, projectassistant.ErrNotFound
+	}
+	record = projectAssistantProposalRecordWithApplyResult(record, attempt.Result)
+	record.ApplyAttempts = append(record.ApplyAttempts, attempt)
+	written, err := s.writeRecord(ctx, record)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, projectAssistantCairnlineAuthorityError(err)
+	}
+	if s.shadow != nil {
+		if shadowed, err := s.shadow.RecordApplyAttempt(ctx, attempt); err == nil {
+			return shadowed, nil
+		} else if s.handler != nil {
+			s.handler.logCairnlineMirrorError(ctx, "project_assistant_proposal_cairnline_authority_shadow_apply_attempt", record.ProjectID, err)
+		}
+	}
+	return normalizeProjectAssistantProposalRecordForAuthority(written)
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) DeleteProject(ctx context.Context, projectID string) (int, error) {
+	if s.shadow == nil {
+		return 0, nil
+	}
+	return s.shadow.DeleteProject(ctx, projectID)
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) Clear(ctx context.Context) (int, error) {
+	if s.shadow == nil {
+		return 0, nil
+	}
+	return s.shadow.Clear(ctx)
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) getRecord(ctx context.Context, id string) (projectassistant.ProposalRecord, bool, error) {
+	if s.handler == nil {
+		return projectassistant.ProposalRecord{}, false, projectassistant.ErrStoreNotConfigured
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return projectassistant.ProposalRecord{}, false, nil
+	}
+	var record projectassistant.ProposalRecord
+	err := s.handler.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		item, err := service.GetAssistantProposal(ctx, id)
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return projectassistant.ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		projected, ok := cairnlinebridge.ProjectAssistantProposalRecord(item)
+		if !ok {
+			return projectassistant.ErrNotFound
+		}
+		record = projected
+		return nil
+	})
+	if errors.Is(err, projectassistant.ErrNotFound) {
+		return projectassistant.ProposalRecord{}, false, nil
+	}
+	if err != nil {
+		return projectassistant.ProposalRecord{}, false, projectAssistantCairnlineAuthorityError(err)
+	}
+	return record, true, nil
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) writeRecord(ctx context.Context, record projectassistant.ProposalRecord) (projectassistant.ProposalRecord, error) {
+	if s.handler == nil {
+		return projectassistant.ProposalRecord{}, projectassistant.ErrStoreNotConfigured
+	}
+	var written projectassistant.ProposalRecord
+	err := s.handler.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		projectID := strings.TrimSpace(record.ProjectID)
+		if projectID != "" && s.handler.projects != nil {
+			project, ok, err := s.handler.projects.Get(ctx, projectID)
+			if err != nil {
+				return err
+			}
+			if ok {
+				if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+					return err
+				}
+			}
+		}
+		item, ok := cairnlinebridge.AssistantProposalRecord(record)
+		if !ok {
+			return fmt.Errorf("%w: project assistant proposal cannot be projected to Cairnline", projectassistant.ErrInvalid)
+		}
+		imported, err := service.ImportAssistantProposalRecord(ctx, item)
+		if err != nil {
+			return err
+		}
+		projected, ok := cairnlinebridge.ProjectAssistantProposalRecord(imported)
+		if !ok {
+			return fmt.Errorf("%w: Cairnline assistant proposal cannot be projected to Hecate", projectassistant.ErrInvalid)
+		}
+		written = projected
+		return nil
+	})
+	if err != nil {
+		return projectassistant.ProposalRecord{}, err
+	}
+	return written, nil
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) shadowProposalRecord(ctx context.Context, operation string, record projectassistant.ProposalRecord) (projectassistant.ProposalRecord, bool) {
+	if s.shadow == nil {
+		return projectassistant.ProposalRecord{}, false
+	}
+	shadowed, err := s.shadow.UpsertProposal(ctx, record)
+	if err != nil {
+		if s.handler != nil {
+			s.handler.logCairnlineMirrorError(ctx, operation, record.ProjectID, err)
+		}
+		return projectassistant.ProposalRecord{}, false
+	}
+	return shadowed, true
+}
+
+func normalizeProjectAssistantProposalRecordForAuthority(record projectassistant.ProposalRecord) (projectassistant.ProposalRecord, error) {
+	store := projectassistant.NewMemoryProposalStore()
+	normalized, err := store.UpsertProposal(context.Background(), record)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, err
+	}
+	for _, attempt := range record.ApplyAttempts {
+		normalized, err = store.RecordApplyAttempt(context.Background(), attempt)
+		if err != nil {
+			return projectassistant.ProposalRecord{}, err
+		}
+	}
+	return normalized, nil
+}
+
+func projectAssistantProposalRecordWithApplyResult(record projectassistant.ProposalRecord, result projectassistant.ApplyResult) projectassistant.ProposalRecord {
+	if result.ProposalID == "" {
+		result.ProposalID = record.ID
+	}
+	if result.TotalActionCount == 0 {
+		result.TotalActionCount = len(record.Proposal.Actions)
+	}
+	record.LatestResult = &result
+	record.Status = firstNonEmpty(result.Status, record.Status, projectassistant.ProposalStatusProposed)
+	return record
+}
+
+func projectAssistantCairnlineAuthorityError(err error) error {
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return projectassistant.ErrNotFound
+	}
+	if errors.Is(err, cairnline.ErrInvalid) {
+		return projectassistant.ErrInvalid
+	}
+	if errors.Is(err, cairnline.ErrConflict) || errors.Is(err, cairnline.ErrDuplicate) {
+		return projectassistant.ErrConflict
+	}
+	return err
+}

--- a/internal/api/handler_project_assistant_cairnline.go
+++ b/internal/api/handler_project_assistant_cairnline.go
@@ -54,7 +54,7 @@ func (h *Handler) cairnlineProjectAssistantDraft(ctx context.Context, command pr
 		ProjectSkills:    seed.skills,
 		Memory:           seed.memory,
 		MemoryCandidates: seed.memory,
-		Proposals:        h.projectAssistantProposals,
+		Proposals:        h.projectAssistantProposalStoreForApplication(),
 		LLM:              gatewayAgentLLMClient{service: h.service},
 	}, newOpaqueTaskResourceID).Draft(ctx, projectassistant.DraftInput{
 		ProjectID:        command.ProjectID,

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -120,6 +120,26 @@ func (s failingCreateAssignmentProjectWorkStore) CreateAssignment(context.Contex
 	return projectwork.Assignment{}, s.err
 }
 
+type failingCreateRoleProjectWorkStore struct {
+	projectwork.Store
+	err error
+}
+
+func (s failingCreateRoleProjectWorkStore) CreateRole(context.Context, projectwork.AgentRoleProfile) (projectwork.AgentRoleProfile, error) {
+	return projectwork.AgentRoleProfile{}, s.err
+}
+
+type failingProposalUpsertStore struct {
+	projectassistant.ProposalStore
+	err error
+}
+
+func (s failingProposalUpsertStore) Backend() string { return "failing" }
+
+func (s failingProposalUpsertStore) UpsertProposal(context.Context, projectassistant.ProposalRecord) (projectassistant.ProposalRecord, error) {
+	return projectassistant.ProposalRecord{}, s.err
+}
+
 func TestProjectAssistantAPI_ContextBuildsSelectionPacket(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantTestHandler()
@@ -915,6 +935,175 @@ func TestProjectAssistantAPI_MirrorsProposalLedgerToCairnlineWhenConfigured(t *t
 	}
 	if workItem.Title != "Mirror assistant ledger" || workItem.Status != cairnline.WorkStatusReady {
 		t.Fatalf("mirrored work item = %+v, want assistant-created work item", workItem)
+	}
+}
+
+func TestProjectAssistantAPI_CairnlineProposalAuthorityCommitsLedgerFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineWriteAuthority = projectCairnlineWriteAuthorityProjectAssistantProposals
+	client := newAPITestClient(t, server)
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_pa_authority",
+		Name: "Assistant Authority",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	proposed := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/propose", `{
+		"id":"pa_authority_apply",
+		"title":"Create authoritative work",
+		"summary":"Create a work item through the Project Assistant ledger authority path.",
+		"actions":[{
+			"kind":"create_work_item",
+			"reason":"The project needs one reviewable task.",
+			"patch":{
+				"id":"work_pa_authority",
+				"project_id":"proj_pa_authority",
+				"title":"Authoritative assistant ledger",
+				"brief":"Verify Project Assistant proposal records can commit to Cairnline first.",
+				"status":"ready"
+			}
+		}]
+	}`)
+	written := getMirroredCairnlineAssistantProposalForTest(t, handler, proposed.Data.ID)
+	if written.Status != cairnline.AssistantProposalStatusProposed || written.Source != cairnline.AssistantProposalSourceAPI || len(written.Proposal.Actions) != 1 {
+		t.Fatalf("Cairnline proposal = %+v, want proposed API ledger record", written)
+	}
+	shadow, ok, err := handler.projectAssistantProposals.GetProposal(t.Context(), proposed.Data.ID)
+	if err != nil || !ok {
+		t.Fatalf("GetProposal shadow = ok %v err %v, want Hecate compatibility shadow", ok, err)
+	}
+	if shadow.Fingerprint == "" {
+		t.Fatalf("shadow proposal = %+v, want Hecate fingerprint preserved for apply safety", shadow)
+	}
+
+	applied := mustRequestJSON[projectAssistantApplyResponse](client, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposed.Data,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 1 {
+		t.Fatalf("apply response = %+v, want applied proposal ledger result", applied.Data)
+	}
+	appliedLedger := getMirroredCairnlineAssistantProposalForTest(t, handler, proposed.Data.ID)
+	if appliedLedger.Status != cairnline.AssistantProposalStatusApplied || appliedLedger.LatestResult == nil || !appliedLedger.LatestResult.Applied || len(appliedLedger.ApplyAttempts) != 1 {
+		t.Fatalf("Cairnline applied proposal = %+v, want applied ledger result and attempt", appliedLedger)
+	}
+	shadow, ok, err = handler.projectAssistantProposals.GetProposal(t.Context(), proposed.Data.ID)
+	if err != nil || !ok || shadow.LatestResult == nil || !shadow.LatestResult.Applied || len(shadow.ApplyAttempts) != 1 {
+		t.Fatalf("shadow proposal after apply = %+v ok %v err %v, want compatibility shadow with apply attempt", shadow, ok, err)
+	}
+}
+
+func TestProjectAssistantAPI_CairnlineProposalAuthorityDoesNotBlockOnShadowUpsertFailure(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineWriteAuthority = projectCairnlineWriteAuthorityProjectAssistantProposals
+	handler.SetProjectAssistantProposalStore(failingProposalUpsertStore{
+		ProposalStore: projectassistant.NewMemoryProposalStore(),
+		err:           errors.New("shadow proposal store unavailable"),
+	})
+	client := newAPITestClient(t, server)
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_pa_shadow_failure",
+		Name: "Assistant Shadow Failure",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	proposed := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/propose", `{
+		"id":"pa_shadow_failure",
+		"title":"Create ledger despite shadow failure",
+		"summary":"The authoritative Cairnline ledger should commit before the Hecate compatibility shadow.",
+		"actions":[{
+			"kind":"create_work_item",
+			"reason":"The proposal should survive a Hecate shadow write failure.",
+			"patch":{
+				"id":"work_pa_shadow_failure",
+				"project_id":"proj_pa_shadow_failure",
+				"title":"Shadow failure proof",
+				"brief":"Verify Project Assistant proposal authority is not just a post-commit mirror.",
+				"status":"ready"
+			}
+		}]
+	}`)
+	if proposed.Data.ID != "pa_shadow_failure" || len(proposed.Data.Actions) != 1 {
+		t.Fatalf("proposal response = %+v, want successful proposal despite Hecate shadow failure", proposed.Data)
+	}
+	written := getMirroredCairnlineAssistantProposalForTest(t, handler, proposed.Data.ID)
+	if written.ProjectID != "proj_pa_shadow_failure" || written.Status != cairnline.AssistantProposalStatusProposed {
+		t.Fatalf("Cairnline proposal = %+v, want authoritative proposal committed despite shadow failure", written)
+	}
+}
+
+func TestProjectAssistantAPI_CairnlineApplyWorkAuthorityDoesNotBlockOnRoleShadowFailure(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineWriteAuthority = strings.Join([]string{
+		projectCairnlineWriteAuthorityProjectAssistantProposals,
+		projectCairnlineWriteAuthorityProjectRoles,
+	}, ",")
+	handler.SetProjectWorkStore(failingCreateRoleProjectWorkStore{
+		Store: projectwork.NewMemoryStore(),
+		err:   errors.New("shadow role store unavailable"),
+	})
+	client := newAPITestClient(t, server)
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_pa_apply_role_authority",
+		Name: "Assistant Apply Role Authority",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	proposed := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/propose", `{
+		"id":"pa_apply_role_authority",
+		"title":"Create role through authority",
+		"summary":"Project Assistant apply should use the Cairnline-first work authority seam.",
+		"actions":[{
+			"kind":"create_role",
+			"reason":"The project needs an implementation owner.",
+			"patch":{
+				"id":"role_apply_authority",
+				"project_id":"proj_pa_apply_role_authority",
+				"name":"Implementation Owner",
+				"description":"Owns scoped implementation work.",
+				"instructions":"Implement only the requested slice and leave evidence.",
+				"default_driver_kind":"external_agent",
+				"default_provider":"openai",
+				"default_model":"gpt-5",
+				"default_agent_profile":"implementation",
+				"skill_ids":["backend"]
+			}
+		}]
+	}`)
+	applied := mustRequestJSON[projectAssistantApplyResponse](client, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposed.Data,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 1 {
+		t.Fatalf("apply response = %+v, want applied role action despite Hecate shadow failure", applied.Data)
+	}
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	role, err := getCairnlineProjectRoleForAuthority(t.Context(), service, "proj_pa_apply_role_authority", "role_apply_authority")
+	if err != nil {
+		t.Fatalf("Get role_apply_authority from Cairnline: %v", err)
+	}
+	if role.Name != "Implementation Owner" || role.DefaultExecutionMode != cairnline.ExecutionExternalAdapter || !reflect.DeepEqual(role.DefaultSkillIDs, []string{"backend"}) {
+		t.Fatalf("Cairnline role = %+v, want authoritative external-agent role with backend skill", role)
+	}
+	roles, err := handler.projectWork.ListRoles(t.Context(), "proj_pa_apply_role_authority")
+	if err != nil {
+		t.Fatalf("ListRoles shadow: %v", err)
+	}
+	for _, role := range roles {
+		if role.ID == "role_apply_authority" {
+			t.Fatalf("shadow role store unexpectedly contains %+v, want Cairnline authority to survive failed Hecate shadow", role)
+		}
 	}
 }
 

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -47,7 +47,8 @@ func (h *Handler) HandleSyncProjectsToCairnline(w http.ResponseWriter, r *http.R
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	item, err := projectCairnlineServiceParity(r.Context(), dbPath, true, snapshots, service)
+	smoke := h.projectCairnlineStrictEmbeddedSmoke(r.Context(), snapshots)
+	item, err := projectCairnlineServiceParity(r.Context(), dbPath, true, "embedded_sync", snapshots, service, smoke)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
@@ -83,7 +84,8 @@ func (h *Handler) HandleProjectCairnlineMirrorParity(w http.ResponseWriter, r *h
 		return
 	}
 	defer store.Close()
-	item, err := projectCairnlineServiceParity(r.Context(), dbPath, true, snapshots, service)
+	smoke := h.projectCairnlineStrictEmbeddedSmoke(r.Context(), snapshots)
+	item, err := projectCairnlineServiceParity(r.Context(), dbPath, true, "mirror_parity", snapshots, service, smoke)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
@@ -159,6 +161,7 @@ func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.
 			MemoryEntryCount:       graph.MemoryEntries,
 			MemoryCandidateCount:   graph.MemoryCandidates,
 			AssistantProposalCount: len(assistantProposals),
+			MigrationRehearsal:     projectCairnlineMigrationRehearsal("project_export", true, true, nil),
 		},
 	})
 }
@@ -439,7 +442,7 @@ func projectCairnlineReadModelFromService(ctx context.Context, service *cairnlin
 	}, nil
 }
 
-func projectCairnlineServiceParity(ctx context.Context, dbPath string, databaseExists bool, snapshots []cairnlinebridge.Snapshot, service *cairnline.Service) (ProjectCairnlineSyncResponseItem, error) {
+func projectCairnlineServiceParity(ctx context.Context, dbPath string, databaseExists bool, operation string, snapshots []cairnlinebridge.Snapshot, service *cairnline.Service, smoke *ProjectCairnlineMigrationEmbeddedSmoke) (ProjectCairnlineSyncResponseItem, error) {
 	hecateCounts := projectCairnlineSnapshotAllCounts(snapshots)
 	cairnlineCounts, err := projectCairnlineServiceAllCounts(ctx, service)
 	if err != nil {
@@ -461,16 +464,18 @@ func projectCairnlineServiceParity(ctx context.Context, dbPath string, databaseE
 		return ProjectCairnlineSyncResponseItem{}, err
 	}
 	contentDifferences := projectCairnlineSyncContentDifferences(hecateContent, cairnlineContent)
+	match := len(differences) == 0 && len(idDifferences) == 0 && len(contentDifferences) == 0
 	return ProjectCairnlineSyncResponseItem{
 		DatabasePath:       dbPath,
 		DatabaseExists:     databaseExists,
-		Match:              len(differences) == 0 && len(idDifferences) == 0 && len(contentDifferences) == 0,
+		Match:              match,
 		Differences:        differences,
 		IDDifferences:      idDifferences,
 		ContentDifferences: contentDifferences,
 		Hecate:             hecateCounts,
 		Cairnline:          cairnlineCounts,
 		Authoritative:      false,
+		MigrationRehearsal: projectCairnlineMigrationRehearsal(operation, databaseExists, match, smoke),
 	}, nil
 }
 
@@ -491,7 +496,228 @@ func projectCairnlineMissingMirrorParity(dbPath string, snapshots []cairnlinebri
 		Hecate:             hecateCounts,
 		Cairnline:          cairnlineCounts,
 		Authoritative:      false,
+		MigrationRehearsal: projectCairnlineMigrationRehearsal("mirror_parity", false, false, nil),
 	}
+}
+
+func projectCairnlineMigrationRehearsal(operation string, databaseExists, match bool, smoke *ProjectCairnlineMigrationEmbeddedSmoke) ProjectCairnlineMigrationRehearsal {
+	target := "embedded_cairnline_sqlite"
+	refreshesTarget := false
+	status := "drift_detected"
+	switch operation {
+	case "embedded_sync":
+		refreshesTarget = true
+		if match {
+			status = "rehearsed"
+		}
+	case "mirror_parity":
+		if !databaseExists {
+			status = "not_run"
+		} else if match {
+			status = "verified"
+		}
+	case "project_export":
+		target = "project_cairnline_sqlite_export"
+		refreshesTarget = true
+		if databaseExists {
+			status = "exported"
+		} else {
+			status = "not_run"
+		}
+	}
+	return ProjectCairnlineMigrationRehearsal{
+		Operation:       operation,
+		ImportMode:      "cairnline_snapshot_import",
+		SnapshotVersion: cairnline.SnapshotVersion,
+		SourceAuthority: "hecate_authoritative_stores",
+		Target:          target,
+		RefreshesTarget: refreshesTarget,
+		Authoritative:   false,
+		CutoverReady:    false,
+		Status:          status,
+		Checklist: []ProjectCairnlineMigrationRehearsalCheck{
+			{
+				ID:     "load-hecate-stores",
+				Status: "complete",
+				Detail: "Loaded Hecate's authoritative project, profile, work, skill, memory, and assistant stores.",
+			},
+			{
+				ID:     "native-snapshot-import",
+				Status: projectCairnlineMigrationCheckStatus(databaseExists, "complete", "not_run"),
+				Detail: "Imported through Cairnline's versioned snapshot contract.",
+			},
+			{
+				ID:     "parity-check",
+				Status: projectCairnlineMigrationParityStatus(databaseExists, match),
+				Detail: "Compared counts, IDs, launch packets, and content digests where available.",
+			},
+			{
+				ID:     "strict-embedded-read-smoke",
+				Status: projectCairnlineMigrationSmokeStatus(smoke),
+				Detail: "Set Hecate to the embedded Cairnline read source and exercise Projects routes before any cutover.",
+			},
+			{
+				ID:     "rollback-plan",
+				Status: "documented",
+				Detail: "Hecate remains authoritative; rollback is deleting the generated Cairnline SQLite files or switching reads back to Hecate.",
+			},
+			{
+				ID:     "authoritative-switchpoint",
+				Status: "blocked",
+				Detail: "No write authority has moved to Cairnline yet.",
+			},
+		},
+		Rollback: []string{
+			"Hecate stores remain authoritative; do not treat the generated Cairnline database as source of truth.",
+			"Rollback the rehearsal by deleting the generated Cairnline SQLite database files under the reported database path.",
+			"Keep or restore HECATE_PROJECTS_COORDINATION_BACKEND=hecate until write switchpoints and cutover are implemented.",
+		},
+		EmbeddedSmoke: smoke,
+	}
+}
+
+func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snapshots []cairnlinebridge.Snapshot) *ProjectCairnlineMigrationEmbeddedSmoke {
+	smoke := &ProjectCairnlineMigrationEmbeddedSmoke{Status: "passed"}
+	if h == nil {
+		smoke.Status = "failed"
+		smoke.Errors = append(smoke.Errors, ProjectCairnlineMigrationEmbeddedSmokeError{
+			Check: "handler",
+			Error: "handler is nil",
+		})
+		return smoke
+	}
+	strict := h.projectCairnlineStrictEmbeddedProbeHandler()
+	strict.config.Projects.CoordinationBackend = "cairnline"
+	strict.config.Projects.CairnlineReadSource = "embedded"
+	for _, snapshot := range snapshots {
+		projectID := strings.TrimSpace(snapshot.Project.ID)
+		if projectID == "" {
+			continue
+		}
+		smoke.ProjectCount++
+		smoke.CheckedProjectIDs = append(smoke.CheckedProjectIDs, projectID)
+		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "project-detail", func() error {
+			_, err := strict.renderCairnlineProject(ctx, snapshot.Project)
+			return err
+		})
+		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "setup-readiness", func() error {
+			_, err := strict.renderCairnlineProjectSetupReadiness(ctx, projectID)
+			return err
+		})
+		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "health", func() error {
+			_, err := strict.renderCairnlineProjectHealth(ctx, projectID)
+			return err
+		})
+		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "work-items", func() error {
+			_, err := strict.renderCairnlineProjectWorkItems(ctx, projectID)
+			return err
+		})
+		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "activity", func() error {
+			_, err := strict.renderCairnlineProjectActivity(ctx, projectID)
+			return err
+		})
+		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "operations-brief", func() error {
+			_, err := strict.renderCairnlineProjectOperationsBrief(ctx, snapshot.Project)
+			return err
+		})
+		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "embedded-read-model", func() error {
+			readModel, err := strict.projectCairnlineEmbeddedReadModel(ctx, projectID)
+			if err != nil {
+				return err
+			}
+			smoke.ReadModelCount++
+			smoke.LaunchPacketCount += readModel.LaunchPacketCount
+			smoke.LaunchPacketWarningCount += readModel.LaunchPacketWarningCount
+			smoke.LaunchPacketErrorCount += len(readModel.LaunchPacketErrors)
+			if len(readModel.LaunchPacketErrors) > 0 {
+				return errors.New("embedded read model reported launch packet errors")
+			}
+			return nil
+		})
+	}
+	if len(smoke.Errors) > 0 {
+		smoke.Status = "failed"
+	}
+	return smoke
+}
+
+func (h *Handler) projectCairnlineStrictEmbeddedProbeHandler() *Handler {
+	if h == nil {
+		return nil
+	}
+	return &Handler{
+		config:                    h.config,
+		logger:                    h.logger,
+		service:                   h.service,
+		controlPlane:              h.controlPlane,
+		providerRuntime:           h.providerRuntime,
+		taskStore:                 h.taskStore,
+		taskRunner:                h.taskRunner,
+		tracer:                    h.tracer,
+		agentChat:                 h.agentChat,
+		projects:                  h.projects,
+		memory:                    h.memory,
+		memoryCandidates:          h.memoryCandidates,
+		projectWork:               h.projectWork,
+		projectSkills:             h.projectSkills,
+		projectAssistantProposals: h.projectAssistantProposals,
+		pluginRegistry:            h.pluginRegistry,
+		projectAssistant:          h.projectAssistant,
+		agentProfiles:             h.agentProfiles,
+		agentChatRunner:           h.agentChatRunner,
+		agentChatLive:             h.agentChatLive,
+		agentChatIdleSweepCancel:  h.agentChatIdleSweepCancel,
+		operatorTerminals:         h.operatorTerminals,
+		rateLimiter:               h.rateLimiter,
+		secretCipher:              h.secretCipher,
+		mcpClientCache:            h.mcpClientCache,
+		orchestratorMetrics:       h.orchestratorMetrics,
+		agentChatMetrics:          h.agentChatMetrics,
+		approvalConfig:            h.approvalConfig,
+		agentAdapterProbe:         h.agentAdapterProbe,
+		agentAdapterLogout:        h.agentAdapterLogout,
+		agentAdapterAuthenticate:  h.agentAdapterAuthenticate,
+		stateCleaner:              h.stateCleaner,
+		quitFunc:                  h.quitFunc,
+	}
+}
+
+func checkProjectCairnlineEmbeddedSmoke(smoke *ProjectCairnlineMigrationEmbeddedSmoke, projectID, check string, fn func() error) {
+	smoke.ReadRouteChecks++
+	if err := fn(); err != nil {
+		smoke.Errors = append(smoke.Errors, ProjectCairnlineMigrationEmbeddedSmokeError{
+			ProjectID: projectID,
+			Check:     check,
+			Error:     err.Error(),
+		})
+	}
+}
+
+func projectCairnlineMigrationSmokeStatus(smoke *ProjectCairnlineMigrationEmbeddedSmoke) string {
+	if smoke == nil {
+		return "operator_required"
+	}
+	if smoke.Status == "passed" {
+		return "complete"
+	}
+	return smoke.Status
+}
+
+func projectCairnlineMigrationCheckStatus(condition bool, whenTrue, whenFalse string) string {
+	if condition {
+		return whenTrue
+	}
+	return whenFalse
+}
+
+func projectCairnlineMigrationParityStatus(databaseExists, match bool) string {
+	if !databaseExists {
+		return "not_run"
+	}
+	if match {
+		return "complete"
+	}
+	return "drift_detected"
 }
 
 func projectCairnlineSnapshotGraphCounts(snapshot cairnlinebridge.Snapshot) ProjectCairnlineGraphParityCounts {

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -262,6 +262,12 @@ func TestProjectCairnlineExportAPI_WritesRefreshableSQLiteExport(t *testing.T) {
 	if second.Data.ProjectID != projectID || second.Data.RootCount != 1 || second.Data.ContextSourceCount != 0 || second.Data.AgentProfileCount != readModel.Data.AgentProfileCount || second.Data.ExecutionProfileCount != readModel.Data.ExecutionProfileCount || second.Data.WorkItemCount != 1 || second.Data.AssignmentCount != 1 || second.Data.ArtifactCount != 2 || second.Data.HandoffCount != 1 || second.Data.MemoryEntryCount != 1 || second.Data.MemoryCandidateCount != 1 || second.Data.AssistantProposalCount != 1 {
 		t.Fatalf("export response = %+v, want project counts", second.Data)
 	}
+	if second.Data.MigrationRehearsal.Operation != "project_export" || second.Data.MigrationRehearsal.ImportMode != "cairnline_snapshot_import" || second.Data.MigrationRehearsal.SnapshotVersion != cairnline.SnapshotVersion || second.Data.MigrationRehearsal.SourceAuthority != "hecate_authoritative_stores" || second.Data.MigrationRehearsal.Target != "project_cairnline_sqlite_export" || !second.Data.MigrationRehearsal.RefreshesTarget || second.Data.MigrationRehearsal.Authoritative || second.Data.MigrationRehearsal.CutoverReady || second.Data.MigrationRehearsal.Status != "exported" {
+		t.Fatalf("export migration rehearsal = %+v, want exported non-authoritative Cairnline snapshot import", second.Data.MigrationRehearsal)
+	}
+	if !hasProjectCairnlineMigrationCheck(second.Data.MigrationRehearsal.Checklist, "native-snapshot-import", "complete") || !hasProjectCairnlineMigrationCheck(second.Data.MigrationRehearsal.Checklist, "rollback-plan", "documented") || !hasProjectCairnlineMigrationCheck(second.Data.MigrationRehearsal.Checklist, "authoritative-switchpoint", "blocked") || len(second.Data.MigrationRehearsal.Rollback) == 0 {
+		t.Fatalf("export migration checklist = %+v rollback %+v, want replacement rehearsal evidence and rollback steps", second.Data.MigrationRehearsal.Checklist, second.Data.MigrationRehearsal.Rollback)
+	}
 	if !filepath.IsAbs(second.Data.DatabasePath) {
 		t.Fatalf("database path = %q, want absolute path", second.Data.DatabasePath)
 	}
@@ -379,6 +385,15 @@ func TestProjectCairnlineSyncAPI_WritesDurableAllProjectsSQLiteDB(t *testing.T) 
 	if second.Data.Authoritative {
 		t.Fatalf("sync response authoritative = true, want replacement rehearsal only")
 	}
+	if second.Data.MigrationRehearsal.Operation != "embedded_sync" || second.Data.MigrationRehearsal.ImportMode != "cairnline_snapshot_import" || second.Data.MigrationRehearsal.SnapshotVersion != cairnline.SnapshotVersion || second.Data.MigrationRehearsal.SourceAuthority != "hecate_authoritative_stores" || second.Data.MigrationRehearsal.Target != "embedded_cairnline_sqlite" || !second.Data.MigrationRehearsal.RefreshesTarget || second.Data.MigrationRehearsal.Authoritative || second.Data.MigrationRehearsal.CutoverReady || second.Data.MigrationRehearsal.Status != "rehearsed" {
+		t.Fatalf("sync migration rehearsal = %+v, want non-authoritative embedded sync rehearsal", second.Data.MigrationRehearsal)
+	}
+	if !hasProjectCairnlineMigrationCheck(second.Data.MigrationRehearsal.Checklist, "load-hecate-stores", "complete") || !hasProjectCairnlineMigrationCheck(second.Data.MigrationRehearsal.Checklist, "native-snapshot-import", "complete") || !hasProjectCairnlineMigrationCheck(second.Data.MigrationRehearsal.Checklist, "parity-check", "complete") || !hasProjectCairnlineMigrationCheck(second.Data.MigrationRehearsal.Checklist, "strict-embedded-read-smoke", "complete") || len(second.Data.MigrationRehearsal.Rollback) == 0 {
+		t.Fatalf("sync migration checklist = %+v rollback %+v, want explicit rehearsal checklist and rollback steps", second.Data.MigrationRehearsal.Checklist, second.Data.MigrationRehearsal.Rollback)
+	}
+	if second.Data.MigrationRehearsal.EmbeddedSmoke == nil || second.Data.MigrationRehearsal.EmbeddedSmoke.Status != "passed" || second.Data.MigrationRehearsal.EmbeddedSmoke.ProjectCount != 2 || second.Data.MigrationRehearsal.EmbeddedSmoke.ReadRouteChecks != 14 || second.Data.MigrationRehearsal.EmbeddedSmoke.ReadModelCount != 2 || second.Data.MigrationRehearsal.EmbeddedSmoke.LaunchPacketCount != 1 || second.Data.MigrationRehearsal.EmbeddedSmoke.LaunchPacketErrorCount != 0 || len(second.Data.MigrationRehearsal.EmbeddedSmoke.Errors) != 0 {
+		t.Fatalf("sync embedded smoke = %+v, want strict embedded route smoke across both synced projects", second.Data.MigrationRehearsal.EmbeddedSmoke)
+	}
 	if !second.Data.Match || len(second.Data.Differences) != 0 || len(second.Data.IDDifferences) != 0 || len(second.Data.ContentDifferences) != 0 {
 		t.Fatalf("sync parity = match %v differences %+v id_differences %+v content_differences %+v, want exact count, id, and content match", second.Data.Match, second.Data.Differences, second.Data.IDDifferences, second.Data.ContentDifferences)
 	}
@@ -474,6 +489,12 @@ func TestProjectCairnlineMirrorParityAPI_MissingDatabaseDoesNotCreateMirror(t *t
 	if response.Data.DatabaseExists || response.Data.Match {
 		t.Fatalf("mirror parity = %+v, want missing database and no match", response.Data)
 	}
+	if response.Data.MigrationRehearsal.Operation != "mirror_parity" || response.Data.MigrationRehearsal.Status != "not_run" || response.Data.MigrationRehearsal.RefreshesTarget || response.Data.MigrationRehearsal.Authoritative || response.Data.MigrationRehearsal.CutoverReady {
+		t.Fatalf("missing mirror rehearsal = %+v, want read-only missing mirror state", response.Data.MigrationRehearsal)
+	}
+	if !hasProjectCairnlineMigrationCheck(response.Data.MigrationRehearsal.Checklist, "native-snapshot-import", "not_run") || !hasProjectCairnlineMigrationCheck(response.Data.MigrationRehearsal.Checklist, "parity-check", "not_run") {
+		t.Fatalf("missing mirror checklist = %+v, want not-run import/parity checks", response.Data.MigrationRehearsal.Checklist)
+	}
 	if response.Data.Hecate.Projects != 1 || response.Data.Cairnline.Projects != 0 {
 		t.Fatalf("mirror parity counts = hecate %+v cairnline %+v, want one Hecate project and empty mirror", response.Data.Hecate, response.Data.Cairnline)
 	}
@@ -529,6 +550,15 @@ func TestProjectCairnlineMirrorParityAPI_ReportsLiveMirrorMatch(t *testing.T) {
 	}
 	if !response.Data.DatabaseExists || !response.Data.Match || response.Data.Authoritative {
 		t.Fatalf("mirror parity = %+v, want existing non-authoritative mirror with exact parity", response.Data)
+	}
+	if response.Data.MigrationRehearsal.Operation != "mirror_parity" || response.Data.MigrationRehearsal.Status != "verified" || response.Data.MigrationRehearsal.RefreshesTarget || response.Data.MigrationRehearsal.Authoritative || response.Data.MigrationRehearsal.CutoverReady {
+		t.Fatalf("mirror rehearsal = %+v, want verified read-only mirror parity", response.Data.MigrationRehearsal)
+	}
+	if !hasProjectCairnlineMigrationCheck(response.Data.MigrationRehearsal.Checklist, "native-snapshot-import", "complete") || !hasProjectCairnlineMigrationCheck(response.Data.MigrationRehearsal.Checklist, "parity-check", "complete") {
+		t.Fatalf("mirror checklist = %+v, want completed import and parity checks", response.Data.MigrationRehearsal.Checklist)
+	}
+	if !hasProjectCairnlineMigrationCheck(response.Data.MigrationRehearsal.Checklist, "strict-embedded-read-smoke", "complete") || response.Data.MigrationRehearsal.EmbeddedSmoke == nil || response.Data.MigrationRehearsal.EmbeddedSmoke.Status != "passed" || response.Data.MigrationRehearsal.EmbeddedSmoke.ProjectCount != 1 || response.Data.MigrationRehearsal.EmbeddedSmoke.ReadRouteChecks != 7 || len(response.Data.MigrationRehearsal.EmbeddedSmoke.Errors) != 0 {
+		t.Fatalf("mirror embedded smoke = %+v checklist %+v, want read-only strict embedded route smoke", response.Data.MigrationRehearsal.EmbeddedSmoke, response.Data.MigrationRehearsal.Checklist)
 	}
 	if len(response.Data.Differences) != 0 || len(response.Data.IDDifferences) != 0 || len(response.Data.ContentDifferences) != 0 {
 		t.Fatalf("mirror parity differences = %+v id %+v content %+v, want none", response.Data.Differences, response.Data.IDDifferences, response.Data.ContentDifferences)
@@ -1081,6 +1111,15 @@ func hasProjectCairnlineIDDifference(items []ProjectCairnlineIDDifference, path 
 func hasProjectCairnlineContentDifference(items []ProjectCairnlineContentDifference, path, id, hecate, cairnline string) bool {
 	for _, item := range items {
 		if item.Path == path && item.ID == id && item.Hecate == hecate && item.Cairnline == cairnline {
+			return true
+		}
+	}
+	return false
+}
+
+func hasProjectCairnlineMigrationCheck(items []ProjectCairnlineMigrationRehearsalCheck, id, status string) bool {
+	for _, item := range items {
+		if item.ID == id && item.Status == status {
 			return true
 		}
 	}

--- a/internal/api/handler_project_collaboration_authority.go
+++ b/internal/api/handler_project_collaboration_authority.go
@@ -1,0 +1,377 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
+)
+
+const projectCairnlineWriteAuthorityProjectCollaboration = "project-collaboration"
+
+func (h *Handler) projectCollaborationWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectCollaboration)
+}
+
+func (h *Handler) createProjectWorkArtifactWithCairnlineAuthority(ctx context.Context, projectID, workItemID string, cmd projectworkapp.CreateArtifactCommand) (projectwork.CollaborationArtifact, error) {
+	artifact := projectwork.CollaborationArtifact{
+		ID:                     firstNonEmptyString(strings.TrimSpace(cmd.ID), newOpaqueTaskResourceID("art")),
+		ProjectID:              projectID,
+		WorkItemID:             workItemID,
+		AssignmentID:           cmd.AssignmentID,
+		Kind:                   cmd.Kind,
+		Title:                  cmd.Title,
+		Body:                   cmd.Body,
+		AuthorRoleID:           cmd.AuthorRoleID,
+		EvidenceSourceKind:     cmd.EvidenceSourceKind,
+		EvidenceURL:            cmd.EvidenceURL,
+		EvidenceExternalID:     cmd.EvidenceExternalID,
+		EvidenceProvider:       cmd.EvidenceProvider,
+		EvidenceTrustLabel:     cmd.EvidenceTrustLabel,
+		ReviewedAssignmentID:   cmd.ReviewedAssignmentID,
+		ReviewVerdict:          cmd.ReviewVerdict,
+		ReviewRisk:             cmd.ReviewRisk,
+		ReviewFollowUpRequired: cmd.ReviewFollowUpRequired,
+	}
+	if err := validateProjectCollaborationArtifactForCairnlineAuthority(artifact); err != nil {
+		return projectwork.CollaborationArtifact{}, err
+	}
+
+	var created projectwork.CollaborationArtifact
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.seedProjectArtifactDependenciesForCairnlineAuthority(ctx, service, artifact); err != nil {
+			return err
+		}
+		switch strings.TrimSpace(artifact.Kind) {
+		case projectwork.ArtifactKindEvidenceLink:
+			item, ok := cairnlinebridge.Evidence(artifact)
+			if !ok {
+				return errors.Join(cairnline.ErrInvalid, errors.New("artifact kind is not evidence"))
+			}
+			if item.Title == "" {
+				item.Title = "Evidence link"
+			}
+			recorded, err := service.CreateEvidence(ctx, item)
+			if err != nil {
+				return err
+			}
+			created = projectHealthEvidenceFromCairnline(recorded)
+		case projectwork.ArtifactKindReview:
+			item, ok := cairnlinebridge.Review(artifact)
+			if !ok {
+				return errors.Join(cairnline.ErrInvalid, errors.New("artifact kind is not review"))
+			}
+			recorded, err := service.CreateReview(ctx, item)
+			if err != nil {
+				return err
+			}
+			created = projectHealthReviewFromCairnline(recorded)
+		default:
+			item, ok := cairnlinebridge.Artifact(artifact)
+			if !ok {
+				return errors.Join(cairnline.ErrInvalid, errors.New("artifact kind is not generic collaboration artifact"))
+			}
+			recorded, err := service.CreateArtifact(ctx, item)
+			if err != nil {
+				return err
+			}
+			created = projectWorkArtifactFromCairnline(recorded)
+		}
+		return nil
+	})
+	if err != nil {
+		return projectwork.CollaborationArtifact{}, err
+	}
+	h.shadowProjectWorkArtifactToHecate(ctx, "project_artifact_cairnline_authority", created)
+	return created, nil
+}
+
+func (h *Handler) createProjectHandoffWithCairnlineAuthority(ctx context.Context, projectID, workItemID string, cmd projectworkapp.CreateHandoffCommand) (projectwork.Handoff, error) {
+	handoff := projectwork.Handoff{
+		ID:                    firstNonEmptyString(strings.TrimSpace(cmd.ID), newOpaqueTaskResourceID("handoff")),
+		ProjectID:             projectID,
+		WorkItemID:            workItemID,
+		SourceAssignmentID:    cmd.SourceAssignmentID,
+		SourceRunID:           cmd.SourceRunID,
+		SourceChatSessionID:   cmd.SourceChatSessionID,
+		SourceMessageID:       cmd.SourceMessageID,
+		TargetRoleID:          cmd.TargetRoleID,
+		TargetAssignmentID:    cmd.TargetAssignmentID,
+		TargetWorkItemID:      cmd.TargetWorkItemID,
+		Title:                 cmd.Title,
+		Summary:               cmd.Summary,
+		RecommendedNextAction: cmd.RecommendedNextAction,
+		LinkedArtifactIDs:     append([]string(nil), cmd.LinkedArtifactIDs...),
+		LinkedMemoryIDs:       append([]string(nil), cmd.LinkedMemoryIDs...),
+		ContextRefs:           append([]string(nil), cmd.ContextRefs...),
+		Status:                cmd.Status,
+		ProvenanceKind:        cmd.ProvenanceKind,
+		TrustLabel:            cmd.TrustLabel,
+		CreatedByRoleID:       cmd.CreatedByRoleID,
+	}
+	if err := validateProjectHandoffForCairnlineAuthority(handoff); err != nil {
+		return projectwork.Handoff{}, err
+	}
+	var created projectwork.Handoff
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.seedProjectHandoffDependenciesForCairnlineAuthority(ctx, service, handoff); err != nil {
+			return err
+		}
+		item := cairnlinebridge.Handoff(handoff)
+		recorded, err := service.CreateHandoff(ctx, item)
+		if err != nil {
+			return err
+		}
+		created = projectHealthHandoffFromCairnline(recorded)
+		return nil
+	})
+	if err != nil {
+		return projectwork.Handoff{}, err
+	}
+	h.shadowProjectHandoffToHecate(ctx, "project_handoff_cairnline_authority_create", created)
+	return created, nil
+}
+
+func (h *Handler) updateProjectHandoffWithCairnlineAuthority(ctx context.Context, projectID, workItemID, handoffID string, cmd projectworkapp.UpdateHandoffCommand) (projectwork.Handoff, error) {
+	var updated projectwork.Handoff
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := service.GetHandoff(ctx, projectID, workItemID, handoffID)
+		if err != nil {
+			return err
+		}
+		handoff := projectHealthHandoffFromCairnline(existing)
+		applyProjectHandoffUpdate(&handoff, cmd)
+		if err := validateProjectHandoffForCairnlineAuthority(handoff); err != nil {
+			return err
+		}
+		if err := h.seedProjectHandoffDependenciesForCairnlineAuthority(ctx, service, handoff); err != nil {
+			return err
+		}
+		recorded, err := service.UpdateHandoff(ctx, cairnlinebridge.Handoff(handoff))
+		if err != nil {
+			return err
+		}
+		updated = projectHealthHandoffFromCairnline(recorded)
+		return nil
+	})
+	if err != nil {
+		return projectwork.Handoff{}, err
+	}
+	h.shadowProjectHandoffToHecate(ctx, "project_handoff_cairnline_authority_update", updated)
+	return updated, nil
+}
+
+func (h *Handler) deleteProjectHandoffWithCairnlineAuthority(ctx context.Context, projectID, workItemID, handoffID string) error {
+	if err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		return service.DeleteHandoff(ctx, projectID, workItemID, handoffID)
+	}); err != nil {
+		return err
+	}
+	h.shadowProjectHandoffDeleteToHecate(ctx, "project_handoff_cairnline_authority_delete", projectID, workItemID, handoffID)
+	return nil
+}
+
+func (h *Handler) seedProjectArtifactDependenciesForCairnlineAuthority(ctx context.Context, service *cairnline.Service, artifact projectwork.CollaborationArtifact) error {
+	if err := h.writeProjectWorkItemDependencyToCairnline(ctx, service, "project_artifact_authority", artifact.ProjectID, artifact.WorkItemID); err != nil {
+		return err
+	}
+	if err := h.writeProjectRoleDependencyToCairnline(ctx, service, artifact.ProjectID, artifact.AuthorRoleID); err != nil {
+		return err
+	}
+	if err := h.writeProjectAssignmentDependencyToCairnline(ctx, service, artifact.ProjectID, artifact.AssignmentID); err != nil {
+		return err
+	}
+	return h.writeProjectAssignmentDependencyToCairnline(ctx, service, artifact.ProjectID, artifact.ReviewedAssignmentID)
+}
+
+func (h *Handler) seedProjectHandoffDependenciesForCairnlineAuthority(ctx context.Context, service *cairnline.Service, handoff projectwork.Handoff) error {
+	if err := h.writeProjectWorkItemDependencyToCairnline(ctx, service, "project_handoff_authority", handoff.ProjectID, handoff.WorkItemID); err != nil {
+		return err
+	}
+	if err := h.writeProjectWorkItemDependencyToCairnline(ctx, service, "project_handoff_authority", handoff.ProjectID, handoff.TargetWorkItemID); err != nil {
+		return err
+	}
+	if err := h.writeProjectRoleDependencyToCairnline(ctx, service, handoff.ProjectID, handoff.CreatedByRoleID); err != nil {
+		return err
+	}
+	if err := h.writeProjectRoleDependencyToCairnline(ctx, service, handoff.ProjectID, handoff.TargetRoleID); err != nil {
+		return err
+	}
+	if err := h.writeProjectAssignmentDependencyToCairnline(ctx, service, handoff.ProjectID, handoff.SourceAssignmentID); err != nil {
+		return err
+	}
+	return h.writeProjectAssignmentDependencyToCairnline(ctx, service, handoff.ProjectID, handoff.TargetAssignmentID)
+}
+
+func validateProjectHandoffForCairnlineAuthority(handoff projectwork.Handoff) error {
+	if strings.TrimSpace(handoff.Title) == "" {
+		return fmt.Errorf("%w: handoff title is required", projectwork.ErrInvalid)
+	}
+	if strings.TrimSpace(handoff.Summary) == "" {
+		return fmt.Errorf("%w: handoff summary is required", projectwork.ErrInvalid)
+	}
+	if strings.TrimSpace(handoff.RecommendedNextAction) == "" {
+		return fmt.Errorf("%w: recommended_next_action is required", projectwork.ErrInvalid)
+	}
+	switch strings.TrimSpace(handoff.Status) {
+	case "", projectwork.HandoffStatusPending, projectwork.HandoffStatusAccepted, projectwork.HandoffStatusSuperseded, projectwork.HandoffStatusDismissed:
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported handoff status %q", projectwork.ErrInvalid, strings.TrimSpace(handoff.Status))
+	}
+}
+
+func validateProjectCollaborationArtifactForCairnlineAuthority(artifact projectwork.CollaborationArtifact) error {
+	kind := strings.TrimSpace(artifact.Kind)
+	if kind == "" {
+		return fmt.Errorf("%w: collaboration artifact kind is required", projectwork.ErrInvalid)
+	}
+	switch kind {
+	case projectwork.ArtifactKindBrief, projectwork.ArtifactKindHandoff, projectwork.ArtifactKindReview, projectwork.ArtifactKindDecisionNote, projectwork.ArtifactKindEvidenceLink:
+	default:
+		return fmt.Errorf("%w: unsupported collaboration artifact kind %q", projectwork.ErrInvalid, kind)
+	}
+	if strings.TrimSpace(artifact.Body) == "" {
+		return fmt.Errorf("%w: artifact body is required", projectwork.ErrInvalid)
+	}
+	if kind == projectwork.ArtifactKindEvidenceLink && strings.TrimSpace(artifact.EvidenceURL) == "" && strings.TrimSpace(artifact.EvidenceExternalID) == "" {
+		return fmt.Errorf("%w: evidence_url or evidence_external_id is required for evidence links", projectwork.ErrInvalid)
+	}
+	if kind == projectwork.ArtifactKindReview {
+		if strings.TrimSpace(artifact.ReviewVerdict) == "" {
+			return fmt.Errorf("%w: review_verdict is required for Cairnline-authoritative reviews", projectwork.ErrInvalid)
+		}
+		if !validProjectCollaborationReviewVerdictForCairnlineAuthority(artifact.ReviewVerdict) {
+			return fmt.Errorf("%w: unsupported review_verdict %q", projectwork.ErrInvalid, strings.TrimSpace(artifact.ReviewVerdict))
+		}
+		if strings.TrimSpace(artifact.ReviewRisk) != "" && !validProjectCollaborationReviewRiskForCairnlineAuthority(artifact.ReviewRisk) {
+			return fmt.Errorf("%w: unsupported review_risk %q", projectwork.ErrInvalid, strings.TrimSpace(artifact.ReviewRisk))
+		}
+	}
+	return nil
+}
+
+func validProjectCollaborationReviewVerdictForCairnlineAuthority(verdict string) bool {
+	switch strings.TrimSpace(verdict) {
+	case projectwork.ReviewVerdictApproved, projectwork.ReviewVerdictChangesRequested, projectwork.ReviewVerdictBlocked, projectwork.ReviewVerdictRisk:
+		return true
+	default:
+		return false
+	}
+}
+
+func validProjectCollaborationReviewRiskForCairnlineAuthority(risk string) bool {
+	switch strings.TrimSpace(risk) {
+	case projectwork.ReviewRiskLow, projectwork.ReviewRiskMedium, projectwork.ReviewRiskHigh, projectwork.ReviewRiskUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func applyProjectHandoffUpdate(item *projectwork.Handoff, cmd projectworkapp.UpdateHandoffCommand) {
+	if item == nil {
+		return
+	}
+	if cmd.SourceAssignmentID != nil {
+		item.SourceAssignmentID = *cmd.SourceAssignmentID
+	}
+	if cmd.SourceRunID != nil {
+		item.SourceRunID = *cmd.SourceRunID
+	}
+	if cmd.SourceChatSessionID != nil {
+		item.SourceChatSessionID = *cmd.SourceChatSessionID
+	}
+	if cmd.SourceMessageID != nil {
+		item.SourceMessageID = *cmd.SourceMessageID
+	}
+	if cmd.TargetRoleID != nil {
+		item.TargetRoleID = *cmd.TargetRoleID
+	}
+	if cmd.TargetAssignmentID != nil {
+		item.TargetAssignmentID = *cmd.TargetAssignmentID
+	}
+	if cmd.TargetWorkItemID != nil {
+		item.TargetWorkItemID = *cmd.TargetWorkItemID
+	}
+	if cmd.Title != nil {
+		item.Title = *cmd.Title
+	}
+	if cmd.Summary != nil {
+		item.Summary = *cmd.Summary
+	}
+	if cmd.RecommendedNextAction != nil {
+		item.RecommendedNextAction = *cmd.RecommendedNextAction
+	}
+	if cmd.LinkedArtifactIDs != nil {
+		item.LinkedArtifactIDs = append([]string(nil), *cmd.LinkedArtifactIDs...)
+	}
+	if cmd.LinkedMemoryIDs != nil {
+		item.LinkedMemoryIDs = append([]string(nil), *cmd.LinkedMemoryIDs...)
+	}
+	if cmd.ContextRefs != nil {
+		item.ContextRefs = append([]string(nil), *cmd.ContextRefs...)
+	}
+	if cmd.Status != nil {
+		item.Status = *cmd.Status
+	}
+	if cmd.ProvenanceKind != nil {
+		item.ProvenanceKind = *cmd.ProvenanceKind
+	}
+	if cmd.TrustLabel != nil {
+		item.TrustLabel = *cmd.TrustLabel
+	}
+	if cmd.CreatedByRoleID != nil {
+		item.CreatedByRoleID = *cmd.CreatedByRoleID
+	}
+}
+
+func (h *Handler) shadowProjectWorkArtifactToHecate(ctx context.Context, operation string, artifact projectwork.CollaborationArtifact) {
+	if h == nil || h.projectWork == nil {
+		return
+	}
+	if _, err := h.projectWork.CreateArtifact(ctx, artifact); err != nil && !errors.Is(err, projectwork.ErrDuplicate) {
+		h.logProjectCollaborationShadowError(ctx, operation, artifact.ProjectID, artifact.ID, err)
+	}
+}
+
+func (h *Handler) shadowProjectHandoffToHecate(ctx context.Context, operation string, handoff projectwork.Handoff) {
+	if h == nil || h.projectWork == nil {
+		return
+	}
+	if existing, err := h.projectWork.UpdateHandoff(ctx, handoff.ProjectID, handoff.WorkItemID, handoff.ID, func(item *projectwork.Handoff) {
+		*item = handoff
+	}); err == nil {
+		_ = existing
+		return
+	} else if !errors.Is(err, projectwork.ErrNotFound) {
+		h.logProjectCollaborationShadowError(ctx, operation, handoff.ProjectID, handoff.ID, err)
+		return
+	}
+	if _, err := h.projectWork.CreateHandoff(ctx, handoff); err != nil && !errors.Is(err, projectwork.ErrDuplicate) {
+		h.logProjectCollaborationShadowError(ctx, operation, handoff.ProjectID, handoff.ID, err)
+	}
+}
+
+func (h *Handler) shadowProjectHandoffDeleteToHecate(ctx context.Context, operation, projectID, workItemID, handoffID string) {
+	if h == nil || h.projectWork == nil {
+		return
+	}
+	if err := h.projectWork.DeleteHandoff(ctx, projectID, workItemID, handoffID); err != nil && !errors.Is(err, projectwork.ErrNotFound) {
+		h.logProjectCollaborationShadowError(ctx, operation, projectID, handoffID, err)
+	}
+}
+
+func (h *Handler) logProjectCollaborationShadowError(ctx context.Context, operation, projectID, recordID string, err error) {
+	if err == nil || h == nil || h.logger == nil {
+		return
+	}
+	h.logger.WarnContext(ctx, "project collaboration Hecate shadow failed", "operation", operation, "project_id", projectID, "record_id", recordID, "error", err)
+}

--- a/internal/api/handler_project_context_discovery.go
+++ b/internal/api/handler_project_context_discovery.go
@@ -30,6 +30,12 @@ func (h *Handler) HandleDiscoverProjectContextSources(w http.ResponseWriter, r *
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
+	merged := mergeDiscoveredContextSources(project.ContextSources, discovered)
+	if h.projectContextSourceWritesUseCairnlineAuthority() {
+		project, err = h.replaceProjectContextSourcesWithCairnlineAuthority(r.Context(), projectID, merged, "project_context_sources_cairnline_authority_discover")
+		writeProjectListReplaceCairnlineAuthorityResponse(w, project, err)
+		return
+	}
 	project, err = h.projects.Update(r.Context(), projectID, func(item *projects.Project) {
 		item.ContextSources = mergeDiscoveredContextSources(item.ContextSources, discovered)
 	})

--- a/internal/api/handler_project_context_discovery_test.go
+++ b/internal/api/handler_project_context_discovery_test.go
@@ -224,9 +224,119 @@ func TestProjectContextDiscovery_MirrorsDiscoveredSourcesToCairnlineWhenConfigur
 	}
 }
 
+func TestProjectContextDiscovery_CairnlineAuthorityCommitsDiscoveredSourcesFirst(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeDiscoveryFile(t, root, "AGENTS.md")
+	writeDiscoveryFile(t, root, "CLAUDE.md")
+
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectContextSources,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+
+	if _, err := projectStore.Create(t.Context(), projects.Project{
+		ID:   "proj_guidance_authority",
+		Name: "Guidance authority",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   root,
+			Kind:   "local",
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_existing_agents",
+			Kind:    "workspace_instruction",
+			Path:    "AGENTS.md",
+			Title:   "AGENTS.md",
+			Enabled: false,
+			Metadata: map[string]string{
+				"root_id": "root_main",
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	dbPath := handler.cairnlineEmbeddedDatabasePath()
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create Cairnline mirror directory: %v", err)
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	if _, err := service.CreateProject(t.Context(), cairnline.Project{
+		ID:   "proj_guidance_authority",
+		Name: "Guidance authority",
+		ContextSources: []cairnline.Source{{
+			ID:      "ctx_cairnline_only",
+			Kind:    "operator_note",
+			Title:   "Cairnline-only source",
+			Locator: "cairnline://source",
+			Enabled: true,
+		}},
+	}); err != nil {
+		t.Fatalf("CreateProject(cairnline seed): %v", err)
+	}
+	store.Close()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_guidance_authority/context-sources/discover", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var resp ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode discovery response: %v", err)
+	}
+	if len(resp.Data.ContextSources) != 2 {
+		t.Fatalf("response sources = %+v, want discovered AGENTS.md and CLAUDE.md", resp.Data.ContextSources)
+	}
+	if got := projectContextSourceResponseByPath(resp.Data.ContextSources, "AGENTS.md"); got == nil || got.ID != "ctx_existing_agents" || got.Enabled {
+		t.Fatalf("response AGENTS source = %+v, want existing disabled source preserved", got)
+	}
+	if got := projectContextSourceResponseByPath(resp.Data.ContextSources, "CLAUDE.md"); got == nil || got.Kind != "host_instruction" || got.Metadata["host"] != "claude" {
+		t.Fatalf("response CLAUDE source = %+v, want discovered Claude source", got)
+	}
+
+	service, store, err = cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	project, err := service.GetProject(t.Context(), "proj_guidance_authority")
+	if err != nil {
+		t.Fatalf("GetProject(proj_guidance_authority): %v", err)
+	}
+	if len(project.ContextSources) != 2 {
+		t.Fatalf("Cairnline sources = %+v, want authoritative discovery replacement without Cairnline-only source", project.ContextSources)
+	}
+	if findCairnlineSourceForAPITest(project.ContextSources, "ctx_existing_agents") == nil {
+		t.Fatalf("Cairnline sources = %+v, want existing AGENTS source id preserved", project.ContextSources)
+	}
+	if findCairnlineSourceForAPITest(project.ContextSources, "ctx_cairnline_only") != nil {
+		t.Fatalf("Cairnline sources = %+v, want stale Cairnline-only source removed by authoritative discovery replacement", project.ContextSources)
+	}
+}
+
 func findCairnlineSourceForAPITest(sources []cairnline.Source, id string) *cairnline.Source {
 	for idx := range sources {
 		if sources[idx].ID == id {
+			return &sources[idx]
+		}
+	}
+	return nil
+}
+
+func projectContextSourceResponseByPath(sources []ProjectContextSourceResponseItem, path string) *ProjectContextSourceResponseItem {
+	for idx := range sources {
+		if sources[idx].Path == path {
 			return &sources[idx]
 		}
 	}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -88,6 +88,7 @@ var projectCairnlineWriteAdapterGapNames = []string{
 	"artifacts",
 	"handoffs",
 	"project-assistant-proposals",
+	"project-assistant-apply-side-effects",
 	"migration-cutover",
 }
 
@@ -120,7 +121,7 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 		BlocksAuthority:  true,
 		Seams:            []string{"project-roots-live-mirror"},
 		Gap:              "roots",
-		Detail:           "Root create/update/delete, root discovery, root list replacement, and worktree-root creation still commit to Hecate first, then mirror through Cairnline root APIs.",
+		Detail:           "Root create/update/delete, root discovery, root list replacement, and worktree-created root record mutations still commit to Hecate first, then mirror through Cairnline root APIs; Hecate owns the Git worktree creation side effect.",
 	},
 	{
 		Name:             "context-sources",
@@ -233,22 +234,33 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 		Detail:           "Memory-candidate create/promote/reject/delete still commits to Hecate first, then mirrors review state and promoted-memory references into Cairnline.",
 	},
 	{
-		Name:             "project-assistant-proposals",
+		Name:             "project-assistant-proposal-ledger",
 		CurrentAuthority: "hecate",
 		CairnlineState:   "live_mirror_non_authoritative",
 		LiveMirror:       true,
 		BlocksAuthority:  true,
-		Seams:            []string{"project-assistant-proposal-ledger-live-mirror", "project-assistant-apply-side-effects-live-mirror"},
+		Seams:            []string{"project-assistant-proposal-ledger-live-mirror"},
 		Gap:              "project-assistant-proposals",
-		Detail:           "Project Assistant draft/propose/apply records and committed side effects still commit to Hecate first, then mirror into the portable proposal ledger.",
+		Detail:           "Project Assistant draft/propose/apply-attempt ledger records still commit to Hecate first, then mirror into the portable proposal ledger.",
+	},
+	{
+		Name:             "project-assistant-apply-side-effects",
+		CurrentAuthority: "hecate",
+		CairnlineState:   "side_effect_mirror_only",
+		LiveMirror:       true,
+		BlocksAuthority:  true,
+		Seams:            []string{"project-assistant-apply-side-effects-live-mirror"},
+		Gap:              "project-assistant-apply-side-effects",
+		Detail:           "Project Assistant confirmed apply still executes Hecate-owned project mutations, then mirrors committed side effects into Cairnline as replacement evidence.",
 	},
 	{
 		Name:             "migration-cutover",
 		CurrentAuthority: "hecate",
-		CairnlineState:   "missing_authoritative_switchpoint",
+		CairnlineState:   "snapshot_import_rehearsal_available",
 		BlocksAuthority:  true,
+		Seams:            []string{"sync-rehearsal"},
 		Gap:              "migration-cutover",
-		Detail:           "No import/export cutover, rollback, or authoritative Cairnline storage switch exists yet.",
+		Detail:           "Snapshot import/export rehearsal and rollback notes exist, but no authoritative Cairnline storage cutover switch exists yet.",
 	},
 }
 
@@ -298,18 +310,18 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 			response.Warnings = []string{
 				"Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
 				projectCairnlineReadSourceWarning(readSource),
-				"Project create/delete still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database.",
-				"Project metadata updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata seam.",
-				"Root create/update/delete, root list replacement, root discovery, and worktree-root creation mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API.",
-				"Direct context-source create/update/delete, context-source list replacement, and discovery mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's source-level API.",
-				"Default-only project updates still write Hecate-native stores first, then best-effort mirror portable launch defaults through Cairnline's project-defaults seam.",
-				"Agent profile create/update/delete mutations still write Hecate-native stores first, then best-effort mirror portable profile metadata and execution posture into Cairnline.",
-				"Project skill discovery and metadata updates still write Hecate-native stores first, then best-effort mirror metadata-only skill records into Cairnline.",
-				"Project role and work-item mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline.",
-				"Project assignment create/update/delete mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results.",
-				"Project collaboration artifact creation and handoff mutations still write Hecate-native stores first, then best-effort mirror portable collaboration metadata into Cairnline.",
+				projectCairnlineProjectIdentityWriteWarning(writeAuthority),
+				projectCairnlineProjectMetadataDefaultsWriteWarning(writeAuthority),
+				projectCairnlineProjectRootWriteWarning(writeAuthority),
+				projectCairnlineProjectContextSourceWriteWarning(writeAuthority),
+				projectCairnlineAgentProfileWriteWarning(writeAuthority),
+				projectCairnlineProjectSkillWriteWarning(writeAuthority),
+				projectCairnlineProjectWorkItemWriteWarning(writeAuthority),
+				projectCairnlineProjectAssignmentWriteWarning(writeAuthority),
+				projectCairnlineProjectCollaborationWriteWarning(writeAuthority),
 				projectCairnlineProjectMemoryWriteWarning(writeAuthority),
-				"Project Assistant proposal draft/propose/apply ledger mutations still write Hecate-native stores first, then best-effort mirror proposal records plus committed apply side effects into Cairnline.",
+				projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority),
+				projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority),
 				"Other project mutation routes still write only Hecate-native stores.",
 				"Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready.",
 			}
@@ -351,8 +363,8 @@ func projectCairnlineReplacementGates(readRoutesReady bool) []ProjectCoordinatio
 		{
 			ID:     "migration-and-rollback",
 			Ready:  false,
-			Status: "blocked",
-			Detail: "No migration cutover, rollback, or authoritative Cairnline storage switch exists yet.",
+			Status: "rehearsal_available",
+			Detail: "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet.",
 		},
 	}
 }
@@ -366,13 +378,50 @@ func projectReplacementGateStatus(ready bool) string {
 
 func projectCairnlineWriteAdapterGapsSnapshot(writeAuthority []string) []string {
 	out := make([]string, 0, len(projectCairnlineWriteAdapterGapNames))
+	projectIdentityAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectIdentity)
+	projectMetadataDefaultsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectMetadataDefaults)
 	projectMemoryAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory")
 	memoryCandidatesAuthoritative := projectMemoryAuthoritative && projectCairnlineWriteAuthorityEnabled(writeAuthority, "memory-candidates")
+	projectCollaborationAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectCollaboration)
+	agentProfilesAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityAgentProfiles)
+	projectSkillsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectSkills)
+	projectRolesAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles)
+	projectWorkItemsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems)
+	projectAssignmentsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments)
+	projectContextSourcesAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectContextSources)
+	projectAssistantProposalsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssistantProposals)
 	for _, item := range projectCairnlineWriteAdapterGapNames {
+		if projectIdentityAuthoritative && projectMetadataDefaultsAuthoritative && item == "projects" {
+			continue
+		}
 		if projectMemoryAuthoritative && item == "memory" {
 			continue
 		}
 		if memoryCandidatesAuthoritative && item == "memory-candidates" {
+			continue
+		}
+		if projectCollaborationAuthoritative && (item == "artifacts" || item == "handoffs") {
+			continue
+		}
+		if agentProfilesAuthoritative && item == "agent-profiles" {
+			continue
+		}
+		if projectSkillsAuthoritative && item == "skills" {
+			continue
+		}
+		if projectRolesAuthoritative && item == "roles" {
+			continue
+		}
+		if projectWorkItemsAuthoritative && item == "work-items" {
+			continue
+		}
+		if projectAssignmentsAuthoritative && item == "assignments" {
+			continue
+		}
+		if projectContextSourcesAuthoritative && item == "context-sources" {
+			continue
+		}
+		if projectAssistantProposalsAuthoritative && item == "project-assistant-proposals" {
 			continue
 		}
 		out = append(out, item)
@@ -384,7 +433,126 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 	out := make([]ProjectCoordinationBackendWriteSwitchpoint, 0, len(projectCairnlineWriteSwitchpoints))
 	projectMemoryAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory")
 	memoryCandidatesAuthoritative := projectMemoryAuthoritative && projectCairnlineWriteAuthorityEnabled(writeAuthority, "memory-candidates")
+	projectCollaborationAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectCollaboration)
+	agentProfilesAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityAgentProfiles)
+	projectIdentityAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectIdentity)
+	projectMetadataDefaultsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectMetadataDefaults)
+	projectRootsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoots)
+	projectContextSourcesAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectContextSources)
+	projectSkillsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectSkills)
+	projectRolesAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles)
+	projectWorkItemsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems)
+	projectAssignmentsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments)
+	projectAssistantProposalsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssistantProposals)
+	projectAssistantWorkEffectsAuthoritative := projectCairnlineAssistantApplyWorkEffectsAuthoritative(writeAuthority)
 	for _, item := range projectCairnlineWriteSwitchpoints {
+		if projectIdentityAuthoritative && item.Name == "project-identity" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Project create/delete commits portable identity, roots, context sources, launch defaults, and project identity removal to the embedded Cairnline database first, then best-effort shadows Hecate's compatibility row; delete rolls the Cairnline snapshot back if Hecate compatibility cleanup fails."
+		}
+		if projectMetadataDefaultsAuthoritative && item.Name == "project-metadata-defaults" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Project metadata/default-only update mutations commit portable project metadata and launch defaults to the embedded Cairnline database first, then best-effort shadow Hecate's compatibility row back into Hecate-native stores; project identity, roots, context sources, and mixed metadata/root/source replacement routes are controlled by separate switchpoints."
+		}
+		if projectRootsAuthoritative && item.Name == "roots-and-worktrees" {
+			item.CurrentAuthority = "mixed"
+			item.CairnlineState = "partial_authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = true
+			item.Gap = "roots"
+			item.Detail = "Project root create/update/delete, root list replacement, discovery-result replacement, and worktree-created root record mutations commit to the embedded Cairnline database first, then best-effort shadow Hecate's compatibility row; Hecate still performs root discovery scans and Git worktree creation side effects."
+		}
+		if projectContextSourcesAuthoritative && item.Name == "context-sources" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Context-source create/update/delete, list replacement, and discovery-result replacement mutations commit to the embedded Cairnline database first, then best-effort shadow Hecate's compatibility row; Hecate still performs the workspace scan for its operator UI."
+		}
+		if agentProfilesAuthoritative && item.Name == "agent-profiles" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Agent profile create, update, and delete mutations commit portable profile metadata plus execution posture to the embedded Cairnline database first, then best-effort shadow Hecate's combined profile row back into Hecate-native stores for compatibility."
+		}
+		if projectSkillsAuthoritative && item.Name == "skills" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Project skill discovery and update mutations commit metadata-only skill records to the embedded Cairnline database first, then best-effort shadow them back into Hecate-native stores for compatibility."
+		}
+		if projectRolesAuthoritative && item.Name == "roles" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Project role create, update, and delete mutations commit to the embedded Cairnline database first, then best-effort shadow portable role defaults back into Hecate-native stores for compatibility."
+		}
+		if projectWorkItemsAuthoritative && item.Name == "work-items" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Work-item create, update, and delete mutations commit to the embedded Cairnline database first, then best-effort shadow portable work-item state back into Hecate-native stores for compatibility."
+		}
+		if projectAssignmentsAuthoritative && item.Name == "assignments" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Assignment create, update, and delete record mutations commit to the embedded Cairnline database first, then best-effort shadow portable assignment state back into Hecate-native stores for compatibility; assignment start remains Hecate-owned."
+		}
+		if projectAssistantProposalsAuthoritative && item.Name == "project-assistant-proposal-ledger" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Project Assistant draft/propose/apply-attempt ledger records commit to the embedded Cairnline database first, then best-effort shadow Hecate's proposal store for compatibility; confirmed apply side effects remain Hecate-owned."
+			if projectAssistantWorkEffectsAuthoritative {
+				item.Detail = "Project Assistant draft/propose/apply-attempt ledger records commit to the embedded Cairnline database first, then best-effort shadow Hecate's proposal store for compatibility; confirmed apply is mixed-authority when enabled work-family actions route through Cairnline."
+			}
+		}
+		if projectAssistantWorkEffectsAuthoritative && item.Name == "project-assistant-apply-side-effects" {
+			item.CurrentAuthority = "mixed"
+			item.CairnlineState = "partial_authoritative_via_work_switchpoints"
+			item.LiveMirror = true
+			item.BlocksAuthority = true
+			item.Gap = "project-assistant-apply-side-effects"
+			item.Detail = "Project Assistant confirmed apply routes role, work-item, assignment, and handoff actions through the same opt-in Cairnline authority switchpoints when enabled; project/default/chat/memory/runtime side effects still keep apply as a blocking mixed-authority gap."
+		}
+		if projectCollaborationAuthoritative && item.Name == "collaboration-artifacts" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Generic artifact, evidence, and review creation commits to the embedded Cairnline database first, then best-effort shadows the portable collaboration record back into Hecate-native stores for compatibility."
+		}
+		if projectCollaborationAuthoritative && item.Name == "handoffs" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "authoritative_opt_in"
+			item.LiveMirror = true
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Handoff create, update, status, and delete mutations commit to the embedded Cairnline database first, then best-effort shadow portable handoff state back into Hecate-native stores for compatibility."
+		}
 		if projectMemoryAuthoritative && item.Name == "project-memory" {
 			item.CurrentAuthority = "cairnline"
 			item.CairnlineState = "authoritative_opt_in"
@@ -425,6 +593,101 @@ func projectCairnlineProjectMemoryWriteWarning(writeAuthority []string) string {
 		return "Accepted project memory entry mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores; memory-candidate mutations still write Hecate-native stores first, then mirror reviewable candidate state into Cairnline."
 	}
 	return "Project memory entry and memory-candidate mutations still write Hecate-native stores first, then best-effort mirror accepted memory and reviewable candidate state into Cairnline."
+}
+
+func projectCairnlineProjectCollaborationWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectCollaboration) {
+		return "Project collaboration artifact creation and handoff mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility."
+	}
+	return "Project collaboration artifact creation and handoff mutations still write Hecate-native stores first, then best-effort mirror portable collaboration metadata into Cairnline."
+}
+
+func projectCairnlineProjectMetadataDefaultsWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectMetadataDefaults) {
+		return "Project metadata/default-only update mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; project identity, roots, context sources, and mixed root/source replacement routes are controlled by separate switchpoints."
+	}
+	return "Project metadata/default updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata and project-defaults seams."
+}
+
+func projectCairnlineProjectIdentityWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectIdentity) {
+		return "Project create/delete mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; delete restores the Cairnline snapshot if Hecate compatibility cleanup fails."
+	}
+	return "Project create/delete still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database."
+}
+
+func projectCairnlineProjectRootWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoots) {
+		return "Project root create/update/delete, root list replacement, discovery-result replacement, and worktree-created root record mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; Hecate still performs root discovery scans and Git worktree creation side effects."
+	}
+	return "Root create/update/delete, root list replacement, root discovery, and worktree-created root record mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API; Hecate owns the Git worktree creation side effect."
+}
+
+func projectCairnlineProjectContextSourceWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectContextSources) {
+		return "Context-source create/update/delete, list replacement, and discovery-result replacement mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; Hecate still performs the workspace scan for its operator UI."
+	}
+	return "Direct context-source create/update/delete, context-source list replacement, and discovery mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's source-level API."
+}
+
+func projectCairnlineProjectSkillWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectSkills) {
+		return "Project skill discovery and metadata updates are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility."
+	}
+	return "Project skill discovery and metadata updates still write Hecate-native stores first, then best-effort mirror metadata-only skill records into Cairnline."
+}
+
+func projectCairnlineAgentProfileWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityAgentProfiles) {
+		return "Agent profile create/update/delete mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; Cairnline stores portable profile metadata and execution posture as separate records."
+	}
+	return "Agent profile create/update/delete mutations still write Hecate-native stores first, then best-effort mirror portable profile metadata and execution posture into Cairnline."
+}
+
+func projectCairnlineProjectWorkItemWriteWarning(writeAuthority []string) string {
+	rolesAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles)
+	workItemsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems)
+	if rolesAuthoritative && workItemsAuthoritative {
+		return "Project role and work-item mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility."
+	}
+	if rolesAuthoritative {
+		return "Project role mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; work-item mutations still write Hecate-native stores first, then mirror portable work-item state into Cairnline."
+	}
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems) {
+		return "Project work-item mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; role mutations still write Hecate-native stores first, then mirror portable role defaults into Cairnline."
+	}
+	return "Project role and work-item mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline."
+}
+
+func projectCairnlineProjectAssignmentWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments) {
+		return "Project assignment create/update/delete record mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results."
+	}
+	return "Project assignment create/update/delete mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results."
+}
+
+func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []string) string {
+	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssistantProposals) {
+		if projectCairnlineAssistantApplyWorkEffectsAuthoritative(writeAuthority) {
+			return "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; confirmed apply is mixed-authority when enabled work-family actions route through Cairnline."
+		}
+		return "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; confirmed apply side effects still execute through Hecate-owned project mutation services."
+	}
+	return "Project Assistant proposal draft/propose/apply-attempt ledger mutations still write Hecate-native stores first, then best-effort mirror proposal records into Cairnline."
+}
+
+func projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority []string) string {
+	if projectCairnlineAssistantApplyWorkEffectsAuthoritative(writeAuthority) {
+		return "Project Assistant confirmed apply uses the enabled Cairnline authority seams for role, work-item, assignment, and handoff actions, but project/default/chat/memory/runtime side effects still keep apply as a mixed-authority replacement blocker."
+	}
+	return "Project Assistant confirmed apply side effects still execute through Hecate-owned mutation services, then best-effort mirror committed results into Cairnline."
+}
+
+func projectCairnlineAssistantApplyWorkEffectsAuthoritative(writeAuthority []string) bool {
+	return projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles) ||
+		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems) ||
+		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments) ||
+		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectCollaboration)
 }
 
 func projectCairnlineReadSourceDetail(source string) string {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -65,6 +65,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "blocked" {
 		t.Fatalf("write-authority gate = %+v, want blocking gate", gate)
 	}
+	if gate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); gate == nil || gate.Ready || gate.Status != "rehearsal_available" {
+		t.Fatalf("migration gate = %+v, want rehearsal-available blocker", gate)
+	}
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "result_mirror_only" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "assignment-start" {
 		t.Fatalf("assignment-start switchpoint = %+v, want Hecate-owned result mirror blocker", point)
 	}
@@ -98,7 +101,7 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if !containsString(status.ReadRoutes, "project-list") || !containsString(status.ReadRoutes, "assignment-context") || !containsString(status.ReadRoutes, "launch-readiness") || !containsString(status.ReadRoutes, "assignment-preflight") || !containsString(status.ReadRoutes, "project-assistant-context") || !containsString(status.ReadRoutes, "project-assistant-proposal") || !containsString(status.ReadRoutes, "operations-brief") {
 		t.Fatalf("read routes = %+v, want structured Cairnline read-route coverage", status.ReadRoutes)
 	}
-	if !containsString(status.WriteAdapterGaps, "agent-profiles") || !containsString(status.WriteAdapterGaps, "assignments") || !containsString(status.WriteAdapterGaps, "project-assistant-proposals") || !containsString(status.WriteAdapterGaps, "migration-cutover") {
+	if !containsString(status.WriteAdapterGaps, "agent-profiles") || !containsString(status.WriteAdapterGaps, "assignments") || !containsString(status.WriteAdapterGaps, "project-assistant-proposals") || !containsString(status.WriteAdapterGaps, "project-assistant-apply-side-effects") || !containsString(status.WriteAdapterGaps, "migration-cutover") {
 		t.Fatalf("write gaps = %+v, want structured remaining write-adapter gaps", status.WriteAdapterGaps)
 	}
 	if !containsString(status.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(status.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(status.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(status.WriteAdapterSeams, "agent-profiles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(status.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(status.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(status.WriteAdapterSeams, "assignment-status") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-import") || !containsString(status.WriteAdapterSeams, "memory-candidates") {
@@ -113,8 +116,8 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-memory"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "live_mirror_non_authoritative" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "memory" {
 		t.Fatalf("project-memory switchpoint = %+v, want Hecate-owned live mirror blocker", point)
 	}
-	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "missing_authoritative_switchpoint" || point.LiveMirror || !point.BlocksAuthority || point.Gap != "migration-cutover" {
-		t.Fatalf("migration switchpoint = %+v, want missing authoritative switchpoint blocker", point)
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "snapshot_import_rehearsal_available" || point.LiveMirror || !point.BlocksAuthority || point.Gap != "migration-cutover" || !containsString(point.Seams, "sync-rehearsal") {
+		t.Fatalf("migration switchpoint = %+v, want snapshot-import rehearsal blocker", point)
 	}
 	if status.SyncReadinessURL != projectCoordinationBackendSyncReadinessURL {
 		t.Fatalf("sync readiness URL = %q, want %q", status.SyncReadinessURL, projectCoordinationBackendSyncReadinessURL)
@@ -190,6 +193,361 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectMemoryCandidateAuthori
 	}
 }
 
+func TestProjectCoordinationBackendStatus_CairnlineProjectCollaborationAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-collaboration",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "artifacts") || containsString(status.WriteAdapterGaps, "handoffs") {
+		t.Fatalf("write gaps = %+v, want artifacts and handoffs removed for opt-in Cairnline authority", status.WriteAdapterGaps)
+	}
+	for _, name := range []string{"collaboration-artifacts", "handoffs"} {
+		point := findWriteSwitchpoint(status.WriteSwitchpoints, name)
+		if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+			t.Fatalf("%s switchpoint = %+v, want opt-in Cairnline authority", name, point)
+		}
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	if !strings.Contains(strings.Join(status.Warnings, "\n"), "Project collaboration artifact creation and handoff mutations are opt-in Cairnline-authoritative") {
+		t.Fatalf("warnings = %+v, want collaboration authority warning", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectMetadataDefaultsAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-metadata-defaults",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if !containsString(status.WriteAdapterGaps, "projects") {
+		t.Fatalf("write gaps = %+v, want projects gap to remain until project identity create/delete authority exists", status.WriteAdapterGaps)
+	}
+	point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-metadata-defaults")
+	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("project-metadata-defaults switchpoint = %+v, want opt-in Cairnline authority", point)
+	}
+	identityPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-identity")
+	if identityPoint == nil || identityPoint.CurrentAuthority != "hecate" || !identityPoint.BlocksAuthority || identityPoint.Gap != "projects" {
+		t.Fatalf("project-identity switchpoint = %+v, want create/delete to remain Hecate-owned and blocking", identityPoint)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "Project metadata/default-only update mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "controlled by separate switchpoints") {
+		t.Fatalf("warnings = %+v, want metadata/default authority plus separate-switchpoint caveat", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectIdentityAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-identity",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if !containsString(status.WriteAdapterGaps, "projects") {
+		t.Fatalf("write gaps = %+v, want projects gap to remain until metadata/default authority is also enabled", status.WriteAdapterGaps)
+	}
+	point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-identity")
+	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("project-identity switchpoint = %+v, want opt-in Cairnline authority", point)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "Project create/delete mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "delete restores the Cairnline snapshot") {
+		t.Fatalf("warnings = %+v, want project identity authority plus rollback caveat", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectIdentityAndMetadataAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-identity,project-metadata-defaults",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "projects") {
+		t.Fatalf("write gaps = %+v, want projects gap removed when identity and metadata/defaults are authoritative", status.WriteAdapterGaps)
+	}
+	for _, name := range []string{"project-identity", "project-metadata-defaults"} {
+		point := findWriteSwitchpoint(status.WriteSwitchpoints, name)
+		if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+			t.Fatalf("%s switchpoint = %+v, want opt-in Cairnline authority", name, point)
+		}
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineDirectRootSourceAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-roots,project-context-sources",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if !containsString(status.WriteAdapterGaps, "roots") || containsString(status.WriteAdapterGaps, "context-sources") {
+		t.Fatalf("write gaps = %+v, want roots to remain blocking and context-sources removed for discovery-result authority", status.WriteAdapterGaps)
+	}
+	rootPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "roots-and-worktrees")
+	if rootPoint == nil || rootPoint.CurrentAuthority != "mixed" || rootPoint.CairnlineState != "partial_authoritative_opt_in" || !rootPoint.LiveMirror || !rootPoint.BlocksAuthority || rootPoint.Gap != "roots" {
+		t.Fatalf("roots-and-worktrees switchpoint = %+v, want partial opt-in authority with roots gap still blocking", rootPoint)
+	}
+	sourcePoint := findWriteSwitchpoint(status.WriteSwitchpoints, "context-sources")
+	if sourcePoint == nil || sourcePoint.CurrentAuthority != "cairnline" || sourcePoint.CairnlineState != "authoritative_opt_in" || !sourcePoint.LiveMirror || sourcePoint.BlocksAuthority || sourcePoint.Gap != "" {
+		t.Fatalf("context-sources switchpoint = %+v, want opt-in authority including discovery-result replacement", sourcePoint)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "Project root create/update/delete, root list replacement, discovery-result replacement, and worktree-created root record mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "Hecate still performs root discovery scans and Git worktree creation side effects") {
+		t.Fatalf("warnings = %+v, want root authority plus scan/worktree caveat", status.Warnings)
+	}
+	if !strings.Contains(warnings, "Context-source create/update/delete, list replacement, and discovery-result replacement mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "Hecate still performs the workspace scan") {
+		t.Fatalf("warnings = %+v, want context-source authority plus scan caveat", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectSkillsAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-skills",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "skills") {
+		t.Fatalf("write gaps = %+v, want skills removed for opt-in Cairnline authority", status.WriteAdapterGaps)
+	}
+	point := findWriteSwitchpoint(status.WriteSwitchpoints, "skills")
+	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("skills switchpoint = %+v, want opt-in Cairnline authority", point)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	if !strings.Contains(strings.Join(status.Warnings, "\n"), "Project skill discovery and metadata updates are opt-in Cairnline-authoritative") {
+		t.Fatalf("warnings = %+v, want project-skills authority warning", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineAgentProfilesAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "agent-profiles",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "agent-profiles") {
+		t.Fatalf("write gaps = %+v, want agent-profiles removed for opt-in Cairnline authority", status.WriteAdapterGaps)
+	}
+	point := findWriteSwitchpoint(status.WriteSwitchpoints, "agent-profiles")
+	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("agent-profiles switchpoint = %+v, want opt-in Cairnline authority", point)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	if !strings.Contains(strings.Join(status.Warnings, "\n"), "Agent profile create/update/delete mutations are opt-in Cairnline-authoritative") {
+		t.Fatalf("warnings = %+v, want agent-profile authority warning", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectWorkItemsAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-work-items",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "work-items") {
+		t.Fatalf("write gaps = %+v, want work-items removed for opt-in Cairnline authority", status.WriteAdapterGaps)
+	}
+	point := findWriteSwitchpoint(status.WriteSwitchpoints, "work-items")
+	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("work-items switchpoint = %+v, want opt-in Cairnline authority", point)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "Project work-item mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "role mutations still write Hecate-native stores first, then mirror portable role defaults into Cairnline") {
+		t.Fatalf("warnings = %+v, want work-item authority plus role mirror warning", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectRolesAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-roles,project-work-items",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "roles") || containsString(status.WriteAdapterGaps, "work-items") {
+		t.Fatalf("write gaps = %+v, want roles and work-items removed for opt-in Cairnline authority", status.WriteAdapterGaps)
+	}
+	for _, name := range []string{"roles", "work-items"} {
+		point := findWriteSwitchpoint(status.WriteSwitchpoints, name)
+		if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+			t.Fatalf("%s switchpoint = %+v, want opt-in Cairnline authority", name, point)
+		}
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	if !strings.Contains(strings.Join(status.Warnings, "\n"), "Project role and work-item mutations are opt-in Cairnline-authoritative") {
+		t.Fatalf("warnings = %+v, want role/work-item authority warning", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectAssignmentsAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-assignments",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "assignments") {
+		t.Fatalf("write gaps = %+v, want assignments removed for opt-in Cairnline authority", status.WriteAdapterGaps)
+	}
+	if !containsString(status.WriteAdapterGaps, "assignment-start") {
+		t.Fatalf("write gaps = %+v, want assignment-start to remain Hecate-owned and blocking", status.WriteAdapterGaps)
+	}
+	point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignments")
+	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("assignments switchpoint = %+v, want opt-in Cairnline authority", point)
+	}
+	startPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch")
+	if startPoint == nil || startPoint.CurrentAuthority != "hecate" || startPoint.CairnlineState != "result_mirror_only" || !startPoint.BlocksAuthority || startPoint.Gap != "assignment-start" {
+		t.Fatalf("assignment-start switchpoint = %+v, want Hecate start authority to remain blocking", startPoint)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "Project assignment create/update/delete record mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "assignment start remains Hecate-owned") {
+		t.Fatalf("warnings = %+v, want assignment authority plus Hecate-owned start warning", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantProposalAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "project-assistant-proposals",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if containsString(status.WriteAdapterGaps, "project-assistant-proposals") {
+		t.Fatalf("write gaps = %+v, want assistant proposal ledger removed for opt-in Cairnline authority", status.WriteAdapterGaps)
+	}
+	if !containsString(status.WriteAdapterGaps, "project-assistant-apply-side-effects") {
+		t.Fatalf("write gaps = %+v, want assistant apply side effects to remain Hecate-owned and blocking", status.WriteAdapterGaps)
+	}
+	point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-proposal-ledger")
+	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("project-assistant-proposal-ledger switchpoint = %+v, want opt-in Cairnline authority", point)
+	}
+	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
+	if applyPoint == nil || applyPoint.CurrentAuthority != "hecate" || applyPoint.CairnlineState != "side_effect_mirror_only" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want Hecate-owned side-effect mirror blocker", applyPoint)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "confirmed apply side effects still execute through Hecate-owned project mutation services") {
+		t.Fatalf("warnings = %+v, want assistant proposal authority plus side-effect caveat", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyWorkAuthorityConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+			CairnlineWriteAuthority: strings.Join([]string{
+				projectCairnlineWriteAuthorityProjectAssistantProposals,
+				projectCairnlineWriteAuthorityProjectRoles,
+				projectCairnlineWriteAuthorityProjectWorkItems,
+				projectCairnlineWriteAuthorityProjectAssignments,
+				projectCairnlineWriteAuthorityProjectCollaboration,
+			}, ","),
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if !containsString(status.WriteAdapterGaps, "project-assistant-apply-side-effects") {
+		t.Fatalf("write gaps = %+v, want assistant apply side effects to remain a blocking mixed-authority gap", status.WriteAdapterGaps)
+	}
+	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
+	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_work_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed authority through enabled work switchpoints", applyPoint)
+	}
+	for _, name := range []string{"roles", "work-items", "assignments", "artifacts", "handoffs", "project-assistant-proposals"} {
+		if containsString(status.WriteAdapterGaps, name) {
+			t.Fatalf("write gaps = %+v, did not expect %q when underlying work/proposal switchpoints are enabled", status.WriteAdapterGaps, name)
+		}
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "confirmed apply is mixed-authority") || !strings.Contains(warnings, "Project Assistant confirmed apply uses the enabled Cairnline authority seams") {
+		t.Fatalf("warnings = %+v, want assistant proposal authority and mixed apply-work authority caveats", status.Warnings)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+}
+
 func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	cfg := config.Config{
@@ -222,7 +580,15 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if response.Data.ReplacementReady {
 		t.Fatalf("response replacement_ready = true, want false until write authority and migration gates are ready")
 	}
-	if findReplacementGate(response.Data.ReplacementGates, "write-authority-switchpoints") == nil || findWriteSwitchpoint(response.Data.WriteSwitchpoints, "project-assistant-proposals") == nil {
+	migrationGate := findReplacementGate(response.Data.ReplacementGates, "migration-and-rollback")
+	if migrationGate == nil || migrationGate.Status != "rehearsal_available" {
+		t.Fatalf("response migration gate = %+v, want rehearsal-available blocker", migrationGate)
+	}
+	migrationSwitchpoint := findWriteSwitchpoint(response.Data.WriteSwitchpoints, "migration-cutover")
+	if migrationSwitchpoint == nil || migrationSwitchpoint.CairnlineState != "snapshot_import_rehearsal_available" || !containsString(migrationSwitchpoint.Seams, "sync-rehearsal") {
+		t.Fatalf("response migration switchpoint = %+v, want snapshot-import rehearsal blocker", migrationSwitchpoint)
+	}
+	if findReplacementGate(response.Data.ReplacementGates, "write-authority-switchpoints") == nil || findWriteSwitchpoint(response.Data.WriteSwitchpoints, "project-assistant-proposal-ledger") == nil || findWriteSwitchpoint(response.Data.WriteSwitchpoints, "project-assistant-apply-side-effects") == nil {
 		t.Fatalf("response gates/switchpoints = %+v / %+v, want structured replacement blockers", response.Data.ReplacementGates, response.Data.WriteSwitchpoints)
 	}
 }

--- a/internal/api/handler_project_health_cairnline.go
+++ b/internal/api/handler_project_health_cairnline.go
@@ -175,8 +175,10 @@ func projectHealthEvidenceFromCairnline(item cairnline.Evidence) projectwork.Col
 		Kind:               projectwork.ArtifactKindEvidenceLink,
 		Title:              item.Title,
 		Body:               item.Body,
-		EvidenceSourceKind: projectwork.EvidenceSourceExternal,
+		EvidenceSourceKind: firstNonEmptyString(strings.TrimSpace(item.SourceKind), projectwork.EvidenceSourceExternal),
 		EvidenceURL:        item.Locator,
+		EvidenceExternalID: item.ExternalID,
+		EvidenceProvider:   item.Provider,
 		EvidenceTrustLabel: item.TrustLabel,
 		CreatedAt:          item.CreatedAt,
 		UpdatedAt:          item.UpdatedAt,
@@ -196,7 +198,7 @@ func projectHealthReviewFromCairnline(item cairnline.Review) projectwork.Collabo
 		ReviewedAssignmentID:   item.AssignmentID,
 		ReviewVerdict:          projectHealthReviewVerdictFromCairnline(item.Verdict),
 		ReviewRisk:             projectHealthReviewRiskFromCairnline(item.Risk),
-		ReviewFollowUpRequired: item.Verdict != cairnline.ReviewVerdictPass,
+		ReviewFollowUpRequired: projectHealthReviewRequiresFollowUpFromCairnline(item.Verdict),
 		CreatedAt:              item.CreatedAt,
 		UpdatedAt:              item.UpdatedAt,
 	}
@@ -226,16 +228,20 @@ func projectHealthHandoffFromCairnline(item cairnline.Handoff) projectwork.Hando
 		CreatedByRoleID:       item.FromRoleID,
 		CreatedAt:             item.CreatedAt,
 		UpdatedAt:             item.UpdatedAt,
-		StatusChangedAt:       item.UpdatedAt,
+		StatusChangedAt:       projectworkTime(item.StatusChangedAt, item.UpdatedAt),
 	}
 }
 
 func projectHealthReviewVerdictFromCairnline(verdict string) string {
 	switch strings.TrimSpace(verdict) {
-	case cairnline.ReviewVerdictPass:
+	case cairnline.ReviewVerdictApproved:
 		return projectwork.ReviewVerdictApproved
+	case cairnline.ReviewVerdictChangesRequested:
+		return projectwork.ReviewVerdictChangesRequested
 	case cairnline.ReviewVerdictBlocked:
 		return projectwork.ReviewVerdictBlocked
+	case cairnline.ReviewVerdictRisk:
+		return projectwork.ReviewVerdictRisk
 	default:
 		return projectwork.ReviewVerdictChangesRequested
 	}
@@ -247,6 +253,15 @@ func projectHealthReviewRiskFromCairnline(risk string) string {
 		return strings.TrimSpace(risk)
 	default:
 		return projectwork.ReviewRiskUnknown
+	}
+}
+
+func projectHealthReviewRequiresFollowUpFromCairnline(verdict string) bool {
+	switch strings.TrimSpace(verdict) {
+	case cairnline.ReviewVerdictChangesRequested, cairnline.ReviewVerdictBlocked:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/api/handler_project_identity_authority.go
+++ b/internal/api/handler_project_identity_authority.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projectapp"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+const projectCairnlineWriteAuthorityProjectIdentity = "project-identity"
+
+func (h *Handler) projectIdentityWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectIdentity)
+}
+
+func (h *Handler) createProjectWithCairnlineAuthority(ctx context.Context, project projects.Project) (projects.Project, error) {
+	if err := h.validateProjectMetadataDefaultsHecateCompatibility(ctx, project); err != nil {
+		return projects.Project{}, err
+	}
+	if err := h.validateProjectRootsHecateCompatibility(ctx, project); err != nil {
+		return projects.Project{}, err
+	}
+	if err := validateProjectContextSourcesHecateCompatibility(project); err != nil {
+		return projects.Project{}, err
+	}
+
+	var written cairnline.Project
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if executionProfile, ok := cairnlinebridge.ProjectExecutionProfile(project); ok {
+			if err := upsertProjectExecutionProfileForCairnlineAuthority(ctx, service, executionProfile); err != nil {
+				return err
+			}
+		}
+		created, err := service.CreateProject(ctx, cairnlinebridge.Project(project))
+		if err != nil {
+			if executionProfile, ok := cairnlinebridge.ProjectExecutionProfile(project); ok {
+				_ = service.DeleteExecutionProfile(ctx, executionProfile.ID)
+			}
+			return err
+		}
+		written = created
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, err
+	}
+	shadow := projectFromCairnlineProjectCreate(project, written)
+	if shadowed, ok := h.shadowProjectCreateToHecate(ctx, "project_identity_cairnline_authority_create", shadow); ok {
+		return shadowed, nil
+	}
+	return shadow, nil
+}
+
+func (h *Handler) deleteProjectWithCairnlineAuthority(ctx context.Context, projectID string) (projectapp.DeleteProjectResult, error) {
+	snapshot, err := cairnlinebridge.LoadSnapshot(ctx, h.cairnlineSnapshotSources(), projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		return projectapp.DeleteProjectResult{}, projectapp.ErrProjectNotFound
+	}
+	if err != nil {
+		return projectapp.DeleteProjectResult{}, err
+	}
+	if err := h.deleteProjectIdentityFromCairnline(ctx, snapshot.Project); err != nil {
+		return projectapp.DeleteProjectResult{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	result, err := h.projectApplication().DeleteProject(ctx, projectID)
+	if err == nil {
+		return result, nil
+	}
+	if restoreErr := h.restoreProjectSnapshotToCairnline(ctx, snapshot); restoreErr != nil {
+		h.logCairnlineMirrorError(ctx, "project_identity_cairnline_authority_delete_rollback", snapshot.Project.ID, restoreErr)
+		return result, errors.Join(err, fmt.Errorf("restore Cairnline project snapshot after failed delete: %w", restoreErr))
+	}
+	return result, err
+}
+
+func (h *Handler) restoreProjectSnapshotToCairnline(ctx context.Context, snapshot cairnlinebridge.Snapshot) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		return cairnlinebridge.Seed(ctx, service, snapshot)
+	})
+}
+
+func upsertProjectExecutionProfileForCairnlineAuthority(ctx context.Context, service *cairnline.Service, profile cairnline.ExecutionProfile) error {
+	if service == nil {
+		return errors.New("cairnline service is required")
+	}
+	if strings.TrimSpace(profile.ID) == "" {
+		return nil
+	}
+	if _, err := service.UpdateExecutionProfile(ctx, profile); err != nil {
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		_, err = service.CreateExecutionProfile(ctx, profile)
+		return err
+	}
+	return nil
+}
+
+func projectFromCairnlineProjectCreate(native projects.Project, written cairnline.Project) projects.Project {
+	project := native
+	project.ID = written.ID
+	project.Name = written.Name
+	project.Description = written.Description
+	project.Roots = projectRootsFromCairnline(written.Roots, nil)
+	project.ContextSources = projectContextSourcesFromCairnline(written.ContextSources)
+	project.DefaultRootID = written.DefaultRootID
+	project.DefaultAgentProfile = strings.TrimSpace(written.DefaultProfileID)
+	project.CreatedAt = written.CreatedAt
+	project.UpdatedAt = written.UpdatedAt
+	return project
+}
+
+func (h *Handler) shadowProjectCreateToHecate(ctx context.Context, operation string, project projects.Project) (projects.Project, bool) {
+	if h == nil || h.projects == nil {
+		return project, false
+	}
+	created, err := h.projects.Create(ctx, project)
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+		return project, false
+	}
+	return created, true
+}

--- a/internal/api/handler_project_metadata_authority.go
+++ b/internal/api/handler_project_metadata_authority.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+const projectCairnlineWriteAuthorityProjectMetadataDefaults = "project-metadata-defaults"
+
+func (h *Handler) projectMetadataDefaultsWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectMetadataDefaults)
+}
+
+func projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req updateProjectRequest) bool {
+	if req.Roots != nil || req.ContextSources != nil || req.LastOpenedAt != nil {
+		return false
+	}
+	return projectUpdateTouchesPortableMetadata(req) || projectUpdateTouchesPortableDefaults(req)
+}
+
+func (h *Handler) updateProjectMetadataDefaultsWithCairnlineAuthority(ctx context.Context, projectID string, req updateProjectRequest) (projects.Project, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, err
+	}
+	applyProjectMetadataDefaultsUpdate(&project, req)
+	if err := validateProjectDefaultRoot(project.DefaultRootID, project.Roots); err != nil {
+		return projects.Project{}, errors.Join(projects.ErrInvalid, err)
+	}
+	if err := h.validateProjectMetadataDefaultsHecateCompatibility(ctx, project); err != nil {
+		return projects.Project{}, err
+	}
+
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.seedProjectMetadataDefaultsDependenciesForCairnlineAuthority(ctx, service, project); err != nil {
+			return err
+		}
+		if projectUpdateTouchesPortableMetadata(req) {
+			if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+				return err
+			}
+		}
+		if projectUpdateTouchesPortableDefaults(req) {
+			if _, err := cairnlinebridge.UpsertProjectDefaults(ctx, service, project); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, err
+	}
+	if shadowed, ok := h.shadowProjectMetadataDefaultsToHecate(ctx, "project_metadata_defaults_cairnline_authority_update", project); ok {
+		project = shadowed
+	}
+	return project, nil
+}
+
+func applyProjectMetadataDefaultsUpdate(project *projects.Project, req updateProjectRequest) {
+	if project == nil {
+		return
+	}
+	if req.Name != nil {
+		project.Name = strings.TrimSpace(*req.Name)
+	}
+	if req.Description != nil {
+		project.Description = strings.TrimSpace(*req.Description)
+	}
+	if req.DefaultRootID != nil {
+		project.DefaultRootID = strings.TrimSpace(*req.DefaultRootID)
+	}
+	if req.DefaultProvider != nil {
+		project.DefaultProvider = strings.TrimSpace(*req.DefaultProvider)
+	}
+	if req.DefaultModel != nil {
+		project.DefaultModel = strings.TrimSpace(*req.DefaultModel)
+	}
+	if req.DefaultAgentProfile != nil {
+		project.DefaultAgentProfile = strings.TrimSpace(*req.DefaultAgentProfile)
+	}
+	if req.DefaultToolsEnabled != nil {
+		project.DefaultToolsEnabled = cloneBool(req.DefaultToolsEnabled)
+	}
+	if req.DefaultWorkspaceMode != nil {
+		project.DefaultWorkspaceMode = strings.TrimSpace(*req.DefaultWorkspaceMode)
+	}
+	if req.DefaultSystemPrompt != nil {
+		project.DefaultSystemPrompt = strings.TrimSpace(*req.DefaultSystemPrompt)
+	}
+	if req.DefaultCompactToolOutput != nil {
+		project.DefaultCompactToolOutput = cloneBool(req.DefaultCompactToolOutput)
+	}
+}
+
+func (h *Handler) validateProjectMetadataDefaultsHecateCompatibility(ctx context.Context, project projects.Project) error {
+	if h == nil || h.projects == nil {
+		return nil
+	}
+	if strings.TrimSpace(project.Name) == "" {
+		return fmt.Errorf("%w: project name is required", projects.ErrInvalid)
+	}
+	items, err := h.projects.List(ctx)
+	if err != nil {
+		return err
+	}
+	projectID := strings.TrimSpace(project.ID)
+	nameKey := strings.ToLower(strings.TrimSpace(project.Name))
+	for _, existing := range items {
+		if strings.TrimSpace(existing.ID) == projectID {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(existing.Name)) == nameKey {
+			return fmt.Errorf("%w: project name %q already exists", projects.ErrAlreadyExists, project.Name)
+		}
+	}
+	return nil
+}
+
+func (h *Handler) seedProjectMetadataDefaultsDependenciesForCairnlineAuthority(ctx context.Context, service *cairnline.Service, project projects.Project) error {
+	if strings.TrimSpace(project.DefaultRootID) != "" {
+		root, ok := projectRootForCairnlineMirror(project, project.DefaultRootID)
+		if !ok {
+			return errors.Join(projects.ErrInvalid, errors.New("default project root not found for Cairnline authority"))
+		}
+		if _, err := cairnlinebridge.UpsertRoot(ctx, service, project, root); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(project.DefaultAgentProfile) != "" {
+		if h == nil || h.agentProfiles == nil {
+			return nil
+		}
+		profile, ok, err := h.agentProfiles.Get(ctx, project.DefaultAgentProfile)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if _, err := cairnlinebridge.UpsertAgentProfile(ctx, service, profile); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (h *Handler) shadowProjectMetadataDefaultsToHecate(ctx context.Context, operation string, project projects.Project) (projects.Project, bool) {
+	if h == nil || h.projects == nil {
+		return project, false
+	}
+	updated, err := h.projects.Update(ctx, project.ID, func(item *projects.Project) {
+		item.Name = project.Name
+		item.Description = project.Description
+		item.DefaultRootID = project.DefaultRootID
+		item.DefaultProvider = project.DefaultProvider
+		item.DefaultModel = project.DefaultModel
+		item.DefaultAgentProfile = project.DefaultAgentProfile
+		item.DefaultToolsEnabled = cloneBool(project.DefaultToolsEnabled)
+		item.DefaultWorkspaceMode = project.DefaultWorkspaceMode
+		item.DefaultSystemPrompt = project.DefaultSystemPrompt
+		item.DefaultCompactToolOutput = cloneBool(project.DefaultCompactToolOutput)
+	})
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+		return project, false
+	}
+	return updated, true
+}

--- a/internal/api/handler_project_role_authority.go
+++ b/internal/api/handler_project_role_authority.go
@@ -1,0 +1,272 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
+)
+
+const projectCairnlineWriteAuthorityProjectRoles = "project-roles"
+
+func (h *Handler) projectRoleWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectRoles)
+}
+
+func (h *Handler) createProjectWorkRoleWithCairnlineAuthority(ctx context.Context, projectID string, cmd projectworkapp.CreateRoleCommand) (projectwork.AgentRoleProfile, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, err
+	}
+	role := projectwork.AgentRoleProfile{
+		ID:                  firstNonEmptyString(strings.TrimSpace(cmd.ID), newOpaqueTaskResourceID("role")),
+		ProjectID:           projectID,
+		Name:                cmd.Name,
+		Description:         cmd.Description,
+		Instructions:        cmd.Instructions,
+		DefaultDriverKind:   cmd.DefaultDriverKind,
+		DefaultProvider:     cmd.DefaultProvider,
+		DefaultModel:        cmd.DefaultModel,
+		DefaultAgentProfile: cmd.DefaultAgentProfile,
+		SkillIDs:            append([]string(nil), cmd.SkillIDs...),
+	}
+	role = normalizeProjectRoleForCairnlineAuthority(role)
+	if err := validateProjectRoleForCairnlineAuthority(role); err != nil {
+		return projectwork.AgentRoleProfile{}, err
+	}
+
+	var created projectwork.AgentRoleProfile
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		if _, err := getCairnlineProjectRoleForAuthority(ctx, service, projectID, role.ID); err == nil {
+			return cairnline.ErrDuplicate
+		} else if !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+		if _, err := h.writeRoleAgentProfileToCairnline(ctx, service, role); err != nil {
+			return err
+		}
+		recorded, err := cairnlinebridge.UpsertRole(ctx, service, role)
+		if err != nil {
+			return err
+		}
+		created, err = h.projectWorkRoleFromCairnlineAuthority(ctx, service, recorded, projectwork.AgentRoleProfile{})
+		return err
+	})
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, err
+	}
+	if shadowed, ok := h.shadowProjectRoleToHecate(ctx, "project_role_cairnline_authority_create", created); ok {
+		created = shadowed
+	}
+	return created, nil
+}
+
+func (h *Handler) updateProjectWorkRoleWithCairnlineAuthority(ctx context.Context, projectID, roleID string, cmd projectworkapp.UpdateRoleCommand) (projectwork.AgentRoleProfile, error) {
+	if projectwork.IsBuiltInRoleID(roleID) {
+		return projectwork.AgentRoleProfile{}, projectwork.ErrBuiltInRole
+	}
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, err
+	}
+
+	var updated projectwork.AgentRoleProfile
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		existing, err := getCairnlineProjectRoleForAuthority(ctx, service, projectID, roleID)
+		if err != nil {
+			return err
+		}
+		role, err := h.projectWorkRoleFromCairnlineAuthority(ctx, service, existing, projectwork.AgentRoleProfile{})
+		if err != nil {
+			return err
+		}
+		applyProjectRoleUpdate(&role, cmd)
+		role = normalizeProjectRoleForCairnlineAuthority(role)
+		if err := validateProjectRoleForCairnlineAuthority(role); err != nil {
+			return err
+		}
+		if _, err := h.writeRoleAgentProfileToCairnline(ctx, service, role); err != nil {
+			return err
+		}
+		recorded, err := cairnlinebridge.UpsertRole(ctx, service, role)
+		if err != nil {
+			return err
+		}
+		updated, err = h.projectWorkRoleFromCairnlineAuthority(ctx, service, recorded, projectwork.AgentRoleProfile{})
+		return err
+	})
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, err
+	}
+	if shadowed, ok := h.shadowProjectRoleToHecate(ctx, "project_role_cairnline_authority_update", updated); ok {
+		updated = shadowed
+	}
+	return updated, nil
+}
+
+func (h *Handler) deleteProjectWorkRoleWithCairnlineAuthority(ctx context.Context, projectID, roleID string) error {
+	if projectwork.IsBuiltInRoleID(roleID) {
+		return projectwork.ErrBuiltInRole
+	}
+	var deleted projectwork.AgentRoleProfile
+	if err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := getCairnlineProjectRoleForAuthority(ctx, service, projectID, roleID)
+		if err != nil {
+			return err
+		}
+		deleted, err = h.projectWorkRoleFromCairnlineAuthority(ctx, service, existing, projectwork.AgentRoleProfile{})
+		if err != nil {
+			return err
+		}
+		return cairnlinebridge.DeleteRole(ctx, service, deleted)
+	}); err != nil {
+		return err
+	}
+	h.shadowProjectRoleDeleteToHecate(ctx, "project_role_cairnline_authority_delete", projectID, roleID)
+	return nil
+}
+
+func (h *Handler) projectWorkRoleFromCairnlineAuthority(ctx context.Context, service *cairnline.Service, role cairnline.Role, native projectwork.AgentRoleProfile) (projectwork.AgentRoleProfile, error) {
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return projectwork.AgentRoleProfile{}, err
+	}
+	return projectWorkRoleFromCairnline(role, cairnlineExecutionProfilesByID(executionProfiles), native), nil
+}
+
+func getCairnlineProjectRoleForAuthority(ctx context.Context, service *cairnline.Service, projectID, roleID string) (cairnline.Role, error) {
+	roles, err := service.ListRoles(ctx, projectID)
+	if err != nil {
+		return cairnline.Role{}, err
+	}
+	roleID = strings.TrimSpace(roleID)
+	for _, role := range roles {
+		if role.ID == roleID {
+			return role, nil
+		}
+	}
+	return cairnline.Role{}, cairnline.ErrNotFound
+}
+
+func normalizeProjectRoleForCairnlineAuthority(role projectwork.AgentRoleProfile) projectwork.AgentRoleProfile {
+	role.ID = strings.TrimSpace(role.ID)
+	role.ProjectID = strings.TrimSpace(role.ProjectID)
+	role.Name = strings.TrimSpace(role.Name)
+	role.Description = strings.TrimSpace(role.Description)
+	role.Instructions = strings.TrimSpace(role.Instructions)
+	role.DefaultDriverKind = strings.TrimSpace(role.DefaultDriverKind)
+	role.DefaultProvider = strings.TrimSpace(role.DefaultProvider)
+	role.DefaultModel = strings.TrimSpace(role.DefaultModel)
+	role.DefaultAgentProfile = strings.TrimSpace(role.DefaultAgentProfile)
+	role.SkillIDs = compactProjectWorkAuthorityStrings(role.SkillIDs)
+	return role
+}
+
+func validateProjectRoleForCairnlineAuthority(role projectwork.AgentRoleProfile) error {
+	if projectwork.IsBuiltInRoleID(role.ID) || role.BuiltIn {
+		return projectwork.ErrBuiltInRole
+	}
+	if role.ProjectID == "" {
+		return fmt.Errorf("%w: project_id is required", projectwork.ErrInvalid)
+	}
+	if role.ID == "" {
+		return fmt.Errorf("%w: role id is required", projectwork.ErrInvalid)
+	}
+	if role.Name == "" {
+		return fmt.Errorf("%w: role name is required", projectwork.ErrInvalid)
+	}
+	if !validProjectRoleDefaultDriverForCairnlineAuthority(role.DefaultDriverKind) {
+		return fmt.Errorf("%w: unsupported role default_driver_kind %q", projectwork.ErrInvalid, role.DefaultDriverKind)
+	}
+	return nil
+}
+
+func validProjectRoleDefaultDriverForCairnlineAuthority(driver string) bool {
+	switch strings.TrimSpace(driver) {
+	case "", projectwork.AssignmentDriverHecateTask, projectwork.AssignmentDriverExternalAgent:
+		return true
+	default:
+		return false
+	}
+}
+
+func applyProjectRoleUpdate(role *projectwork.AgentRoleProfile, cmd projectworkapp.UpdateRoleCommand) {
+	if role == nil {
+		return
+	}
+	if cmd.Name != nil {
+		role.Name = *cmd.Name
+	}
+	if cmd.Description != nil {
+		role.Description = *cmd.Description
+	}
+	if cmd.Instructions != nil {
+		role.Instructions = *cmd.Instructions
+	}
+	if cmd.DefaultDriverKind != nil {
+		role.DefaultDriverKind = *cmd.DefaultDriverKind
+	}
+	if cmd.DefaultProvider != nil {
+		role.DefaultProvider = *cmd.DefaultProvider
+	}
+	if cmd.DefaultModel != nil {
+		role.DefaultModel = *cmd.DefaultModel
+	}
+	if cmd.DefaultAgentProfile != nil {
+		role.DefaultAgentProfile = *cmd.DefaultAgentProfile
+	}
+	if cmd.SkillIDs != nil {
+		role.SkillIDs = append([]string(nil), cmd.SkillIDs...)
+	}
+}
+
+func (h *Handler) shadowProjectRoleToHecate(ctx context.Context, operation string, role projectwork.AgentRoleProfile) (projectwork.AgentRoleProfile, bool) {
+	if h == nil || h.projectWork == nil {
+		return projectwork.AgentRoleProfile{}, false
+	}
+	if updated, err := h.projectWork.UpdateRole(ctx, role.ProjectID, role.ID, func(existing *projectwork.AgentRoleProfile) {
+		*existing = role
+	}); err == nil {
+		return updated, true
+	} else if !errors.Is(err, projectwork.ErrNotFound) {
+		h.logProjectRoleShadowError(ctx, operation, role.ProjectID, role.ID, err)
+		return projectwork.AgentRoleProfile{}, false
+	}
+	created, err := h.projectWork.CreateRole(ctx, role)
+	if err == nil {
+		return created, true
+	}
+	if !errors.Is(err, projectwork.ErrDuplicateRole) {
+		h.logProjectRoleShadowError(ctx, operation, role.ProjectID, role.ID, err)
+	}
+	return projectwork.AgentRoleProfile{}, false
+}
+
+func (h *Handler) shadowProjectRoleDeleteToHecate(ctx context.Context, operation, projectID, roleID string) {
+	if h == nil || h.projectWork == nil {
+		return
+	}
+	if err := h.projectWork.DeleteRole(ctx, projectID, roleID); err != nil && !errors.Is(err, projectwork.ErrNotFound) {
+		h.logProjectRoleShadowError(ctx, operation, projectID, roleID, err)
+	}
+}
+
+func (h *Handler) logProjectRoleShadowError(ctx context.Context, operation, projectID, roleID string, err error) {
+	if err == nil || h == nil || h.logger == nil {
+		return
+	}
+	h.logger.WarnContext(ctx, "project role Hecate shadow failed", "operation", operation, "project_id", projectID, "role_id", roleID, "error", err)
+}

--- a/internal/api/handler_project_root_source_authority.go
+++ b/internal/api/handler_project_root_source_authority.go
@@ -1,0 +1,695 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projectapp"
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+const (
+	projectCairnlineWriteAuthorityProjectRoots          = "project-roots"
+	projectCairnlineWriteAuthorityProjectContextSources = "project-context-sources"
+)
+
+func (h *Handler) projectRootWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectRoots)
+}
+
+func (h *Handler) projectContextSourceWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectContextSources)
+}
+
+func (h *Handler) projectRootSourceListUpdateWritesUseCairnlineAuthority(req updateProjectRequest) bool {
+	if req.Roots == nil && req.ContextSources == nil {
+		return false
+	}
+	if req.LastOpenedAt != nil || projectUpdateTouchesPortableMetadata(req) {
+		return false
+	}
+	if req.DefaultProvider != nil ||
+		req.DefaultModel != nil ||
+		req.DefaultAgentProfile != nil ||
+		req.DefaultToolsEnabled != nil ||
+		req.DefaultWorkspaceMode != nil ||
+		req.DefaultSystemPrompt != nil ||
+		req.DefaultCompactToolOutput != nil {
+		return false
+	}
+	if req.DefaultRootID != nil && req.Roots == nil {
+		return false
+	}
+	if req.Roots != nil && !h.projectRootWritesUseCairnlineAuthority() {
+		return false
+	}
+	if req.ContextSources != nil && !h.projectContextSourceWritesUseCairnlineAuthority() {
+		return false
+	}
+	return true
+}
+
+func (h *Handler) updateProjectRootSourceListsWithCairnlineAuthority(ctx context.Context, projectID string, req updateProjectRequest, roots []projects.Root, sources []projects.ContextSource) (projects.Project, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	if req.Roots != nil {
+		project.Roots = append([]projects.Root(nil), roots...)
+		if req.DefaultRootID != nil {
+			project.DefaultRootID = strings.TrimSpace(*req.DefaultRootID)
+		} else if !projectRootIDExists(project.DefaultRootID, project.Roots) {
+			project.DefaultRootID = ""
+		}
+		if project.DefaultRootID == "" && len(project.Roots) > 0 {
+			project.DefaultRootID = project.Roots[0].ID
+		}
+	}
+	if req.ContextSources != nil {
+		project.ContextSources = append([]projects.ContextSource(nil), sources...)
+	}
+	if err := h.validateProjectRootsHecateCompatibility(ctx, project); err != nil {
+		return projects.Project{}, err
+	}
+	if err := validateProjectContextSourcesHecateCompatibility(project); err != nil {
+		return projects.Project{}, err
+	}
+
+	var written cairnline.Project
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		next := cairnline.Project{}
+		if req.Roots != nil {
+			updated, err := cairnlinebridge.ReplaceProjectRoots(ctx, service, project, project.Roots)
+			if err != nil {
+				return err
+			}
+			next = updated
+		}
+		if req.ContextSources != nil {
+			updated, err := cairnlinebridge.ReplaceProjectContextSources(ctx, service, project, project.ContextSources)
+			if err != nil {
+				return err
+			}
+			next = updated
+		}
+		written = next
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	if shadowed, ok := h.shadowProjectRootSourceListsToHecate(ctx, "project_root_source_lists_cairnline_authority_replace", project, written, req.Roots != nil, req.ContextSources != nil); ok {
+		return shadowed, nil
+	}
+	return projectFromCairnlineRootSourceListReplace(project, written, req.Roots != nil, req.ContextSources != nil), nil
+}
+
+func (h *Handler) replaceProjectContextSourcesWithCairnlineAuthority(ctx context.Context, projectID string, sources []projects.ContextSource, operation string) (projects.Project, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	project.ContextSources = append([]projects.ContextSource(nil), sources...)
+	if err := validateProjectContextSourcesHecateCompatibility(project); err != nil {
+		return projects.Project{}, err
+	}
+	var written cairnline.Project
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		updated, err := cairnlinebridge.ReplaceProjectContextSources(ctx, service, project, project.ContextSources)
+		if err != nil {
+			return err
+		}
+		written = updated
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	if shadowed, ok := h.shadowProjectRootSourceListsToHecate(ctx, operation, project, written, false, true); ok {
+		return shadowed, nil
+	}
+	return projectFromCairnlineRootSourceListReplace(project, written, false, true), nil
+}
+
+func (h *Handler) replaceProjectRootsWithCairnlineAuthority(ctx context.Context, projectID string, roots []projects.Root, defaultRootID string, operation string) (projects.Project, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	project.Roots = append([]projects.Root(nil), roots...)
+	project.DefaultRootID = strings.TrimSpace(defaultRootID)
+	if err := h.validateProjectRootsHecateCompatibility(ctx, project); err != nil {
+		return projects.Project{}, err
+	}
+	var written cairnline.Project
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		updated, err := cairnlinebridge.ReplaceProjectRoots(ctx, service, project, project.Roots)
+		if err != nil {
+			return err
+		}
+		written = updated
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	if shadowed, ok := h.shadowProjectRootSourceListsToHecate(ctx, operation, project, written, true, false); ok {
+		return shadowed, nil
+	}
+	return projectFromCairnlineRootSourceListReplace(project, written, true, false), nil
+}
+
+func (h *Handler) createProjectRootWithCairnlineAuthority(ctx context.Context, projectID string, root projects.Root) (projects.Project, projects.Root, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projects.Root{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	root.ID = strings.TrimSpace(root.ID)
+	if root.ID == "" {
+		return projects.Project{}, projects.Root{}, fmt.Errorf("%w: project root id is required", projects.ErrInvalid)
+	}
+	if projectRootIDExists(root.ID, project.Roots) {
+		return projects.Project{}, projects.Root{}, fmt.Errorf("%w: project root %q already exists", projectapp.ErrProjectRootConflict, root.ID)
+	}
+	candidate := project
+	candidate.Roots = append(append([]projects.Root(nil), project.Roots...), root)
+	if err := h.validateProjectRootsHecateCompatibility(ctx, candidate); err != nil {
+		return projects.Project{}, projects.Root{}, err
+	}
+
+	var written cairnline.Project
+	var created cairnline.Root
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		next, item, err := service.CreateRoot(ctx, project.ID, cairnlinebridge.Root(root))
+		if err != nil {
+			return err
+		}
+		written = next
+		created = item
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projects.Root{}, projectAppErrorFromCairnlineAuthority(err, "root")
+	}
+	project, createdRoot := h.shadowProjectRootsToHecate(ctx, "project_root_cairnline_authority_create", project, written, created.ID)
+	return project, createdRoot, nil
+}
+
+func (h *Handler) updateProjectRootWithCairnlineAuthority(ctx context.Context, projectID, rootID string, root projects.Root) (projects.Project, projects.Root, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projects.Root{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	rootID = strings.TrimSpace(rootID)
+	if rootID == "" {
+		return projects.Project{}, projects.Root{}, projectapp.ErrProjectRootNotFound
+	}
+	if _, ok := findProjectRootByID(project.Roots, rootID); !ok {
+		return projects.Project{}, projects.Root{}, projectapp.ErrProjectRootNotFound
+	}
+	root.ID = rootID
+	candidate := project
+	candidate.Roots = replaceProjectRootByID(project.Roots, rootID, root)
+	if err := h.validateProjectRootsHecateCompatibility(ctx, candidate); err != nil {
+		return projects.Project{}, projects.Root{}, err
+	}
+
+	var written cairnline.Project
+	var updated cairnline.Root
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		next, item, err := service.UpdateRoot(ctx, project.ID, rootID, cairnlinebridge.Root(root))
+		if err != nil {
+			return err
+		}
+		written = next
+		updated = item
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projects.Root{}, projectAppErrorFromCairnlineAuthority(err, "root")
+	}
+	project, updatedRoot := h.shadowProjectRootsToHecate(ctx, "project_root_cairnline_authority_update", project, written, updated.ID)
+	return project, updatedRoot, nil
+}
+
+func (h *Handler) deleteProjectRootWithCairnlineAuthority(ctx context.Context, projectID, rootID string) (projects.Project, projects.Root, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projects.Root{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	rootID = strings.TrimSpace(rootID)
+	if rootID == "" {
+		return projects.Project{}, projects.Root{}, projectapp.ErrProjectRootNotFound
+	}
+	deleted, ok := findProjectRootByID(project.Roots, rootID)
+	if !ok {
+		return projects.Project{}, projects.Root{}, projectapp.ErrProjectRootNotFound
+	}
+	var written cairnline.Project
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		next, _, err := service.DeleteRoot(ctx, project.ID, rootID)
+		if err != nil {
+			return err
+		}
+		written = next
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projects.Root{}, projectAppErrorFromCairnlineAuthority(err, "root")
+	}
+	project, _ = h.shadowProjectRootsToHecate(ctx, "project_root_cairnline_authority_delete", project, written, rootID)
+	return project, deleted, nil
+}
+
+func (h *Handler) createProjectContextSourceWithCairnlineAuthority(ctx context.Context, projectID string, source projects.ContextSource) (projects.Project, projects.ContextSource, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projects.ContextSource{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	source.ID = strings.TrimSpace(source.ID)
+	if source.ID == "" {
+		return projects.Project{}, projects.ContextSource{}, fmt.Errorf("%w: context source id is required", projects.ErrInvalid)
+	}
+	if projectContextSourceIDExists(source.ID, project.ContextSources) {
+		return projects.Project{}, projects.ContextSource{}, fmt.Errorf("%w: context source %q already exists", projectapp.ErrProjectContextSourceConflict, source.ID)
+	}
+	candidate := project
+	candidate.ContextSources = append(append([]projects.ContextSource(nil), project.ContextSources...), source)
+	if err := validateProjectContextSourcesHecateCompatibility(candidate); err != nil {
+		return projects.Project{}, projects.ContextSource{}, err
+	}
+
+	var written cairnline.Project
+	var created cairnline.Source
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		next, item, err := service.CreateContextSource(ctx, project.ID, cairnlinebridge.Source(source))
+		if err != nil {
+			return err
+		}
+		written = next
+		created = item
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projects.ContextSource{}, projectAppErrorFromCairnlineAuthority(err, "context-source")
+	}
+	project, createdSource := h.shadowProjectContextSourcesToHecate(ctx, "project_context_source_cairnline_authority_create", project, written, created.ID)
+	return project, createdSource, nil
+}
+
+func (h *Handler) updateProjectContextSourceWithCairnlineAuthority(ctx context.Context, projectID, sourceID string, source projects.ContextSource) (projects.Project, projects.ContextSource, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projects.ContextSource{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return projects.Project{}, projects.ContextSource{}, projectapp.ErrProjectContextSourceNotFound
+	}
+	if _, ok := findProjectContextSourceByID(project.ContextSources, sourceID); !ok {
+		return projects.Project{}, projects.ContextSource{}, projectapp.ErrProjectContextSourceNotFound
+	}
+	source.ID = sourceID
+	candidate := project
+	candidate.ContextSources = replaceProjectContextSourceByID(project.ContextSources, sourceID, source)
+	if err := validateProjectContextSourcesHecateCompatibility(candidate); err != nil {
+		return projects.Project{}, projects.ContextSource{}, err
+	}
+
+	var written cairnline.Project
+	var updated cairnline.Source
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		next, item, err := service.UpdateContextSource(ctx, project.ID, sourceID, cairnlinebridge.Source(source))
+		if err != nil {
+			return err
+		}
+		written = next
+		updated = item
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projects.ContextSource{}, projectAppErrorFromCairnlineAuthority(err, "context-source")
+	}
+	project, updatedSource := h.shadowProjectContextSourcesToHecate(ctx, "project_context_source_cairnline_authority_update", project, written, updated.ID)
+	return project, updatedSource, nil
+}
+
+func (h *Handler) deleteProjectContextSourceWithCairnlineAuthority(ctx context.Context, projectID, sourceID string) (projects.Project, projects.ContextSource, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, projects.ContextSource{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return projects.Project{}, projects.ContextSource{}, projectapp.ErrProjectContextSourceNotFound
+	}
+	deleted, ok := findProjectContextSourceByID(project.ContextSources, sourceID)
+	if !ok {
+		return projects.Project{}, projects.ContextSource{}, projectapp.ErrProjectContextSourceNotFound
+	}
+	var written cairnline.Project
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		next, _, err := service.DeleteContextSource(ctx, project.ID, sourceID)
+		if err != nil {
+			return err
+		}
+		written = next
+		return nil
+	})
+	if err != nil {
+		return projects.Project{}, projects.ContextSource{}, projectAppErrorFromCairnlineAuthority(err, "context-source")
+	}
+	project, _ = h.shadowProjectContextSourcesToHecate(ctx, "project_context_source_cairnline_authority_delete", project, written, sourceID)
+	return project, deleted, nil
+}
+
+func (h *Handler) validateProjectRootsHecateCompatibility(ctx context.Context, project projects.Project) error {
+	if strings.TrimSpace(project.ID) == "" {
+		return fmt.Errorf("%w: project id is required", projects.ErrInvalid)
+	}
+	rootIDs := make(map[string]struct{}, len(project.Roots))
+	rootPathKeys := make(map[string]string, len(project.Roots))
+	for _, root := range project.Roots {
+		rootID := strings.TrimSpace(root.ID)
+		if rootID == "" {
+			return fmt.Errorf("%w: project root id is required", projects.ErrInvalid)
+		}
+		rootPath := strings.TrimSpace(root.Path)
+		if rootPath == "" {
+			return fmt.Errorf("%w: project root path is required", projects.ErrInvalid)
+		}
+		if _, ok := rootIDs[rootID]; ok {
+			return fmt.Errorf("%w: duplicate project root id %q", projects.ErrInvalid, rootID)
+		}
+		rootIDs[rootID] = struct{}{}
+		pathKey := projectRootPathKeyForCairnlineAuthority(rootPath)
+		if prior, ok := rootPathKeys[pathKey]; ok {
+			return fmt.Errorf("%w: duplicate project root path %q", projects.ErrInvalid, prior)
+		}
+		rootPathKeys[pathKey] = rootPath
+	}
+	if project.DefaultRootID != "" {
+		if _, ok := rootIDs[strings.TrimSpace(project.DefaultRootID)]; !ok {
+			return fmt.Errorf("%w: default_root_id %q does not match a project root", projects.ErrInvalid, project.DefaultRootID)
+		}
+	}
+	if h == nil || h.projects == nil || len(rootPathKeys) == 0 {
+		return nil
+	}
+	items, err := h.projects.List(ctx)
+	if err != nil {
+		return err
+	}
+	projectID := strings.TrimSpace(project.ID)
+	for _, existing := range items {
+		if strings.TrimSpace(existing.ID) == projectID {
+			continue
+		}
+		for _, root := range existing.Roots {
+			if path, ok := rootPathKeys[projectRootPathKeyForCairnlineAuthority(root.Path)]; ok {
+				return fmt.Errorf("%w: project root path %q already belongs to project %q", projects.ErrAlreadyExists, path, existing.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func validateProjectContextSourcesHecateCompatibility(project projects.Project) error {
+	sourceIDs := make(map[string]struct{}, len(project.ContextSources))
+	for _, source := range project.ContextSources {
+		sourceID := strings.TrimSpace(source.ID)
+		if sourceID == "" {
+			return fmt.Errorf("%w: project context source id is required", projects.ErrInvalid)
+		}
+		if strings.TrimSpace(source.Path) == "" {
+			return fmt.Errorf("%w: project context source path is required", projects.ErrInvalid)
+		}
+		if _, ok := sourceIDs[sourceID]; ok {
+			return fmt.Errorf("%w: duplicate project context source id %q", projects.ErrInvalid, sourceID)
+		}
+		sourceIDs[sourceID] = struct{}{}
+	}
+	return nil
+}
+
+func projectRootPathKeyForCairnlineAuthority(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = filepath.Clean(path)
+	if runtime.GOOS == "windows" {
+		path = strings.ToLower(path)
+	}
+	return path
+}
+
+func findProjectRootByID(items []projects.Root, id string) (projects.Root, bool) {
+	id = strings.TrimSpace(id)
+	for _, item := range items {
+		if strings.TrimSpace(item.ID) == id {
+			return item, true
+		}
+	}
+	return projects.Root{}, false
+}
+
+func replaceProjectRootByID(items []projects.Root, id string, replacement projects.Root) []projects.Root {
+	id = strings.TrimSpace(id)
+	out := append([]projects.Root(nil), items...)
+	for idx := range out {
+		if strings.TrimSpace(out[idx].ID) == id {
+			out[idx] = replacement
+			return out
+		}
+	}
+	return out
+}
+
+func projectContextSourceIDExists(id string, items []projects.ContextSource) bool {
+	_, ok := findProjectContextSourceByID(items, id)
+	return ok
+}
+
+func findProjectContextSourceByID(items []projects.ContextSource, id string) (projects.ContextSource, bool) {
+	id = strings.TrimSpace(id)
+	for _, item := range items {
+		if strings.TrimSpace(item.ID) == id {
+			return item, true
+		}
+	}
+	return projects.ContextSource{}, false
+}
+
+func replaceProjectContextSourceByID(items []projects.ContextSource, id string, replacement projects.ContextSource) []projects.ContextSource {
+	id = strings.TrimSpace(id)
+	out := append([]projects.ContextSource(nil), items...)
+	for idx := range out {
+		if strings.TrimSpace(out[idx].ID) == id {
+			out[idx] = replacement
+			return out
+		}
+	}
+	return out
+}
+
+func (h *Handler) shadowProjectRootsToHecate(ctx context.Context, operation string, project projects.Project, written cairnline.Project, rootID string) (projects.Project, projects.Root) {
+	project.Roots = projectRootsFromCairnline(written.Roots, project.Roots)
+	project.DefaultRootID = strings.TrimSpace(written.DefaultRootID)
+	shadowed, err := h.projects.Update(ctx, project.ID, func(item *projects.Project) {
+		item.Roots = append([]projects.Root(nil), project.Roots...)
+		item.DefaultRootID = project.DefaultRootID
+	})
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+		root, _ := findProjectRootByID(project.Roots, rootID)
+		return project, root
+	}
+	root, _ := findProjectRootByID(shadowed.Roots, rootID)
+	return shadowed, root
+}
+
+func (h *Handler) shadowProjectContextSourcesToHecate(ctx context.Context, operation string, project projects.Project, written cairnline.Project, sourceID string) (projects.Project, projects.ContextSource) {
+	project.ContextSources = projectContextSourcesFromCairnline(written.ContextSources)
+	shadowed, err := h.projects.Update(ctx, project.ID, func(item *projects.Project) {
+		item.ContextSources = append([]projects.ContextSource(nil), project.ContextSources...)
+	})
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+		source, _ := findProjectContextSourceByID(project.ContextSources, sourceID)
+		return project, source
+	}
+	source, _ := findProjectContextSourceByID(shadowed.ContextSources, sourceID)
+	return shadowed, source
+}
+
+func projectFromCairnlineRootSourceListReplace(project projects.Project, written cairnline.Project, replaceRoots, replaceSources bool) projects.Project {
+	if replaceRoots {
+		project.Roots = projectRootsFromCairnline(written.Roots, project.Roots)
+		project.DefaultRootID = strings.TrimSpace(written.DefaultRootID)
+	}
+	if replaceSources {
+		project.ContextSources = projectContextSourcesFromCairnline(written.ContextSources)
+	}
+	project.UpdatedAt = written.UpdatedAt
+	return project
+}
+
+func (h *Handler) shadowProjectRootSourceListsToHecate(ctx context.Context, operation string, project projects.Project, written cairnline.Project, replaceRoots, replaceSources bool) (projects.Project, bool) {
+	project = projectFromCairnlineRootSourceListReplace(project, written, replaceRoots, replaceSources)
+	shadowed, err := h.projects.Update(ctx, project.ID, func(item *projects.Project) {
+		if replaceRoots {
+			item.Roots = append([]projects.Root(nil), project.Roots...)
+			item.DefaultRootID = project.DefaultRootID
+		}
+		if replaceSources {
+			item.ContextSources = append([]projects.ContextSource(nil), project.ContextSources...)
+		}
+	})
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
+		return project, false
+	}
+	return shadowed, true
+}
+
+func projectAppErrorFromCairnlineAuthority(err error, missing string) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, projectapp.ErrProjectNotFound),
+		errors.Is(err, projectapp.ErrProjectRootNotFound),
+		errors.Is(err, projectapp.ErrProjectContextSourceNotFound),
+		errors.Is(err, projectapp.ErrProjectRootConflict),
+		errors.Is(err, projectapp.ErrProjectContextSourceConflict),
+		errors.Is(err, projects.ErrInvalid),
+		errors.Is(err, projects.ErrAlreadyExists):
+		return err
+	case errors.Is(err, cairnline.ErrNotFound):
+		switch missing {
+		case "root":
+			return projectapp.ErrProjectRootNotFound
+		case "context-source":
+			return projectapp.ErrProjectContextSourceNotFound
+		default:
+			return projectapp.ErrProjectNotFound
+		}
+	case errors.Is(err, cairnline.ErrDuplicate):
+		switch missing {
+		case "context-source":
+			return projectapp.ErrProjectContextSourceConflict
+		default:
+			return projectapp.ErrProjectRootConflict
+		}
+	case errors.Is(err, cairnline.ErrInvalid):
+		return errors.Join(projects.ErrInvalid, err)
+	default:
+		return err
+	}
+}
+
+func writeProjectRootCairnlineAuthorityResponse(w http.ResponseWriter, status int, project projects.Project, err error) {
+	if errors.Is(err, projectapp.ErrProjectNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	if errors.Is(err, projectapp.ErrProjectRootNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project root not found")
+		return
+	}
+	if errors.Is(err, projectapp.ErrProjectRootConflict) || errors.Is(err, projects.ErrAlreadyExists) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+		return
+	}
+	if errors.Is(err, projects.ErrInvalid) {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, status, ProjectResponse{Object: "project", Data: renderProject(project)})
+}
+
+func writeProjectListReplaceCairnlineAuthorityResponse(w http.ResponseWriter, project projects.Project, err error) {
+	if errors.Is(err, projectapp.ErrProjectNotFound) || errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	if errors.Is(err, projectapp.ErrProjectRootConflict) || errors.Is(err, projectapp.ErrProjectContextSourceConflict) || errors.Is(err, projects.ErrAlreadyExists) || errors.Is(err, cairnline.ErrDuplicate) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+		return
+	}
+	if errors.Is(err, projects.ErrInvalid) || errors.Is(err, cairnline.ErrInvalid) {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
+}
+
+func writeProjectContextSourceCairnlineAuthorityResponse(w http.ResponseWriter, status int, project projects.Project, err error) {
+	if errors.Is(err, projectapp.ErrProjectNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+		return
+	}
+	if errors.Is(err, projectapp.ErrProjectContextSourceNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project context source not found")
+		return
+	}
+	if errors.Is(err, projectapp.ErrProjectContextSourceConflict) || errors.Is(err, projects.ErrAlreadyExists) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+		return
+	}
+	if errors.Is(err, projects.ErrInvalid) {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, status, ProjectResponse{Object: "project", Data: renderProject(project)})
+}

--- a/internal/api/handler_project_roots_discovery.go
+++ b/internal/api/handler_project_roots_discovery.go
@@ -48,6 +48,16 @@ func (h *Handler) HandleDiscoverProjectRoots(w http.ResponseWriter, r *http.Requ
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
+	merged := mergeDiscoveredProjectRoots(project.Roots, discovered)
+	defaultRootID := strings.TrimSpace(project.DefaultRootID)
+	if defaultRootID == "" && len(merged) > 0 {
+		defaultRootID = merged[0].ID
+	}
+	if h.projectRootWritesUseCairnlineAuthority() {
+		updated, err := h.replaceProjectRootsWithCairnlineAuthority(r.Context(), project.ID, merged, defaultRootID, "project_roots_cairnline_authority_discover")
+		writeProjectListReplaceCairnlineAuthorityResponse(w, updated, err)
+		return
+	}
 	updated, err := h.projects.Update(r.Context(), project.ID, func(item *projects.Project) {
 		item.Roots = mergeDiscoveredProjectRoots(item.Roots, discovered)
 		if item.DefaultRootID == "" && len(item.Roots) > 0 {
@@ -84,6 +94,16 @@ func (h *Handler) HandleCreateProjectWorktreeRoot(w http.ResponseWriter, r *http
 	root, _, err := createProjectWorktreeRoot(r.Context(), project, req, gitrunner.NewLocalRunner())
 	if err != nil {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return
+	}
+	if h.projectRootWritesUseCairnlineAuthority() {
+		roots := append(append([]projects.Root(nil), project.Roots...), root)
+		defaultRootID := strings.TrimSpace(project.DefaultRootID)
+		if req.SetDefault {
+			defaultRootID = root.ID
+		}
+		updated, err := h.replaceProjectRootsWithCairnlineAuthority(r.Context(), project.ID, roots, defaultRootID, "project_worktree_root_cairnline_authority_create")
+		writeProjectRootCairnlineAuthorityResponse(w, http.StatusCreated, updated, err)
 		return
 	}
 	updated, err := h.projects.Update(r.Context(), project.ID, func(item *projects.Project) {

--- a/internal/api/handler_project_roots_discovery_test.go
+++ b/internal/api/handler_project_roots_discovery_test.go
@@ -131,6 +131,74 @@ func TestProjectRootsDiscovery_MirrorsRootsWithoutReplacingCairnlineState(t *tes
 	}
 }
 
+func TestProjectRootsDiscovery_CairnlineAuthorityCommitsDiscoveredRootsFirst(t *testing.T) {
+	t.Parallel()
+	repo := initProjectRootDiscoveryRepo(t)
+	worktree := filepath.Join(t.TempDir(), "feature-worktree")
+	if err := exec.Command("git", "-C", repo, "worktree", "add", "-b", "feature/worktrees", worktree).Run(); err != nil {
+		t.Fatalf("git worktree add: %v", err)
+	}
+
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectRoots,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+
+	project := projects.Project{
+		ID:            "proj_roots_authority",
+		Name:          "Roots authority",
+		DefaultRootID: "root_main",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   repo,
+			Kind:   "git",
+			Active: true,
+		}},
+	}
+	if _, err := projectStore.Create(t.Context(), project); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	seedCairnlineProjectRootsForTest(t, handler, project.ID, repo)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_roots_authority/roots/discover", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var resp ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode discovery response: %v", err)
+	}
+	if resp.Data.DefaultRootID != "root_main" {
+		t.Fatalf("response default_root_id = %q, want root_main", resp.Data.DefaultRootID)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, project.ID)
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_cairnline_only") != nil {
+		t.Fatalf("mirrored roots = %+v, want stale Cairnline-only root removed by authoritative discovery replacement", mirrored.Roots)
+	}
+	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
+		t.Fatalf("mirrored context sources = %+v, want unrelated Cairnline-only source preserved", mirrored.ContextSources)
+	}
+	var discoveredRoot *cairnline.Root
+	wantPath := canonicalProjectRootDiscoveryTestPath(t, worktree)
+	for idx := range mirrored.Roots {
+		if canonicalProjectRootDiscoveryTestPath(t, mirrored.Roots[idx].Path) == wantPath {
+			discoveredRoot = &mirrored.Roots[idx]
+			break
+		}
+	}
+	if discoveredRoot == nil || discoveredRoot.Kind != "git_worktree" || discoveredRoot.GitBranch != "feature/worktrees" || discoveredRoot.Active {
+		t.Fatalf("mirrored discovered root = %+v in %+v, want inactive feature worktree root", discoveredRoot, mirrored.Roots)
+	}
+}
+
 func TestProjectRoots_CreateWorktreeRoot(t *testing.T) {
 	t.Parallel()
 	repo := initProjectRootDiscoveryRepo(t)
@@ -212,6 +280,88 @@ func TestProjectRoots_CreateWorktreeRoot(t *testing.T) {
 	}
 	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
 		t.Fatalf("mirrored context sources = %+v, want Cairnline-only source preserved", mirrored.ContextSources)
+	}
+}
+
+func TestProjectRoots_CreateWorktreeRoot_CairnlineAuthorityCommitsRootRecordFirst(t *testing.T) {
+	t.Parallel()
+	repo := initProjectRootDiscoveryRepo(t)
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectRoots,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(quietLogger(), handler)
+
+	project := projects.Project{
+		ID:            "proj_roots_authority",
+		Name:          "Roots authority",
+		DefaultRootID: "root_main",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   repo,
+			Kind:   "git",
+			Active: true,
+		}},
+	}
+	if _, err := projectStore.Create(t.Context(), project); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	seedCairnlineProjectRootsForTest(t, handler, project.ID, repo)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_roots_authority/roots/worktrees", bytes.NewReader([]byte(`{
+		"base_root_id":"root_main",
+		"branch":"feature/create-root-authority",
+		"active":true,
+		"set_default":true
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create worktree status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var resp ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode create worktree response: %v", err)
+	}
+	if len(resp.Data.Roots) != 2 {
+		t.Fatalf("roots = %+v, want main plus created worktree", resp.Data.Roots)
+	}
+	created := resp.Data.Roots[1]
+	wantPath := filepath.Join(repo, ".worktrees", "feature-create-root-authority")
+	if created.ID == "" || created.Kind != "git_worktree" || created.GitBranch != "feature/create-root-authority" || !created.Active || resp.Data.DefaultRootID != created.ID {
+		t.Fatalf("created root = %+v default=%q, want active default git worktree", created, resp.Data.DefaultRootID)
+	}
+	if canonicalProjectRootDiscoveryTestPath(t, created.Path) != canonicalProjectRootDiscoveryTestPath(t, wantPath) {
+		t.Fatalf("created path = %q, want %q", created.Path, wantPath)
+	}
+
+	shadowed, ok, err := projectStore.Get(t.Context(), project.ID)
+	if err != nil || !ok {
+		t.Fatalf("shadowed Hecate project lookup ok=%v err=%v", ok, err)
+	}
+	if _, ok := findProjectRootByID(shadowed.Roots, created.ID); !ok || shadowed.DefaultRootID != created.ID {
+		t.Fatalf("shadowed roots = %+v default=%q, want created root shadowed as default", shadowed.Roots, shadowed.DefaultRootID)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, project.ID)
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_cairnline_only") != nil {
+		t.Fatalf("mirrored roots = %+v, want stale Cairnline-only root removed by authoritative worktree-root record replacement", mirrored.Roots)
+	}
+	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
+		t.Fatalf("mirrored context sources = %+v, want unrelated Cairnline-only source preserved", mirrored.ContextSources)
+	}
+	var mirroredRootFound bool
+	for _, root := range mirrored.Roots {
+		if root.ID == created.ID && root.Kind == "git_worktree" && root.GitBranch == "feature/create-root-authority" && root.Active {
+			mirroredRootFound = true
+		}
+	}
+	if !mirroredRootFound || mirrored.DefaultRootID != created.ID {
+		t.Fatalf("mirrored roots = %+v default=%q, want created active worktree root as default", mirrored.Roots, mirrored.DefaultRootID)
 	}
 }
 

--- a/internal/api/handler_project_setup_readiness_cairnline.go
+++ b/internal/api/handler_project_setup_readiness_cairnline.go
@@ -97,19 +97,42 @@ func projectSetupSkillsFromCairnline(items []cairnline.ProjectSkill) []projectsk
 	out := make([]projectskills.Skill, 0, len(items))
 	for _, item := range items {
 		out = append(out, projectskills.Skill{
-			ID:          item.ID,
-			ProjectID:   item.ProjectID,
-			Title:       item.Title,
-			Description: item.Description,
-			Path:        item.Path,
-			RootID:      item.RootID,
-			Format:      item.Format,
-			Enabled:     item.Enabled,
-			Status:      item.Status,
-			TrustLabel:  item.TrustLabel,
+			ID:                     item.ID,
+			ProjectID:              item.ProjectID,
+			Title:                  item.Title,
+			Description:            item.Description,
+			Path:                   item.Path,
+			RootID:                 item.RootID,
+			Format:                 item.Format,
+			SuggestedTools:         append([]string(nil), item.SuggestedTools...),
+			RequiredPermissions:    projectSkillRequiredPermissionsFromCairnline(item.RequiredPermissions),
+			Enabled:                item.Enabled,
+			Status:                 item.Status,
+			TrustLabel:             item.TrustLabel,
+			SourceContextSourceIDs: append([]string(nil), item.SourceRefs...),
+			Warnings:               append([]string(nil), item.Warnings...),
+			DiscoveredAt:           item.DiscoveredAt,
+			CreatedAt:              item.CreatedAt,
+			UpdatedAt:              item.UpdatedAt,
 		})
 	}
 	return out
+}
+
+func projectSkillRequiredPermissionsFromCairnline(permissions cairnline.RequiredPermissions) projectskills.RequiredPermissions {
+	return projectskills.RequiredPermissions{
+		Tools:   cloneBoolPointer(permissions.Tools),
+		Writes:  cloneBoolPointer(permissions.Writes),
+		Network: cloneBoolPointer(permissions.Network),
+	}
+}
+
+func cloneBoolPointer(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
 }
 
 func projectSetupMemoryEntriesFromCairnline(items []cairnline.MemoryEntry) []memory.Entry {

--- a/internal/api/handler_project_skill_authority.go
+++ b/internal/api/handler_project_skill_authority.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+)
+
+const projectCairnlineWriteAuthorityProjectSkills = "project-skills"
+
+func (h *Handler) projectSkillWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectSkills)
+}
+
+func (h *Handler) upsertDiscoveredProjectSkillsWithCairnlineAuthority(ctx context.Context, project projects.Project, discovered []projectskills.Skill, warnings []string) ([]projectskills.Skill, error) {
+	var recorded []projectskills.Skill
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		existing, err := service.ListProjectSkills(ctx, project.ID)
+		if err != nil {
+			return err
+		}
+		existingSkills := projectSkillsFromCairnline(existing)
+		merged := projectskills.MergeDiscovered(existingSkills, discovered, project.ID, time.Now().UTC())
+		if len(warnings) > 0 {
+			for idx := range merged {
+				merged[idx].Warnings = appendUniqueProjectSkillWarnings(merged[idx].Warnings, warnings...)
+			}
+		}
+		items, err := cairnlinebridge.UpsertProjectSkills(ctx, service, merged)
+		if err != nil {
+			return err
+		}
+		recorded = projectSkillsFromCairnline(items)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	h.shadowProjectSkillsToHecate(ctx, "project_skills_cairnline_authority_discover", project.ID, recorded)
+	return recorded, nil
+}
+
+func (h *Handler) updateProjectSkillWithCairnlineAuthority(ctx context.Context, project projects.Project, skillID string, req updateProjectSkillRequest) (projectskills.Skill, error) {
+	var recorded projectskills.Skill
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+			return err
+		}
+		existing, err := service.GetProjectSkill(ctx, project.ID, skillID)
+		if err != nil {
+			return err
+		}
+		item := projectSkillFromCairnline(existing, projectskills.Skill{})
+		applyProjectSkillUpdate(&item, req)
+		updated, err := cairnlinebridge.UpsertProjectSkill(ctx, service, item)
+		if err != nil {
+			return err
+		}
+		recorded = projectSkillFromCairnline(updated, projectskills.Skill{})
+		return nil
+	})
+	if err != nil {
+		return projectskills.Skill{}, err
+	}
+	h.shadowProjectSkillUpdateToHecate(ctx, "project_skill_cairnline_authority_update", project.ID, recorded)
+	return recorded, nil
+}
+
+func applyProjectSkillUpdate(item *projectskills.Skill, req updateProjectSkillRequest) {
+	if item == nil {
+		return
+	}
+	if req.Title != nil {
+		item.Title = strings.TrimSpace(*req.Title)
+	}
+	if req.Description != nil {
+		item.Description = strings.TrimSpace(*req.Description)
+	}
+	if req.Enabled != nil {
+		item.Enabled = *req.Enabled
+	}
+	if req.TrustLabel != nil {
+		item.TrustLabel = strings.TrimSpace(*req.TrustLabel)
+	}
+}
+
+func projectSkillsFromCairnline(items []cairnline.ProjectSkill) []projectskills.Skill {
+	out := make([]projectskills.Skill, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectSkillFromCairnline(item, projectskills.Skill{}))
+	}
+	return out
+}
+
+func (h *Handler) shadowProjectSkillsToHecate(ctx context.Context, operation, projectID string, skills []projectskills.Skill) {
+	if h == nil || h.projectSkills == nil || len(skills) == 0 {
+		return
+	}
+	if _, err := h.projectSkills.UpsertDiscovered(ctx, projectID, skills); err != nil {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
+	}
+}
+
+func (h *Handler) shadowProjectSkillUpdateToHecate(ctx context.Context, operation, projectID string, skill projectskills.Skill) {
+	if h == nil || h.projectSkills == nil {
+		return
+	}
+	_, err := h.projectSkills.Update(ctx, projectID, skill.ID, func(item *projectskills.Skill) {
+		item.Title = skill.Title
+		item.Description = skill.Description
+		item.Path = skill.Path
+		item.RootID = skill.RootID
+		item.Format = skill.Format
+		item.SuggestedTools = append([]string(nil), skill.SuggestedTools...)
+		item.RequiredPermissions = skill.RequiredPermissions
+		item.Enabled = skill.Enabled
+		item.Status = skill.Status
+		item.TrustLabel = skill.TrustLabel
+		item.SourceContextSourceIDs = append([]string(nil), skill.SourceContextSourceIDs...)
+		item.Warnings = append([]string(nil), skill.Warnings...)
+	})
+	if err == nil {
+		return
+	}
+	if errors.Is(err, projectskills.ErrNotFound) {
+		h.shadowProjectSkillsToHecate(ctx, operation, projectID, []projectskills.Skill{skill})
+		return
+	}
+	h.logCairnlineMirrorError(ctx, operation, projectID, err)
+}
+
+func writeProjectSkillAuthorityError(w http.ResponseWriter, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, projectskills.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+		WriteError(w, http.StatusNotFound, errCodeNotFound, "project skill not found")
+		return true
+	}
+	if errors.Is(err, projectskills.ErrInvalid) || errors.Is(err, cairnline.ErrInvalid) {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+		return true
+	}
+	if errors.Is(err, cairnline.ErrDuplicate) || errors.Is(err, cairnline.ErrConflict) {
+		WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+		return true
+	}
+	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+	return true
+}

--- a/internal/api/handler_project_skills.go
+++ b/internal/api/handler_project_skills.go
@@ -42,7 +42,7 @@ func (h *Handler) HandleProjectSkills(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) HandleDiscoverProjectSkills(w http.ResponseWriter, r *http.Request) {
-	if h.projectSkills == nil {
+	if h.projectSkills == nil && !h.projectSkillWritesUseCairnlineAuthority() {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project skills store is not configured")
 		return
 	}
@@ -56,6 +56,14 @@ func (h *Handler) HandleDiscoverProjectSkills(w http.ResponseWriter, r *http.Req
 		return
 	}
 	discovered, warnings := projectskills.Discover(r.Context(), project)
+	if h.projectSkillWritesUseCairnlineAuthority() {
+		items, err := h.upsertDiscoveredProjectSkillsWithCairnlineAuthority(r.Context(), project, discovered, warnings)
+		if writeProjectSkillAuthorityError(w, err) {
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectSkillsResponse{Object: "project_skills", Data: renderProjectSkills(items, "cairnline")})
+		return
+	}
 	items, err := h.projectSkills.UpsertDiscovered(r.Context(), project.ID, discovered)
 	if errors.Is(err, projectskills.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
@@ -75,7 +83,7 @@ func (h *Handler) HandleDiscoverProjectSkills(w http.ResponseWriter, r *http.Req
 }
 
 func (h *Handler) HandleUpdateProjectSkill(w http.ResponseWriter, r *http.Request) {
-	if h.projectSkills == nil {
+	if h.projectSkills == nil && !h.projectSkillWritesUseCairnlineAuthority() {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project skills store is not configured")
 		return
 	}
@@ -90,6 +98,14 @@ func (h *Handler) HandleUpdateProjectSkill(w http.ResponseWriter, r *http.Reques
 	}
 	var req updateProjectSkillRequest
 	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if h.projectSkillWritesUseCairnlineAuthority() {
+		item, err := h.updateProjectSkillWithCairnlineAuthority(r.Context(), project, r.PathValue("skill_id"), req)
+		if writeProjectSkillAuthorityError(w, err) {
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectSkillResponse{Object: "project_skill", Data: renderProjectSkill(item, "cairnline")})
 		return
 	}
 	item, err := h.projectSkills.Update(r.Context(), r.PathValue("id"), r.PathValue("skill_id"), func(item *projectskills.Skill) {
@@ -191,6 +207,14 @@ func projectSkillsByID(items []projectskills.Skill) map[string]projectskills.Ski
 }
 
 func projectSkillFromCairnline(item cairnline.ProjectSkill, native projectskills.Skill) projectskills.Skill {
+	suggestedTools := append([]string(nil), native.SuggestedTools...)
+	if len(suggestedTools) == 0 {
+		suggestedTools = append([]string(nil), item.SuggestedTools...)
+	}
+	permissions := native.RequiredPermissions
+	if permissions.Empty() {
+		permissions = projectSkillRequiredPermissionsFromCairnline(item.RequiredPermissions)
+	}
 	return projectskills.Skill{
 		ID:                     item.ID,
 		ProjectID:              item.ProjectID,
@@ -199,8 +223,8 @@ func projectSkillFromCairnline(item cairnline.ProjectSkill, native projectskills
 		Path:                   item.Path,
 		RootID:                 item.RootID,
 		Format:                 item.Format,
-		SuggestedTools:         append([]string(nil), native.SuggestedTools...),
-		RequiredPermissions:    native.RequiredPermissions,
+		SuggestedTools:         suggestedTools,
+		RequiredPermissions:    permissions,
 		Enabled:                item.Enabled,
 		Status:                 item.Status,
 		TrustLabel:             item.TrustLabel,

--- a/internal/api/handler_project_skills_test.go
+++ b/internal/api/handler_project_skills_test.go
@@ -285,6 +285,132 @@ description: Build backend changes.
 	}
 }
 
+func TestProjectSkillsAPI_CairnlineWriteAuthorityCommitsSkillsFirst(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectSkills,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	root := t.TempDir()
+	writeProjectSkillAPITestFile(t, root, "docs-ai/skills/backend/SKILL.md", `---
+name: Backend
+description: Build backend changes.
+hecate:
+  suggested_tools:
+    - git.diff
+  required_permissions:
+    tools: true
+    writes: true
+    network: false
+---
+`)
+	writeProjectSkillAPITestFile(t, root, "AGENTS.md", "Use docs-ai/skills/backend/SKILL.md.\n")
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_skills_authority",
+		Name: "Skills Authority",
+		Roots: []projects.Root{{
+			ID:     "root_skills_authority",
+			Path:   root,
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_agents",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Path:    "AGENTS.md",
+			Enabled: true,
+			Format:  "agents_md",
+			Metadata: map[string]string{
+				"root_id": "root_skills_authority",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	discoverRec := httptest.NewRecorder()
+	server.ServeHTTP(discoverRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_skills_authority/skills/discover", nil))
+	if discoverRec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", discoverRec.Code, discoverRec.Body.String())
+	}
+	var discovered ProjectSkillsResponse
+	if err := json.Unmarshal(discoverRec.Body.Bytes(), &discovered); err != nil {
+		t.Fatalf("decode discover response: %v", err)
+	}
+	backend := projectSkillResponseFor(discovered.Data, "backend")
+	if backend == nil {
+		t.Fatalf("discovered skills = %+v, want backend", discovered.Data)
+	}
+	if backend.ReadBackend != "cairnline" || backend.Path != "docs-ai/skills/backend/SKILL.md" || backend.RootID != "root_skills_authority" {
+		t.Fatalf("backend response = %+v, want Cairnline-authoritative projection", *backend)
+	}
+	if len(backend.SuggestedTools) != 1 || backend.SuggestedTools[0] != "git.diff" {
+		t.Fatalf("backend suggested tools = %+v, want git.diff", backend.SuggestedTools)
+	}
+	if backend.RequiredPermissions == nil || backend.RequiredPermissions.Writes == nil || !*backend.RequiredPermissions.Writes || backend.RequiredPermissions.Network == nil || *backend.RequiredPermissions.Network {
+		t.Fatalf("backend required permissions = %+v, want writes true and network false", backend.RequiredPermissions)
+	}
+	if len(backend.SourceContextSourceIDs) != 1 || backend.SourceContextSourceIDs[0] != "ctx_agents" {
+		t.Fatalf("backend source refs = %+v, want ctx_agents", backend.SourceContextSourceIDs)
+	}
+	mirrored := getMirroredCairnlineProjectSkillForTest(t, handler, project.ID, "backend")
+	if mirrored.Title != "Backend" || len(mirrored.SuggestedTools) != 1 || mirrored.SuggestedTools[0] != "git.diff" || mirrored.RequiredPermissions.Network == nil || *mirrored.RequiredPermissions.Network {
+		t.Fatalf("Cairnline skill = %+v, want discovered metadata committed first", mirrored)
+	}
+	native, err := handler.projectSkills.List(t.Context(), project.ID)
+	if err != nil {
+		t.Fatalf("List native skills: %v", err)
+	}
+	if shadow := projectSkillResponseFor(renderProjectSkills(native, "hecate"), "backend"); shadow == nil || shadow.Title != "Backend" {
+		t.Fatalf("native shadow skills = %+v, want backend compatibility shadow", native)
+	}
+
+	patchRec := httptest.NewRecorder()
+	server.ServeHTTP(patchRec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/proj_skills_authority/skills/backend", projectSkillAPITestJSONBody(t, map[string]any{
+		"enabled":     false,
+		"title":       "Backend Owner",
+		"description": "Operator-reviewed backend guidance.",
+		"trust_label": "operator_curated_skill",
+	})))
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s, want 200", patchRec.Code, patchRec.Body.String())
+	}
+	var patched ProjectSkillResponse
+	if err := json.Unmarshal(patchRec.Body.Bytes(), &patched); err != nil {
+		t.Fatalf("decode patch response: %v", err)
+	}
+	if patched.Data.ReadBackend != "cairnline" || patched.Data.Enabled || patched.Data.Title != "Backend Owner" || patched.Data.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("patched response = %+v, want disabled Cairnline-authoritative skill", patched.Data)
+	}
+	mirrored = getMirroredCairnlineProjectSkillForTest(t, handler, project.ID, "backend")
+	if mirrored.Enabled || mirrored.Title != "Backend Owner" || mirrored.Description != "Operator-reviewed backend guidance." || mirrored.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("patched Cairnline skill = %+v, want operator override", mirrored)
+	}
+	native, err = handler.projectSkills.List(t.Context(), project.ID)
+	if err != nil {
+		t.Fatalf("List native patched skills: %v", err)
+	}
+	if shadow := projectSkillResponseFor(renderProjectSkills(native, "hecate"), "backend"); shadow == nil || shadow.Enabled || shadow.Title != "Backend Owner" || shadow.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("native shadow skills = %+v, want patched compatibility shadow", native)
+	}
+
+	rediscoverRec := httptest.NewRecorder()
+	server.ServeHTTP(rediscoverRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_skills_authority/skills/discover", nil))
+	if rediscoverRec.Code != http.StatusOK {
+		t.Fatalf("rediscover status = %d body=%s, want 200", rediscoverRec.Code, rediscoverRec.Body.String())
+	}
+	mirrored = getMirroredCairnlineProjectSkillForTest(t, handler, project.ID, "backend")
+	if mirrored.Enabled || mirrored.Title != "Backend Owner" || mirrored.Description != "Operator-reviewed backend guidance." || mirrored.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("rediscovered Cairnline skill = %+v, want operator overrides preserved", mirrored)
+	}
+}
+
 func TestProjectSkillsAPI_MirrorRefreshesSkillSourceRefsOnRediscovery(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
@@ -360,7 +361,7 @@ func (h *Handler) HandleCreateProjectWorkRole(w http.ResponseWriter, r *http.Req
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	role, err := h.projectWorkApplication().CreateRole(r.Context(), projectID, projectworkapp.CreateRoleCommand{
+	cmd := projectworkapp.CreateRoleCommand{
 		ID:                  req.ID,
 		Name:                req.Name,
 		Description:         req.Description,
@@ -370,11 +371,20 @@ func (h *Handler) HandleCreateProjectWorkRole(w http.ResponseWriter, r *http.Req
 		DefaultModel:        req.DefaultModel,
 		DefaultAgentProfile: req.DefaultAgentProfile,
 		SkillIDs:            req.SkillIDs,
-	})
+	}
+	var role projectwork.AgentRoleProfile
+	var err error
+	if h.projectRoleWritesUseCairnlineAuthority() {
+		role, err = h.createProjectWorkRoleWithCairnlineAuthority(r.Context(), projectID, cmd)
+	} else {
+		role, err = h.projectWorkApplication().CreateRole(r.Context(), projectID, cmd)
+	}
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectRoleByIDToCairnline(r.Context(), "project_role_create", projectID, role)
+	if !h.projectRoleWritesUseCairnlineAuthority() {
+		h.mirrorProjectRoleByIDToCairnline(r.Context(), "project_role_create", projectID, role)
+	}
 	WriteJSON(w, http.StatusCreated, ProjectWorkRoleEnvelope{Object: "project_role", Data: renderProjectWorkRole(role)})
 }
 
@@ -387,7 +397,7 @@ func (h *Handler) HandleUpdateProjectWorkRole(w http.ResponseWriter, r *http.Req
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	role, err := h.projectWorkApplication().UpdateRole(r.Context(), projectID, r.PathValue("role_id"), projectworkapp.UpdateRoleCommand{
+	cmd := projectworkapp.UpdateRoleCommand{
 		Name:                req.Name,
 		Description:         req.Description,
 		Instructions:        req.Instructions,
@@ -396,11 +406,20 @@ func (h *Handler) HandleUpdateProjectWorkRole(w http.ResponseWriter, r *http.Req
 		DefaultModel:        req.DefaultModel,
 		DefaultAgentProfile: req.DefaultAgentProfile,
 		SkillIDs:            req.SkillIDs,
-	})
+	}
+	var role projectwork.AgentRoleProfile
+	var err error
+	if h.projectRoleWritesUseCairnlineAuthority() {
+		role, err = h.updateProjectWorkRoleWithCairnlineAuthority(r.Context(), projectID, r.PathValue("role_id"), cmd)
+	} else {
+		role, err = h.projectWorkApplication().UpdateRole(r.Context(), projectID, r.PathValue("role_id"), cmd)
+	}
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectRoleByIDToCairnline(r.Context(), "project_role_update", projectID, role)
+	if !h.projectRoleWritesUseCairnlineAuthority() {
+		h.mirrorProjectRoleByIDToCairnline(r.Context(), "project_role_update", projectID, role)
+	}
 	WriteJSON(w, http.StatusOK, ProjectWorkRoleEnvelope{Object: "project_role", Data: renderProjectWorkRole(role)})
 }
 
@@ -409,12 +428,18 @@ func (h *Handler) HandleDeleteProjectWorkRole(w http.ResponseWriter, r *http.Req
 	if !h.requireProject(w, r, projectID) {
 		return
 	}
-	role, roleLoaded := h.projectWorkRoleForCairnlineMirror(r.Context(), "project_role_delete", projectID, r.PathValue("role_id"))
-	if err := h.projectWorkApplication().DeleteRole(r.Context(), projectID, r.PathValue("role_id")); !writeProjectWorkError(w, err) {
-		return
-	}
-	if roleLoaded {
-		h.mirrorProjectRoleDeleteToCairnline(r.Context(), "project_role_delete", role)
+	if h.projectRoleWritesUseCairnlineAuthority() {
+		if err := h.deleteProjectWorkRoleWithCairnlineAuthority(r.Context(), projectID, r.PathValue("role_id")); !writeProjectWorkError(w, err) {
+			return
+		}
+	} else {
+		role, roleLoaded := h.projectWorkRoleForCairnlineMirror(r.Context(), "project_role_delete", projectID, r.PathValue("role_id"))
+		if err := h.projectWorkApplication().DeleteRole(r.Context(), projectID, r.PathValue("role_id")); !writeProjectWorkError(w, err) {
+			return
+		}
+		if roleLoaded {
+			h.mirrorProjectRoleDeleteToCairnline(r.Context(), "project_role_delete", role)
+		}
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -444,7 +469,7 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if !h.requireProjectRootRef(w, r, projectID, req.RootID) {
 		return
 	}
-	item, err := h.projectWorkApplication().CreateWorkItem(r.Context(), projectID, projectworkapp.CreateWorkItemCommand{
+	cmd := projectworkapp.CreateWorkItemCommand{
 		ID:              req.ID,
 		Title:           req.Title,
 		Brief:           req.Brief,
@@ -453,11 +478,20 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 		OwnerRoleID:     req.OwnerRoleID,
 		RootID:          req.RootID,
 		ReviewerRoleIDs: req.ReviewerRoleIDs,
-	})
+	}
+	var item projectwork.WorkItem
+	var err error
+	if h.projectWorkItemWritesUseCairnlineAuthority() {
+		item, err = h.createProjectWorkItemWithCairnlineAuthority(r.Context(), projectID, cmd)
+	} else {
+		item, err = h.projectWorkApplication().CreateWorkItem(r.Context(), projectID, cmd)
+	}
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectWorkItemByIDToCairnline(r.Context(), "project_work_item_create", projectID, item)
+	if !h.projectWorkItemWritesUseCairnlineAuthority() {
+		h.mirrorProjectWorkItemByIDToCairnline(r.Context(), "project_work_item_create", projectID, item)
+	}
 	projected, err := h.renderProjectedProjectWorkItem(r.Context(), item)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -515,7 +549,7 @@ func (h *Handler) HandleUpdateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if req.RootID != nil && !h.requireProjectRootRef(w, r, projectID, *req.RootID) {
 		return
 	}
-	item, err := h.projectWorkApplication().UpdateWorkItem(r.Context(), projectID, r.PathValue("work_item_id"), projectworkapp.UpdateWorkItemCommand{
+	cmd := projectworkapp.UpdateWorkItemCommand{
 		Title:           req.Title,
 		Brief:           req.Brief,
 		Status:          req.Status,
@@ -523,11 +557,20 @@ func (h *Handler) HandleUpdateProjectWorkItem(w http.ResponseWriter, r *http.Req
 		OwnerRoleID:     req.OwnerRoleID,
 		RootID:          req.RootID,
 		ReviewerRoleIDs: req.ReviewerRoleIDs,
-	})
+	}
+	var item projectwork.WorkItem
+	var err error
+	if h.projectWorkItemWritesUseCairnlineAuthority() {
+		item, err = h.updateProjectWorkItemWithCairnlineAuthority(r.Context(), projectID, r.PathValue("work_item_id"), cmd)
+	} else {
+		item, err = h.projectWorkApplication().UpdateWorkItem(r.Context(), projectID, r.PathValue("work_item_id"), cmd)
+	}
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectWorkItemByIDToCairnline(r.Context(), "project_work_item_update", projectID, item)
+	if !h.projectWorkItemWritesUseCairnlineAuthority() {
+		h.mirrorProjectWorkItemByIDToCairnline(r.Context(), "project_work_item_update", projectID, item)
+	}
 	projected, err := h.renderProjectedProjectWorkItem(r.Context(), item)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -541,10 +584,18 @@ func (h *Handler) HandleDeleteProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if !h.requireProject(w, r, projectID) {
 		return
 	}
-	if err := h.projectWorkApplication().DeleteWorkItem(r.Context(), projectID, r.PathValue("work_item_id")); !writeProjectWorkError(w, err) {
+	var err error
+	if h.projectWorkItemWritesUseCairnlineAuthority() {
+		err = h.deleteProjectWorkItemWithCairnlineAuthority(r.Context(), projectID, r.PathValue("work_item_id"))
+	} else {
+		err = h.projectWorkApplication().DeleteWorkItem(r.Context(), projectID, r.PathValue("work_item_id"))
+	}
+	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectWorkItemDeleteToCairnline(r.Context(), "project_work_item_delete", projectID, r.PathValue("work_item_id"))
+	if !h.projectWorkItemWritesUseCairnlineAuthority() {
+		h.mirrorProjectWorkItemDeleteToCairnline(r.Context(), "project_work_item_delete", projectID, r.PathValue("work_item_id"))
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -588,7 +639,7 @@ func (h *Handler) HandleProjectWorkAssignments(w http.ResponseWriter, r *http.Re
 func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
-	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+	if !h.projectAssignmentWritesUseCairnlineAuthority() && !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
 	var req createProjectWorkAssignmentRequest
@@ -600,6 +651,29 @@ func (h *Handler) HandleCreateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	}
 	startedAt, completedAt, ok := parseProjectWorkRequestTimes(w, req.StartedAt, req.CompletedAt)
 	if !ok {
+		return
+	}
+	if h.projectAssignmentWritesUseCairnlineAuthority() {
+		item, err := h.createProjectWorkAssignmentWithCairnlineAuthority(r.Context(), projectID, workItemID, projectworkapp.CreateAssignmentCommand{
+			ID:           req.ID,
+			RoleID:       req.RoleID,
+			RootID:       req.RootID,
+			DriverKind:   req.DriverKind,
+			Status:       req.Status,
+			ExecutionRef: projectWorkAssignmentExecutionRefFromRequest(req.ExecutionRef),
+			StartedAt:    startedAt,
+			CompletedAt:  completedAt,
+		})
+		if !writeProjectWorkError(w, err) {
+			return
+		}
+		projected, err := h.renderProjectedProjectWorkAssignment(r.Context(), item)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		projected.ReadBackend = "cairnline"
+		WriteJSON(w, http.StatusCreated, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 		return
 	}
 	item, err := h.projectWorkApplication().CreateAssignment(r.Context(), projectID, workItemID, projectworkapp.CreateAssignmentCommand{
@@ -628,7 +702,7 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
 	assignmentID := r.PathValue("assignment_id")
-	if !h.requireProjectAssignment(w, r, projectID, workItemID, assignmentID) {
+	if !h.projectAssignmentWritesUseCairnlineAuthority() && !h.requireProjectAssignment(w, r, projectID, workItemID, assignmentID) {
 		return
 	}
 	var req updateProjectWorkAssignmentRequest
@@ -649,6 +723,28 @@ func (h *Handler) HandleUpdateProjectWorkAssignment(w http.ResponseWriter, r *ht
 	var completedAtPtr *time.Time
 	if req.CompletedAt != nil {
 		completedAtPtr = &completedAt
+	}
+	if h.projectAssignmentWritesUseCairnlineAuthority() {
+		item, err := h.updateProjectWorkAssignmentWithCairnlineAuthority(r.Context(), projectID, workItemID, assignmentID, projectworkapp.UpdateAssignmentCommand{
+			RoleID:       req.RoleID,
+			RootID:       req.RootID,
+			DriverKind:   req.DriverKind,
+			Status:       req.Status,
+			ExecutionRef: projectWorkAssignmentExecutionRefPtrFromRequest(req.ExecutionRef),
+			StartedAt:    startedAtPtr,
+			CompletedAt:  completedAtPtr,
+		})
+		if !writeProjectWorkError(w, err) {
+			return
+		}
+		projected, err := h.renderProjectedProjectWorkAssignment(r.Context(), item)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		projected.ReadBackend = "cairnline"
+		WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+		return
 	}
 	item, err := h.projectWorkApplication().UpdateAssignment(r.Context(), projectID, assignmentID, projectworkapp.UpdateAssignmentCommand{
 		RoleID:       req.RoleID,
@@ -675,7 +771,14 @@ func (h *Handler) HandleDeleteProjectWorkAssignment(w http.ResponseWriter, r *ht
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
 	assignmentID := r.PathValue("assignment_id")
-	if !h.requireProjectAssignment(w, r, projectID, workItemID, assignmentID) {
+	if !h.projectAssignmentWritesUseCairnlineAuthority() && !h.requireProjectAssignment(w, r, projectID, workItemID, assignmentID) {
+		return
+	}
+	if h.projectAssignmentWritesUseCairnlineAuthority() {
+		if err := h.deleteProjectWorkAssignmentWithCairnlineAuthority(r.Context(), projectID, workItemID, assignmentID); !writeProjectWorkError(w, err) {
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	if err := h.projectWorkApplication().DeleteAssignment(r.Context(), projectID, workItemID, assignmentID); !writeProjectWorkError(w, err) {
@@ -775,7 +878,7 @@ func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	item, err := h.projectWorkApplication().CreateArtifact(r.Context(), projectID, workItemID, projectworkapp.CreateArtifactCommand{
+	cmd := projectworkapp.CreateArtifactCommand{
 		ID:                     req.ID,
 		AssignmentID:           req.AssignmentID,
 		Kind:                   req.Kind,
@@ -791,11 +894,20 @@ func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http
 		ReviewVerdict:          req.ReviewVerdict,
 		ReviewRisk:             req.ReviewRisk,
 		ReviewFollowUpRequired: req.ReviewFollowUpRequired,
-	})
+	}
+	var item projectwork.CollaborationArtifact
+	var err error
+	if h.projectCollaborationWritesUseCairnlineAuthority() {
+		item, err = h.createProjectWorkArtifactWithCairnlineAuthority(r.Context(), projectID, workItemID, cmd)
+	} else {
+		item, err = h.projectWorkApplication().CreateArtifact(r.Context(), projectID, workItemID, cmd)
+	}
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectArtifactToCairnline(r.Context(), "project_artifact_create", item)
+	if !h.projectCollaborationWritesUseCairnlineAuthority() {
+		h.mirrorProjectArtifactToCairnline(r.Context(), "project_artifact_create", item)
+	}
 	WriteJSON(w, http.StatusCreated, ProjectWorkArtifactEnvelope{Object: "project_collaboration_artifact", Data: renderProjectWorkArtifact(item)})
 }
 
@@ -843,7 +955,7 @@ func (h *Handler) HandleCreateProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	item, err := h.projectWorkApplication().CreateHandoff(r.Context(), projectID, workItemID, projectworkapp.CreateHandoffCommand{
+	cmd := projectworkapp.CreateHandoffCommand{
 		ID:                    req.ID,
 		SourceAssignmentID:    req.SourceAssignmentID,
 		SourceRunID:           req.SourceRunID,
@@ -862,11 +974,20 @@ func (h *Handler) HandleCreateProjectHandoff(w http.ResponseWriter, r *http.Requ
 		ProvenanceKind:        req.ProvenanceKind,
 		TrustLabel:            req.TrustLabel,
 		CreatedByRoleID:       req.CreatedByRoleID,
-	})
+	}
+	var item projectwork.Handoff
+	var err error
+	if h.projectCollaborationWritesUseCairnlineAuthority() {
+		item, err = h.createProjectHandoffWithCairnlineAuthority(r.Context(), projectID, workItemID, cmd)
+	} else {
+		item, err = h.projectWorkApplication().CreateHandoff(r.Context(), projectID, workItemID, cmd)
+	}
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_create", item)
+	if !h.projectCollaborationWritesUseCairnlineAuthority() {
+		h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_create", item)
+	}
 	WriteJSON(w, http.StatusCreated, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
 }
 
@@ -881,7 +1002,7 @@ func (h *Handler) HandleUpdateProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	item, err := h.projectWorkApplication().UpdateHandoff(r.Context(), projectID, workItemID, handoffID, projectworkapp.UpdateHandoffCommand{
+	cmd := projectworkapp.UpdateHandoffCommand{
 		SourceAssignmentID:    req.SourceAssignmentID,
 		SourceRunID:           req.SourceRunID,
 		SourceChatSessionID:   req.SourceChatSessionID,
@@ -899,11 +1020,20 @@ func (h *Handler) HandleUpdateProjectHandoff(w http.ResponseWriter, r *http.Requ
 		ProvenanceKind:        req.ProvenanceKind,
 		TrustLabel:            req.TrustLabel,
 		CreatedByRoleID:       req.CreatedByRoleID,
-	})
+	}
+	var item projectwork.Handoff
+	var err error
+	if h.projectCollaborationWritesUseCairnlineAuthority() {
+		item, err = h.updateProjectHandoffWithCairnlineAuthority(r.Context(), projectID, workItemID, handoffID, cmd)
+	} else {
+		item, err = h.projectWorkApplication().UpdateHandoff(r.Context(), projectID, workItemID, handoffID, cmd)
+	}
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_update", item)
+	if !h.projectCollaborationWritesUseCairnlineAuthority() {
+		h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_update", item)
+	}
 	WriteJSON(w, http.StatusOK, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
 }
 
@@ -918,13 +1048,20 @@ func (h *Handler) HandleUpdateProjectHandoffStatus(w http.ResponseWriter, r *htt
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	item, err := h.projectWorkApplication().UpdateHandoff(r.Context(), projectID, workItemID, handoffID, projectworkapp.UpdateHandoffCommand{
-		Status: &req.Status,
-	})
+	cmd := projectworkapp.UpdateHandoffCommand{Status: &req.Status}
+	var item projectwork.Handoff
+	var err error
+	if h.projectCollaborationWritesUseCairnlineAuthority() {
+		item, err = h.updateProjectHandoffWithCairnlineAuthority(r.Context(), projectID, workItemID, handoffID, cmd)
+	} else {
+		item, err = h.projectWorkApplication().UpdateHandoff(r.Context(), projectID, workItemID, handoffID, cmd)
+	}
 	if !writeProjectWorkError(w, err) {
 		return
 	}
-	h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_status_update", item)
+	if !h.projectCollaborationWritesUseCairnlineAuthority() {
+		h.mirrorProjectHandoffToCairnline(r.Context(), "project_handoff_status_update", item)
+	}
 	WriteJSON(w, http.StatusOK, ProjectHandoffEnvelope{Object: "project_handoff", Data: renderProjectHandoff(item)})
 }
 
@@ -935,10 +1072,16 @@ func (h *Handler) HandleDeleteProjectHandoff(w http.ResponseWriter, r *http.Requ
 	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
-	if err := h.projectWorkApplication().DeleteHandoff(r.Context(), projectID, workItemID, handoffID); !writeProjectWorkError(w, err) {
-		return
+	if h.projectCollaborationWritesUseCairnlineAuthority() {
+		if err := h.deleteProjectHandoffWithCairnlineAuthority(r.Context(), projectID, workItemID, handoffID); !writeProjectWorkError(w, err) {
+			return
+		}
+	} else {
+		if err := h.projectWorkApplication().DeleteHandoff(r.Context(), projectID, workItemID, handoffID); !writeProjectWorkError(w, err) {
+			return
+		}
+		h.mirrorProjectHandoffDeleteToCairnline(r.Context(), "project_handoff_delete", projectID, workItemID, handoffID)
 	}
-	h.mirrorProjectHandoffDeleteToCairnline(r.Context(), "project_handoff_delete", projectID, workItemID, handoffID)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -1039,11 +1182,14 @@ var projectWorkErrorMappings = []appErrorMapping{
 		projectworkapp.ErrAgentRunnerNotConfigured,
 	),
 	sentinelAppErrorMapping(http.StatusNotFound, errCodeNotFound, projectwork.ErrNotFound),
-	sentinelAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest, projectwork.ErrInvalid),
+	sentinelAppErrorMapping(http.StatusNotFound, errCodeNotFound, cairnline.ErrNotFound),
+	sentinelAppErrorMapping(http.StatusBadRequest, errCodeInvalidRequest, projectwork.ErrInvalid, cairnline.ErrInvalid),
 	sentinelAppErrorMapping(http.StatusConflict, errCodeConflict,
 		projectwork.ErrBuiltInRole,
 		projectwork.ErrDuplicateRole,
 		projectwork.ErrDuplicate,
+		cairnline.ErrDuplicate,
+		cairnline.ErrConflict,
 	),
 }
 

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -539,8 +539,10 @@ func projectWorkAssignmentFromCairnline(item cairnline.Assignment) projectwork.A
 		ExecutionRef: projectwork.NormalizeAssignmentExecutionRef(projectwork.AssignmentExecutionRef{
 			ContextSnapshotID: item.ContextSnapshotID,
 		}),
-		CreatedAt: item.CreatedAt,
-		UpdatedAt: item.UpdatedAt,
+		CreatedAt:   item.CreatedAt,
+		UpdatedAt:   item.UpdatedAt,
+		StartedAt:   item.StartedAt,
+		CompletedAt: item.CompletedAt,
 	}
 }
 

--- a/internal/api/handler_project_work_item_authority.go
+++ b/internal/api/handler_project_work_item_authority.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
+)
+
+const projectCairnlineWriteAuthorityProjectWorkItems = "project-work-items"
+
+func (h *Handler) projectWorkItemWritesUseCairnlineAuthority() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectWorkItems)
+}
+
+func (h *Handler) createProjectWorkItemWithCairnlineAuthority(ctx context.Context, projectID string, cmd projectworkapp.CreateWorkItemCommand) (projectwork.WorkItem, error) {
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projectwork.WorkItem{}, err
+	}
+	item := projectwork.WorkItem{
+		ID:              firstNonEmptyString(strings.TrimSpace(cmd.ID), newOpaqueTaskResourceID("work")),
+		ProjectID:       projectID,
+		Title:           cmd.Title,
+		Brief:           cmd.Brief,
+		Status:          cmd.Status,
+		Priority:        cmd.Priority,
+		OwnerRoleID:     cmd.OwnerRoleID,
+		RootID:          cmd.RootID,
+		ReviewerRoleIDs: append([]string(nil), cmd.ReviewerRoleIDs...),
+	}
+	item = normalizeProjectWorkItemForCairnlineAuthority(item)
+	if err := validateProjectWorkItemForCairnlineAuthority(item); err != nil {
+		return projectwork.WorkItem{}, err
+	}
+
+	var created projectwork.WorkItem
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		if err := h.seedProjectWorkItemDependenciesForCairnlineAuthority(ctx, service, project, item); err != nil {
+			return err
+		}
+		recorded, err := service.CreateWorkItem(ctx, cairnlinebridge.WorkItem(item))
+		if err != nil {
+			return err
+		}
+		created = projectWorkItemFromCairnline(recorded)
+		return nil
+	})
+	if err != nil {
+		return projectwork.WorkItem{}, err
+	}
+	h.shadowProjectWorkItemToHecate(ctx, "project_work_item_cairnline_authority_create", created)
+	return created, nil
+}
+
+func (h *Handler) updateProjectWorkItemWithCairnlineAuthority(ctx context.Context, projectID, workItemID string, cmd projectworkapp.UpdateWorkItemCommand) (projectwork.WorkItem, error) {
+	if cmd.Status != nil && strings.TrimSpace(*cmd.Status) == projectwork.WorkItemStatusDone {
+		readiness, err := h.projectWorkApplication().WorkItemReadiness(ctx, projectID, workItemID)
+		if err != nil {
+			return projectwork.WorkItem{}, err
+		}
+		if readiness.Status != "done" && !readiness.Ready {
+			return projectwork.WorkItem{}, projectworkapp.WorkItemCloseoutBlockedError{Readiness: readiness}
+		}
+	}
+	project, err := h.projectForCairnlineWriteAuthority(ctx, projectID)
+	if err != nil {
+		return projectwork.WorkItem{}, err
+	}
+
+	var updated projectwork.WorkItem
+	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := service.GetWorkItem(ctx, projectID, workItemID)
+		if err != nil {
+			return err
+		}
+		item := projectWorkItemFromCairnline(existing)
+		applyProjectWorkItemUpdate(&item, cmd)
+		item = normalizeProjectWorkItemForCairnlineAuthority(item)
+		if err := validateProjectWorkItemForCairnlineAuthority(item); err != nil {
+			return err
+		}
+		if err := h.seedProjectWorkItemDependenciesForCairnlineAuthority(ctx, service, project, item); err != nil {
+			return err
+		}
+		recorded, err := service.UpdateWorkItem(ctx, cairnlinebridge.WorkItem(item))
+		if err != nil {
+			return err
+		}
+		updated = projectWorkItemFromCairnline(recorded)
+		return nil
+	})
+	if err != nil {
+		return projectwork.WorkItem{}, err
+	}
+	h.shadowProjectWorkItemToHecate(ctx, "project_work_item_cairnline_authority_update", updated)
+	return updated, nil
+}
+
+func (h *Handler) deleteProjectWorkItemWithCairnlineAuthority(ctx context.Context, projectID, workItemID string) error {
+	if err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		return service.DeleteWorkItem(ctx, projectID, workItemID)
+	}); err != nil {
+		return err
+	}
+	h.shadowProjectWorkItemDeleteToHecate(ctx, "project_work_item_cairnline_authority_delete", projectID, workItemID)
+	return nil
+}
+
+func (h *Handler) projectForCairnlineWriteAuthority(ctx context.Context, projectID string) (projects.Project, error) {
+	if h == nil || h.projects == nil {
+		return projects.Project{}, errors.New("project store is not configured")
+	}
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, err
+	}
+	if !ok {
+		return projects.Project{}, errors.Join(cairnline.ErrNotFound, errors.New("project not found for Cairnline write authority"))
+	}
+	return project, nil
+}
+
+func (h *Handler) seedProjectWorkItemDependenciesForCairnlineAuthority(ctx context.Context, service *cairnline.Service, project projects.Project, item projectwork.WorkItem) error {
+	if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+		return err
+	}
+	if strings.TrimSpace(item.RootID) == "" {
+		return nil
+	}
+	root, ok := projectRootForCairnlineMirror(project, item.RootID)
+	if !ok {
+		return errors.Join(cairnline.ErrNotFound, errors.New("project root not found for Cairnline work-item authority"))
+	}
+	_, err := cairnlinebridge.UpsertRoot(ctx, service, project, root)
+	return err
+}
+
+func normalizeProjectWorkItemForCairnlineAuthority(item projectwork.WorkItem) projectwork.WorkItem {
+	item.ID = strings.TrimSpace(item.ID)
+	item.ProjectID = strings.TrimSpace(item.ProjectID)
+	item.Title = strings.TrimSpace(item.Title)
+	item.Brief = strings.TrimSpace(item.Brief)
+	item.Status = strings.TrimSpace(item.Status)
+	item.Priority = strings.TrimSpace(item.Priority)
+	item.OwnerRoleID = strings.TrimSpace(item.OwnerRoleID)
+	item.RootID = strings.TrimSpace(item.RootID)
+	item.ReviewerRoleIDs = compactProjectWorkAuthorityStrings(item.ReviewerRoleIDs)
+	if item.Status == "" {
+		item.Status = projectwork.WorkItemStatusBacklog
+	}
+	if item.Priority == "" {
+		item.Priority = "normal"
+	}
+	return item
+}
+
+func validateProjectWorkItemForCairnlineAuthority(item projectwork.WorkItem) error {
+	if item.ProjectID == "" {
+		return fmt.Errorf("%w: project_id is required", projectwork.ErrInvalid)
+	}
+	if item.ID == "" {
+		return fmt.Errorf("%w: work item id is required", projectwork.ErrInvalid)
+	}
+	if item.Title == "" {
+		return fmt.Errorf("%w: work item title is required", projectwork.ErrInvalid)
+	}
+	if !validProjectWorkItemStatusForCairnlineAuthority(item.Status) {
+		return fmt.Errorf("%w: unsupported work item status %q", projectwork.ErrInvalid, item.Status)
+	}
+	if !validProjectWorkItemPriorityForCairnlineAuthority(item.Priority) {
+		return fmt.Errorf("%w: unsupported work item priority %q", projectwork.ErrInvalid, item.Priority)
+	}
+	return nil
+}
+
+func validProjectWorkItemStatusForCairnlineAuthority(status string) bool {
+	switch strings.TrimSpace(status) {
+	case projectwork.WorkItemStatusBacklog, projectwork.WorkItemStatusReady, projectwork.WorkItemStatusRunning, projectwork.WorkItemStatusReview, projectwork.WorkItemStatusBlocked, projectwork.WorkItemStatusDone, projectwork.WorkItemStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func validProjectWorkItemPriorityForCairnlineAuthority(priority string) bool {
+	switch strings.TrimSpace(priority) {
+	case "low", "normal", "high", "urgent":
+		return true
+	default:
+		return false
+	}
+}
+
+func applyProjectWorkItemUpdate(item *projectwork.WorkItem, cmd projectworkapp.UpdateWorkItemCommand) {
+	if item == nil {
+		return
+	}
+	if cmd.Title != nil {
+		item.Title = *cmd.Title
+	}
+	if cmd.Brief != nil {
+		item.Brief = *cmd.Brief
+	}
+	if cmd.Status != nil {
+		item.Status = *cmd.Status
+	}
+	if cmd.Priority != nil {
+		item.Priority = *cmd.Priority
+	}
+	if cmd.OwnerRoleID != nil {
+		item.OwnerRoleID = *cmd.OwnerRoleID
+	}
+	if cmd.RootID != nil {
+		item.RootID = *cmd.RootID
+	}
+	if cmd.ReviewerRoleIDs != nil {
+		item.ReviewerRoleIDs = append([]string(nil), *cmd.ReviewerRoleIDs...)
+	}
+}
+
+func compactProjectWorkAuthorityStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func (h *Handler) shadowProjectWorkItemToHecate(ctx context.Context, operation string, item projectwork.WorkItem) {
+	if h == nil || h.projectWork == nil {
+		return
+	}
+	if _, err := h.projectWork.UpdateWorkItem(ctx, item.ProjectID, item.ID, func(existing *projectwork.WorkItem) {
+		*existing = item
+	}); err == nil {
+		return
+	} else if !errors.Is(err, projectwork.ErrNotFound) {
+		h.logProjectWorkItemShadowError(ctx, operation, item.ProjectID, item.ID, err)
+		return
+	}
+	if _, err := h.projectWork.CreateWorkItem(ctx, item); err != nil && !errors.Is(err, projectwork.ErrDuplicate) {
+		h.logProjectWorkItemShadowError(ctx, operation, item.ProjectID, item.ID, err)
+	}
+}
+
+func (h *Handler) shadowProjectWorkItemDeleteToHecate(ctx context.Context, operation, projectID, workItemID string) {
+	if h == nil || h.projectWork == nil {
+		return
+	}
+	if err := h.projectWork.DeleteWorkItem(ctx, projectID, workItemID); err != nil && !errors.Is(err, projectwork.ErrNotFound) {
+		h.logProjectWorkItemShadowError(ctx, operation, projectID, workItemID, err)
+	}
+}
+
+func (h *Handler) logProjectWorkItemShadowError(ctx context.Context, operation, projectID, workItemID string, err error) {
+	if err == nil || h == nil || h.logger == nil {
+		return
+	}
+	h.logger.WarnContext(ctx, "project work-item Hecate shadow failed", "operation", operation, "project_id", projectID, "work_item_id", workItemID, "error", err)
+}

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -78,6 +78,73 @@ func newProjectWorkCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handl
 	return handler, NewServer(quietLogger(), handler)
 }
 
+func newProjectWorkCairnlineCollaborationAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectCollaboration,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectWorkCairnlineWorkItemAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectWorkItems,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectWorkCairnlineRoleAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectRoles,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectWorkCairnlineAssignmentAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectAssignments,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+type projectWorkErrorResponse struct {
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
 func newProjectWorkCairnlineReadSourceTestHandler(t *testing.T, source string) *Handler {
 	t.Helper()
 	handler := NewHandler(config.Config{
@@ -601,6 +668,441 @@ func TestProjectWorkAPI_CRUD(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_CairnlineCollaborationAuthorityWritesCairnlineAndShadowsHecate(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineCollaborationAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Authority project",
+	}))
+	projectID := project.Data.ID
+
+	mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":   "role_authority",
+		"name": "Authority role",
+	}))
+	mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_authority",
+		"title":         "Exercise authority",
+		"owner_role_id": "role_authority",
+	}))
+	mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments", projectJourneyJSON(t, map[string]any{
+		"id":      "asgn_authority",
+		"role_id": "role_authority",
+	}))
+
+	decision := mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":             "art_authority_decision",
+		"assignment_id":  "asgn_authority",
+		"kind":           "decision_note",
+		"title":          "Authority decision",
+		"body":           "Cairnline should store this first.",
+		"author_role_id": "role_authority",
+	}))
+	if decision.Data.ID != "art_authority_decision" || decision.Data.Kind != projectwork.ArtifactKindDecisionNote {
+		t.Fatalf("decision artifact = %+v, want decision note response", decision.Data)
+	}
+	mirroredDecision := getMirroredCairnlineArtifactForTest(t, handler, projectID, "work_authority", "art_authority_decision")
+	if mirroredDecision.AssignmentID != "asgn_authority" || mirroredDecision.AuthorRoleID != "role_authority" {
+		t.Fatalf("mirrored decision = %+v, want Cairnline authority record", mirroredDecision)
+	}
+	assertHecateShadowArtifactForTest(t, handler, projectID, "work_authority", "art_authority_decision", projectwork.ArtifactKindDecisionNote)
+
+	evidence := mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                   "art_authority_evidence",
+		"assignment_id":        "asgn_authority",
+		"kind":                 "evidence_link",
+		"body":                 "External evidence was attached.",
+		"evidence_url":         "https://example.invalid/authority",
+		"evidence_external_id": "AUTH-1",
+		"evidence_provider":    "example",
+	}))
+	if evidence.Data.Title != "Evidence link" || evidence.Data.EvidenceURL != "https://example.invalid/authority" {
+		t.Fatalf("evidence response = %+v, want defaulted title and locator metadata", evidence.Data)
+	}
+	mirroredEvidence := getMirroredCairnlineEvidenceForTest(t, handler, projectID, "work_authority", "art_authority_evidence")
+	if mirroredEvidence.Locator != "https://example.invalid/authority" || mirroredEvidence.ExternalID != "AUTH-1" || mirroredEvidence.Provider != "example" {
+		t.Fatalf("mirrored evidence = %+v, want Cairnline evidence metadata", mirroredEvidence)
+	}
+	assertHecateShadowArtifactForTest(t, handler, projectID, "work_authority", "art_authority_evidence", projectwork.ArtifactKindEvidenceLink)
+
+	missingVerdict := mustRequestJSONStatus[projectWorkErrorResponse](client, http.StatusBadRequest, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                     "art_authority_review_missing_verdict",
+		"assignment_id":          "asgn_authority",
+		"reviewed_assignment_id": "asgn_authority",
+		"kind":                   "review",
+		"body":                   "Missing verdict.",
+	}))
+	if missingVerdict.Error.Type != errCodeInvalidRequest || !strings.Contains(missingVerdict.Error.Message, "review_verdict is required") {
+		t.Fatalf("missing verdict error = %+v, want invalid review verdict response", missingVerdict.Error)
+	}
+
+	review := mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                     "art_authority_review",
+		"assignment_id":          "asgn_authority",
+		"reviewed_assignment_id": "asgn_authority",
+		"kind":                   "review",
+		"body":                   "Needs follow-up.",
+		"author_role_id":         "role_authority",
+		"review_verdict":         "changes_requested",
+		"review_risk":            "medium",
+	}))
+	if review.Data.ReviewVerdict != projectwork.ReviewVerdictChangesRequested || !review.Data.ReviewFollowUpRequired {
+		t.Fatalf("review response = %+v, want changes-requested follow-up", review.Data)
+	}
+	mirroredReview := getMirroredCairnlineReviewForTest(t, handler, projectID, "work_authority", "art_authority_review")
+	if mirroredReview.Verdict != cairnline.ReviewVerdictChangesRequested || mirroredReview.Risk != cairnline.ReviewRiskMedium {
+		t.Fatalf("mirrored review = %+v, want Cairnline review metadata", mirroredReview)
+	}
+	assertHecateShadowArtifactForTest(t, handler, projectID, "work_authority", "art_authority_review", projectwork.ArtifactKindReview)
+
+	handoff := mustRequestJSONStatus[ProjectHandoffEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/handoffs", projectJourneyJSON(t, map[string]any{
+		"id":                      "handoff_authority",
+		"source_assignment_id":    "asgn_authority",
+		"target_role_id":          "role_authority",
+		"title":                   "Authority handoff",
+		"summary":                 "Cairnline should own this handoff.",
+		"recommended_next_action": "Accept the handoff.",
+		"created_by_role_id":      "role_authority",
+	}))
+	if handoff.Data.Status != projectwork.HandoffStatusPending {
+		t.Fatalf("handoff response = %+v, want Hecate pending status projection", handoff.Data)
+	}
+	mirroredHandoff := getMirroredCairnlineHandoffForTest(t, handler, projectID, "work_authority", "handoff_authority")
+	if mirroredHandoff.Status != cairnline.HandoffStatusOpen || mirroredHandoff.ToRoleID != "role_authority" {
+		t.Fatalf("mirrored handoff = %+v, want open Cairnline handoff", mirroredHandoff)
+	}
+	assertHecateShadowHandoffStatusForTest(t, handler, projectID, "work_authority", "handoff_authority", projectwork.HandoffStatusPending)
+
+	updated := mustRequestJSONStatus[ProjectHandoffEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/handoffs/handoff_authority", projectJourneyJSON(t, map[string]any{
+		"summary":                 "Cairnline updated this handoff.",
+		"recommended_next_action": "Finish it.",
+	}))
+	if updated.Data.Summary != "Cairnline updated this handoff." || updated.Data.RecommendedNextAction != "Finish it." {
+		t.Fatalf("updated handoff response = %+v, want edited text", updated.Data)
+	}
+
+	accepted := mustRequestJSONStatus[ProjectHandoffEnvelope](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/handoffs/handoff_authority/status", projectJourneyJSON(t, map[string]any{
+		"status": "accepted",
+	}))
+	if accepted.Data.Status != projectwork.HandoffStatusAccepted {
+		t.Fatalf("accepted handoff response = %+v, want accepted", accepted.Data)
+	}
+	mirroredHandoff = getMirroredCairnlineHandoffForTest(t, handler, projectID, "work_authority", "handoff_authority")
+	if mirroredHandoff.Status != cairnline.HandoffStatusAccepted || mirroredHandoff.Body != "Cairnline updated this handoff." {
+		t.Fatalf("mirrored accepted handoff = %+v, want updated accepted Cairnline handoff", mirroredHandoff)
+	}
+	assertHecateShadowHandoffStatusForTest(t, handler, projectID, "work_authority", "handoff_authority", projectwork.HandoffStatusAccepted)
+
+	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/handoffs/handoff_authority", "")
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	if _, err := service.GetHandoff(t.Context(), projectID, "work_authority", "handoff_authority"); !errors.Is(err, cairnline.ErrNotFound) {
+		store.Close()
+		t.Fatalf("deleted Cairnline handoff error = %v, want ErrNotFound", err)
+	}
+	store.Close()
+	if _, err := handler.projectWork.UpdateHandoff(t.Context(), projectID, "work_authority", "handoff_authority", nil); !errors.Is(err, projectwork.ErrNotFound) {
+		t.Fatalf("deleted Hecate shadow handoff error = %v, want ErrNotFound", err)
+	}
+	client.mustRequestStatus(http.StatusNotFound, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/handoffs/handoff_authority", "")
+}
+
+func TestProjectWorkAPI_CairnlineWorkItemAuthorityWritesCairnlineAndShadowsHecate(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineWorkItemAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Work item authority project",
+		"roots": []map[string]any{{
+			"id":   "root_main",
+			"path": "/tmp/hecate-work-item-authority",
+			"kind": "local",
+		}},
+	}))
+	projectID := project.Data.ID
+
+	mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":   "role_authority",
+		"name": "Authority role",
+	}))
+
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":                "work_authority",
+		"title":             "Exercise work authority",
+		"priority":          "high",
+		"owner_role_id":     "role_authority",
+		"root_id":           "root_main",
+		"reviewer_role_ids": []string{"role_authority", " role_authority "},
+	}))
+	if work.Data.Status != projectwork.WorkItemStatusBacklog || work.Data.Priority != "high" || work.Data.RootID != "root_main" || len(work.Data.ReviewerRoleIDs) != 1 {
+		t.Fatalf("work item response = %+v, want Hecate defaults, root, and compacted reviewers", work.Data)
+	}
+	mirroredWork := getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_authority")
+	if mirroredWork.Status != projectwork.WorkItemStatusBacklog || mirroredWork.Priority != "high" || mirroredWork.RootID != "root_main" || len(mirroredWork.ReviewerRoleIDs) != 1 {
+		t.Fatalf("mirrored work item = %+v, want Cairnline authority record with Hecate defaults", mirroredWork)
+	}
+	assertHecateShadowWorkItemForTest(t, handler, projectID, "work_authority", projectwork.WorkItemStatusBacklog)
+
+	invalid := mustRequestJSONStatus[projectWorkErrorResponse](client, http.StatusBadRequest, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":     "work_bad_status",
+		"title":  "Bad status",
+		"status": "needs_triage",
+	}))
+	if invalid.Error.Type != errCodeInvalidRequest || !strings.Contains(invalid.Error.Message, "unsupported work item status") {
+		t.Fatalf("invalid status response = %+v, want Hecate validation error", invalid.Error)
+	}
+
+	mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments", projectJourneyJSON(t, map[string]any{
+		"id":      "asgn_authority",
+		"role_id": "role_authority",
+	}))
+	blocked := mustRequestJSONStatus[projectWorkErrorResponse](client, http.StatusConflict, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_authority", projectJourneyJSON(t, map[string]any{
+		"status": "done",
+	}))
+	if blocked.Error.Type != errCodeConflict || !strings.Contains(blocked.Error.Message, "closeout blocked") {
+		t.Fatalf("done blocker response = %+v, want closeout conflict", blocked.Error)
+	}
+	mirroredWork = getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_authority")
+	if mirroredWork.Status == projectwork.WorkItemStatusDone {
+		t.Fatalf("mirrored work item = %+v, want status unchanged after blocked closeout", mirroredWork)
+	}
+
+	updated := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_authority", projectJourneyJSON(t, map[string]any{
+		"title":             "Updated work authority",
+		"status":            "ready",
+		"priority":          "urgent",
+		"reviewer_role_ids": []string{},
+	}))
+	if updated.Data.Title != "Updated work authority" || updated.Data.Status != projectwork.WorkItemStatusReady || updated.Data.Priority != "urgent" || len(updated.Data.ReviewerRoleIDs) != 0 {
+		t.Fatalf("updated response = %+v, want edited work item", updated.Data)
+	}
+	mirroredWork = getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_authority")
+	if mirroredWork.Title != "Updated work authority" || mirroredWork.Status != projectwork.WorkItemStatusReady || mirroredWork.Priority != "urgent" || len(mirroredWork.ReviewerRoleIDs) != 0 {
+		t.Fatalf("mirrored updated work item = %+v, want Cairnline authority edits", mirroredWork)
+	}
+	assertHecateShadowWorkItemForTest(t, handler, projectID, "work_authority", projectwork.WorkItemStatusReady)
+
+	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority", "")
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	if _, err := service.GetWorkItem(t.Context(), projectID, "work_authority"); !errors.Is(err, cairnline.ErrNotFound) {
+		store.Close()
+		t.Fatalf("deleted Cairnline work item error = %v, want ErrNotFound", err)
+	}
+	store.Close()
+	if _, ok, err := handler.projectWork.GetWorkItem(t.Context(), projectID, "work_authority"); err != nil || ok {
+		t.Fatalf("deleted Hecate shadow work item ok=%v err=%v, want not found", ok, err)
+	}
+	client.mustRequestStatus(http.StatusNotFound, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority", "")
+}
+
+func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineAndShadowsHecate(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineRoleAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Role authority project",
+	}))
+	projectID := project.Data.ID
+
+	created := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                    "role_authority",
+		"name":                  "Authority reviewer",
+		"description":           "Reviews Cairnline authority writes.",
+		"instructions":          "Keep the historical assignment record intact.",
+		"default_driver_kind":   projectwork.AssignmentDriverExternalAgent,
+		"default_provider":      "anthropic",
+		"default_model":         "claude-sonnet-4",
+		"default_agent_profile": "safe_external_review",
+		"skill_ids":             []string{"review", "review"},
+	}))
+	if created.Data.ID != "role_authority" || created.Data.DefaultDriverKind != projectwork.AssignmentDriverExternalAgent || created.Data.DefaultModel != "claude-sonnet-4" {
+		t.Fatalf("created role response = %+v, want role authority defaults", created.Data)
+	}
+	if created.Data.CreatedAt == "" || created.Data.UpdatedAt == "" {
+		t.Fatalf("created role timestamps = created:%q updated:%q, want Hecate shadow timestamps", created.Data.CreatedAt, created.Data.UpdatedAt)
+	}
+	mirroredRole := getMirroredCairnlineRoleForTest(t, handler, projectID, "role_authority")
+	if mirroredRole.Name != "Authority reviewer" || mirroredRole.DefaultProfileID != "safe_external_review" || mirroredRole.DefaultExecutionMode != cairnline.ExecutionExternalAdapter {
+		t.Fatalf("Cairnline role = %+v, want role authority record", mirroredRole)
+	}
+	if len(mirroredRole.DefaultSkillIDs) != 1 || mirroredRole.DefaultSkillIDs[0] != "review" {
+		t.Fatalf("Cairnline role skills = %+v, want compacted review skill", mirroredRole.DefaultSkillIDs)
+	}
+	assertHecateShadowRoleForTest(t, handler, projectID, "role_authority")
+
+	updated := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/roles/role_authority", projectJourneyJSON(t, map[string]any{
+		"name":          "Authority owner",
+		"default_model": "claude-opus-4",
+		"skill_ids":     []string{"review", "release"},
+	}))
+	if updated.Data.Name != "Authority owner" || updated.Data.DefaultModel != "claude-opus-4" || !containsString(updated.Data.SkillIDs, "release") {
+		t.Fatalf("updated role response = %+v, want edited role authority defaults", updated.Data)
+	}
+	mirroredRole = getMirroredCairnlineRoleForTest(t, handler, projectID, "role_authority")
+	if mirroredRole.Name != "Authority owner" || !containsString(mirroredRole.DefaultSkillIDs, "release") {
+		t.Fatalf("updated Cairnline role = %+v, want edited role authority record", mirroredRole)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirroredRole.DefaultExecutionProfileID, "anthropic", "claude-opus-4")
+
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_role_authority",
+		"title":         "Keep role history",
+		"owner_role_id": "role_authority",
+	}))
+	if work.Data.OwnerRoleID != "role_authority" {
+		t.Fatalf("work item response = %+v, want owner role", work.Data)
+	}
+	assignment := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_role_authority/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_role_authority",
+		"role_id":     "role_authority",
+		"driver_kind": projectwork.AssignmentDriverExternalAgent,
+	}))
+	if assignment.Data.RoleID != "role_authority" {
+		t.Fatalf("assignment response = %+v, want role authority assignment", assignment.Data)
+	}
+
+	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/roles/role_authority", "")
+	if role := mirroredCairnlineRoleForTest(t, handler, projectID, "role_authority"); role != nil {
+		t.Fatalf("deleted Cairnline role = %+v, want missing", role)
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	historicalAssignment, err := service.GetAssignment(t.Context(), projectID, "asgn_role_authority")
+	if err != nil {
+		store.Close()
+		t.Fatalf("GetAssignment() after role delete error = %v", err)
+	}
+	if historicalAssignment.RoleID != "role_authority" {
+		store.Close()
+		t.Fatalf("assignment after role delete = %+v, want historical role id", historicalAssignment)
+	}
+	store.Close()
+	if hasHecateRoleForTest(t, handler, projectID, "role_authority") {
+		t.Fatalf("Hecate shadow role still exists after Cairnline-authoritative delete")
+	}
+
+	client.mustRequestStatus(http.StatusConflict, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/roles/product_manager", "")
+}
+
+func TestProjectWorkAPI_CairnlineAssignmentAuthorityWritesCairnlineAndShadowsHecate(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineAssignmentAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Assignment authority project",
+		"roots": []map[string]any{{
+			"id":   "root_main",
+			"path": "/tmp/hecate-assignment-authority",
+			"kind": "local",
+		}},
+	}))
+	projectID := project.Data.ID
+
+	mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":   "role_authority",
+		"name": "Authority implementer",
+	}))
+	mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":      "work_authority",
+		"title":   "Exercise assignment authority",
+		"root_id": "root_main",
+	}))
+
+	invalidStatus := mustRequestJSONStatus[projectWorkErrorResponse](client, http.StatusBadRequest, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments", projectJourneyJSON(t, map[string]any{
+		"id":      "asgn_bad_status",
+		"role_id": "role_authority",
+		"status":  "needs_triage",
+	}))
+	if invalidStatus.Error.Type != errCodeInvalidRequest || !strings.Contains(invalidStatus.Error.Message, "unsupported assignment status") {
+		t.Fatalf("invalid status response = %+v, want Hecate validation error", invalidStatus.Error)
+	}
+	invalidDriver := mustRequestJSONStatus[projectWorkErrorResponse](client, http.StatusBadRequest, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_bad_driver",
+		"role_id":     "role_authority",
+		"driver_kind": "mcp_pull",
+	}))
+	if invalidDriver.Error.Type != errCodeInvalidRequest || !strings.Contains(invalidDriver.Error.Message, "unsupported assignment driver_kind") {
+		t.Fatalf("invalid driver response = %+v, want Hecate validation error", invalidDriver.Error)
+	}
+
+	created := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments", projectJourneyJSON(t, map[string]any{
+		"id":      "asgn_authority",
+		"role_id": "role_authority",
+		"root_id": "root_main",
+		"execution_ref": map[string]any{
+			"kind":                "hecate_task",
+			"context_snapshot_id": "ctx_authority",
+			"trace_id":            "trace_authority",
+		},
+	}))
+	if created.Data.ReadBackend != "cairnline" || created.Data.DriverKind != projectwork.AssignmentDriverHecateTask || created.Data.Status != projectwork.AssignmentStatusQueued || created.Data.RootID != "root_main" {
+		t.Fatalf("created assignment = %+v, want Cairnline response with Hecate defaults and root", created.Data)
+	}
+	if created.Data.ExecutionRef == nil || created.Data.ExecutionRef.ContextSnapshotID != "ctx_authority" || created.Data.ExecutionRef.TraceID != "trace_authority" {
+		t.Fatalf("created execution_ref = %+v, want Hecate ref shadowed through authority path", created.Data.ExecutionRef)
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_authority")
+	if mirrored.ExecutionMode != cairnline.ExecutionOrchestrated || mirrored.Status != cairnline.AssignmentQueued || mirrored.WorkItemID != "work_authority" || mirrored.RootID != "root_main" || mirrored.ContextSnapshotID != "ctx_authority" {
+		t.Fatalf("mirrored assignment = %+v, want Cairnline-authoritative queued orchestrated record", mirrored)
+	}
+	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_authority", "asgn_authority")
+	if shadow.DriverKind != projectwork.AssignmentDriverHecateTask || shadow.Status != projectwork.AssignmentStatusQueued || shadow.ExecutionRef.ContextSnapshotID != "ctx_authority" {
+		t.Fatalf("Hecate shadow assignment = %+v, want compatibility shadow", shadow)
+	}
+
+	updated := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments/asgn_authority", projectJourneyJSON(t, map[string]any{
+		"driver_kind": projectwork.AssignmentDriverExternalAgent,
+		"status":      projectwork.AssignmentStatusCompleted,
+		"execution_ref": map[string]any{
+			"kind":            "external_agent",
+			"chat_session_id": "chat_authority",
+			"message_id":      "msg_authority",
+			"status":          "completed",
+		},
+	}))
+	if updated.Data.ReadBackend != "cairnline" || updated.Data.DriverKind != projectwork.AssignmentDriverExternalAgent || updated.Data.Status != projectwork.AssignmentStatusCompleted {
+		t.Fatalf("updated assignment = %+v, want Cairnline response with external completed status", updated.Data)
+	}
+	if updated.Data.ExecutionRef == nil || updated.Data.ExecutionRef.ChatSessionID != "chat_authority" || updated.Data.ExecutionRef.MessageID != "msg_authority" {
+		t.Fatalf("updated execution_ref = %+v, want native execution ref preserved", updated.Data.ExecutionRef)
+	}
+	mirrored = getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_authority")
+	if mirrored.ExecutionMode != cairnline.ExecutionExternalAdapter || mirrored.Status != cairnline.AssignmentCompleted || !strings.Contains(mirrored.ExecutionRef, "chat_authority") {
+		t.Fatalf("updated mirrored assignment = %+v, want Cairnline-authoritative external completion", mirrored)
+	}
+	shadow = getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_authority", "asgn_authority")
+	if shadow.DriverKind != projectwork.AssignmentDriverExternalAgent || shadow.Status != projectwork.AssignmentStatusCompleted || shadow.ExecutionRef.ChatSessionID != "chat_authority" {
+		t.Fatalf("updated Hecate shadow assignment = %+v, want compatibility shadow update", shadow)
+	}
+
+	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments/asgn_authority", "")
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	if _, err := service.GetAssignment(t.Context(), projectID, "asgn_authority"); !errors.Is(err, cairnline.ErrNotFound) {
+		store.Close()
+		t.Fatalf("deleted Cairnline assignment error = %v, want ErrNotFound", err)
+	}
+	store.Close()
+	assignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: "work_authority"})
+	if err != nil {
+		t.Fatalf("ListAssignments() after delete: %v", err)
+	}
+	if len(assignments) != 0 {
+		t.Fatalf("Hecate shadow assignments after delete = %+v, want empty", assignments)
+	}
+	client.mustRequestStatus(http.StatusNotFound, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments/asgn_authority", "")
+}
+
 func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkCairnlineMirrorTestServer(t)
@@ -749,7 +1251,7 @@ func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured
 		t.Fatalf("create review artifact status = %d body=%s, want 201", rec.Code, rec.Body.String())
 	}
 	mirroredReview := getMirroredCairnlineReviewForTest(t, handler, project.Data.ID, "work_release", "art_release_review")
-	if mirroredReview.AssignmentID != "asgn_release" || mirroredReview.ReviewerRoleID != "role_release" || mirroredReview.Verdict != cairnline.ReviewVerdictPass || mirroredReview.Risk != cairnline.ReviewRiskLow {
+	if mirroredReview.AssignmentID != "asgn_release" || mirroredReview.ReviewerRoleID != "role_release" || mirroredReview.Verdict != cairnline.ReviewVerdictApproved || mirroredReview.Risk != cairnline.ReviewRiskLow {
 		t.Fatalf("mirrored review = %+v, want approved release review metadata", mirroredReview)
 	}
 
@@ -3375,6 +3877,44 @@ func TestProjectWorkAPI_StartAssignmentClearsClaimWhenTaskCreateFails(t *testing
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentReleasesMirroredCairnlineClaimWhenTaskCreateFails(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineMirrorTestServer(t)
+	handler.taskStore = failingCreateTaskStore{Store: handler.taskStore}
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+	assignment := getStoredProjectWorkAssignmentForTest(t, handler, "proj_start", "work_start", "asgn_start")
+	if err := handler.writeProjectAssignmentToCairnline(t.Context(), assignment); err != nil {
+		t.Fatalf("writeProjectAssignmentToCairnline() error = %v", err)
+	}
+	func() {
+		service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+		if err != nil {
+			t.Fatalf("open Cairnline mirror: %v", err)
+		}
+		defer store.Close()
+		claimed, err := service.ClaimAssignment(t.Context(), "proj_start", "asgn_start", "hecate")
+		if err != nil {
+			t.Fatalf("ClaimAssignment() error = %v", err)
+		}
+		if claimed.Status != cairnline.AssignmentClaimed || claimed.ClaimedBy != "hecate" {
+			t.Fatalf("claimed assignment = %+v, want hecate claim", claimed)
+		}
+	}()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("task create failure status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_start", "asgn_start")
+	if mirrored.Status != cairnline.AssignmentQueued || mirrored.ClaimedBy != "" || mirrored.ExecutionRef != "" || mirrored.ContextSnapshotID != "" || !mirrored.StartedAt.IsZero() || !mirrored.CompletedAt.IsZero() {
+		t.Fatalf("mirrored assignment = %+v, want released queued claim for retry", mirrored)
+	}
+}
+
 func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
 	t.Parallel()
 	for _, backend := range []string{"memory", "sqlite"} {
@@ -4780,7 +5320,7 @@ func seedProjectWorkProjectionCase(t *testing.T, handler *Handler, workID, assig
 			Summary:               "Implementation is ready for queue review.",
 			RecommendedNextAction: "Review the queued follow-up assignment.",
 			CreatedAt:             runFinishedAt.Add(2 * time.Minute),
-			UpdatedAt:             runFinishedAt.Add(2 * time.Minute),
+			UpdatedAt:             runFinishedAt.Add(3 * time.Minute),
 			StatusChangedAt:       runFinishedAt.Add(2 * time.Minute),
 		}); err != nil {
 			t.Fatalf("CreateHandoff(%s): %v", assignmentID, err)
@@ -5032,6 +5572,54 @@ func findProjectHandoffForTest(t *testing.T, items []ProjectHandoffResponse, han
 	return ProjectHandoffResponse{}
 }
 
+func assertHecateShadowArtifactForTest(t *testing.T, handler *Handler, projectID, workItemID, artifactID, kind string) {
+	t.Helper()
+	items, err := handler.projectWork.ListArtifacts(t.Context(), projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		t.Fatalf("ListArtifacts(%q, %q): %v", projectID, workItemID, err)
+	}
+	for _, item := range items {
+		if item.ID == artifactID {
+			if item.Kind != kind {
+				t.Fatalf("shadow artifact %q kind = %q, want %q", artifactID, item.Kind, kind)
+			}
+			return
+		}
+	}
+	t.Fatalf("shadow artifact %q not found in %+v", artifactID, items)
+}
+
+func assertHecateShadowWorkItemForTest(t *testing.T, handler *Handler, projectID, workItemID, status string) {
+	t.Helper()
+	item, ok, err := handler.projectWork.GetWorkItem(t.Context(), projectID, workItemID)
+	if err != nil {
+		t.Fatalf("GetWorkItem(%q, %q): %v", projectID, workItemID, err)
+	}
+	if !ok {
+		t.Fatalf("shadow work item %q not found", workItemID)
+	}
+	if item.Status != status {
+		t.Fatalf("shadow work item %q status = %q, want %q", workItemID, item.Status, status)
+	}
+}
+
+func assertHecateShadowHandoffStatusForTest(t *testing.T, handler *Handler, projectID, workItemID, handoffID, status string) {
+	t.Helper()
+	items, err := handler.projectWork.ListHandoffs(t.Context(), projectwork.HandoffFilter{ProjectID: projectID, WorkItemID: workItemID})
+	if err != nil {
+		t.Fatalf("ListHandoffs(%q, %q): %v", projectID, workItemID, err)
+	}
+	for _, item := range items {
+		if item.ID == handoffID {
+			if item.Status != status {
+				t.Fatalf("shadow handoff %q status = %q, want %q", handoffID, item.Status, status)
+			}
+			return
+		}
+	}
+	t.Fatalf("shadow handoff %q not found in %+v", handoffID, items)
+}
+
 func allProjectActivityItemsForTest(data ProjectActivityDataResponse) []ProjectActivityItemResponse {
 	items := make([]ProjectActivityItemResponse, 0, len(data.Buckets.Active)+len(data.Buckets.Blocked)+len(data.Buckets.Completed)+len(data.Buckets.Recent)+len(data.Recent))
 	items = append(items, data.Buckets.Active...)
@@ -5090,6 +5678,27 @@ func mirroredCairnlineRoleForTest(t *testing.T, handler *Handler, projectID, rol
 		}
 	}
 	return nil
+}
+
+func assertHecateShadowRoleForTest(t *testing.T, handler *Handler, projectID, roleID string) {
+	t.Helper()
+	if !hasHecateRoleForTest(t, handler, projectID, roleID) {
+		t.Fatalf("Hecate shadow role %q not found", roleID)
+	}
+}
+
+func hasHecateRoleForTest(t *testing.T, handler *Handler, projectID, roleID string) bool {
+	t.Helper()
+	roles, err := handler.projectWork.ListRoles(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("ListRoles(%q): %v", projectID, err)
+	}
+	for _, role := range roles {
+		if role.ID == roleID {
+			return true
+		}
+	}
+	return false
 }
 
 func getMirroredCairnlineWorkItemForTest(t *testing.T, handler *Handler, projectID, workItemID string) cairnline.WorkItem {

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -106,6 +106,23 @@ func (h *Handler) HandleCreateProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
+	if h.projectIdentityWritesUseCairnlineAuthority() {
+		project, err = h.createProjectWithCairnlineAuthority(r.Context(), project)
+		if errors.Is(err, projects.ErrInvalid) || errors.Is(err, cairnline.ErrInvalid) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
+		if errors.Is(err, projects.ErrAlreadyExists) || errors.Is(err, cairnline.ErrDuplicate) {
+			WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+			return
+		}
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusCreated, ProjectResponse{Object: "project", Data: renderProject(project)})
+		return
+	}
 	project, err = h.projects.Create(r.Context(), project)
 	if errors.Is(err, projects.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
@@ -205,6 +222,32 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 			return
 		}
+	}
+	if h.projectMetadataDefaultsWritesUseCairnlineAuthority() && projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req) {
+		project, err := h.updateProjectMetadataDefaultsWithCairnlineAuthority(r.Context(), r.PathValue("id"), req)
+		if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		if errors.Is(err, projects.ErrInvalid) || errors.Is(err, cairnline.ErrInvalid) {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
+			return
+		}
+		if errors.Is(err, projects.ErrAlreadyExists) || errors.Is(err, cairnline.ErrDuplicate) {
+			WriteError(w, http.StatusConflict, errCodeConflict, err.Error())
+			return
+		}
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
+		return
+	}
+	if h.projectRootSourceListUpdateWritesUseCairnlineAuthority(req) {
+		project, err := h.updateProjectRootSourceListsWithCairnlineAuthority(r.Context(), r.PathValue("id"), req, roots, contextSources)
+		writeProjectListReplaceCairnlineAuthorityResponse(w, project, err)
+		return
 	}
 	project, err := h.projects.Update(r.Context(), r.PathValue("id"), func(item *projects.Project) {
 		if req.Name != nil {
@@ -312,6 +355,11 @@ func (h *Handler) HandleCreateProjectRoot(w http.ResponseWriter, r *http.Request
 	if root.ID == "" {
 		root.ID = newOpaqueTaskResourceID("root")
 	}
+	if h.projectRootWritesUseCairnlineAuthority() {
+		project, _, err := h.createProjectRootWithCairnlineAuthority(r.Context(), r.PathValue("id"), root)
+		writeProjectRootCairnlineAuthorityResponse(w, http.StatusCreated, project, err)
+		return
+	}
 	project, created, err := h.projectApplication().CreateRoot(r.Context(), r.PathValue("id"), root)
 	h.writeProjectRootMutationResponse(r.Context(), w, http.StatusCreated, project, created, false, err)
 }
@@ -326,11 +374,21 @@ func (h *Handler) HandleUpdateProjectRoot(w http.ResponseWriter, r *http.Request
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
+	if h.projectRootWritesUseCairnlineAuthority() {
+		project, _, err := h.updateProjectRootWithCairnlineAuthority(r.Context(), r.PathValue("id"), r.PathValue("root_id"), root)
+		writeProjectRootCairnlineAuthorityResponse(w, http.StatusOK, project, err)
+		return
+	}
 	project, updated, err := h.projectApplication().UpdateRoot(r.Context(), r.PathValue("id"), r.PathValue("root_id"), root)
 	h.writeProjectRootMutationResponse(r.Context(), w, http.StatusOK, project, updated, false, err)
 }
 
 func (h *Handler) HandleDeleteProjectRoot(w http.ResponseWriter, r *http.Request) {
+	if h.projectRootWritesUseCairnlineAuthority() {
+		project, _, err := h.deleteProjectRootWithCairnlineAuthority(r.Context(), r.PathValue("id"), r.PathValue("root_id"))
+		writeProjectRootCairnlineAuthorityResponse(w, http.StatusOK, project, err)
+		return
+	}
 	project, deleted, err := h.projectApplication().DeleteRoot(r.Context(), r.PathValue("id"), r.PathValue("root_id"))
 	h.writeProjectRootMutationResponse(r.Context(), w, http.StatusOK, project, deleted, true, err)
 }
@@ -348,6 +406,11 @@ func (h *Handler) HandleCreateProjectContextSource(w http.ResponseWriter, r *htt
 	if source.ID == "" {
 		source.ID = newOpaqueTaskResourceID("ctxsrc")
 	}
+	if h.projectContextSourceWritesUseCairnlineAuthority() {
+		project, _, err := h.createProjectContextSourceWithCairnlineAuthority(r.Context(), r.PathValue("id"), source)
+		writeProjectContextSourceCairnlineAuthorityResponse(w, http.StatusCreated, project, err)
+		return
+	}
 	project, created, err := h.projectApplication().CreateContextSource(r.Context(), r.PathValue("id"), source)
 	h.writeProjectContextSourceMutationResponse(r.Context(), w, http.StatusCreated, project, created, false, err)
 }
@@ -362,17 +425,39 @@ func (h *Handler) HandleUpdateProjectContextSource(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())
 		return
 	}
+	if h.projectContextSourceWritesUseCairnlineAuthority() {
+		project, _, err := h.updateProjectContextSourceWithCairnlineAuthority(r.Context(), r.PathValue("id"), r.PathValue("source_id"), source)
+		writeProjectContextSourceCairnlineAuthorityResponse(w, http.StatusOK, project, err)
+		return
+	}
 	project, updated, err := h.projectApplication().UpdateContextSource(r.Context(), r.PathValue("id"), r.PathValue("source_id"), source)
 	h.writeProjectContextSourceMutationResponse(r.Context(), w, http.StatusOK, project, updated, false, err)
 }
 
 func (h *Handler) HandleDeleteProjectContextSource(w http.ResponseWriter, r *http.Request) {
+	if h.projectContextSourceWritesUseCairnlineAuthority() {
+		project, _, err := h.deleteProjectContextSourceWithCairnlineAuthority(r.Context(), r.PathValue("id"), r.PathValue("source_id"))
+		writeProjectContextSourceCairnlineAuthorityResponse(w, http.StatusOK, project, err)
+		return
+	}
 	project, deleted, err := h.projectApplication().DeleteContextSource(r.Context(), r.PathValue("id"), r.PathValue("source_id"))
 	h.writeProjectContextSourceMutationResponse(r.Context(), w, http.StatusOK, project, deleted, true, err)
 }
 
 func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
+	if h.projectIdentityWritesUseCairnlineAuthority() {
+		result, err := h.deleteProjectWithCairnlineAuthority(r.Context(), r.PathValue("id"))
+		h.writeProjectDeleteResponse(w, result, err)
+		return
+	}
 	result, err := h.projectApplication().DeleteProject(r.Context(), r.PathValue("id"))
+	if err == nil {
+		h.mirrorProjectDeleteToCairnline(r.Context(), "project_delete", result.Project)
+	}
+	h.writeProjectDeleteResponse(w, result, err)
+}
+
+func (h *Handler) writeProjectDeleteResponse(w http.ResponseWriter, result projectapp.DeleteProjectResult, err error) {
 	if errors.Is(err, projectapp.ErrProjectNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 		return
@@ -385,7 +470,6 @@ func (h *Handler) HandleDeleteProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	h.mirrorProjectDeleteToCairnline(r.Context(), "project_delete", result.Project)
 	WriteJSON(w, http.StatusOK, ProjectDeleteResponse{Object: "project_delete", Data: renderProjectDeleteResult(result)})
 }
 

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -39,6 +40,45 @@ func newProjectsCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handler)
 	handler := NewHandler(config.Config{
 		Server:   config.ServerConfig{DataDir: t.TempDir()},
 		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectsCairnlineMetadataDefaultsAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectMetadataDefaults,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectsCairnlineIdentityAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectIdentity,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
+func newProjectsCairnlineRootSourceAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectRoots + "," + projectCairnlineWriteAuthorityProjectContextSources,
+		},
 	}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
 	return handler, NewServer(quietLogger(), handler)
@@ -434,6 +474,543 @@ func TestProjectsAPI_MirrorsIdentityMutationsToCairnlineWhenConfigured(t *testin
 	defer store.Close()
 	if _, err := service.GetProject(t.Context(), created.Data.ID); !errors.Is(err, cairnline.ErrNotFound) {
 		t.Fatalf("mirrored deleted project error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestProjectsAPI_CairnlineIdentityAuthorityCommitsCreateFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineIdentityAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Identity Authority",
+		"description":"created through Cairnline",
+		"roots":[{"id":"root_main","path":"/workspace/identity","kind":"git","git_branch":"main"}],
+		"context_sources":[{"id":"ctx_agents","path":"AGENTS.md","kind":"workspace_instruction","title":"AGENTS.md","format":"agents_md"}],
+		"default_provider":"openai",
+		"default_model":"gpt-5",
+		"default_workspace_mode":"worktree"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Data.Name != "Identity Authority" || created.Data.DefaultRootID != "root_main" || created.Data.DefaultProvider != "openai" || created.Data.DefaultModel != "gpt-5" || len(created.Data.Roots) != 1 || len(created.Data.ContextSources) != 1 {
+		t.Fatalf("created project = %+v, want Cairnline-authored project shadowed into Hecate", created.Data)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.Name != "Identity Authority" || mirrored.Description != "created through Cairnline" || mirrored.DefaultRootID != "root_main" || len(mirrored.Roots) != 1 || len(mirrored.ContextSources) != 1 {
+		t.Fatalf("mirrored project = %+v, want identity create committed to Cairnline", mirrored)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "openai", "gpt-5")
+}
+
+func TestProjectsAPI_CairnlineIdentityAuthorityCommitsDeleteFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineIdentityAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Identity Delete Authority",
+		"roots":[{"id":"root_main","path":"/workspace/delete-authority","kind":"git"}],
+		"default_provider":"openai",
+		"default_model":"gpt-5"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID); mirrored.ID != created.Data.ID {
+		t.Fatalf("mirrored project = %+v, want created project before delete", mirrored)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+created.Data.ID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || ok {
+		t.Fatalf("Hecate project after delete ok=%v err=%v, want missing", ok, err)
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror after delete: %v", err)
+	}
+	defer store.Close()
+	if _, err := service.GetProject(t.Context(), created.Data.ID); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("Cairnline project after delete error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestProjectsAPI_CairnlineIdentityAuthorityRollsBackDeleteWhenCompatibilityCleanupFails(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineIdentityAuthorityTestServer(t)
+	handler.SetProjectSkillStore(failingProjectSkillDeleteStore{
+		Store: projectskills.NewMemoryStore(),
+		err:   errors.New("skill cleanup failed"),
+	})
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Identity Delete Rollback",
+		"roots":[{"id":"root_main","path":"/workspace/delete-rollback","kind":"git"}],
+		"default_provider":"openai",
+		"default_model":"gpt-5"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+created.Data.ID, nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("delete status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || !ok {
+		t.Fatalf("Hecate project after failed delete ok=%v err=%v, want retained", ok, err)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.Name != "Identity Delete Rollback" || findMirroredCairnlineRootForTest(mirrored.Roots, "root_main") == nil {
+		t.Fatalf("rolled-back Cairnline project = %+v, want restored project snapshot", mirrored)
+	}
+}
+
+func TestProjectsAPI_CairnlineIdentityAuthorityRejectsDuplicateNameBeforeCommit(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineIdentityAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"Existing"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create existing status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":" existing "}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate create status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "project name") {
+		t.Fatalf("duplicate create body = %s, want project name conflict", rec.Body.String())
+	}
+	items := listMirroredCairnlineProjectsForTest(t, handler)
+	if len(items) != 1 || items[0].Name != "Existing" {
+		t.Fatalf("mirrored projects = %+v, want rejected duplicate create to leave only original Cairnline row", items)
+	}
+}
+
+func TestProjectsAPI_CairnlineMetadataDefaultsAuthorityCommitsScopedUpdatesFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineMetadataDefaultsAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Authority Project",
+		"description":"initial",
+		"roots":[{"id":"root_main","path":"/workspace/main","kind":"git","git_branch":"main"}],
+		"default_provider":"openai",
+		"default_model":"gpt-5"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
+		"name":"Authority Rename",
+		"description":"Cairnline owns scoped project settings.",
+		"default_root_id":"root_main",
+		"default_provider":"anthropic",
+		"default_model":"claude-sonnet-4-5",
+		"default_agent_profile":"architecture",
+		"default_tools_enabled":false,
+		"default_workspace_mode":"worktree",
+		"default_system_prompt":"Use the portable project context.",
+		"default_compact_tool_output":true
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("metadata/default patch status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var updated ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode metadata/default patch response: %v", err)
+	}
+	if updated.Data.Name != "Authority Rename" || updated.Data.DefaultProvider != "anthropic" || updated.Data.DefaultModel != "claude-sonnet-4-5" || updated.Data.DefaultAgentProfile != "architecture" || updated.Data.DefaultWorkspaceMode != "worktree" || updated.Data.DefaultSystemPrompt != "Use the portable project context." {
+		t.Fatalf("updated project = %+v, want Cairnline-authority settings shadowed into Hecate", updated.Data)
+	}
+	if updated.Data.DefaultToolsEnabled == nil || *updated.Data.DefaultToolsEnabled {
+		t.Fatalf("default_tools_enabled = %+v, want false", updated.Data.DefaultToolsEnabled)
+	}
+	if updated.Data.DefaultCompactToolOutput == nil || !*updated.Data.DefaultCompactToolOutput {
+		t.Fatalf("default_compact_tool_output = %+v, want true", updated.Data.DefaultCompactToolOutput)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.Name != "Authority Rename" || mirrored.Description != "Cairnline owns scoped project settings." || mirrored.DefaultRootID != "root_main" || mirrored.DefaultProfileID != "architecture" {
+		t.Fatalf("mirrored project = %+v, want scoped metadata/default authority", mirrored)
+	}
+	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" {
+		t.Fatalf("mirrored roots = %+v, want existing root preserved", mirrored.Roots)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "anthropic", "claude-sonnet-4-5")
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
+		"name":"Mixed Root Replacement",
+		"roots":[{"id":"root_replaced","path":"/workspace/replaced","kind":"git","git_branch":"feature/root"}]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mixed root patch status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode mixed root patch response: %v", err)
+	}
+	if updated.Data.Name != "Mixed Root Replacement" || len(updated.Data.Roots) != 1 || updated.Data.Roots[0].ID != "root_replaced" {
+		t.Fatalf("mixed root patch project = %+v, want Hecate-owned root replacement path", updated.Data)
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.Name != "Mixed Root Replacement" || len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_replaced" {
+		t.Fatalf("mirrored mixed root patch = %+v, want root replacement still mirrored through Hecate-owned path", mirrored)
+	}
+}
+
+func TestProjectsAPI_CairnlineMetadataDefaultsAuthorityRejectsDuplicateNameBeforeCommit(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineMetadataDefaultsAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"Existing"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create existing status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"Target"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create target status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var target ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &target); err != nil {
+		t.Fatalf("decode target response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+target.Data.ID, bytes.NewReader([]byte(`{"name":" existing "}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate metadata authority rename status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "project name") {
+		t.Fatalf("duplicate metadata authority rename body = %s, want project name conflict", rec.Body.String())
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, target.Data.ID)
+	if mirrored.Name != "Target" {
+		t.Fatalf("mirrored target name = %q, want rejected duplicate rename to leave Cairnline row unchanged", mirrored.Name)
+	}
+}
+
+func TestProjectsAPI_CairnlineRootAuthorityCommitsDirectMutationsFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineRootSourceAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Root Authority",
+		"roots":[{"id":"root_main","path":"/workspace/root-main","kind":"git","git_branch":"main"}]
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+created.Data.ID+"/roots", bytes.NewReader([]byte(`{
+		"id":"root_feature",
+		"path":"/workspace/root-feature",
+		"kind":"git_worktree",
+		"git_branch":"feature/cairnline-roots",
+		"active":false
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create root status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var withRoot ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &withRoot); err != nil {
+		t.Fatalf("decode root create response: %v", err)
+	}
+	if len(withRoot.Data.Roots) != 2 || withRoot.Data.DefaultRootID != "root_main" {
+		t.Fatalf("root create response = %+v, want Hecate compatibility row shadowed with two roots and stable default", withRoot.Data)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if feature := findMirroredCairnlineRootForTest(mirrored.Roots, "root_feature"); feature == nil || feature.Path != "/workspace/root-feature" || feature.Active {
+		t.Fatalf("mirrored root_feature = %+v in %+v, want inactive created root", feature, mirrored.Roots)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID+"/roots/root_feature", bytes.NewReader([]byte(`{
+		"path":"/workspace/root-feature-updated",
+		"kind":"git_worktree",
+		"git_branch":"feature/cairnline-roots-updated",
+		"active":true
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update root status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &withRoot); err != nil {
+		t.Fatalf("decode root update response: %v", err)
+	}
+	if feature := findProjectResponseRootForTest(withRoot.Data.Roots, "root_feature"); feature == nil || feature.Path != "/workspace/root-feature-updated" || !feature.Active {
+		t.Fatalf("updated response root_feature = %+v in %+v, want active updated root", feature, withRoot.Data.Roots)
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if feature := findMirroredCairnlineRootForTest(mirrored.Roots, "root_feature"); feature == nil || feature.Path != "/workspace/root-feature-updated" || !feature.Active {
+		t.Fatalf("updated mirrored root_feature = %+v in %+v, want active updated root", feature, mirrored.Roots)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+created.Data.ID+"/roots/root_main", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete root status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &withRoot); err != nil {
+		t.Fatalf("decode root delete response: %v", err)
+	}
+	if len(withRoot.Data.Roots) != 1 || withRoot.Data.Roots[0].ID != "root_feature" || withRoot.Data.DefaultRootID != "root_feature" {
+		t.Fatalf("root delete response = %+v, want remaining root promoted to default", withRoot.Data)
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_feature" || mirrored.DefaultRootID != "root_feature" {
+		t.Fatalf("mirrored roots after delete = %+v default=%q, want remaining root promoted", mirrored.Roots, mirrored.DefaultRootID)
+	}
+}
+
+func TestProjectsAPI_CairnlineRootAuthorityRejectsDuplicatePathBeforeCommit(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineRootSourceAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Existing Root Project",
+		"roots":[{"id":"root_existing","path":"/workspace/shared-root","kind":"git"}]
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create existing status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"Root Target"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create target status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var target ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &target); err != nil {
+		t.Fatalf("decode target response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+target.Data.ID+"/roots", bytes.NewReader([]byte(`{
+		"id":"root_conflict",
+		"path":"/workspace/shared-root/",
+		"kind":"git"
+	}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate root path status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, target.Data.ID)
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_conflict") != nil {
+		t.Fatalf("mirrored roots = %+v, want rejected duplicate root path to leave Cairnline row unchanged", mirrored.Roots)
+	}
+}
+
+func TestProjectsAPI_CairnlineRootAuthorityCommitsListReplacementFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineRootSourceAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Root List Authority",
+		"roots":[
+			{"id":"root_main","path":"/workspace/root-list-main","kind":"git","git_branch":"main"},
+			{"id":"root_old","path":"/workspace/root-list-old","kind":"git_worktree","git_branch":"old"}
+		],
+		"default_root_id":"root_old"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
+		"roots":[
+			{"id":"root_next","path":"/workspace/root-list-next","kind":"git_worktree","git_branch":"next"},
+			{"id":"root_docs","path":"/workspace/root-list-docs","kind":"directory","active":false}
+		]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("replace roots status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var updated ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode root replacement response: %v", err)
+	}
+	if len(updated.Data.Roots) != 2 || updated.Data.Roots[0].ID != "root_next" || updated.Data.Roots[1].ID != "root_docs" || updated.Data.DefaultRootID != "root_next" {
+		t.Fatalf("root replacement response = %+v, want replacement roots with first root promoted to default", updated.Data)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if len(mirrored.Roots) != 2 || mirrored.Roots[0].ID != "root_next" || mirrored.Roots[1].ID != "root_docs" || mirrored.DefaultRootID != "root_next" {
+		t.Fatalf("mirrored roots after list replacement = %+v default=%q, want replacement committed to Cairnline first", mirrored.Roots, mirrored.DefaultRootID)
+	}
+}
+
+func TestProjectsAPI_CairnlineContextSourceAuthorityCommitsDirectMutationsFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineRootSourceAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{"name":"Source Authority"}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+created.Data.ID+"/context-sources", bytes.NewReader([]byte(`{
+		"id":"ctx_agents",
+		"path":"AGENTS.md",
+		"kind":"workspace_instruction",
+		"title":"AGENTS.md",
+		"format":"agents_md",
+		"scope":"workspace",
+		"trust_label":"workspace_guidance"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create source status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var withSource ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &withSource); err != nil {
+		t.Fatalf("decode source create response: %v", err)
+	}
+	if len(withSource.Data.ContextSources) != 1 || withSource.Data.ContextSources[0].ID != "ctx_agents" {
+		t.Fatalf("source create response = %+v, want ctx_agents", withSource.Data.ContextSources)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if source := findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_agents"); source == nil || source.Locator != "AGENTS.md" || source.Format != "agents_md" {
+		t.Fatalf("mirrored ctx_agents = %+v in %+v, want created source", source, mirrored.ContextSources)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID+"/context-sources/ctx_agents", bytes.NewReader([]byte(`{
+		"path":"docs/AGENTS.md",
+		"kind":"workspace_instruction",
+		"title":"Project agents",
+		"format":"agents_md",
+		"scope":"project",
+		"trust_label":"workspace_guidance",
+		"enabled":false
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update source status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &withSource); err != nil {
+		t.Fatalf("decode source update response: %v", err)
+	}
+	if source := findProjectResponseContextSourceForTest(withSource.Data.ContextSources, "ctx_agents"); source == nil || source.Path != "docs/AGENTS.md" || source.Enabled {
+		t.Fatalf("updated response ctx_agents = %+v in %+v, want disabled updated source", source, withSource.Data.ContextSources)
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if source := findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_agents"); source == nil || source.Locator != "docs/AGENTS.md" || source.Enabled {
+		t.Fatalf("updated mirrored ctx_agents = %+v in %+v, want disabled updated source", source, mirrored.ContextSources)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+created.Data.ID+"/context-sources", bytes.NewReader([]byte(`{
+		"id":"ctx_agents",
+		"path":"duplicate.md"
+	}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate source id status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+created.Data.ID+"/context-sources/ctx_agents", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete source status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &withSource); err != nil {
+		t.Fatalf("decode source delete response: %v", err)
+	}
+	if len(withSource.Data.ContextSources) != 0 {
+		t.Fatalf("source delete response = %+v, want no sources", withSource.Data.ContextSources)
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if len(mirrored.ContextSources) != 0 {
+		t.Fatalf("mirrored sources after delete = %+v, want none", mirrored.ContextSources)
+	}
+}
+
+func TestProjectsAPI_CairnlineContextSourceAuthorityCommitsListReplacementFirst(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineRootSourceAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Source List Authority",
+		"context_sources":[
+			{"id":"ctx_old","path":"AGENTS.md","kind":"workspace_instruction","title":"Old agents","format":"agents_md","scope":"workspace","trust_label":"workspace_guidance"}
+		]
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
+		"context_sources":[
+			{"id":"ctx_agents","path":"AGENTS.md","kind":"workspace_instruction","title":"AGENTS.md","format":"agents_md","scope":"workspace","trust_label":"workspace_guidance"},
+			{"id":"ctx_claude","path":"CLAUDE.md","kind":"workspace_instruction","title":"CLAUDE.md","format":"claude_md","scope":"workspace","trust_label":"workspace_guidance","enabled":false}
+		]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("replace sources status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var updated ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode source replacement response: %v", err)
+	}
+	if len(updated.Data.ContextSources) != 2 || updated.Data.ContextSources[0].ID != "ctx_agents" || updated.Data.ContextSources[1].ID != "ctx_claude" || updated.Data.ContextSources[1].Enabled {
+		t.Fatalf("source replacement response = %+v, want replacement sources with disabled ctx_claude", updated.Data.ContextSources)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if len(mirrored.ContextSources) != 2 || mirrored.ContextSources[0].ID != "ctx_agents" || mirrored.ContextSources[1].ID != "ctx_claude" || mirrored.ContextSources[1].Enabled {
+		t.Fatalf("mirrored sources after list replacement = %+v, want replacement committed to Cairnline first", mirrored.ContextSources)
 	}
 }
 
@@ -916,10 +1493,42 @@ func getMirroredCairnlineProjectForTest(t *testing.T, handler *Handler, projectI
 	return project
 }
 
+func listMirroredCairnlineProjectsForTest(t *testing.T, handler *Handler) []cairnline.Project {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	items, err := service.ListProjects(t.Context())
+	if err != nil {
+		t.Fatalf("ListProjects(): %v", err)
+	}
+	return items
+}
+
 func findMirroredCairnlineRootForTest(roots []cairnline.Root, id string) *cairnline.Root {
 	for idx := range roots {
 		if roots[idx].ID == id {
 			return &roots[idx]
+		}
+	}
+	return nil
+}
+
+func findProjectResponseRootForTest(roots []ProjectRootResponseItem, id string) *ProjectRootResponseItem {
+	for idx := range roots {
+		if roots[idx].ID == id {
+			return &roots[idx]
+		}
+	}
+	return nil
+}
+
+func findProjectResponseContextSourceForTest(sources []ProjectContextSourceResponseItem, id string) *ProjectContextSourceResponseItem {
+	for idx := range sources {
+		if sources[idx].ID == id {
+			return &sources[idx]
 		}
 	}
 	return nil
@@ -958,6 +1567,15 @@ func assertMirroredExecutionProfileForTest(t *testing.T, handler *Handler, profi
 		return
 	}
 	t.Fatalf("execution profile %q not found in %+v", profileID, profiles)
+}
+
+type failingProjectSkillDeleteStore struct {
+	projectskills.Store
+	err error
+}
+
+func (s failingProjectSkillDeleteStore) DeleteProject(context.Context, string) (int, error) {
+	return 0, s.err
 }
 
 func seedCairnlineOnlyProjectGraphForTest(t *testing.T, handler *Handler, projectID string) {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -297,21 +297,22 @@ type ProjectCairnlineExportResponse struct {
 }
 
 type ProjectCairnlineExportResponseItem struct {
-	ProjectID              string `json:"project_id"`
-	DatabasePath           string `json:"database_path"`
-	RootCount              int    `json:"root_count"`
-	ContextSourceCount     int    `json:"context_source_count"`
-	AgentProfileCount      int    `json:"agent_profile_count"`
-	ExecutionProfileCount  int    `json:"execution_profile_count"`
-	SkillCount             int    `json:"skill_count"`
-	RoleCount              int    `json:"role_count"`
-	WorkItemCount          int    `json:"work_item_count"`
-	AssignmentCount        int    `json:"assignment_count"`
-	ArtifactCount          int    `json:"artifact_count"`
-	HandoffCount           int    `json:"handoff_count"`
-	MemoryEntryCount       int    `json:"memory_entry_count"`
-	MemoryCandidateCount   int    `json:"memory_candidate_count"`
-	AssistantProposalCount int    `json:"assistant_proposal_count"`
+	ProjectID              string                             `json:"project_id"`
+	DatabasePath           string                             `json:"database_path"`
+	RootCount              int                                `json:"root_count"`
+	ContextSourceCount     int                                `json:"context_source_count"`
+	AgentProfileCount      int                                `json:"agent_profile_count"`
+	ExecutionProfileCount  int                                `json:"execution_profile_count"`
+	SkillCount             int                                `json:"skill_count"`
+	RoleCount              int                                `json:"role_count"`
+	WorkItemCount          int                                `json:"work_item_count"`
+	AssignmentCount        int                                `json:"assignment_count"`
+	ArtifactCount          int                                `json:"artifact_count"`
+	HandoffCount           int                                `json:"handoff_count"`
+	MemoryEntryCount       int                                `json:"memory_entry_count"`
+	MemoryCandidateCount   int                                `json:"memory_candidate_count"`
+	AssistantProposalCount int                                `json:"assistant_proposal_count"`
+	MigrationRehearsal     ProjectCairnlineMigrationRehearsal `json:"migration_rehearsal"`
 }
 
 type ProjectCairnlineSyncResponse struct {
@@ -329,6 +330,46 @@ type ProjectCairnlineSyncResponseItem struct {
 	Hecate             ProjectCairnlineSyncCounts          `json:"hecate"`
 	Cairnline          ProjectCairnlineSyncCounts          `json:"cairnline"`
 	Authoritative      bool                                `json:"authoritative"`
+	MigrationRehearsal ProjectCairnlineMigrationRehearsal  `json:"migration_rehearsal"`
+}
+
+type ProjectCairnlineMigrationRehearsal struct {
+	Operation       string                                    `json:"operation"`
+	ImportMode      string                                    `json:"import_mode"`
+	SnapshotVersion int                                       `json:"snapshot_version"`
+	SourceAuthority string                                    `json:"source_authority"`
+	Target          string                                    `json:"target"`
+	RefreshesTarget bool                                      `json:"refreshes_target"`
+	Authoritative   bool                                      `json:"authoritative"`
+	CutoverReady    bool                                      `json:"cutover_ready"`
+	Status          string                                    `json:"status"`
+	Checklist       []ProjectCairnlineMigrationRehearsalCheck `json:"checklist"`
+	Rollback        []string                                  `json:"rollback"`
+	EmbeddedSmoke   *ProjectCairnlineMigrationEmbeddedSmoke   `json:"embedded_smoke,omitempty"`
+}
+
+type ProjectCairnlineMigrationRehearsalCheck struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+type ProjectCairnlineMigrationEmbeddedSmoke struct {
+	Status                   string                                        `json:"status"`
+	ProjectCount             int                                           `json:"project_count"`
+	CheckedProjectIDs        []string                                      `json:"checked_project_ids,omitempty"`
+	ReadRouteChecks          int                                           `json:"read_route_checks"`
+	ReadModelCount           int                                           `json:"read_model_count"`
+	LaunchPacketCount        int                                           `json:"launch_packet_count"`
+	LaunchPacketWarningCount int                                           `json:"launch_packet_warning_count"`
+	LaunchPacketErrorCount   int                                           `json:"launch_packet_error_count"`
+	Errors                   []ProjectCairnlineMigrationEmbeddedSmokeError `json:"errors,omitempty"`
+}
+
+type ProjectCairnlineMigrationEmbeddedSmokeError struct {
+	ProjectID string `json:"project_id,omitempty"`
+	Check     string `json:"check"`
+	Error     string `json:"error"`
 }
 
 type ProjectCairnlineSyncCounts struct {

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -90,7 +90,7 @@ func seedProjectScopedSnapshot(ctx context.Context, service *cairnline.Service, 
 		if _, err := service.CreateAssignment(ctx, item); err != nil {
 			return err
 		}
-		if err := syncAssignmentStatus(ctx, service, item); err != nil {
+		if err := syncAssignmentStatus(ctx, service, cairnline.Assignment{}, item); err != nil {
 			return err
 		}
 	}
@@ -290,21 +290,23 @@ func RoleExecutionProfile(role projectwork.AgentRoleProfile) (cairnline.Executio
 
 func ProjectSkill(skill projectskills.Skill) cairnline.ProjectSkill {
 	return cairnline.ProjectSkill{
-		ID:           strings.TrimSpace(skill.ID),
-		ProjectID:    strings.TrimSpace(skill.ProjectID),
-		Title:        strings.TrimSpace(skill.Title),
-		Description:  strings.TrimSpace(skill.Description),
-		Path:         strings.TrimSpace(skill.Path),
-		RootID:       strings.TrimSpace(skill.RootID),
-		Format:       strings.TrimSpace(skill.Format),
-		Enabled:      skill.Enabled,
-		Status:       strings.TrimSpace(skill.Status),
-		TrustLabel:   strings.TrimSpace(skill.TrustLabel),
-		SourceRefs:   compactStrings(skill.SourceContextSourceIDs),
-		Warnings:     compactStrings(skill.Warnings),
-		DiscoveredAt: skill.DiscoveredAt,
-		CreatedAt:    skill.CreatedAt,
-		UpdatedAt:    skill.UpdatedAt,
+		ID:                  strings.TrimSpace(skill.ID),
+		ProjectID:           strings.TrimSpace(skill.ProjectID),
+		Title:               strings.TrimSpace(skill.Title),
+		Description:         strings.TrimSpace(skill.Description),
+		Path:                strings.TrimSpace(skill.Path),
+		RootID:              strings.TrimSpace(skill.RootID),
+		Format:              strings.TrimSpace(skill.Format),
+		SuggestedTools:      compactStrings(skill.SuggestedTools),
+		RequiredPermissions: RequiredPermissions(skill.RequiredPermissions),
+		Enabled:             skill.Enabled,
+		Status:              strings.TrimSpace(skill.Status),
+		TrustLabel:          strings.TrimSpace(skill.TrustLabel),
+		SourceRefs:          compactStrings(skill.SourceContextSourceIDs),
+		Warnings:            compactStrings(skill.Warnings),
+		DiscoveredAt:        skill.DiscoveredAt,
+		CreatedAt:           skill.CreatedAt,
+		UpdatedAt:           skill.UpdatedAt,
 	}
 }
 
@@ -357,6 +359,8 @@ func Assignment(assignment projectwork.Assignment, role projectwork.AgentRolePro
 		ContextSnapshotID: strings.TrimSpace(assignment.ExecutionRef.ContextSnapshotID),
 		CreatedAt:         assignment.CreatedAt,
 		UpdatedAt:         assignment.UpdatedAt,
+		StartedAt:         assignment.StartedAt,
+		CompletedAt:       assignment.CompletedAt,
 	}
 }
 
@@ -391,6 +395,9 @@ func Evidence(artifact projectwork.CollaborationArtifact) (cairnline.Evidence, b
 		Title:        strings.TrimSpace(artifact.Title),
 		Body:         strings.TrimSpace(artifact.Body),
 		Locator:      firstNonEmpty(strings.TrimSpace(artifact.EvidenceURL), strings.TrimSpace(artifact.EvidenceExternalID)),
+		SourceKind:   strings.TrimSpace(artifact.EvidenceSourceKind),
+		ExternalID:   strings.TrimSpace(artifact.EvidenceExternalID),
+		Provider:     strings.TrimSpace(artifact.EvidenceProvider),
 		TrustLabel:   firstNonEmpty(strings.TrimSpace(artifact.EvidenceTrustLabel), projectwork.EvidenceTrustOperatorProvided),
 		CreatedAt:    artifact.CreatedAt,
 		UpdatedAt:    artifact.UpdatedAt,
@@ -418,6 +425,10 @@ func Review(artifact projectwork.CollaborationArtifact) (cairnline.Review, bool)
 }
 
 func Handoff(handoff projectwork.Handoff) cairnline.Handoff {
+	statusChangedAt := handoff.StatusChangedAt
+	if statusChangedAt.IsZero() {
+		statusChangedAt = handoff.CreatedAt
+	}
 	return cairnline.Handoff{
 		ID:                    strings.TrimSpace(handoff.ID),
 		ProjectID:             strings.TrimSpace(handoff.ProjectID),
@@ -441,6 +452,7 @@ func Handoff(handoff projectwork.Handoff) cairnline.Handoff {
 		TrustLabel:            strings.TrimSpace(handoff.TrustLabel),
 		CreatedAt:             handoff.CreatedAt,
 		UpdatedAt:             handoff.UpdatedAt,
+		StatusChangedAt:       statusChangedAt,
 	}
 }
 
@@ -527,11 +539,15 @@ func AssignmentStatus(status string) string {
 func ReviewVerdict(verdict string) string {
 	switch strings.TrimSpace(verdict) {
 	case projectwork.ReviewVerdictApproved:
-		return cairnline.ReviewVerdictPass
+		return cairnline.ReviewVerdictApproved
+	case projectwork.ReviewVerdictChangesRequested:
+		return cairnline.ReviewVerdictChangesRequested
 	case projectwork.ReviewVerdictBlocked:
 		return cairnline.ReviewVerdictBlocked
+	case projectwork.ReviewVerdictRisk:
+		return cairnline.ReviewVerdictRisk
 	default:
-		return cairnline.ReviewVerdictConcerns
+		return cairnline.ReviewVerdictChangesRequested
 	}
 }
 
@@ -543,6 +559,8 @@ func ReviewRisk(risk string) string {
 		return cairnline.ReviewRiskMedium
 	case projectwork.ReviewRiskHigh:
 		return cairnline.ReviewRiskHigh
+	case projectwork.ReviewRiskUnknown:
+		return cairnline.ReviewRiskUnknown
 	default:
 		return ""
 	}
@@ -579,31 +597,20 @@ func DesiredAgentKind(driverKind string) string {
 	return cairnline.DesiredAgentAny
 }
 
-func syncAssignmentStatus(ctx context.Context, service *cairnline.Service, assignment cairnline.Assignment) error {
+func syncAssignmentStatus(ctx context.Context, service *cairnline.Service, existing, assignment cairnline.Assignment) error {
 	switch assignment.Status {
 	case cairnline.AssignmentQueued:
+		if existing.Status == cairnline.AssignmentClaimed {
+			_, err := service.ReleaseAssignment(ctx, assignment.ProjectID, assignment.ID, existing.ClaimedBy)
+			return err
+		}
 		return nil
 	case cairnline.AssignmentRunning, cairnline.AssignmentReview:
-		current, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
-		if err != nil {
-			return err
-		}
-		if current.Status == cairnline.AssignmentQueued {
-			if _, err := service.ClaimAssignment(ctx, assignment.ProjectID, assignment.ID, claimedBy(assignment)); err != nil {
-				return err
-			}
-		}
-		_, err = service.UpdateAssignmentStatus(ctx, assignment.ProjectID, assignment.ID, assignment.Status, assignment.ExecutionRef)
+		assignment.ClaimedBy = claimedBy(assignment)
+		_, err := service.UpdateAssignment(ctx, assignment)
 		return err
 	case cairnline.AssignmentCompleted, cairnline.AssignmentFailed, cairnline.AssignmentCancelled:
-		current, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
-		if err != nil {
-			return err
-		}
-		if current.Status == assignment.Status {
-			return nil
-		}
-		_, err = service.CompleteAssignment(ctx, assignment.ProjectID, assignment.ID, assignment.Status, assignment.ExecutionRef)
+		_, err := service.UpdateAssignment(ctx, assignment)
 		return err
 	default:
 		return nil
@@ -706,6 +713,22 @@ func optionalBoolPolicy(value *bool) string {
 		return ""
 	}
 	return boolPolicy(*value)
+}
+
+func RequiredPermissions(permissions projectskills.RequiredPermissions) cairnline.RequiredPermissions {
+	return cairnline.RequiredPermissions{
+		Tools:   cloneBoolPointer(permissions.Tools),
+		Writes:  cloneBoolPointer(permissions.Writes),
+		Network: cloneBoolPointer(permissions.Network),
+	}
+}
+
+func cloneBoolPointer(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
 }
 
 func projectExecutionAdapterOptions(project projects.Project) map[string]any {

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -81,17 +81,17 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if packet.Assignment.ExecutionMode != cairnline.ExecutionOrchestrated || packet.Assignment.RootID != "root_main" || packet.Assignment.ContextSnapshotID != "ctx_123" {
 		t.Fatalf("packet assignment = %+v, want orchestrated root-scoped assignment", packet.Assignment)
 	}
-	if len(packet.Skills) != 1 || packet.Skills[0].ID != "backend" || len(packet.Skills[0].SourceRefs) != 1 {
-		t.Fatalf("packet skills = %+v, want mapped backend skill with provenance", packet.Skills)
+	if len(packet.Skills) != 1 || packet.Skills[0].ID != "backend" || len(packet.Skills[0].SourceRefs) != 1 || len(packet.Skills[0].SuggestedTools) != 2 || packet.Skills[0].RequiredPermissions.Writes == nil || *packet.Skills[0].RequiredPermissions.Writes {
+		t.Fatalf("packet skills = %+v, want mapped backend skill with provenance and capability hints", packet.Skills)
 	}
 	if len(packet.Artifacts) != 1 || packet.Artifacts[0].ID != "art_decision" || packet.Artifacts[0].Kind != projectwork.ArtifactKindDecisionNote || packet.Artifacts[0].AuthorRoleID != "bridge_developer" {
 		t.Fatalf("packet artifacts = %+v, want mapped generic collaboration artifact", packet.Artifacts)
 	}
-	if len(packet.Evidence) != 1 || packet.Evidence[0].ID != "art_evidence" || packet.Evidence[0].AssignmentID != "asgn_external" || packet.Evidence[0].Locator != "https://github.com/hecatehq/hecate/actions/runs/123" {
+	if len(packet.Evidence) != 1 || packet.Evidence[0].ID != "art_evidence" || packet.Evidence[0].AssignmentID != "asgn_external" || packet.Evidence[0].Locator != "https://github.com/hecatehq/hecate/actions/runs/123" || packet.Evidence[0].SourceKind != "pull_request" || packet.Evidence[0].ExternalID != "PR 123" || packet.Evidence[0].Provider != "github" {
 		t.Fatalf("packet evidence = %+v, want mapped assignment-scoped evidence link", packet.Evidence)
 	}
-	if len(packet.Reviews) != 1 || packet.Reviews[0].ID != "art_review" || packet.Reviews[0].AssignmentID != "asgn_external" || packet.Reviews[0].Verdict != cairnline.ReviewVerdictConcerns || packet.Reviews[0].Risk != cairnline.ReviewRiskMedium {
-		t.Fatalf("packet reviews = %+v, want mapped review with reduced verdict", packet.Reviews)
+	if len(packet.Reviews) != 1 || packet.Reviews[0].ID != "art_review" || packet.Reviews[0].AssignmentID != "asgn_external" || packet.Reviews[0].Verdict != cairnline.ReviewVerdictChangesRequested || packet.Reviews[0].Risk != cairnline.ReviewRiskMedium {
+		t.Fatalf("packet reviews = %+v, want mapped review with portable verdict", packet.Reviews)
 	}
 	if len(packet.Handoffs) != 1 || packet.Handoffs[0].ID != "handoff_review" || packet.Handoffs[0].FromRoleID != "bridge_developer" || packet.Handoffs[0].ToRoleID != "bridge_reviewer" {
 		t.Fatalf("packet handoffs = %+v, want mapped handoff roles", packet.Handoffs)
@@ -190,6 +190,43 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	}
 	if externalPacket.Assignment.Status != cairnline.AssignmentCompleted || externalPacket.Assignment.ExecutionMode != cairnline.ExecutionExternalAdapter || externalPacket.Assignment.ExecutionRef != "chat_123" {
 		t.Fatalf("external assignment = %+v, want completed external-adapter assignment", externalPacket.Assignment)
+	}
+}
+
+func TestCairnlineSnapshotMapsHecateSnapshotToPortableContract(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	source := bridgeSnapshotFixture(now)
+	snapshot := CairnlineSnapshot([]Snapshot{source})
+
+	if snapshot.Version != cairnline.SnapshotVersion {
+		t.Fatalf("snapshot version = %d, want %d", snapshot.Version, cairnline.SnapshotVersion)
+	}
+	if len(snapshot.Projects) != 1 || snapshot.Projects[0].ID != source.Project.ID {
+		t.Fatalf("snapshot projects = %+v, want mapped Hecate project", snapshot.Projects)
+	}
+	if len(snapshot.AgentProfiles) != len(source.AgentProfiles) {
+		t.Fatalf("snapshot agent profiles = %+v, want %d", snapshot.AgentProfiles, len(source.AgentProfiles))
+	}
+	if len(snapshot.ExecutionProfiles) != SnapshotExecutionProfileCount(source) {
+		t.Fatalf("snapshot execution profiles = %+v, want %d unique execution profiles", snapshot.ExecutionProfiles, SnapshotExecutionProfileCount(source))
+	}
+	if len(snapshot.ProjectSkills) != len(source.Skills) || snapshot.ProjectSkills[0].RequiredPermissions.Writes == nil || *snapshot.ProjectSkills[0].RequiredPermissions.Writes {
+		t.Fatalf("snapshot skills = %+v, want project skill capability metadata", snapshot.ProjectSkills)
+	}
+	if len(snapshot.WorkItems) != len(source.WorkItems) || len(snapshot.Assignments) != len(source.Assignments) {
+		t.Fatalf("snapshot work/assignments = %d/%d, want %d/%d", len(snapshot.WorkItems), len(snapshot.Assignments), len(source.WorkItems), len(source.Assignments))
+	}
+	if len(snapshot.Artifacts) != 1 || len(snapshot.Evidence) != 1 || len(snapshot.Reviews) != 1 {
+		t.Fatalf("snapshot artifacts/evidence/reviews = %d/%d/%d, want split portable collaboration records", len(snapshot.Artifacts), len(snapshot.Evidence), len(snapshot.Reviews))
+	}
+	if len(snapshot.Handoffs) != len(source.Handoffs) || snapshot.Handoffs[0].StatusChangedAt.IsZero() {
+		t.Fatalf("snapshot handoffs = %+v, want handoff with status-change timestamp", snapshot.Handoffs)
+	}
+	if len(snapshot.MemoryEntries) != len(source.MemoryEntries) || len(snapshot.MemoryCandidates) != len(source.MemoryCandidates) {
+		t.Fatalf("snapshot memory entries/candidates = %d/%d, want %d/%d", len(snapshot.MemoryEntries), len(snapshot.MemoryCandidates), len(source.MemoryEntries), len(source.MemoryCandidates))
+	}
+	if len(snapshot.AssistantProposals) == 0 || len(snapshot.AssistantProposals[0].Proposal.Actions) == 0 {
+		t.Fatalf("snapshot assistant proposals = %+v, want proposal ledger imported without replay", snapshot.AssistantProposals)
 	}
 }
 
@@ -1337,13 +1374,28 @@ func TestUpsertAssignmentCreatesAndSyncsLifecycle(t *testing.T) {
 		t.Fatalf("updated queued desired agent = %+v, want external role skill metadata", updatedQueued.DesiredAgent)
 	}
 
+	if _, err := service.ClaimAssignment(ctx, assignment.ProjectID, assignment.ID, "external_adapter"); err != nil {
+		t.Fatalf("ClaimAssignment(pre-dispatch) error = %v", err)
+	}
+	assignment.ExecutionRef = projectwork.AssignmentExecutionRef{}
+	assignment.StartedAt = time.Time{}
+	assignment.CompletedAt = time.Time{}
+	releasedQueued, err := UpsertAssignment(ctx, service, assignment, externalRole, profile)
+	if err != nil {
+		t.Fatalf("UpsertAssignment(release queued) error = %v", err)
+	}
+	if releasedQueued.Status != cairnline.AssignmentQueued || releasedQueued.ClaimedBy != "" || releasedQueued.ExecutionRef != "" || releasedQueued.ContextSnapshotID != "" || !releasedQueued.StartedAt.IsZero() || !releasedQueued.CompletedAt.IsZero() {
+		t.Fatalf("released queued assignment = %+v, want claimed assignment released for retry", releasedQueued)
+	}
+
 	assignment.Status = projectwork.AssignmentStatusRunning
 	assignment.ExecutionRef = projectwork.AssignmentExecutionRef{TaskID: "task_1", RunID: "run_1", ContextSnapshotID: "ctx_running"}
+	assignment.StartedAt = now.Add(5 * time.Minute)
 	running, err := UpsertAssignment(ctx, service, assignment, externalRole, profile)
 	if err != nil {
 		t.Fatalf("UpsertAssignment(running) error = %v", err)
 	}
-	if running.Status != cairnline.AssignmentRunning || running.ClaimedBy != "external_adapter" || running.ExecutionRef != "run_1" || running.WorkItemID != followUpWork.ID || running.RoleID != externalRole.ID {
+	if running.Status != cairnline.AssignmentRunning || running.ClaimedBy != "external_adapter" || running.ExecutionRef != "run_1" || running.WorkItemID != followUpWork.ID || running.RoleID != externalRole.ID || !running.StartedAt.Equal(assignment.StartedAt) {
 		t.Fatalf("running assignment = %+v, want claimed running assignment", running)
 	}
 	if _, err := UpsertAssignment(ctx, service, assignment, externalRole, profile); err != nil {
@@ -1351,11 +1403,12 @@ func TestUpsertAssignmentCreatesAndSyncsLifecycle(t *testing.T) {
 	}
 
 	assignment.Status = projectwork.AssignmentStatusCompleted
+	assignment.CompletedAt = now.Add(10 * time.Minute)
 	completed, err := UpsertAssignment(ctx, service, assignment, externalRole, profile)
 	if err != nil {
 		t.Fatalf("UpsertAssignment(completed) error = %v", err)
 	}
-	if completed.Status != cairnline.AssignmentCompleted || completed.ExecutionRef != "run_1" {
+	if completed.Status != cairnline.AssignmentCompleted || completed.ExecutionRef != "run_1" || !completed.StartedAt.Equal(assignment.StartedAt) || !completed.CompletedAt.Equal(assignment.CompletedAt) {
 		t.Fatalf("completed assignment = %+v, want completed assignment with execution ref", completed)
 	}
 	if _, err := UpsertAssignment(ctx, service, assignment, externalRole, profile); err != nil {
@@ -1481,7 +1534,10 @@ func TestRecordCollaborationArtifactsAndUpsertHandoff(t *testing.T) {
 		Kind:               projectwork.ArtifactKindEvidenceLink,
 		Title:              "CI run",
 		Body:               "Tests passed.",
+		EvidenceSourceKind: "pull_request",
 		EvidenceURL:        "https://github.com/hecatehq/hecate/actions/runs/42",
+		EvidenceExternalID: "PR 42",
+		EvidenceProvider:   "github",
 		EvidenceTrustLabel: projectwork.EvidenceTrustOperatorProvided,
 		CreatedAt:          now,
 		UpdatedAt:          now,
@@ -1490,7 +1546,7 @@ func TestRecordCollaborationArtifactsAndUpsertHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RecordEvidence() error = %v", err)
 	}
-	if evidence.ID != "art_evidence" || evidence.AssignmentID != assignment.ID || evidence.Locator != evidenceArtifact.EvidenceURL || evidence.TrustLabel != projectwork.EvidenceTrustOperatorProvided {
+	if evidence.ID != "art_evidence" || evidence.AssignmentID != assignment.ID || evidence.Locator != evidenceArtifact.EvidenceURL || evidence.SourceKind != "pull_request" || evidence.ExternalID != "PR 42" || evidence.Provider != "github" || evidence.TrustLabel != projectwork.EvidenceTrustOperatorProvided {
 		t.Fatalf("recorded evidence = %+v, want evidence link metadata", evidence)
 	}
 
@@ -1513,8 +1569,8 @@ func TestRecordCollaborationArtifactsAndUpsertHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RecordReview() error = %v", err)
 	}
-	if review.ID != "art_review" || review.AssignmentID != assignment.ID || review.ReviewerRoleID != role.ID || review.Verdict != cairnline.ReviewVerdictConcerns || review.Risk != cairnline.ReviewRiskHigh {
-		t.Fatalf("recorded review = %+v, want reduced review metadata", review)
+	if review.ID != "art_review" || review.AssignmentID != assignment.ID || review.ReviewerRoleID != role.ID || review.Verdict != cairnline.ReviewVerdictChangesRequested || review.Risk != cairnline.ReviewRiskHigh {
+		t.Fatalf("recorded review = %+v, want portable review metadata", review)
 	}
 
 	handoff := projectwork.Handoff{
@@ -1535,12 +1591,13 @@ func TestRecordCollaborationArtifactsAndUpsertHandoff(t *testing.T) {
 		CreatedByRoleID:       role.ID,
 		CreatedAt:             now,
 		UpdatedAt:             now,
+		StatusChangedAt:       now.Add(-time.Minute),
 	}
 	createdHandoff, err := UpsertHandoff(ctx, service, handoff)
 	if err != nil {
 		t.Fatalf("UpsertHandoff(create) error = %v", err)
 	}
-	if createdHandoff.ID != handoff.ID || createdHandoff.SourceAssignmentID != assignment.ID || createdHandoff.FromRoleID != role.ID || createdHandoff.ToRoleID != role.ID || len(createdHandoff.LinkedArtifactIDs) != 1 || createdHandoff.Status != cairnline.HandoffStatusOpen {
+	if createdHandoff.ID != handoff.ID || createdHandoff.SourceAssignmentID != assignment.ID || createdHandoff.FromRoleID != role.ID || createdHandoff.ToRoleID != role.ID || len(createdHandoff.LinkedArtifactIDs) != 1 || createdHandoff.Status != cairnline.HandoffStatusOpen || !createdHandoff.StatusChangedAt.Equal(handoff.StatusChangedAt) {
 		t.Fatalf("created handoff = %+v, want mapped handoff metadata", createdHandoff)
 	}
 
@@ -1548,11 +1605,12 @@ func TestRecordCollaborationArtifactsAndUpsertHandoff(t *testing.T) {
 	handoff.TargetAssignmentID = assignment.ID
 	handoff.TargetWorkItemID = workItem.ID
 	handoff.Summary = "Accepted follow-up."
+	handoff.StatusChangedAt = now.Add(2 * time.Minute)
 	updatedHandoff, err := UpsertHandoff(ctx, service, handoff)
 	if err != nil {
 		t.Fatalf("UpsertHandoff(update) error = %v", err)
 	}
-	if updatedHandoff.Status != cairnline.HandoffStatusAccepted || updatedHandoff.TargetAssignmentID != assignment.ID || updatedHandoff.TargetWorkItemID != workItem.ID || updatedHandoff.Body != "Accepted follow-up." {
+	if updatedHandoff.Status != cairnline.HandoffStatusAccepted || updatedHandoff.TargetAssignmentID != assignment.ID || updatedHandoff.TargetWorkItemID != workItem.ID || updatedHandoff.Body != "Accepted follow-up." || !updatedHandoff.StatusChangedAt.Equal(handoff.StatusChangedAt) {
 		t.Fatalf("updated handoff = %+v, want accepted handoff update", updatedHandoff)
 	}
 
@@ -1583,6 +1641,8 @@ func TestUpsertProjectSkillMirrorsSkillMetadata(t *testing.T) {
 		Path:                   ".agents/skills/backend/SKILL.md",
 		RootID:                 "root_main",
 		Format:                 projectskills.FormatSkillMD,
+		SuggestedTools:         []string{"git.diff", "file.read"},
+		RequiredPermissions:    projectskills.RequiredPermissions{Writes: boolPtrForTest(false)},
 		Enabled:                false,
 		Status:                 projectskills.StatusAvailable,
 		TrustLabel:             projectskills.TrustWorkspaceSkill,
@@ -1606,9 +1666,14 @@ func TestUpsertProjectSkillMirrorsSkillMetadata(t *testing.T) {
 	if created.Status != cairnline.SkillStatusAvailable || created.TrustLabel != cairnline.SkillTrustWorkspace || len(created.SourceRefs) != 1 || created.SourceRefs[0] != "ctx_agents" || len(created.Warnings) != 1 {
 		t.Fatalf("created skill = %+v, want status/trust/provenance/warnings", created)
 	}
+	if len(created.SuggestedTools) != 2 || created.RequiredPermissions.Writes == nil || *created.RequiredPermissions.Writes {
+		t.Fatalf("created skill capability hints = %+v / %+v, want mapped tools and permissions", created.SuggestedTools, created.RequiredPermissions)
+	}
 
 	skill.Title = "Backend Lead"
 	skill.Description = "Operator edited description."
+	skill.SuggestedTools = []string{"shell.exec"}
+	skill.RequiredPermissions = projectskills.RequiredPermissions{Network: boolPtrForTest(false)}
 	skill.Enabled = true
 	skill.Status = projectskills.StatusConflict
 	skill.TrustLabel = "operator_curated_skill"
@@ -1619,6 +1684,9 @@ func TestUpsertProjectSkillMirrorsSkillMetadata(t *testing.T) {
 	}
 	if updated.Title != "Backend Lead" || updated.Description != "Operator edited description." || !updated.Enabled || updated.Status != cairnline.SkillStatusConflict || updated.TrustLabel != "operator_curated_skill" {
 		t.Fatalf("updated skill = %+v, want operator-edited metadata", updated)
+	}
+	if len(updated.SuggestedTools) != 1 || updated.SuggestedTools[0] != "shell.exec" || updated.RequiredPermissions.Network == nil || *updated.RequiredPermissions.Network {
+		t.Fatalf("updated skill capability hints = %+v / %+v, want updated tools and permissions", updated.SuggestedTools, updated.RequiredPermissions)
 	}
 	if updated.CreatedAt.IsZero() || !updated.DiscoveredAt.Equal(now) {
 		t.Fatalf("updated skill times = created %s discovered %s, want preserved created and Hecate discovered time", updated.CreatedAt, updated.DiscoveredAt)
@@ -2013,6 +2081,8 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			Path:                   "docs-ai/skills/backend/SKILL.md",
 			RootID:                 "root_main",
 			Format:                 projectskills.FormatSkillMD,
+			SuggestedTools:         []string{"git.diff", "file.read"},
+			RequiredPermissions:    projectskills.RequiredPermissions{Writes: boolPtrForTest(false)},
 			Enabled:                true,
 			Status:                 projectskills.StatusAvailable,
 			TrustLabel:             projectskills.TrustWorkspaceSkill,
@@ -2104,7 +2174,9 @@ func bridgeSnapshotFixture(now time.Time) Snapshot {
 			Kind:               projectwork.ArtifactKindEvidenceLink,
 			Title:              "CI run",
 			Body:               "Focused bridge tests passed.",
+			EvidenceSourceKind: "pull_request",
 			EvidenceURL:        "https://github.com/hecatehq/hecate/actions/runs/123",
+			EvidenceExternalID: "PR 123",
 			EvidenceProvider:   "github",
 			EvidenceTrustLabel: projectwork.EvidenceTrustOperatorProvided,
 			CreatedAt:          now,

--- a/internal/cairnlinebridge/snapshot.go
+++ b/internal/cairnlinebridge/snapshot.go
@@ -49,13 +49,32 @@ func SeedSnapshots(ctx context.Context, service *cairnline.Service, snapshots []
 	if service == nil {
 		return errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
 	}
-	profilesByID := map[string]agentprofiles.Profile{}
-	executionProfileIDs := map[string]struct{}{}
+	_, err := service.ImportSnapshot(ctx, CairnlineSnapshot(snapshots))
+	return err
+}
+
+func CairnlineSnapshot(snapshots []Snapshot) cairnline.Snapshot {
+	out := cairnline.Snapshot{
+		Version: cairnline.SnapshotVersion,
+	}
+	profilesByID := make(map[string]agentprofiles.Profile)
+	rolesByID := make(map[string]projectwork.AgentRoleProfile)
+	seenAgentProfiles := make(map[string]struct{})
+	seenExecutionProfiles := make(map[string]struct{})
+	addExecutionProfile := func(profile cairnline.ExecutionProfile) {
+		id := strings.TrimSpace(profile.ID)
+		if id == "" {
+			return
+		}
+		if _, ok := seenExecutionProfiles[id]; ok {
+			return
+		}
+		seenExecutionProfiles[id] = struct{}{}
+		out.ExecutionProfiles = append(out.ExecutionProfiles, profile)
+	}
 	for _, snapshot := range snapshots {
 		if executionProfile, ok := ProjectExecutionProfile(snapshot.Project); ok {
-			if err := createExecutionProfileOnce(ctx, service, executionProfileIDs, executionProfile); err != nil {
-				return err
-			}
+			addExecutionProfile(executionProfile)
 		}
 		for _, profile := range snapshot.AgentProfiles {
 			if _, seen := profilesByID[profile.ID]; seen {
@@ -64,36 +83,73 @@ func SeedSnapshots(ctx context.Context, service *cairnline.Service, snapshots []
 			profilesByID[profile.ID] = profile
 		}
 	}
-	createdProfiles := map[string]struct{}{}
 	for _, snapshot := range snapshots {
 		for _, profile := range snapshot.AgentProfiles {
-			if _, seen := createdProfiles[profile.ID]; seen {
+			id := strings.TrimSpace(profile.ID)
+			if id == "" {
 				continue
 			}
-			createdProfiles[profile.ID] = struct{}{}
-			if _, err := service.CreateAgentProfile(ctx, AgentProfile(profile)); err != nil {
-				return err
+			if _, seen := seenAgentProfiles[id]; seen {
+				continue
 			}
-			if err := createExecutionProfileOnce(ctx, service, executionProfileIDs, ExecutionProfile(profile)); err != nil {
-				return err
-			}
+			seenAgentProfiles[id] = struct{}{}
+			out.AgentProfiles = append(out.AgentProfiles, AgentProfile(profile))
+			addExecutionProfile(ExecutionProfile(profile))
 		}
 	}
 	for _, snapshot := range snapshots {
+		out.Projects = append(out.Projects, Project(snapshot.Project))
+		for _, skill := range snapshot.Skills {
+			out.ProjectSkills = append(out.ProjectSkills, ProjectSkill(skill))
+		}
 		for _, role := range snapshot.Roles {
+			rolesByID[role.ID] = role
+			out.Roles = append(out.Roles, Role(role))
 			executionProfile, ok := RoleExecutionProfile(role)
 			if !ok {
 				continue
 			}
-			if err := createExecutionProfileOnce(ctx, service, executionProfileIDs, executionProfile); err != nil {
-				return err
+			addExecutionProfile(executionProfile)
+		}
+		for _, item := range snapshot.WorkItems {
+			out.WorkItems = append(out.WorkItems, WorkItem(item))
+		}
+		for _, assignment := range snapshot.Assignments {
+			role := rolesByID[assignment.RoleID]
+			profile := profilesByID[role.DefaultAgentProfile]
+			out.Assignments = append(out.Assignments, Assignment(assignment, role, profile))
+		}
+		for _, artifact := range snapshot.Artifacts {
+			if item, ok := Artifact(artifact); ok {
+				out.Artifacts = append(out.Artifacts, item)
+				continue
+			}
+			if item, ok := Evidence(artifact); ok {
+				out.Evidence = append(out.Evidence, item)
+				continue
+			}
+			if item, ok := Review(artifact); ok {
+				out.Reviews = append(out.Reviews, item)
 			}
 		}
-		if err := seedProjectScopedSnapshot(ctx, service, snapshot, profilesByID); err != nil {
-			return err
+		for _, handoff := range snapshot.Handoffs {
+			out.Handoffs = append(out.Handoffs, Handoff(handoff))
+		}
+		for _, entry := range snapshot.MemoryEntries {
+			out.MemoryEntries = append(out.MemoryEntries, MemoryEntry(entry))
+		}
+		for _, candidate := range snapshot.MemoryCandidates {
+			out.MemoryCandidates = append(out.MemoryCandidates, MemoryCandidate(candidate))
+		}
+		for _, proposal := range snapshot.AssistantProposals {
+			item, ok := AssistantProposalRecord(proposal)
+			if !ok {
+				continue
+			}
+			out.AssistantProposals = append(out.AssistantProposals, item)
 		}
 	}
-	return nil
+	return out
 }
 
 func SeedProjectFromStores(ctx context.Context, service *cairnline.Service, sources SnapshotSources, projectID string) (Snapshot, error) {

--- a/internal/cairnlinebridge/work_write.go
+++ b/internal/cairnlinebridge/work_write.go
@@ -91,10 +91,11 @@ func DeleteWorkItem(ctx context.Context, service *cairnline.Service, projectID, 
 	return service.DeleteWorkItem(ctx, projectID, id)
 }
 
-// UpsertAssignment creates or updates a Cairnline assignment and then syncs the
-// Hecate assignment lifecycle state through the portable claim/status/complete
-// methods. Existing rows are first updated with their current Cairnline status
-// so metadata parity does not bypass lifecycle transition semantics.
+// UpsertAssignment creates or updates a Cairnline assignment and then syncs
+// Hecate's assignment lifecycle metadata. Existing rows are first updated with
+// their current Cairnline status so metadata parity does not bypass claim
+// ownership; claimed rows move back to queued through ReleaseAssignment when
+// Hecate clears a pre-dispatch claim for retry.
 func UpsertAssignment(ctx context.Context, service *cairnline.Service, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, profile agentprofiles.Profile) (cairnline.Assignment, error) {
 	if service == nil {
 		return cairnline.Assignment{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
@@ -119,7 +120,7 @@ func UpsertAssignment(ctx context.Context, service *cairnline.Service, assignmen
 			return cairnline.Assignment{}, err
 		}
 	}
-	if err := syncAssignmentStatus(ctx, service, item); err != nil {
+	if err := syncAssignmentStatus(ctx, service, existing, item); err != nil {
 		return cairnline.Assignment{}, err
 	}
 	return service.GetAssignment(ctx, item.ProjectID, item.ID)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -587,7 +587,7 @@ func (c Config) Validate() error {
 	validateBackend("HECATE_PROJECTS_COORDINATION_BACKEND", c.ProjectsCoordinationBackend(), "hecate", "cairnline")
 	validateBackend("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", c.ProjectsCairnlineReadSource(), "auto", "snapshot", "embedded")
 	for _, item := range c.ProjectsCairnlineWriteAuthority() {
-		validateBackend("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", item, "project-memory", "memory-candidates")
+		validateBackend("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", item, "project-memory", "memory-candidates", "project-collaboration", "project-skills", "project-work-items", "project-roles", "project-assignments", "agent-profiles", "project-metadata-defaults", "project-roots", "project-context-sources", "project-identity", "project-assistant-proposals")
 	}
 	if c.ProjectsCairnlineWriteAuthorityEnabled("memory-candidates") && !c.ProjectsCairnlineWriteAuthorityEnabled("project-memory") {
 		errs = append(errs, errors.New("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=memory-candidates requires project-memory because candidate promotion creates accepted project memory"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -473,10 +473,10 @@ func TestLoadFromEnvProjectsCairnlineWriteAuthority(t *testing.T) {
 		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-memory) = true, want false by default")
 	}
 
-	t.Setenv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", " Project-Memory, none, memory-candidates, project-memory ")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", " Project-Memory, none, memory-candidates, project-collaboration, project-skills, project-work-items, project-roles, project-assignments, agent-profiles, project-metadata-defaults, project-roots, project-context-sources, project-identity, project-assistant-proposals, project-memory ")
 	cfg = LoadFromEnv()
-	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 2 || got[0] != "project-memory" || got[1] != "memory-candidates" {
-		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want [project-memory memory-candidates]", got)
+	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 13 || got[0] != "project-memory" || got[1] != "memory-candidates" || got[2] != "project-collaboration" || got[3] != "project-skills" || got[4] != "project-work-items" || got[5] != "project-roles" || got[6] != "project-assignments" || got[7] != "agent-profiles" || got[8] != "project-metadata-defaults" || got[9] != "project-roots" || got[10] != "project-context-sources" || got[11] != "project-identity" || got[12] != "project-assistant-proposals" {
+		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want [project-memory memory-candidates project-collaboration project-skills project-work-items project-roles project-assignments agent-profiles project-metadata-defaults project-roots project-context-sources project-identity project-assistant-proposals]", got)
 	}
 	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-memory") {
 		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-memory) = false, want true")
@@ -484,8 +484,41 @@ func TestLoadFromEnvProjectsCairnlineWriteAuthority(t *testing.T) {
 	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("memory-candidates") {
 		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(memory-candidates) = false, want true")
 	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-collaboration") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-collaboration) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-skills") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-skills) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-work-items") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-work-items) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-roles") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-roles) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-assignments") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-assignments) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("agent-profiles") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(agent-profiles) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-metadata-defaults") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-metadata-defaults) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-roots") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-roots) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-context-sources") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-context-sources) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-identity") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-identity) = false, want true")
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-assistant-proposals") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled(project-assistant-proposals) = false, want true")
+	}
 	if err := cfg.Validate(); err != nil {
-		t.Fatalf("Validate() error = %v, want nil for project memory and candidate Cairnline write authority opt-ins", err)
+		t.Fatalf("Validate() error = %v, want nil for project memory, candidate, collaboration, skills, role, work-item, assignment, agent-profile, project metadata/default, root, context-source, identity, and assistant proposal Cairnline write authority opt-ins", err)
 	}
 }
 

--- a/internal/projectassistantapp/application.go
+++ b/internal/projectassistantapp/application.go
@@ -20,6 +20,7 @@ type Options struct {
 	Projects         projects.Store
 	Chats            chat.Store
 	Work             projectwork.Store
+	WorkAuthority    projectassistant.WorkAuthority
 	WorkApplication  *projectworkapp.Application
 	ProjectSkills    projectskills.Store
 	Memory           memory.Store
@@ -66,7 +67,9 @@ type ApplyCommand struct {
 
 func New(options Options) *Application {
 	var workAuthority projectassistant.WorkAuthority
-	if options.WorkApplication != nil {
+	if options.WorkAuthority != nil {
+		workAuthority = options.WorkAuthority
+	} else if options.WorkApplication != nil {
 		workAuthority = projectWorkAuthority{app: options.WorkApplication}
 	}
 	return &Application{

--- a/internal/projectskills/store.go
+++ b/internal/projectskills/store.go
@@ -155,6 +155,11 @@ func (s *MemoryStore) Clear(_ context.Context) (int, error) {
 	return count, nil
 }
 
+// MergeDiscovered applies the store rediscovery rules without committing them.
+func MergeDiscovered(existing, discovered []Skill, projectID string, now time.Time) []Skill {
+	return mergeDiscoveredSkills(existing, discovered, projectID, now)
+}
+
 func mergeDiscoveredSkills(existing, discovered []Skill, projectID string, now time.Time) []Skill {
 	if now.IsZero() {
 		now = time.Now().UTC()


### PR DESCRIPTION
## Summary
- add Cairnline-first authority seams for project identity, metadata/defaults, roots, context sources, profiles, skills, roles, work items, assignments, collaboration artifacts, memory, and Project Assistant proposal/apply coordination paths
- extend Cairnline-backed read/projection coverage and backend status reporting for replacement-readiness gates
- bump Cairnline to include assignment claim release, and mirror Hecate pre-dispatch cleanup/conflict states without making Cairnline own dispatch yet
- update runtime/operator/design docs for the current replacement boundary

## Verification
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/cairnline-parity-bridge/.gocache" go test ./internal/cairnlinebridge ./internal/api -run 'TestUpsertAssignmentCreatesAndSyncsLifecycle|TestProjectWorkAPI_StartAssignmentReleasesMirroredCairnlineClaimWhenTaskCreateFails'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/cairnline-parity-bridge/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/cairnline-parity-bridge/.gocache" go test -race -timeout 10m ./internal/cairnlinebridge ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/cairnline-parity-bridge/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/cairnline-parity-bridge/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/cairnline-parity-bridge/.gocache" go test -race -timeout 10m ./...
- just agent-docs-check
- git diff --check