### PR TITLE
feat(projects): add Cairnline sidecar detail smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -129,7 +129,9 @@ local-only standalone Cairnline MCP contract probe/connect surfaces at
 `POST /hecate/v1/projects/cairnline/sidecar-probe` and
 `POST /hecate/v1/projects/cairnline/sidecar-connect`, plus a read smoke at
 `POST /hecate/v1/projects/cairnline/sidecar-read-smoke` that calls read-only
-`projects.list` through the cached sidecar client. Hecate does not yet route
+`projects.list` and a detail smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-detail-smoke` that calls read-only
+`projects.get` through the cached sidecar client. Hecate does not yet route
 Projects reads, writes, or mirrors through the sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -345,9 +345,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   command for the minimum portable Projects tool contract via
   `POST /hecate/v1/projects/cairnline/sidecar-probe` and can connect a cached
   sidecar MCP client via `POST /hecate/v1/projects/cairnline/sidecar-connect`.
-  This is contract/client-lifecycle evidence only: Hecate does not yet route
-  live Projects reads, writes, mirrors, or write-authority switchpoints through
-  the sidecar.
+  Hecate can also call read-only `projects.list` and `projects.get` through
+  local-only sidecar smoke endpoints to verify typed `structuredContent` for
+  project list/detail contracts. This is contract/client-lifecycle/read-shape
+  evidence only: Hecate does not yet route live Projects reads, writes,
+  mirrors, or write-authority switchpoints through the sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -362,7 +362,9 @@ bridge. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` lets operators run
 check or `POST /hecate/v1/projects/cairnline/sidecar-connect` to connect a
 cached standalone Cairnline MCP client. Operators can then run
 `POST /hecate/v1/projects/cairnline/sidecar-read-smoke` to call the sidecar's
-read-only `projects.list` MCP tool through that persistent client. Projects
+read-only `projects.list` MCP tool, or
+`POST /hecate/v1/projects/cairnline/sidecar-detail-smoke` to call read-only
+`projects.get`, through that persistent client. Projects
 reads, writes, mirrors, and write-authority switchpoints still stay on
 Hecate-native stores until Hecate has a sidecar backend adapter.
 When the embedded Cairnline read adapter is fully wired,
@@ -411,9 +413,10 @@ The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. `sidecar-probe` verifies MCP
 tool presence only. `sidecar-connect` keeps the process warm in Hecate's
-Cairnline-specific MCP client cache. `sidecar-read-smoke` uses that cached
-client to call read-only `projects.list` and return diagnostic evidence, but it
-does not route operator project reads or writes through the sidecar backend.
+Cairnline-specific MCP client cache. `sidecar-read-smoke` and
+`sidecar-detail-smoke` use that cached client to call read-only `projects.list`
+and `projects.get` and return diagnostic evidence, but they do not route
+operator project reads or writes through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read smoke,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail smoke,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -469,8 +469,9 @@ sequenceDiagram
   `sidecar` can start a standalone Cairnline MCP process through the
   local-only `sidecar-probe` endpoint, connect a cached client through
   `POST /hecate/v1/projects/cairnline/sidecar-connect`, or call read-only
-  `projects.list` through `POST /hecate/v1/projects/cairnline/sidecar-read-smoke`,
-  but live Projects reads and writes still use Hecate-native stores.
+  `projects.list` / `projects.get` through the `sidecar-read-smoke` and
+  `sidecar-detail-smoke` endpoints, but live Projects reads and writes still
+  use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2478,7 +2479,10 @@ embedded SQLite rehearsal sync, which replaces that database from Hecate stores.
 Cairnline MCP contract probe. `cairnline_sidecar_connect_url` points at the
 local-only cached-client connect surface. `cairnline_sidecar_read_url` points at
 the local-only read smoke that calls Cairnline's read-only `projects.list` tool
-through that cached client. None of these changes live route authority.
+through that cached client. `cairnline_sidecar_detail_url` points at the
+local-only detail smoke that calls Cairnline's read-only `projects.get` tool,
+using either an explicit `project_id` or the first typed project from
+`projects.list`. None of these changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -2661,7 +2665,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "mirror_parity_url": "/hecate/v1/projects/cairnline/mirror-parity",
     "cairnline_sidecar_probe_url": "/hecate/v1/projects/cairnline/sidecar-probe",
     "cairnline_sidecar_connect_url": "/hecate/v1/projects/cairnline/sidecar-connect",
-    "cairnline_sidecar_read_url": "/hecate/v1/projects/cairnline/sidecar-read-smoke"
+    "cairnline_sidecar_read_url": "/hecate/v1/projects/cairnline/sidecar-read-smoke",
+    "cairnline_sidecar_detail_url": "/hecate/v1/projects/cairnline/sidecar-detail-smoke"
   }
 }
 ```
@@ -2686,6 +2691,7 @@ Required tools:
 
 ```text
 projects.list
+projects.get
 projects.create
 roles.list
 work_items.create
@@ -2712,8 +2718,8 @@ Example response, shortened:
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
     "probe_timeout_ms": 10000,
-    "tool_count": 12,
-    "required_tools": ["projects.list", "projects.create"],
+    "tool_count": 13,
+    "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
     "warnings": []
@@ -2757,8 +2763,8 @@ Example response, shortened:
     "client_cache_entries": 1,
     "client_cache_in_use": 0,
     "client_cache_idle": 1,
-    "tool_count": 12,
-    "required_tools": ["projects.list", "projects.create"],
+    "tool_count": 13,
+    "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
     "warnings": []
@@ -2834,6 +2840,90 @@ Example response, shortened:
         ]
       }
     ],
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-detail-smoke`
+
+Local-only standalone Cairnline MCP project-detail smoke. It uses the same
+sidecar command, database, timeout, and Cairnline-specific MCP client cache as
+`sidecar-connect`. With an empty body, Hecate first calls read-only
+`projects.list`, parses typed `structuredContent`, selects the first project id,
+and then calls read-only `projects.get`. With a body such as
+`{"project_id":"proj_123"}`, Hecate skips the list selection and calls
+`projects.get` directly.
+
+This endpoint is diagnostic only. It proves Hecate can read a typed project
+detail record through the standalone Cairnline sidecar, including roots and
+context-source metadata, but it does not switch live Projects routing,
+mirroring, dispatch, approvals, or write authority.
+
+The response reports:
+
+- `tool="projects.get"` and `read_only=true` for the detail call.
+- `requested_project_id` when the operator supplied one.
+- `selected_project_id` and `selected_project_source` (`request` or
+  `projects.list`) for the id Hecate passed to `projects.get`.
+- `list_*` fields when Hecate had to call `projects.list` to select a project.
+- `tool_text`, `tool_is_error`, `structured_content`, and `_meta` for the
+  `projects.get` result.
+- `structured_ready` and `structured_project` when Hecate parsed typed
+  `projects.get` `structuredContent`.
+- `structured_parse_error` when `projects.get` returned structured content that
+  did not match the expected project-detail shape.
+- The same persistent-client cache counters as `sidecar-connect`.
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_detail",
+  "data": {
+    "ready": true,
+    "status": "sidecar_detail_ready",
+    "detail": "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "client_cache_entries": 1,
+    "client_cache_in_use": 0,
+    "client_cache_idle": 1,
+    "tool": "projects.get",
+    "read_only": true,
+    "selected_project_id": "proj_123",
+    "selected_project_source": "projects.list",
+    "list_structured_ready": true,
+    "list_project_count": 1,
+    "tool_text": "Project proj_123: Example Project",
+    "tool_is_error": false,
+    "structured_ready": true,
+    "structured_project": {
+      "id": "proj_123",
+      "name": "Example Project",
+      "description": "Portable coordination state",
+      "roots": [
+        {
+          "id": "root_main",
+          "path": "/Users/alice/projects/example",
+          "kind": "local",
+          "active": true
+        }
+      ],
+      "context_sources": [
+        {
+          "id": "ctxsrc_agents",
+          "kind": "workspace_instruction",
+          "title": "AGENTS.md",
+          "locator": "AGENTS.md",
+          "enabled": true
+        }
+      ]
+    },
     "warnings": []
   }
 }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -133,6 +133,45 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 			}})
 		}
 		return result, nil
+	case "projects.get":
+		if mode == "get-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture projects.get failed"),
+				IsError: true,
+			}, nil
+		}
+		var input struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid projects.get arguments")
+		}
+		if input.ID == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing project id")
+		}
+		project := ProjectCairnlineSidecarProjectItem{
+			ID:          input.ID,
+			Name:        "Fixture Project",
+			Description: "Structured fixture project detail",
+			Roots: []ProjectCairnlineSidecarRootItem{{
+				ID:     "root_fixture",
+				Path:   "/workspace/fixture",
+				Kind:   "local",
+				Active: true,
+			}},
+			ContextSources: []ProjectCairnlineSidecarSourceItem{{
+				ID:      "src_fixture",
+				Kind:    "workspace_instruction",
+				Title:   "AGENTS.md",
+				Locator: "AGENTS.md",
+				Enabled: true,
+			}},
+		}
+		result := mcp.CallToolResult{Content: mcp.TextContent("Project " + input.ID + ": Fixture Project")}
+		if mode != "text-only" {
+			result.StructuredContent = mustRawJSON(project)
+		}
+		return result, nil
 	default:
 		return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeMethodNotFound, params.Name)
 	}

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -21,6 +22,7 @@ const projectCairnlineSidecarMCPServerName = "cairnline"
 
 var projectCairnlineSidecarRequiredTools = []string{
 	"projects.list",
+	"projects.get",
 	"projects.create",
 	"roles.list",
 	"work_items.create",
@@ -94,6 +96,20 @@ func (h *Handler) HandleProjectCairnlineSidecarReadSmoke(w http.ResponseWriter, 
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarReadEnvelope{
 		Object: "project_cairnline_sidecar_read",
 		Data:   h.projectCairnlineSidecarReadSmoke(r.Context()),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarDetailSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar detail smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarDetailRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarDetailEnvelope{
+		Object: "project_cairnline_sidecar_detail",
+		Data:   h.projectCairnlineSidecarDetailSmoke(r.Context(), req),
 	})
 }
 
@@ -267,6 +283,129 @@ func (h *Handler) projectCairnlineSidecarReadSmoke(ctx context.Context) ProjectC
 	return response
 }
 
+func (h *Handler) projectCairnlineSidecarDetailSmoke(ctx context.Context, req ProjectCairnlineSidecarDetailRequest) ProjectCairnlineSidecarDetailResponse {
+	const (
+		listToolName   = "projects.list"
+		detailToolName = "projects.get"
+	)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	requestedProjectID := strings.TrimSpace(req.ProjectID)
+	response := ProjectCairnlineSidecarDetailResponse{
+		Ready:                 false,
+		Status:                "sidecar_detail_not_run",
+		Detail:                "Cairnline sidecar detail smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		Tool:                  detailToolName,
+		ReadOnly:              true,
+		RequestedProjectID:    requestedProjectID,
+	}
+	if h == nil {
+		response.Status = "sidecar_detail_failed"
+		response.Detail = "Cairnline sidecar detail smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this detail smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	detailCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := requestedProjectID
+	if projectID == "" {
+		listResult, err := orchestrator.CallCachedMCPServerTool(detailCtx, cfg, h.secretCipher, cache, listToolName, json.RawMessage(`{}`))
+		if err != nil {
+			response.Status = "sidecar_detail_failed"
+			response.Detail = err.Error()
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		response.ListToolText = listResult.Text
+		response.ListToolIsError = listResult.IsError
+		response.ListStructuredContent = listResult.Result.StructuredContent
+		response.ListMeta = listResult.Result.Meta
+		if listResult.IsError {
+			response.Status = "sidecar_detail_list_tool_failed"
+			response.Detail = "Cairnline sidecar projects.list returned a tool-level error before Hecate could select a project for projects.get. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		projects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(listResult.Result.StructuredContent)
+		response.ListStructuredReady = structuredReady
+		response.ListProjectCount = len(projects)
+		if structuredErr != nil {
+			response.ListStructuredParseError = structuredErr.Error()
+			response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list returned structuredContent that Hecate could not parse as a project list.")
+		} else if !structuredReady {
+			response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list did not return structuredContent, so Hecate could not select a project for projects.get.")
+		} else if len(projects) > 0 {
+			projectID = strings.TrimSpace(projects[0].ID)
+			response.SelectedProjectSource = "projects.list"
+		}
+		if projectID == "" {
+			response.Status = "sidecar_detail_no_project"
+			response.Detail = "Hecate called Cairnline sidecar projects.list through the persistent sidecar client, but no typed project id was available for projects.get."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+	} else {
+		response.SelectedProjectSource = "request"
+	}
+	response.SelectedProjectID = projectID
+
+	args, err := json.Marshal(map[string]string{"id": projectID})
+	if err != nil {
+		response.Status = "sidecar_detail_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	result, err := orchestrator.CallCachedMCPServerTool(detailCtx, cfg, h.secretCipher, cache, detailToolName, args)
+	if err != nil {
+		response.Status = "sidecar_detail_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	response.ToolText = result.Text
+	response.ToolIsError = result.IsError
+	response.StructuredContent = result.Result.StructuredContent
+	response.Meta = result.Result.Meta
+	response.setSidecarCacheStats(cache.Stats())
+	if result.IsError {
+		response.Status = "sidecar_detail_tool_failed"
+		response.Detail = "Cairnline sidecar projects.get returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+		return response
+	}
+	structuredProject, structuredReady, structuredErr := projectCairnlineSidecarStructuredProject(result.Result.StructuredContent)
+	response.StructuredReady = structuredReady
+	response.StructuredProject = structuredProject
+	if structuredErr != nil {
+		response.StructuredParseError = structuredErr.Error()
+		response.Warnings = append(response.Warnings, "Cairnline sidecar projects.get returned structuredContent that Hecate could not parse as a project.")
+	} else if !structuredReady {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar projects.get did not return structuredContent; Hecate verified the tool call but not a typed project-detail contract.")
+	} else if structuredProject.ID != projectID {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar projects.get returned a project id different from the requested id.")
+	}
+	response.Ready = true
+	response.Status = "sidecar_detail_ready"
+	response.Detail = "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	return response
+}
+
 func projectCairnlineSidecarStructuredProjects(raw json.RawMessage) ([]ProjectCairnlineSidecarProjectItem, bool, error) {
 	if len(raw) == 0 {
 		return nil, false, nil
@@ -286,6 +425,37 @@ func projectCairnlineSidecarStructuredProjects(raw json.RawMessage) ([]ProjectCa
 		projects = []ProjectCairnlineSidecarProjectItem{}
 	}
 	return projects, true, nil
+}
+
+func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairnlineSidecarProjectItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarProjectItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarProjectItem{}, false, nil
+	}
+	var project ProjectCairnlineSidecarProjectItem
+	if err := json.Unmarshal(trimmed, &project); err != nil {
+		return ProjectCairnlineSidecarProjectItem{}, false, err
+	}
+	return project, true, nil
+}
+
+func decodeOptionalJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request body must be readable")
+		return false
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return true
+	}
+	if err := json.Unmarshal(raw, v); err != nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "request body must be valid JSON")
+		return false
+	}
+	return true
 }
 
 func (h *Handler) projectCairnlineSidecarMCPClientCache() *mcpclient.SharedClientCache {
@@ -316,6 +486,15 @@ func (r *ProjectCairnlineSidecarProbeResponse) setSidecarCacheStats(stats mcpcli
 }
 
 func (r *ProjectCairnlineSidecarReadResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarDetailResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -116,7 +116,7 @@ func TestProjectCairnlineSidecarProbe_MissingRequiredTools(t *testing.T) {
 	if got.Ready || got.Status != "sidecar_contract_incomplete" {
 		t.Fatalf("probe = %+v, want incomplete contract", got)
 	}
-	if !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assistant.propose") {
+	if !containsString(got.MissingTools, "projects.get") || !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assistant.propose") {
 		t.Fatalf("missing tools = %+v, want representative missing contract tools", got.MissingTools)
 	}
 	if got.ToolCount != 1 {
@@ -171,7 +171,7 @@ func TestProjectCairnlineSidecarConnect_MissingRequiredTools(t *testing.T) {
 	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
 		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
 	}
-	if !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assistant.propose") {
+	if !containsString(got.MissingTools, "projects.get") || !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assistant.propose") {
 		t.Fatalf("missing tools = %+v, want representative missing contract tools", got.MissingTools)
 	}
 }
@@ -260,5 +260,115 @@ func TestProjectCairnlineSidecarReadSmoke_ToolLevelError(t *testing.T) {
 	}
 	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
 		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+}
+
+func TestProjectCairnlineSidecarDetailSmoke_SelectsProjectFromStructuredList(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarDetailSmoke(t.Context(), ProjectCairnlineSidecarDetailRequest{})
+	if !got.Ready || got.Status != "sidecar_detail_ready" {
+		t.Fatalf("detail smoke = %+v, want ready", got)
+	}
+	if got.Tool != "projects.get" || !got.ReadOnly || got.ToolIsError {
+		t.Fatalf("tool fields = tool:%q read_only:%t is_error:%t, want projects.get read-only success", got.Tool, got.ReadOnly, got.ToolIsError)
+	}
+	if got.SelectedProjectID != "proj_fixture" || got.SelectedProjectSource != "projects.list" {
+		t.Fatalf("selected project = %q source %q, want fixture from list", got.SelectedProjectID, got.SelectedProjectSource)
+	}
+	if !got.ListStructuredReady || got.ListProjectCount != 1 {
+		t.Fatalf("list structured readiness/count = %t/%d, want ready with one project", got.ListStructuredReady, got.ListProjectCount)
+	}
+	if !got.StructuredReady || got.StructuredProject.ID != "proj_fixture" || got.StructuredProject.Name != "Fixture Project" {
+		t.Fatalf("structured project = ready:%t project:%+v, want fixture project", got.StructuredReady, got.StructuredProject)
+	}
+	if len(got.StructuredProject.Roots) != 1 || got.StructuredProject.Roots[0].ID != "root_fixture" {
+		t.Fatalf("structured roots = %+v, want fixture root", got.StructuredProject.Roots)
+	}
+	if !got.PersistentClient || !got.ClientCacheConfigured {
+		t.Fatalf("detail smoke persistent/cache flags = persistent:%t configured:%t, want true/true", got.PersistentClient, got.ClientCacheConfigured)
+	}
+	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
+		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+}
+
+func TestProjectCairnlineSidecarDetailSmoke_UsesRequestedProjectID(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarDetailSmoke(t.Context(), ProjectCairnlineSidecarDetailRequest{ProjectID: "proj_requested"})
+	if !got.Ready || got.Status != "sidecar_detail_ready" {
+		t.Fatalf("detail smoke = %+v, want ready", got)
+	}
+	if got.RequestedProjectID != "proj_requested" || got.SelectedProjectID != "proj_requested" || got.SelectedProjectSource != "request" {
+		t.Fatalf("project selection = requested:%q selected:%q source:%q, want explicit request", got.RequestedProjectID, got.SelectedProjectID, got.SelectedProjectSource)
+	}
+	if got.ListStructuredReady || got.ListProjectCount != 0 || got.ListToolText != "" {
+		t.Fatalf("list fields = ready:%t count:%d text:%q, want no projects.list call for explicit id", got.ListStructuredReady, got.ListProjectCount, got.ListToolText)
+	}
+	if !got.StructuredReady || got.StructuredProject.ID != "proj_requested" {
+		t.Fatalf("structured project = ready:%t project:%+v, want requested id", got.StructuredReady, got.StructuredProject)
+	}
+}
+
+func TestProjectCairnlineSidecarDetailSmoke_TextOnlyListCannotSelectProject(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "text-only"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarDetailSmoke(t.Context(), ProjectCairnlineSidecarDetailRequest{})
+	if got.Ready || got.Status != "sidecar_detail_no_project" {
+		t.Fatalf("detail smoke = %+v, want no typed project to fetch", got)
+	}
+	if got.ListStructuredReady || got.SelectedProjectID != "" || got.StructuredReady {
+		t.Fatalf("structured fields = list:%t selected:%q detail:%t, want no typed selection", got.ListStructuredReady, got.SelectedProjectID, got.StructuredReady)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "projects.list did not return structuredContent") {
+		t.Fatalf("warnings = %+v, want missing structuredContent warning", got.Warnings)
+	}
+}
+
+func TestProjectCairnlineSidecarDetailSmoke_ToolLevelError(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "get-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarDetailSmoke(t.Context(), ProjectCairnlineSidecarDetailRequest{ProjectID: "proj_requested"})
+	if got.Ready || got.Status != "sidecar_detail_tool_failed" {
+		t.Fatalf("detail smoke = %+v, want tool-level failure", got)
+	}
+	if !got.ToolIsError {
+		t.Fatalf("tool_is_error = false, want true")
+	}
+	if !strings.Contains(got.ToolText, "fixture projects.get failed") {
+		t.Fatalf("tool text = %q, want fixture tool-level error evidence", got.ToolText)
 	}
 }

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -9,6 +9,7 @@ const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnli
 const projectCoordinationBackendSidecarProbeURL = "/hecate/v1/projects/cairnline/sidecar-probe"
 const projectCoordinationBackendSidecarConnectURL = "/hecate/v1/projects/cairnline/sidecar-connect"
 const projectCoordinationBackendSidecarReadURL = "/hecate/v1/projects/cairnline/sidecar-read-smoke"
+const projectCoordinationBackendSidecarDetailURL = "/hecate/v1/projects/cairnline/sidecar-detail-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -301,6 +302,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarProbeURL:   projectCoordinationBackendSidecarProbeURL,
 		CairnlineSidecarConnectURL: projectCoordinationBackendSidecarConnectURL,
 		CairnlineSidecarReadURL:    projectCoordinationBackendSidecarReadURL,
+		CairnlineSidecarDetailURL:  projectCoordinationBackendSidecarDetailURL,
 		EmbeddedReadModelURL:       projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:    projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:           projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -36,6 +36,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarReadURL != projectCoordinationBackendSidecarReadURL {
 		t.Fatalf("sidecar read URL = %q, want %q", status.CairnlineSidecarReadURL, projectCoordinationBackendSidecarReadURL)
 	}
+	if status.CairnlineSidecarDetailURL != projectCoordinationBackendSidecarDetailURL {
+		t.Fatalf("sidecar detail URL = %q, want %q", status.CairnlineSidecarDetailURL, projectCoordinationBackendSidecarDetailURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -114,6 +117,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 	if status.CairnlineSidecarReadURL != projectCoordinationBackendSidecarReadURL {
 		t.Fatalf("sidecar read URL = %q, want %q", status.CairnlineSidecarReadURL, projectCoordinationBackendSidecarReadURL)
+	}
+	if status.CairnlineSidecarDetailURL != projectCoordinationBackendSidecarDetailURL {
+		t.Fatalf("sidecar detail URL = %q, want %q", status.CairnlineSidecarDetailURL, projectCoordinationBackendSidecarDetailURL)
 	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -578,6 +578,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarProbeURL   string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
 	CairnlineSidecarConnectURL string                                       `json:"cairnline_sidecar_connect_url,omitempty"`
 	CairnlineSidecarReadURL    string                                       `json:"cairnline_sidecar_read_url,omitempty"`
+	CairnlineSidecarDetailURL  string                                       `json:"cairnline_sidecar_detail_url,omitempty"`
 	EmbeddedReadModelURL       string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL    string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL           string                                       `json:"sync_readiness_url,omitempty"`
@@ -1679,6 +1680,15 @@ type ProjectCairnlineSidecarReadEnvelope struct {
 	Data   ProjectCairnlineSidecarReadResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarDetailEnvelope struct {
+	Object string                                `json:"object"`
+	Data   ProjectCairnlineSidecarDetailResponse `json:"data"`
+}
+
+type ProjectCairnlineSidecarDetailRequest struct {
+	ProjectID string `json:"project_id,omitempty"`
+}
+
 type ProjectCairnlineSidecarProbeResponse struct {
 	Ready                 bool                     `json:"ready"`
 	Status                string                   `json:"status"`
@@ -1723,6 +1733,41 @@ type ProjectCairnlineSidecarReadResponse struct {
 	StructuredProjects     []ProjectCairnlineSidecarProjectItem `json:"structured_projects,omitempty"`
 	StructuredParseError   string                               `json:"structured_parse_error,omitempty"`
 	Warnings               []string                             `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarDetailResponse struct {
+	Ready                    bool                               `json:"ready"`
+	Status                   string                             `json:"status"`
+	Detail                   string                             `json:"detail"`
+	Command                  string                             `json:"command"`
+	Args                     []string                           `json:"args,omitempty"`
+	DatabasePath             string                             `json:"database_path,omitempty"`
+	ProbeTimeoutMS           int64                              `json:"probe_timeout_ms"`
+	PersistentClient         bool                               `json:"persistent_client,omitempty"`
+	ClientCacheConfigured    bool                               `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries       int                                `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse         int                                `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle          int                                `json:"client_cache_idle,omitempty"`
+	Tool                     string                             `json:"tool"`
+	ReadOnly                 bool                               `json:"read_only"`
+	RequestedProjectID       string                             `json:"requested_project_id,omitempty"`
+	SelectedProjectID        string                             `json:"selected_project_id,omitempty"`
+	SelectedProjectSource    string                             `json:"selected_project_source,omitempty"`
+	ListToolText             string                             `json:"list_tool_text,omitempty"`
+	ListToolIsError          bool                               `json:"list_tool_is_error,omitempty"`
+	ListStructuredContent    json.RawMessage                    `json:"list_structured_content,omitempty"`
+	ListMeta                 json.RawMessage                    `json:"list_meta,omitempty"`
+	ListStructuredReady      bool                               `json:"list_structured_ready"`
+	ListProjectCount         int                                `json:"list_project_count"`
+	ListStructuredParseError string                             `json:"list_structured_parse_error,omitempty"`
+	ToolText                 string                             `json:"tool_text,omitempty"`
+	ToolIsError              bool                               `json:"tool_is_error,omitempty"`
+	StructuredContent        json.RawMessage                    `json:"structured_content,omitempty"`
+	Meta                     json.RawMessage                    `json:"meta,omitempty"`
+	StructuredReady          bool                               `json:"structured_ready"`
+	StructuredProject        ProjectCairnlineSidecarProjectItem `json:"structured_project,omitempty"`
+	StructuredParseError     string                             `json:"structured_parse_error,omitempty"`
+	Warnings                 []string                           `json:"warnings,omitempty"`
 }
 
 type ProjectCairnlineSidecarProjectItem struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -24,6 +24,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/cairnline/mirror-parity"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-connect"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-detail-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -84,6 +84,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
 	mux.HandleFunc("GET /hecate/v1/projects/cairnline/mirror-parity", handler.HandleProjectCairnlineMirrorParity)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-connect", handler.HandleProjectCairnlineSidecarConnect)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-detail-smoke", handler.HandleProjectCairnlineSidecarDetailSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4260,6 +4260,22 @@ func TestProjectCairnlineSidecarReadSmokeRejectsNonLoopbackClientsBeforeCommandH
 	}
 }
 
+func TestProjectCairnlineSidecarDetailSmokeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-detail-smoke", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a local-only Cairnline sidecar detail smoke endpoint for read-only projects.get
- make projects.get part of the required sidecar contract and expose the new diagnostic URL in backend status
- extend sidecar fixture/tests and docs for typed project-detail structuredContent

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus|TestRemoteRuntime|TestServerRoute|TestMCPProbeRejects'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api ./internal/orchestrator
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/orchestrator
- just docs-format
- just docs-format-check
- just agent-docs-check
- just check-mermaid
- just docs-env-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...