### PR TITLE
feat(projects): add Cairnline sidecar read smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -127,8 +127,10 @@ mirrors, still-Hecate-owned dispatch, and missing migration/rollback authority.
 dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes
 local-only standalone Cairnline MCP contract probe/connect surfaces at
 `POST /hecate/v1/projects/cairnline/sidecar-probe` and
-`POST /hecate/v1/projects/cairnline/sidecar-connect`, but Hecate does not yet
-route Projects reads, writes, or mirrors through the sidecar client.
+`POST /hecate/v1/projects/cairnline/sidecar-connect`, plus a read smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-read-smoke` that calls read-only
+`projects.list` through the cached sidecar client. Hecate does not yet route
+Projects reads, writes, or mirrors through the sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -360,9 +360,11 @@ is the current live-route dogfood path and uses Hecate's embedded Cairnline Go
 bridge. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` lets operators run
 `POST /hecate/v1/projects/cairnline/sidecar-probe` for a one-shot contract
 check or `POST /hecate/v1/projects/cairnline/sidecar-connect` to connect a
-cached standalone Cairnline MCP client. Projects reads, writes, mirrors, and
-write-authority switchpoints still stay on Hecate-native stores until Hecate
-has a sidecar backend adapter.
+cached standalone Cairnline MCP client. Operators can then run
+`POST /hecate/v1/projects/cairnline/sidecar-read-smoke` to call the sidecar's
+read-only `projects.list` MCP tool through that persistent client. Projects
+reads, writes, mirrors, and write-authority switchpoints still stay on
+Hecate-native stores until Hecate has a sidecar backend adapter.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project list/detail, setup readiness,
@@ -407,10 +409,11 @@ The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`,
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
-`HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. They verify MCP tool
-presence only; `sidecar-connect` keeps the process warm in Hecate's
-Cairnline-specific MCP client cache, but neither endpoint routes operator
-project data through the sidecar.
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. `sidecar-probe` verifies MCP
+tool presence only. `sidecar-connect` keeps the process warm in Hecate's
+Cairnline-specific MCP client cache. `sidecar-read-smoke` uses that cached
+client to call read-only `projects.list` and return diagnostic evidence, but it
+does not route operator project reads or writes through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read smoke,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -467,9 +467,10 @@ sequenceDiagram
   `embedded` is the current replacement-readiness path: Hecate uses the
   embedded Cairnline Go package bridge and optional embedded mirror database.
   `sidecar` can start a standalone Cairnline MCP process through the
-  local-only `sidecar-probe` endpoint or connect a cached client through
-  `POST /hecate/v1/projects/cairnline/sidecar-connect`, but live Projects reads
-  and writes still use Hecate-native stores.
+  local-only `sidecar-probe` endpoint, connect a cached client through
+  `POST /hecate/v1/projects/cairnline/sidecar-connect`, or call read-only
+  `projects.list` through `POST /hecate/v1/projects/cairnline/sidecar-read-smoke`,
+  but live Projects reads and writes still use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2475,7 +2476,9 @@ creating or repairing it. `sync_readiness_url` points at the all-project
 embedded SQLite rehearsal sync, which replaces that database from Hecate stores.
 `cairnline_sidecar_probe_url` points at the local-only one-shot standalone
 Cairnline MCP contract probe. `cairnline_sidecar_connect_url` points at the
-local-only cached-client connect surface. Neither changes live route authority.
+local-only cached-client connect surface. `cairnline_sidecar_read_url` points at
+the local-only read smoke that calls Cairnline's read-only `projects.list` tool
+through that cached client. None of these changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -2657,7 +2660,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "sync_readiness_url": "/hecate/v1/projects/cairnline/sync",
     "mirror_parity_url": "/hecate/v1/projects/cairnline/mirror-parity",
     "cairnline_sidecar_probe_url": "/hecate/v1/projects/cairnline/sidecar-probe",
-    "cairnline_sidecar_connect_url": "/hecate/v1/projects/cairnline/sidecar-connect"
+    "cairnline_sidecar_connect_url": "/hecate/v1/projects/cairnline/sidecar-connect",
+    "cairnline_sidecar_read_url": "/hecate/v1/projects/cairnline/sidecar-read-smoke"
   }
 }
 ```
@@ -2757,6 +2761,53 @@ Example response, shortened:
     "required_tools": ["projects.list", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-read-smoke`
+
+Local-only standalone Cairnline MCP read smoke. It uses the same sidecar
+command, database, timeout, and Cairnline-specific MCP client cache as
+`sidecar-connect`, then calls the read-only `projects.list` tool with empty
+arguments. This proves Hecate can perform a real MCP tool call through the
+persistent standalone Cairnline sidecar. It is diagnostic only: Hecate still
+keeps live Projects reads, writes, mirrors, dispatch, approvals, and
+write-authority switchpoints on Hecate-native stores in sidecar mode.
+
+The response reports:
+
+- `tool="projects.list"` and `read_only=true` for the called tool.
+- `tool_text` with the flattened MCP text result.
+- `tool_is_error=true` when Cairnline returned a tool-level MCP error rather
+  than a transport/protocol error.
+- `structured_content` and `_meta` when the MCP result carries those optional
+  fields.
+- The same persistent-client cache counters as `sidecar-connect`.
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_read",
+  "data": {
+    "ready": true,
+    "status": "sidecar_read_ready",
+    "detail": "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "client_cache_entries": 1,
+    "client_cache_in_use": 0,
+    "client_cache_idle": 1,
+    "tool": "projects.list",
+    "read_only": true,
+    "tool_text": "Projects (1):\n- proj_123: Example Project",
+    "tool_is_error": false,
     "warnings": []
   }
 }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -57,6 +57,13 @@ func cairnlineSidecarFixtureMain(mode string) {
 			}
 		case "tools/list":
 			result = mcp.ListToolsResult{Tools: cairnlineSidecarFixtureTools(mode)}
+		case "tools/call":
+			var params mcp.CallToolParams
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				rpcErr = mcp.NewError(mcp.ErrCodeInvalidParams, "invalid tools/call params")
+				break
+			}
+			result, rpcErr = cairnlineSidecarFixtureCallTool(mode, params)
 		default:
 			rpcErr = mcp.NewError(mcp.ErrCodeMethodNotFound, req.Method)
 		}
@@ -93,4 +100,19 @@ func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
 		})
 	}
 	return tools
+}
+
+func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mcp.CallToolResult, *mcp.RPCError) {
+	switch params.Name {
+	case "projects.list":
+		if mode == "tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture projects.list failed"),
+				IsError: true,
+			}, nil
+		}
+		return mcp.CallToolResult{Content: mcp.TextContent("Projects (1):\n- proj_fixture: Fixture Project")}, nil
+	default:
+		return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeMethodNotFound, params.Name)
+	}
 }

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -62,7 +63,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP connect/probe surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read-smoke surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
@@ -82,6 +83,16 @@ func (h *Handler) HandleProjectCairnlineSidecarConnect(w http.ResponseWriter, r 
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarClientEnvelope{
 		Object: "project_cairnline_sidecar_client",
 		Data:   h.projectCairnlineSidecarConnect(r.Context()),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarReadSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar read smoke") {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarReadEnvelope{
+		Object: "project_cairnline_sidecar_read",
+		Data:   h.projectCairnlineSidecarReadSmoke(r.Context()),
 	})
 }
 
@@ -188,6 +199,63 @@ func (h *Handler) projectCairnlineSidecarConnect(ctx context.Context) ProjectCai
 	return response
 }
 
+func (h *Handler) projectCairnlineSidecarReadSmoke(ctx context.Context) ProjectCairnlineSidecarReadResponse {
+	const toolName = "projects.list"
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	response := ProjectCairnlineSidecarReadResponse{
+		Ready:                 false,
+		Status:                "sidecar_read_not_run",
+		Detail:                "Cairnline sidecar read smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		Tool:                  toolName,
+		ReadOnly:              true,
+	}
+	if h == nil {
+		response.Status = "sidecar_read_failed"
+		response.Detail = "Cairnline sidecar read smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this read smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	readCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := orchestrator.CallCachedMCPServerTool(readCtx, cfg, h.secretCipher, cache, toolName, json.RawMessage(`{}`))
+	if err != nil {
+		response.Status = "sidecar_read_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	response.ToolText = result.Text
+	response.ToolIsError = result.IsError
+	response.StructuredContent = result.Result.StructuredContent
+	response.Meta = result.Result.Meta
+	response.setSidecarCacheStats(cache.Stats())
+	if result.IsError {
+		response.Status = "sidecar_read_tool_failed"
+		response.Detail = "Cairnline sidecar projects.list returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+		return response
+	}
+	response.Ready = true
+	response.Status = "sidecar_read_ready"
+	response.Detail = "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	return response
+}
+
 func (h *Handler) projectCairnlineSidecarMCPClientCache() *mcpclient.SharedClientCache {
 	if h == nil {
 		return nil
@@ -207,6 +275,15 @@ func (h *Handler) projectCairnlineSidecarMCPClientCache() *mcpclient.SharedClien
 }
 
 func (r *ProjectCairnlineSidecarProbeResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarReadResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -175,3 +175,58 @@ func TestProjectCairnlineSidecarConnect_MissingRequiredTools(t *testing.T) {
 		t.Fatalf("missing tools = %+v, want representative missing contract tools", got.MissingTools)
 	}
 }
+
+func TestProjectCairnlineSidecarReadSmoke_ProjectsListUsesPersistentClientCache(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarReadSmoke(t.Context())
+	if !got.Ready || got.Status != "sidecar_read_ready" {
+		t.Fatalf("read smoke = %+v, want ready", got)
+	}
+	if got.Tool != "projects.list" || !got.ReadOnly || got.ToolIsError {
+		t.Fatalf("tool fields = tool:%q read_only:%t is_error:%t, want projects.list read-only success", got.Tool, got.ReadOnly, got.ToolIsError)
+	}
+	if !strings.Contains(got.ToolText, "proj_fixture") {
+		t.Fatalf("tool text = %q, want fixture project evidence", got.ToolText)
+	}
+	if !got.PersistentClient || !got.ClientCacheConfigured {
+		t.Fatalf("read smoke persistent/cache flags = persistent:%t configured:%t, want true/true", got.PersistentClient, got.ClientCacheConfigured)
+	}
+	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
+		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+}
+
+func TestProjectCairnlineSidecarReadSmoke_ToolLevelError(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarReadSmoke(t.Context())
+	if got.Ready || got.Status != "sidecar_read_tool_failed" {
+		t.Fatalf("read smoke = %+v, want tool-level failure", got)
+	}
+	if !got.ToolIsError {
+		t.Fatalf("tool_is_error = false, want true")
+	}
+	if !strings.Contains(got.ToolText, "fixture projects.list failed") {
+		t.Fatalf("tool text = %q, want fixture tool-level error evidence", got.ToolText)
+	}
+	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
+		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -8,6 +8,7 @@ import (
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
 const projectCoordinationBackendSidecarProbeURL = "/hecate/v1/projects/cairnline/sidecar-probe"
 const projectCoordinationBackendSidecarConnectURL = "/hecate/v1/projects/cairnline/sidecar-connect"
+const projectCoordinationBackendSidecarReadURL = "/hecate/v1/projects/cairnline/sidecar-read-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -299,6 +300,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		ReplacementReadinessURL:    projectCoordinationBackendReadinessURL,
 		CairnlineSidecarProbeURL:   projectCoordinationBackendSidecarProbeURL,
 		CairnlineSidecarConnectURL: projectCoordinationBackendSidecarConnectURL,
+		CairnlineSidecarReadURL:    projectCoordinationBackendSidecarReadURL,
 		EmbeddedReadModelURL:       projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:    projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:           projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -33,6 +33,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarConnectURL != projectCoordinationBackendSidecarConnectURL {
 		t.Fatalf("sidecar connect URL = %q, want %q", status.CairnlineSidecarConnectURL, projectCoordinationBackendSidecarConnectURL)
 	}
+	if status.CairnlineSidecarReadURL != projectCoordinationBackendSidecarReadURL {
+		t.Fatalf("sidecar read URL = %q, want %q", status.CairnlineSidecarReadURL, projectCoordinationBackendSidecarReadURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -108,6 +111,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 	if status.CairnlineSidecarConnectURL != projectCoordinationBackendSidecarConnectURL {
 		t.Fatalf("sidecar connect URL = %q, want %q", status.CairnlineSidecarConnectURL, projectCoordinationBackendSidecarConnectURL)
+	}
+	if status.CairnlineSidecarReadURL != projectCoordinationBackendSidecarReadURL {
+		t.Fatalf("sidecar read URL = %q, want %q", status.CairnlineSidecarReadURL, projectCoordinationBackendSidecarReadURL)
 	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -577,6 +577,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	ReplacementReadinessURL    string                                       `json:"replacement_readiness_url,omitempty"`
 	CairnlineSidecarProbeURL   string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
 	CairnlineSidecarConnectURL string                                       `json:"cairnline_sidecar_connect_url,omitempty"`
+	CairnlineSidecarReadURL    string                                       `json:"cairnline_sidecar_read_url,omitempty"`
 	EmbeddedReadModelURL       string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL    string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL           string                                       `json:"sync_readiness_url,omitempty"`
@@ -1673,6 +1674,11 @@ type ProjectCairnlineSidecarClientEnvelope struct {
 	Data   ProjectCairnlineSidecarProbeResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarReadEnvelope struct {
+	Object string                              `json:"object"`
+	Data   ProjectCairnlineSidecarReadResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarProbeResponse struct {
 	Ready                 bool                     `json:"ready"`
 	Status                string                   `json:"status"`
@@ -1691,6 +1697,28 @@ type ProjectCairnlineSidecarProbeResponse struct {
 	MissingTools          []string                 `json:"missing_tools,omitempty"`
 	Tools                 []MCPProbeToolDescriptor `json:"tools,omitempty"`
 	Warnings              []string                 `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarReadResponse struct {
+	Ready                 bool            `json:"ready"`
+	Status                string          `json:"status"`
+	Detail                string          `json:"detail"`
+	Command               string          `json:"command"`
+	Args                  []string        `json:"args,omitempty"`
+	DatabasePath          string          `json:"database_path,omitempty"`
+	ProbeTimeoutMS        int64           `json:"probe_timeout_ms"`
+	PersistentClient      bool            `json:"persistent_client,omitempty"`
+	ClientCacheConfigured bool            `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries    int             `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse      int             `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle       int             `json:"client_cache_idle,omitempty"`
+	Tool                  string          `json:"tool"`
+	ReadOnly              bool            `json:"read_only"`
+	ToolText              string          `json:"tool_text,omitempty"`
+	ToolIsError           bool            `json:"tool_is_error,omitempty"`
+	StructuredContent     json.RawMessage `json:"structured_content,omitempty"`
+	Meta                  json.RawMessage `json:"meta,omitempty"`
+	Warnings              []string        `json:"warnings,omitempty"`
 }
 
 // MCPCacheStatsResponse is the wire shape for GET /hecate/v1/system/mcp/cache.

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -25,6 +25,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/projects/cairnline/mirror-parity"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-connect"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,6 +85,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/projects/cairnline/mirror-parity", handler.HandleProjectCairnlineMirrorParity)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-connect", handler.HandleProjectCairnlineSidecarConnect)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4244,6 +4244,22 @@ func TestProjectCairnlineSidecarConnectRejectsNonLoopbackClientsBeforeCommandHan
 	}
 }
 
+func TestProjectCairnlineSidecarReadSmokeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-read-smoke", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/mcp_host.go
+++ b/internal/orchestrator/mcp_host.go
@@ -325,6 +325,52 @@ func ProbeCachedMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher
 	return mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools()), nil
 }
 
+// CachedMCPToolCallResult is the diagnostic shape returned by
+// CallCachedMCPServerTool. It keeps the full MCP result for operator-facing
+// smoke checks while preserving the flattened text fallback used by the agent
+// loop.
+type CachedMCPToolCallResult struct {
+	ToolName string
+	Text     string
+	IsError  bool
+	Result   mcp.CallToolResult
+}
+
+// CallCachedMCPServerTool invokes a single tool on one MCP server through a
+// SharedClientCache. It is intentionally a narrow operator-diagnostic seam: the
+// agent loop still uses AgentMCPHostFactory, while sidecar/readiness probes can
+// prove a persistent client can do real work without wiring model-origin tool
+// dispatch to that sidecar.
+func CallCachedMCPServerTool(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher, cache *mcpclient.SharedClientCache, toolName string, args json.RawMessage) (*CachedMCPToolCallResult, error) {
+	if cache == nil {
+		return nil, errors.New("cached mcp tool call requires a client cache")
+	}
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return nil, errors.New("cached mcp tool call requires a tool name")
+	}
+	resolved, err := resolveEnvConfigs([]types.MCPServerConfig{cfg}, cipher)
+	if err != nil {
+		return nil, err
+	}
+	clientCfgs := toClientServerConfigs(resolved)
+	pool, err := mcpclient.NewPoolWithCache(ctx, clientCfgs, cache)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = pool.Close() }()
+	result, err := pool.CallDetailed(ctx, mcpclient.NamespacedToolName(strings.TrimSpace(cfg.Name), toolName), args)
+	if err != nil {
+		return nil, err
+	}
+	return &CachedMCPToolCallResult{
+		ToolName: toolName,
+		Text:     result.Text,
+		IsError:  result.IsError,
+		Result:   result.Result,
+	}, nil
+}
+
 func mcpProbeResultFromPoolTools(serverName string, tools []mcpclient.NamespacedTool) *MCPProbeResult {
 	out := &MCPProbeResult{Tools: make([]mcpclient.NamespacedTool, 0, len(tools))}
 	prefix := mcpclient.NamespacedToolName(strings.TrimSpace(serverName), "")


### PR DESCRIPTION
## Summary
- add a local-only Cairnline sidecar read-smoke endpoint that calls read-only projects.list through the persistent sidecar MCP client
- surface the endpoint from Projects backend status and remote-runtime local-only policy
- extend Cairnline sidecar fixture/tests and document the probe/connect/read-smoke ladder

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus|TestProjectCairnlineSidecarReadSmokeRejects'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/orchestrator
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api ./internal/orchestrator
- just docs-format
- just docs-format-check
- just agent-docs-check
- just check-mermaid
- just docs-env-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...