### PR TITLE
Add Cairnline sidecar setup smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -151,8 +151,13 @@ at `POST /hecate/v1/projects/cairnline/sidecar-write-smoke` also requires
 `confirm_mutation=true`, creates a temporary rootless Cairnline project, finds
 it through typed `projects.list`, updates and verifies it through
 `projects.update` / `projects.get`, deletes it, and verifies the deleted record
-is missing. Hecate does not yet route Projects reads, writes, or mirrors through
-the sidecar client.
+is missing. A setup smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-setup-smoke` requires
+`confirm_mutation=true`, creates a temporary rootless Cairnline project,
+creates/updates/lists/deletes a root and context source through typed
+`structuredContent`, then deletes and verifies removal of the temporary project.
+Hecate does not yet route Projects reads, writes, or mirrors through the sidecar
+client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -354,10 +354,12 @@ launch agents. Those remain explicit operator or orchestrator actions.
   exercises `assignments.next`, claim, `update_status`, launch-packet read, and
   complete against the standalone sidecar database only, plus an explicit
   confirmed sidecar write smoke that creates, lists, updates, gets, deletes, and
-  verifies deletion of a temporary rootless standalone Cairnline project. This is
-  contract/client-lifecycle/read-shape and standalone mutation evidence only:
-  Hecate does not yet route live Projects reads, writes, mirrors, or
-  write-authority switchpoints through the sidecar.
+  verifies deletion of a temporary rootless standalone Cairnline project, and an
+  explicit confirmed setup smoke that creates, updates, lists, deletes, and
+  verifies typed root and context-source metadata on a temporary standalone
+  Cairnline project. This is contract/client-lifecycle/read-shape and standalone
+  mutation evidence only: Hecate does not yet route live Projects reads, writes,
+  mirrors, or write-authority switchpoints through the sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,7 +47,7 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write smoke,
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup smoke,
 plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
@@ -481,8 +481,12 @@ sequenceDiagram
   completes it in the standalone Cairnline sidecar database.
   `sidecar-write-smoke` is the project-identity mutation smoke: after
   `confirm_mutation=true`, it creates, lists, updates, reads, deletes, and
-  verifies deletion of a temporary standalone Cairnline project. Live Projects
-  reads and writes still use Hecate-native stores.
+  verifies deletion of a temporary standalone Cairnline project.
+  `sidecar-setup-smoke` is the project setup metadata mutation smoke: after
+  `confirm_mutation=true`, it creates a temporary standalone Cairnline project,
+  creates/updates/lists/deletes a root and context source, then deletes and
+  verifies removal of the temporary project. Live Projects reads and writes
+  still use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2495,8 +2499,9 @@ local-only detail smoke that calls Cairnline's read-only `projects.get` tool,
 using either an explicit `project_id` or the first typed project from
 `projects.list`. The remaining sidecar smoke URLs cover coordination list
 tools, assignment context, launch packets, the explicitly confirmed standalone
-assignment lifecycle, and the explicitly confirmed temporary-project write
-smoke. None of these changes live route authority.
+assignment lifecycle, the explicitly confirmed temporary-project write smoke,
+and the explicitly confirmed temporary root/context-source setup smoke. None of
+these changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -2685,6 +2690,7 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_assignment_context_url": "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke",
     "cairnline_sidecar_launch_packet_url": "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke",
     "cairnline_sidecar_lifecycle_url": "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke",
+    "cairnline_sidecar_setup_url": "/hecate/v1/projects/cairnline/sidecar-setup-smoke",
     "cairnline_sidecar_write_url": "/hecate/v1/projects/cairnline/sidecar-write-smoke"
   }
 }
@@ -3426,6 +3432,94 @@ Example response, shortened:
     "updated_project": {
       "id": "proj_123",
       "name": "Hecate sidecar write smoke updated"
+    },
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-setup-smoke`
+
+Local-only standalone Cairnline MCP project setup write smoke. This endpoint
+mutates only the standalone Cairnline sidecar database after explicit
+confirmation. It does not mutate Hecate-native Projects stores and does not
+make Cairnline authoritative for live Projects routes.
+
+Without `confirm_mutation=true`, the endpoint returns
+`sidecar_setup_confirmation_required` and makes no sidecar tool calls. With
+confirmation, Hecate uses the same sidecar command, database, timeout, and
+Cairnline-specific MCP client cache as `sidecar-connect`.
+
+The smoke creates a temporary rootless project, finds it through typed
+`projects.list`, creates and updates a root through `roots.create` /
+`roots.update`, verifies it through typed `roots.list`, creates and updates a
+workspace-instruction context source through `context_sources.create` /
+`context_sources.update`, verifies it through typed `context_sources.list`,
+deletes the source and root, verifies both no longer appear in their typed
+lists, then deletes the temporary project and expects a final `projects.get` to
+return a tool-level missing/error result. If a step fails after the temporary
+project id is known, Hecate attempts a best-effort project cleanup delete and
+verifies that cleanup through another `projects.get`.
+
+Example request:
+
+```json
+{
+  "confirm_mutation": true,
+  "project_name": "Hecate sidecar setup smoke"
+}
+```
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_setup",
+  "data": {
+    "ready": true,
+    "status": "sidecar_setup_ready",
+    "detail": "Hecate created, updated, listed, deleted, and verified removal of temporary standalone Cairnline root and context-source setup metadata through the persistent sidecar client. Hecate-native Projects stores were not mutated.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "confirmed_mutation": true,
+    "project_name": "Hecate sidecar setup smoke",
+    "selected_project_id": "proj_123",
+    "root_id": "root_setup_smoke",
+    "context_source_id": "src_setup_smoke",
+    "cleanup_verified": true,
+    "steps": [
+      {
+        "name": "create_root",
+        "tool": "roots.create",
+        "read_only": false,
+        "status": "ready",
+        "structured_ready": true
+      },
+      {
+        "name": "get_after_project_delete",
+        "tool": "projects.get",
+        "read_only": true,
+        "status": "expected_missing",
+        "tool_is_error": true,
+        "tool_text": "project not found: proj_123"
+      }
+    ],
+    "created_root": {
+      "id": "root_setup_smoke",
+      "path": "/tmp/hecate-sidecar-setup-smoke",
+      "kind": "local",
+      "active": true
+    },
+    "updated_source": {
+      "id": "src_setup_smoke",
+      "kind": "workspace_instruction",
+      "title": "Setup smoke guidance updated",
+      "locator": "AGENTS.md",
+      "enabled": false
     },
     "warnings": []
   }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -32,6 +32,8 @@ func cairnlineSidecarFixtureMain(mode string) {
 		assignmentStatus: "queued",
 		projects:         make(map[string]ProjectCairnlineSidecarProjectItem),
 		deletedProjects:  make(map[string]struct{}),
+		roots:            make(map[string]map[string]ProjectCairnlineSidecarRootItem),
+		contextSources:   make(map[string]map[string]ProjectCairnlineSidecarSourceItem),
 	}
 	for {
 		line, err := in.ReadBytes('\n')
@@ -98,6 +100,8 @@ type cairnlineSidecarFixtureState struct {
 	projectSequence  int
 	projects         map[string]ProjectCairnlineSidecarProjectItem
 	deletedProjects  map[string]struct{}
+	roots            map[string]map[string]ProjectCairnlineSidecarRootItem
+	contextSources   map[string]map[string]ProjectCairnlineSidecarSourceItem
 }
 
 func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
@@ -424,6 +428,8 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		project := cairnlineSidecarFixtureProject(input.ID)
 		if stored, ok := state.projects[input.ID]; ok {
 			project = stored
+			project.Roots = cairnlineSidecarFixtureProjectRoots(state, input.ID)
+			project.ContextSources = cairnlineSidecarFixtureProjectSources(state, input.ID)
 		}
 		result := mcp.CallToolResult{Content: mcp.TextContent("Project " + input.ID + ": " + project.Name)}
 		if mode != "text-only" {
@@ -492,7 +498,217 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		}
 		delete(state.projects, input.ID)
 		state.deletedProjects[input.ID] = struct{}{}
+		delete(state.roots, input.ID)
+		delete(state.contextSources, input.ID)
 		return mcp.CallToolResult{Content: mcp.TextContent("Deleted project " + input.ID)}, nil
+	case "roots.list":
+		var input struct {
+			ProjectID string `json:"project_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid roots.list arguments")
+		}
+		roots := cairnlineSidecarFixtureProjectRoots(state, input.ProjectID)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Roots for %s (%d)", input.ProjectID, len(roots)), roots)
+	case "roots.create":
+		var input struct {
+			ProjectID string `json:"project_id"`
+			ID        string `json:"id"`
+			Path      string `json:"path"`
+			Kind      string `json:"kind"`
+			GitRemote string `json:"git_remote"`
+			GitBranch string `json:"git_branch"`
+			Active    *bool  `json:"active"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid roots.create arguments")
+		}
+		if input.ProjectID == "" || input.ID == "" || input.Path == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing root create arguments")
+		}
+		active := true
+		if input.Active != nil {
+			active = *input.Active
+		}
+		root := ProjectCairnlineSidecarRootItem{
+			ID:        input.ID,
+			Path:      input.Path,
+			Kind:      input.Kind,
+			GitRemote: input.GitRemote,
+			GitBranch: input.GitBranch,
+			Active:    active,
+		}
+		cairnlineSidecarFixtureEnsureRoots(state, input.ProjectID)[input.ID] = root
+		return mcp.CallToolResult{Content: mcp.TextContent("Created root " + input.ID), StructuredContent: mustRawJSON(root)}, nil
+	case "roots.update":
+		if mode == "root-update-tool-error" {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture roots.update failed"),
+				IsError: true,
+			}, nil
+		}
+		var input struct {
+			ProjectID string  `json:"project_id"`
+			RootID    string  `json:"root_id"`
+			Path      *string `json:"path"`
+			Kind      *string `json:"kind"`
+			GitRemote *string `json:"git_remote"`
+			GitBranch *string `json:"git_branch"`
+			Active    *bool   `json:"active"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid roots.update arguments")
+		}
+		roots := cairnlineSidecarFixtureEnsureRoots(state, input.ProjectID)
+		root, ok := roots[input.RootID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture root not found: " + input.RootID), IsError: true}, nil
+		}
+		if input.Path != nil {
+			root.Path = *input.Path
+		}
+		if input.Kind != nil {
+			root.Kind = *input.Kind
+		}
+		if input.GitRemote != nil {
+			root.GitRemote = *input.GitRemote
+		}
+		if input.GitBranch != nil {
+			root.GitBranch = *input.GitBranch
+		}
+		if input.Active != nil {
+			root.Active = *input.Active
+		}
+		roots[input.RootID] = root
+		return mcp.CallToolResult{Content: mcp.TextContent("Updated root " + input.RootID), StructuredContent: mustRawJSON(root)}, nil
+	case "roots.delete":
+		var input struct {
+			ProjectID string `json:"project_id"`
+			RootID    string `json:"root_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid roots.delete arguments")
+		}
+		roots := cairnlineSidecarFixtureEnsureRoots(state, input.ProjectID)
+		root, ok := roots[input.RootID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture root not found: " + input.RootID), IsError: true}, nil
+		}
+		delete(roots, input.RootID)
+		return mcp.CallToolResult{Content: mcp.TextContent("Deleted root " + input.RootID), StructuredContent: mustRawJSON(root)}, nil
+	case "context_sources.list":
+		var input struct {
+			ProjectID string `json:"project_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid context_sources.list arguments")
+		}
+		sources := cairnlineSidecarFixtureProjectSources(state, input.ProjectID)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Context sources for %s (%d)", input.ProjectID, len(sources)), sources)
+	case "context_sources.create":
+		var input struct {
+			ProjectID      string            `json:"project_id"`
+			ID             string            `json:"id"`
+			Kind           string            `json:"kind"`
+			Title          string            `json:"title"`
+			Locator        string            `json:"locator"`
+			Enabled        *bool             `json:"enabled"`
+			Format         string            `json:"format"`
+			Scope          string            `json:"scope"`
+			TrustLabel     string            `json:"trust_label"`
+			SourceCategory string            `json:"source_category"`
+			Metadata       map[string]string `json:"metadata"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid context_sources.create arguments")
+		}
+		if input.ProjectID == "" || input.ID == "" || input.Title == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing context source create arguments")
+		}
+		enabled := true
+		if input.Enabled != nil {
+			enabled = *input.Enabled
+		}
+		source := ProjectCairnlineSidecarSourceItem{
+			ID:             input.ID,
+			Kind:           input.Kind,
+			Title:          input.Title,
+			Locator:        input.Locator,
+			Enabled:        enabled,
+			Format:         input.Format,
+			Scope:          input.Scope,
+			TrustLabel:     input.TrustLabel,
+			SourceCategory: input.SourceCategory,
+			Metadata:       input.Metadata,
+		}
+		cairnlineSidecarFixtureEnsureSources(state, input.ProjectID)[input.ID] = source
+		return mcp.CallToolResult{Content: mcp.TextContent("Created context source " + input.ID), StructuredContent: mustRawJSON(source)}, nil
+	case "context_sources.update":
+		var input struct {
+			ProjectID      string            `json:"project_id"`
+			SourceID       string            `json:"source_id"`
+			Kind           *string           `json:"kind"`
+			Title          *string           `json:"title"`
+			Locator        *string           `json:"locator"`
+			Enabled        *bool             `json:"enabled"`
+			Format         *string           `json:"format"`
+			Scope          *string           `json:"scope"`
+			TrustLabel     *string           `json:"trust_label"`
+			SourceCategory *string           `json:"source_category"`
+			Metadata       map[string]string `json:"metadata"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid context_sources.update arguments")
+		}
+		sources := cairnlineSidecarFixtureEnsureSources(state, input.ProjectID)
+		source, ok := sources[input.SourceID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture context source not found: " + input.SourceID), IsError: true}, nil
+		}
+		if input.Kind != nil {
+			source.Kind = *input.Kind
+		}
+		if input.Title != nil {
+			source.Title = *input.Title
+		}
+		if input.Locator != nil {
+			source.Locator = *input.Locator
+		}
+		if input.Enabled != nil {
+			source.Enabled = *input.Enabled
+		}
+		if input.Format != nil {
+			source.Format = *input.Format
+		}
+		if input.Scope != nil {
+			source.Scope = *input.Scope
+		}
+		if input.TrustLabel != nil {
+			source.TrustLabel = *input.TrustLabel
+		}
+		if input.SourceCategory != nil {
+			source.SourceCategory = *input.SourceCategory
+		}
+		if input.Metadata != nil {
+			source.Metadata = input.Metadata
+		}
+		sources[input.SourceID] = source
+		return mcp.CallToolResult{Content: mcp.TextContent("Updated context source " + input.SourceID), StructuredContent: mustRawJSON(source)}, nil
+	case "context_sources.delete":
+		var input struct {
+			ProjectID string `json:"project_id"`
+			SourceID  string `json:"source_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid context_sources.delete arguments")
+		}
+		sources := cairnlineSidecarFixtureEnsureSources(state, input.ProjectID)
+		source, ok := sources[input.SourceID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture context source not found: " + input.SourceID), IsError: true}, nil
+		}
+		delete(sources, input.SourceID)
+		return mcp.CallToolResult{Content: mcp.TextContent("Deleted context source " + input.SourceID), StructuredContent: mustRawJSON(source)}, nil
 	default:
 		return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeMethodNotFound, params.Name)
 	}
@@ -522,9 +738,43 @@ func cairnlineSidecarFixtureProject(id string) ProjectCairnlineSidecarProjectIte
 func cairnlineSidecarFixtureProjects(state *cairnlineSidecarFixtureState) []ProjectCairnlineSidecarProjectItem {
 	projects := []ProjectCairnlineSidecarProjectItem{cairnlineSidecarFixtureProject("proj_fixture")}
 	for _, project := range state.projects {
+		project.Roots = cairnlineSidecarFixtureProjectRoots(state, project.ID)
+		project.ContextSources = cairnlineSidecarFixtureProjectSources(state, project.ID)
 		projects = append(projects, project)
 	}
 	return projects
+}
+
+func cairnlineSidecarFixtureEnsureRoots(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarRootItem {
+	if state.roots[projectID] == nil {
+		state.roots[projectID] = make(map[string]ProjectCairnlineSidecarRootItem)
+	}
+	return state.roots[projectID]
+}
+
+func cairnlineSidecarFixtureProjectRoots(state *cairnlineSidecarFixtureState, projectID string) []ProjectCairnlineSidecarRootItem {
+	rootsByID := state.roots[projectID]
+	roots := make([]ProjectCairnlineSidecarRootItem, 0, len(rootsByID))
+	for _, root := range rootsByID {
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+func cairnlineSidecarFixtureEnsureSources(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarSourceItem {
+	if state.contextSources[projectID] == nil {
+		state.contextSources[projectID] = make(map[string]ProjectCairnlineSidecarSourceItem)
+	}
+	return state.contextSources[projectID]
+}
+
+func cairnlineSidecarFixtureProjectSources(state *cairnlineSidecarFixtureState, projectID string) []ProjectCairnlineSidecarSourceItem {
+	sourcesByID := state.contextSources[projectID]
+	sources := make([]ProjectCairnlineSidecarSourceItem, 0, len(sourcesByID))
+	for _, source := range sourcesByID {
+		sources = append(sources, source)
+	}
+	return sources
 }
 
 func cairnlineSidecarFixtureListResult(mode, text string, structured any) (mcp.CallToolResult, *mcp.RPCError) {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
@@ -263,6 +263,20 @@ func (h *Handler) HandleProjectCairnlineSidecarWriteSmoke(w http.ResponseWriter,
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarWriteEnvelope{
 		Object: "project_cairnline_sidecar_write",
 		Data:   h.projectCairnlineSidecarWriteSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarSetupSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar setup smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarSetupRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarSetupEnvelope{
+		Object: "project_cairnline_sidecar_setup",
+		Data:   h.projectCairnlineSidecarSetupSmoke(r.Context(), req),
 	})
 }
 
@@ -1187,6 +1201,246 @@ func (h *Handler) projectCairnlineSidecarWriteSmoke(ctx context.Context, req Pro
 	return fail("sidecar_write_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary project.")
 }
 
+func (h *Handler) projectCairnlineSidecarSetupSmoke(ctx context.Context, req ProjectCairnlineSidecarSetupRequest) ProjectCairnlineSidecarSetupResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	projectName := strings.TrimSpace(req.ProjectName)
+	if projectName == "" {
+		projectName = "Hecate sidecar setup smoke " + time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+	response := ProjectCairnlineSidecarSetupResponse{
+		Ready:                 false,
+		Status:                "sidecar_setup_not_run",
+		Detail:                "Cairnline sidecar setup smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ConfirmedMutation:     req.ConfirmMutation,
+		ProjectName:           projectName,
+		RootID:                "root_setup_smoke",
+		ContextSourceID:       "src_setup_smoke",
+	}
+	if h == nil {
+		response.Status = "sidecar_setup_failed"
+		response.Detail = "Cairnline sidecar setup smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this setup smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+	if !req.ConfirmMutation {
+		response.Status = "sidecar_setup_confirmation_required"
+		response.Detail = "Set confirm_mutation=true to let Hecate create, update, verify, delete, and re-check temporary roots and context sources in the standalone Cairnline sidecar. Hecate-native Projects stores are not mutated."
+		return response
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := ""
+	cleanup := func() {
+		if projectID == "" || response.CleanupVerified {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+		defer cleanupCancel()
+		cleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_delete_project", "projects.delete", false, map[string]string{"id": projectID})
+		response.Steps = append(response.Steps, cleanupStep)
+		if cleanupStep.Status == "ready" {
+			verifyCleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+			if verifyCleanupStep.Status == "tool_failed" {
+				verifyCleanupStep.Status = "expected_missing"
+				response.CleanupVerified = true
+				response.Warnings = append(response.Warnings, "Hecate deleted and verified removal of the temporary standalone Cairnline setup project after the setup smoke failed; inspect the reported steps before retrying.")
+			} else {
+				response.Warnings = append(response.Warnings, "Hecate deleted the temporary standalone Cairnline setup project after the setup smoke failed, but removal could not be verified; inspect the reported steps before retrying.")
+			}
+			response.Steps = append(response.Steps, verifyCleanupStep)
+			return
+		}
+		response.Warnings = append(response.Warnings, "Hecate tried to delete the temporary standalone Cairnline setup project after the setup smoke failed, but cleanup did not succeed; inspect the standalone Cairnline sidecar before retrying.")
+	}
+	fail := func(status, detail string) ProjectCairnlineSidecarSetupResponse {
+		response.Status = status
+		response.Detail = detail
+		cleanup()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	appendStep := func(step ProjectCairnlineSidecarWriteStep) bool {
+		response.Steps = append(response.Steps, step)
+		if step.Status == "tool_failed" {
+			response.Status = "sidecar_setup_tool_failed"
+			response.Detail = "Cairnline sidecar " + step.Tool + " returned a tool-level error. Review the step output before retrying."
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		if step.Status == "failed" {
+			response.Status = "sidecar_setup_failed"
+			response.Detail = firstNonEmpty(step.ToolText, "Cairnline sidecar "+step.Tool+" failed.")
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		return true
+	}
+
+	createProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_project", "projects.create", false, map[string]string{
+		"name":        projectName,
+		"description": "Temporary Hecate sidecar setup smoke project. It should be deleted by the same diagnostic run.",
+	})
+	if !appendStep(createProject) {
+		return response
+	}
+	listProjects := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_after_project_create", "projects.list", true, map[string]string{})
+	if !appendStep(listProjects) {
+		return response
+	}
+	project, ok := projectCairnlineSidecarProjectByName(listProjects.StructuredProjects, projectName)
+	if !ok || strings.TrimSpace(project.ID) == "" {
+		return fail("sidecar_setup_created_project_not_listed", "Cairnline sidecar projects.create succeeded, but projects.list did not return the temporary setup project by name.")
+	}
+	projectID = strings.TrimSpace(project.ID)
+	response.SelectedProjectID = projectID
+
+	createRoot := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_root", "roots.create", false, map[string]any{
+		"project_id": projectID,
+		"id":         response.RootID,
+		"path":       "/tmp/hecate-sidecar-setup-smoke",
+		"kind":       "local",
+		"active":     true,
+	})
+	if !appendStep(createRoot) {
+		return response
+	}
+	if createRoot.StructuredRoot.ID != response.RootID || createRoot.StructuredRoot.Path != "/tmp/hecate-sidecar-setup-smoke" {
+		return fail("sidecar_setup_root_create_verification_failed", "Cairnline sidecar roots.create did not return the expected root id and path.")
+	}
+	response.CreatedRoot = createRoot.StructuredRoot
+
+	updateRoot := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "update_root", "roots.update", false, map[string]any{
+		"project_id": projectID,
+		"root_id":    response.RootID,
+		"path":       "/tmp/hecate-sidecar-setup-smoke-updated",
+		"kind":       "git_worktree",
+		"git_branch": "setup-smoke",
+		"active":     false,
+	})
+	if !appendStep(updateRoot) {
+		return response
+	}
+	if updateRoot.StructuredRoot.ID != response.RootID || updateRoot.StructuredRoot.Path != "/tmp/hecate-sidecar-setup-smoke-updated" || updateRoot.StructuredRoot.Active {
+		return fail("sidecar_setup_root_update_verification_failed", "Cairnline sidecar roots.update did not return the expected inactive updated root.")
+	}
+	response.UpdatedRoot = updateRoot.StructuredRoot
+
+	listRoots := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_roots_after_update", "roots.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listRoots) {
+		return response
+	}
+	if root, ok := projectCairnlineSidecarRootByID(listRoots.StructuredRoots, response.RootID); !ok || root.Path != "/tmp/hecate-sidecar-setup-smoke-updated" || root.Active {
+		return fail("sidecar_setup_root_list_verification_failed", "Cairnline sidecar roots.list did not return the updated inactive root.")
+	}
+
+	createSource := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_context_source", "context_sources.create", false, map[string]any{
+		"project_id":      projectID,
+		"id":              response.ContextSourceID,
+		"kind":            "workspace_instruction",
+		"title":           "Setup smoke guidance",
+		"locator":         "AGENTS.md",
+		"enabled":         true,
+		"format":          "agents_md",
+		"scope":           "workspace",
+		"trust_label":     "workspace_guidance",
+		"source_category": "instructions",
+		"metadata":        map[string]string{"root_id": response.RootID},
+	})
+	if !appendStep(createSource) {
+		return response
+	}
+	if createSource.StructuredSource.ID != response.ContextSourceID || createSource.StructuredSource.Title != "Setup smoke guidance" || !createSource.StructuredSource.Enabled {
+		return fail("sidecar_setup_source_create_verification_failed", "Cairnline sidecar context_sources.create did not return the expected enabled source.")
+	}
+	response.CreatedSource = createSource.StructuredSource
+
+	updateSource := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "update_context_source", "context_sources.update", false, map[string]any{
+		"project_id": projectID,
+		"source_id":  response.ContextSourceID,
+		"title":      "Setup smoke guidance updated",
+		"enabled":    false,
+		"metadata":   map[string]string{"root_id": response.RootID, "updated": "true"},
+	})
+	if !appendStep(updateSource) {
+		return response
+	}
+	if updateSource.StructuredSource.ID != response.ContextSourceID || updateSource.StructuredSource.Title != "Setup smoke guidance updated" || updateSource.StructuredSource.Enabled {
+		return fail("sidecar_setup_source_update_verification_failed", "Cairnline sidecar context_sources.update did not return the expected disabled updated source.")
+	}
+	response.UpdatedSource = updateSource.StructuredSource
+
+	listSources := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_sources_after_update", "context_sources.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listSources) {
+		return response
+	}
+	if source, ok := projectCairnlineSidecarSourceByID(listSources.StructuredSources, response.ContextSourceID); !ok || source.Title != "Setup smoke guidance updated" || source.Enabled {
+		return fail("sidecar_setup_source_list_verification_failed", "Cairnline sidecar context_sources.list did not return the updated disabled source.")
+	}
+
+	deleteSource := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_context_source", "context_sources.delete", false, map[string]string{"project_id": projectID, "source_id": response.ContextSourceID})
+	if !appendStep(deleteSource) {
+		return response
+	}
+	listSourcesAfterDelete := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_sources_after_delete", "context_sources.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listSourcesAfterDelete) {
+		return response
+	}
+	if _, ok := projectCairnlineSidecarSourceByID(listSourcesAfterDelete.StructuredSources, response.ContextSourceID); ok {
+		return fail("sidecar_setup_source_delete_verification_failed", "Cairnline sidecar context_sources.delete succeeded, but context_sources.list still returned the temporary source.")
+	}
+
+	deleteRoot := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_root", "roots.delete", false, map[string]string{"project_id": projectID, "root_id": response.RootID})
+	if !appendStep(deleteRoot) {
+		return response
+	}
+	listRootsAfterDelete := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_roots_after_delete", "roots.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listRootsAfterDelete) {
+		return response
+	}
+	if _, ok := projectCairnlineSidecarRootByID(listRootsAfterDelete.StructuredRoots, response.RootID); ok {
+		return fail("sidecar_setup_root_delete_verification_failed", "Cairnline sidecar roots.delete succeeded, but roots.list still returned the temporary root.")
+	}
+
+	deleteProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_project", "projects.delete", false, map[string]string{"id": projectID})
+	if !appendStep(deleteProject) {
+		return response
+	}
+	verifyDelete := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+	if verifyDelete.Status == "tool_failed" {
+		verifyDelete.Status = "expected_missing"
+		response.Steps = append(response.Steps, verifyDelete)
+		response.CleanupVerified = true
+		response.Ready = true
+		response.Status = "sidecar_setup_ready"
+		response.Detail = "Hecate created, updated, listed, deleted, and verified removal of temporary standalone Cairnline root and context-source setup metadata through the persistent sidecar client. Hecate-native Projects stores were not mutated."
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	if !appendStep(verifyDelete) {
+		return response
+	}
+	return fail("sidecar_setup_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary setup project.")
+}
+
 func projectCairnlineSidecarLifecycleShouldReleaseAfterFailure(steps []ProjectCairnlineSidecarLifecycleStep) bool {
 	claimed := false
 	for _, step := range steps {
@@ -1557,6 +1811,68 @@ func (h *Handler) callProjectCairnlineSidecarWriteTool(ctx context.Context, cfg 
 			step.ToolText = "Cairnline sidecar projects.get did not return structuredContent; the write smoke needs typed project detail to verify the temporary project."
 			return step
 		}
+	case "roots.list":
+		roots, structuredReady, structuredErr := projectCairnlineSidecarStructuredRoots(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredRoots = roots
+		step.StructuredRootCount = len(roots)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar roots.list returned structuredContent that Hecate could not parse as a root list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar roots.list did not return structuredContent; the setup smoke needs typed roots to verify setup mutations."
+			return step
+		}
+	case "roots.create", "roots.update", "roots.delete":
+		root, structuredReady, structuredErr := projectCairnlineSidecarStructuredRoot(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredRoot = root
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " returned structuredContent that Hecate could not parse as a root: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " did not return structuredContent; the setup smoke needs typed root detail to verify setup mutations."
+			return step
+		}
+	case "context_sources.list":
+		sources, structuredReady, structuredErr := projectCairnlineSidecarStructuredSources(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredSources = sources
+		step.StructuredSourceCount = len(sources)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar context_sources.list returned structuredContent that Hecate could not parse as a context source list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar context_sources.list did not return structuredContent; the setup smoke needs typed context sources to verify setup mutations."
+			return step
+		}
+	case "context_sources.create", "context_sources.update", "context_sources.delete":
+		source, structuredReady, structuredErr := projectCairnlineSidecarStructuredSource(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredSource = source
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " returned structuredContent that Hecate could not parse as a context source: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " did not return structuredContent; the setup smoke needs typed context source detail to verify setup mutations."
+			return step
+		}
 	}
 	step.Status = "ready"
 	return step
@@ -1626,6 +1942,26 @@ func projectCairnlineSidecarProjectByName(projects []ProjectCairnlineSidecarProj
 	return ProjectCairnlineSidecarProjectItem{}, false
 }
 
+func projectCairnlineSidecarRootByID(roots []ProjectCairnlineSidecarRootItem, id string) (ProjectCairnlineSidecarRootItem, bool) {
+	id = strings.TrimSpace(id)
+	for _, root := range roots {
+		if strings.TrimSpace(root.ID) == id {
+			return root, true
+		}
+	}
+	return ProjectCairnlineSidecarRootItem{}, false
+}
+
+func projectCairnlineSidecarSourceByID(sources []ProjectCairnlineSidecarSourceItem, id string) (ProjectCairnlineSidecarSourceItem, bool) {
+	id = strings.TrimSpace(id)
+	for _, source := range sources {
+		if strings.TrimSpace(source.ID) == id {
+			return source, true
+		}
+	}
+	return ProjectCairnlineSidecarSourceItem{}, false
+}
+
 func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairnlineSidecarProjectItem, bool, error) {
 	if len(raw) == 0 {
 		return ProjectCairnlineSidecarProjectItem{}, false, nil
@@ -1639,6 +1975,78 @@ func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairn
 		return ProjectCairnlineSidecarProjectItem{}, false, err
 	}
 	return project, true, nil
+}
+
+func projectCairnlineSidecarStructuredRoots(raw json.RawMessage) ([]ProjectCairnlineSidecarRootItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarRootItem{}, true, nil
+	}
+	var roots []ProjectCairnlineSidecarRootItem
+	if err := json.Unmarshal(trimmed, &roots); err != nil {
+		return nil, false, err
+	}
+	if roots == nil {
+		roots = []ProjectCairnlineSidecarRootItem{}
+	}
+	return roots, true, nil
+}
+
+func projectCairnlineSidecarStructuredRoot(raw json.RawMessage) (ProjectCairnlineSidecarRootItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarRootItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarRootItem{}, false, nil
+	}
+	var root ProjectCairnlineSidecarRootItem
+	if err := json.Unmarshal(trimmed, &root); err != nil {
+		return ProjectCairnlineSidecarRootItem{}, false, err
+	}
+	return root, true, nil
+}
+
+func projectCairnlineSidecarStructuredSources(raw json.RawMessage) ([]ProjectCairnlineSidecarSourceItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarSourceItem{}, true, nil
+	}
+	var sources []ProjectCairnlineSidecarSourceItem
+	if err := json.Unmarshal(trimmed, &sources); err != nil {
+		return nil, false, err
+	}
+	if sources == nil {
+		sources = []ProjectCairnlineSidecarSourceItem{}
+	}
+	return sources, true, nil
+}
+
+func projectCairnlineSidecarStructuredSource(raw json.RawMessage) (ProjectCairnlineSidecarSourceItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarSourceItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarSourceItem{}, false, nil
+	}
+	var source ProjectCairnlineSidecarSourceItem
+	if err := json.Unmarshal(trimmed, &source); err != nil {
+		return ProjectCairnlineSidecarSourceItem{}, false, err
+	}
+	return source, true, nil
 }
 
 func projectCairnlineSidecarStructuredAssignments(raw json.RawMessage) ([]ProjectCairnlineSidecarAssignmentItem, bool, error) {
@@ -1903,6 +2311,15 @@ func (r *ProjectCairnlineSidecarLifecycleResponse) setSidecarCacheStats(stats mc
 }
 
 func (r *ProjectCairnlineSidecarWriteResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarSetupResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -1011,6 +1011,81 @@ func TestProjectCairnlineSidecarWriteSmoke_CleansUpAfterUpdateFailure(t *testing
 	}
 }
 
+func TestProjectCairnlineSidecarSetupSmoke_RequiresConfirmation(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarSetupSmoke(t.Context(), ProjectCairnlineSidecarSetupRequest{ProjectName: "Fixture setup smoke"})
+	if got.Ready || got.Status != "sidecar_setup_confirmation_required" || got.ConfirmedMutation {
+		t.Fatalf("setup smoke = %+v, want confirmation-required without mutation", got)
+	}
+	if len(got.Steps) != 0 || got.ClientCacheEntries != 0 {
+		t.Fatalf("steps/cache = %d/%d, want no sidecar calls before confirmation", len(got.Steps), got.ClientCacheEntries)
+	}
+}
+
+func TestProjectCairnlineSidecarSetupSmoke_CreatesUpdatesDeletesSetupMetadata(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarSetupSmoke(t.Context(), ProjectCairnlineSidecarSetupRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture setup smoke",
+	})
+	if !got.Ready || got.Status != "sidecar_setup_ready" || !got.CleanupVerified {
+		t.Fatalf("setup smoke = %+v, want ready with verified cleanup", got)
+	}
+	if got.SelectedProjectID == "" || got.CreatedRoot.ID != "root_setup_smoke" || got.UpdatedRoot.Active || got.CreatedSource.ID != "src_setup_smoke" || got.UpdatedSource.Enabled {
+		t.Fatalf("setup records = project:%q roots:%+v/%+v sources:%+v/%+v, want temporary setup metadata", got.SelectedProjectID, got.CreatedRoot, got.UpdatedRoot, got.CreatedSource, got.UpdatedSource)
+	}
+	if len(got.Steps) != 14 {
+		t.Fatalf("steps = %+v, want project/root/source create-update-list-delete flow", got.Steps)
+	}
+	if got.Steps[2].Tool != "roots.create" || got.Steps[5].Tool != "context_sources.create" || got.Steps[10].Tool != "roots.delete" || got.Steps[13].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want setup smoke order and missing-after-project-delete verification", got.Steps)
+	}
+}
+
+func TestProjectCairnlineSidecarSetupSmoke_CleansUpAfterRootUpdateFailure(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "root-update-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarSetupSmoke(t.Context(), ProjectCairnlineSidecarSetupRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture setup smoke cleanup",
+	})
+	if got.Ready || got.Status != "sidecar_setup_tool_failed" || !got.CleanupVerified {
+		t.Fatalf("setup smoke = %+v, want root update tool failure with verified project cleanup", got)
+	}
+	if len(got.Steps) != 6 || got.Steps[3].Tool != "roots.update" || !got.Steps[3].ToolIsError || got.Steps[4].Name != "cleanup_delete_project" || got.Steps[5].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want root update failure followed by project cleanup delete and verification", got.Steps)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "deleted and verified removal") {
+		t.Fatalf("warnings = %+v, want verified cleanup warning", got.Warnings)
+	}
+}
+
 func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureAfterRunningCannotRelease(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -14,6 +14,7 @@ const projectCoordinationBackendSidecarCoordinationURL = "/hecate/v1/projects/ca
 const projectCoordinationBackendSidecarAssignmentContextURL = "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"
 const projectCoordinationBackendSidecarLaunchPacketURL = "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"
 const projectCoordinationBackendSidecarLifecycleURL = "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"
+const projectCoordinationBackendSidecarSetupURL = "/hecate/v1/projects/cairnline/sidecar-setup-smoke"
 const projectCoordinationBackendSidecarWriteURL = "/hecate/v1/projects/cairnline/sidecar-write-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
@@ -312,6 +313,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarAssignmentContextURL: projectCoordinationBackendSidecarAssignmentContextURL,
 		CairnlineSidecarLaunchPacketURL:      projectCoordinationBackendSidecarLaunchPacketURL,
 		CairnlineSidecarLifecycleURL:         projectCoordinationBackendSidecarLifecycleURL,
+		CairnlineSidecarSetupURL:             projectCoordinationBackendSidecarSetupURL,
 		CairnlineSidecarWriteURL:             projectCoordinationBackendSidecarWriteURL,
 		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -51,6 +51,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarLifecycleURL != projectCoordinationBackendSidecarLifecycleURL {
 		t.Fatalf("sidecar lifecycle URL = %q, want %q", status.CairnlineSidecarLifecycleURL, projectCoordinationBackendSidecarLifecycleURL)
 	}
+	if status.CairnlineSidecarSetupURL != projectCoordinationBackendSidecarSetupURL {
+		t.Fatalf("sidecar setup URL = %q, want %q", status.CairnlineSidecarSetupURL, projectCoordinationBackendSidecarSetupURL)
+	}
 	if status.CairnlineSidecarWriteURL != projectCoordinationBackendSidecarWriteURL {
 		t.Fatalf("sidecar write URL = %q, want %q", status.CairnlineSidecarWriteURL, projectCoordinationBackendSidecarWriteURL)
 	}
@@ -121,7 +124,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.Status != "cairnline_connector_not_ready" || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
 		t.Fatalf("status = %+v, want sidecar connector mode to block live Cairnline routing", status)
 	}
-	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
+	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write/setup diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
 		t.Fatalf("connector detail = %q, want full sidecar diagnostic surface", status.CairnlineConnectorDetail)
 	}
 	if handler.projectReadRoutesUseCairnlineReadModel() || handler.projectIdentityWritesUseCairnlineAuthority() || handler.projectMemoryWritesUseCairnlineAuthority() || handler.projectAssignmentWritesUseCairnlineAuthority() {
@@ -151,6 +154,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.CairnlineSidecarLifecycleURL != projectCoordinationBackendSidecarLifecycleURL {
 		t.Fatalf("sidecar lifecycle URL = %q, want %q", status.CairnlineSidecarLifecycleURL, projectCoordinationBackendSidecarLifecycleURL)
 	}
+	if status.CairnlineSidecarSetupURL != projectCoordinationBackendSidecarSetupURL {
+		t.Fatalf("sidecar setup URL = %q, want %q", status.CairnlineSidecarSetupURL, projectCoordinationBackendSidecarSetupURL)
+	}
 	if status.CairnlineSidecarWriteURL != projectCoordinationBackendSidecarWriteURL {
 		t.Fatalf("sidecar write URL = %q, want %q", status.CairnlineSidecarWriteURL, projectCoordinationBackendSidecarWriteURL)
 	}
@@ -167,7 +173,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 		t.Fatalf("project-identity switchpoint = %+v, want Hecate authority while sidecar routing is not live", point)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
+	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
 		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
 	}
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -583,6 +583,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarAssignmentContextURL string                                       `json:"cairnline_sidecar_assignment_context_url,omitempty"`
 	CairnlineSidecarLaunchPacketURL      string                                       `json:"cairnline_sidecar_launch_packet_url,omitempty"`
 	CairnlineSidecarLifecycleURL         string                                       `json:"cairnline_sidecar_lifecycle_url,omitempty"`
+	CairnlineSidecarSetupURL             string                                       `json:"cairnline_sidecar_setup_url,omitempty"`
 	CairnlineSidecarWriteURL             string                                       `json:"cairnline_sidecar_write_url,omitempty"`
 	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
@@ -1715,6 +1716,11 @@ type ProjectCairnlineSidecarWriteEnvelope struct {
 	Data   ProjectCairnlineSidecarWriteResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarSetupEnvelope struct {
+	Object string                               `json:"object"`
+	Data   ProjectCairnlineSidecarSetupResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
@@ -1746,6 +1752,11 @@ type ProjectCairnlineSidecarLifecycleRequest struct {
 }
 
 type ProjectCairnlineSidecarWriteRequest struct {
+	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
+	ProjectName     string `json:"project_name,omitempty"`
+}
+
+type ProjectCairnlineSidecarSetupRequest struct {
 	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
 	ProjectName     string `json:"project_name,omitempty"`
 }
@@ -2043,6 +2054,33 @@ type ProjectCairnlineSidecarWriteResponse struct {
 	Warnings              []string                           `json:"warnings,omitempty"`
 }
 
+type ProjectCairnlineSidecarSetupResponse struct {
+	Ready                 bool                               `json:"ready"`
+	Status                string                             `json:"status"`
+	Detail                string                             `json:"detail"`
+	Command               string                             `json:"command"`
+	Args                  []string                           `json:"args,omitempty"`
+	DatabasePath          string                             `json:"database_path,omitempty"`
+	ProbeTimeoutMS        int64                              `json:"probe_timeout_ms"`
+	PersistentClient      bool                               `json:"persistent_client,omitempty"`
+	ClientCacheConfigured bool                               `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries    int                                `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse      int                                `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle       int                                `json:"client_cache_idle,omitempty"`
+	ConfirmedMutation     bool                               `json:"confirmed_mutation"`
+	ProjectName           string                             `json:"project_name,omitempty"`
+	SelectedProjectID     string                             `json:"selected_project_id,omitempty"`
+	RootID                string                             `json:"root_id,omitempty"`
+	ContextSourceID       string                             `json:"context_source_id,omitempty"`
+	Steps                 []ProjectCairnlineSidecarWriteStep `json:"steps,omitempty"`
+	CreatedRoot           ProjectCairnlineSidecarRootItem    `json:"created_root,omitempty"`
+	UpdatedRoot           ProjectCairnlineSidecarRootItem    `json:"updated_root,omitempty"`
+	CreatedSource         ProjectCairnlineSidecarSourceItem  `json:"created_source,omitempty"`
+	UpdatedSource         ProjectCairnlineSidecarSourceItem  `json:"updated_source,omitempty"`
+	CleanupVerified       bool                               `json:"cleanup_verified"`
+	Warnings              []string                           `json:"warnings,omitempty"`
+}
+
 type ProjectCairnlineSidecarWriteStep struct {
 	Name                   string                               `json:"name"`
 	Tool                   string                               `json:"tool"`
@@ -2056,6 +2094,12 @@ type ProjectCairnlineSidecarWriteStep struct {
 	StructuredProject      ProjectCairnlineSidecarProjectItem   `json:"structured_project,omitempty"`
 	StructuredProjects     []ProjectCairnlineSidecarProjectItem `json:"structured_projects,omitempty"`
 	StructuredProjectCount int                                  `json:"structured_project_count"`
+	StructuredRoot         ProjectCairnlineSidecarRootItem      `json:"structured_root,omitempty"`
+	StructuredRoots        []ProjectCairnlineSidecarRootItem    `json:"structured_roots,omitempty"`
+	StructuredRootCount    int                                  `json:"structured_root_count"`
+	StructuredSource       ProjectCairnlineSidecarSourceItem    `json:"structured_source,omitempty"`
+	StructuredSources      []ProjectCairnlineSidecarSourceItem  `json:"structured_sources,omitempty"`
+	StructuredSourceCount  int                                  `json:"structured_source_count"`
 	StructuredParseError   string                               `json:"structured_parse_error,omitempty"`
 }
 

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -31,6 +31,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-setup-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-write-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -91,6 +91,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke", handler.HandleProjectCairnlineSidecarLifecycleSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-setup-smoke", handler.HandleProjectCairnlineSidecarSetupSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-write-smoke", handler.HandleProjectCairnlineSidecarWriteSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)


### PR DESCRIPTION
## Summary
- add a local-only confirmed Cairnline sidecar setup smoke endpoint for temporary project setup metadata
- exercise `roots.create/update/list/delete` and `context_sources.create/update/list/delete` through the persistent sidecar MCP client
- surface the setup smoke URL from backend status and document the standalone-only mutation boundary

## Boundary
- requires `confirm_mutation=true`
- mutates only the standalone Cairnline sidecar database
- creates and deletes a temporary rootless project as the cleanup boundary
- does not mutate Hecate-native Projects stores
- does not switch live Projects read/write authority to Cairnline

## Tests
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecar(Probe|Connect|Read|Detail|Coordination|AssignmentContext|LaunchPacket|Lifecycle|Write|Setup)|TestProjectCoordinationBackendStatus|TestRemoteRuntime' -count=1`
- `git diff --check`
- `just docs-format-check`
- `GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client`
- `GOCACHE="$PWD/.gocache" go test ./...`
- `GOCACHE="$PWD/.gocache" go vet ./...`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
- `just agent-docs-check`
- `just docs-env-check`
