### PR TITLE
Add Cairnline sidecar write smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -146,8 +146,13 @@ counts, and packet warnings. A lifecycle smoke at
 `POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke` requires
 `confirm_mutation=true`, selects a compatible sidecar assignment through
 `assignments.next`, then claims, marks running, reads the launch packet, and
-completes it in the standalone Cairnline sidecar database only. Hecate does not
-yet route Projects reads, writes, or mirrors through the sidecar client.
+completes it in the standalone Cairnline sidecar database only. A write smoke
+at `POST /hecate/v1/projects/cairnline/sidecar-write-smoke` also requires
+`confirm_mutation=true`, creates a temporary rootless Cairnline project, finds
+it through typed `projects.list`, updates and verifies it through
+`projects.update` / `projects.get`, deletes it, and verifies the deleted record
+is missing. Hecate does not yet route Projects reads, writes, or mirrors through
+the sidecar client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -342,7 +342,7 @@ launch agents. Those remain explicit operator or orchestrator actions.
 - Hecate can use the MCP server for side-by-side interoperability and the
   public Go package for controlled embed experiments.
 - Current Hecate sidecar experiments can probe a standalone Cairnline MCP
-  command for the minimum portable Projects tool contract via
+  command for the current portable Projects backend tool contract via
   `POST /hecate/v1/projects/cairnline/sidecar-probe` and can connect a cached
   sidecar MCP client via `POST /hecate/v1/projects/cairnline/sidecar-connect`.
   Hecate can also call read-only `projects.list`, `projects.get`,
@@ -352,7 +352,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   profile/skill/role/work/assignment list, assignment-context, and launch-packet
   contracts. Hecate also has an explicit confirmed sidecar lifecycle smoke that
   exercises `assignments.next`, claim, `update_status`, launch-packet read, and
-  complete against the standalone sidecar database only. This is
+  complete against the standalone sidecar database only, plus an explicit
+  confirmed sidecar write smoke that creates, lists, updates, gets, deletes, and
+  verifies deletion of a temporary rootless standalone Cairnline project. This is
   contract/client-lifecycle/read-shape and standalone mutation evidence only:
   Hecate does not yet route live Projects reads, writes, mirrors, or
   write-authority switchpoints through the sidecar.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle smoke,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write smoke,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -475,10 +475,13 @@ sequenceDiagram
   `structuredContent` arrays. `sidecar-assignment-context-smoke` calls
   read-only `assignments.context`, and `sidecar-launch-packet-smoke` calls
   read-only `assignments.launch_packet`; both check typed MCP-pull assignment
-  metadata. `sidecar-lifecycle-smoke` is the explicit mutation smoke: after
+  metadata. `sidecar-lifecycle-smoke` is the assignment mutation smoke: after
   `confirm_mutation=true`, it selects a compatible sidecar assignment through
   `assignments.next`, claims it, marks it running, reads its launch packet, and
-  completes it in the standalone Cairnline sidecar database. Live Projects
+  completes it in the standalone Cairnline sidecar database.
+  `sidecar-write-smoke` is the project-identity mutation smoke: after
+  `confirm_mutation=true`, it creates, lists, updates, reads, deletes, and
+  verifies deletion of a temporary standalone Cairnline project. Live Projects
   reads and writes still use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
@@ -2491,8 +2494,9 @@ through that cached client. `cairnline_sidecar_detail_url` points at the
 local-only detail smoke that calls Cairnline's read-only `projects.get` tool,
 using either an explicit `project_id` or the first typed project from
 `projects.list`. The remaining sidecar smoke URLs cover coordination list
-tools, assignment context, launch packets, and the explicitly confirmed
-standalone assignment lifecycle. None of these changes live route authority.
+tools, assignment context, launch packets, the explicitly confirmed standalone
+assignment lifecycle, and the explicitly confirmed temporary-project write
+smoke. None of these changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -2680,7 +2684,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_coordination_url": "/hecate/v1/projects/cairnline/sidecar-coordination-smoke",
     "cairnline_sidecar_assignment_context_url": "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke",
     "cairnline_sidecar_launch_packet_url": "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke",
-    "cairnline_sidecar_lifecycle_url": "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"
+    "cairnline_sidecar_lifecycle_url": "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke",
+    "cairnline_sidecar_write_url": "/hecate/v1/projects/cairnline/sidecar-write-smoke"
   }
 }
 ```
@@ -3342,6 +3347,86 @@ Example response, shortened:
       "execution_ref": "run-smoke"
     },
     "launch_packet_ready": true,
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-write-smoke`
+
+Local-only standalone Cairnline MCP project write smoke. This endpoint mutates
+only the standalone Cairnline sidecar database after explicit confirmation. It
+does not mutate Hecate-native Projects stores and does not make Cairnline
+authoritative for live Projects routes.
+
+Without `confirm_mutation=true`, the endpoint returns
+`sidecar_write_confirmation_required` and makes no sidecar tool calls. With
+confirmation, Hecate uses the same sidecar command, database, timeout, and
+Cairnline-specific MCP client cache as `sidecar-connect`.
+
+The smoke creates a temporary rootless project with a unique or supplied
+`project_name`, finds the created record through typed `projects.list`
+`structuredContent`, updates it through `projects.update`, verifies the updated
+name through typed `projects.get`, deletes it through `projects.delete`, and
+then expects a final `projects.get` to return a tool-level missing/error result.
+If a step fails after the temporary project id is known, Hecate attempts a
+best-effort cleanup delete and verifies that cleanup through another
+`projects.get`.
+
+Example request:
+
+```json
+{
+  "confirm_mutation": true,
+  "project_name": "Hecate sidecar write smoke"
+}
+```
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_write",
+  "data": {
+    "ready": true,
+    "status": "sidecar_write_ready",
+    "detail": "Hecate created, listed, updated, verified, deleted, and confirmed removal of a temporary standalone Cairnline project through the persistent sidecar client. Hecate-native Projects stores were not mutated.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "confirmed_mutation": true,
+    "project_name": "Hecate sidecar write smoke",
+    "updated_project_name": "Hecate sidecar write smoke updated",
+    "selected_project_id": "proj_123",
+    "cleanup_verified": true,
+    "steps": [
+      {
+        "name": "create_project",
+        "tool": "projects.create",
+        "read_only": false,
+        "status": "ready",
+        "tool_text": "Created project proj_123: Hecate sidecar write smoke"
+      },
+      {
+        "name": "get_after_delete",
+        "tool": "projects.get",
+        "read_only": true,
+        "status": "expected_missing",
+        "tool_is_error": true,
+        "tool_text": "project not found: proj_123"
+      }
+    ],
+    "created_project": {
+      "id": "proj_123",
+      "name": "Hecate sidecar write smoke"
+    },
+    "updated_project": {
+      "id": "proj_123",
+      "name": "Hecate sidecar write smoke updated"
+    },
     "warnings": []
   }
 }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -28,7 +28,11 @@ func TestMain(m *testing.M) {
 func cairnlineSidecarFixtureMain(mode string) {
 	in := bufio.NewReader(os.Stdin)
 	enc := json.NewEncoder(os.Stdout)
-	state := &cairnlineSidecarFixtureState{assignmentStatus: "queued"}
+	state := &cairnlineSidecarFixtureState{
+		assignmentStatus: "queued",
+		projects:         make(map[string]ProjectCairnlineSidecarProjectItem),
+		deletedProjects:  make(map[string]struct{}),
+	}
 	for {
 		line, err := in.ReadBytes('\n')
 		if err != nil {
@@ -91,6 +95,9 @@ type cairnlineSidecarFixtureState struct {
 	assignmentStatus string
 	claimedBy        string
 	executionRef     string
+	projectSequence  int
+	projects         map[string]ProjectCairnlineSidecarProjectItem
+	deletedProjects  map[string]struct{}
 }
 
 func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
@@ -120,24 +127,7 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		}
 		result := mcp.CallToolResult{Content: mcp.TextContent("Projects (1):\n- proj_fixture: Fixture Project")}
 		if mode != "text-only" {
-			result.StructuredContent = mustRawJSON([]ProjectCairnlineSidecarProjectItem{{
-				ID:          "proj_fixture",
-				Name:        "Fixture Project",
-				Description: "Structured fixture project",
-				Roots: []ProjectCairnlineSidecarRootItem{{
-					ID:     "root_fixture",
-					Path:   "/workspace/fixture",
-					Kind:   "local",
-					Active: true,
-				}},
-				ContextSources: []ProjectCairnlineSidecarSourceItem{{
-					ID:      "src_fixture",
-					Kind:    "workspace_instruction",
-					Title:   "AGENTS.md",
-					Locator: "AGENTS.md",
-					Enabled: true,
-				}},
-			}})
+			result.StructuredContent = mustRawJSON(cairnlineSidecarFixtureProjects(state))
 		}
 		return result, nil
 	case "profiles.list":
@@ -425,32 +415,116 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		if input.ID == "" {
 			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing project id")
 		}
-		project := ProjectCairnlineSidecarProjectItem{
-			ID:          input.ID,
-			Name:        "Fixture Project",
-			Description: "Structured fixture project detail",
-			Roots: []ProjectCairnlineSidecarRootItem{{
-				ID:     "root_fixture",
-				Path:   "/workspace/fixture",
-				Kind:   "local",
-				Active: true,
-			}},
-			ContextSources: []ProjectCairnlineSidecarSourceItem{{
-				ID:      "src_fixture",
-				Kind:    "workspace_instruction",
-				Title:   "AGENTS.md",
-				Locator: "AGENTS.md",
-				Enabled: true,
-			}},
+		if _, ok := state.deletedProjects[input.ID]; ok {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture project not found: " + input.ID),
+				IsError: true,
+			}, nil
 		}
-		result := mcp.CallToolResult{Content: mcp.TextContent("Project " + input.ID + ": Fixture Project")}
+		project := cairnlineSidecarFixtureProject(input.ID)
+		if stored, ok := state.projects[input.ID]; ok {
+			project = stored
+		}
+		result := mcp.CallToolResult{Content: mcp.TextContent("Project " + input.ID + ": " + project.Name)}
 		if mode != "text-only" {
 			result.StructuredContent = mustRawJSON(project)
 		}
 		return result, nil
+	case "projects.create":
+		var input struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid projects.create arguments")
+		}
+		if strings.TrimSpace(input.Name) == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing project name")
+		}
+		state.projectSequence++
+		id := fmt.Sprintf("proj_write_fixture_%d", state.projectSequence)
+		state.projects[id] = ProjectCairnlineSidecarProjectItem{
+			ID:          id,
+			Name:        input.Name,
+			Description: input.Description,
+		}
+		delete(state.deletedProjects, id)
+		return mcp.CallToolResult{Content: mcp.TextContent("Created project " + id + ": " + input.Name)}, nil
+	case "projects.update":
+		if mode == "project-update-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture projects.update failed"),
+				IsError: true,
+			}, nil
+		}
+		var input struct {
+			ID          string  `json:"id"`
+			Name        *string `json:"name"`
+			Description *string `json:"description"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid projects.update arguments")
+		}
+		project, ok := state.projects[input.ID]
+		if !ok {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture project not found: " + input.ID),
+				IsError: true,
+			}, nil
+		}
+		if input.Name != nil {
+			project.Name = *input.Name
+		}
+		if input.Description != nil {
+			project.Description = *input.Description
+		}
+		state.projects[input.ID] = project
+		return mcp.CallToolResult{Content: mcp.TextContent("Updated project " + input.ID + ": " + project.Name)}, nil
+	case "projects.delete":
+		var input struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid projects.delete arguments")
+		}
+		if input.ID == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing project id")
+		}
+		delete(state.projects, input.ID)
+		state.deletedProjects[input.ID] = struct{}{}
+		return mcp.CallToolResult{Content: mcp.TextContent("Deleted project " + input.ID)}, nil
 	default:
 		return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeMethodNotFound, params.Name)
 	}
+}
+
+func cairnlineSidecarFixtureProject(id string) ProjectCairnlineSidecarProjectItem {
+	return ProjectCairnlineSidecarProjectItem{
+		ID:          id,
+		Name:        "Fixture Project",
+		Description: "Structured fixture project",
+		Roots: []ProjectCairnlineSidecarRootItem{{
+			ID:     "root_fixture",
+			Path:   "/workspace/fixture",
+			Kind:   "local",
+			Active: true,
+		}},
+		ContextSources: []ProjectCairnlineSidecarSourceItem{{
+			ID:      "src_fixture",
+			Kind:    "workspace_instruction",
+			Title:   "AGENTS.md",
+			Locator: "AGENTS.md",
+			Enabled: true,
+		}},
+	}
+}
+
+func cairnlineSidecarFixtureProjects(state *cairnlineSidecarFixtureState) []ProjectCairnlineSidecarProjectItem {
+	projects := []ProjectCairnlineSidecarProjectItem{cairnlineSidecarFixtureProject("proj_fixture")}
+	for _, project := range state.projects {
+		projects = append(projects, project)
+	}
+	return projects
 }
 
 func cairnlineSidecarFixtureListResult(mode, text string, structured any) (mcp.CallToolResult, *mcp.RPCError) {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -249,6 +249,20 @@ func (h *Handler) HandleProjectCairnlineSidecarLifecycleSmoke(w http.ResponseWri
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarLifecycleEnvelope{
 		Object: "project_cairnline_sidecar_lifecycle",
 		Data:   h.projectCairnlineSidecarLifecycleSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarWriteSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar write smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarWriteRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarWriteEnvelope{
+		Object: "project_cairnline_sidecar_write",
+		Data:   h.projectCairnlineSidecarWriteSmoke(r.Context(), req),
 	})
 }
 
@@ -1018,6 +1032,161 @@ func (h *Handler) projectCairnlineSidecarLifecycleSmoke(ctx context.Context, req
 	return response
 }
 
+func (h *Handler) projectCairnlineSidecarWriteSmoke(ctx context.Context, req ProjectCairnlineSidecarWriteRequest) ProjectCairnlineSidecarWriteResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	projectName := strings.TrimSpace(req.ProjectName)
+	if projectName == "" {
+		projectName = "Hecate sidecar write smoke " + time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+	updatedProjectName := projectName + " updated"
+	response := ProjectCairnlineSidecarWriteResponse{
+		Ready:                 false,
+		Status:                "sidecar_write_not_run",
+		Detail:                "Cairnline sidecar write smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ConfirmedMutation:     req.ConfirmMutation,
+		ProjectName:           projectName,
+		UpdatedProjectName:    updatedProjectName,
+	}
+	if h == nil {
+		response.Status = "sidecar_write_failed"
+		response.Detail = "Cairnline sidecar write smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this write smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+	if !req.ConfirmMutation {
+		response.Status = "sidecar_write_confirmation_required"
+		response.Detail = "Set confirm_mutation=true to let Hecate create, update, verify, delete, and re-check a temporary project in the standalone Cairnline sidecar. Hecate-native Projects stores are not mutated."
+		return response
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := ""
+	cleanup := func() {
+		if projectID == "" || response.CleanupVerified {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+		defer cleanupCancel()
+		cleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_delete", "projects.delete", false, map[string]string{"id": projectID})
+		response.Steps = append(response.Steps, cleanupStep)
+		if cleanupStep.Status == "ready" {
+			verifyCleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_get_after_delete", "projects.get", true, map[string]string{"id": projectID})
+			if verifyCleanupStep.Status == "tool_failed" {
+				verifyCleanupStep.Status = "expected_missing"
+				response.CleanupVerified = true
+				response.Warnings = append(response.Warnings, "Hecate deleted and verified removal of the temporary standalone Cairnline project after the write smoke failed; inspect the reported steps before retrying.")
+			} else {
+				response.Warnings = append(response.Warnings, "Hecate deleted the temporary standalone Cairnline project after the write smoke failed, but removal could not be verified; inspect the reported steps before retrying.")
+			}
+			response.Steps = append(response.Steps, verifyCleanupStep)
+			return
+		}
+		response.Warnings = append(response.Warnings, "Hecate tried to delete the temporary standalone Cairnline project after the write smoke failed, but cleanup did not succeed; inspect the standalone Cairnline sidecar before retrying.")
+	}
+	fail := func(status, detail string) ProjectCairnlineSidecarWriteResponse {
+		response.Status = status
+		response.Detail = detail
+		cleanup()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	appendStep := func(step ProjectCairnlineSidecarWriteStep) bool {
+		response.Steps = append(response.Steps, step)
+		if step.Status == "tool_failed" {
+			response.Status = "sidecar_write_tool_failed"
+			response.Detail = "Cairnline sidecar " + step.Tool + " returned a tool-level error. Review the step output before retrying."
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		if step.Status == "failed" {
+			response.Status = "sidecar_write_failed"
+			response.Detail = firstNonEmpty(step.ToolText, "Cairnline sidecar "+step.Tool+" failed.")
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		return true
+	}
+
+	createStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_project", "projects.create", false, map[string]string{
+		"name":        projectName,
+		"description": "Temporary Hecate sidecar write smoke project. It should be deleted by the same diagnostic run.",
+	})
+	if !appendStep(createStep) {
+		return response
+	}
+
+	listStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_after_create", "projects.list", true, map[string]string{})
+	if !appendStep(listStep) {
+		return response
+	}
+	project, ok := projectCairnlineSidecarProjectByName(listStep.StructuredProjects, projectName)
+	if !ok || strings.TrimSpace(project.ID) == "" {
+		return fail("sidecar_write_created_project_not_listed", "Cairnline sidecar projects.create succeeded, but projects.list did not return the temporary project by name.")
+	}
+	projectID = strings.TrimSpace(project.ID)
+	response.SelectedProjectID = projectID
+	response.CreatedProject = project
+
+	updateStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "update_project", "projects.update", false, map[string]string{
+		"id":          projectID,
+		"name":        updatedProjectName,
+		"description": "Temporary Hecate sidecar write smoke project updated through projects.update.",
+	})
+	if !appendStep(updateStep) {
+		return response
+	}
+
+	getStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_after_update", "projects.get", true, map[string]string{"id": projectID})
+	if !appendStep(getStep) {
+		return response
+	}
+	updatedProject := getStep.StructuredProject
+	if strings.TrimSpace(updatedProject.ID) != projectID || strings.TrimSpace(updatedProject.Name) != updatedProjectName {
+		return fail("sidecar_write_update_verification_failed", "Cairnline sidecar projects.get did not return the expected project id and updated name after projects.update.")
+	}
+	response.UpdatedProject = updatedProject
+
+	deleteStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_project", "projects.delete", false, map[string]string{"id": projectID})
+	if !appendStep(deleteStep) {
+		return response
+	}
+
+	verifyDeleteStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_after_delete", "projects.get", true, map[string]string{"id": projectID})
+	if verifyDeleteStep.Status == "tool_failed" {
+		verifyDeleteStep.Status = "expected_missing"
+		response.Steps = append(response.Steps, verifyDeleteStep)
+		response.CleanupVerified = true
+		response.Ready = true
+		response.Status = "sidecar_write_ready"
+		response.Detail = "Hecate created, listed, updated, verified, deleted, and confirmed removal of a temporary standalone Cairnline project through the persistent sidecar client. Hecate-native Projects stores were not mutated."
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	if !appendStep(verifyDeleteStep) {
+		return response
+	}
+	return fail("sidecar_write_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary project.")
+}
+
 func projectCairnlineSidecarLifecycleShouldReleaseAfterFailure(steps []ProjectCairnlineSidecarLifecycleStep) bool {
 	claimed := false
 	for _, step := range steps {
@@ -1329,6 +1498,70 @@ func (h *Handler) callProjectCairnlineSidecarLifecycleTool(ctx context.Context, 
 	return step
 }
 
+func (h *Handler) callProjectCairnlineSidecarWriteTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, name, tool string, readOnly bool, args any) ProjectCairnlineSidecarWriteStep {
+	step := ProjectCairnlineSidecarWriteStep{
+		Name:     name,
+		Tool:     tool,
+		ReadOnly: readOnly,
+		Status:   "not_run",
+	}
+	rawArgs, err := json.Marshal(args)
+	if err != nil {
+		step.Status = "failed"
+		step.ToolText = err.Error()
+		return step
+	}
+	result, err := orchestrator.CallCachedMCPServerTool(ctx, cfg, h.secretCipher, cache, tool, rawArgs)
+	if err != nil {
+		step.Status = "failed"
+		step.ToolText = err.Error()
+		return step
+	}
+	step.ToolText = result.Text
+	step.ToolIsError = result.IsError
+	step.StructuredContent = result.Result.StructuredContent
+	step.Meta = result.Result.Meta
+	if result.IsError {
+		step.Status = "tool_failed"
+		return step
+	}
+	switch tool {
+	case "projects.list":
+		projects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredProjects = projects
+		step.StructuredProjectCount = len(projects)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar projects.list returned structuredContent that Hecate could not parse as a project list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar projects.list did not return structuredContent; the write smoke needs a typed project list to find the temporary project."
+			return step
+		}
+	case "projects.get":
+		project, structuredReady, structuredErr := projectCairnlineSidecarStructuredProject(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredProject = project
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar projects.get returned structuredContent that Hecate could not parse as a project: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar projects.get did not return structuredContent; the write smoke needs typed project detail to verify the temporary project."
+			return step
+		}
+	}
+	step.Status = "ready"
+	return step
+}
+
 func (h *Handler) callProjectCairnlineSidecarCoordinationTool(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, tool projectCairnlineSidecarCoordinationTool, projectID string) (ProjectCairnlineSidecarCoordinationListResult, error) {
 	args := json.RawMessage(`{}`)
 	if tool.ProjectScoped {
@@ -1381,6 +1614,16 @@ func projectCairnlineSidecarStructuredProjects(raw json.RawMessage) ([]ProjectCa
 		projects = []ProjectCairnlineSidecarProjectItem{}
 	}
 	return projects, true, nil
+}
+
+func projectCairnlineSidecarProjectByName(projects []ProjectCairnlineSidecarProjectItem, name string) (ProjectCairnlineSidecarProjectItem, bool) {
+	name = strings.TrimSpace(name)
+	for _, project := range projects {
+		if strings.TrimSpace(project.Name) == name {
+			return project, true
+		}
+	}
+	return ProjectCairnlineSidecarProjectItem{}, false
 }
 
 func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairnlineSidecarProjectItem, bool, error) {
@@ -1651,6 +1894,15 @@ func (r *ProjectCairnlineSidecarLaunchPacketResponse) setSidecarCacheStats(stats
 }
 
 func (r *ProjectCairnlineSidecarLifecycleResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarWriteResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -936,6 +936,81 @@ func TestProjectCairnlineSidecarLifecycleSmoke_ReleasesEarlyClaimWhenFailureFoll
 	}
 }
 
+func TestProjectCairnlineSidecarWriteSmoke_RequiresConfirmation(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarWriteSmoke(t.Context(), ProjectCairnlineSidecarWriteRequest{ProjectName: "Fixture write smoke"})
+	if got.Ready || got.Status != "sidecar_write_confirmation_required" || got.ConfirmedMutation {
+		t.Fatalf("write smoke = %+v, want confirmation-required without mutation", got)
+	}
+	if len(got.Steps) != 0 || got.ClientCacheEntries != 0 {
+		t.Fatalf("steps/cache = %d/%d, want no sidecar calls before confirmation", len(got.Steps), got.ClientCacheEntries)
+	}
+}
+
+func TestProjectCairnlineSidecarWriteSmoke_CreatesUpdatesDeletesTemporaryProject(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarWriteSmoke(t.Context(), ProjectCairnlineSidecarWriteRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture write smoke",
+	})
+	if !got.Ready || got.Status != "sidecar_write_ready" || !got.CleanupVerified {
+		t.Fatalf("write smoke = %+v, want ready with verified cleanup", got)
+	}
+	if got.SelectedProjectID == "" || got.CreatedProject.Name != "Fixture write smoke" || got.UpdatedProject.Name != "Fixture write smoke updated" {
+		t.Fatalf("project ids = selected:%q created:%+v updated:%+v, want named temporary project", got.SelectedProjectID, got.CreatedProject, got.UpdatedProject)
+	}
+	if len(got.Steps) != 6 {
+		t.Fatalf("steps = %+v, want create/list/update/get/delete/get flow", got.Steps)
+	}
+	if got.Steps[0].Tool != "projects.create" || got.Steps[1].Tool != "projects.list" || got.Steps[2].Tool != "projects.update" || got.Steps[3].Tool != "projects.get" || got.Steps[4].Tool != "projects.delete" || got.Steps[5].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want write smoke order and missing-after-delete verification", got.Steps)
+	}
+}
+
+func TestProjectCairnlineSidecarWriteSmoke_CleansUpAfterUpdateFailure(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "project-update-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarWriteSmoke(t.Context(), ProjectCairnlineSidecarWriteRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture write smoke cleanup",
+	})
+	if got.Ready || got.Status != "sidecar_write_tool_failed" || !got.CleanupVerified {
+		t.Fatalf("write smoke = %+v, want update tool failure with verified cleanup", got)
+	}
+	if len(got.Steps) != 5 || got.Steps[2].Tool != "projects.update" || !got.Steps[2].ToolIsError || got.Steps[3].Name != "cleanup_delete" || got.Steps[4].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want update failure followed by cleanup delete and verification", got.Steps)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "deleted and verified removal") {
+		t.Fatalf("warnings = %+v, want verified cleanup warning", got.Warnings)
+	}
+}
+
 func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureAfterRunningCannotRelease(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -14,6 +14,7 @@ const projectCoordinationBackendSidecarCoordinationURL = "/hecate/v1/projects/ca
 const projectCoordinationBackendSidecarAssignmentContextURL = "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"
 const projectCoordinationBackendSidecarLaunchPacketURL = "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"
 const projectCoordinationBackendSidecarLifecycleURL = "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"
+const projectCoordinationBackendSidecarWriteURL = "/hecate/v1/projects/cairnline/sidecar-write-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -311,6 +312,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarAssignmentContextURL: projectCoordinationBackendSidecarAssignmentContextURL,
 		CairnlineSidecarLaunchPacketURL:      projectCoordinationBackendSidecarLaunchPacketURL,
 		CairnlineSidecarLifecycleURL:         projectCoordinationBackendSidecarLifecycleURL,
+		CairnlineSidecarWriteURL:             projectCoordinationBackendSidecarWriteURL,
 		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -51,6 +51,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarLifecycleURL != projectCoordinationBackendSidecarLifecycleURL {
 		t.Fatalf("sidecar lifecycle URL = %q, want %q", status.CairnlineSidecarLifecycleURL, projectCoordinationBackendSidecarLifecycleURL)
 	}
+	if status.CairnlineSidecarWriteURL != projectCoordinationBackendSidecarWriteURL {
+		t.Fatalf("sidecar write URL = %q, want %q", status.CairnlineSidecarWriteURL, projectCoordinationBackendSidecarWriteURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -118,7 +121,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.Status != "cairnline_connector_not_ready" || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
 		t.Fatalf("status = %+v, want sidecar connector mode to block live Cairnline routing", status)
 	}
-	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
+	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
 		t.Fatalf("connector detail = %q, want full sidecar diagnostic surface", status.CairnlineConnectorDetail)
 	}
 	if handler.projectReadRoutesUseCairnlineReadModel() || handler.projectIdentityWritesUseCairnlineAuthority() || handler.projectMemoryWritesUseCairnlineAuthority() || handler.projectAssignmentWritesUseCairnlineAuthority() {
@@ -147,6 +150,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 	if status.CairnlineSidecarLifecycleURL != projectCoordinationBackendSidecarLifecycleURL {
 		t.Fatalf("sidecar lifecycle URL = %q, want %q", status.CairnlineSidecarLifecycleURL, projectCoordinationBackendSidecarLifecycleURL)
+	}
+	if status.CairnlineSidecarWriteURL != projectCoordinationBackendSidecarWriteURL {
+		t.Fatalf("sidecar write URL = %q, want %q", status.CairnlineSidecarWriteURL, projectCoordinationBackendSidecarWriteURL)
 	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -583,6 +583,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarAssignmentContextURL string                                       `json:"cairnline_sidecar_assignment_context_url,omitempty"`
 	CairnlineSidecarLaunchPacketURL      string                                       `json:"cairnline_sidecar_launch_packet_url,omitempty"`
 	CairnlineSidecarLifecycleURL         string                                       `json:"cairnline_sidecar_lifecycle_url,omitempty"`
+	CairnlineSidecarWriteURL             string                                       `json:"cairnline_sidecar_write_url,omitempty"`
 	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
@@ -1709,6 +1710,11 @@ type ProjectCairnlineSidecarLifecycleEnvelope struct {
 	Data   ProjectCairnlineSidecarLifecycleResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarWriteEnvelope struct {
+	Object string                               `json:"object"`
+	Data   ProjectCairnlineSidecarWriteResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
@@ -1737,6 +1743,11 @@ type ProjectCairnlineSidecarLifecycleRequest struct {
 	AgentKind        string   `json:"agent_kind,omitempty"`
 	SkillIDs         []string `json:"skill_ids,omitempty"`
 	ExecutionModes   []string `json:"execution_modes,omitempty"`
+}
+
+type ProjectCairnlineSidecarWriteRequest struct {
+	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
+	ProjectName     string `json:"project_name,omitempty"`
 }
 
 type ProjectCairnlineSidecarProbeResponse struct {
@@ -2006,6 +2017,46 @@ type ProjectCairnlineSidecarLifecycleStep struct {
 	LaunchPacketCounts   ProjectCairnlineSidecarLaunchPacketCounts `json:"launch_packet_counts,omitempty"`
 	LaunchPacketWarnings []string                                  `json:"launch_packet_warnings,omitempty"`
 	StructuredParseError string                                    `json:"structured_parse_error,omitempty"`
+}
+
+type ProjectCairnlineSidecarWriteResponse struct {
+	Ready                 bool                               `json:"ready"`
+	Status                string                             `json:"status"`
+	Detail                string                             `json:"detail"`
+	Command               string                             `json:"command"`
+	Args                  []string                           `json:"args,omitempty"`
+	DatabasePath          string                             `json:"database_path,omitempty"`
+	ProbeTimeoutMS        int64                              `json:"probe_timeout_ms"`
+	PersistentClient      bool                               `json:"persistent_client,omitempty"`
+	ClientCacheConfigured bool                               `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries    int                                `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse      int                                `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle       int                                `json:"client_cache_idle,omitempty"`
+	ConfirmedMutation     bool                               `json:"confirmed_mutation"`
+	ProjectName           string                             `json:"project_name,omitempty"`
+	UpdatedProjectName    string                             `json:"updated_project_name,omitempty"`
+	SelectedProjectID     string                             `json:"selected_project_id,omitempty"`
+	Steps                 []ProjectCairnlineSidecarWriteStep `json:"steps,omitempty"`
+	CreatedProject        ProjectCairnlineSidecarProjectItem `json:"created_project,omitempty"`
+	UpdatedProject        ProjectCairnlineSidecarProjectItem `json:"updated_project,omitempty"`
+	CleanupVerified       bool                               `json:"cleanup_verified"`
+	Warnings              []string                           `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarWriteStep struct {
+	Name                   string                               `json:"name"`
+	Tool                   string                               `json:"tool"`
+	ReadOnly               bool                                 `json:"read_only"`
+	Status                 string                               `json:"status"`
+	ToolText               string                               `json:"tool_text,omitempty"`
+	ToolIsError            bool                                 `json:"tool_is_error,omitempty"`
+	StructuredContent      json.RawMessage                      `json:"structured_content,omitempty"`
+	Meta                   json.RawMessage                      `json:"meta,omitempty"`
+	StructuredReady        bool                                 `json:"structured_ready"`
+	StructuredProject      ProjectCairnlineSidecarProjectItem   `json:"structured_project,omitempty"`
+	StructuredProjects     []ProjectCairnlineSidecarProjectItem `json:"structured_projects,omitempty"`
+	StructuredProjectCount int                                  `json:"structured_project_count"`
+	StructuredParseError   string                               `json:"structured_parse_error,omitempty"`
 }
 
 type ProjectCairnlineSidecarProjectItem struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -31,6 +31,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-write-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -91,6 +91,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke", handler.HandleProjectCairnlineSidecarLifecycleSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-write-smoke", handler.HandleProjectCairnlineSidecarWriteSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)


### PR DESCRIPTION
## Summary
- add a local-only confirmed Cairnline sidecar write smoke endpoint that creates, lists, updates, gets, deletes, and verifies deletion of a temporary standalone Cairnline project
- surface the write smoke URL from project coordination backend status and classify the route as remote local-only
- extend the sidecar MCP fixture, API tests, and runtime/design docs for the new diagnostic boundary

## Boundary
- requires `confirm_mutation=true`
- mutates only the standalone Cairnline sidecar database
- does not mutate Hecate-native Projects stores
- does not switch live Projects read/write authority to Cairnline

## Tests
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecar(Probe|Connect|Read|Detail|Coordination|AssignmentContext|LaunchPacket|Lifecycle|Write)|TestProjectCoordinationBackendStatus|TestRemoteRuntime' -count=1`
- `GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go vet ./...`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
- `just agent-docs-check`
- `just docs-env-check`
- `just docs-format-check`
- `git diff --check`
