### PR TITLE
feat(projects): add Cairnline launch packet smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -139,8 +139,11 @@ reports whether each returned typed `structuredContent` arrays. An
 assignment-context smoke at
 `POST /hecate/v1/projects/cairnline/sidecar-assignment-context-smoke` calls
 read-only `assignments.context` and reports whether typed
-assignment/project/work/role context metadata is present. Hecate does not yet
-route Projects reads, writes, or mirrors through the sidecar client.
+assignment/project/work/role context metadata is present. A launch-packet smoke
+at `POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke` calls
+read-only `assignments.launch_packet` and reports typed launch-packet ids,
+counts, and packet warnings. Hecate does not yet route Projects reads, writes,
+or mirrors through the sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -346,10 +346,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `POST /hecate/v1/projects/cairnline/sidecar-probe` and can connect a cached
   sidecar MCP client via `POST /hecate/v1/projects/cairnline/sidecar-connect`.
   Hecate can also call read-only `projects.list`, `projects.get`,
-  `assignments.context`, and the portable coordination list tools through
-  local-only sidecar smoke endpoints to verify typed `structuredContent` for
-  project list/detail, profile/skill/role/work/assignment list, and
-  assignment-context contracts. This is
+  `assignments.context`, `assignments.launch_packet`, and the portable
+  coordination list tools through local-only sidecar smoke endpoints to verify
+  typed `structuredContent` for project list/detail,
+  profile/skill/role/work/assignment list, assignment-context, and launch-packet
+  contracts. This is
   contract/client-lifecycle/read-shape evidence only: Hecate does not yet route
   live Projects reads, writes, mirrors, or write-authority switchpoints through
   the sidecar.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -375,7 +375,10 @@ Hecate-native stores until Hecate has a sidecar backend adapter. For MCP-pull
 context evidence, operators can run
 `POST /hecate/v1/projects/cairnline/sidecar-assignment-context-smoke` to select
 or request an assignment and confirm `assignments.context` returns typed
-assignment/project/work/role metadata.
+assignment/project/work/role metadata. Operators can also run
+`POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke` to confirm
+`assignments.launch_packet` returns typed launch-packet ids, counts, and packet
+warnings for the same MCP-pull path.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project list/detail, setup readiness,
@@ -424,9 +427,10 @@ The sidecar probe/connect surfaces are configured with
 tool presence only. `sidecar-connect` keeps the process warm in Hecate's
 Cairnline-specific MCP client cache. `sidecar-read-smoke`,
 `sidecar-detail-smoke`, `sidecar-coordination-smoke`, and
-`sidecar-assignment-context-smoke` use that cached client to call read-only
-Cairnline MCP tools and return diagnostic evidence, but they do not route
-operator project reads or writes through the sidecar backend.
+`sidecar-assignment-context-smoke`, and `sidecar-launch-packet-smoke` use that
+cached client to call read-only Cairnline MCP tools and return diagnostic
+evidence, but they do not route operator project reads or writes through the
+sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context smoke,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context/launch-packet smoke,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -473,9 +473,9 @@ sequenceDiagram
   `sidecar-detail-smoke` endpoints. `sidecar-coordination-smoke` also calls
   the read-only portable coordination list tools and checks their typed
   `structuredContent` arrays. `sidecar-assignment-context-smoke` calls
-  read-only `assignments.context` and checks typed assignment/project/work/role
-  context metadata, but live Projects reads and writes still use Hecate-native
-  stores.
+  read-only `assignments.context`, and `sidecar-launch-packet-smoke` calls
+  read-only `assignments.launch_packet`; both check typed MCP-pull assignment
+  metadata, but live Projects reads and writes still use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2672,7 +2672,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_read_url": "/hecate/v1/projects/cairnline/sidecar-read-smoke",
     "cairnline_sidecar_detail_url": "/hecate/v1/projects/cairnline/sidecar-detail-smoke",
     "cairnline_sidecar_coordination_url": "/hecate/v1/projects/cairnline/sidecar-coordination-smoke",
-    "cairnline_sidecar_assignment_context_url": "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"
+    "cairnline_sidecar_assignment_context_url": "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke",
+    "cairnline_sidecar_launch_packet_url": "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"
   }
 }
 ```
@@ -2708,6 +2709,7 @@ work_items.create
 assignments.list
 assignments.claim
 assignments.context
+assignments.launch_packet
 assignments.complete
 evidence.record
 reviews.record
@@ -2729,7 +2731,7 @@ Example response, shortened:
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
     "probe_timeout_ms": 10000,
-    "tool_count": 18,
+    "tool_count": 19,
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
@@ -2774,7 +2776,7 @@ Example response, shortened:
     "client_cache_entries": 1,
     "client_cache_in_use": 0,
     "client_cache_idle": 1,
-    "tool_count": 18,
+    "tool_count": 19,
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
@@ -3079,6 +3081,91 @@ Example response, shortened:
       "project_id": "proj_123",
       "work_item_id": "work_123",
       "role_id": "role_reviewer"
+    },
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke`
+
+Local-only standalone Cairnline MCP launch-packet smoke. It uses the same
+sidecar command, database, timeout, and Cairnline-specific MCP client cache as
+`sidecar-connect`. With an empty body, Hecate calls read-only `projects.list`,
+selects the first typed project id, calls read-only `assignments.list`, selects
+the first typed assignment id, and then calls read-only
+`assignments.launch_packet`. With a body such as
+`{"project_id":"proj_123","assignment_id":"asg_123"}`, Hecate skips list
+selection and calls `assignments.launch_packet` directly.
+
+This endpoint is diagnostic only. It proves Hecate can read the richer
+MCP-pull launch packet a compatible agent or orchestrator would consume from a
+standalone Cairnline sidecar. It does not claim, start, mutate, dispatch, or
+complete assignments. `ready=true` means the MCP tool call succeeded.
+`structured_ready=true` means Hecate parsed `assignments.launch_packet`
+`structuredContent` and found stable launch-packet metadata.
+
+The response reports:
+
+- `requested_project_id` / `requested_assignment_id` when the operator supplied
+  ids.
+- `selected_project_id` / `selected_assignment_id` and their selection sources
+  (`request`, `projects.list`, or `assignments.list`).
+- `project_list` and `assignment_list` evidence when Hecate had to select ids.
+- `tool="assignments.launch_packet"` and `read_only=true` for the packet call.
+- `tool_text`, `tool_is_error`, `structured_content`, and `_meta` for the
+  `assignments.launch_packet` result.
+- `structured_ready`, `structured_ids`, `structured_counts`,
+  `structured_warnings`, and `structured_parse_error` for the typed packet
+  contract.
+- The same persistent-client cache counters as `sidecar-connect`.
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_launch_packet",
+  "data": {
+    "ready": true,
+    "status": "sidecar_launch_packet_ready",
+    "detail": "Hecate called the read-only Cairnline sidecar assignments.launch_packet tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "client_cache_entries": 1,
+    "client_cache_in_use": 0,
+    "client_cache_idle": 1,
+    "tool": "assignments.launch_packet",
+    "read_only": true,
+    "selected_project_id": "proj_123",
+    "selected_project_source": "projects.list",
+    "selected_assignment_id": "asg_123",
+    "selected_assignment_source": "assignments.list",
+    "tool_text": "Launch packet launch_123 for asg_123",
+    "tool_is_error": false,
+    "structured_ready": true,
+    "structured_ids": {
+      "launch_packet_id": "launch_123",
+      "kind": "assignment_launch_packet",
+      "project_id": "proj_123",
+      "assignment_id": "asg_123",
+      "work_item_id": "work_123",
+      "role_id": "role_reviewer",
+      "profile_id": "profile_review",
+      "execution_profile_id": "exec_local"
+    },
+    "structured_counts": {
+      "skills": 1,
+      "artifacts": 0,
+      "evidence": 1,
+      "reviews": 1,
+      "handoffs": 0,
+      "memory": 2,
+      "memory_candidates": 1,
+      "warnings": 0
     },
     "warnings": []
   }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -233,6 +233,69 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 			})
 		}
 		return result, nil
+	case "assignments.launch_packet":
+		if mode == "launch-packet-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture assignments.launch_packet failed"),
+				IsError: true,
+			}, nil
+		}
+		var input struct {
+			ProjectID    string `json:"project_id"`
+			AssignmentID string `json:"assignment_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assignments.launch_packet arguments")
+		}
+		if input.ProjectID == "" || input.AssignmentID == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing launch packet ids")
+		}
+		result := mcp.CallToolResult{Content: mcp.TextContent("Launch packet launch_fixture for " + input.AssignmentID)}
+		if mode != "text-only" {
+			result.StructuredContent = mustRawJSON(map[string]any{
+				"id":   "launch_fixture",
+				"kind": "assignment_launch_packet",
+				"project": map[string]any{
+					"id":   input.ProjectID,
+					"name": "Fixture Project",
+				},
+				"work_item": map[string]any{
+					"id":    "work_fixture",
+					"title": "Fixture Work",
+				},
+				"role": map[string]any{
+					"id":   "role_fixture",
+					"name": "Fixture Reviewer",
+				},
+				"profile": map[string]any{
+					"id":   "profile_fixture",
+					"name": "Fixture Profile",
+				},
+				"execution_profile": map[string]any{
+					"id":   "exec_fixture",
+					"name": "Fixture Execution",
+				},
+				"skills": []map[string]any{{
+					"id":    "skill_fixture",
+					"title": "Fixture Skill",
+				}},
+				"assignment": map[string]any{
+					"id":           input.AssignmentID,
+					"project_id":   input.ProjectID,
+					"work_item_id": "work_fixture",
+					"role_id":      "role_fixture",
+					"status":       "queued",
+				},
+				"artifacts":         []map[string]any{{"id": "artifact_fixture"}},
+				"evidence":          []map[string]any{{"id": "evidence_fixture"}},
+				"reviews":           []map[string]any{{"id": "review_fixture"}},
+				"handoffs":          []map[string]any{{"id": "handoff_fixture"}},
+				"memory":            []map[string]any{{"id": "memory_fixture"}},
+				"memory_candidates": []map[string]any{{"id": "candidate_fixture"}},
+				"warnings":          []string{"fixture warning"},
+			})
+		}
+		return result, nil
 	case "projects.get":
 		if mode == "get-tool-error" {
 			return mcp.CallToolResult{

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -33,6 +33,7 @@ var projectCairnlineSidecarRequiredTools = []string{
 	"assignments.list",
 	"assignments.claim",
 	"assignments.context",
+	"assignments.launch_packet",
 	"assignments.complete",
 	"evidence.record",
 	"reviews.record",
@@ -158,6 +159,20 @@ func (h *Handler) HandleProjectCairnlineSidecarAssignmentContextSmoke(w http.Res
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarAssignmentContextEnvelope{
 		Object: "project_cairnline_sidecar_assignment_context",
 		Data:   h.projectCairnlineSidecarAssignmentContextSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarLaunchPacketSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar launch packet smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarLaunchPacketRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarLaunchPacketEnvelope{
+		Object: "project_cairnline_sidecar_launch_packet",
+		Data:   h.projectCairnlineSidecarLaunchPacketSmoke(r.Context(), req),
 	})
 }
 
@@ -541,11 +556,7 @@ func (h *Handler) projectCairnlineSidecarCoordinationSmoke(ctx context.Context, 
 }
 
 func (h *Handler) projectCairnlineSidecarAssignmentContextSmoke(ctx context.Context, req ProjectCairnlineSidecarAssignmentContextRequest) ProjectCairnlineSidecarAssignmentContextResponse {
-	const (
-		projectListToolName    = "projects.list"
-		assignmentListToolName = "assignments.list"
-		contextToolName        = "assignments.context"
-	)
+	const contextToolName = "assignments.context"
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -583,85 +594,22 @@ func (h *Handler) projectCairnlineSidecarAssignmentContextSmoke(ctx context.Cont
 	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	projectID := requestedProjectID
-	if projectID == "" {
-		listResult, err := h.callProjectCairnlineSidecarCoordinationTool(smokeCtx, cfg, cache, projectCairnlineSidecarCoordinationTool{Name: projectListToolName}, "")
-		if err != nil {
-			response.Status = "sidecar_assignment_context_failed"
-			response.Detail = err.Error()
-			response.setSidecarCacheStats(cache.Stats())
-			return response
-		}
-		response.ProjectList = &listResult
-		if listResult.ToolIsError {
-			response.Status = "sidecar_assignment_context_project_list_tool_failed"
-			response.Detail = "Cairnline sidecar projects.list returned a tool-level error before Hecate could select a project for assignments.context."
-			response.setSidecarCacheStats(cache.Stats())
-			return response
-		}
-		projects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(listResult.StructuredContent)
-		response.ProjectList.StructuredReady = structuredReady
-		response.ProjectList.StructuredCount = len(projects)
-		if structuredErr != nil {
-			response.ProjectList.StructuredParseError = structuredErr.Error()
-			response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list returned structuredContent that Hecate could not parse as a project list.")
-		} else if !structuredReady {
-			response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list did not return structuredContent, so Hecate could not select a project for assignments.context.")
-		} else if len(projects) > 0 {
-			projectID = strings.TrimSpace(projects[0].ID)
-			response.SelectedProjectID = projectID
-			response.SelectedProjectSource = "projects.list"
-		}
-		if projectID == "" {
-			response.Status = "sidecar_assignment_context_no_project"
-			response.Detail = "Hecate called Cairnline sidecar projects.list through the persistent sidecar client, but no typed project id was available for assignments.context."
-			response.setSidecarCacheStats(cache.Stats())
-			return response
-		}
-	} else {
-		response.SelectedProjectID = projectID
-		response.SelectedProjectSource = "request"
+	selection := h.projectCairnlineSidecarSelectAssignmentForTool(smokeCtx, cfg, cache, requestedProjectID, requestedAssignmentID, "sidecar_assignment_context", contextToolName)
+	response.SelectedProjectID = selection.ProjectID
+	response.SelectedProjectSource = selection.ProjectSource
+	response.SelectedAssignmentID = selection.AssignmentID
+	response.SelectedAssignmentSource = selection.AssignmentSource
+	response.ProjectList = selection.ProjectList
+	response.AssignmentList = selection.AssignmentList
+	response.Warnings = append(response.Warnings, selection.Warnings...)
+	if selection.Status != "" {
+		response.Status = selection.Status
+		response.Detail = selection.Detail
+		response.setSidecarCacheStats(cache.Stats())
+		return response
 	}
-
-	assignmentID := requestedAssignmentID
-	if assignmentID == "" {
-		listResult, err := h.callProjectCairnlineSidecarCoordinationTool(smokeCtx, cfg, cache, projectCairnlineSidecarCoordinationTool{Name: assignmentListToolName, ProjectScoped: true}, projectID)
-		if err != nil {
-			response.Status = "sidecar_assignment_context_failed"
-			response.Detail = err.Error()
-			response.setSidecarCacheStats(cache.Stats())
-			return response
-		}
-		response.AssignmentList = &listResult
-		if listResult.ToolIsError {
-			response.Status = "sidecar_assignment_context_assignment_list_tool_failed"
-			response.Detail = "Cairnline sidecar assignments.list returned a tool-level error before Hecate could select an assignment for assignments.context."
-			response.setSidecarCacheStats(cache.Stats())
-			return response
-		}
-		assignments, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignments(listResult.StructuredContent)
-		response.AssignmentList.StructuredReady = structuredReady
-		response.AssignmentList.StructuredCount = len(assignments)
-		if structuredErr != nil {
-			response.AssignmentList.StructuredParseError = structuredErr.Error()
-			response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.list returned structuredContent that Hecate could not parse as an assignment list.")
-		} else if !structuredReady {
-			response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.list did not return structuredContent, so Hecate could not select an assignment for assignments.context.")
-		} else if len(assignments) > 0 {
-			assignmentID = strings.TrimSpace(assignments[0].ID)
-			response.SelectedAssignmentID = assignmentID
-			response.SelectedAssignmentSource = "assignments.list"
-		}
-		if assignmentID == "" {
-			response.Status = "sidecar_assignment_context_no_assignment"
-			response.Detail = "Hecate called Cairnline sidecar assignments.list through the persistent sidecar client, but no typed assignment id was available for assignments.context."
-			response.setSidecarCacheStats(cache.Stats())
-			return response
-		}
-	} else {
-		response.SelectedAssignmentID = assignmentID
-		response.SelectedAssignmentSource = "request"
-	}
+	projectID := selection.ProjectID
+	assignmentID := selection.AssignmentID
 
 	args, err := json.Marshal(map[string]string{"project_id": projectID, "assignment_id": assignmentID})
 	if err != nil {
@@ -704,6 +652,205 @@ func (h *Handler) projectCairnlineSidecarAssignmentContextSmoke(ctx context.Cont
 	response.Status = "sidecar_assignment_context_ready"
 	response.Detail = "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
 	return response
+}
+
+func (h *Handler) projectCairnlineSidecarLaunchPacketSmoke(ctx context.Context, req ProjectCairnlineSidecarLaunchPacketRequest) ProjectCairnlineSidecarLaunchPacketResponse {
+	const toolName = "assignments.launch_packet"
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	requestedProjectID := strings.TrimSpace(req.ProjectID)
+	requestedAssignmentID := strings.TrimSpace(req.AssignmentID)
+	response := ProjectCairnlineSidecarLaunchPacketResponse{
+		Ready:                 false,
+		Status:                "sidecar_launch_packet_not_run",
+		Detail:                "Cairnline sidecar launch packet smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		Tool:                  toolName,
+		ReadOnly:              true,
+		RequestedProjectID:    requestedProjectID,
+		RequestedAssignmentID: requestedAssignmentID,
+	}
+	if h == nil {
+		response.Status = "sidecar_launch_packet_failed"
+		response.Detail = "Cairnline sidecar launch packet smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this launch packet smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	selection := h.projectCairnlineSidecarSelectAssignmentForTool(smokeCtx, cfg, cache, requestedProjectID, requestedAssignmentID, "sidecar_launch_packet", toolName)
+	response.SelectedProjectID = selection.ProjectID
+	response.SelectedProjectSource = selection.ProjectSource
+	response.SelectedAssignmentID = selection.AssignmentID
+	response.SelectedAssignmentSource = selection.AssignmentSource
+	response.ProjectList = selection.ProjectList
+	response.AssignmentList = selection.AssignmentList
+	response.Warnings = append(response.Warnings, selection.Warnings...)
+	if selection.Status != "" {
+		response.Status = selection.Status
+		response.Detail = selection.Detail
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+
+	args, err := json.Marshal(map[string]string{"project_id": selection.ProjectID, "assignment_id": selection.AssignmentID})
+	if err != nil {
+		response.Status = "sidecar_launch_packet_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	result, err := orchestrator.CallCachedMCPServerTool(smokeCtx, cfg, h.secretCipher, cache, toolName, args)
+	if err != nil {
+		response.Status = "sidecar_launch_packet_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	response.ToolText = result.Text
+	response.ToolIsError = result.IsError
+	response.StructuredContent = result.Result.StructuredContent
+	response.Meta = result.Result.Meta
+	response.setSidecarCacheStats(cache.Stats())
+	if result.IsError {
+		response.Status = "sidecar_launch_packet_tool_failed"
+		response.Detail = "Cairnline sidecar assignments.launch_packet returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+		return response
+	}
+	ids, counts, packetWarnings, structuredReady, structuredErr := projectCairnlineSidecarStructuredLaunchPacket(result.Result.StructuredContent)
+	response.StructuredReady = structuredReady
+	response.StructuredIDs = ids
+	response.StructuredCounts = counts
+	response.StructuredWarnings = packetWarnings
+	if structuredErr != nil {
+		response.StructuredParseError = structuredErr.Error()
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.launch_packet returned structuredContent that Hecate could not parse as a launch packet.")
+	} else if !structuredReady {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.launch_packet did not return structuredContent; Hecate verified the tool call but not a typed launch-packet contract.")
+	} else if ids.AssignmentID != selection.AssignmentID {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.launch_packet returned an assignment id different from the requested id.")
+	} else if ids.ProjectID != "" && ids.ProjectID != selection.ProjectID {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.launch_packet returned a project id different from the requested project id.")
+	}
+	response.Ready = true
+	response.Status = "sidecar_launch_packet_ready"
+	response.Detail = "Hecate called the read-only Cairnline sidecar assignments.launch_packet tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	return response
+}
+
+type projectCairnlineSidecarAssignmentSelection struct {
+	ProjectID        string
+	ProjectSource    string
+	AssignmentID     string
+	AssignmentSource string
+	ProjectList      *ProjectCairnlineSidecarCoordinationListResult
+	AssignmentList   *ProjectCairnlineSidecarCoordinationListResult
+	Status           string
+	Detail           string
+	Warnings         []string
+}
+
+func (h *Handler) projectCairnlineSidecarSelectAssignmentForTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, requestedProjectID, requestedAssignmentID, statusPrefix, targetTool string) projectCairnlineSidecarAssignmentSelection {
+	const (
+		projectListToolName    = "projects.list"
+		assignmentListToolName = "assignments.list"
+	)
+	var selection projectCairnlineSidecarAssignmentSelection
+	projectID := requestedProjectID
+	if projectID == "" {
+		listResult, err := h.callProjectCairnlineSidecarCoordinationTool(ctx, cfg, cache, projectCairnlineSidecarCoordinationTool{Name: projectListToolName}, "")
+		if err != nil {
+			selection.Status = statusPrefix + "_failed"
+			selection.Detail = err.Error()
+			return selection
+		}
+		selection.ProjectList = &listResult
+		if listResult.ToolIsError {
+			selection.Status = statusPrefix + "_project_list_tool_failed"
+			selection.Detail = "Cairnline sidecar projects.list returned a tool-level error before Hecate could select a project for " + targetTool + "."
+			return selection
+		}
+		projects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(listResult.StructuredContent)
+		selection.ProjectList.StructuredReady = structuredReady
+		selection.ProjectList.StructuredCount = len(projects)
+		if structuredErr != nil {
+			selection.ProjectList.StructuredParseError = structuredErr.Error()
+			selection.Warnings = append(selection.Warnings, "Cairnline sidecar projects.list returned structuredContent that Hecate could not parse as a project list.")
+		} else if !structuredReady {
+			selection.Warnings = append(selection.Warnings, "Cairnline sidecar projects.list did not return structuredContent, so Hecate could not select a project for "+targetTool+".")
+		} else if len(projects) > 0 {
+			projectID = strings.TrimSpace(projects[0].ID)
+			selection.ProjectID = projectID
+			selection.ProjectSource = "projects.list"
+		}
+		if projectID == "" {
+			selection.Status = statusPrefix + "_no_project"
+			selection.Detail = "Hecate called Cairnline sidecar projects.list through the persistent sidecar client, but no typed project id was available for " + targetTool + "."
+			return selection
+		}
+	} else {
+		selection.ProjectID = projectID
+		selection.ProjectSource = "request"
+	}
+	if selection.ProjectID == "" {
+		selection.ProjectID = projectID
+	}
+
+	assignmentID := requestedAssignmentID
+	if assignmentID == "" {
+		listResult, err := h.callProjectCairnlineSidecarCoordinationTool(ctx, cfg, cache, projectCairnlineSidecarCoordinationTool{Name: assignmentListToolName, ProjectScoped: true}, projectID)
+		if err != nil {
+			selection.Status = statusPrefix + "_failed"
+			selection.Detail = err.Error()
+			return selection
+		}
+		selection.AssignmentList = &listResult
+		if listResult.ToolIsError {
+			selection.Status = statusPrefix + "_assignment_list_tool_failed"
+			selection.Detail = "Cairnline sidecar assignments.list returned a tool-level error before Hecate could select an assignment for " + targetTool + "."
+			return selection
+		}
+		assignments, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignments(listResult.StructuredContent)
+		selection.AssignmentList.StructuredReady = structuredReady
+		selection.AssignmentList.StructuredCount = len(assignments)
+		if structuredErr != nil {
+			selection.AssignmentList.StructuredParseError = structuredErr.Error()
+			selection.Warnings = append(selection.Warnings, "Cairnline sidecar assignments.list returned structuredContent that Hecate could not parse as an assignment list.")
+		} else if !structuredReady {
+			selection.Warnings = append(selection.Warnings, "Cairnline sidecar assignments.list did not return structuredContent, so Hecate could not select an assignment for "+targetTool+".")
+		} else if len(assignments) > 0 {
+			assignmentID = strings.TrimSpace(assignments[0].ID)
+			selection.AssignmentID = assignmentID
+			selection.AssignmentSource = "assignments.list"
+		}
+		if assignmentID == "" {
+			selection.Status = statusPrefix + "_no_assignment"
+			selection.Detail = "Hecate called Cairnline sidecar assignments.list through the persistent sidecar client, but no typed assignment id was available for " + targetTool + "."
+			return selection
+		}
+	} else {
+		selection.AssignmentID = assignmentID
+		selection.AssignmentSource = "request"
+	}
+	if selection.AssignmentID == "" {
+		selection.AssignmentID = assignmentID
+	}
+	return selection
 }
 
 func (h *Handler) callProjectCairnlineSidecarCoordinationTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, tool projectCairnlineSidecarCoordinationTool, projectID string) (ProjectCairnlineSidecarCoordinationListResult, error) {
@@ -827,6 +974,71 @@ func projectCairnlineSidecarStructuredAssignmentContextIDs(raw json.RawMessage) 
 	}, true, nil
 }
 
+func projectCairnlineSidecarStructuredLaunchPacket(raw json.RawMessage) (ProjectCairnlineSidecarLaunchPacketIDs, ProjectCairnlineSidecarLaunchPacketCounts, []string, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarLaunchPacketIDs{}, ProjectCairnlineSidecarLaunchPacketCounts{}, nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarLaunchPacketIDs{}, ProjectCairnlineSidecarLaunchPacketCounts{}, nil, false, nil
+	}
+	var packet struct {
+		ID      string `json:"id"`
+		Kind    string `json:"kind"`
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+		WorkItem struct {
+			ID string `json:"id"`
+		} `json:"work_item"`
+		Role struct {
+			ID string `json:"id"`
+		} `json:"role"`
+		Profile struct {
+			ID string `json:"id"`
+		} `json:"profile"`
+		ExecutionProfile struct {
+			ID string `json:"id"`
+		} `json:"execution_profile"`
+		Assignment struct {
+			ID        string `json:"id"`
+			ProjectID string `json:"project_id"`
+		} `json:"assignment"`
+		Skills           []json.RawMessage `json:"skills"`
+		Artifacts        []json.RawMessage `json:"artifacts"`
+		Evidence         []json.RawMessage `json:"evidence"`
+		Reviews          []json.RawMessage `json:"reviews"`
+		Handoffs         []json.RawMessage `json:"handoffs"`
+		Memory           []json.RawMessage `json:"memory"`
+		MemoryCandidates []json.RawMessage `json:"memory_candidates"`
+		Warnings         []string          `json:"warnings"`
+	}
+	if err := json.Unmarshal(trimmed, &packet); err != nil {
+		return ProjectCairnlineSidecarLaunchPacketIDs{}, ProjectCairnlineSidecarLaunchPacketCounts{}, nil, false, err
+	}
+	ids := ProjectCairnlineSidecarLaunchPacketIDs{
+		LaunchPacketID:     strings.TrimSpace(packet.ID),
+		Kind:               strings.TrimSpace(packet.Kind),
+		ProjectID:          firstNonEmpty(strings.TrimSpace(packet.Project.ID), strings.TrimSpace(packet.Assignment.ProjectID)),
+		AssignmentID:       strings.TrimSpace(packet.Assignment.ID),
+		WorkItemID:         strings.TrimSpace(packet.WorkItem.ID),
+		RoleID:             strings.TrimSpace(packet.Role.ID),
+		ProfileID:          strings.TrimSpace(packet.Profile.ID),
+		ExecutionProfileID: strings.TrimSpace(packet.ExecutionProfile.ID),
+	}
+	counts := ProjectCairnlineSidecarLaunchPacketCounts{
+		Skills:           len(packet.Skills),
+		Artifacts:        len(packet.Artifacts),
+		Evidence:         len(packet.Evidence),
+		Reviews:          len(packet.Reviews),
+		Handoffs:         len(packet.Handoffs),
+		Memory:           len(packet.Memory),
+		MemoryCandidates: len(packet.MemoryCandidates),
+		Warnings:         len(packet.Warnings),
+	}
+	return ids, counts, append([]string(nil), packet.Warnings...), true, nil
+}
+
 func projectCairnlineSidecarStructuredArrayCount(raw json.RawMessage) (int, bool, error) {
 	if len(raw) == 0 {
 		return 0, false, nil
@@ -928,6 +1140,15 @@ func (r *ProjectCairnlineSidecarCoordinationResponse) setSidecarCacheStats(stats
 }
 
 func (r *ProjectCairnlineSidecarAssignmentContextResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarLaunchPacketResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -117,7 +117,7 @@ func TestProjectCairnlineSidecarProbe_MissingRequiredTools(t *testing.T) {
 	if got.Ready || got.Status != "sidecar_contract_incomplete" {
 		t.Fatalf("probe = %+v, want incomplete contract", got)
 	}
-	if !containsString(got.MissingTools, "projects.get") || !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assistant.propose") {
+	if !containsString(got.MissingTools, "projects.get") || !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assignments.launch_packet") || !containsString(got.MissingTools, "assistant.propose") {
 		t.Fatalf("missing tools = %+v, want representative missing contract tools", got.MissingTools)
 	}
 	if got.ToolCount != 1 {
@@ -172,7 +172,7 @@ func TestProjectCairnlineSidecarConnect_MissingRequiredTools(t *testing.T) {
 	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
 		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
 	}
-	if !containsString(got.MissingTools, "projects.get") || !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assistant.propose") {
+	if !containsString(got.MissingTools, "projects.get") || !containsString(got.MissingTools, "assignments.context") || !containsString(got.MissingTools, "assignments.launch_packet") || !containsString(got.MissingTools, "assistant.propose") {
 		t.Fatalf("missing tools = %+v, want representative missing contract tools", got.MissingTools)
 	}
 }
@@ -640,6 +640,137 @@ func TestProjectCairnlineSidecarAssignmentContextSmoke_ToolLevelError(t *testing
 	}
 	if !got.ToolIsError || !strings.Contains(got.ToolText, "fixture assignments.context failed") {
 		t.Fatalf("tool result = error:%t text:%q, want fixture context tool error", got.ToolIsError, got.ToolText)
+	}
+}
+
+func TestProjectCairnlineSidecarLaunchPacketSmoke_SelectsAssignmentFromStructuredLists(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLaunchPacketSmoke(t.Context(), ProjectCairnlineSidecarLaunchPacketRequest{})
+	if !got.Ready || got.Status != "sidecar_launch_packet_ready" || !got.StructuredReady {
+		t.Fatalf("launch packet smoke = %+v, want structured ready", got)
+	}
+	if got.SelectedProjectID != "proj_fixture" || got.SelectedProjectSource != "projects.list" || got.SelectedAssignmentID != "asg_fixture" || got.SelectedAssignmentSource != "assignments.list" {
+		t.Fatalf("selection = project %q/%q assignment %q/%q, want list-selected ids", got.SelectedProjectID, got.SelectedProjectSource, got.SelectedAssignmentID, got.SelectedAssignmentSource)
+	}
+	if got.ProjectList == nil || got.AssignmentList == nil || !got.ProjectList.StructuredReady || got.ProjectList.StructuredCount != 1 || !got.AssignmentList.StructuredReady || got.AssignmentList.StructuredCount != 1 {
+		t.Fatalf("list readiness = projects %+v assignments %+v, want typed selection lists", got.ProjectList, got.AssignmentList)
+	}
+	if got.StructuredIDs.LaunchPacketID != "launch_fixture" || got.StructuredIDs.Kind != "assignment_launch_packet" || got.StructuredIDs.ProjectID != "proj_fixture" || got.StructuredIDs.AssignmentID != "asg_fixture" || got.StructuredIDs.WorkItemID != "work_fixture" || got.StructuredIDs.RoleID != "role_fixture" {
+		t.Fatalf("structured ids = %+v, want launch/project/assignment/work/role ids", got.StructuredIDs)
+	}
+	if got.StructuredIDs.ProfileID != "profile_fixture" || got.StructuredIDs.ExecutionProfileID != "exec_fixture" {
+		t.Fatalf("structured profile ids = %+v, want profile/execution ids", got.StructuredIDs)
+	}
+	if got.StructuredCounts.Skills != 1 || got.StructuredCounts.Artifacts != 1 || got.StructuredCounts.Evidence != 1 || got.StructuredCounts.Reviews != 1 || got.StructuredCounts.Handoffs != 1 || got.StructuredCounts.Memory != 1 || got.StructuredCounts.MemoryCandidates != 1 || got.StructuredCounts.Warnings != 1 {
+		t.Fatalf("structured counts = %+v, want one item in every launch-packet bucket", got.StructuredCounts)
+	}
+	if len(got.StructuredWarnings) != 1 || got.StructuredWarnings[0] != "fixture warning" {
+		t.Fatalf("structured warnings = %+v, want fixture warning", got.StructuredWarnings)
+	}
+	if !strings.Contains(got.ToolText, "Launch packet launch_fixture") {
+		t.Fatalf("tool text = %q, want launch packet evidence", got.ToolText)
+	}
+}
+
+func TestProjectCairnlineSidecarLaunchPacketSmoke_UsesRequestedIDs(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLaunchPacketSmoke(t.Context(), ProjectCairnlineSidecarLaunchPacketRequest{ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if !got.Ready || got.Status != "sidecar_launch_packet_ready" || !got.StructuredReady {
+		t.Fatalf("launch packet smoke = %+v, want structured ready", got)
+	}
+	if got.SelectedProjectID != "proj_requested" || got.SelectedProjectSource != "request" || got.SelectedAssignmentID != "asg_requested" || got.SelectedAssignmentSource != "request" {
+		t.Fatalf("selection = project %q/%q assignment %q/%q, want request ids", got.SelectedProjectID, got.SelectedProjectSource, got.SelectedAssignmentID, got.SelectedAssignmentSource)
+	}
+	if got.ProjectList != nil || got.AssignmentList != nil {
+		t.Fatalf("selection lists = projects %+v assignments %+v, want skipped lists for explicit ids", got.ProjectList, got.AssignmentList)
+	}
+	if got.StructuredIDs.ProjectID != "proj_requested" || got.StructuredIDs.AssignmentID != "asg_requested" {
+		t.Fatalf("structured ids = %+v, want requested project/assignment ids", got.StructuredIDs)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if strings.Contains(string(encoded), "project_list") || strings.Contains(string(encoded), "assignment_list") {
+		t.Fatalf("encoded response = %s, want omitted selection lists for explicit ids", encoded)
+	}
+}
+
+func TestProjectCairnlineSidecarLaunchPacketSmoke_TextOnlyWarns(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "text-only"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLaunchPacketSmoke(t.Context(), ProjectCairnlineSidecarLaunchPacketRequest{ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if !got.Ready || got.Status != "sidecar_launch_packet_ready" || got.StructuredReady {
+		t.Fatalf("launch packet smoke = %+v, want ready with structured warning", got)
+	}
+	if got.StructuredIDs.LaunchPacketID != "" || !strings.Contains(strings.Join(got.Warnings, "\n"), "assignments.launch_packet did not return structuredContent") {
+		t.Fatalf("structured ids/warnings = %+v / %+v, want text-only warning", got.StructuredIDs, got.Warnings)
+	}
+}
+
+func TestProjectCairnlineSidecarLaunchPacketSmoke_NoAssignment(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "assignment-list-empty"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLaunchPacketSmoke(t.Context(), ProjectCairnlineSidecarLaunchPacketRequest{})
+	if got.Ready || got.Status != "sidecar_launch_packet_no_assignment" {
+		t.Fatalf("launch packet smoke = %+v, want no assignment", got)
+	}
+	if got.AssignmentList == nil || got.SelectedProjectID != "proj_fixture" || got.SelectedAssignmentID != "" || !got.AssignmentList.StructuredReady || got.AssignmentList.StructuredCount != 0 {
+		t.Fatalf("selection/list = project:%q assignment:%q list:%+v, want empty assignment list after project selection", got.SelectedProjectID, got.SelectedAssignmentID, got.AssignmentList)
+	}
+}
+
+func TestProjectCairnlineSidecarLaunchPacketSmoke_ToolLevelError(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "launch-packet-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLaunchPacketSmoke(t.Context(), ProjectCairnlineSidecarLaunchPacketRequest{ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if got.Ready || got.Status != "sidecar_launch_packet_tool_failed" {
+		t.Fatalf("launch packet smoke = %+v, want launch-packet tool-level failure", got)
+	}
+	if !got.ToolIsError || !strings.Contains(got.ToolText, "fixture assignments.launch_packet failed") {
+		t.Fatalf("tool result = error:%t text:%q, want fixture launch-packet tool error", got.ToolIsError, got.ToolText)
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -12,6 +12,7 @@ const projectCoordinationBackendSidecarReadURL = "/hecate/v1/projects/cairnline/
 const projectCoordinationBackendSidecarDetailURL = "/hecate/v1/projects/cairnline/sidecar-detail-smoke"
 const projectCoordinationBackendSidecarCoordinationURL = "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"
 const projectCoordinationBackendSidecarAssignmentContextURL = "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"
+const projectCoordinationBackendSidecarLaunchPacketURL = "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -307,6 +308,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarDetailURL:            projectCoordinationBackendSidecarDetailURL,
 		CairnlineSidecarCoordinationURL:      projectCoordinationBackendSidecarCoordinationURL,
 		CairnlineSidecarAssignmentContextURL: projectCoordinationBackendSidecarAssignmentContextURL,
+		CairnlineSidecarLaunchPacketURL:      projectCoordinationBackendSidecarLaunchPacketURL,
 		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -45,6 +45,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarAssignmentContextURL != projectCoordinationBackendSidecarAssignmentContextURL {
 		t.Fatalf("sidecar assignment context URL = %q, want %q", status.CairnlineSidecarAssignmentContextURL, projectCoordinationBackendSidecarAssignmentContextURL)
 	}
+	if status.CairnlineSidecarLaunchPacketURL != projectCoordinationBackendSidecarLaunchPacketURL {
+		t.Fatalf("sidecar launch packet URL = %q, want %q", status.CairnlineSidecarLaunchPacketURL, projectCoordinationBackendSidecarLaunchPacketURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -132,6 +135,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 	if status.CairnlineSidecarAssignmentContextURL != projectCoordinationBackendSidecarAssignmentContextURL {
 		t.Fatalf("sidecar assignment context URL = %q, want %q", status.CairnlineSidecarAssignmentContextURL, projectCoordinationBackendSidecarAssignmentContextURL)
+	}
+	if status.CairnlineSidecarLaunchPacketURL != projectCoordinationBackendSidecarLaunchPacketURL {
+		t.Fatalf("sidecar launch packet URL = %q, want %q", status.CairnlineSidecarLaunchPacketURL, projectCoordinationBackendSidecarLaunchPacketURL)
 	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -581,6 +581,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarDetailURL            string                                       `json:"cairnline_sidecar_detail_url,omitempty"`
 	CairnlineSidecarCoordinationURL      string                                       `json:"cairnline_sidecar_coordination_url,omitempty"`
 	CairnlineSidecarAssignmentContextURL string                                       `json:"cairnline_sidecar_assignment_context_url,omitempty"`
+	CairnlineSidecarLaunchPacketURL      string                                       `json:"cairnline_sidecar_launch_packet_url,omitempty"`
 	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
@@ -1697,6 +1698,11 @@ type ProjectCairnlineSidecarAssignmentContextEnvelope struct {
 	Data   ProjectCairnlineSidecarAssignmentContextResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarLaunchPacketEnvelope struct {
+	Object string                                      `json:"object"`
+	Data   ProjectCairnlineSidecarLaunchPacketResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
@@ -1706,6 +1712,11 @@ type ProjectCairnlineSidecarCoordinationRequest struct {
 }
 
 type ProjectCairnlineSidecarAssignmentContextRequest struct {
+	ProjectID    string `json:"project_id,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+}
+
+type ProjectCairnlineSidecarLaunchPacketRequest struct {
 	ProjectID    string `json:"project_id,omitempty"`
 	AssignmentID string `json:"assignment_id,omitempty"`
 }
@@ -1866,6 +1877,63 @@ type ProjectCairnlineSidecarAssignmentContextIDs struct {
 	ProjectID    string `json:"project_id,omitempty"`
 	WorkItemID   string `json:"work_item_id,omitempty"`
 	RoleID       string `json:"role_id,omitempty"`
+}
+
+type ProjectCairnlineSidecarLaunchPacketResponse struct {
+	Ready                    bool                                           `json:"ready"`
+	Status                   string                                         `json:"status"`
+	Detail                   string                                         `json:"detail"`
+	Command                  string                                         `json:"command"`
+	Args                     []string                                       `json:"args,omitempty"`
+	DatabasePath             string                                         `json:"database_path,omitempty"`
+	ProbeTimeoutMS           int64                                          `json:"probe_timeout_ms"`
+	PersistentClient         bool                                           `json:"persistent_client,omitempty"`
+	ClientCacheConfigured    bool                                           `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries       int                                            `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse         int                                            `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle          int                                            `json:"client_cache_idle,omitempty"`
+	Tool                     string                                         `json:"tool"`
+	ReadOnly                 bool                                           `json:"read_only"`
+	RequestedProjectID       string                                         `json:"requested_project_id,omitempty"`
+	RequestedAssignmentID    string                                         `json:"requested_assignment_id,omitempty"`
+	SelectedProjectID        string                                         `json:"selected_project_id,omitempty"`
+	SelectedProjectSource    string                                         `json:"selected_project_source,omitempty"`
+	SelectedAssignmentID     string                                         `json:"selected_assignment_id,omitempty"`
+	SelectedAssignmentSource string                                         `json:"selected_assignment_source,omitempty"`
+	ProjectList              *ProjectCairnlineSidecarCoordinationListResult `json:"project_list,omitempty"`
+	AssignmentList           *ProjectCairnlineSidecarCoordinationListResult `json:"assignment_list,omitempty"`
+	ToolText                 string                                         `json:"tool_text,omitempty"`
+	ToolIsError              bool                                           `json:"tool_is_error,omitempty"`
+	StructuredContent        json.RawMessage                                `json:"structured_content,omitempty"`
+	Meta                     json.RawMessage                                `json:"meta,omitempty"`
+	StructuredReady          bool                                           `json:"structured_ready"`
+	StructuredIDs            ProjectCairnlineSidecarLaunchPacketIDs         `json:"structured_ids,omitempty"`
+	StructuredCounts         ProjectCairnlineSidecarLaunchPacketCounts      `json:"structured_counts,omitempty"`
+	StructuredWarnings       []string                                       `json:"structured_warnings,omitempty"`
+	StructuredParseError     string                                         `json:"structured_parse_error,omitempty"`
+	Warnings                 []string                                       `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarLaunchPacketIDs struct {
+	LaunchPacketID     string `json:"launch_packet_id,omitempty"`
+	Kind               string `json:"kind,omitempty"`
+	ProjectID          string `json:"project_id,omitempty"`
+	AssignmentID       string `json:"assignment_id,omitempty"`
+	WorkItemID         string `json:"work_item_id,omitempty"`
+	RoleID             string `json:"role_id,omitempty"`
+	ProfileID          string `json:"profile_id,omitempty"`
+	ExecutionProfileID string `json:"execution_profile_id,omitempty"`
+}
+
+type ProjectCairnlineSidecarLaunchPacketCounts struct {
+	Skills           int `json:"skills"`
+	Artifacts        int `json:"artifacts"`
+	Evidence         int `json:"evidence"`
+	Reviews          int `json:"reviews"`
+	Handoffs         int `json:"handoffs"`
+	Memory           int `json:"memory"`
+	MemoryCandidates int `json:"memory_candidates"`
+	Warnings         int `json:"warnings"`
 }
 
 type ProjectCairnlineSidecarProjectItem struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -27,6 +27,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-connect"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-detail-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -87,6 +87,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-connect", handler.HandleProjectCairnlineSidecarConnect)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke", handler.HandleProjectCairnlineSidecarCoordinationSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-detail-smoke", handler.HandleProjectCairnlineSidecarDetailSmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke", handler.HandleProjectCairnlineSidecarLaunchPacketSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4308,6 +4308,22 @@ func TestProjectCairnlineSidecarAssignmentContextSmokeRejectsNonLoopbackClientsB
 	}
 }
 
+func TestProjectCairnlineSidecarLaunchPacketSmokeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a local-only Cairnline sidecar launch-packet smoke endpoint for assignments.launch_packet
- parse typed launch-packet ids, counts, and packet warnings from structuredContent
- expose the diagnostic URL in backend status and update runtime/operator/design docs

## Validation
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus|TestRemoteRuntime|TestServerRoute|TestMCPProbeRejects'\n- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client\n- GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/orchestrator ./internal/mcp/client ./pkg/types\n- just docs-format\n- just docs-format-check\n- just agent-docs-check\n- just check-mermaid\n- just docs-env-check\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n\nNote: the package/full/race Go suites were run with loopback permissions because sandboxed httptest listeners cannot bind.