### PR TITLE
chore(projects): update Cairnline module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260629024923-2e83ea36ee1c
+	github.com/hecatehq/cairnline v0.0.0-20260630025003-e4a4320b3c45
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.0.0-20260629024923-2e83ea36ee1c h1:xgf0Ztd2L6jtDxEfTWnu6j2dIm2pf3eXE0H8wrTsL2E=
-github.com/hecatehq/cairnline v0.0.0-20260629024923-2e83ea36ee1c/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260630025003-e4a4320b3c45 h1:14//IDdFJuYxc9dubT7vC993QIuk+jDPmRMUTbrDwY8=
+github.com/hecatehq/cairnline v0.0.0-20260630025003-e4a4320b3c45/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
## Summary
- update Hecate's Cairnline module pin to include the latest structured MCP list results
- keep Hecate code unchanged; this just brings the embedded module forward after Cairnline PRs #47 and #48

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/cairnlinebridge ./internal/api -run 'TestProjectCairnline|TestProjectCoordinationBackendStatus|TestProjectWorkAPI|TestProjectAssistant'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/cairnlinebridge ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/cairnlinebridge ./internal/projectassistant ./internal/projectwork ./pkg/types
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...