### PR TITLE
feat(projects): add Cairnline assignment context smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -135,8 +135,12 @@ local-only standalone Cairnline MCP contract probe/connect surfaces at
 `POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke` calls
 read-only `projects.list`, `profiles.list`, `execution_profiles.list`,
 `skills.list`, `roles.list`, `work_items.list`, and `assignments.list` and
-reports whether each returned typed `structuredContent` arrays. Hecate does not
-yet route Projects reads, writes, or mirrors through the sidecar client.
+reports whether each returned typed `structuredContent` arrays. An
+assignment-context smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-assignment-context-smoke` calls
+read-only `assignments.context` and reports whether typed
+assignment/project/work/role context metadata is present. Hecate does not yet
+route Projects reads, writes, or mirrors through the sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -345,10 +345,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   command for the minimum portable Projects tool contract via
   `POST /hecate/v1/projects/cairnline/sidecar-probe` and can connect a cached
   sidecar MCP client via `POST /hecate/v1/projects/cairnline/sidecar-connect`.
-  Hecate can also call read-only `projects.list`, `projects.get`, and the
-  portable coordination list tools through local-only sidecar smoke endpoints
-  to verify typed `structuredContent` for project list/detail and
-  profile/skill/role/work/assignment list contracts. This is
+  Hecate can also call read-only `projects.list`, `projects.get`,
+  `assignments.context`, and the portable coordination list tools through
+  local-only sidecar smoke endpoints to verify typed `structuredContent` for
+  project list/detail, profile/skill/role/work/assignment list, and
+  assignment-context contracts. This is
   contract/client-lifecycle/read-shape evidence only: Hecate does not yet route
   live Projects reads, writes, mirrors, or write-authority switchpoints through
   the sidecar.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -371,7 +371,11 @@ read-only portable coordination list tools (`projects.list`, `profiles.list`,
 `assignments.list`) and confirm Hecate can parse their typed
 `structuredContent` arrays. Projects
 reads, writes, mirrors, and write-authority switchpoints still stay on
-Hecate-native stores until Hecate has a sidecar backend adapter.
+Hecate-native stores until Hecate has a sidecar backend adapter. For MCP-pull
+context evidence, operators can run
+`POST /hecate/v1/projects/cairnline/sidecar-assignment-context-smoke` to select
+or request an assignment and confirm `assignments.context` returns typed
+assignment/project/work/role metadata.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project list/detail, setup readiness,
@@ -419,9 +423,10 @@ The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. `sidecar-probe` verifies MCP
 tool presence only. `sidecar-connect` keeps the process warm in Hecate's
 Cairnline-specific MCP client cache. `sidecar-read-smoke`,
-`sidecar-detail-smoke`, and `sidecar-coordination-smoke` use that cached client
-to call read-only Cairnline MCP tools and return diagnostic evidence, but they
-do not route operator project reads or writes through the sidecar backend.
+`sidecar-detail-smoke`, `sidecar-coordination-smoke`, and
+`sidecar-assignment-context-smoke` use that cached client to call read-only
+Cairnline MCP tools and return diagnostic evidence, but they do not route
+operator project reads or writes through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination smoke,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context smoke,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -472,8 +472,10 @@ sequenceDiagram
   `projects.list` / `projects.get` through the `sidecar-read-smoke` and
   `sidecar-detail-smoke` endpoints. `sidecar-coordination-smoke` also calls
   the read-only portable coordination list tools and checks their typed
-  `structuredContent` arrays, but live Projects reads and writes still use
-  Hecate-native stores.
+  `structuredContent` arrays. `sidecar-assignment-context-smoke` calls
+  read-only `assignments.context` and checks typed assignment/project/work/role
+  context metadata, but live Projects reads and writes still use Hecate-native
+  stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2669,7 +2671,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_connect_url": "/hecate/v1/projects/cairnline/sidecar-connect",
     "cairnline_sidecar_read_url": "/hecate/v1/projects/cairnline/sidecar-read-smoke",
     "cairnline_sidecar_detail_url": "/hecate/v1/projects/cairnline/sidecar-detail-smoke",
-    "cairnline_sidecar_coordination_url": "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"
+    "cairnline_sidecar_coordination_url": "/hecate/v1/projects/cairnline/sidecar-coordination-smoke",
+    "cairnline_sidecar_assignment_context_url": "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"
   }
 }
 ```
@@ -3007,6 +3010,76 @@ Example response, shortened:
         "structured_count": 2
       }
     ],
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-assignment-context-smoke`
+
+Local-only standalone Cairnline MCP assignment-context smoke. It uses the same
+sidecar command, database, timeout, and Cairnline-specific MCP client cache as
+`sidecar-connect`. With an empty body, Hecate calls read-only `projects.list`,
+selects the first typed project id, calls read-only `assignments.list`, selects
+the first typed assignment id, and then calls read-only `assignments.context`.
+With a body such as `{"project_id":"proj_123","assignment_id":"asg_123"}`,
+Hecate skips list selection and calls `assignments.context` directly.
+
+This endpoint is diagnostic only. It proves Hecate can read the MCP-pull
+assignment context shape a compatible agent would consume from a standalone
+Cairnline sidecar. It does not claim, start, mutate, dispatch, or complete
+assignments. `ready=true` means the MCP tool call succeeded.
+`structured_ready=true` means Hecate parsed `assignments.context`
+`structuredContent` and found assignment, project, work item, and role ids.
+
+The response reports:
+
+- `requested_project_id` / `requested_assignment_id` when the operator supplied
+  ids.
+- `selected_project_id` / `selected_assignment_id` and their selection sources
+  (`request`, `projects.list`, or `assignments.list`).
+- `project_list` and `assignment_list` evidence when Hecate had to select ids.
+- `tool="assignments.context"` and `read_only=true` for the context call.
+- `tool_text`, `tool_is_error`, `structured_content`, and `_meta` for the
+  `assignments.context` result.
+- `structured_ready`, `structured_ids`, and `structured_parse_error` for the
+  typed assignment-context contract, including assignment/project/work/role ids
+  when present.
+- The same persistent-client cache counters as `sidecar-connect`.
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_assignment_context",
+  "data": {
+    "ready": true,
+    "status": "sidecar_assignment_context_ready",
+    "detail": "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "client_cache_entries": 1,
+    "client_cache_in_use": 0,
+    "client_cache_idle": 1,
+    "tool": "assignments.context",
+    "read_only": true,
+    "selected_project_id": "proj_123",
+    "selected_project_source": "projects.list",
+    "selected_assignment_id": "asg_123",
+    "selected_assignment_source": "assignments.list",
+    "tool_text": "Assignment context asg_123 for project proj_123",
+    "tool_is_error": false,
+    "structured_ready": true,
+    "structured_ids": {
+      "assignment_id": "asg_123",
+      "project_id": "proj_123",
+      "work_item_id": "work_123",
+      "role_id": "role_reviewer"
+    },
     "warnings": []
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260630025003-e4a4320b3c45
+	github.com/hecatehq/cairnline v0.0.0-20260630034324-bb4d449008d8
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.0.0-20260630025003-e4a4320b3c45 h1:14//IDdFJuYxc9dubT7vC993QIuk+jDPmRMUTbrDwY8=
-github.com/hecatehq/cairnline v0.0.0-20260630025003-e4a4320b3c45/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260630034324-bb4d449008d8 h1:H64pvdRd31kiF1W9Phg6gjy0EjK0e69tSzzT5UOvtao=
+github.com/hecatehq/cairnline v0.0.0-20260630034324-bb4d449008d8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -183,6 +183,9 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 			"priority":   "normal",
 		}})
 	case "assignments.list":
+		if mode == "assignment-list-empty" {
+			return cairnlineSidecarFixtureListResult(mode, "No assignments yet.", []map[string]any{})
+		}
 		return cairnlineSidecarFixtureListResult(mode, "Assignments (1):\n- asg_fixture: Fixture Assignment", []map[string]any{{
 			"project_id":     cairnlineSidecarFixtureProjectID(params.Arguments),
 			"id":             "asg_fixture",
@@ -192,6 +195,44 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 			"execution_mode": "mcp_pull",
 			"status":         "queued",
 		}})
+	case "assignments.context":
+		if mode == "context-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture assignments.context failed"),
+				IsError: true,
+			}, nil
+		}
+		var input struct {
+			ProjectID    string `json:"project_id"`
+			AssignmentID string `json:"assignment_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assignments.context arguments")
+		}
+		if input.ProjectID == "" || input.AssignmentID == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing assignment context ids")
+		}
+		result := mcp.CallToolResult{Content: mcp.TextContent("Assignment context " + input.AssignmentID + " for project " + input.ProjectID)}
+		if mode != "text-only" {
+			result.StructuredContent = mustRawJSON(map[string]any{
+				"assignment": map[string]any{
+					"id":           input.AssignmentID,
+					"project_id":   input.ProjectID,
+					"work_item_id": "work_fixture",
+					"role_id":      "role_fixture",
+					"status":       "queued",
+				},
+				"work_item": map[string]any{
+					"id":    "work_fixture",
+					"title": "Fixture Work",
+				},
+				"role": map[string]any{
+					"id":   "role_fixture",
+					"name": "Fixture Reviewer",
+				},
+			})
+		}
+		return result, nil
 	case "projects.get":
 		if mode == "get-tool-error" {
 			return mcp.CallToolResult{

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -147,6 +147,20 @@ func (h *Handler) HandleProjectCairnlineSidecarCoordinationSmoke(w http.Response
 	})
 }
 
+func (h *Handler) HandleProjectCairnlineSidecarAssignmentContextSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar assignment context smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarAssignmentContextRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarAssignmentContextEnvelope{
+		Object: "project_cairnline_sidecar_assignment_context",
+		Data:   h.projectCairnlineSidecarAssignmentContextSmoke(r.Context(), req),
+	})
+}
+
 func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairnlineSidecarProbeResponse {
 	if ctx == nil {
 		ctx = context.Background()
@@ -526,6 +540,172 @@ func (h *Handler) projectCairnlineSidecarCoordinationSmoke(ctx context.Context, 
 	return response
 }
 
+func (h *Handler) projectCairnlineSidecarAssignmentContextSmoke(ctx context.Context, req ProjectCairnlineSidecarAssignmentContextRequest) ProjectCairnlineSidecarAssignmentContextResponse {
+	const (
+		projectListToolName    = "projects.list"
+		assignmentListToolName = "assignments.list"
+		contextToolName        = "assignments.context"
+	)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	requestedProjectID := strings.TrimSpace(req.ProjectID)
+	requestedAssignmentID := strings.TrimSpace(req.AssignmentID)
+	response := ProjectCairnlineSidecarAssignmentContextResponse{
+		Ready:                 false,
+		Status:                "sidecar_assignment_context_not_run",
+		Detail:                "Cairnline sidecar assignment context smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		Tool:                  contextToolName,
+		ReadOnly:              true,
+		RequestedProjectID:    requestedProjectID,
+		RequestedAssignmentID: requestedAssignmentID,
+	}
+	if h == nil {
+		response.Status = "sidecar_assignment_context_failed"
+		response.Detail = "Cairnline sidecar assignment context smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this assignment context smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := requestedProjectID
+	if projectID == "" {
+		listResult, err := h.callProjectCairnlineSidecarCoordinationTool(smokeCtx, cfg, cache, projectCairnlineSidecarCoordinationTool{Name: projectListToolName}, "")
+		if err != nil {
+			response.Status = "sidecar_assignment_context_failed"
+			response.Detail = err.Error()
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		response.ProjectList = &listResult
+		if listResult.ToolIsError {
+			response.Status = "sidecar_assignment_context_project_list_tool_failed"
+			response.Detail = "Cairnline sidecar projects.list returned a tool-level error before Hecate could select a project for assignments.context."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		projects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(listResult.StructuredContent)
+		response.ProjectList.StructuredReady = structuredReady
+		response.ProjectList.StructuredCount = len(projects)
+		if structuredErr != nil {
+			response.ProjectList.StructuredParseError = structuredErr.Error()
+			response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list returned structuredContent that Hecate could not parse as a project list.")
+		} else if !structuredReady {
+			response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list did not return structuredContent, so Hecate could not select a project for assignments.context.")
+		} else if len(projects) > 0 {
+			projectID = strings.TrimSpace(projects[0].ID)
+			response.SelectedProjectID = projectID
+			response.SelectedProjectSource = "projects.list"
+		}
+		if projectID == "" {
+			response.Status = "sidecar_assignment_context_no_project"
+			response.Detail = "Hecate called Cairnline sidecar projects.list through the persistent sidecar client, but no typed project id was available for assignments.context."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+	} else {
+		response.SelectedProjectID = projectID
+		response.SelectedProjectSource = "request"
+	}
+
+	assignmentID := requestedAssignmentID
+	if assignmentID == "" {
+		listResult, err := h.callProjectCairnlineSidecarCoordinationTool(smokeCtx, cfg, cache, projectCairnlineSidecarCoordinationTool{Name: assignmentListToolName, ProjectScoped: true}, projectID)
+		if err != nil {
+			response.Status = "sidecar_assignment_context_failed"
+			response.Detail = err.Error()
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		response.AssignmentList = &listResult
+		if listResult.ToolIsError {
+			response.Status = "sidecar_assignment_context_assignment_list_tool_failed"
+			response.Detail = "Cairnline sidecar assignments.list returned a tool-level error before Hecate could select an assignment for assignments.context."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		assignments, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignments(listResult.StructuredContent)
+		response.AssignmentList.StructuredReady = structuredReady
+		response.AssignmentList.StructuredCount = len(assignments)
+		if structuredErr != nil {
+			response.AssignmentList.StructuredParseError = structuredErr.Error()
+			response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.list returned structuredContent that Hecate could not parse as an assignment list.")
+		} else if !structuredReady {
+			response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.list did not return structuredContent, so Hecate could not select an assignment for assignments.context.")
+		} else if len(assignments) > 0 {
+			assignmentID = strings.TrimSpace(assignments[0].ID)
+			response.SelectedAssignmentID = assignmentID
+			response.SelectedAssignmentSource = "assignments.list"
+		}
+		if assignmentID == "" {
+			response.Status = "sidecar_assignment_context_no_assignment"
+			response.Detail = "Hecate called Cairnline sidecar assignments.list through the persistent sidecar client, but no typed assignment id was available for assignments.context."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+	} else {
+		response.SelectedAssignmentID = assignmentID
+		response.SelectedAssignmentSource = "request"
+	}
+
+	args, err := json.Marshal(map[string]string{"project_id": projectID, "assignment_id": assignmentID})
+	if err != nil {
+		response.Status = "sidecar_assignment_context_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	result, err := orchestrator.CallCachedMCPServerTool(smokeCtx, cfg, h.secretCipher, cache, contextToolName, args)
+	if err != nil {
+		response.Status = "sidecar_assignment_context_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	response.ToolText = result.Text
+	response.ToolIsError = result.IsError
+	response.StructuredContent = result.Result.StructuredContent
+	response.Meta = result.Result.Meta
+	response.setSidecarCacheStats(cache.Stats())
+	if result.IsError {
+		response.Status = "sidecar_assignment_context_tool_failed"
+		response.Detail = "Cairnline sidecar assignments.context returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+		return response
+	}
+	contextIDs, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignmentContextIDs(result.Result.StructuredContent)
+	response.StructuredReady = structuredReady
+	response.StructuredIDs = contextIDs
+	if structuredErr != nil {
+		response.StructuredParseError = structuredErr.Error()
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.context returned structuredContent that Hecate could not parse as assignment context.")
+	} else if !structuredReady {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.context did not return structuredContent; Hecate verified the tool call but not a typed assignment-context contract.")
+	} else if contextIDs.AssignmentID != assignmentID {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.context returned an assignment id different from the requested id.")
+	} else if contextIDs.ProjectID != "" && contextIDs.ProjectID != projectID {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.context returned a project id different from the requested project id.")
+	}
+	response.Ready = true
+	response.Status = "sidecar_assignment_context_ready"
+	response.Detail = "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	return response
+}
+
 func (h *Handler) callProjectCairnlineSidecarCoordinationTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, tool projectCairnlineSidecarCoordinationTool, projectID string) (ProjectCairnlineSidecarCoordinationListResult, error) {
 	args := json.RawMessage(`{}`)
 	if tool.ProjectScoped {
@@ -593,6 +773,58 @@ func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairn
 		return ProjectCairnlineSidecarProjectItem{}, false, err
 	}
 	return project, true, nil
+}
+
+func projectCairnlineSidecarStructuredAssignments(raw json.RawMessage) ([]ProjectCairnlineSidecarAssignmentItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarAssignmentItem{}, true, nil
+	}
+	var assignments []ProjectCairnlineSidecarAssignmentItem
+	if err := json.Unmarshal(trimmed, &assignments); err != nil {
+		return nil, false, err
+	}
+	if assignments == nil {
+		assignments = []ProjectCairnlineSidecarAssignmentItem{}
+	}
+	return assignments, true, nil
+}
+
+func projectCairnlineSidecarStructuredAssignmentContextIDs(raw json.RawMessage) (ProjectCairnlineSidecarAssignmentContextIDs, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarAssignmentContextIDs{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarAssignmentContextIDs{}, false, nil
+	}
+	var context struct {
+		Assignment struct {
+			ID        string `json:"id"`
+			ProjectID string `json:"project_id"`
+		} `json:"assignment"`
+		WorkItem struct {
+			ID string `json:"id"`
+		} `json:"work_item"`
+		Role struct {
+			ID string `json:"id"`
+		} `json:"role"`
+	}
+	if err := json.Unmarshal(trimmed, &context); err != nil {
+		return ProjectCairnlineSidecarAssignmentContextIDs{}, false, err
+	}
+	return ProjectCairnlineSidecarAssignmentContextIDs{
+		AssignmentID: strings.TrimSpace(context.Assignment.ID),
+		ProjectID:    strings.TrimSpace(context.Assignment.ProjectID),
+		WorkItemID:   strings.TrimSpace(context.WorkItem.ID),
+		RoleID:       strings.TrimSpace(context.Role.ID),
+	}, true, nil
 }
 
 func projectCairnlineSidecarStructuredArrayCount(raw json.RawMessage) (int, bool, error) {
@@ -687,6 +919,15 @@ func (r *ProjectCairnlineSidecarDetailResponse) setSidecarCacheStats(stats mcpcl
 }
 
 func (r *ProjectCairnlineSidecarCoordinationResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarAssignmentContextResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -508,6 +509,137 @@ func TestProjectCairnlineSidecarCoordinationSmoke_ToolLevelError(t *testing.T) {
 	item, ok := projectCairnlineSidecarCoordinationTestList(got.Lists, "skills.list")
 	if !ok || !item.ToolIsError || !strings.Contains(item.ToolText, "fixture skills.list failed") {
 		t.Fatalf("skills.list result = %+v ok=%t, want tool-level error", item, ok)
+	}
+}
+
+func TestProjectCairnlineSidecarAssignmentContextSmoke_SelectsAssignmentFromStructuredLists(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarAssignmentContextSmoke(t.Context(), ProjectCairnlineSidecarAssignmentContextRequest{})
+	if !got.Ready || got.Status != "sidecar_assignment_context_ready" || !got.StructuredReady {
+		t.Fatalf("assignment context smoke = %+v, want structured ready", got)
+	}
+	if got.SelectedProjectID != "proj_fixture" || got.SelectedProjectSource != "projects.list" {
+		t.Fatalf("selected project = %q source %q, want fixture from projects.list", got.SelectedProjectID, got.SelectedProjectSource)
+	}
+	if got.SelectedAssignmentID != "asg_fixture" || got.SelectedAssignmentSource != "assignments.list" {
+		t.Fatalf("selected assignment = %q source %q, want fixture from assignments.list", got.SelectedAssignmentID, got.SelectedAssignmentSource)
+	}
+	if got.ProjectList == nil || got.AssignmentList == nil || !got.ProjectList.StructuredReady || got.ProjectList.StructuredCount != 1 || !got.AssignmentList.StructuredReady || got.AssignmentList.StructuredCount != 1 {
+		t.Fatalf("list readiness = projects %+v assignments %+v, want typed selection lists", got.ProjectList, got.AssignmentList)
+	}
+	if got.StructuredIDs.AssignmentID != "asg_fixture" || got.StructuredIDs.ProjectID != "proj_fixture" || got.StructuredIDs.WorkItemID != "work_fixture" || got.StructuredIDs.RoleID != "role_fixture" {
+		t.Fatalf("structured ids = %+v, want assignment/project/work/role ids", got.StructuredIDs)
+	}
+	if !strings.Contains(got.ToolText, "Assignment context asg_fixture") {
+		t.Fatalf("tool text = %q, want assignment context evidence", got.ToolText)
+	}
+	if !got.PersistentClient || !got.ClientCacheConfigured {
+		t.Fatalf("assignment context persistent/cache flags = persistent:%t configured:%t, want true/true", got.PersistentClient, got.ClientCacheConfigured)
+	}
+	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
+		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+}
+
+func TestProjectCairnlineSidecarAssignmentContextSmoke_UsesRequestedIDs(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarAssignmentContextSmoke(t.Context(), ProjectCairnlineSidecarAssignmentContextRequest{ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if !got.Ready || got.Status != "sidecar_assignment_context_ready" || !got.StructuredReady {
+		t.Fatalf("assignment context smoke = %+v, want structured ready", got)
+	}
+	if got.SelectedProjectID != "proj_requested" || got.SelectedProjectSource != "request" || got.SelectedAssignmentID != "asg_requested" || got.SelectedAssignmentSource != "request" {
+		t.Fatalf("selection = project %q/%q assignment %q/%q, want request ids", got.SelectedProjectID, got.SelectedProjectSource, got.SelectedAssignmentID, got.SelectedAssignmentSource)
+	}
+	if got.ProjectList != nil || got.AssignmentList != nil {
+		t.Fatalf("selection lists = projects %+v assignments %+v, want skipped lists for explicit ids", got.ProjectList, got.AssignmentList)
+	}
+	if got.StructuredIDs.AssignmentID != "asg_requested" {
+		t.Fatalf("structured assignment id = %q, want requested", got.StructuredIDs.AssignmentID)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if strings.Contains(string(encoded), "project_list") || strings.Contains(string(encoded), "assignment_list") {
+		t.Fatalf("encoded response = %s, want omitted selection lists for explicit ids", encoded)
+	}
+}
+
+func TestProjectCairnlineSidecarAssignmentContextSmoke_TextOnlyContextWarns(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "text-only"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarAssignmentContextSmoke(t.Context(), ProjectCairnlineSidecarAssignmentContextRequest{ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if !got.Ready || got.Status != "sidecar_assignment_context_ready" || got.StructuredReady {
+		t.Fatalf("assignment context smoke = %+v, want ready with structured warning", got)
+	}
+	if got.StructuredIDs.AssignmentID != "" || !strings.Contains(strings.Join(got.Warnings, "\n"), "assignments.context did not return structuredContent") {
+		t.Fatalf("structured ids/warnings = %+v / %+v, want text-only warning", got.StructuredIDs, got.Warnings)
+	}
+}
+
+func TestProjectCairnlineSidecarAssignmentContextSmoke_NoAssignment(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "assignment-list-empty"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarAssignmentContextSmoke(t.Context(), ProjectCairnlineSidecarAssignmentContextRequest{})
+	if got.Ready || got.Status != "sidecar_assignment_context_no_assignment" {
+		t.Fatalf("assignment context smoke = %+v, want no assignment", got)
+	}
+	if got.AssignmentList == nil || got.SelectedProjectID != "proj_fixture" || got.SelectedAssignmentID != "" || !got.AssignmentList.StructuredReady || got.AssignmentList.StructuredCount != 0 {
+		t.Fatalf("selection/list = project:%q assignment:%q list:%+v, want empty assignment list after project selection", got.SelectedProjectID, got.SelectedAssignmentID, got.AssignmentList)
+	}
+}
+
+func TestProjectCairnlineSidecarAssignmentContextSmoke_ToolLevelError(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "context-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarAssignmentContextSmoke(t.Context(), ProjectCairnlineSidecarAssignmentContextRequest{ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if got.Ready || got.Status != "sidecar_assignment_context_tool_failed" {
+		t.Fatalf("assignment context smoke = %+v, want context tool-level failure", got)
+	}
+	if !got.ToolIsError || !strings.Contains(got.ToolText, "fixture assignments.context failed") {
+		t.Fatalf("tool result = error:%t text:%q, want fixture context tool error", got.ToolIsError, got.ToolText)
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -11,6 +11,7 @@ const projectCoordinationBackendSidecarConnectURL = "/hecate/v1/projects/cairnli
 const projectCoordinationBackendSidecarReadURL = "/hecate/v1/projects/cairnline/sidecar-read-smoke"
 const projectCoordinationBackendSidecarDetailURL = "/hecate/v1/projects/cairnline/sidecar-detail-smoke"
 const projectCoordinationBackendSidecarCoordinationURL = "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"
+const projectCoordinationBackendSidecarAssignmentContextURL = "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -289,26 +290,27 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 	}
 	connectorReady := projectCairnlineConnectorReady(connector)
 	response := ProjectCoordinationBackendStatusResponse{
-		ConfiguredBackend:               configured,
-		AuthoritativeBackend:            "hecate",
-		StorageBackend:                  storageBackend,
-		CairnlineConnector:              connector,
-		CairnlineConnectorReady:         connectorReady,
-		CairnlineConnectorDetail:        projectCairnlineConnectorDetail(connector),
-		CairnlineReadSource:             readSource,
-		CairnlineBridgeReady:            true,
-		CairnlineAuthoritative:          false,
-		WriteAdapterReady:               false,
-		ReplacementReadinessURL:         projectCoordinationBackendReadinessURL,
-		CairnlineSidecarProbeURL:        projectCoordinationBackendSidecarProbeURL,
-		CairnlineSidecarConnectURL:      projectCoordinationBackendSidecarConnectURL,
-		CairnlineSidecarReadURL:         projectCoordinationBackendSidecarReadURL,
-		CairnlineSidecarDetailURL:       projectCoordinationBackendSidecarDetailURL,
-		CairnlineSidecarCoordinationURL: projectCoordinationBackendSidecarCoordinationURL,
-		EmbeddedReadModelURL:            projectCoordinationBackendEmbeddedReadModelURL,
-		EmbeddedParityReportURL:         projectCoordinationBackendEmbeddedParityReportURL,
-		SyncReadinessURL:                projectCoordinationBackendSyncReadinessURL,
-		MirrorParityURL:                 projectCoordinationBackendMirrorParityURL,
+		ConfiguredBackend:                    configured,
+		AuthoritativeBackend:                 "hecate",
+		StorageBackend:                       storageBackend,
+		CairnlineConnector:                   connector,
+		CairnlineConnectorReady:              connectorReady,
+		CairnlineConnectorDetail:             projectCairnlineConnectorDetail(connector),
+		CairnlineReadSource:                  readSource,
+		CairnlineBridgeReady:                 true,
+		CairnlineAuthoritative:               false,
+		WriteAdapterReady:                    false,
+		ReplacementReadinessURL:              projectCoordinationBackendReadinessURL,
+		CairnlineSidecarProbeURL:             projectCoordinationBackendSidecarProbeURL,
+		CairnlineSidecarConnectURL:           projectCoordinationBackendSidecarConnectURL,
+		CairnlineSidecarReadURL:              projectCoordinationBackendSidecarReadURL,
+		CairnlineSidecarDetailURL:            projectCoordinationBackendSidecarDetailURL,
+		CairnlineSidecarCoordinationURL:      projectCoordinationBackendSidecarCoordinationURL,
+		CairnlineSidecarAssignmentContextURL: projectCoordinationBackendSidecarAssignmentContextURL,
+		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
+		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
+		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,
+		MirrorParityURL:                      projectCoordinationBackendMirrorParityURL,
 	}
 	switch configured {
 	case "cairnline":

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -42,6 +42,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarCoordinationURL != projectCoordinationBackendSidecarCoordinationURL {
 		t.Fatalf("sidecar coordination URL = %q, want %q", status.CairnlineSidecarCoordinationURL, projectCoordinationBackendSidecarCoordinationURL)
 	}
+	if status.CairnlineSidecarAssignmentContextURL != projectCoordinationBackendSidecarAssignmentContextURL {
+		t.Fatalf("sidecar assignment context URL = %q, want %q", status.CairnlineSidecarAssignmentContextURL, projectCoordinationBackendSidecarAssignmentContextURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -126,6 +129,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 	if status.CairnlineSidecarCoordinationURL != projectCoordinationBackendSidecarCoordinationURL {
 		t.Fatalf("sidecar coordination URL = %q, want %q", status.CairnlineSidecarCoordinationURL, projectCoordinationBackendSidecarCoordinationURL)
+	}
+	if status.CairnlineSidecarAssignmentContextURL != projectCoordinationBackendSidecarAssignmentContextURL {
+		t.Fatalf("sidecar assignment context URL = %q, want %q", status.CairnlineSidecarAssignmentContextURL, projectCoordinationBackendSidecarAssignmentContextURL)
 	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -554,36 +554,37 @@ type ProjectCoordinationBackendStatusEnvelope struct {
 }
 
 type ProjectCoordinationBackendStatusResponse struct {
-	ConfiguredBackend               string                                       `json:"configured_backend"`
-	AuthoritativeBackend            string                                       `json:"authoritative_backend"`
-	StorageBackend                  string                                       `json:"storage_backend"`
-	CairnlineConnector              string                                       `json:"cairnline_connector,omitempty"`
-	CairnlineConnectorReady         bool                                         `json:"cairnline_connector_ready"`
-	CairnlineConnectorDetail        string                                       `json:"cairnline_connector_detail,omitempty"`
-	CairnlineReadSource             string                                       `json:"cairnline_read_source,omitempty"`
-	CairnlineBridgeReady            bool                                         `json:"cairnline_bridge_ready"`
-	CairnlineAuthoritative          bool                                         `json:"cairnline_authoritative"`
-	ReadModelSwitchReady            bool                                         `json:"read_model_switch_ready"`
-	WriteAdapterReady               bool                                         `json:"write_adapter_ready"`
-	ReplacementReady                bool                                         `json:"replacement_ready"`
-	ReadRoutes                      []string                                     `json:"read_routes,omitempty"`
-	WriteAdapterSeams               []string                                     `json:"write_adapter_seams,omitempty"`
-	WriteAdapterGaps                []string                                     `json:"write_adapter_gaps,omitempty"`
-	ReplacementGates                []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
-	WriteSwitchpoints               []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
-	Status                          string                                       `json:"status"`
-	Detail                          string                                       `json:"detail"`
-	Warnings                        []string                                     `json:"warnings,omitempty"`
-	ReplacementReadinessURL         string                                       `json:"replacement_readiness_url,omitempty"`
-	CairnlineSidecarProbeURL        string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
-	CairnlineSidecarConnectURL      string                                       `json:"cairnline_sidecar_connect_url,omitempty"`
-	CairnlineSidecarReadURL         string                                       `json:"cairnline_sidecar_read_url,omitempty"`
-	CairnlineSidecarDetailURL       string                                       `json:"cairnline_sidecar_detail_url,omitempty"`
-	CairnlineSidecarCoordinationURL string                                       `json:"cairnline_sidecar_coordination_url,omitempty"`
-	EmbeddedReadModelURL            string                                       `json:"embedded_read_model_url,omitempty"`
-	EmbeddedParityReportURL         string                                       `json:"embedded_parity_report_url,omitempty"`
-	SyncReadinessURL                string                                       `json:"sync_readiness_url,omitempty"`
-	MirrorParityURL                 string                                       `json:"mirror_parity_url,omitempty"`
+	ConfiguredBackend                    string                                       `json:"configured_backend"`
+	AuthoritativeBackend                 string                                       `json:"authoritative_backend"`
+	StorageBackend                       string                                       `json:"storage_backend"`
+	CairnlineConnector                   string                                       `json:"cairnline_connector,omitempty"`
+	CairnlineConnectorReady              bool                                         `json:"cairnline_connector_ready"`
+	CairnlineConnectorDetail             string                                       `json:"cairnline_connector_detail,omitempty"`
+	CairnlineReadSource                  string                                       `json:"cairnline_read_source,omitempty"`
+	CairnlineBridgeReady                 bool                                         `json:"cairnline_bridge_ready"`
+	CairnlineAuthoritative               bool                                         `json:"cairnline_authoritative"`
+	ReadModelSwitchReady                 bool                                         `json:"read_model_switch_ready"`
+	WriteAdapterReady                    bool                                         `json:"write_adapter_ready"`
+	ReplacementReady                     bool                                         `json:"replacement_ready"`
+	ReadRoutes                           []string                                     `json:"read_routes,omitempty"`
+	WriteAdapterSeams                    []string                                     `json:"write_adapter_seams,omitempty"`
+	WriteAdapterGaps                     []string                                     `json:"write_adapter_gaps,omitempty"`
+	ReplacementGates                     []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
+	WriteSwitchpoints                    []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
+	Status                               string                                       `json:"status"`
+	Detail                               string                                       `json:"detail"`
+	Warnings                             []string                                     `json:"warnings,omitempty"`
+	ReplacementReadinessURL              string                                       `json:"replacement_readiness_url,omitempty"`
+	CairnlineSidecarProbeURL             string                                       `json:"cairnline_sidecar_probe_url,omitempty"`
+	CairnlineSidecarConnectURL           string                                       `json:"cairnline_sidecar_connect_url,omitempty"`
+	CairnlineSidecarReadURL              string                                       `json:"cairnline_sidecar_read_url,omitempty"`
+	CairnlineSidecarDetailURL            string                                       `json:"cairnline_sidecar_detail_url,omitempty"`
+	CairnlineSidecarCoordinationURL      string                                       `json:"cairnline_sidecar_coordination_url,omitempty"`
+	CairnlineSidecarAssignmentContextURL string                                       `json:"cairnline_sidecar_assignment_context_url,omitempty"`
+	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
+	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
+	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
+	MirrorParityURL                      string                                       `json:"mirror_parity_url,omitempty"`
 }
 
 type ProjectCoordinationBackendReplacementGate struct {
@@ -1691,12 +1692,22 @@ type ProjectCairnlineSidecarCoordinationEnvelope struct {
 	Data   ProjectCairnlineSidecarCoordinationResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarAssignmentContextEnvelope struct {
+	Object string                                           `json:"object"`
+	Data   ProjectCairnlineSidecarAssignmentContextResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
 
 type ProjectCairnlineSidecarCoordinationRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssignmentContextRequest struct {
+	ProjectID    string `json:"project_id,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
 }
 
 type ProjectCairnlineSidecarProbeResponse struct {
@@ -1817,6 +1828,46 @@ type ProjectCairnlineSidecarCoordinationListResult struct {
 	StructuredParseError string          `json:"structured_parse_error,omitempty"`
 }
 
+type ProjectCairnlineSidecarAssignmentContextResponse struct {
+	Ready                    bool                                           `json:"ready"`
+	Status                   string                                         `json:"status"`
+	Detail                   string                                         `json:"detail"`
+	Command                  string                                         `json:"command"`
+	Args                     []string                                       `json:"args,omitempty"`
+	DatabasePath             string                                         `json:"database_path,omitempty"`
+	ProbeTimeoutMS           int64                                          `json:"probe_timeout_ms"`
+	PersistentClient         bool                                           `json:"persistent_client,omitempty"`
+	ClientCacheConfigured    bool                                           `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries       int                                            `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse         int                                            `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle          int                                            `json:"client_cache_idle,omitempty"`
+	Tool                     string                                         `json:"tool"`
+	ReadOnly                 bool                                           `json:"read_only"`
+	RequestedProjectID       string                                         `json:"requested_project_id,omitempty"`
+	RequestedAssignmentID    string                                         `json:"requested_assignment_id,omitempty"`
+	SelectedProjectID        string                                         `json:"selected_project_id,omitempty"`
+	SelectedProjectSource    string                                         `json:"selected_project_source,omitempty"`
+	SelectedAssignmentID     string                                         `json:"selected_assignment_id,omitempty"`
+	SelectedAssignmentSource string                                         `json:"selected_assignment_source,omitempty"`
+	ProjectList              *ProjectCairnlineSidecarCoordinationListResult `json:"project_list,omitempty"`
+	AssignmentList           *ProjectCairnlineSidecarCoordinationListResult `json:"assignment_list,omitempty"`
+	ToolText                 string                                         `json:"tool_text,omitempty"`
+	ToolIsError              bool                                           `json:"tool_is_error,omitempty"`
+	StructuredContent        json.RawMessage                                `json:"structured_content,omitempty"`
+	Meta                     json.RawMessage                                `json:"meta,omitempty"`
+	StructuredReady          bool                                           `json:"structured_ready"`
+	StructuredIDs            ProjectCairnlineSidecarAssignmentContextIDs    `json:"structured_ids,omitempty"`
+	StructuredParseError     string                                         `json:"structured_parse_error,omitempty"`
+	Warnings                 []string                                       `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssignmentContextIDs struct {
+	AssignmentID string `json:"assignment_id,omitempty"`
+	ProjectID    string `json:"project_id,omitempty"`
+	WorkItemID   string `json:"work_item_id,omitempty"`
+	RoleID       string `json:"role_id,omitempty"`
+}
+
 type ProjectCairnlineSidecarProjectItem struct {
 	ID                        string                              `json:"id"`
 	Name                      string                              `json:"name"`
@@ -1828,6 +1879,17 @@ type ProjectCairnlineSidecarProjectItem struct {
 	ContextSources            []ProjectCairnlineSidecarSourceItem `json:"context_sources,omitempty"`
 	CreatedAt                 string                              `json:"created_at,omitempty"`
 	UpdatedAt                 string                              `json:"updated_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssignmentItem struct {
+	ID            string   `json:"id"`
+	ProjectID     string   `json:"project_id,omitempty"`
+	WorkItemID    string   `json:"work_item_id,omitempty"`
+	RoleID        string   `json:"role_id,omitempty"`
+	ProfileID     string   `json:"profile_id,omitempty"`
+	ExecutionMode string   `json:"execution_mode,omitempty"`
+	Status        string   `json:"status,omitempty"`
+	SkillIDs      []string `json:"skill_ids,omitempty"`
 }
 
 type ProjectCairnlineSidecarRootItem struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -23,6 +23,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/system/shutdown"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/cairnline/mirror-parity"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-connect"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-detail-smoke"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -83,6 +83,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("PATCH /hecate/v1/projects/{id}", handler.HandleUpdateProject)
 	mux.HandleFunc("DELETE /hecate/v1/projects/{id}", handler.HandleDeleteProject)
 	mux.HandleFunc("GET /hecate/v1/projects/cairnline/mirror-parity", handler.HandleProjectCairnlineMirrorParity)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-assignment-context-smoke", handler.HandleProjectCairnlineSidecarAssignmentContextSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-connect", handler.HandleProjectCairnlineSidecarConnect)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke", handler.HandleProjectCairnlineSidecarCoordinationSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-detail-smoke", handler.HandleProjectCairnlineSidecarDetailSmoke)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4292,6 +4292,22 @@ func TestProjectCairnlineSidecarCoordinationSmokeRejectsNonLoopbackClientsBefore
 	}
 }
 
+func TestProjectCairnlineSidecarAssignmentContextSmokeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- bump Cairnline to the build that returns structured assignment context
- add a local-only sidecar assignment-context smoke endpoint for read-only assignments.context verification
- expose the endpoint from backend status and document the sidecar MCP-pull context check

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus|TestRemoteRuntime|TestServerRoute|TestMCPProbeRejects'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/orchestrator ./internal/mcp/client ./pkg/types
- just docs-format
- just docs-format-check
- just agent-docs-check
- just check-mermaid
- just docs-env-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...