### PR TITLE
docs(projects): clarify Cairnline sidecar diagnostics

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2490,7 +2490,9 @@ the local-only read smoke that calls Cairnline's read-only `projects.list` tool
 through that cached client. `cairnline_sidecar_detail_url` points at the
 local-only detail smoke that calls Cairnline's read-only `projects.get` tool,
 using either an explicit `project_id` or the first typed project from
-`projects.list`. None of these changes live route authority.
+`projects.list`. The remaining sidecar smoke URLs cover coordination list
+tools, assignment context, launch packets, and the explicitly confirmed
+standalone assignment lifecycle. None of these changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -80,7 +80,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be connected through the local-only sidecar connect endpoint, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -90,7 +90,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read-smoke surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -118,6 +118,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.Status != "cairnline_connector_not_ready" || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
 		t.Fatalf("status = %+v, want sidecar connector mode to block live Cairnline routing", status)
 	}
+	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
+		t.Fatalf("connector detail = %q, want full sidecar diagnostic surface", status.CairnlineConnectorDetail)
+	}
 	if handler.projectReadRoutesUseCairnlineReadModel() || handler.projectIdentityWritesUseCairnlineAuthority() || handler.projectMemoryWritesUseCairnlineAuthority() || handler.projectAssignmentWritesUseCairnlineAuthority() {
 		t.Fatal("sidecar connector enabled embedded Cairnline read/write route predicates, want connect/probe-only mode")
 	}
@@ -158,8 +161,8 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 		t.Fatalf("project-identity switchpoint = %+v, want Hecate authority while sidecar routing is not live", point)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "Hecate-native stores") {
-		t.Fatalf("warnings = %+v, want sidecar connect/probe-only warning", status.Warnings)
+	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
+		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary
- update Cairnline sidecar backend-status detail/warning text to name the full local-only diagnostic surface, including launch-packet and lifecycle smokes
- add regression assertions so the stale read-smoke-only wording does not return
- note the broader sidecar smoke coverage in runtime API docs

## Validation
- GOCACHE="$PWD/.gocache" go test -count=1 ./internal/api -run 'TestProjectCoordinationBackendStatus|TestProjectCairnlineSidecar'\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n- just docs-format-check\n- just agent-docs-check\n- just docs-env-check\n- git diff --check