### PR TITLE
feat(projects): parse Cairnline sidecar project lists

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2775,6 +2775,11 @@ arguments. This proves Hecate can perform a real MCP tool call through the
 persistent standalone Cairnline sidecar. It is diagnostic only: Hecate still
 keeps live Projects reads, writes, mirrors, dispatch, approvals, and
 write-authority switchpoints on Hecate-native stores in sidecar mode.
+`ready=true` means the MCP tool call succeeded. `structured_ready=true` means
+Hecate also parsed `projects.list` `structuredContent` as typed project-list
+data, which is the contract a future sidecar read adapter would consume.
+Text-only sidecars can still be `ready=true`, but return a warning and
+`structured_ready=false`.
 
 The response reports:
 
@@ -2784,6 +2789,10 @@ The response reports:
   than a transport/protocol error.
 - `structured_content` and `_meta` when the MCP result carries those optional
   fields.
+- `structured_ready`, `structured_project_count`, and `structured_projects`
+  with the typed project-list data Hecate parsed from `structuredContent`.
+- `structured_parse_error` when `structuredContent` was present but did not
+  match the expected project-list shape.
 - The same persistent-client cache counters as `sidecar-connect`.
 
 Example response, shortened:
@@ -2808,6 +2817,23 @@ Example response, shortened:
     "read_only": true,
     "tool_text": "Projects (1):\n- proj_123: Example Project",
     "tool_is_error": false,
+    "structured_ready": true,
+    "structured_project_count": 1,
+    "structured_projects": [
+      {
+        "id": "proj_123",
+        "name": "Example Project",
+        "description": "Portable coordination state",
+        "roots": [
+          {
+            "id": "root_main",
+            "path": "/Users/alice/projects/example",
+            "kind": "local",
+            "active": true
+          }
+        ]
+      }
+    ],
     "warnings": []
   }
 }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -111,8 +111,37 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 				IsError: true,
 			}, nil
 		}
-		return mcp.CallToolResult{Content: mcp.TextContent("Projects (1):\n- proj_fixture: Fixture Project")}, nil
+		result := mcp.CallToolResult{Content: mcp.TextContent("Projects (1):\n- proj_fixture: Fixture Project")}
+		if mode != "text-only" {
+			result.StructuredContent = mustRawJSON([]ProjectCairnlineSidecarProjectItem{{
+				ID:          "proj_fixture",
+				Name:        "Fixture Project",
+				Description: "Structured fixture project",
+				Roots: []ProjectCairnlineSidecarRootItem{{
+					ID:     "root_fixture",
+					Path:   "/workspace/fixture",
+					Kind:   "local",
+					Active: true,
+				}},
+				ContextSources: []ProjectCairnlineSidecarSourceItem{{
+					ID:      "src_fixture",
+					Kind:    "workspace_instruction",
+					Title:   "AGENTS.md",
+					Locator: "AGENTS.md",
+					Enabled: true,
+				}},
+			}})
+		}
+		return result, nil
 	default:
 		return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeMethodNotFound, params.Name)
 	}
+}
+
+func mustRawJSON(value any) json.RawMessage {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return raw
 }

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -250,10 +251,41 @@ func (h *Handler) projectCairnlineSidecarReadSmoke(ctx context.Context) ProjectC
 		response.Detail = "Cairnline sidecar projects.list returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
 		return response
 	}
+	structuredProjects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(result.Result.StructuredContent)
+	response.StructuredReady = structuredReady
+	response.StructuredProjectCount = len(structuredProjects)
+	response.StructuredProjects = structuredProjects
+	if structuredErr != nil {
+		response.StructuredParseError = structuredErr.Error()
+		response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list returned structuredContent that Hecate could not parse as a project list.")
+	} else if !structuredReady {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list did not return structuredContent; Hecate verified the tool call but not a typed project-list contract.")
+	}
 	response.Ready = true
 	response.Status = "sidecar_read_ready"
 	response.Detail = "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
 	return response
+}
+
+func projectCairnlineSidecarStructuredProjects(raw json.RawMessage) ([]ProjectCairnlineSidecarProjectItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarProjectItem{}, true, nil
+	}
+	var projects []ProjectCairnlineSidecarProjectItem
+	if err := json.Unmarshal(trimmed, &projects); err != nil {
+		return nil, false, err
+	}
+	if projects == nil {
+		projects = []ProjectCairnlineSidecarProjectItem{}
+	}
+	return projects, true, nil
 }
 
 func (h *Handler) projectCairnlineSidecarMCPClientCache() *mcpclient.SharedClientCache {

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -197,11 +197,43 @@ func TestProjectCairnlineSidecarReadSmoke_ProjectsListUsesPersistentClientCache(
 	if !strings.Contains(got.ToolText, "proj_fixture") {
 		t.Fatalf("tool text = %q, want fixture project evidence", got.ToolText)
 	}
+	if !got.StructuredReady || got.StructuredProjectCount != 1 {
+		t.Fatalf("structured readiness/count = %t/%d, want ready with one project", got.StructuredReady, got.StructuredProjectCount)
+	}
+	if len(got.StructuredProjects) != 1 || got.StructuredProjects[0].ID != "proj_fixture" || got.StructuredProjects[0].Name != "Fixture Project" {
+		t.Fatalf("structured projects = %+v, want fixture project", got.StructuredProjects)
+	}
+	if len(got.StructuredProjects[0].Roots) != 1 || got.StructuredProjects[0].Roots[0].ID != "root_fixture" {
+		t.Fatalf("structured roots = %+v, want fixture root", got.StructuredProjects[0].Roots)
+	}
 	if !got.PersistentClient || !got.ClientCacheConfigured {
 		t.Fatalf("read smoke persistent/cache flags = persistent:%t configured:%t, want true/true", got.PersistentClient, got.ClientCacheConfigured)
 	}
 	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
 		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+}
+
+func TestProjectCairnlineSidecarReadSmoke_TextOnlyProjectsListWarns(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "text-only"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarReadSmoke(t.Context())
+	if !got.Ready || got.Status != "sidecar_read_ready" {
+		t.Fatalf("read smoke = %+v, want tool-call ready", got)
+	}
+	if got.StructuredReady || got.StructuredProjectCount != 0 || len(got.StructuredProjects) != 0 {
+		t.Fatalf("structured fields = ready:%t count:%d projects:%+v, want text-only downgrade", got.StructuredReady, got.StructuredProjectCount, got.StructuredProjects)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "Cairnline sidecar projects.list did not return structuredContent") {
+		t.Fatalf("warnings = %+v, want missing structuredContent warning", got.Warnings)
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -1700,25 +1700,64 @@ type ProjectCairnlineSidecarProbeResponse struct {
 }
 
 type ProjectCairnlineSidecarReadResponse struct {
-	Ready                 bool            `json:"ready"`
-	Status                string          `json:"status"`
-	Detail                string          `json:"detail"`
-	Command               string          `json:"command"`
-	Args                  []string        `json:"args,omitempty"`
-	DatabasePath          string          `json:"database_path,omitempty"`
-	ProbeTimeoutMS        int64           `json:"probe_timeout_ms"`
-	PersistentClient      bool            `json:"persistent_client,omitempty"`
-	ClientCacheConfigured bool            `json:"client_cache_configured,omitempty"`
-	ClientCacheEntries    int             `json:"client_cache_entries,omitempty"`
-	ClientCacheInUse      int             `json:"client_cache_in_use,omitempty"`
-	ClientCacheIdle       int             `json:"client_cache_idle,omitempty"`
-	Tool                  string          `json:"tool"`
-	ReadOnly              bool            `json:"read_only"`
-	ToolText              string          `json:"tool_text,omitempty"`
-	ToolIsError           bool            `json:"tool_is_error,omitempty"`
-	StructuredContent     json.RawMessage `json:"structured_content,omitempty"`
-	Meta                  json.RawMessage `json:"meta,omitempty"`
-	Warnings              []string        `json:"warnings,omitempty"`
+	Ready                  bool                                 `json:"ready"`
+	Status                 string                               `json:"status"`
+	Detail                 string                               `json:"detail"`
+	Command                string                               `json:"command"`
+	Args                   []string                             `json:"args,omitempty"`
+	DatabasePath           string                               `json:"database_path,omitempty"`
+	ProbeTimeoutMS         int64                                `json:"probe_timeout_ms"`
+	PersistentClient       bool                                 `json:"persistent_client,omitempty"`
+	ClientCacheConfigured  bool                                 `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries     int                                  `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse       int                                  `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle        int                                  `json:"client_cache_idle,omitempty"`
+	Tool                   string                               `json:"tool"`
+	ReadOnly               bool                                 `json:"read_only"`
+	ToolText               string                               `json:"tool_text,omitempty"`
+	ToolIsError            bool                                 `json:"tool_is_error,omitempty"`
+	StructuredContent      json.RawMessage                      `json:"structured_content,omitempty"`
+	Meta                   json.RawMessage                      `json:"meta,omitempty"`
+	StructuredReady        bool                                 `json:"structured_ready"`
+	StructuredProjectCount int                                  `json:"structured_project_count"`
+	StructuredProjects     []ProjectCairnlineSidecarProjectItem `json:"structured_projects,omitempty"`
+	StructuredParseError   string                               `json:"structured_parse_error,omitempty"`
+	Warnings               []string                             `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarProjectItem struct {
+	ID                        string                              `json:"id"`
+	Name                      string                              `json:"name"`
+	Description               string                              `json:"description,omitempty"`
+	DefaultRootID             string                              `json:"default_root_id,omitempty"`
+	DefaultProfileID          string                              `json:"default_profile_id,omitempty"`
+	DefaultExecutionProfileID string                              `json:"default_execution_profile_id,omitempty"`
+	Roots                     []ProjectCairnlineSidecarRootItem   `json:"roots,omitempty"`
+	ContextSources            []ProjectCairnlineSidecarSourceItem `json:"context_sources,omitempty"`
+	CreatedAt                 string                              `json:"created_at,omitempty"`
+	UpdatedAt                 string                              `json:"updated_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarRootItem struct {
+	ID        string `json:"id"`
+	Path      string `json:"path"`
+	Kind      string `json:"kind,omitempty"`
+	GitRemote string `json:"git_remote,omitempty"`
+	GitBranch string `json:"git_branch,omitempty"`
+	Active    bool   `json:"active"`
+}
+
+type ProjectCairnlineSidecarSourceItem struct {
+	ID             string            `json:"id"`
+	Kind           string            `json:"kind"`
+	Title          string            `json:"title"`
+	Locator        string            `json:"locator,omitempty"`
+	Enabled        bool              `json:"enabled"`
+	Format         string            `json:"format,omitempty"`
+	Scope          string            `json:"scope,omitempty"`
+	TrustLabel     string            `json:"trust_label,omitempty"`
+	SourceCategory string            `json:"source_category,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
 }
 
 // MCPCacheStatsResponse is the wire shape for GET /hecate/v1/system/mcp/cache.


### PR DESCRIPTION
## Summary
- parse projects.list structuredContent in the Cairnline sidecar read-smoke response
- expose structured_ready, structured_project_count, structured_projects, and structured_parse_error as typed adapter evidence
- keep text-only sidecars as successful tool-call smokes with a warning instead of changing live Projects routing

## Related
- Depends on Cairnline structured project-list contract from hecatehq/cairnline#47 for structured_ready=true against a real sidecar.

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecarReadSmoke|TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/orchestrator
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api ./internal/orchestrator
- just docs-format
- just docs-format-check
- just agent-docs-check
- just check-mermaid
- just docs-env-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...