### PR TITLE
feat(projects): add Cairnline sidecar client status

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -124,10 +124,11 @@ is actually authoritative. It also reports `replacement_ready`,
 ready read routes from strict embedded probe work, non-authoritative live
 mirrors, still-Hecate-owned dispatch, and missing migration/rollback authority.
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded` is the current live-route
-dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes a
-local-only standalone Cairnline MCP contract probe at
-`POST /hecate/v1/projects/cairnline/sidecar-probe`, but Hecate does not yet
-route Projects reads, writes, or mirrors through a persistent sidecar client.
+dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes
+local-only standalone Cairnline MCP contract probe/connect surfaces at
+`POST /hecate/v1/projects/cairnline/sidecar-probe` and
+`POST /hecate/v1/projects/cairnline/sidecar-connect`, but Hecate does not yet
+route Projects reads, writes, or mirrors through the sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -343,10 +343,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   public Go package for controlled embed experiments.
 - Current Hecate sidecar experiments can probe a standalone Cairnline MCP
   command for the minimum portable Projects tool contract via
-  `POST /hecate/v1/projects/cairnline/sidecar-probe`. This is contract evidence
-  only: Hecate does not yet keep a persistent sidecar client or route live
-  Projects reads, writes, mirrors, or write-authority switchpoints through the
-  sidecar.
+  `POST /hecate/v1/projects/cairnline/sidecar-probe` and can connect a cached
+  sidecar MCP client via `POST /hecate/v1/projects/cairnline/sidecar-connect`.
+  This is contract/client-lifecycle evidence only: Hecate does not yet route
+  live Projects reads, writes, mirrors, or write-authority switchpoints through
+  the sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -357,11 +357,12 @@ and durable grants so transcripts and approval history move together.
 storage backend. The default is `hecate`. `cairnline` records replacement intent
 for local bridge experiments. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`
 is the current live-route dogfood path and uses Hecate's embedded Cairnline Go
-bridge. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` is probe-only for now: it
-lets operators run `POST /hecate/v1/projects/cairnline/sidecar-probe` against a
-standalone Cairnline MCP command, but Projects reads, writes, mirrors, and
-write-authority switchpoints stay on Hecate-native stores until Hecate has a
-persistent sidecar backend client.
+bridge. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` lets operators run
+`POST /hecate/v1/projects/cairnline/sidecar-probe` for a one-shot contract
+check or `POST /hecate/v1/projects/cairnline/sidecar-connect` to connect a
+cached standalone Cairnline MCP client. Projects reads, writes, mirrors, and
+write-authority switchpoints still stay on Hecate-native stores until Hecate
+has a sidecar backend adapter.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project list/detail, setup readiness,
@@ -402,13 +403,14 @@ mirror into the embedded Cairnline database through their
 identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.
-The sidecar probe is configured with
+The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`,
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
-`HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. It verifies MCP tool
-presence only; it does not keep a long-lived process or route operator data
-through the sidecar.
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. They verify MCP tool
+presence only; `sidecar-connect` keeps the process warm in Hecate's
+Cairnline-specific MCP client cache, but neither endpoint routes operator
+project data through the sidecar.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -466,10 +466,10 @@ sequenceDiagram
   connector mode while `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`.
   `embedded` is the current replacement-readiness path: Hecate uses the
   embedded Cairnline Go package bridge and optional embedded mirror database.
-  `sidecar` is probe-only in this slice: it can start a standalone Cairnline MCP
-  process through `POST /hecate/v1/projects/cairnline/sidecar-probe` and verify
-  the portable tool contract, but live Projects reads and writes still use
-  Hecate-native stores.
+  `sidecar` can start a standalone Cairnline MCP process through the
+  local-only `sidecar-probe` endpoint or connect a cached client through
+  `POST /hecate/v1/projects/cairnline/sidecar-connect`, but live Projects reads
+  and writes still use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -541,10 +541,11 @@ sequenceDiagram
 - `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`, `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
   `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
   `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT` configure the standalone
-  Cairnline MCP probe. The default command is `cairnline`; the default timeout
-  is `10s`. If sidecar args are empty and a database path is configured, Hecate
-  appends `-db <path>` for the probe. Relative database paths resolve under
-  `HECATE_DATA_DIR` when set, otherwise under `.data`.
+  Cairnline MCP probe/connect surfaces. The default command is `cairnline`; the
+  default timeout is `10s`. If sidecar args are empty and a database path is
+  configured, Hecate appends `-db <path>` for the probe/connect command.
+  Relative database paths resolve under `HECATE_DATA_DIR` when set, otherwise
+  under `.data`.
 - `HECATE_POSTGRES_URL=postgres://...` or `DATABASE_URL=postgres://...` is
   required when `HECATE_BACKEND=postgres`. Optional Postgres knobs:
   `HECATE_POSTGRES_TABLE_PREFIX`, `HECATE_POSTGRES_MAX_OPEN_CONNS`, and
@@ -2294,9 +2295,9 @@ being built.
 `configured_backend` reflects `HECATE_PROJECTS_COORDINATION_BACKEND`.
 `cairnline_connector` reflects `HECATE_PROJECTS_CAIRNLINE_CONNECTOR`.
 `embedded` is the only connector that can make live Hecate routes use Cairnline
-today. `sidecar` exposes only the standalone MCP contract probe and reports
-`cairnline_connector_ready=false`, so read/write routing and write-authority
-switchpoints stay disabled.
+today. `sidecar` exposes standalone MCP contract probe/connect surfaces and
+reports `cairnline_connector_ready=false`, so read/write routing and
+write-authority switchpoints stay disabled.
 `cairnline_read_source` reflects `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables the first
 disabled-by-default write authority switchpoint: accepted project memory entries
@@ -2472,8 +2473,9 @@ mutation routes still write only Hecate-native stores.
 project stores with the existing embedded Cairnline mirror database without
 creating or repairing it. `sync_readiness_url` points at the all-project
 embedded SQLite rehearsal sync, which replaces that database from Hecate stores.
-`cairnline_sidecar_probe_url` points at the local-only standalone Cairnline MCP
-contract probe. That probe does not change live route authority.
+`cairnline_sidecar_probe_url` points at the local-only one-shot standalone
+Cairnline MCP contract probe. `cairnline_sidecar_connect_url` points at the
+local-only cached-client connect surface. Neither changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -2654,7 +2656,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "embedded_parity_report_url": "/hecate/v1/projects/{id}/cairnline/embedded-parity-report",
     "sync_readiness_url": "/hecate/v1/projects/cairnline/sync",
     "mirror_parity_url": "/hecate/v1/projects/cairnline/mirror-parity",
-    "cairnline_sidecar_probe_url": "/hecate/v1/projects/cairnline/sidecar-probe"
+    "cairnline_sidecar_probe_url": "/hecate/v1/projects/cairnline/sidecar-probe",
+    "cairnline_sidecar_connect_url": "/hecate/v1/projects/cairnline/sidecar-connect"
   }
 }
 ```
@@ -2705,6 +2708,51 @@ Example response, shortened:
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
     "probe_timeout_ms": 10000,
+    "tool_count": 12,
+    "required_tools": ["projects.list", "projects.create"],
+    "missing_tools": [],
+    "tools": [{ "name": "projects.list" }],
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-connect`
+
+Local-only standalone Cairnline MCP client connect/status surface. It uses the
+same command, database, timeout, and required-tool contract as
+`sidecar-probe`, but acquires the sidecar through Hecate's Cairnline-specific
+MCP client cache. A successful call leaves the sidecar process idle in that
+cache until the cache evicts it or Hecate shuts down. This is still not live
+Projects routing: read/write routes and write-authority switchpoints remain
+disabled in `sidecar` connector mode.
+
+The response uses the same fields as `sidecar-probe` plus cache metadata:
+
+- `persistent_client=true` means the operation used the cached sidecar client.
+- `client_cache_configured=true` means the handler owns the sidecar client
+  cache.
+- `client_cache_entries`, `client_cache_in_use`, and `client_cache_idle`
+  report the cache occupancy after the connect attempt.
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_client",
+  "data": {
+    "ready": true,
+    "status": "sidecar_client_ready",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "client_cache_entries": 1,
+    "client_cache_in_use": 0,
+    "client_cache_idle": 1,
     "tool_count": 12,
     "required_tools": ["projects.list", "projects.create"],
     "missing_tools": [],

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -77,6 +77,14 @@ type Handler struct {
 	// own subprocesses. Owned by the handler — Shutdown closes it
 	// after the runner has drained.
 	mcpClientCache *mcpclient.SharedClientCache
+	// projectCairnlineSidecarCache is separate from the task MCP
+	// cache because a future Cairnline connector is Hecate operator
+	// infrastructure, not task-scoped model/tool context. Keeping the
+	// caches distinct prevents a project-coordination sidecar from
+	// sharing lifecycle or metrics assumptions with arbitrary task MCP
+	// servers.
+	projectCairnlineSidecarMu    sync.Mutex
+	projectCairnlineSidecarCache *mcpclient.SharedClientCache
 	// orchestratorMetrics is shared between the runner and the MCP
 	// client cache observer. Built once in NewHandler so a second
 	// NewOrchestratorMetrics() can't register duplicate instruments;
@@ -587,6 +595,13 @@ func (h *Handler) Shutdown(ctx context.Context) error {
 	if h.mcpClientCache != nil {
 		cacheErr = h.mcpClientCache.Close()
 	}
+	var cairnlineSidecarCacheErr error
+	h.projectCairnlineSidecarMu.Lock()
+	cairnlineSidecarCache := h.projectCairnlineSidecarCache
+	h.projectCairnlineSidecarMu.Unlock()
+	if cairnlineSidecarCache != nil {
+		cairnlineSidecarCacheErr = cairnlineSidecarCache.Close()
+	}
 	var agentChatErr error
 	if h.agentChatRunner != nil {
 		agentChatErr = h.agentChatRunner.Shutdown(ctx)
@@ -601,6 +616,9 @@ func (h *Handler) Shutdown(ctx context.Context) error {
 	}
 	if cacheErr != nil {
 		shutdownErrs = append(shutdownErrs, fmt.Errorf("mcp cache close: %w", cacheErr))
+	}
+	if cairnlineSidecarCacheErr != nil {
+		shutdownErrs = append(shutdownErrs, fmt.Errorf("cairnline sidecar cache close: %w", cairnlineSidecarCacheErr))
 	}
 	if agentChatErr != nil {
 		shutdownErrs = append(shutdownErrs, fmt.Errorf("agent chat shutdown: %w", agentChatErr))

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/mcp"
+	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/version"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -49,7 +52,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be probed through the local-only sidecar probe endpoint, but Hecate does not yet route Projects reads or writes through a long-lived standalone Cairnline MCP client."
+		return "Cairnline sidecar connector is configured and can be connected through the local-only sidecar connect endpoint, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -59,7 +62,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables the standalone Cairnline MCP probe only; Cairnline read/write routing stays disabled until Hecate has a persistent sidecar Projects backend."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP connect/probe surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
@@ -69,6 +72,16 @@ func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *h
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarProbeEnvelope{
 		Object: "project_cairnline_sidecar_probe",
 		Data:   h.projectCairnlineSidecarProbe(r.Context()),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarConnect(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar connect") {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarClientEnvelope{
+		Object: "project_cairnline_sidecar_client",
+		Data:   h.projectCairnlineSidecarConnect(r.Context()),
 	})
 }
 
@@ -119,6 +132,87 @@ func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairn
 	response.Status = "sidecar_probe_ready"
 	response.Detail = "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
 	return response
+}
+
+func (h *Handler) projectCairnlineSidecarConnect(ctx context.Context) ProjectCairnlineSidecarProbeResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	response := ProjectCairnlineSidecarProbeResponse{
+		Ready:                 false,
+		Status:                "sidecar_client_not_connected",
+		Detail:                "Cairnline sidecar client has not connected.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		RequiredTools:         append([]string(nil), projectCairnlineSidecarRequiredTools...),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+	}
+	if h == nil {
+		response.Status = "sidecar_client_failed"
+		response.Detail = "Cairnline sidecar client requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this client does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	connectCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := orchestrator.ProbeCachedMCPServer(connectCtx, cfg, h.secretCipher, cache)
+	if err != nil {
+		response.Status = "sidecar_client_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	response.Tools = renderMCPProbeTools(result.Tools)
+	response.ToolCount = len(response.Tools)
+	response.MissingTools = projectCairnlineSidecarMissingTools(projectCairnlineSidecarToolNames(response.Tools))
+	response.setSidecarCacheStats(cache.Stats())
+	if len(response.MissingTools) > 0 {
+		response.Status = "sidecar_contract_incomplete"
+		response.Detail = "Cairnline sidecar MCP client connected, but it does not expose every tool Hecate needs for a future Projects backend connector."
+		return response
+	}
+	response.Ready = true
+	response.Status = "sidecar_client_ready"
+	response.Detail = "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	return response
+}
+
+func (h *Handler) projectCairnlineSidecarMCPClientCache() *mcpclient.SharedClientCache {
+	if h == nil {
+		return nil
+	}
+	h.projectCairnlineSidecarMu.Lock()
+	defer h.projectCairnlineSidecarMu.Unlock()
+	if h.projectCairnlineSidecarCache == nil {
+		h.projectCairnlineSidecarCache = mcpclient.NewSharedClientCacheWithOptions(mcpclient.SharedClientCacheOptions{
+			MaxEntries: 1,
+			Info: mcp.ClientInfo{
+				Name:    "hecate-cairnline-sidecar",
+				Version: version.Version,
+			},
+		})
+	}
+	return h.projectCairnlineSidecarCache
+}
+
+func (r *ProjectCairnlineSidecarProbeResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
 }
 
 func (h *Handler) projectCairnlineSidecarMCPConfig() (types.MCPServerConfig, string, time.Duration) {

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,5 +121,57 @@ func TestProjectCairnlineSidecarProbe_MissingRequiredTools(t *testing.T) {
 	}
 	if got.ToolCount != 1 {
 		t.Fatalf("tool count = %d, want 1", got.ToolCount)
+	}
+}
+
+func TestProjectCairnlineSidecarConnect_ReadyUsesPersistentClientCache(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarConnect(t.Context())
+	if !got.Ready || got.Status != "sidecar_client_ready" {
+		t.Fatalf("connect = %+v, want ready", got)
+	}
+	if !got.PersistentClient || !got.ClientCacheConfigured {
+		t.Fatalf("connect persistent/cache flags = persistent:%t configured:%t, want true/true", got.PersistentClient, got.ClientCacheConfigured)
+	}
+	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
+		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+	if got.ToolCount != len(projectCairnlineSidecarRequiredTools) || len(got.MissingTools) != 0 {
+		t.Fatalf("tool count=%d missing=%+v, want full contract", got.ToolCount, got.MissingTools)
+	}
+}
+
+func TestProjectCairnlineSidecarConnect_MissingRequiredTools(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "missing"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarConnect(t.Context())
+	if got.Ready || got.Status != "sidecar_contract_incomplete" {
+		t.Fatalf("connect = %+v, want incomplete contract", got)
+	}
+	if !got.PersistentClient || !got.ClientCacheConfigured {
+		t.Fatalf("connect persistent/cache flags = persistent:%t configured:%t, want true/true", got.PersistentClient, got.ClientCacheConfigured)
+	}
+	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
+		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+	if !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assistant.propose") {
+		t.Fatalf("missing tools = %+v, want representative missing contract tools", got.MissingTools)
 	}
 }

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -7,6 +7,7 @@ import (
 
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
 const projectCoordinationBackendSidecarProbeURL = "/hecate/v1/projects/cairnline/sidecar-probe"
+const projectCoordinationBackendSidecarConnectURL = "/hecate/v1/projects/cairnline/sidecar-connect"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -285,22 +286,23 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 	}
 	connectorReady := projectCairnlineConnectorReady(connector)
 	response := ProjectCoordinationBackendStatusResponse{
-		ConfiguredBackend:        configured,
-		AuthoritativeBackend:     "hecate",
-		StorageBackend:           storageBackend,
-		CairnlineConnector:       connector,
-		CairnlineConnectorReady:  connectorReady,
-		CairnlineConnectorDetail: projectCairnlineConnectorDetail(connector),
-		CairnlineReadSource:      readSource,
-		CairnlineBridgeReady:     true,
-		CairnlineAuthoritative:   false,
-		WriteAdapterReady:        false,
-		ReplacementReadinessURL:  projectCoordinationBackendReadinessURL,
-		CairnlineSidecarProbeURL: projectCoordinationBackendSidecarProbeURL,
-		EmbeddedReadModelURL:     projectCoordinationBackendEmbeddedReadModelURL,
-		EmbeddedParityReportURL:  projectCoordinationBackendEmbeddedParityReportURL,
-		SyncReadinessURL:         projectCoordinationBackendSyncReadinessURL,
-		MirrorParityURL:          projectCoordinationBackendMirrorParityURL,
+		ConfiguredBackend:          configured,
+		AuthoritativeBackend:       "hecate",
+		StorageBackend:             storageBackend,
+		CairnlineConnector:         connector,
+		CairnlineConnectorReady:    connectorReady,
+		CairnlineConnectorDetail:   projectCairnlineConnectorDetail(connector),
+		CairnlineReadSource:        readSource,
+		CairnlineBridgeReady:       true,
+		CairnlineAuthoritative:     false,
+		WriteAdapterReady:          false,
+		ReplacementReadinessURL:    projectCoordinationBackendReadinessURL,
+		CairnlineSidecarProbeURL:   projectCoordinationBackendSidecarProbeURL,
+		CairnlineSidecarConnectURL: projectCoordinationBackendSidecarConnectURL,
+		EmbeddedReadModelURL:       projectCoordinationBackendEmbeddedReadModelURL,
+		EmbeddedParityReportURL:    projectCoordinationBackendEmbeddedParityReportURL,
+		SyncReadinessURL:           projectCoordinationBackendSyncReadinessURL,
+		MirrorParityURL:            projectCoordinationBackendMirrorParityURL,
 	}
 	switch configured {
 	case "cairnline":

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -30,6 +30,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarProbeURL != projectCoordinationBackendSidecarProbeURL {
 		t.Fatalf("sidecar probe URL = %q, want %q", status.CairnlineSidecarProbeURL, projectCoordinationBackendSidecarProbeURL)
 	}
+	if status.CairnlineSidecarConnectURL != projectCoordinationBackendSidecarConnectURL {
+		t.Fatalf("sidecar connect URL = %q, want %q", status.CairnlineSidecarConnectURL, projectCoordinationBackendSidecarConnectURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -95,16 +98,19 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 		t.Fatalf("cairnline connector = %q ready=%t, want sidecar not ready for live routing", status.CairnlineConnector, status.CairnlineConnectorReady)
 	}
 	if status.Status != "cairnline_connector_not_ready" || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
-		t.Fatalf("status = %+v, want sidecar probe mode to block live Cairnline routing", status)
+		t.Fatalf("status = %+v, want sidecar connector mode to block live Cairnline routing", status)
 	}
 	if handler.projectReadRoutesUseCairnlineReadModel() || handler.projectIdentityWritesUseCairnlineAuthority() || handler.projectMemoryWritesUseCairnlineAuthority() || handler.projectAssignmentWritesUseCairnlineAuthority() {
-		t.Fatal("sidecar connector enabled embedded Cairnline read/write route predicates, want probe-only mode")
+		t.Fatal("sidecar connector enabled embedded Cairnline read/write route predicates, want connect/probe-only mode")
 	}
 	if status.CairnlineSidecarProbeURL != projectCoordinationBackendSidecarProbeURL {
 		t.Fatalf("sidecar probe URL = %q, want %q", status.CairnlineSidecarProbeURL, projectCoordinationBackendSidecarProbeURL)
 	}
+	if status.CairnlineSidecarConnectURL != projectCoordinationBackendSidecarConnectURL {
+		t.Fatalf("sidecar connect URL = %q, want %q", status.CairnlineSidecarConnectURL, projectCoordinationBackendSidecarConnectURL)
+	}
 	if len(status.ReadRoutes) != 0 {
-		t.Fatalf("read routes = %+v, want none in sidecar probe mode", status.ReadRoutes)
+		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)
 	}
 	if !containsString(status.WriteAdapterGaps, "projects") || !containsString(status.WriteAdapterGaps, "memory") || !containsString(status.WriteAdapterGaps, "memory-candidates") || !containsString(status.WriteAdapterGaps, "assignment-start") || !containsString(status.WriteAdapterGaps, "migration-cutover") {
 		t.Fatalf("write gaps = %+v, want configured write authority ignored until a live sidecar connector exists", status.WriteAdapterGaps)
@@ -117,7 +123,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 	warnings := strings.Join(status.Warnings, "\n")
 	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "Hecate-native stores") {
-		t.Fatalf("warnings = %+v, want sidecar probe-only warning", status.Warnings)
+		t.Fatalf("warnings = %+v, want sidecar connect/probe-only warning", status.Warnings)
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -554,32 +554,33 @@ type ProjectCoordinationBackendStatusEnvelope struct {
 }
 
 type ProjectCoordinationBackendStatusResponse struct {
-	ConfiguredBackend        string                                       `json:"configured_backend"`
-	AuthoritativeBackend     string                                       `json:"authoritative_backend"`
-	StorageBackend           string                                       `json:"storage_backend"`
-	CairnlineConnector       string                                       `json:"cairnline_connector,omitempty"`
-	CairnlineConnectorReady  bool                                         `json:"cairnline_connector_ready"`
-	CairnlineConnectorDetail string                                       `json:"cairnline_connector_detail,omitempty"`
-	CairnlineReadSource      string                                       `json:"cairnline_read_source,omitempty"`
-	CairnlineBridgeReady     bool                                         `json:"cairnline_bridge_ready"`
-	CairnlineAuthoritative   bool                                         `json:"cairnline_authoritative"`
-	ReadModelSwitchReady     bool                                         `json:"read_model_switch_ready"`
-	WriteAdapterReady        bool                                         `json:"write_adapter_ready"`
-	ReplacementReady         bool                                         `json:"replacement_ready"`
-	ReadRoutes               []string                                     `json:"read_routes,omitempty"`
-	WriteAdapterSeams        []string                                     `json:"write_adapter_seams,omitempty"`
-	WriteAdapterGaps         []string                                     `json:"write_adapter_gaps,omitempty"`
-	ReplacementGates         []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
-	WriteSwitchpoints        []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
-	Status                   string                                       `json:"status"`
-	Detail                   string                                       `json:"detail"`
-	Warnings                 []string                                     `json:"warnings,omitempty"`
-	ReplacementReadinessURL  string                                       `json:"replacement_readiness_url,omitempty"`
-	CairnlineSidecarProbeURL string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
-	EmbeddedReadModelURL     string                                       `json:"embedded_read_model_url,omitempty"`
-	EmbeddedParityReportURL  string                                       `json:"embedded_parity_report_url,omitempty"`
-	SyncReadinessURL         string                                       `json:"sync_readiness_url,omitempty"`
-	MirrorParityURL          string                                       `json:"mirror_parity_url,omitempty"`
+	ConfiguredBackend          string                                       `json:"configured_backend"`
+	AuthoritativeBackend       string                                       `json:"authoritative_backend"`
+	StorageBackend             string                                       `json:"storage_backend"`
+	CairnlineConnector         string                                       `json:"cairnline_connector,omitempty"`
+	CairnlineConnectorReady    bool                                         `json:"cairnline_connector_ready"`
+	CairnlineConnectorDetail   string                                       `json:"cairnline_connector_detail,omitempty"`
+	CairnlineReadSource        string                                       `json:"cairnline_read_source,omitempty"`
+	CairnlineBridgeReady       bool                                         `json:"cairnline_bridge_ready"`
+	CairnlineAuthoritative     bool                                         `json:"cairnline_authoritative"`
+	ReadModelSwitchReady       bool                                         `json:"read_model_switch_ready"`
+	WriteAdapterReady          bool                                         `json:"write_adapter_ready"`
+	ReplacementReady           bool                                         `json:"replacement_ready"`
+	ReadRoutes                 []string                                     `json:"read_routes,omitempty"`
+	WriteAdapterSeams          []string                                     `json:"write_adapter_seams,omitempty"`
+	WriteAdapterGaps           []string                                     `json:"write_adapter_gaps,omitempty"`
+	ReplacementGates           []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
+	WriteSwitchpoints          []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
+	Status                     string                                       `json:"status"`
+	Detail                     string                                       `json:"detail"`
+	Warnings                   []string                                     `json:"warnings,omitempty"`
+	ReplacementReadinessURL    string                                       `json:"replacement_readiness_url,omitempty"`
+	CairnlineSidecarProbeURL   string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
+	CairnlineSidecarConnectURL string                                       `json:"cairnline_sidecar_connect_url,omitempty"`
+	EmbeddedReadModelURL       string                                       `json:"embedded_read_model_url,omitempty"`
+	EmbeddedParityReportURL    string                                       `json:"embedded_parity_report_url,omitempty"`
+	SyncReadinessURL           string                                       `json:"sync_readiness_url,omitempty"`
+	MirrorParityURL            string                                       `json:"mirror_parity_url,omitempty"`
 }
 
 type ProjectCoordinationBackendReplacementGate struct {
@@ -1667,19 +1668,29 @@ type ProjectCairnlineSidecarProbeEnvelope struct {
 	Data   ProjectCairnlineSidecarProbeResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarClientEnvelope struct {
+	Object string                               `json:"object"`
+	Data   ProjectCairnlineSidecarProbeResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarProbeResponse struct {
-	Ready          bool                     `json:"ready"`
-	Status         string                   `json:"status"`
-	Detail         string                   `json:"detail"`
-	Command        string                   `json:"command"`
-	Args           []string                 `json:"args,omitempty"`
-	DatabasePath   string                   `json:"database_path,omitempty"`
-	ProbeTimeoutMS int64                    `json:"probe_timeout_ms"`
-	ToolCount      int                      `json:"tool_count"`
-	RequiredTools  []string                 `json:"required_tools"`
-	MissingTools   []string                 `json:"missing_tools,omitempty"`
-	Tools          []MCPProbeToolDescriptor `json:"tools,omitempty"`
-	Warnings       []string                 `json:"warnings,omitempty"`
+	Ready                 bool                     `json:"ready"`
+	Status                string                   `json:"status"`
+	Detail                string                   `json:"detail"`
+	Command               string                   `json:"command"`
+	Args                  []string                 `json:"args,omitempty"`
+	DatabasePath          string                   `json:"database_path,omitempty"`
+	ProbeTimeoutMS        int64                    `json:"probe_timeout_ms"`
+	PersistentClient      bool                     `json:"persistent_client,omitempty"`
+	ClientCacheConfigured bool                     `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries    int                      `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse      int                      `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle       int                      `json:"client_cache_idle,omitempty"`
+	ToolCount             int                      `json:"tool_count"`
+	RequiredTools         []string                 `json:"required_tools"`
+	MissingTools          []string                 `json:"missing_tools,omitempty"`
+	Tools                 []MCPProbeToolDescriptor `json:"tools,omitempty"`
+	Warnings              []string                 `json:"warnings,omitempty"`
 }
 
 // MCPCacheStatsResponse is the wire shape for GET /hecate/v1/system/mcp/cache.

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -23,6 +23,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/cairnline/mirror-parity"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-connect"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -83,6 +83,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
 	mux.HandleFunc("GET /hecate/v1/projects/cairnline/mirror-parity", handler.HandleProjectCairnlineMirrorParity)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-connect", handler.HandleProjectCairnlineSidecarConnect)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4228,6 +4228,22 @@ func TestProjectCairnlineSidecarProbeRejectsNonLoopbackClientsBeforeCommandHandl
 	}
 }
 
+func TestProjectCairnlineSidecarConnectRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-connect", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/mcp_host.go
+++ b/internal/orchestrator/mcp_host.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -297,14 +298,36 @@ func ProbeMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secre
 	}
 	defer func() { _ = pool.Close() }()
 
-	// Pool.AllTools() is already populated by NewPool's bring-up
-	// (initialize + tools/list) so no extra round-trip is needed.
-	// We strip the namespacing for the response — the probe surface
-	// is for understanding the upstream, not the gateway's runtime
-	// alias.
-	tools := pool.AllTools()
+	return mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools()), nil
+}
+
+// ProbeCachedMCPServer is the cached-client counterpart to
+// ProbeMCPServer. It validates/resolves cfg, acquires the upstream MCP
+// process from cache, exposes the tools/list snapshot, then releases
+// the client back to the cache instead of tearing it down. Use this
+// for operator-controlled infrastructure clients where "connect and
+// inspect" should leave a warm subprocess for future calls.
+func ProbeCachedMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher, cache *mcpclient.SharedClientCache) (*MCPProbeResult, error) {
+	if cache == nil {
+		return nil, errors.New("mcp cached probe: cache is required")
+	}
+	resolved, err := resolveEnvConfigs([]types.MCPServerConfig{cfg}, cipher)
+	if err != nil {
+		return nil, err
+	}
+	clientCfgs := toClientServerConfigs(resolved)
+	pool, err := mcpclient.NewPoolWithCache(ctx, clientCfgs, cache)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = pool.Close() }()
+
+	return mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools()), nil
+}
+
+func mcpProbeResultFromPoolTools(serverName string, tools []mcpclient.NamespacedTool) *MCPProbeResult {
 	out := &MCPProbeResult{Tools: make([]mcpclient.NamespacedTool, 0, len(tools))}
-	prefix := mcpclient.NamespacedToolName(strings.TrimSpace(cfg.Name), "")
+	prefix := mcpclient.NamespacedToolName(strings.TrimSpace(serverName), "")
 	for _, t := range tools {
 		stripped := t
 		// Strip the "mcp__<name>__" prefix to surface the upstream
@@ -316,7 +339,7 @@ func ProbeMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secre
 		}
 		out.Tools = append(out.Tools, stripped)
 	}
-	return out, nil
+	return out
 }
 
 // toClientServerConfigs converts the orchestrator-side config slice


### PR DESCRIPTION
## Summary
- add a cached Cairnline sidecar MCP client connect/status endpoint alongside the one-shot probe
- keep sidecar mode non-authoritative for Projects routing while exposing cache/tool-contract readiness
- update backend-status, remote-runtime policy, tests, and docs for the sidecar connect surface

## Verification
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/orchestrator
- just docs-format-check
- just agent-docs-check
- just check-mermaid
- just docs-env-check
- just go-format-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api ./internal/orchestrator
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbeddedRoutes'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...

Note: the first full race attempt timed out in a broad internal/api run; the named timeout test passed alone under race, and the full race suite passed on rerun with the warmed cache.