### PR TITLE
feat(projects): add Cairnline sidecar coordination smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -131,8 +131,12 @@ local-only standalone Cairnline MCP contract probe/connect surfaces at
 `POST /hecate/v1/projects/cairnline/sidecar-read-smoke` that calls read-only
 `projects.list` and a detail smoke at
 `POST /hecate/v1/projects/cairnline/sidecar-detail-smoke` that calls read-only
-`projects.get` through the cached sidecar client. Hecate does not yet route
-Projects reads, writes, or mirrors through the sidecar client.
+`projects.get` through the cached sidecar client. A coordination-list smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke` calls
+read-only `projects.list`, `profiles.list`, `execution_profiles.list`,
+`skills.list`, `roles.list`, `work_items.list`, and `assignments.list` and
+reports whether each returned typed `structuredContent` arrays. Hecate does not
+yet route Projects reads, writes, or mirrors through the sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -345,11 +345,13 @@ launch agents. Those remain explicit operator or orchestrator actions.
   command for the minimum portable Projects tool contract via
   `POST /hecate/v1/projects/cairnline/sidecar-probe` and can connect a cached
   sidecar MCP client via `POST /hecate/v1/projects/cairnline/sidecar-connect`.
-  Hecate can also call read-only `projects.list` and `projects.get` through
-  local-only sidecar smoke endpoints to verify typed `structuredContent` for
-  project list/detail contracts. This is contract/client-lifecycle/read-shape
-  evidence only: Hecate does not yet route live Projects reads, writes,
-  mirrors, or write-authority switchpoints through the sidecar.
+  Hecate can also call read-only `projects.list`, `projects.get`, and the
+  portable coordination list tools through local-only sidecar smoke endpoints
+  to verify typed `structuredContent` for project list/detail and
+  profile/skill/role/work/assignment list contracts. This is
+  contract/client-lifecycle/read-shape evidence only: Hecate does not yet route
+  live Projects reads, writes, mirrors, or write-authority switchpoints through
+  the sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -364,7 +364,12 @@ cached standalone Cairnline MCP client. Operators can then run
 `POST /hecate/v1/projects/cairnline/sidecar-read-smoke` to call the sidecar's
 read-only `projects.list` MCP tool, or
 `POST /hecate/v1/projects/cairnline/sidecar-detail-smoke` to call read-only
-`projects.get`, through that persistent client. Projects
+`projects.get`, through that persistent client. Operators can also run
+`POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke` to call the
+read-only portable coordination list tools (`projects.list`, `profiles.list`,
+`execution_profiles.list`, `skills.list`, `roles.list`, `work_items.list`, and
+`assignments.list`) and confirm Hecate can parse their typed
+`structuredContent` arrays. Projects
 reads, writes, mirrors, and write-authority switchpoints still stay on
 Hecate-native stores until Hecate has a sidecar backend adapter.
 When the embedded Cairnline read adapter is fully wired,
@@ -413,10 +418,10 @@ The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. `sidecar-probe` verifies MCP
 tool presence only. `sidecar-connect` keeps the process warm in Hecate's
-Cairnline-specific MCP client cache. `sidecar-read-smoke` and
-`sidecar-detail-smoke` use that cached client to call read-only `projects.list`
-and `projects.get` and return diagnostic evidence, but they do not route
-operator project reads or writes through the sidecar backend.
+Cairnline-specific MCP client cache. `sidecar-read-smoke`,
+`sidecar-detail-smoke`, and `sidecar-coordination-smoke` use that cached client
+to call read-only Cairnline MCP tools and return diagnostic evidence, but they
+do not route operator project reads or writes through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail smoke,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination smoke,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -470,8 +470,10 @@ sequenceDiagram
   local-only `sidecar-probe` endpoint, connect a cached client through
   `POST /hecate/v1/projects/cairnline/sidecar-connect`, or call read-only
   `projects.list` / `projects.get` through the `sidecar-read-smoke` and
-  `sidecar-detail-smoke` endpoints, but live Projects reads and writes still
-  use Hecate-native stores.
+  `sidecar-detail-smoke` endpoints. `sidecar-coordination-smoke` also calls
+  the read-only portable coordination list tools and checks their typed
+  `structuredContent` arrays, but live Projects reads and writes still use
+  Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2666,7 +2668,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_probe_url": "/hecate/v1/projects/cairnline/sidecar-probe",
     "cairnline_sidecar_connect_url": "/hecate/v1/projects/cairnline/sidecar-connect",
     "cairnline_sidecar_read_url": "/hecate/v1/projects/cairnline/sidecar-read-smoke",
-    "cairnline_sidecar_detail_url": "/hecate/v1/projects/cairnline/sidecar-detail-smoke"
+    "cairnline_sidecar_detail_url": "/hecate/v1/projects/cairnline/sidecar-detail-smoke",
+    "cairnline_sidecar_coordination_url": "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"
   }
 }
 ```
@@ -2693,8 +2696,13 @@ Required tools:
 projects.list
 projects.get
 projects.create
+profiles.list
+execution_profiles.list
+skills.list
 roles.list
+work_items.list
 work_items.create
+assignments.list
 assignments.claim
 assignments.context
 assignments.complete
@@ -2718,7 +2726,7 @@ Example response, shortened:
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
     "probe_timeout_ms": 10000,
-    "tool_count": 13,
+    "tool_count": 18,
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
@@ -2763,7 +2771,7 @@ Example response, shortened:
     "client_cache_entries": 1,
     "client_cache_in_use": 0,
     "client_cache_idle": 1,
-    "tool_count": 13,
+    "tool_count": 18,
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
@@ -2924,6 +2932,81 @@ Example response, shortened:
         }
       ]
     },
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke`
+
+Local-only standalone Cairnline MCP coordination-list smoke. It uses the same
+sidecar command, database, timeout, and Cairnline-specific MCP client cache as
+`sidecar-connect`. Hecate calls read-only `projects.list`, `profiles.list`,
+`execution_profiles.list`, `skills.list`, `roles.list`, `work_items.list`, and
+`assignments.list`. With an empty body, Hecate selects the first typed project
+id from `projects.list` before calling project-scoped tools. With a body such
+as `{"project_id":"proj_123"}`, Hecate uses that id for project-scoped tools.
+
+This endpoint is diagnostic only. It proves Hecate can call Cairnline's
+portable coordination list surfaces and parse each tool's `structuredContent`
+as a JSON array. It does not switch live Projects routing, mirroring, dispatch,
+approvals, or write authority. `ready=true` means all MCP tool calls succeeded.
+`structured_ready=true` means every called list surface returned parseable typed
+`structuredContent`; text-only results can be `ready=true` with
+`structured_ready=false` and warnings.
+
+The response reports:
+
+- `requested_project_id` when the operator supplied one.
+- `selected_project_id` and `selected_project_source` (`request` or
+  `projects.list`) for project-scoped list calls.
+- `tool_count` for the number of read-only list tools Hecate attempted.
+- `lists[]` with per-tool `tool`, `project_scoped`, `project_id`, `tool_text`,
+  `tool_is_error`, `structured_content`, `_meta`, `structured_ready`,
+  `structured_count`, and `structured_parse_error`.
+- The same persistent-client cache counters as `sidecar-connect`.
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_coordination",
+  "data": {
+    "ready": true,
+    "status": "sidecar_coordination_ready",
+    "detail": "Hecate called read-only Cairnline sidecar coordination list tools through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "client_cache_entries": 1,
+    "client_cache_in_use": 0,
+    "client_cache_idle": 1,
+    "read_only": true,
+    "selected_project_id": "proj_123",
+    "selected_project_source": "projects.list",
+    "tool_count": 7,
+    "structured_ready": true,
+    "lists": [
+      {
+        "tool": "projects.list",
+        "read_only": true,
+        "project_scoped": false,
+        "tool_text": "Projects (1):\n- proj_123: Example Project",
+        "structured_ready": true,
+        "structured_count": 1
+      },
+      {
+        "tool": "assignments.list",
+        "read_only": true,
+        "project_scoped": true,
+        "project_id": "proj_123",
+        "structured_ready": true,
+        "structured_count": 2
+      }
+    ],
     "warnings": []
   }
 }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -133,6 +133,65 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 			}})
 		}
 		return result, nil
+	case "profiles.list":
+		return cairnlineSidecarFixtureListResult(mode, "Profiles (1):\n- profile_fixture: Fixture Profile", []map[string]any{{
+			"id":          "profile_fixture",
+			"name":        "Fixture Profile",
+			"description": "Portable fixture profile",
+			"skill_ids":   []string{"skill_fixture"},
+		}})
+	case "execution_profiles.list":
+		return cairnlineSidecarFixtureListResult(mode, "Execution profiles (1):\n- exec_fixture: Fixture Execution", []map[string]any{{
+			"id":           "exec_fixture",
+			"name":         "Fixture Execution",
+			"agent_kind":   "any",
+			"model_hint":   "fixture-model",
+			"tools_policy": "readonly",
+		}})
+	case "skills.list":
+		if mode == "coordination-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture skills.list failed"),
+				IsError: true,
+			}, nil
+		}
+		return cairnlineSidecarFixtureListResult(mode, "Skills (1):\n- skill_fixture: Fixture Skill", []map[string]any{{
+			"project_id":  cairnlineSidecarFixtureProjectID(params.Arguments),
+			"id":          "skill_fixture",
+			"title":       "Fixture Skill",
+			"path":        ".agents/skills/fixture/SKILL.md",
+			"enabled":     true,
+			"status":      "available",
+			"trust_label": "workspace_skill",
+		}})
+	case "roles.list":
+		return cairnlineSidecarFixtureListResult(mode, "Roles (1):\n- role_fixture: Fixture Reviewer", []map[string]any{{
+			"project_id":                   cairnlineSidecarFixtureProjectID(params.Arguments),
+			"id":                           "role_fixture",
+			"name":                         "Fixture Reviewer",
+			"default_profile_id":           "profile_fixture",
+			"default_execution_mode":       "mcp_pull",
+			"default_skill_ids":            []string{"skill_fixture"},
+			"default_execution_profile_id": "exec_fixture",
+		}})
+	case "work_items.list":
+		return cairnlineSidecarFixtureListResult(mode, "Work items (1):\n- work_fixture: Fixture Work", []map[string]any{{
+			"project_id": cairnlineSidecarFixtureProjectID(params.Arguments),
+			"id":         "work_fixture",
+			"title":      "Fixture Work",
+			"status":     "open",
+			"priority":   "normal",
+		}})
+	case "assignments.list":
+		return cairnlineSidecarFixtureListResult(mode, "Assignments (1):\n- asg_fixture: Fixture Assignment", []map[string]any{{
+			"project_id":     cairnlineSidecarFixtureProjectID(params.Arguments),
+			"id":             "asg_fixture",
+			"work_item_id":   "work_fixture",
+			"role_id":        "role_fixture",
+			"profile_id":     "profile_fixture",
+			"execution_mode": "mcp_pull",
+			"status":         "queued",
+		}})
 	case "projects.get":
 		if mode == "get-tool-error" {
 			return mcp.CallToolResult{
@@ -175,6 +234,22 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 	default:
 		return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeMethodNotFound, params.Name)
 	}
+}
+
+func cairnlineSidecarFixtureListResult(mode, text string, structured any) (mcp.CallToolResult, *mcp.RPCError) {
+	result := mcp.CallToolResult{Content: mcp.TextContent(text)}
+	if mode != "text-only" {
+		result.StructuredContent = mustRawJSON(structured)
+	}
+	return result, nil
+}
+
+func cairnlineSidecarFixtureProjectID(raw json.RawMessage) string {
+	var input struct {
+		ProjectID string `json:"project_id"`
+	}
+	_ = json.Unmarshal(raw, &input)
+	return input.ProjectID
 }
 
 func mustRawJSON(value any) json.RawMessage {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -24,8 +24,13 @@ var projectCairnlineSidecarRequiredTools = []string{
 	"projects.list",
 	"projects.get",
 	"projects.create",
+	"profiles.list",
+	"execution_profiles.list",
+	"skills.list",
 	"roles.list",
+	"work_items.list",
 	"work_items.create",
+	"assignments.list",
 	"assignments.claim",
 	"assignments.context",
 	"assignments.complete",
@@ -34,6 +39,21 @@ var projectCairnlineSidecarRequiredTools = []string{
 	"handoffs.create",
 	"memory_candidates.create",
 	"assistant.propose",
+}
+
+type projectCairnlineSidecarCoordinationTool struct {
+	Name          string
+	ProjectScoped bool
+}
+
+var projectCairnlineSidecarCoordinationListTools = []projectCairnlineSidecarCoordinationTool{
+	{Name: "projects.list"},
+	{Name: "profiles.list"},
+	{Name: "execution_profiles.list"},
+	{Name: "skills.list", ProjectScoped: true},
+	{Name: "roles.list", ProjectScoped: true},
+	{Name: "work_items.list", ProjectScoped: true},
+	{Name: "assignments.list", ProjectScoped: true},
 }
 
 func (h *Handler) projectCairnlineConnectorMode() string {
@@ -110,6 +130,20 @@ func (h *Handler) HandleProjectCairnlineSidecarDetailSmoke(w http.ResponseWriter
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarDetailEnvelope{
 		Object: "project_cairnline_sidecar_detail",
 		Data:   h.projectCairnlineSidecarDetailSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarCoordinationSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar coordination smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarCoordinationRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarCoordinationEnvelope{
+		Object: "project_cairnline_sidecar_coordination",
+		Data:   h.projectCairnlineSidecarCoordinationSmoke(r.Context(), req),
 	})
 }
 
@@ -406,6 +440,125 @@ func (h *Handler) projectCairnlineSidecarDetailSmoke(ctx context.Context, req Pr
 	return response
 }
 
+func (h *Handler) projectCairnlineSidecarCoordinationSmoke(ctx context.Context, req ProjectCairnlineSidecarCoordinationRequest) ProjectCairnlineSidecarCoordinationResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	requestedProjectID := strings.TrimSpace(req.ProjectID)
+	response := ProjectCairnlineSidecarCoordinationResponse{
+		Ready:                 false,
+		Status:                "sidecar_coordination_not_run",
+		Detail:                "Cairnline sidecar coordination smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ReadOnly:              true,
+		RequestedProjectID:    requestedProjectID,
+		ToolCount:             len(projectCairnlineSidecarCoordinationListTools),
+	}
+	if h == nil {
+		response.Status = "sidecar_coordination_failed"
+		response.Detail = "Cairnline sidecar coordination smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this coordination smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := requestedProjectID
+	for index, tool := range projectCairnlineSidecarCoordinationListTools {
+		if tool.ProjectScoped && projectID == "" {
+			response.Status = "sidecar_coordination_no_project"
+			response.Detail = "Hecate called Cairnline sidecar projects.list through the persistent sidecar client, but no project id was available for project-scoped coordination list tools."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		result, err := h.callProjectCairnlineSidecarCoordinationTool(smokeCtx, cfg, cache, tool, projectID)
+		if err != nil {
+			response.Status = "sidecar_coordination_failed"
+			response.Detail = err.Error()
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		response.Lists = append(response.Lists, result)
+		if result.ToolIsError {
+			response.Status = "sidecar_coordination_tool_failed"
+			response.Detail = "Cairnline sidecar " + result.Tool + " returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		if result.StructuredParseError != "" {
+			response.Warnings = append(response.Warnings, "Cairnline sidecar "+result.Tool+" returned structuredContent that Hecate could not parse as a list.")
+		} else if !result.StructuredReady {
+			response.Warnings = append(response.Warnings, "Cairnline sidecar "+result.Tool+" did not return structuredContent; Hecate verified the tool call but not a typed list contract.")
+		}
+		if index == 0 && projectID == "" && result.StructuredReady && result.StructuredCount > 0 {
+			projects, _, structuredErr := projectCairnlineSidecarStructuredProjects(result.StructuredContent)
+			if structuredErr == nil && len(projects) > 0 {
+				projectID = strings.TrimSpace(projects[0].ID)
+				response.SelectedProjectID = projectID
+				response.SelectedProjectSource = "projects.list"
+			}
+		}
+	}
+	if response.SelectedProjectID == "" && projectID != "" {
+		response.SelectedProjectID = projectID
+		if requestedProjectID != "" {
+			response.SelectedProjectSource = "request"
+		}
+	}
+	response.StructuredReady = projectCairnlineSidecarCoordinationStructuredReady(response.Lists)
+	response.Ready = true
+	response.Status = "sidecar_coordination_ready"
+	response.Detail = "Hecate called read-only Cairnline sidecar coordination list tools through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	response.setSidecarCacheStats(cache.Stats())
+	return response
+}
+
+func (h *Handler) callProjectCairnlineSidecarCoordinationTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, tool projectCairnlineSidecarCoordinationTool, projectID string) (ProjectCairnlineSidecarCoordinationListResult, error) {
+	args := json.RawMessage(`{}`)
+	if tool.ProjectScoped {
+		raw, err := json.Marshal(map[string]string{"project_id": projectID})
+		if err != nil {
+			return ProjectCairnlineSidecarCoordinationListResult{}, err
+		}
+		args = raw
+	}
+	result, err := orchestrator.CallCachedMCPServerTool(ctx, cfg, h.secretCipher, cache, tool.Name, args)
+	if err != nil {
+		return ProjectCairnlineSidecarCoordinationListResult{}, err
+	}
+	count, structuredReady, structuredErr := projectCairnlineSidecarStructuredArrayCount(result.Result.StructuredContent)
+	item := ProjectCairnlineSidecarCoordinationListResult{
+		Tool:                 tool.Name,
+		ReadOnly:             true,
+		ProjectScoped:        tool.ProjectScoped,
+		ProjectID:            projectID,
+		ToolText:             result.Text,
+		ToolIsError:          result.IsError,
+		StructuredContent:    result.Result.StructuredContent,
+		Meta:                 result.Result.Meta,
+		StructuredReady:      structuredReady,
+		StructuredCount:      count,
+		StructuredParseError: "",
+	}
+	if structuredErr != nil {
+		item.StructuredParseError = structuredErr.Error()
+	}
+	return item, nil
+}
+
 func projectCairnlineSidecarStructuredProjects(raw json.RawMessage) ([]ProjectCairnlineSidecarProjectItem, bool, error) {
 	if len(raw) == 0 {
 		return nil, false, nil
@@ -440,6 +593,36 @@ func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairn
 		return ProjectCairnlineSidecarProjectItem{}, false, err
 	}
 	return project, true, nil
+}
+
+func projectCairnlineSidecarStructuredArrayCount(raw json.RawMessage) (int, bool, error) {
+	if len(raw) == 0 {
+		return 0, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return 0, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return 0, true, nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(trimmed, &items); err != nil {
+		return 0, false, err
+	}
+	return len(items), true, nil
+}
+
+func projectCairnlineSidecarCoordinationStructuredReady(items []ProjectCairnlineSidecarCoordinationListResult) bool {
+	if len(items) != len(projectCairnlineSidecarCoordinationListTools) {
+		return false
+	}
+	for _, item := range items {
+		if item.ToolIsError || !item.StructuredReady || item.StructuredParseError != "" {
+			return false
+		}
+	}
+	return true
 }
 
 func decodeOptionalJSON(w http.ResponseWriter, r *http.Request, v any) bool {
@@ -495,6 +678,15 @@ func (r *ProjectCairnlineSidecarReadResponse) setSidecarCacheStats(stats mcpclie
 }
 
 func (r *ProjectCairnlineSidecarDetailResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarCoordinationResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -372,3 +372,150 @@ func TestProjectCairnlineSidecarDetailSmoke_ToolLevelError(t *testing.T) {
 		t.Fatalf("tool text = %q, want fixture tool-level error evidence", got.ToolText)
 	}
 }
+
+func TestProjectCairnlineSidecarCoordinationSmoke_ListsPortableSurfaces(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarCoordinationSmoke(t.Context(), ProjectCairnlineSidecarCoordinationRequest{})
+	if !got.Ready || got.Status != "sidecar_coordination_ready" || !got.StructuredReady {
+		t.Fatalf("coordination smoke = %+v, want structured ready", got)
+	}
+	if got.SelectedProjectID != "proj_fixture" || got.SelectedProjectSource != "projects.list" {
+		t.Fatalf("selected project = %q source %q, want fixture from projects.list", got.SelectedProjectID, got.SelectedProjectSource)
+	}
+	if got.ToolCount != len(projectCairnlineSidecarCoordinationListTools) || len(got.Lists) != len(projectCairnlineSidecarCoordinationListTools) {
+		t.Fatalf("tool count/list count = %d/%d, want %d", got.ToolCount, len(got.Lists), len(projectCairnlineSidecarCoordinationListTools))
+	}
+	for _, tool := range []string{"projects.list", "profiles.list", "execution_profiles.list", "skills.list", "roles.list", "work_items.list", "assignments.list"} {
+		item, ok := projectCairnlineSidecarCoordinationTestList(got.Lists, tool)
+		if !ok {
+			t.Fatalf("missing coordination list result for %s: %+v", tool, got.Lists)
+		}
+		if item.ToolIsError || !item.StructuredReady || item.StructuredCount != 1 || item.StructuredParseError != "" {
+			t.Fatalf("%s result = %+v, want one structured item", tool, item)
+		}
+	}
+	if item, _ := projectCairnlineSidecarCoordinationTestList(got.Lists, "skills.list"); item.ProjectID != "proj_fixture" || !item.ProjectScoped {
+		t.Fatalf("skills.list project scope = id:%q scoped:%t, want fixture project scoped", item.ProjectID, item.ProjectScoped)
+	}
+	if !got.PersistentClient || !got.ClientCacheConfigured {
+		t.Fatalf("coordination smoke persistent/cache flags = persistent:%t configured:%t, want true/true", got.PersistentClient, got.ClientCacheConfigured)
+	}
+	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
+		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+}
+
+func TestProjectCairnlineSidecarCoordinationSmoke_UsesRequestedProjectID(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarCoordinationSmoke(t.Context(), ProjectCairnlineSidecarCoordinationRequest{ProjectID: "proj_requested"})
+	if !got.Ready || got.Status != "sidecar_coordination_ready" || !got.StructuredReady {
+		t.Fatalf("coordination smoke = %+v, want structured ready", got)
+	}
+	if got.RequestedProjectID != "proj_requested" || got.SelectedProjectID != "proj_requested" || got.SelectedProjectSource != "request" {
+		t.Fatalf("project selection = requested:%q selected:%q source:%q, want explicit request", got.RequestedProjectID, got.SelectedProjectID, got.SelectedProjectSource)
+	}
+	if item, _ := projectCairnlineSidecarCoordinationTestList(got.Lists, "assignments.list"); item.ProjectID != "proj_requested" {
+		t.Fatalf("assignments.list project id = %q, want requested project", item.ProjectID)
+	}
+}
+
+func TestProjectCairnlineSidecarCoordinationSmoke_TextOnlyListsWarn(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "text-only"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarCoordinationSmoke(t.Context(), ProjectCairnlineSidecarCoordinationRequest{ProjectID: "proj_requested"})
+	if !got.Ready || got.Status != "sidecar_coordination_ready" || got.StructuredReady {
+		t.Fatalf("coordination smoke = %+v, want ready with structured warnings", got)
+	}
+	if len(got.Lists) != len(projectCairnlineSidecarCoordinationListTools) {
+		t.Fatalf("list count = %d, want %d", len(got.Lists), len(projectCairnlineSidecarCoordinationListTools))
+	}
+	for _, item := range got.Lists {
+		if item.StructuredReady || item.StructuredCount != 0 || item.StructuredParseError != "" {
+			t.Fatalf("%s result = %+v, want text-only downgrade", item.Tool, item)
+		}
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "did not return structuredContent") {
+		t.Fatalf("warnings = %+v, want missing structuredContent warning", got.Warnings)
+	}
+}
+
+func TestProjectCairnlineSidecarCoordinationSmoke_TextOnlyListCannotSelectProject(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "text-only"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarCoordinationSmoke(t.Context(), ProjectCairnlineSidecarCoordinationRequest{})
+	if got.Ready || got.Status != "sidecar_coordination_no_project" {
+		t.Fatalf("coordination smoke = %+v, want no typed project selection", got)
+	}
+	if got.SelectedProjectID != "" || len(got.Lists) != 3 {
+		t.Fatalf("selection/lists = selected:%q lists:%+v, want global list evidence only", got.SelectedProjectID, got.Lists)
+	}
+	for _, tool := range []string{"projects.list", "profiles.list", "execution_profiles.list"} {
+		if _, ok := projectCairnlineSidecarCoordinationTestList(got.Lists, tool); !ok {
+			t.Fatalf("lists = %+v, want %s before project-scoped stop", got.Lists, tool)
+		}
+	}
+}
+
+func TestProjectCairnlineSidecarCoordinationSmoke_ToolLevelError(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "coordination-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarCoordinationSmoke(t.Context(), ProjectCairnlineSidecarCoordinationRequest{ProjectID: "proj_requested"})
+	if got.Ready || got.Status != "sidecar_coordination_tool_failed" {
+		t.Fatalf("coordination smoke = %+v, want tool-level failure", got)
+	}
+	item, ok := projectCairnlineSidecarCoordinationTestList(got.Lists, "skills.list")
+	if !ok || !item.ToolIsError || !strings.Contains(item.ToolText, "fixture skills.list failed") {
+		t.Fatalf("skills.list result = %+v ok=%t, want tool-level error", item, ok)
+	}
+}
+
+func projectCairnlineSidecarCoordinationTestList(items []ProjectCairnlineSidecarCoordinationListResult, tool string) (ProjectCairnlineSidecarCoordinationListResult, bool) {
+	for _, item := range items {
+		if item.Tool == tool {
+			return item, true
+		}
+	}
+	return ProjectCairnlineSidecarCoordinationListResult{}, false
+}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -10,6 +10,7 @@ const projectCoordinationBackendSidecarProbeURL = "/hecate/v1/projects/cairnline
 const projectCoordinationBackendSidecarConnectURL = "/hecate/v1/projects/cairnline/sidecar-connect"
 const projectCoordinationBackendSidecarReadURL = "/hecate/v1/projects/cairnline/sidecar-read-smoke"
 const projectCoordinationBackendSidecarDetailURL = "/hecate/v1/projects/cairnline/sidecar-detail-smoke"
+const projectCoordinationBackendSidecarCoordinationURL = "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -288,25 +289,26 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 	}
 	connectorReady := projectCairnlineConnectorReady(connector)
 	response := ProjectCoordinationBackendStatusResponse{
-		ConfiguredBackend:          configured,
-		AuthoritativeBackend:       "hecate",
-		StorageBackend:             storageBackend,
-		CairnlineConnector:         connector,
-		CairnlineConnectorReady:    connectorReady,
-		CairnlineConnectorDetail:   projectCairnlineConnectorDetail(connector),
-		CairnlineReadSource:        readSource,
-		CairnlineBridgeReady:       true,
-		CairnlineAuthoritative:     false,
-		WriteAdapterReady:          false,
-		ReplacementReadinessURL:    projectCoordinationBackendReadinessURL,
-		CairnlineSidecarProbeURL:   projectCoordinationBackendSidecarProbeURL,
-		CairnlineSidecarConnectURL: projectCoordinationBackendSidecarConnectURL,
-		CairnlineSidecarReadURL:    projectCoordinationBackendSidecarReadURL,
-		CairnlineSidecarDetailURL:  projectCoordinationBackendSidecarDetailURL,
-		EmbeddedReadModelURL:       projectCoordinationBackendEmbeddedReadModelURL,
-		EmbeddedParityReportURL:    projectCoordinationBackendEmbeddedParityReportURL,
-		SyncReadinessURL:           projectCoordinationBackendSyncReadinessURL,
-		MirrorParityURL:            projectCoordinationBackendMirrorParityURL,
+		ConfiguredBackend:               configured,
+		AuthoritativeBackend:            "hecate",
+		StorageBackend:                  storageBackend,
+		CairnlineConnector:              connector,
+		CairnlineConnectorReady:         connectorReady,
+		CairnlineConnectorDetail:        projectCairnlineConnectorDetail(connector),
+		CairnlineReadSource:             readSource,
+		CairnlineBridgeReady:            true,
+		CairnlineAuthoritative:          false,
+		WriteAdapterReady:               false,
+		ReplacementReadinessURL:         projectCoordinationBackendReadinessURL,
+		CairnlineSidecarProbeURL:        projectCoordinationBackendSidecarProbeURL,
+		CairnlineSidecarConnectURL:      projectCoordinationBackendSidecarConnectURL,
+		CairnlineSidecarReadURL:         projectCoordinationBackendSidecarReadURL,
+		CairnlineSidecarDetailURL:       projectCoordinationBackendSidecarDetailURL,
+		CairnlineSidecarCoordinationURL: projectCoordinationBackendSidecarCoordinationURL,
+		EmbeddedReadModelURL:            projectCoordinationBackendEmbeddedReadModelURL,
+		EmbeddedParityReportURL:         projectCoordinationBackendEmbeddedParityReportURL,
+		SyncReadinessURL:                projectCoordinationBackendSyncReadinessURL,
+		MirrorParityURL:                 projectCoordinationBackendMirrorParityURL,
 	}
 	switch configured {
 	case "cairnline":

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -39,6 +39,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarDetailURL != projectCoordinationBackendSidecarDetailURL {
 		t.Fatalf("sidecar detail URL = %q, want %q", status.CairnlineSidecarDetailURL, projectCoordinationBackendSidecarDetailURL)
 	}
+	if status.CairnlineSidecarCoordinationURL != projectCoordinationBackendSidecarCoordinationURL {
+		t.Fatalf("sidecar coordination URL = %q, want %q", status.CairnlineSidecarCoordinationURL, projectCoordinationBackendSidecarCoordinationURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -120,6 +123,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 	if status.CairnlineSidecarDetailURL != projectCoordinationBackendSidecarDetailURL {
 		t.Fatalf("sidecar detail URL = %q, want %q", status.CairnlineSidecarDetailURL, projectCoordinationBackendSidecarDetailURL)
+	}
+	if status.CairnlineSidecarCoordinationURL != projectCoordinationBackendSidecarCoordinationURL {
+		t.Fatalf("sidecar coordination URL = %q, want %q", status.CairnlineSidecarCoordinationURL, projectCoordinationBackendSidecarCoordinationURL)
 	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -554,35 +554,36 @@ type ProjectCoordinationBackendStatusEnvelope struct {
 }
 
 type ProjectCoordinationBackendStatusResponse struct {
-	ConfiguredBackend          string                                       `json:"configured_backend"`
-	AuthoritativeBackend       string                                       `json:"authoritative_backend"`
-	StorageBackend             string                                       `json:"storage_backend"`
-	CairnlineConnector         string                                       `json:"cairnline_connector,omitempty"`
-	CairnlineConnectorReady    bool                                         `json:"cairnline_connector_ready"`
-	CairnlineConnectorDetail   string                                       `json:"cairnline_connector_detail,omitempty"`
-	CairnlineReadSource        string                                       `json:"cairnline_read_source,omitempty"`
-	CairnlineBridgeReady       bool                                         `json:"cairnline_bridge_ready"`
-	CairnlineAuthoritative     bool                                         `json:"cairnline_authoritative"`
-	ReadModelSwitchReady       bool                                         `json:"read_model_switch_ready"`
-	WriteAdapterReady          bool                                         `json:"write_adapter_ready"`
-	ReplacementReady           bool                                         `json:"replacement_ready"`
-	ReadRoutes                 []string                                     `json:"read_routes,omitempty"`
-	WriteAdapterSeams          []string                                     `json:"write_adapter_seams,omitempty"`
-	WriteAdapterGaps           []string                                     `json:"write_adapter_gaps,omitempty"`
-	ReplacementGates           []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
-	WriteSwitchpoints          []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
-	Status                     string                                       `json:"status"`
-	Detail                     string                                       `json:"detail"`
-	Warnings                   []string                                     `json:"warnings,omitempty"`
-	ReplacementReadinessURL    string                                       `json:"replacement_readiness_url,omitempty"`
-	CairnlineSidecarProbeURL   string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
-	CairnlineSidecarConnectURL string                                       `json:"cairnline_sidecar_connect_url,omitempty"`
-	CairnlineSidecarReadURL    string                                       `json:"cairnline_sidecar_read_url,omitempty"`
-	CairnlineSidecarDetailURL  string                                       `json:"cairnline_sidecar_detail_url,omitempty"`
-	EmbeddedReadModelURL       string                                       `json:"embedded_read_model_url,omitempty"`
-	EmbeddedParityReportURL    string                                       `json:"embedded_parity_report_url,omitempty"`
-	SyncReadinessURL           string                                       `json:"sync_readiness_url,omitempty"`
-	MirrorParityURL            string                                       `json:"mirror_parity_url,omitempty"`
+	ConfiguredBackend               string                                       `json:"configured_backend"`
+	AuthoritativeBackend            string                                       `json:"authoritative_backend"`
+	StorageBackend                  string                                       `json:"storage_backend"`
+	CairnlineConnector              string                                       `json:"cairnline_connector,omitempty"`
+	CairnlineConnectorReady         bool                                         `json:"cairnline_connector_ready"`
+	CairnlineConnectorDetail        string                                       `json:"cairnline_connector_detail,omitempty"`
+	CairnlineReadSource             string                                       `json:"cairnline_read_source,omitempty"`
+	CairnlineBridgeReady            bool                                         `json:"cairnline_bridge_ready"`
+	CairnlineAuthoritative          bool                                         `json:"cairnline_authoritative"`
+	ReadModelSwitchReady            bool                                         `json:"read_model_switch_ready"`
+	WriteAdapterReady               bool                                         `json:"write_adapter_ready"`
+	ReplacementReady                bool                                         `json:"replacement_ready"`
+	ReadRoutes                      []string                                     `json:"read_routes,omitempty"`
+	WriteAdapterSeams               []string                                     `json:"write_adapter_seams,omitempty"`
+	WriteAdapterGaps                []string                                     `json:"write_adapter_gaps,omitempty"`
+	ReplacementGates                []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
+	WriteSwitchpoints               []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
+	Status                          string                                       `json:"status"`
+	Detail                          string                                       `json:"detail"`
+	Warnings                        []string                                     `json:"warnings,omitempty"`
+	ReplacementReadinessURL         string                                       `json:"replacement_readiness_url,omitempty"`
+	CairnlineSidecarProbeURL        string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
+	CairnlineSidecarConnectURL      string                                       `json:"cairnline_sidecar_connect_url,omitempty"`
+	CairnlineSidecarReadURL         string                                       `json:"cairnline_sidecar_read_url,omitempty"`
+	CairnlineSidecarDetailURL       string                                       `json:"cairnline_sidecar_detail_url,omitempty"`
+	CairnlineSidecarCoordinationURL string                                       `json:"cairnline_sidecar_coordination_url,omitempty"`
+	EmbeddedReadModelURL            string                                       `json:"embedded_read_model_url,omitempty"`
+	EmbeddedParityReportURL         string                                       `json:"embedded_parity_report_url,omitempty"`
+	SyncReadinessURL                string                                       `json:"sync_readiness_url,omitempty"`
+	MirrorParityURL                 string                                       `json:"mirror_parity_url,omitempty"`
 }
 
 type ProjectCoordinationBackendReplacementGate struct {
@@ -1685,7 +1686,16 @@ type ProjectCairnlineSidecarDetailEnvelope struct {
 	Data   ProjectCairnlineSidecarDetailResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarCoordinationEnvelope struct {
+	Object string                                      `json:"object"`
+	Data   ProjectCairnlineSidecarCoordinationResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
+	ProjectID string `json:"project_id,omitempty"`
+}
+
+type ProjectCairnlineSidecarCoordinationRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
 
@@ -1768,6 +1778,43 @@ type ProjectCairnlineSidecarDetailResponse struct {
 	StructuredProject        ProjectCairnlineSidecarProjectItem `json:"structured_project,omitempty"`
 	StructuredParseError     string                             `json:"structured_parse_error,omitempty"`
 	Warnings                 []string                           `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarCoordinationResponse struct {
+	Ready                 bool                                            `json:"ready"`
+	Status                string                                          `json:"status"`
+	Detail                string                                          `json:"detail"`
+	Command               string                                          `json:"command"`
+	Args                  []string                                        `json:"args,omitempty"`
+	DatabasePath          string                                          `json:"database_path,omitempty"`
+	ProbeTimeoutMS        int64                                           `json:"probe_timeout_ms"`
+	PersistentClient      bool                                            `json:"persistent_client,omitempty"`
+	ClientCacheConfigured bool                                            `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries    int                                             `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse      int                                             `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle       int                                             `json:"client_cache_idle,omitempty"`
+	ReadOnly              bool                                            `json:"read_only"`
+	RequestedProjectID    string                                          `json:"requested_project_id,omitempty"`
+	SelectedProjectID     string                                          `json:"selected_project_id,omitempty"`
+	SelectedProjectSource string                                          `json:"selected_project_source,omitempty"`
+	ToolCount             int                                             `json:"tool_count"`
+	StructuredReady       bool                                            `json:"structured_ready"`
+	Lists                 []ProjectCairnlineSidecarCoordinationListResult `json:"lists,omitempty"`
+	Warnings              []string                                        `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarCoordinationListResult struct {
+	Tool                 string          `json:"tool"`
+	ReadOnly             bool            `json:"read_only"`
+	ProjectScoped        bool            `json:"project_scoped"`
+	ProjectID            string          `json:"project_id,omitempty"`
+	ToolText             string          `json:"tool_text,omitempty"`
+	ToolIsError          bool            `json:"tool_is_error,omitempty"`
+	StructuredContent    json.RawMessage `json:"structured_content,omitempty"`
+	Meta                 json.RawMessage `json:"meta,omitempty"`
+	StructuredReady      bool            `json:"structured_ready"`
+	StructuredCount      int             `json:"structured_count"`
+	StructuredParseError string          `json:"structured_parse_error,omitempty"`
 }
 
 type ProjectCairnlineSidecarProjectItem struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -24,6 +24,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/cairnline/mirror-parity"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-connect"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-detail-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -84,6 +84,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
 	mux.HandleFunc("GET /hecate/v1/projects/cairnline/mirror-parity", handler.HandleProjectCairnlineMirrorParity)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-connect", handler.HandleProjectCairnlineSidecarConnect)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke", handler.HandleProjectCairnlineSidecarCoordinationSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-detail-smoke", handler.HandleProjectCairnlineSidecarDetailSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4276,6 +4276,22 @@ func TestProjectCairnlineSidecarDetailSmokeRejectsNonLoopbackClientsBeforeComman
 	}
 }
 
+func TestProjectCairnlineSidecarCoordinationSmokeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-coordination-smoke", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a local-only Cairnline sidecar coordination smoke endpoint for read-only portable list tools
- extend the sidecar required-tool contract and backend-status URL reporting
- cover structured list parsing, text-only downgrade, tool errors, loopback guard, and docs

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus|TestRemoteRuntime|TestServerRoute|TestMCPProbeRejects'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api ./internal/orchestrator
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/orchestrator
- just docs-format
- just agent-docs-check
- just check-mermaid
- just docs-format-check
- just docs-env-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 2m ./internal/api -run TestHecateAgentChatRejectsSessionLevelMCPServers -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 3m ./internal/api -run 'TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus|TestRemoteRuntime|TestServerRoute|TestMCPProbeRejects' -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 5m ./internal/api ./internal/orchestrator ./internal/mcp/client ./pkg/types

Note: GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./... timed out in TestHecateAgentChatRejectsSessionLevelMCPServers during the broad run; that test passed alone under race, and the affected race package set passed.