### PR TITLE
fix(projects): release early Cairnline sidecar claims

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3196,7 +3196,11 @@ confirmation, Hecate uses the same sidecar command, database, timeout, and
 Cairnline-specific MCP client cache as `sidecar-connect`.
 If a later lifecycle step fails after a successful mutation, the response
 includes a warning because the standalone sidecar assignment may already be
-claimed or running; inspect the returned steps before retrying.
+claimed or running; inspect the returned steps before retrying. If the failure
+happens after claim but before `assignments.update_status` succeeds, Hecate
+attempts a best-effort `assignments.release` cleanup and appends that cleanup
+step to the response. Once the assignment is marked running, Hecate does not
+try to release it.
 
 With an empty confirmed body, Hecate:
 

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -843,13 +843,32 @@ func (h *Handler) projectCairnlineSidecarLifecycleSmoke(ctx context.Context, req
 
 	projectID := selection.ProjectID
 	assignmentID := selection.AssignmentID
+	releaseEarlyClaim := func() bool {
+		if !projectCairnlineSidecarLifecycleShouldReleaseAfterFailure(response.Steps) {
+			return false
+		}
+		releaseStep := h.callProjectCairnlineSidecarLifecycleTool(smokeCtx, cfg, cache, "release_after_failure", "assignments.release", false, map[string]string{
+			"project_id":    projectID,
+			"assignment_id": assignmentID,
+			"claimed_by":    claimedBy,
+		})
+		response.Steps = append(response.Steps, releaseStep)
+		if releaseStep.Status == "ready" {
+			response.Warnings = append(response.Warnings, "Hecate released the standalone Cairnline sidecar assignment after the early lifecycle failure; inspect the reported steps before retrying.")
+			return true
+		}
+		response.Warnings = append(response.Warnings, "Hecate tried to release the standalone Cairnline sidecar assignment after the early lifecycle failure, but the release step did not succeed; inspect the reported assignment before retrying.")
+		return false
+	}
 	appendStep := func(step ProjectCairnlineSidecarLifecycleStep) bool {
 		response.Steps = append(response.Steps, step)
 		if step.Status == "tool_failed" {
 			response.Status = "sidecar_lifecycle_tool_failed"
 			response.Detail = "Cairnline sidecar " + step.Tool + " returned a tool-level error. Review the step output before retrying."
 			if projectCairnlineSidecarLifecycleHasCommittedMutation(response.Steps) {
-				response.Warnings = append(response.Warnings, "The standalone Cairnline sidecar assignment may have been mutated before this failure; inspect the reported assignment before retrying.")
+				if !releaseEarlyClaim() {
+					response.Warnings = append(response.Warnings, "The standalone Cairnline sidecar assignment may have been mutated before this failure; inspect the reported assignment before retrying.")
+				}
 			}
 			response.setSidecarCacheStats(cache.Stats())
 			return false
@@ -858,7 +877,9 @@ func (h *Handler) projectCairnlineSidecarLifecycleSmoke(ctx context.Context, req
 			response.Status = "sidecar_lifecycle_failed"
 			response.Detail = firstNonEmpty(step.ToolText, "Cairnline sidecar "+step.Tool+" failed.")
 			if projectCairnlineSidecarLifecycleHasCommittedMutation(response.Steps) {
-				response.Warnings = append(response.Warnings, "The standalone Cairnline sidecar assignment may have been mutated before this failure; inspect the reported assignment before retrying.")
+				if !releaseEarlyClaim() {
+					response.Warnings = append(response.Warnings, "The standalone Cairnline sidecar assignment may have been mutated before this failure; inspect the reported assignment before retrying.")
+				}
 			}
 			response.setSidecarCacheStats(cache.Stats())
 			return false
@@ -936,6 +957,22 @@ func (h *Handler) projectCairnlineSidecarLifecycleSmoke(ctx context.Context, req
 	response.Detail = "Hecate selected a compatible standalone Cairnline assignment, claimed it, marked it running, read its launch packet, and completed it through the persistent sidecar client. Hecate-native Projects stores were not mutated."
 	response.setSidecarCacheStats(cache.Stats())
 	return response
+}
+
+func projectCairnlineSidecarLifecycleShouldReleaseAfterFailure(steps []ProjectCairnlineSidecarLifecycleStep) bool {
+	claimed := false
+	for _, step := range steps {
+		if step.Status != "ready" || step.ReadOnly {
+			continue
+		}
+		switch step.Tool {
+		case "assignments.claim":
+			claimed = true
+		case "assignments.update_status", "assignments.complete", "assignments.release":
+			return false
+		}
+	}
+	return claimed
 }
 
 func projectCairnlineSidecarLifecycleHasCommittedMutation(steps []ProjectCairnlineSidecarLifecycleStep) bool {

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -902,7 +902,7 @@ func TestProjectCairnlineSidecarLifecycleSmoke_ToolLevelError(t *testing.T) {
 	}
 }
 
-func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureFollowsMutation(t *testing.T) {
+func TestProjectCairnlineSidecarLifecycleSmoke_ReleasesEarlyClaimWhenFailureFollowsMutation(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{
 			CairnlineConnector:           "sidecar",
@@ -917,11 +917,40 @@ func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureFollowsMutation(t
 	if got.Ready || got.Status != "sidecar_lifecycle_tool_failed" {
 		t.Fatalf("lifecycle smoke = %+v, want tool-level failure after mutation", got)
 	}
-	if len(got.Steps) != 3 || got.Steps[0].Status != "ready" || got.Steps[2].Tool != "assignments.update_status" || !got.Steps[2].ToolIsError {
-		t.Fatalf("steps = %+v, want claim/context ready then update_status failure", got.Steps)
+	if len(got.Steps) != 4 || got.Steps[0].Status != "ready" || got.Steps[2].Tool != "assignments.update_status" || !got.Steps[2].ToolIsError || got.Steps[3].Tool != "assignments.release" || got.Steps[3].Status != "ready" {
+		t.Fatalf("steps = %+v, want claim/context ready, update_status failure, then release cleanup", got.Steps)
+	}
+	warnings := strings.Join(got.Warnings, "\n")
+	if !strings.Contains(warnings, "released the standalone Cairnline sidecar assignment") || strings.Contains(warnings, "may have been mutated") {
+		t.Fatalf("warnings = %+v, want release cleanup warning without unresolved mutation warning", got.Warnings)
+	}
+}
+
+func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureAfterRunningCannotRelease(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "launch-packet-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarLifecycleSmoke(t.Context(), ProjectCairnlineSidecarLifecycleRequest{ConfirmMutation: true, ProjectID: "proj_requested", AssignmentID: "asg_requested"})
+	if got.Ready || got.Status != "sidecar_lifecycle_tool_failed" {
+		t.Fatalf("lifecycle smoke = %+v, want tool-level failure after running", got)
+	}
+	if len(got.Steps) != 5 || got.Steps[2].Tool != "assignments.update_status" || got.Steps[2].Status != "ready" || got.Steps[4].Tool != "assignments.launch_packet" || !got.Steps[4].ToolIsError {
+		t.Fatalf("steps = %+v, want running state then launch_packet failure", got.Steps)
+	}
+	for _, step := range got.Steps {
+		if step.Tool == "assignments.release" {
+			t.Fatalf("steps = %+v, did not expect release after running", got.Steps)
+		}
 	}
 	if !strings.Contains(strings.Join(got.Warnings, "\n"), "may have been mutated") {
-		t.Fatalf("warnings = %+v, want mutation warning", got.Warnings)
+		t.Fatalf("warnings = %+v, want unresolved mutation warning after running failure", got.Warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary
- best-effort release a standalone Cairnline sidecar assignment when lifecycle smoke fails after claim but before mark-running succeeds
- keep warning-only behavior after the assignment is marked running
- document the cleanup boundary and add regression tests for early-release and post-running failure paths

## Validation
- GOCACHE="$PWD/.gocache" go test -count=1 ./internal/api -run 'TestProjectCairnlineSidecarLifecycleSmoke'\n- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n- just docs-format-check\n- just agent-docs-check\n- just docs-env-check\n- git diff --check