### PR TITLE
feat(projects): add Cairnline sidecar lifecycle smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -142,8 +142,12 @@ read-only `assignments.context` and reports whether typed
 assignment/project/work/role context metadata is present. A launch-packet smoke
 at `POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke` calls
 read-only `assignments.launch_packet` and reports typed launch-packet ids,
-counts, and packet warnings. Hecate does not yet route Projects reads, writes,
-or mirrors through the sidecar client.
+counts, and packet warnings. A lifecycle smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke` requires
+`confirm_mutation=true`, selects a compatible sidecar assignment through
+`assignments.next`, then claims, marks running, reads the launch packet, and
+completes it in the standalone Cairnline sidecar database only. Hecate does not
+yet route Projects reads, writes, or mirrors through the sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -350,10 +350,12 @@ launch agents. Those remain explicit operator or orchestrator actions.
   coordination list tools through local-only sidecar smoke endpoints to verify
   typed `structuredContent` for project list/detail,
   profile/skill/role/work/assignment list, assignment-context, and launch-packet
-  contracts. This is
-  contract/client-lifecycle/read-shape evidence only: Hecate does not yet route
-  live Projects reads, writes, mirrors, or write-authority switchpoints through
-  the sidecar.
+  contracts. Hecate also has an explicit confirmed sidecar lifecycle smoke that
+  exercises `assignments.next`, claim, `update_status`, launch-packet read, and
+  complete against the standalone sidecar database only. This is
+  contract/client-lifecycle/read-shape and standalone mutation evidence only:
+  Hecate does not yet route live Projects reads, writes, mirrors, or
+  write-authority switchpoints through the sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -378,7 +378,12 @@ or request an assignment and confirm `assignments.context` returns typed
 assignment/project/work/role metadata. Operators can also run
 `POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke` to confirm
 `assignments.launch_packet` returns typed launch-packet ids, counts, and packet
-warnings for the same MCP-pull path.
+warnings for the same MCP-pull path. The explicit mutation smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke` requires
+`confirm_mutation=true` and then proves `assignments.next`, claim,
+`update_status`, launch packet read, and complete against the standalone
+Cairnline sidecar database only; Hecate-native Projects stores remain
+authoritative and are not mutated by that smoke.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project list/detail, setup readiness,
@@ -426,11 +431,12 @@ The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. `sidecar-probe` verifies MCP
 tool presence only. `sidecar-connect` keeps the process warm in Hecate's
 Cairnline-specific MCP client cache. `sidecar-read-smoke`,
-`sidecar-detail-smoke`, `sidecar-coordination-smoke`, and
+`sidecar-detail-smoke`, `sidecar-coordination-smoke`,
 `sidecar-assignment-context-smoke`, and `sidecar-launch-packet-smoke` use that
 cached client to call read-only Cairnline MCP tools and return diagnostic
-evidence, but they do not route operator project reads or writes through the
-sidecar backend.
+evidence. `sidecar-lifecycle-smoke` is opt-in mutation evidence for the
+standalone sidecar assignment lifecycle. None of these routes operator project
+reads or writes through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context/launch-packet smoke,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle smoke,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -475,7 +475,11 @@ sequenceDiagram
   `structuredContent` arrays. `sidecar-assignment-context-smoke` calls
   read-only `assignments.context`, and `sidecar-launch-packet-smoke` calls
   read-only `assignments.launch_packet`; both check typed MCP-pull assignment
-  metadata, but live Projects reads and writes still use Hecate-native stores.
+  metadata. `sidecar-lifecycle-smoke` is the explicit mutation smoke: after
+  `confirm_mutation=true`, it selects a compatible sidecar assignment through
+  `assignments.next`, claims it, marks it running, reads its launch packet, and
+  completes it in the standalone Cairnline sidecar database. Live Projects
+  reads and writes still use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2673,7 +2677,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_detail_url": "/hecate/v1/projects/cairnline/sidecar-detail-smoke",
     "cairnline_sidecar_coordination_url": "/hecate/v1/projects/cairnline/sidecar-coordination-smoke",
     "cairnline_sidecar_assignment_context_url": "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke",
-    "cairnline_sidecar_launch_packet_url": "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"
+    "cairnline_sidecar_launch_packet_url": "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke",
+    "cairnline_sidecar_lifecycle_url": "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"
   }
 }
 ```
@@ -2707,7 +2712,10 @@ roles.list
 work_items.list
 work_items.create
 assignments.list
+assignments.next
 assignments.claim
+assignments.release
+assignments.update_status
 assignments.context
 assignments.launch_packet
 assignments.complete
@@ -2731,7 +2739,7 @@ Example response, shortened:
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
     "probe_timeout_ms": 10000,
-    "tool_count": 19,
+    "tool_count": 22,
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
@@ -2776,7 +2784,7 @@ Example response, shortened:
     "client_cache_entries": 1,
     "client_cache_in_use": 0,
     "client_cache_idle": 1,
-    "tool_count": 19,
+    "tool_count": 22,
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
@@ -3167,6 +3175,108 @@ Example response, shortened:
       "memory_candidates": 1,
       "warnings": 0
     },
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke`
+
+Local-only standalone Cairnline MCP lifecycle smoke. Unlike the read-only sidecar
+smokes above, this endpoint mutates the standalone Cairnline sidecar database
+after explicit confirmation. It never mutates Hecate-native Projects stores,
+does not start a Hecate Task, does not launch an External Agent, and does not
+make Cairnline authoritative for live Projects routes.
+
+Without `confirm_mutation=true`, the endpoint returns
+`sidecar_lifecycle_confirmation_required` and makes no sidecar tool calls. With
+confirmation, Hecate uses the same sidecar command, database, timeout, and
+Cairnline-specific MCP client cache as `sidecar-connect`.
+If a later lifecycle step fails after a successful mutation, the response
+includes a warning because the standalone sidecar assignment may already be
+claimed or running; inspect the returned steps before retrying.
+
+With an empty confirmed body, Hecate:
+
+1. Calls read-only `projects.list` and selects the first typed project id.
+2. Calls read-only `assignments.next` with `agent_kind="any"`,
+   `execution_modes=["mcp_pull"]`, `status="queued"`, and `limit=1`.
+3. Calls `assignments.claim` with `claimed_by="hecate-sidecar-smoke"`.
+4. Reads `assignments.context` to verify claimed state.
+5. Calls `assignments.update_status` with `status="running"`.
+6. Reads `assignments.context` to verify running state.
+7. Reads `assignments.launch_packet`.
+8. Calls `assignments.complete` with `status="completed"`.
+9. Reads final `assignments.context`.
+
+Supplying `project_id` and `assignment_id` skips list/next selection and uses
+the requested assignment. Optional fields are `claimed_by`, `execution_ref`,
+`completion_status`, `agent_kind`, `skill_ids`, and `execution_modes`.
+
+Example request:
+
+```json
+{
+  "confirm_mutation": true,
+  "project_id": "proj_123",
+  "assignment_id": "asg_123",
+  "claimed_by": "agent-smoke",
+  "execution_ref": "run-smoke",
+  "completion_status": "completed"
+}
+```
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_lifecycle",
+  "data": {
+    "ready": true,
+    "status": "sidecar_lifecycle_ready",
+    "detail": "Hecate selected a compatible standalone Cairnline assignment, claimed it, marked it running, read its launch packet, and completed it through the persistent sidecar client. Hecate-native Projects stores were not mutated.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "confirmed_mutation": true,
+    "selected_project_id": "proj_123",
+    "selected_project_source": "request",
+    "selected_assignment_id": "asg_123",
+    "selected_assignment_source": "request",
+    "claimed_by": "agent-smoke",
+    "execution_ref": "run-smoke",
+    "completion_status": "completed",
+    "steps": [
+      {
+        "name": "claim",
+        "tool": "assignments.claim",
+        "read_only": false,
+        "status": "ready",
+        "tool_text": "Claimed assignment asg_123 by agent-smoke"
+      },
+      {
+        "name": "launch_packet",
+        "tool": "assignments.launch_packet",
+        "read_only": true,
+        "status": "ready",
+        "structured_ready": true,
+        "launch_packet_ids": {
+          "assignment_id": "asg_123",
+          "kind": "assignment_launch_packet"
+        }
+      }
+    ],
+    "final_assignment": {
+      "id": "asg_123",
+      "project_id": "proj_123",
+      "status": "completed",
+      "claimed_by": "agent-smoke",
+      "execution_ref": "run-smoke"
+    },
+    "launch_packet_ready": true,
     "warnings": []
   }
 }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -28,6 +28,7 @@ func TestMain(m *testing.M) {
 func cairnlineSidecarFixtureMain(mode string) {
 	in := bufio.NewReader(os.Stdin)
 	enc := json.NewEncoder(os.Stdout)
+	state := &cairnlineSidecarFixtureState{assignmentStatus: "queued"}
 	for {
 		line, err := in.ReadBytes('\n')
 		if err != nil {
@@ -63,7 +64,7 @@ func cairnlineSidecarFixtureMain(mode string) {
 				rpcErr = mcp.NewError(mcp.ErrCodeInvalidParams, "invalid tools/call params")
 				break
 			}
-			result, rpcErr = cairnlineSidecarFixtureCallTool(mode, params)
+			result, rpcErr = cairnlineSidecarFixtureCallTool(mode, state, params)
 		default:
 			rpcErr = mcp.NewError(mcp.ErrCodeMethodNotFound, req.Method)
 		}
@@ -86,6 +87,12 @@ func cairnlineSidecarFixtureMain(mode string) {
 	}
 }
 
+type cairnlineSidecarFixtureState struct {
+	assignmentStatus string
+	claimedBy        string
+	executionRef     string
+}
+
 func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
 	names := append([]string(nil), projectCairnlineSidecarRequiredTools...)
 	if mode == "missing" {
@@ -102,7 +109,7 @@ func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
 	return tools
 }
 
-func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mcp.CallToolResult, *mcp.RPCError) {
+func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixtureState, params mcp.CallToolParams) (mcp.CallToolResult, *mcp.RPCError) {
 	switch params.Name {
 	case "projects.list":
 		if mode == "tool-error" {
@@ -193,8 +200,85 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 			"role_id":        "role_fixture",
 			"profile_id":     "profile_fixture",
 			"execution_mode": "mcp_pull",
-			"status":         "queued",
+			"status":         state.assignmentStatus,
+			"claimed_by":     state.claimedBy,
+			"execution_ref":  state.executionRef,
 		}})
+	case "assignments.next":
+		if mode == "assignment-list-empty" || state.assignmentStatus != "queued" {
+			return cairnlineSidecarFixtureListResult(mode, "No compatible assignments.", []map[string]any{})
+		}
+		return cairnlineSidecarFixtureListResult(mode, "Compatible assignments (1):\n- asg_fixture: Fixture Assignment", []map[string]any{{
+			"project_id":     cairnlineSidecarFixtureProjectID(params.Arguments),
+			"id":             "asg_fixture",
+			"work_item_id":   "work_fixture",
+			"role_id":        "role_fixture",
+			"profile_id":     "profile_fixture",
+			"execution_mode": "mcp_pull",
+			"status":         state.assignmentStatus,
+		}})
+	case "assignments.claim":
+		if mode == "claim-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture assignments.claim failed"),
+				IsError: true,
+			}, nil
+		}
+		var input struct {
+			ProjectID    string `json:"project_id"`
+			AssignmentID string `json:"assignment_id"`
+			ClaimedBy    string `json:"claimed_by"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assignments.claim arguments")
+		}
+		if input.ProjectID == "" || input.AssignmentID == "" || input.ClaimedBy == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing claim arguments")
+		}
+		if state.assignmentStatus != "queued" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture assignment is not queued"),
+				IsError: true,
+			}, nil
+		}
+		state.assignmentStatus = "claimed"
+		state.claimedBy = input.ClaimedBy
+		return mcp.CallToolResult{Content: mcp.TextContent("Claimed assignment " + input.AssignmentID + " by " + input.ClaimedBy)}, nil
+	case "assignments.release":
+		var input struct {
+			ProjectID    string `json:"project_id"`
+			AssignmentID string `json:"assignment_id"`
+			ClaimedBy    string `json:"claimed_by"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assignments.release arguments")
+		}
+		state.assignmentStatus = "queued"
+		state.claimedBy = ""
+		state.executionRef = ""
+		return mcp.CallToolResult{Content: mcp.TextContent("Released assignment " + input.AssignmentID)}, nil
+	case "assignments.update_status":
+		if mode == "update-status-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture assignments.update_status failed"),
+				IsError: true,
+			}, nil
+		}
+		var input struct {
+			ProjectID    string `json:"project_id"`
+			AssignmentID string `json:"assignment_id"`
+			Status       string `json:"status"`
+			ExecutionRef string `json:"execution_ref"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assignments.update_status arguments")
+		}
+		if input.ProjectID == "" || input.AssignmentID == "" || input.Status == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing update_status arguments")
+		}
+		state.assignmentStatus = input.Status
+		state.executionRef = input.ExecutionRef
+		return mcp.CallToolResult{Content: mcp.TextContent("Updated assignment " + input.AssignmentID + ": " + input.Status)}, nil
 	case "assignments.context":
 		if mode == "context-tool-error" {
 			return mcp.CallToolResult{
@@ -216,11 +300,13 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 		if mode != "text-only" {
 			result.StructuredContent = mustRawJSON(map[string]any{
 				"assignment": map[string]any{
-					"id":           input.AssignmentID,
-					"project_id":   input.ProjectID,
-					"work_item_id": "work_fixture",
-					"role_id":      "role_fixture",
-					"status":       "queued",
+					"id":            input.AssignmentID,
+					"project_id":    input.ProjectID,
+					"work_item_id":  "work_fixture",
+					"role_id":       "role_fixture",
+					"status":        state.assignmentStatus,
+					"claimed_by":    state.claimedBy,
+					"execution_ref": state.executionRef,
 				},
 				"work_item": map[string]any{
 					"id":    "work_fixture",
@@ -280,11 +366,13 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 					"title": "Fixture Skill",
 				}},
 				"assignment": map[string]any{
-					"id":           input.AssignmentID,
-					"project_id":   input.ProjectID,
-					"work_item_id": "work_fixture",
-					"role_id":      "role_fixture",
-					"status":       "queued",
+					"id":            input.AssignmentID,
+					"project_id":    input.ProjectID,
+					"work_item_id":  "work_fixture",
+					"role_id":       "role_fixture",
+					"status":        state.assignmentStatus,
+					"claimed_by":    state.claimedBy,
+					"execution_ref": state.executionRef,
 				},
 				"artifacts":         []map[string]any{{"id": "artifact_fixture"}},
 				"evidence":          []map[string]any{{"id": "evidence_fixture"}},
@@ -296,6 +384,31 @@ func cairnlineSidecarFixtureCallTool(mode string, params mcp.CallToolParams) (mc
 			})
 		}
 		return result, nil
+	case "assignments.complete":
+		if mode == "complete-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture assignments.complete failed"),
+				IsError: true,
+			}, nil
+		}
+		var input struct {
+			ProjectID    string `json:"project_id"`
+			AssignmentID string `json:"assignment_id"`
+			Status       string `json:"status"`
+			ExecutionRef string `json:"execution_ref"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assignments.complete arguments")
+		}
+		if input.ProjectID == "" || input.AssignmentID == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing complete arguments")
+		}
+		if input.Status == "" {
+			input.Status = "completed"
+		}
+		state.assignmentStatus = input.Status
+		state.executionRef = input.ExecutionRef
+		return mcp.CallToolResult{Content: mcp.TextContent("Updated assignment " + input.AssignmentID + ": " + input.Status)}, nil
 	case "projects.get":
 		if mode == "get-tool-error" {
 			return mcp.CallToolResult{

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -31,7 +31,10 @@ var projectCairnlineSidecarRequiredTools = []string{
 	"work_items.list",
 	"work_items.create",
 	"assignments.list",
+	"assignments.next",
 	"assignments.claim",
+	"assignments.release",
+	"assignments.update_status",
 	"assignments.context",
 	"assignments.launch_packet",
 	"assignments.complete",
@@ -173,6 +176,20 @@ func (h *Handler) HandleProjectCairnlineSidecarLaunchPacketSmoke(w http.Response
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarLaunchPacketEnvelope{
 		Object: "project_cairnline_sidecar_launch_packet",
 		Data:   h.projectCairnlineSidecarLaunchPacketSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarLifecycleSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar lifecycle smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarLifecycleRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarLifecycleEnvelope{
+		Object: "project_cairnline_sidecar_lifecycle",
+		Data:   h.projectCairnlineSidecarLifecycleSmoke(r.Context(), req),
 	})
 }
 
@@ -753,6 +770,183 @@ func (h *Handler) projectCairnlineSidecarLaunchPacketSmoke(ctx context.Context, 
 	return response
 }
 
+func (h *Handler) projectCairnlineSidecarLifecycleSmoke(ctx context.Context, req ProjectCairnlineSidecarLifecycleRequest) ProjectCairnlineSidecarLifecycleResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	requestedProjectID := strings.TrimSpace(req.ProjectID)
+	requestedAssignmentID := strings.TrimSpace(req.AssignmentID)
+	claimedBy := firstNonEmpty(strings.TrimSpace(req.ClaimedBy), "hecate-sidecar-smoke")
+	executionRef := firstNonEmpty(strings.TrimSpace(req.ExecutionRef), "hecate-sidecar-smoke")
+	completionStatus := firstNonEmpty(strings.TrimSpace(req.CompletionStatus), "completed")
+	agentKind := firstNonEmpty(strings.TrimSpace(req.AgentKind), "any")
+	executionModes := projectCairnlineSidecarCompactStrings(req.ExecutionModes)
+	if len(executionModes) == 0 {
+		executionModes = []string{"mcp_pull"}
+	}
+	response := ProjectCairnlineSidecarLifecycleResponse{
+		Ready:                 false,
+		Status:                "sidecar_lifecycle_not_run",
+		Detail:                "Cairnline sidecar lifecycle smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ConfirmedMutation:     req.ConfirmMutation,
+		RequestedProjectID:    requestedProjectID,
+		RequestedAssignmentID: requestedAssignmentID,
+		ClaimedBy:             claimedBy,
+		ExecutionRef:          executionRef,
+		CompletionStatus:      completionStatus,
+		AgentKind:             agentKind,
+		SkillIDs:              projectCairnlineSidecarCompactStrings(req.SkillIDs),
+		ExecutionModes:        append([]string(nil), executionModes...),
+	}
+	if h == nil {
+		response.Status = "sidecar_lifecycle_failed"
+		response.Detail = "Cairnline sidecar lifecycle smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this lifecycle smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+	if !req.ConfirmMutation {
+		response.Status = "sidecar_lifecycle_confirmation_required"
+		response.Detail = "Set confirm_mutation=true to let Hecate mutate the standalone Cairnline sidecar assignment through claim, update_status, launch_packet, and complete. Hecate-native Projects stores are not mutated."
+		return response
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	selection := h.projectCairnlineSidecarSelectNextAssignmentForLifecycle(smokeCtx, cfg, cache, requestedProjectID, requestedAssignmentID, agentKind, response.SkillIDs, executionModes)
+	response.SelectedProjectID = selection.ProjectID
+	response.SelectedProjectSource = selection.ProjectSource
+	response.SelectedAssignmentID = selection.AssignmentID
+	response.SelectedAssignmentSource = selection.AssignmentSource
+	response.ProjectList = selection.ProjectList
+	response.NextAssignmentList = selection.AssignmentList
+	response.Warnings = append(response.Warnings, selection.Warnings...)
+	if selection.Status != "" {
+		response.Status = selection.Status
+		response.Detail = selection.Detail
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+
+	projectID := selection.ProjectID
+	assignmentID := selection.AssignmentID
+	appendStep := func(step ProjectCairnlineSidecarLifecycleStep) bool {
+		response.Steps = append(response.Steps, step)
+		if step.Status == "tool_failed" {
+			response.Status = "sidecar_lifecycle_tool_failed"
+			response.Detail = "Cairnline sidecar " + step.Tool + " returned a tool-level error. Review the step output before retrying."
+			if projectCairnlineSidecarLifecycleHasCommittedMutation(response.Steps) {
+				response.Warnings = append(response.Warnings, "The standalone Cairnline sidecar assignment may have been mutated before this failure; inspect the reported assignment before retrying.")
+			}
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		if step.Status == "failed" {
+			response.Status = "sidecar_lifecycle_failed"
+			response.Detail = firstNonEmpty(step.ToolText, "Cairnline sidecar "+step.Tool+" failed.")
+			if projectCairnlineSidecarLifecycleHasCommittedMutation(response.Steps) {
+				response.Warnings = append(response.Warnings, "The standalone Cairnline sidecar assignment may have been mutated before this failure; inspect the reported assignment before retrying.")
+			}
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		return true
+	}
+
+	claimStep := h.callProjectCairnlineSidecarLifecycleTool(smokeCtx, cfg, cache, "claim", "assignments.claim", false, map[string]string{
+		"project_id":    projectID,
+		"assignment_id": assignmentID,
+		"claimed_by":    claimedBy,
+	})
+	if !appendStep(claimStep) {
+		return response
+	}
+	claimContextStep := h.callProjectCairnlineSidecarLifecycleTool(smokeCtx, cfg, cache, "context_after_claim", "assignments.context", true, map[string]string{
+		"project_id":    projectID,
+		"assignment_id": assignmentID,
+	})
+	if !appendStep(claimContextStep) {
+		return response
+	}
+
+	runningStep := h.callProjectCairnlineSidecarLifecycleTool(smokeCtx, cfg, cache, "mark_running", "assignments.update_status", false, map[string]string{
+		"project_id":    projectID,
+		"assignment_id": assignmentID,
+		"status":        "running",
+		"execution_ref": executionRef,
+	})
+	if !appendStep(runningStep) {
+		return response
+	}
+	runningContextStep := h.callProjectCairnlineSidecarLifecycleTool(smokeCtx, cfg, cache, "context_after_running", "assignments.context", true, map[string]string{
+		"project_id":    projectID,
+		"assignment_id": assignmentID,
+	})
+	if !appendStep(runningContextStep) {
+		return response
+	}
+
+	launchStep := h.callProjectCairnlineSidecarLifecycleTool(smokeCtx, cfg, cache, "launch_packet", "assignments.launch_packet", true, map[string]string{
+		"project_id":    projectID,
+		"assignment_id": assignmentID,
+	})
+	response.LaunchPacketReady = launchStep.StructuredReady
+	response.LaunchPacketIDs = launchStep.LaunchPacketIDs
+	response.LaunchPacketCounts = launchStep.LaunchPacketCounts
+	response.LaunchPacketWarnings = append([]string(nil), launchStep.LaunchPacketWarnings...)
+	if !appendStep(launchStep) {
+		return response
+	}
+
+	completeStep := h.callProjectCairnlineSidecarLifecycleTool(smokeCtx, cfg, cache, "complete", "assignments.complete", false, map[string]string{
+		"project_id":    projectID,
+		"assignment_id": assignmentID,
+		"status":        completionStatus,
+		"execution_ref": executionRef,
+	})
+	if !appendStep(completeStep) {
+		return response
+	}
+	finalContextStep := h.callProjectCairnlineSidecarLifecycleTool(smokeCtx, cfg, cache, "context_after_complete", "assignments.context", true, map[string]string{
+		"project_id":    projectID,
+		"assignment_id": assignmentID,
+	})
+	if !appendStep(finalContextStep) {
+		return response
+	}
+	response.FinalAssignment = finalContextStep.Assignment
+	if response.FinalAssignment.ID == "" {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar assignments.context did not return typed final assignment state after completion.")
+	}
+	response.Ready = true
+	response.Status = "sidecar_lifecycle_ready"
+	response.Detail = "Hecate selected a compatible standalone Cairnline assignment, claimed it, marked it running, read its launch packet, and completed it through the persistent sidecar client. Hecate-native Projects stores were not mutated."
+	response.setSidecarCacheStats(cache.Stats())
+	return response
+}
+
+func projectCairnlineSidecarLifecycleHasCommittedMutation(steps []ProjectCairnlineSidecarLifecycleStep) bool {
+	for _, step := range steps {
+		if !step.ReadOnly && step.Status == "ready" {
+			return true
+		}
+	}
+	return false
+}
+
 type projectCairnlineSidecarAssignmentSelection struct {
 	ProjectID        string
 	ProjectSource    string
@@ -763,6 +957,23 @@ type projectCairnlineSidecarAssignmentSelection struct {
 	Status           string
 	Detail           string
 	Warnings         []string
+}
+
+func projectCairnlineSidecarCompactStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
 }
 
 func (h *Handler) projectCairnlineSidecarSelectAssignmentForTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, requestedProjectID, requestedAssignmentID, statusPrefix, targetTool string) projectCairnlineSidecarAssignmentSelection {
@@ -851,6 +1062,175 @@ func (h *Handler) projectCairnlineSidecarSelectAssignmentForTool(ctx context.Con
 		selection.AssignmentID = assignmentID
 	}
 	return selection
+}
+
+func (h *Handler) projectCairnlineSidecarSelectNextAssignmentForLifecycle(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, requestedProjectID, requestedAssignmentID, agentKind string, skillIDs, executionModes []string) projectCairnlineSidecarAssignmentSelection {
+	const (
+		projectListToolName = "projects.list"
+		nextToolName        = "assignments.next"
+	)
+	var selection projectCairnlineSidecarAssignmentSelection
+	projectID := requestedProjectID
+	if projectID == "" {
+		listResult, err := h.callProjectCairnlineSidecarCoordinationTool(ctx, cfg, cache, projectCairnlineSidecarCoordinationTool{Name: projectListToolName}, "")
+		if err != nil {
+			selection.Status = "sidecar_lifecycle_failed"
+			selection.Detail = err.Error()
+			return selection
+		}
+		selection.ProjectList = &listResult
+		if listResult.ToolIsError {
+			selection.Status = "sidecar_lifecycle_project_list_tool_failed"
+			selection.Detail = "Cairnline sidecar projects.list returned a tool-level error before Hecate could select a project for assignments.next."
+			return selection
+		}
+		projects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(listResult.StructuredContent)
+		selection.ProjectList.StructuredReady = structuredReady
+		selection.ProjectList.StructuredCount = len(projects)
+		if structuredErr != nil {
+			selection.ProjectList.StructuredParseError = structuredErr.Error()
+			selection.Warnings = append(selection.Warnings, "Cairnline sidecar projects.list returned structuredContent that Hecate could not parse as a project list.")
+		} else if !structuredReady {
+			selection.Warnings = append(selection.Warnings, "Cairnline sidecar projects.list did not return structuredContent, so Hecate could not select a project for assignments.next.")
+		} else if len(projects) > 0 {
+			projectID = strings.TrimSpace(projects[0].ID)
+			selection.ProjectID = projectID
+			selection.ProjectSource = "projects.list"
+		}
+		if projectID == "" {
+			selection.Status = "sidecar_lifecycle_no_project"
+			selection.Detail = "Hecate called Cairnline sidecar projects.list through the persistent sidecar client, but no typed project id was available for assignments.next."
+			return selection
+		}
+	} else {
+		selection.ProjectID = projectID
+		selection.ProjectSource = "request"
+	}
+	if selection.ProjectID == "" {
+		selection.ProjectID = projectID
+	}
+
+	assignmentID := requestedAssignmentID
+	if assignmentID == "" {
+		args := map[string]any{
+			"project_id":      projectID,
+			"agent_kind":      agentKind,
+			"execution_modes": executionModes,
+			"limit":           1,
+			"status":          "queued",
+		}
+		if len(skillIDs) > 0 {
+			args["skill_ids"] = skillIDs
+		}
+		rawArgs, err := json.Marshal(args)
+		if err != nil {
+			selection.Status = "sidecar_lifecycle_failed"
+			selection.Detail = err.Error()
+			return selection
+		}
+		result, err := orchestrator.CallCachedMCPServerTool(ctx, cfg, h.secretCipher, cache, nextToolName, rawArgs)
+		if err != nil {
+			selection.Status = "sidecar_lifecycle_failed"
+			selection.Detail = err.Error()
+			return selection
+		}
+		nextResult := ProjectCairnlineSidecarCoordinationListResult{
+			Tool:              nextToolName,
+			ReadOnly:          true,
+			ProjectScoped:     true,
+			ProjectID:         projectID,
+			ToolText:          result.Text,
+			ToolIsError:       result.IsError,
+			StructuredContent: result.Result.StructuredContent,
+			Meta:              result.Result.Meta,
+		}
+		selection.AssignmentList = &nextResult
+		if result.IsError {
+			selection.Status = "sidecar_lifecycle_next_tool_failed"
+			selection.Detail = "Cairnline sidecar assignments.next returned a tool-level error before Hecate could select an assignment for the lifecycle smoke."
+			return selection
+		}
+		assignments, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignments(result.Result.StructuredContent)
+		selection.AssignmentList.StructuredReady = structuredReady
+		selection.AssignmentList.StructuredCount = len(assignments)
+		if structuredErr != nil {
+			selection.AssignmentList.StructuredParseError = structuredErr.Error()
+			selection.Warnings = append(selection.Warnings, "Cairnline sidecar assignments.next returned structuredContent that Hecate could not parse as an assignment list.")
+		} else if !structuredReady {
+			selection.Warnings = append(selection.Warnings, "Cairnline sidecar assignments.next did not return structuredContent, so Hecate could not select an assignment for the lifecycle smoke.")
+		} else if len(assignments) > 0 {
+			assignmentID = strings.TrimSpace(assignments[0].ID)
+			selection.AssignmentID = assignmentID
+			selection.AssignmentSource = "assignments.next"
+		}
+		if assignmentID == "" {
+			selection.Status = "sidecar_lifecycle_no_assignment"
+			selection.Detail = "Hecate called Cairnline sidecar assignments.next through the persistent sidecar client, but no compatible queued MCP-pull assignment was available for the lifecycle smoke."
+			return selection
+		}
+	} else {
+		selection.AssignmentID = assignmentID
+		selection.AssignmentSource = "request"
+	}
+	if selection.AssignmentID == "" {
+		selection.AssignmentID = assignmentID
+	}
+	return selection
+}
+
+func (h *Handler) callProjectCairnlineSidecarLifecycleTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, name, tool string, readOnly bool, args any) ProjectCairnlineSidecarLifecycleStep {
+	step := ProjectCairnlineSidecarLifecycleStep{
+		Name:     name,
+		Tool:     tool,
+		ReadOnly: readOnly,
+		Status:   "not_run",
+	}
+	rawArgs, err := json.Marshal(args)
+	if err != nil {
+		step.Status = "failed"
+		step.ToolText = err.Error()
+		return step
+	}
+	result, err := orchestrator.CallCachedMCPServerTool(ctx, cfg, h.secretCipher, cache, tool, rawArgs)
+	if err != nil {
+		step.Status = "failed"
+		step.ToolText = err.Error()
+		return step
+	}
+	step.ToolText = result.Text
+	step.ToolIsError = result.IsError
+	step.StructuredContent = result.Result.StructuredContent
+	step.Meta = result.Result.Meta
+	if result.IsError {
+		step.Status = "tool_failed"
+		return step
+	}
+	switch tool {
+	case "assignments.context":
+		assignment, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignmentContextAssignment(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.Assignment = assignment
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assignments.context returned structuredContent that Hecate could not parse as assignment state: " + structuredErr.Error()
+			return step
+		}
+	case "assignments.launch_packet":
+		ids, counts, warnings, structuredReady, structuredErr := projectCairnlineSidecarStructuredLaunchPacket(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.LaunchPacketIDs = ids
+		step.LaunchPacketCounts = counts
+		step.LaunchPacketWarnings = warnings
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assignments.launch_packet returned structuredContent that Hecate could not parse as a launch packet: " + structuredErr.Error()
+			return step
+		}
+	}
+	step.Status = "ready"
+	return step
 }
 
 func (h *Handler) callProjectCairnlineSidecarCoordinationTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, tool projectCairnlineSidecarCoordinationTool, projectID string) (ProjectCairnlineSidecarCoordinationListResult, error) {
@@ -972,6 +1352,23 @@ func projectCairnlineSidecarStructuredAssignmentContextIDs(raw json.RawMessage) 
 		WorkItemID:   strings.TrimSpace(context.WorkItem.ID),
 		RoleID:       strings.TrimSpace(context.Role.ID),
 	}, true, nil
+}
+
+func projectCairnlineSidecarStructuredAssignmentContextAssignment(raw json.RawMessage) (ProjectCairnlineSidecarAssignmentItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarAssignmentItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarAssignmentItem{}, false, nil
+	}
+	var context struct {
+		Assignment ProjectCairnlineSidecarAssignmentItem `json:"assignment"`
+	}
+	if err := json.Unmarshal(trimmed, &context); err != nil {
+		return ProjectCairnlineSidecarAssignmentItem{}, false, err
+	}
+	return context.Assignment, true, nil
 }
 
 func projectCairnlineSidecarStructuredLaunchPacket(raw json.RawMessage) (ProjectCairnlineSidecarLaunchPacketIDs, ProjectCairnlineSidecarLaunchPacketCounts, []string, bool, error) {
@@ -1149,6 +1546,15 @@ func (r *ProjectCairnlineSidecarAssignmentContextResponse) setSidecarCacheStats(
 }
 
 func (r *ProjectCairnlineSidecarLaunchPacketResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarLifecycleResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -774,6 +774,157 @@ func TestProjectCairnlineSidecarLaunchPacketSmoke_ToolLevelError(t *testing.T) {
 	}
 }
 
+func TestProjectCairnlineSidecarLifecycleSmoke_RequiresConfirmation(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLifecycleSmoke(t.Context(), ProjectCairnlineSidecarLifecycleRequest{})
+	if got.Ready || got.Status != "sidecar_lifecycle_confirmation_required" || got.ConfirmedMutation {
+		t.Fatalf("lifecycle smoke = %+v, want confirmation-required without mutation", got)
+	}
+	if len(got.Steps) != 0 || got.ClientCacheEntries != 0 {
+		t.Fatalf("steps/cache = %d/%d, want no sidecar calls before confirmation", len(got.Steps), got.ClientCacheEntries)
+	}
+}
+
+func TestProjectCairnlineSidecarLifecycleSmoke_SelectsNextAssignmentAndCompletes(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLifecycleSmoke(t.Context(), ProjectCairnlineSidecarLifecycleRequest{ConfirmMutation: true})
+	if !got.Ready || got.Status != "sidecar_lifecycle_ready" {
+		t.Fatalf("lifecycle smoke = %+v, want ready", got)
+	}
+	if got.SelectedProjectID != "proj_fixture" || got.SelectedProjectSource != "projects.list" || got.SelectedAssignmentID != "asg_fixture" || got.SelectedAssignmentSource != "assignments.next" {
+		t.Fatalf("selection = project %q/%q assignment %q/%q, want next-selected ids", got.SelectedProjectID, got.SelectedProjectSource, got.SelectedAssignmentID, got.SelectedAssignmentSource)
+	}
+	if got.NextAssignmentList == nil || !got.NextAssignmentList.StructuredReady || got.NextAssignmentList.StructuredCount != 1 {
+		t.Fatalf("next assignment list = %+v, want one typed compatible assignment", got.NextAssignmentList)
+	}
+	if len(got.Steps) != 7 {
+		t.Fatalf("steps = %+v, want claim/context/running/context/launch/complete/context flow", got.Steps)
+	}
+	if got.Steps[0].Name != "claim" || got.Steps[2].Name != "mark_running" || got.Steps[4].Name != "launch_packet" || got.Steps[5].Name != "complete" || got.Steps[6].Name != "context_after_complete" {
+		t.Fatalf("step names = %+v, want lifecycle order", got.Steps)
+	}
+	if !got.LaunchPacketReady || got.LaunchPacketIDs.AssignmentID != "asg_fixture" || got.LaunchPacketCounts.MemoryCandidates != 1 {
+		t.Fatalf("launch packet summary = ready:%t ids:%+v counts:%+v, want typed launch packet", got.LaunchPacketReady, got.LaunchPacketIDs, got.LaunchPacketCounts)
+	}
+	if got.FinalAssignment.ID != "asg_fixture" || got.FinalAssignment.Status != "completed" || got.FinalAssignment.ExecutionRef != "hecate-sidecar-smoke" {
+		t.Fatalf("final assignment = %+v, want completed assignment with smoke execution ref", got.FinalAssignment)
+	}
+}
+
+func TestProjectCairnlineSidecarLifecycleSmoke_UsesRequestedIDs(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLifecycleSmoke(t.Context(), ProjectCairnlineSidecarLifecycleRequest{
+		ProjectID:        "proj_requested",
+		AssignmentID:     "asg_requested",
+		ConfirmMutation:  true,
+		ClaimedBy:        "agent-requested",
+		ExecutionRef:     "run-requested",
+		CompletionStatus: "awaiting_review",
+	})
+	if !got.Ready || got.Status != "sidecar_lifecycle_ready" {
+		t.Fatalf("lifecycle smoke = %+v, want ready", got)
+	}
+	if got.SelectedProjectID != "proj_requested" || got.SelectedProjectSource != "request" || got.SelectedAssignmentID != "asg_requested" || got.SelectedAssignmentSource != "request" {
+		t.Fatalf("selection = project %q/%q assignment %q/%q, want request ids", got.SelectedProjectID, got.SelectedProjectSource, got.SelectedAssignmentID, got.SelectedAssignmentSource)
+	}
+	if got.ProjectList != nil || got.NextAssignmentList != nil {
+		t.Fatalf("selection lists = projects %+v next %+v, want skipped lists for explicit ids", got.ProjectList, got.NextAssignmentList)
+	}
+	if got.FinalAssignment.Status != "awaiting_review" || got.FinalAssignment.ClaimedBy != "agent-requested" || got.FinalAssignment.ExecutionRef != "run-requested" {
+		t.Fatalf("final assignment = %+v, want requested lifecycle metadata", got.FinalAssignment)
+	}
+}
+
+func TestProjectCairnlineSidecarLifecycleSmoke_NoCompatibleAssignment(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "assignment-list-empty"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLifecycleSmoke(t.Context(), ProjectCairnlineSidecarLifecycleRequest{ConfirmMutation: true})
+	if got.Ready || got.Status != "sidecar_lifecycle_no_assignment" {
+		t.Fatalf("lifecycle smoke = %+v, want no compatible assignment", got)
+	}
+	if got.NextAssignmentList == nil || !got.NextAssignmentList.StructuredReady || got.NextAssignmentList.StructuredCount != 0 {
+		t.Fatalf("next assignment list = %+v, want empty typed next result", got.NextAssignmentList)
+	}
+}
+
+func TestProjectCairnlineSidecarLifecycleSmoke_ToolLevelError(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "claim-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLifecycleSmoke(t.Context(), ProjectCairnlineSidecarLifecycleRequest{ConfirmMutation: true, ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if got.Ready || got.Status != "sidecar_lifecycle_tool_failed" {
+		t.Fatalf("lifecycle smoke = %+v, want tool-level failure", got)
+	}
+	if len(got.Steps) != 1 || got.Steps[0].Tool != "assignments.claim" || !got.Steps[0].ToolIsError {
+		t.Fatalf("steps = %+v, want failed claim step only", got.Steps)
+	}
+}
+
+func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureFollowsMutation(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "update-status-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLifecycleSmoke(t.Context(), ProjectCairnlineSidecarLifecycleRequest{ConfirmMutation: true, ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if got.Ready || got.Status != "sidecar_lifecycle_tool_failed" {
+		t.Fatalf("lifecycle smoke = %+v, want tool-level failure after mutation", got)
+	}
+	if len(got.Steps) != 3 || got.Steps[0].Status != "ready" || got.Steps[2].Tool != "assignments.update_status" || !got.Steps[2].ToolIsError {
+		t.Fatalf("steps = %+v, want claim/context ready then update_status failure", got.Steps)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "may have been mutated") {
+		t.Fatalf("warnings = %+v, want mutation warning", got.Warnings)
+	}
+}
+
 func projectCairnlineSidecarCoordinationTestList(items []ProjectCairnlineSidecarCoordinationListResult, tool string) (ProjectCairnlineSidecarCoordinationListResult, bool) {
 	for _, item := range items {
 		if item.Tool == tool {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -13,6 +13,7 @@ const projectCoordinationBackendSidecarDetailURL = "/hecate/v1/projects/cairnlin
 const projectCoordinationBackendSidecarCoordinationURL = "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"
 const projectCoordinationBackendSidecarAssignmentContextURL = "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"
 const projectCoordinationBackendSidecarLaunchPacketURL = "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"
+const projectCoordinationBackendSidecarLifecycleURL = "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -309,6 +310,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarCoordinationURL:      projectCoordinationBackendSidecarCoordinationURL,
 		CairnlineSidecarAssignmentContextURL: projectCoordinationBackendSidecarAssignmentContextURL,
 		CairnlineSidecarLaunchPacketURL:      projectCoordinationBackendSidecarLaunchPacketURL,
+		CairnlineSidecarLifecycleURL:         projectCoordinationBackendSidecarLifecycleURL,
 		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -48,6 +48,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarLaunchPacketURL != projectCoordinationBackendSidecarLaunchPacketURL {
 		t.Fatalf("sidecar launch packet URL = %q, want %q", status.CairnlineSidecarLaunchPacketURL, projectCoordinationBackendSidecarLaunchPacketURL)
 	}
+	if status.CairnlineSidecarLifecycleURL != projectCoordinationBackendSidecarLifecycleURL {
+		t.Fatalf("sidecar lifecycle URL = %q, want %q", status.CairnlineSidecarLifecycleURL, projectCoordinationBackendSidecarLifecycleURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -138,6 +141,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 	if status.CairnlineSidecarLaunchPacketURL != projectCoordinationBackendSidecarLaunchPacketURL {
 		t.Fatalf("sidecar launch packet URL = %q, want %q", status.CairnlineSidecarLaunchPacketURL, projectCoordinationBackendSidecarLaunchPacketURL)
+	}
+	if status.CairnlineSidecarLifecycleURL != projectCoordinationBackendSidecarLifecycleURL {
+		t.Fatalf("sidecar lifecycle URL = %q, want %q", status.CairnlineSidecarLifecycleURL, projectCoordinationBackendSidecarLifecycleURL)
 	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -582,6 +582,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarCoordinationURL      string                                       `json:"cairnline_sidecar_coordination_url,omitempty"`
 	CairnlineSidecarAssignmentContextURL string                                       `json:"cairnline_sidecar_assignment_context_url,omitempty"`
 	CairnlineSidecarLaunchPacketURL      string                                       `json:"cairnline_sidecar_launch_packet_url,omitempty"`
+	CairnlineSidecarLifecycleURL         string                                       `json:"cairnline_sidecar_lifecycle_url,omitempty"`
 	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
@@ -1703,6 +1704,11 @@ type ProjectCairnlineSidecarLaunchPacketEnvelope struct {
 	Data   ProjectCairnlineSidecarLaunchPacketResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarLifecycleEnvelope struct {
+	Object string                                   `json:"object"`
+	Data   ProjectCairnlineSidecarLifecycleResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
@@ -1719,6 +1725,18 @@ type ProjectCairnlineSidecarAssignmentContextRequest struct {
 type ProjectCairnlineSidecarLaunchPacketRequest struct {
 	ProjectID    string `json:"project_id,omitempty"`
 	AssignmentID string `json:"assignment_id,omitempty"`
+}
+
+type ProjectCairnlineSidecarLifecycleRequest struct {
+	ProjectID        string   `json:"project_id,omitempty"`
+	AssignmentID     string   `json:"assignment_id,omitempty"`
+	ConfirmMutation  bool     `json:"confirm_mutation,omitempty"`
+	ClaimedBy        string   `json:"claimed_by,omitempty"`
+	ExecutionRef     string   `json:"execution_ref,omitempty"`
+	CompletionStatus string   `json:"completion_status,omitempty"`
+	AgentKind        string   `json:"agent_kind,omitempty"`
+	SkillIDs         []string `json:"skill_ids,omitempty"`
+	ExecutionModes   []string `json:"execution_modes,omitempty"`
 }
 
 type ProjectCairnlineSidecarProbeResponse struct {
@@ -1936,6 +1954,60 @@ type ProjectCairnlineSidecarLaunchPacketCounts struct {
 	Warnings         int `json:"warnings"`
 }
 
+type ProjectCairnlineSidecarLifecycleResponse struct {
+	Ready                    bool                                           `json:"ready"`
+	Status                   string                                         `json:"status"`
+	Detail                   string                                         `json:"detail"`
+	Command                  string                                         `json:"command"`
+	Args                     []string                                       `json:"args,omitempty"`
+	DatabasePath             string                                         `json:"database_path,omitempty"`
+	ProbeTimeoutMS           int64                                          `json:"probe_timeout_ms"`
+	PersistentClient         bool                                           `json:"persistent_client,omitempty"`
+	ClientCacheConfigured    bool                                           `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries       int                                            `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse         int                                            `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle          int                                            `json:"client_cache_idle,omitempty"`
+	ConfirmedMutation        bool                                           `json:"confirmed_mutation"`
+	RequestedProjectID       string                                         `json:"requested_project_id,omitempty"`
+	RequestedAssignmentID    string                                         `json:"requested_assignment_id,omitempty"`
+	SelectedProjectID        string                                         `json:"selected_project_id,omitempty"`
+	SelectedProjectSource    string                                         `json:"selected_project_source,omitempty"`
+	SelectedAssignmentID     string                                         `json:"selected_assignment_id,omitempty"`
+	SelectedAssignmentSource string                                         `json:"selected_assignment_source,omitempty"`
+	ClaimedBy                string                                         `json:"claimed_by,omitempty"`
+	ExecutionRef             string                                         `json:"execution_ref,omitempty"`
+	CompletionStatus         string                                         `json:"completion_status,omitempty"`
+	AgentKind                string                                         `json:"agent_kind,omitempty"`
+	SkillIDs                 []string                                       `json:"skill_ids,omitempty"`
+	ExecutionModes           []string                                       `json:"execution_modes,omitempty"`
+	ProjectList              *ProjectCairnlineSidecarCoordinationListResult `json:"project_list,omitempty"`
+	NextAssignmentList       *ProjectCairnlineSidecarCoordinationListResult `json:"next_assignment_list,omitempty"`
+	Steps                    []ProjectCairnlineSidecarLifecycleStep         `json:"steps,omitempty"`
+	FinalAssignment          ProjectCairnlineSidecarAssignmentItem          `json:"final_assignment,omitempty"`
+	LaunchPacketReady        bool                                           `json:"launch_packet_ready"`
+	LaunchPacketIDs          ProjectCairnlineSidecarLaunchPacketIDs         `json:"launch_packet_ids,omitempty"`
+	LaunchPacketCounts       ProjectCairnlineSidecarLaunchPacketCounts      `json:"launch_packet_counts,omitempty"`
+	LaunchPacketWarnings     []string                                       `json:"launch_packet_warnings,omitempty"`
+	Warnings                 []string                                       `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarLifecycleStep struct {
+	Name                 string                                    `json:"name"`
+	Tool                 string                                    `json:"tool"`
+	ReadOnly             bool                                      `json:"read_only"`
+	Status               string                                    `json:"status"`
+	ToolText             string                                    `json:"tool_text,omitempty"`
+	ToolIsError          bool                                      `json:"tool_is_error,omitempty"`
+	StructuredContent    json.RawMessage                           `json:"structured_content,omitempty"`
+	Meta                 json.RawMessage                           `json:"meta,omitempty"`
+	StructuredReady      bool                                      `json:"structured_ready"`
+	Assignment           ProjectCairnlineSidecarAssignmentItem     `json:"assignment,omitempty"`
+	LaunchPacketIDs      ProjectCairnlineSidecarLaunchPacketIDs    `json:"launch_packet_ids,omitempty"`
+	LaunchPacketCounts   ProjectCairnlineSidecarLaunchPacketCounts `json:"launch_packet_counts,omitempty"`
+	LaunchPacketWarnings []string                                  `json:"launch_packet_warnings,omitempty"`
+	StructuredParseError string                                    `json:"structured_parse_error,omitempty"`
+}
+
 type ProjectCairnlineSidecarProjectItem struct {
 	ID                        string                              `json:"id"`
 	Name                      string                              `json:"name"`
@@ -1957,6 +2029,8 @@ type ProjectCairnlineSidecarAssignmentItem struct {
 	ProfileID     string   `json:"profile_id,omitempty"`
 	ExecutionMode string   `json:"execution_mode,omitempty"`
 	Status        string   `json:"status,omitempty"`
+	ClaimedBy     string   `json:"claimed_by,omitempty"`
+	ExecutionRef  string   `json:"execution_ref,omitempty"`
 	SkillIDs      []string `json:"skill_ids,omitempty"`
 }
 

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -28,6 +28,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-detail-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -88,6 +88,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke", handler.HandleProjectCairnlineSidecarCoordinationSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-detail-smoke", handler.HandleProjectCairnlineSidecarDetailSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke", handler.HandleProjectCairnlineSidecarLaunchPacketSmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke", handler.HandleProjectCairnlineSidecarLifecycleSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4324,6 +4324,22 @@ func TestProjectCairnlineSidecarLaunchPacketSmokeRejectsNonLoopbackClientsBefore
 	}
 }
 
+func TestProjectCairnlineSidecarLifecycleSmokeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a local-only confirmed Cairnline sidecar lifecycle smoke endpoint that selects a queued MCP-pull assignment, claims it, marks it running, reads its launch packet, and completes it through the persistent sidecar client
- expose the lifecycle smoke URL in backend status and classify the route as local-only for remote runtime mode
- extend the sidecar fixture, API tests, and operator/runtime/design docs for the confirmed sidecar-only mutation boundary

## Validation
- GOCACHE="$PWD/.gocache" go test ./...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...
- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client
- GOCACHE="$PWD/.gocache" go test -count=1 ./internal/api -run 'TestProjectCairnlineSidecar|TestProjectCoordinationBackendStatus|TestRemoteRuntime|TestServerRoute|TestMCPProbeRejects'\n- just docs-format-check\n- just agent-docs-check\n- just check-mermaid\n- just docs-env-check\n- git diff --check