### PR TITLE
feat(projects): add Cairnline sidecar probe

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -123,9 +123,15 @@ is actually authoritative. It also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operator tools can distinguish
 ready read routes from strict embedded probe work, non-authoritative live
 mirrors, still-Hecate-owned dispatch, and missing migration/rollback authority.
+`HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded` is the current live-route
+dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes a
+local-only standalone Cairnline MCP contract probe at
+`POST /hecate/v1/projects/cairnline/sidecar-probe`, but Hecate does not yet
+route Projects reads, writes, or mirrors through a persistent sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
-it reports `cairnline_read_routes_ready`, and the live project activity inbox
+and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
+and the live project activity inbox
 plus project list/detail, setup readiness, health, skills, memory entries,
 memory candidates, roles, work-item list/detail, assignment-list,
 assignment-context, launch-readiness, assignment-preflight, artifact-list,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -341,6 +341,12 @@ launch agents. Those remain explicit operator or orchestrator actions.
 - Hecate can initially continue using its internal Projects implementation.
 - Hecate can use the MCP server for side-by-side interoperability and the
   public Go package for controlled embed experiments.
+- Current Hecate sidecar experiments can probe a standalone Cairnline MCP
+  command for the minimum portable Projects tool contract via
+  `POST /hecate/v1/projects/cairnline/sidecar-probe`. This is contract evidence
+  only: Hecate does not yet keep a persistent sidecar client or route live
+  Projects reads, writes, mirrors, or write-authority switchpoints through the
+  sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -355,7 +355,14 @@ and durable grants so transcripts and approval history move together.
 
 `HECATE_PROJECTS_COORDINATION_BACKEND=hecate|cairnline` is separate from the
 storage backend. The default is `hecate`. `cairnline` records replacement intent
-for local bridge experiments. When the Cairnline read adapter is fully wired,
+for local bridge experiments. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`
+is the current live-route dogfood path and uses Hecate's embedded Cairnline Go
+bridge. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` is probe-only for now: it
+lets operators run `POST /hecate/v1/projects/cairnline/sidecar-probe` against a
+standalone Cairnline MCP command, but Projects reads, writes, mirrors, and
+write-authority switchpoints stay on Hecate-native stores until Hecate has a
+persistent sidecar backend client.
+When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project list/detail, setup readiness,
 health, skills, memory entries, memory candidates, roles, work-item
@@ -395,6 +402,13 @@ mirror into the embedded Cairnline database through their
 identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.
+The sidecar probe is configured with
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`,
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. It verifies MCP tool
+presence only; it does not keep a long-lived process or route operator data
+through the sidecar.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,8 +47,8 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, plugin-registry
-management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe,
+plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
 
@@ -462,10 +462,19 @@ sequenceDiagram
   authoritative until the feature-flagged Cairnline read/write adapter and
   migration path land. Use
   `GET /hecate/v1/projects/backend-status` to inspect the effective state.
+- `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded|sidecar` chooses the Cairnline
+  connector mode while `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`.
+  `embedded` is the current replacement-readiness path: Hecate uses the
+  embedded Cairnline Go package bridge and optional embedded mirror database.
+  `sidecar` is probe-only in this slice: it can start a standalone Cairnline MCP
+  process through `POST /hecate/v1/projects/cairnline/sidecar-probe` and verify
+  the portable tool contract, but live Projects reads and writes still use
+  Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
-  `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. The default `auto` prefers
-  the embedded mirror database under
+  `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
+  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`. The default `auto` prefers the
+  embedded mirror database under
   `{HECATE_DATA_DIR}/cairnline/embedded/projects.db` when it already contains
   the requested project or proposal record and otherwise falls back to the
   snapshot-seeded in-memory bridge. `snapshot` always uses the snapshot-seeded bridge.
@@ -476,7 +485,8 @@ sequenceDiagram
   reads.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
-  `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. The default is `none`.
+  `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
+  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`. The default is `none`.
   `project-memory` makes accepted project memory entry create/update/delete
   commit to the embedded Cairnline database first and then best-effort shadow
   the row back into Hecate-native memory stores. `memory-candidates` requires
@@ -528,6 +538,13 @@ sequenceDiagram
   to Cairnline first, then best-effort shadows Hecate's compatibility project
   row. Delete restores the Cairnline snapshot if Hecate compatibility cleanup
   fails. All other Projects mutations remain Hecate-owned.
+- `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`, `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
+  `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
+  `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT` configure the standalone
+  Cairnline MCP probe. The default command is `cairnline`; the default timeout
+  is `10s`. If sidecar args are empty and a database path is configured, Hecate
+  appends `-db <path>` for the probe. Relative database paths resolve under
+  `HECATE_DATA_DIR` when set, otherwise under `.data`.
 - `HECATE_POSTGRES_URL=postgres://...` or `DATABASE_URL=postgres://...` is
   required when `HECATE_BACKEND=postgres`. Optional Postgres knobs:
   `HECATE_POSTGRES_TABLE_PREFIX`, `HECATE_POSTGRES_MAX_OPEN_CONNS`, and
@@ -2275,6 +2292,11 @@ It exists to make the Cairnline replacement switch explicit while the adapter is
 being built.
 
 `configured_backend` reflects `HECATE_PROJECTS_COORDINATION_BACKEND`.
+`cairnline_connector` reflects `HECATE_PROJECTS_CAIRNLINE_CONNECTOR`.
+`embedded` is the only connector that can make live Hecate routes use Cairnline
+today. `sidecar` exposes only the standalone MCP contract probe and reports
+`cairnline_connector_ready=false`, so read/write routing and write-authority
+switchpoints stay disabled.
 `cairnline_read_source` reflects `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables the first
 disabled-by-default write authority switchpoint: accepted project memory entries
@@ -2320,10 +2342,10 @@ identity removal, then shadows the compatibility project row. Delete restores
 the Cairnline snapshot if Hecate compatibility cleanup fails.
 `authoritative_backend` remains `hecate` until Hecate can run project read/write
 flows against Cairnline without UI-local fallback state. When
-`configured_backend=cairnline`, Hecate still commits live Projects writes to
-the current Hecate-native stores first except for explicitly enabled
-write-authority switchpoints. `read_model_switch_ready=true` means the Cairnline
-read adapter is wired well enough to project the full current Hecate project
+`configured_backend=cairnline` and `cairnline_connector=embedded`, Hecate still
+commits live Projects writes to the current Hecate-native stores first except
+for explicitly enabled write-authority switchpoints. `read_model_switch_ready=true`
+means the Cairnline read adapter is wired well enough to project the full current Hecate project
 graph, including the Project Assistant proposal ledger. In that state, project
 list/detail reads, project setup readiness, project health, skills, memory
 entries, memory candidates, roles, work items, assignment lists, assignment
@@ -2450,6 +2472,8 @@ mutation routes still write only Hecate-native stores.
 project stores with the existing embedded Cairnline mirror database without
 creating or repairing it. `sync_readiness_url` points at the all-project
 embedded SQLite rehearsal sync, which replaces that database from Hecate stores.
+`cairnline_sidecar_probe_url` points at the local-only standalone Cairnline MCP
+contract probe. That probe does not change live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -2460,6 +2484,9 @@ Example response, with `write_switchpoints` shortened for readability:
     "configured_backend": "cairnline",
     "authoritative_backend": "hecate",
     "storage_backend": "sqlite",
+    "cairnline_connector": "embedded",
+    "cairnline_connector_ready": true,
+    "cairnline_connector_detail": "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood.",
     "cairnline_read_source": "auto",
     "cairnline_bridge_ready": true,
     "cairnline_authoritative": false,
@@ -2626,7 +2653,63 @@ Example response, with `write_switchpoints` shortened for readability:
     "embedded_read_model_url": "/hecate/v1/projects/{id}/cairnline/embedded-read-model",
     "embedded_parity_report_url": "/hecate/v1/projects/{id}/cairnline/embedded-parity-report",
     "sync_readiness_url": "/hecate/v1/projects/cairnline/sync",
-    "mirror_parity_url": "/hecate/v1/projects/cairnline/mirror-parity"
+    "mirror_parity_url": "/hecate/v1/projects/cairnline/mirror-parity",
+    "cairnline_sidecar_probe_url": "/hecate/v1/projects/cairnline/sidecar-probe"
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-probe`
+
+Local-only standalone Cairnline MCP contract probe. It starts the configured
+stdio command once, lists MCP tools, and returns whether the process exposes the
+minimum portable Projects tool surface Hecate would need for a future sidecar
+backend. It does not keep a persistent client, proxy Projects reads or writes,
+or make Cairnline authoritative.
+
+The probe is controlled by:
+
+- `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`
+- `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`
+- `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`
+- `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`
+- `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`
+
+Required tools:
+
+```text
+projects.list
+projects.create
+roles.list
+work_items.create
+assignments.claim
+assignments.context
+assignments.complete
+evidence.record
+reviews.record
+handoffs.create
+memory_candidates.create
+assistant.propose
+```
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_probe",
+  "data": {
+    "ready": true,
+    "status": "sidecar_probe_ready",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "tool_count": 12,
+    "required_tools": ["projects.list", "projects.create"],
+    "missing_tools": [],
+    "tools": [{ "name": "projects.list" }],
+    "warnings": []
   }
 }
 ```

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/mcp"
+)
+
+const cairnlineSidecarFixtureArgPrefix = "--hecate-cairnline-sidecar-fixture="
+
+func TestMain(m *testing.M) {
+	for _, arg := range os.Args[1:] {
+		if mode, ok := strings.CutPrefix(arg, cairnlineSidecarFixtureArgPrefix); ok {
+			cairnlineSidecarFixtureMain(mode)
+			os.Exit(0)
+		}
+	}
+	os.Exit(m.Run())
+}
+
+func cairnlineSidecarFixtureMain(mode string) {
+	in := bufio.NewReader(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+	for {
+		line, err := in.ReadBytes('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			fmt.Fprintln(os.Stderr, "cairnline sidecar fixture: read:", err)
+			return
+		}
+		var req mcp.Request
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+		if req.IsNotification() {
+			continue
+		}
+		var (
+			result any
+			rpcErr *mcp.RPCError
+		)
+		switch req.Method {
+		case "initialize":
+			result = mcp.InitializeResult{
+				ProtocolVersion: mcp.DeclaredProtocolVersion,
+				Capabilities:    mcp.ServerCapabilities{Tools: &mcp.ToolsCapability{}},
+				ServerInfo:      mcp.ServerInfo{Name: "cairnline-fixture", Version: "test"},
+			}
+		case "tools/list":
+			result = mcp.ListToolsResult{Tools: cairnlineSidecarFixtureTools(mode)}
+		default:
+			rpcErr = mcp.NewError(mcp.ErrCodeMethodNotFound, req.Method)
+		}
+
+		resp := mcp.Response{JSONRPC: "2.0", ID: req.ID}
+		if rpcErr != nil {
+			resp.Error = rpcErr
+		} else {
+			raw, err := json.Marshal(result)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "cairnline sidecar fixture: marshal:", err)
+				continue
+			}
+			resp.Result = raw
+		}
+		if err := enc.Encode(&resp); err != nil {
+			fmt.Fprintln(os.Stderr, "cairnline sidecar fixture: write:", err)
+			return
+		}
+	}
+}
+
+func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
+	names := append([]string(nil), projectCairnlineSidecarRequiredTools...)
+	if mode == "missing" {
+		names = []string{"projects.list"}
+	}
+	tools := make([]mcp.Tool, 0, len(names))
+	for _, name := range names {
+		tools = append(tools, mcp.Tool{
+			Name:        name,
+			Description: "Cairnline fixture tool " + name,
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		})
+	}
+	return tools
+}

--- a/internal/api/handler_agent_profile_authority.go
+++ b/internal/api/handler_agent_profile_authority.go
@@ -14,7 +14,7 @@ const projectCairnlineWriteAuthorityAgentProfiles = "agent-profiles"
 
 func (h *Handler) agentProfileWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityAgentProfiles)
 }
 

--- a/internal/api/handler_project_assignment_authority.go
+++ b/internal/api/handler_project_assignment_authority.go
@@ -18,7 +18,7 @@ const projectCairnlineWriteAuthorityProjectAssignments = "project-assignments"
 
 func (h *Handler) projectAssignmentWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectAssignments)
 }
 

--- a/internal/api/handler_project_assistant_authority.go
+++ b/internal/api/handler_project_assistant_authority.go
@@ -15,7 +15,7 @@ const projectCairnlineWriteAuthorityProjectAssistantProposals = "project-assista
 
 func (h *Handler) projectAssistantProposalWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectAssistantProposals)
 }
 

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const projectCairnlineSidecarMCPServerName = "cairnline"
+
+var projectCairnlineSidecarRequiredTools = []string{
+	"projects.list",
+	"projects.create",
+	"roles.list",
+	"work_items.create",
+	"assignments.claim",
+	"assignments.context",
+	"assignments.complete",
+	"evidence.record",
+	"reviews.record",
+	"handoffs.create",
+	"memory_candidates.create",
+	"assistant.propose",
+}
+
+func (h *Handler) projectCairnlineConnectorMode() string {
+	if h == nil {
+		return "embedded"
+	}
+	return h.config.ProjectsCairnlineConnector()
+}
+
+func (h *Handler) projectCairnlineEmbeddedConnectorEnabled() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineConnectorMode() == "embedded"
+}
+
+func projectCairnlineConnectorReady(mode string) bool {
+	return mode == "embedded"
+}
+
+func projectCairnlineConnectorDetail(mode string) string {
+	switch mode {
+	case "sidecar":
+		return "Cairnline sidecar connector is configured and can be probed through the local-only sidecar probe endpoint, but Hecate does not yet route Projects reads or writes through a long-lived standalone Cairnline MCP client."
+	default:
+		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
+	}
+}
+
+func projectCairnlineConnectorWarning(mode string) string {
+	if mode != "sidecar" {
+		return ""
+	}
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables the standalone Cairnline MCP probe only; Cairnline read/write routing stays disabled until Hecate has a persistent sidecar Projects backend."
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar probe") {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarProbeEnvelope{
+		Object: "project_cairnline_sidecar_probe",
+		Data:   h.projectCairnlineSidecarProbe(r.Context()),
+	})
+}
+
+func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairnlineSidecarProbeResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	response := ProjectCairnlineSidecarProbeResponse{
+		Ready:          false,
+		Status:         "sidecar_probe_not_run",
+		Detail:         "Cairnline sidecar probe has not run.",
+		Command:        cfg.Command,
+		Args:           append([]string(nil), cfg.Args...),
+		DatabasePath:   dbPath,
+		ProbeTimeoutMS: timeout.Milliseconds(),
+		RequiredTools:  append([]string(nil), projectCairnlineSidecarRequiredTools...),
+	}
+	if h == nil {
+		response.Status = "sidecar_probe_failed"
+		response.Detail = "Cairnline sidecar probe requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this probe does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := orchestrator.ProbeMCPServer(probeCtx, cfg, h.secretCipher)
+	if err != nil {
+		response.Status = "sidecar_probe_failed"
+		response.Detail = err.Error()
+		return response
+	}
+	response.Tools = renderMCPProbeTools(result.Tools)
+	response.ToolCount = len(response.Tools)
+	response.MissingTools = projectCairnlineSidecarMissingTools(projectCairnlineSidecarToolNames(response.Tools))
+	if len(response.MissingTools) > 0 {
+		response.Status = "sidecar_contract_incomplete"
+		response.Detail = "Cairnline sidecar MCP server started, but it does not expose every tool Hecate needs for a future Projects backend connector."
+		return response
+	}
+	response.Ready = true
+	response.Status = "sidecar_probe_ready"
+	response.Detail = "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	return response
+}
+
+func (h *Handler) projectCairnlineSidecarMCPConfig() (types.MCPServerConfig, string, time.Duration) {
+	cfg := types.MCPServerConfig{
+		Name:    projectCairnlineSidecarMCPServerName,
+		Command: "cairnline",
+	}
+	timeout := 10 * time.Second
+	if h == nil {
+		return cfg, "", timeout
+	}
+	cfg.Command = h.config.ProjectsCairnlineSidecarCommand()
+	cfg.Args = h.config.ProjectsCairnlineSidecarArgs()
+	dbPath := h.cairnlineSidecarDatabasePath()
+	if len(cfg.Args) == 0 && dbPath != "" {
+		cfg.Args = []string{"-db", dbPath}
+	}
+	return cfg, dbPath, h.config.ProjectsCairnlineSidecarProbeTimeout()
+}
+
+func (h *Handler) cairnlineSidecarDatabasePath() string {
+	if h == nil {
+		return ""
+	}
+	path := h.config.ProjectsCairnlineSidecarDatabasePath()
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	dataDir := strings.TrimSpace(h.config.Server.DataDir)
+	if dataDir == "" {
+		dataDir = ".data"
+	}
+	path = filepath.Join(dataDir, path)
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return path
+}
+
+func projectCairnlineSidecarToolNames(tools []MCPProbeToolDescriptor) []string {
+	out := make([]string, 0, len(tools))
+	seen := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func projectCairnlineSidecarMissingTools(toolNames []string) []string {
+	seen := make(map[string]struct{}, len(toolNames))
+	for _, name := range toolNames {
+		seen[name] = struct{}{}
+	}
+	var missing []string
+	for _, name := range projectCairnlineSidecarRequiredTools {
+		if _, ok := seen[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/config"
+)
+
+func TestProjectCairnlineSidecarMCPConfig_DefaultsToInMemoryProbe(t *testing.T) {
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+
+	cfg, dbPath, timeout := handler.projectCairnlineSidecarMCPConfig()
+	if cfg.Name != projectCairnlineSidecarMCPServerName || cfg.Command != "cairnline" {
+		t.Fatalf("config = %+v, want default Cairnline stdio config", cfg)
+	}
+	if len(cfg.Args) != 0 {
+		t.Fatalf("args = %+v, want empty args for default in-memory Cairnline probe", cfg.Args)
+	}
+	if dbPath != "" {
+		t.Fatalf("database path = %q, want empty default", dbPath)
+	}
+	if timeout != 10*time.Second {
+		t.Fatalf("timeout = %v, want 10s", timeout)
+	}
+}
+
+func TestProjectCairnlineSidecarMCPConfig_UsesConfiguredCommandArgsAndRelativeDatabase(t *testing.T) {
+	dataDir := t.TempDir()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: dataDir},
+		Projects: config.ProjectsConfig{
+			CairnlineSidecarCommand:      "custom-cairnline",
+			CairnlineSidecarArgs:         []string{"serve", "--stdio"},
+			CairnlineSidecarDatabasePath: "sidecar/projects.db",
+			CairnlineSidecarProbeTimeout: 3 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	cfg, dbPath, timeout := handler.projectCairnlineSidecarMCPConfig()
+	if cfg.Command != "custom-cairnline" {
+		t.Fatalf("command = %q, want custom-cairnline", cfg.Command)
+	}
+	if strings.Join(cfg.Args, " ") != "serve --stdio" {
+		t.Fatalf("args = %+v, want custom args without automatic db append", cfg.Args)
+	}
+	wantDB := filepath.Join(dataDir, "sidecar", "projects.db")
+	if abs, err := filepath.Abs(wantDB); err == nil {
+		wantDB = abs
+	}
+	if dbPath != wantDB {
+		t.Fatalf("database path = %q, want %q", dbPath, wantDB)
+	}
+	if timeout != 3*time.Second {
+		t.Fatalf("timeout = %v, want 3s", timeout)
+	}
+}
+
+func TestProjectCairnlineSidecarMCPConfig_AppendsDatabaseWhenArgsUnset(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "cairnline.db")
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineSidecarDatabasePath: dbPath,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	cfg, gotDB, _ := handler.projectCairnlineSidecarMCPConfig()
+	if gotDB != dbPath {
+		t.Fatalf("database path = %q, want %q", gotDB, dbPath)
+	}
+	if len(cfg.Args) != 2 || cfg.Args[0] != "-db" || cfg.Args[1] != dbPath {
+		t.Fatalf("args = %+v, want automatic -db path", cfg.Args)
+	}
+}
+
+func TestProjectCairnlineSidecarProbe_Ready(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	got := handler.projectCairnlineSidecarProbe(t.Context())
+	if !got.Ready || got.Status != "sidecar_probe_ready" {
+		t.Fatalf("probe = %+v, want ready", got)
+	}
+	if got.ToolCount != len(projectCairnlineSidecarRequiredTools) {
+		t.Fatalf("tool count = %d, want %d", got.ToolCount, len(projectCairnlineSidecarRequiredTools))
+	}
+	if len(got.MissingTools) != 0 {
+		t.Fatalf("missing tools = %+v, want none", got.MissingTools)
+	}
+	if got.Command != os.Args[0] || len(got.Args) != 1 {
+		t.Fatalf("probe config = command %q args %+v, want fixture command", got.Command, got.Args)
+	}
+}
+
+func TestProjectCairnlineSidecarProbe_MissingRequiredTools(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "missing"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	got := handler.projectCairnlineSidecarProbe(t.Context())
+	if got.Ready || got.Status != "sidecar_contract_incomplete" {
+		t.Fatalf("probe = %+v, want incomplete contract", got)
+	}
+	if !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assistant.propose") {
+		t.Fatalf("missing tools = %+v, want representative missing contract tools", got.MissingTools)
+	}
+	if got.ToolCount != 1 {
+		t.Fatalf("tool count = %d, want 1", got.ToolCount)
+	}
+}

--- a/internal/api/handler_project_cairnline_mirror.go
+++ b/internal/api/handler_project_cairnline_mirror.go
@@ -215,7 +215,7 @@ func (h *Handler) mirrorProjectAssistantProposalRecordToCairnline(ctx context.Co
 }
 
 func (h *Handler) mirrorProjectAssistantApplyResultToCairnline(ctx context.Context, operation string, result projectassistant.ApplyResult) {
-	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+	if !h.projectCairnlineEmbeddedConnectorEnabled() {
 		return
 	}
 	for _, action := range result.Actions {
@@ -226,7 +226,7 @@ func (h *Handler) mirrorProjectAssistantApplyResultToCairnline(ctx context.Conte
 }
 
 func (h *Handler) projectForCairnlineMirror(ctx context.Context, operation, projectID string) (projects.Project, bool) {
-	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+	if !h.projectCairnlineEmbeddedConnectorEnabled() {
 		return projects.Project{}, false
 	}
 	project, ok, err := h.projects.Get(ctx, projectID)
@@ -242,7 +242,7 @@ func (h *Handler) projectForCairnlineMirror(ctx context.Context, operation, proj
 }
 
 func (h *Handler) projectWorkRoleForCairnlineMirror(ctx context.Context, operation, projectID, roleID string) (projectwork.AgentRoleProfile, bool) {
-	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+	if !h.projectCairnlineEmbeddedConnectorEnabled() {
 		return projectwork.AgentRoleProfile{}, false
 	}
 	role, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, projectID, roleID)
@@ -840,7 +840,7 @@ func (h *Handler) writeProjectSkillsToCairnline(ctx context.Context, project pro
 }
 
 func (h *Handler) withCairnlineEmbeddedMirrorService(ctx context.Context, fn func(*cairnline.Service) error) error {
-	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+	if !h.projectCairnlineEmbeddedConnectorEnabled() {
 		return nil
 	}
 	dbPath := h.cairnlineEmbeddedDatabasePath()

--- a/internal/api/handler_project_collaboration_authority.go
+++ b/internal/api/handler_project_collaboration_authority.go
@@ -16,7 +16,7 @@ const projectCairnlineWriteAuthorityProjectCollaboration = "project-collaboratio
 
 func (h *Handler) projectCollaborationWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectCollaboration)
 }
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -6,6 +6,7 @@ import (
 )
 
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
+const projectCoordinationBackendSidecarProbeURL = "/hecate/v1/projects/cairnline/sidecar-probe"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -275,33 +276,54 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 	configured := "hecate"
 	storageBackend := ""
 	readSource := "auto"
+	connector := "embedded"
 	if h != nil {
 		configured = h.config.ProjectsCoordinationBackend()
 		storageBackend = h.config.Projects.Backend
 		readSource = h.config.ProjectsCairnlineReadSource()
+		connector = h.config.ProjectsCairnlineConnector()
 	}
+	connectorReady := projectCairnlineConnectorReady(connector)
 	response := ProjectCoordinationBackendStatusResponse{
-		ConfiguredBackend:       configured,
-		AuthoritativeBackend:    "hecate",
-		StorageBackend:          storageBackend,
-		CairnlineReadSource:     readSource,
-		CairnlineBridgeReady:    true,
-		CairnlineAuthoritative:  false,
-		WriteAdapterReady:       false,
-		ReplacementReadinessURL: projectCoordinationBackendReadinessURL,
-		EmbeddedReadModelURL:    projectCoordinationBackendEmbeddedReadModelURL,
-		EmbeddedParityReportURL: projectCoordinationBackendEmbeddedParityReportURL,
-		SyncReadinessURL:        projectCoordinationBackendSyncReadinessURL,
-		MirrorParityURL:         projectCoordinationBackendMirrorParityURL,
+		ConfiguredBackend:        configured,
+		AuthoritativeBackend:     "hecate",
+		StorageBackend:           storageBackend,
+		CairnlineConnector:       connector,
+		CairnlineConnectorReady:  connectorReady,
+		CairnlineConnectorDetail: projectCairnlineConnectorDetail(connector),
+		CairnlineReadSource:      readSource,
+		CairnlineBridgeReady:     true,
+		CairnlineAuthoritative:   false,
+		WriteAdapterReady:        false,
+		ReplacementReadinessURL:  projectCoordinationBackendReadinessURL,
+		CairnlineSidecarProbeURL: projectCoordinationBackendSidecarProbeURL,
+		EmbeddedReadModelURL:     projectCoordinationBackendEmbeddedReadModelURL,
+		EmbeddedParityReportURL:  projectCoordinationBackendEmbeddedParityReportURL,
+		SyncReadinessURL:         projectCoordinationBackendSyncReadinessURL,
+		MirrorParityURL:          projectCoordinationBackendMirrorParityURL,
 	}
 	switch configured {
 	case "cairnline":
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
 		writeAuthority := h.config.ProjectsCairnlineWriteAuthority()
+		effectiveWriteAuthority := writeAuthority
+		if !connectorReady {
+			effectiveWriteAuthority = nil
+		}
 		response.WriteAdapterSeams = append([]string(nil), projectCairnlineWriteAdapterSeamNames...)
-		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsSnapshot(writeAuthority)
-		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(writeAuthority)
+		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsSnapshot(effectiveWriteAuthority)
+		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
 		response.ReplacementGates = projectCairnlineReplacementGates(readReady)
+		if !connectorReady {
+			response.Status = "cairnline_connector_not_ready"
+			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
+			response.ReplacementGates = projectCairnlineReplacementGates(false)
+			response.Warnings = []string{
+				projectCairnlineConnectorWarning(connector),
+				"Project reads and writes still use Hecate-native stores.",
+			}
+			return response
+		}
 		response.ReadModelSwitchReady = readReady
 		if readReady {
 			response.ReadRoutes = append([]string(nil), projectCairnlineReadRouteNames...)

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -24,6 +24,12 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineReadSource != "auto" {
 		t.Fatalf("cairnline read source = %q, want auto", status.CairnlineReadSource)
 	}
+	if status.CairnlineConnector != "embedded" || !status.CairnlineConnectorReady {
+		t.Fatalf("cairnline connector = %q ready=%t, want embedded ready", status.CairnlineConnector, status.CairnlineConnectorReady)
+	}
+	if status.CairnlineSidecarProbeURL != projectCoordinationBackendSidecarProbeURL {
+		t.Fatalf("sidecar probe URL = %q, want %q", status.CairnlineSidecarProbeURL, projectCoordinationBackendSidecarProbeURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -70,6 +76,48 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	}
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "result_mirror_only" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "assignment-start" {
 		t.Fatalf("assignment-start switchpoint = %+v, want Hecate-owned result mirror blocker", point)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbeddedRoutes(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineConnector:      "sidecar",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: strings.Join([]string{projectCairnlineWriteAuthorityProjectIdentity, projectCairnlineWriteAuthorityProjectMetadataDefaults, projectCairnlineWriteAuthorityProjectAssignments, "project-memory", "memory-candidates"}, ","),
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if status.CairnlineConnector != "sidecar" || status.CairnlineConnectorReady {
+		t.Fatalf("cairnline connector = %q ready=%t, want sidecar not ready for live routing", status.CairnlineConnector, status.CairnlineConnectorReady)
+	}
+	if status.Status != "cairnline_connector_not_ready" || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
+		t.Fatalf("status = %+v, want sidecar probe mode to block live Cairnline routing", status)
+	}
+	if handler.projectReadRoutesUseCairnlineReadModel() || handler.projectIdentityWritesUseCairnlineAuthority() || handler.projectMemoryWritesUseCairnlineAuthority() || handler.projectAssignmentWritesUseCairnlineAuthority() {
+		t.Fatal("sidecar connector enabled embedded Cairnline read/write route predicates, want probe-only mode")
+	}
+	if status.CairnlineSidecarProbeURL != projectCoordinationBackendSidecarProbeURL {
+		t.Fatalf("sidecar probe URL = %q, want %q", status.CairnlineSidecarProbeURL, projectCoordinationBackendSidecarProbeURL)
+	}
+	if len(status.ReadRoutes) != 0 {
+		t.Fatalf("read routes = %+v, want none in sidecar probe mode", status.ReadRoutes)
+	}
+	if !containsString(status.WriteAdapterGaps, "projects") || !containsString(status.WriteAdapterGaps, "memory") || !containsString(status.WriteAdapterGaps, "memory-candidates") || !containsString(status.WriteAdapterGaps, "assignment-start") || !containsString(status.WriteAdapterGaps, "migration-cutover") {
+		t.Fatalf("write gaps = %+v, want configured write authority ignored until a live sidecar connector exists", status.WriteAdapterGaps)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "read-routes"); gate == nil || gate.Ready || gate.Status != "blocked" {
+		t.Fatalf("read-routes gate = %+v, want blocked sidecar connector gate", gate)
+	}
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-identity"); point == nil || point.CurrentAuthority != "hecate" || !point.BlocksAuthority || point.Gap != "projects" {
+		t.Fatalf("project-identity switchpoint = %+v, want Hecate authority while sidecar routing is not live", point)
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "Hecate-native stores") {
+		t.Fatalf("warnings = %+v, want sidecar probe-only warning", status.Warnings)
 	}
 }
 

--- a/internal/api/handler_project_identity_authority.go
+++ b/internal/api/handler_project_identity_authority.go
@@ -16,7 +16,7 @@ const projectCairnlineWriteAuthorityProjectIdentity = "project-identity"
 
 func (h *Handler) projectIdentityWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectIdentity)
 }
 

--- a/internal/api/handler_project_memory_authority.go
+++ b/internal/api/handler_project_memory_authority.go
@@ -35,7 +35,7 @@ func applyProjectMemoryUpdate(item *memory.Entry, req updateProjectMemoryRequest
 
 func (h *Handler) projectMemoryWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled("project-memory")
 }
 

--- a/internal/api/handler_project_memory_candidate_authority.go
+++ b/internal/api/handler_project_memory_candidate_authority.go
@@ -12,7 +12,7 @@ import (
 
 func (h *Handler) projectMemoryCandidatesWriteUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled("project-memory") &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled("memory-candidates")
 }

--- a/internal/api/handler_project_metadata_authority.go
+++ b/internal/api/handler_project_metadata_authority.go
@@ -15,7 +15,7 @@ const projectCairnlineWriteAuthorityProjectMetadataDefaults = "project-metadata-
 
 func (h *Handler) projectMetadataDefaultsWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectMetadataDefaults)
 }
 

--- a/internal/api/handler_project_operations_cairnline.go
+++ b/internal/api/handler_project_operations_cairnline.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (h *Handler) projectReadRoutesUseCairnlineReadModel() bool {
-	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+	if !h.projectCairnlineEmbeddedConnectorEnabled() {
 		return false
 	}
 	ready, _ := h.cairnlineReadModelReadiness()

--- a/internal/api/handler_project_role_authority.go
+++ b/internal/api/handler_project_role_authority.go
@@ -16,7 +16,7 @@ const projectCairnlineWriteAuthorityProjectRoles = "project-roles"
 
 func (h *Handler) projectRoleWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectRoles)
 }
 

--- a/internal/api/handler_project_root_source_authority.go
+++ b/internal/api/handler_project_root_source_authority.go
@@ -22,13 +22,13 @@ const (
 
 func (h *Handler) projectRootWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectRoots)
 }
 
 func (h *Handler) projectContextSourceWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectContextSources)
 }
 

--- a/internal/api/handler_project_skill_authority.go
+++ b/internal/api/handler_project_skill_authority.go
@@ -17,7 +17,7 @@ const projectCairnlineWriteAuthorityProjectSkills = "project-skills"
 
 func (h *Handler) projectSkillWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectSkills)
 }
 

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -413,12 +413,12 @@ func (h *Handler) cairnlineProjectReadSource() string {
 
 func (h *Handler) requiresEmbeddedCairnlineProjectReads() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.cairnlineProjectReadSource() == "embedded"
 }
 
 func (h *Handler) prefersEmbeddedCairnlineProjectReads() bool {
-	if h == nil || h.config.ProjectsCoordinationBackend() != "cairnline" {
+	if !h.projectCairnlineEmbeddedConnectorEnabled() {
 		return false
 	}
 	switch h.cairnlineProjectReadSource() {

--- a/internal/api/handler_project_work_item_authority.go
+++ b/internal/api/handler_project_work_item_authority.go
@@ -17,7 +17,7 @@ const projectCairnlineWriteAuthorityProjectWorkItems = "project-work-items"
 
 func (h *Handler) projectWorkItemWritesUseCairnlineAuthority() bool {
 	return h != nil &&
-		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineEmbeddedConnectorEnabled() &&
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectWorkItems)
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -554,28 +554,32 @@ type ProjectCoordinationBackendStatusEnvelope struct {
 }
 
 type ProjectCoordinationBackendStatusResponse struct {
-	ConfiguredBackend       string                                       `json:"configured_backend"`
-	AuthoritativeBackend    string                                       `json:"authoritative_backend"`
-	StorageBackend          string                                       `json:"storage_backend"`
-	CairnlineReadSource     string                                       `json:"cairnline_read_source,omitempty"`
-	CairnlineBridgeReady    bool                                         `json:"cairnline_bridge_ready"`
-	CairnlineAuthoritative  bool                                         `json:"cairnline_authoritative"`
-	ReadModelSwitchReady    bool                                         `json:"read_model_switch_ready"`
-	WriteAdapterReady       bool                                         `json:"write_adapter_ready"`
-	ReplacementReady        bool                                         `json:"replacement_ready"`
-	ReadRoutes              []string                                     `json:"read_routes,omitempty"`
-	WriteAdapterSeams       []string                                     `json:"write_adapter_seams,omitempty"`
-	WriteAdapterGaps        []string                                     `json:"write_adapter_gaps,omitempty"`
-	ReplacementGates        []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
-	WriteSwitchpoints       []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
-	Status                  string                                       `json:"status"`
-	Detail                  string                                       `json:"detail"`
-	Warnings                []string                                     `json:"warnings,omitempty"`
-	ReplacementReadinessURL string                                       `json:"replacement_readiness_url,omitempty"`
-	EmbeddedReadModelURL    string                                       `json:"embedded_read_model_url,omitempty"`
-	EmbeddedParityReportURL string                                       `json:"embedded_parity_report_url,omitempty"`
-	SyncReadinessURL        string                                       `json:"sync_readiness_url,omitempty"`
-	MirrorParityURL         string                                       `json:"mirror_parity_url,omitempty"`
+	ConfiguredBackend        string                                       `json:"configured_backend"`
+	AuthoritativeBackend     string                                       `json:"authoritative_backend"`
+	StorageBackend           string                                       `json:"storage_backend"`
+	CairnlineConnector       string                                       `json:"cairnline_connector,omitempty"`
+	CairnlineConnectorReady  bool                                         `json:"cairnline_connector_ready"`
+	CairnlineConnectorDetail string                                       `json:"cairnline_connector_detail,omitempty"`
+	CairnlineReadSource      string                                       `json:"cairnline_read_source,omitempty"`
+	CairnlineBridgeReady     bool                                         `json:"cairnline_bridge_ready"`
+	CairnlineAuthoritative   bool                                         `json:"cairnline_authoritative"`
+	ReadModelSwitchReady     bool                                         `json:"read_model_switch_ready"`
+	WriteAdapterReady        bool                                         `json:"write_adapter_ready"`
+	ReplacementReady         bool                                         `json:"replacement_ready"`
+	ReadRoutes               []string                                     `json:"read_routes,omitempty"`
+	WriteAdapterSeams        []string                                     `json:"write_adapter_seams,omitempty"`
+	WriteAdapterGaps         []string                                     `json:"write_adapter_gaps,omitempty"`
+	ReplacementGates         []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
+	WriteSwitchpoints        []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
+	Status                   string                                       `json:"status"`
+	Detail                   string                                       `json:"detail"`
+	Warnings                 []string                                     `json:"warnings,omitempty"`
+	ReplacementReadinessURL  string                                       `json:"replacement_readiness_url,omitempty"`
+	CairnlineSidecarProbeURL string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
+	EmbeddedReadModelURL     string                                       `json:"embedded_read_model_url,omitempty"`
+	EmbeddedParityReportURL  string                                       `json:"embedded_parity_report_url,omitempty"`
+	SyncReadinessURL         string                                       `json:"sync_readiness_url,omitempty"`
+	MirrorParityURL          string                                       `json:"mirror_parity_url,omitempty"`
 }
 
 type ProjectCoordinationBackendReplacementGate struct {
@@ -1656,6 +1660,26 @@ type MCPProbeToolDescriptor struct {
 	UIResourceURI string          `json:"ui_resource_uri,omitempty"`
 	UIVisibility  []string        `json:"ui_visibility,omitempty"`
 	ModelVisible  bool            `json:"model_visible"`
+}
+
+type ProjectCairnlineSidecarProbeEnvelope struct {
+	Object string                               `json:"object"`
+	Data   ProjectCairnlineSidecarProbeResponse `json:"data"`
+}
+
+type ProjectCairnlineSidecarProbeResponse struct {
+	Ready          bool                     `json:"ready"`
+	Status         string                   `json:"status"`
+	Detail         string                   `json:"detail"`
+	Command        string                   `json:"command"`
+	Args           []string                 `json:"args,omitempty"`
+	DatabasePath   string                   `json:"database_path,omitempty"`
+	ProbeTimeoutMS int64                    `json:"probe_timeout_ms"`
+	ToolCount      int                      `json:"tool_count"`
+	RequiredTools  []string                 `json:"required_tools"`
+	MissingTools   []string                 `json:"missing_tools,omitempty"`
+	Tools          []MCPProbeToolDescriptor `json:"tools,omitempty"`
+	Warnings       []string                 `json:"warnings,omitempty"`
 }
 
 // MCPCacheStatsResponse is the wire shape for GET /hecate/v1/system/mcp/cache.

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -23,6 +23,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/cairnline/mirror-parity"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -83,6 +83,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
 	mux.HandleFunc("GET /hecate/v1/projects/cairnline/mirror-parity", handler.HandleProjectCairnlineMirrorParity)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4212,6 +4212,22 @@ func TestMCPProbeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
 	}
 }
 
+func TestProjectCairnlineSidecarProbeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-probe", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,14 +226,46 @@ type ChatConfig struct {
 }
 
 type ProjectsConfig struct {
-	Backend                 string
-	CoordinationBackend     string
-	CairnlineReadSource     string
-	CairnlineWriteAuthority string
+	Backend                      string
+	CoordinationBackend          string
+	CairnlineConnector           string
+	CairnlineSidecarCommand      string
+	CairnlineSidecarArgs         []string
+	CairnlineSidecarDatabasePath string
+	CairnlineSidecarProbeTimeout time.Duration
+	CairnlineReadSource          string
+	CairnlineWriteAuthority      string
 }
 
 func (c Config) ProjectsCoordinationBackend() string {
 	return normalizeProjectsCoordinationBackend(c.Projects.CoordinationBackend)
+}
+
+func (c Config) ProjectsCairnlineConnector() string {
+	return normalizeProjectsCairnlineConnector(c.Projects.CairnlineConnector)
+}
+
+func (c Config) ProjectsCairnlineSidecarCommand() string {
+	command := strings.TrimSpace(c.Projects.CairnlineSidecarCommand)
+	if command == "" {
+		return "cairnline"
+	}
+	return command
+}
+
+func (c Config) ProjectsCairnlineSidecarArgs() []string {
+	return append([]string(nil), c.Projects.CairnlineSidecarArgs...)
+}
+
+func (c Config) ProjectsCairnlineSidecarDatabasePath() string {
+	return strings.TrimSpace(c.Projects.CairnlineSidecarDatabasePath)
+}
+
+func (c Config) ProjectsCairnlineSidecarProbeTimeout() time.Duration {
+	if c.Projects.CairnlineSidecarProbeTimeout <= 0 {
+		return 10 * time.Second
+	}
+	return c.Projects.CairnlineSidecarProbeTimeout
 }
 
 func (c Config) ProjectsCairnlineReadSource() string {
@@ -497,10 +529,15 @@ func LoadFromEnv() Config {
 			SessionsBackend: storageBackend,
 		},
 		Projects: ProjectsConfig{
-			Backend:                 storageBackend,
-			CoordinationBackend:     strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_COORDINATION_BACKEND", "hecate"))),
-			CairnlineReadSource:     strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "auto"))),
-			CairnlineWriteAuthority: getEnv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", "none"),
+			Backend:                      storageBackend,
+			CoordinationBackend:          strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_COORDINATION_BACKEND", "hecate"))),
+			CairnlineConnector:           strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded"))),
+			CairnlineSidecarCommand:      strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND", "cairnline")),
+			CairnlineSidecarArgs:         splitCSV(getEnv("HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS", "")),
+			CairnlineSidecarDatabasePath: strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB", "")),
+			CairnlineSidecarProbeTimeout: getEnvDuration("HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT", 10*time.Second),
+			CairnlineReadSource:          strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "auto"))),
+			CairnlineWriteAuthority:      getEnv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", "none"),
 		},
 		OTel: loadOTelFromEnv(),
 		Governor: GovernorConfig{
@@ -585,6 +622,7 @@ func (c Config) Validate() error {
 		validateBackend("HECATE_BACKEND", backend, "memory", "sqlite", "postgres")
 	}
 	validateBackend("HECATE_PROJECTS_COORDINATION_BACKEND", c.ProjectsCoordinationBackend(), "hecate", "cairnline")
+	validateBackend("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", c.ProjectsCairnlineConnector(), "embedded", "sidecar")
 	validateBackend("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", c.ProjectsCairnlineReadSource(), "auto", "snapshot", "embedded")
 	for _, item := range c.ProjectsCairnlineWriteAuthority() {
 		validateBackend("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", item, "project-memory", "memory-candidates", "project-collaboration", "project-skills", "project-work-items", "project-roles", "project-assignments", "agent-profiles", "project-metadata-defaults", "project-roots", "project-context-sources", "project-identity", "project-assistant-proposals")
@@ -1171,6 +1209,14 @@ func normalizeProjectsCoordinationBackend(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
 	if value == "" {
 		return "hecate"
+	}
+	return value
+}
+
+func normalizeProjectsCairnlineConnector(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "embedded"
 	}
 	return value
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -464,6 +464,56 @@ func TestLoadFromEnvProjectsCairnlineReadSource(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvProjectsCairnlineConnector(t *testing.T) {
+	cfg := LoadFromEnv()
+	if got := cfg.ProjectsCairnlineConnector(); got != "embedded" {
+		t.Fatalf("ProjectsCairnlineConnector() = %q, want embedded", got)
+	}
+
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", " Sidecar ")
+	cfg = LoadFromEnv()
+	if got := cfg.ProjectsCairnlineConnector(); got != "sidecar" {
+		t.Fatalf("ProjectsCairnlineConnector() = %q, want sidecar", got)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil for sidecar Cairnline connector", err)
+	}
+}
+
+func TestLoadFromEnvProjectsCairnlineSidecarConfig(t *testing.T) {
+	cfg := LoadFromEnv()
+	if got := cfg.ProjectsCairnlineSidecarCommand(); got != "cairnline" {
+		t.Fatalf("ProjectsCairnlineSidecarCommand() = %q, want cairnline", got)
+	}
+	if got := cfg.ProjectsCairnlineSidecarArgs(); len(got) != 0 {
+		t.Fatalf("ProjectsCairnlineSidecarArgs() = %+v, want empty default", got)
+	}
+	if got := cfg.ProjectsCairnlineSidecarDatabasePath(); got != "" {
+		t.Fatalf("ProjectsCairnlineSidecarDatabasePath() = %q, want empty default", got)
+	}
+	if got := cfg.ProjectsCairnlineSidecarProbeTimeout(); got != 10*time.Second {
+		t.Fatalf("ProjectsCairnlineSidecarProbeTimeout() = %v, want 10s", got)
+	}
+
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND", " /usr/local/bin/cairnline ")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS", "serve,--stdio")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB", " cairnline/projects.db ")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT", "3s")
+	cfg = LoadFromEnv()
+	if got := cfg.ProjectsCairnlineSidecarCommand(); got != "/usr/local/bin/cairnline" {
+		t.Fatalf("ProjectsCairnlineSidecarCommand() = %q, want configured command", got)
+	}
+	if got := cfg.ProjectsCairnlineSidecarArgs(); len(got) != 2 || got[0] != "serve" || got[1] != "--stdio" {
+		t.Fatalf("ProjectsCairnlineSidecarArgs() = %+v, want [serve --stdio]", got)
+	}
+	if got := cfg.ProjectsCairnlineSidecarDatabasePath(); got != "cairnline/projects.db" {
+		t.Fatalf("ProjectsCairnlineSidecarDatabasePath() = %q, want trimmed path", got)
+	}
+	if got := cfg.ProjectsCairnlineSidecarProbeTimeout(); got != 3*time.Second {
+		t.Fatalf("ProjectsCairnlineSidecarProbeTimeout() = %v, want 3s", got)
+	}
+}
+
 func TestLoadFromEnvProjectsCairnlineWriteAuthority(t *testing.T) {
 	cfg := LoadFromEnv()
 	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 0 {
@@ -545,6 +595,19 @@ func TestValidateRejectsInvalidProjectsCairnlineReadSource(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE") {
 		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", err)
+	}
+}
+
+func TestValidateRejectsInvalidProjectsCairnlineConnector(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Projects.CairnlineConnector = "mcp"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid projects Cairnline connector error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_CONNECTOR") {
+		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_CONNECTOR", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a configurable Cairnline connector mode with an embedded default and a sidecar probe mode
- add a local-only sidecar MCP contract probe endpoint and backend-status fields
- keep live Cairnline read/write/mirror routing gated to the embedded connector until a persistent sidecar backend exists
- document the sidecar probe boundary and configuration

## Tests
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-probe/.gocache" go test ./internal/config ./internal/api -run 'Test(LoadFromEnvProjectsCairnline(SidecarConfig|Connector)|ValidateRejectsInvalidProjectsCairnlineConnector|ProjectCairnlineSidecar(MCPConfig|Probe)|ProjectCoordinationBackendStatus_(DefaultHecateAuthoritative|CairnlineSidecarConnectorBlocksEmbeddedRoutes|CairnlineConfiguredReadRoutesReady)|ProjectCairnlineSidecarProbeRejectsNonLoopbackClientsBeforeCommandHandling|RemoteRuntimeEndpointPolicyCoversRegisteredHecateRoutes)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-probe/.gocache" go test ./internal/api ./internal/config
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-probe/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-probe/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-probe/.gocache" go test -race -timeout 10m ./...