### PR TITLE
Add Cairnline sidecar work smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -156,6 +156,12 @@ is missing. A setup smoke at
 `confirm_mutation=true`, creates a temporary rootless Cairnline project,
 creates/updates/lists/deletes a root and context source through typed
 `structuredContent`, then deletes and verifies removal of the temporary project.
+A work smoke at `POST /hecate/v1/projects/cairnline/sidecar-work-smoke`
+requires `confirm_mutation=true`, creates a temporary rootless Cairnline
+project, creates a role, work item, and queued `mcp_pull` assignment through
+typed `structuredContent`, verifies `assignments.context` and
+`assignments.launch_packet` for that assignment, then deletes and verifies
+removal of the temporary project.
 Hecate does not yet route Projects reads, writes, or mirrors through the sidecar
 client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -357,9 +357,12 @@ launch agents. Those remain explicit operator or orchestrator actions.
   verifies deletion of a temporary rootless standalone Cairnline project, and an
   explicit confirmed setup smoke that creates, updates, lists, deletes, and
   verifies typed root and context-source metadata on a temporary standalone
-  Cairnline project. This is contract/client-lifecycle/read-shape and standalone
-  mutation evidence only: Hecate does not yet route live Projects reads, writes,
-  mirrors, or write-authority switchpoints through the sidecar.
+  Cairnline project, plus an explicit confirmed work smoke that creates typed
+  role, work-item, assignment, assignment-context, and launch-packet metadata on
+  a temporary standalone Cairnline project. This is
+  contract/client-lifecycle/read-shape and standalone mutation evidence only:
+  Hecate does not yet route live Projects reads, writes, mirrors, or
+  write-authority switchpoints through the sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -383,7 +383,13 @@ warnings for the same MCP-pull path. The explicit mutation smoke at
 `confirm_mutation=true` and then proves `assignments.next`, claim,
 `update_status`, launch packet read, and complete against the standalone
 Cairnline sidecar database only; Hecate-native Projects stores remain
-authoritative and are not mutated by that smoke.
+authoritative and are not mutated by that smoke. Operators can also run
+`POST /hecate/v1/projects/cairnline/sidecar-write-smoke`,
+`POST /hecate/v1/projects/cairnline/sidecar-setup-smoke`, and
+`POST /hecate/v1/projects/cairnline/sidecar-work-smoke`, each with
+`confirm_mutation=true`, to prove temporary standalone Cairnline project
+identity, setup metadata, and role/work/assignment/context/launch-packet writes
+respectively. Those smokes delete their temporary project and verify removal.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project list/detail, setup readiness,
@@ -435,8 +441,11 @@ Cairnline-specific MCP client cache. `sidecar-read-smoke`,
 `sidecar-assignment-context-smoke`, and `sidecar-launch-packet-smoke` use that
 cached client to call read-only Cairnline MCP tools and return diagnostic
 evidence. `sidecar-lifecycle-smoke` is opt-in mutation evidence for the
-standalone sidecar assignment lifecycle. None of these routes operator project
-reads or writes through the sidecar backend.
+standalone sidecar assignment lifecycle. `sidecar-write-smoke`,
+`sidecar-setup-smoke`, and `sidecar-work-smoke` are opt-in mutation evidence for
+standalone sidecar project identity, project setup metadata, and project work
+coordination records. None of these routes operator project reads or writes
+through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -47,8 +47,10 @@ liveness probe and every other path requires trusted trusted proxy headers:
 context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added to
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
-workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup smoke,
-plugin-registry management, agent-adapter authenticate, and local provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
+workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar
+probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work
+smoke, plugin-registry management, agent-adapter authenticate, and local
+provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
 classified for remote mode, and route coverage tests fail when a new registered
 route is not marked remote-safe or local-only.
 
@@ -485,8 +487,13 @@ sequenceDiagram
   `sidecar-setup-smoke` is the project setup metadata mutation smoke: after
   `confirm_mutation=true`, it creates a temporary standalone Cairnline project,
   creates/updates/lists/deletes a root and context source, then deletes and
-  verifies removal of the temporary project. Live Projects reads and writes
-  still use Hecate-native stores.
+  verifies removal of the temporary project. `sidecar-work-smoke` is the
+  project work coordination mutation smoke: after `confirm_mutation=true`, it
+  creates a temporary standalone Cairnline project, role, work item, and queued
+  MCP-pull assignment, verifies `assignments.context` and
+  `assignments.launch_packet` for that assignment, then deletes and verifies
+  removal of the temporary project. Live Projects reads and writes still use
+  Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2500,8 +2507,9 @@ using either an explicit `project_id` or the first typed project from
 `projects.list`. The remaining sidecar smoke URLs cover coordination list
 tools, assignment context, launch packets, the explicitly confirmed standalone
 assignment lifecycle, the explicitly confirmed temporary-project write smoke,
-and the explicitly confirmed temporary root/context-source setup smoke. None of
-these changes live route authority.
+the explicitly confirmed temporary root/context-source setup smoke, and the
+explicitly confirmed temporary role/work/assignment/context/launch-packet work
+smoke. None of these changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -2691,7 +2699,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_launch_packet_url": "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke",
     "cairnline_sidecar_lifecycle_url": "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke",
     "cairnline_sidecar_setup_url": "/hecate/v1/projects/cairnline/sidecar-setup-smoke",
-    "cairnline_sidecar_write_url": "/hecate/v1/projects/cairnline/sidecar-write-smoke"
+    "cairnline_sidecar_write_url": "/hecate/v1/projects/cairnline/sidecar-write-smoke",
+    "cairnline_sidecar_work_url": "/hecate/v1/projects/cairnline/sidecar-work-smoke"
   }
 }
 ```
@@ -3520,6 +3529,127 @@ Example response, shortened:
       "title": "Setup smoke guidance updated",
       "locator": "AGENTS.md",
       "enabled": false
+    },
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-work-smoke`
+
+Local-only standalone Cairnline MCP project work coordination smoke. This
+endpoint mutates only the standalone Cairnline sidecar database after explicit
+confirmation. It does not mutate Hecate-native Projects stores, does not start
+a Hecate Task, does not launch an External Agent, and does not make Cairnline
+authoritative for live Projects routes.
+
+Without `confirm_mutation=true`, the endpoint returns
+`sidecar_work_confirmation_required` and makes no sidecar tool calls. With
+confirmation, Hecate uses the same sidecar command, database, timeout, and
+Cairnline-specific MCP client cache as `sidecar-connect`.
+
+The smoke creates a temporary rootless project, finds it through typed
+`projects.list`, creates a project role through `roles.create`, verifies it
+through typed `roles.list`, creates a work item through `work_items.create`,
+verifies it through typed `work_items.list`, creates a queued `mcp_pull`
+assignment through `assignments.create`, verifies it through typed
+`assignments.list`, reads typed `assignments.context`, reads typed
+`assignments.launch_packet`, then deletes the temporary project and expects a
+final `projects.get` to return a tool-level missing/error result. If a step
+fails after the temporary project id is known, Hecate attempts a best-effort
+project cleanup delete and verifies that cleanup through another `projects.get`.
+
+Example request:
+
+```json
+{
+  "confirm_mutation": true,
+  "project_name": "Hecate sidecar work smoke"
+}
+```
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_work",
+  "data": {
+    "ready": true,
+    "status": "sidecar_work_ready",
+    "detail": "Hecate created and verified temporary standalone Cairnline role, work item, assignment, assignment context, and launch packet metadata through the persistent sidecar client, then deleted the temporary project. Hecate-native Projects stores were not mutated.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "confirmed_mutation": true,
+    "project_name": "Hecate sidecar work smoke",
+    "selected_project_id": "proj_123",
+    "role_id": "role_123",
+    "work_item_id": "work_123",
+    "assignment_id": "asg_123",
+    "cleanup_verified": true,
+    "context_ids": {
+      "assignment_id": "asg_123",
+      "project_id": "proj_123",
+      "work_item_id": "work_123",
+      "role_id": "role_123"
+    },
+    "launch_packet_ids": {
+      "launch_packet_id": "launch_123",
+      "kind": "assignment_launch_packet",
+      "project_id": "proj_123",
+      "assignment_id": "asg_123",
+      "work_item_id": "work_123",
+      "role_id": "role_123"
+    },
+    "steps": [
+      {
+        "name": "create_role",
+        "tool": "roles.create",
+        "read_only": false,
+        "status": "ready"
+      },
+      {
+        "name": "read_launch_packet",
+        "tool": "assignments.launch_packet",
+        "read_only": true,
+        "status": "ready",
+        "structured_ready": true,
+        "launch_packet_ids": {
+          "assignment_id": "asg_123",
+          "kind": "assignment_launch_packet"
+        }
+      },
+      {
+        "name": "get_after_project_delete",
+        "tool": "projects.get",
+        "read_only": true,
+        "status": "expected_missing",
+        "tool_is_error": true,
+        "tool_text": "project not found: proj_123"
+      }
+    ],
+    "created_role": {
+      "id": "role_123",
+      "project_id": "proj_123",
+      "name": "Sidecar work smoke operator",
+      "default_execution_mode": "mcp_pull"
+    },
+    "created_work_item": {
+      "id": "work_123",
+      "project_id": "proj_123",
+      "title": "Sidecar work smoke task",
+      "owner_role_id": "role_123"
+    },
+    "created_assignment": {
+      "id": "asg_123",
+      "project_id": "proj_123",
+      "work_item_id": "work_123",
+      "role_id": "role_123",
+      "execution_mode": "mcp_pull",
+      "status": "queued"
     },
     "warnings": []
   }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -34,6 +34,9 @@ func cairnlineSidecarFixtureMain(mode string) {
 		deletedProjects:  make(map[string]struct{}),
 		roots:            make(map[string]map[string]ProjectCairnlineSidecarRootItem),
 		contextSources:   make(map[string]map[string]ProjectCairnlineSidecarSourceItem),
+		roles:            make(map[string]map[string]ProjectCairnlineSidecarRoleItem),
+		workItems:        make(map[string]map[string]ProjectCairnlineSidecarWorkItem),
+		assignments:      make(map[string]map[string]ProjectCairnlineSidecarAssignmentItem),
 	}
 	for {
 		line, err := in.ReadBytes('\n')
@@ -94,14 +97,20 @@ func cairnlineSidecarFixtureMain(mode string) {
 }
 
 type cairnlineSidecarFixtureState struct {
-	assignmentStatus string
-	claimedBy        string
-	executionRef     string
-	projectSequence  int
-	projects         map[string]ProjectCairnlineSidecarProjectItem
-	deletedProjects  map[string]struct{}
-	roots            map[string]map[string]ProjectCairnlineSidecarRootItem
-	contextSources   map[string]map[string]ProjectCairnlineSidecarSourceItem
+	assignmentStatus   string
+	claimedBy          string
+	executionRef       string
+	projectSequence    int
+	projects           map[string]ProjectCairnlineSidecarProjectItem
+	deletedProjects    map[string]struct{}
+	roots              map[string]map[string]ProjectCairnlineSidecarRootItem
+	contextSources     map[string]map[string]ProjectCairnlineSidecarSourceItem
+	roleSequence       int
+	workSequence       int
+	assignmentSequence int
+	roles              map[string]map[string]ProjectCairnlineSidecarRoleItem
+	workItems          map[string]map[string]ProjectCairnlineSidecarWorkItem
+	assignments        map[string]map[string]ProjectCairnlineSidecarAssignmentItem
 }
 
 func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
@@ -166,37 +175,49 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			"trust_label": "workspace_skill",
 		}})
 	case "roles.list":
-		return cairnlineSidecarFixtureListResult(mode, "Roles (1):\n- role_fixture: Fixture Reviewer", []map[string]any{{
-			"project_id":                   cairnlineSidecarFixtureProjectID(params.Arguments),
-			"id":                           "role_fixture",
-			"name":                         "Fixture Reviewer",
-			"default_profile_id":           "profile_fixture",
-			"default_execution_mode":       "mcp_pull",
-			"default_skill_ids":            []string{"skill_fixture"},
-			"default_execution_profile_id": "exec_fixture",
+		projectID := cairnlineSidecarFixtureProjectID(params.Arguments)
+		if roles := cairnlineSidecarFixtureProjectRoles(state, projectID); len(roles) > 0 {
+			return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Roles (%d)", len(roles)), roles)
+		}
+		return cairnlineSidecarFixtureListResult(mode, "Roles (1):\n- role_fixture: Fixture Reviewer", []ProjectCairnlineSidecarRoleItem{{
+			ProjectID:                 projectID,
+			ID:                        "role_fixture",
+			Name:                      "Fixture Reviewer",
+			DefaultProfileID:          "profile_fixture",
+			DefaultExecutionMode:      "mcp_pull",
+			DefaultSkillIDs:           []string{"skill_fixture"},
+			DefaultExecutionProfileID: "exec_fixture",
 		}})
 	case "work_items.list":
-		return cairnlineSidecarFixtureListResult(mode, "Work items (1):\n- work_fixture: Fixture Work", []map[string]any{{
-			"project_id": cairnlineSidecarFixtureProjectID(params.Arguments),
-			"id":         "work_fixture",
-			"title":      "Fixture Work",
-			"status":     "open",
-			"priority":   "normal",
+		projectID := cairnlineSidecarFixtureProjectID(params.Arguments)
+		if items := cairnlineSidecarFixtureProjectWorkItems(state, projectID); len(items) > 0 {
+			return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Work items (%d)", len(items)), items)
+		}
+		return cairnlineSidecarFixtureListResult(mode, "Work items (1):\n- work_fixture: Fixture Work", []ProjectCairnlineSidecarWorkItem{{
+			ProjectID: projectID,
+			ID:        "work_fixture",
+			Title:     "Fixture Work",
+			Status:    "open",
+			Priority:  "normal",
 		}})
 	case "assignments.list":
 		if mode == "assignment-list-empty" {
 			return cairnlineSidecarFixtureListResult(mode, "No assignments yet.", []map[string]any{})
 		}
-		return cairnlineSidecarFixtureListResult(mode, "Assignments (1):\n- asg_fixture: Fixture Assignment", []map[string]any{{
-			"project_id":     cairnlineSidecarFixtureProjectID(params.Arguments),
-			"id":             "asg_fixture",
-			"work_item_id":   "work_fixture",
-			"role_id":        "role_fixture",
-			"profile_id":     "profile_fixture",
-			"execution_mode": "mcp_pull",
-			"status":         state.assignmentStatus,
-			"claimed_by":     state.claimedBy,
-			"execution_ref":  state.executionRef,
+		projectID := cairnlineSidecarFixtureProjectID(params.Arguments)
+		if assignments := cairnlineSidecarFixtureProjectAssignments(state, projectID); len(assignments) > 0 {
+			return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Assignments (%d)", len(assignments)), assignments)
+		}
+		return cairnlineSidecarFixtureListResult(mode, "Assignments (1):\n- asg_fixture: Fixture Assignment", []ProjectCairnlineSidecarAssignmentItem{{
+			ProjectID:     projectID,
+			ID:            "asg_fixture",
+			WorkItemID:    "work_fixture",
+			RoleID:        "role_fixture",
+			ProfileID:     "profile_fixture",
+			ExecutionMode: "mcp_pull",
+			Status:        state.assignmentStatus,
+			ClaimedBy:     state.claimedBy,
+			ExecutionRef:  state.executionRef,
 		}})
 	case "assignments.next":
 		if mode == "assignment-list-empty" || state.assignmentStatus != "queued" {
@@ -290,25 +311,39 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		if input.ProjectID == "" || input.AssignmentID == "" {
 			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing assignment context ids")
 		}
+		assignment := ProjectCairnlineSidecarAssignmentItem{
+			ID:            input.AssignmentID,
+			ProjectID:     input.ProjectID,
+			WorkItemID:    "work_fixture",
+			RoleID:        "role_fixture",
+			Status:        state.assignmentStatus,
+			ClaimedBy:     state.claimedBy,
+			ExecutionRef:  state.executionRef,
+			ExecutionMode: "mcp_pull",
+		}
+		if stored, ok := state.assignments[input.ProjectID][input.AssignmentID]; ok {
+			assignment = stored
+		}
 		result := mcp.CallToolResult{Content: mcp.TextContent("Assignment context " + input.AssignmentID + " for project " + input.ProjectID)}
 		if mode != "text-only" {
 			result.StructuredContent = mustRawJSON(map[string]any{
 				"assignment": map[string]any{
-					"id":            input.AssignmentID,
-					"project_id":    input.ProjectID,
-					"work_item_id":  "work_fixture",
-					"role_id":       "role_fixture",
-					"status":        state.assignmentStatus,
-					"claimed_by":    state.claimedBy,
-					"execution_ref": state.executionRef,
+					"id":             assignment.ID,
+					"project_id":     assignment.ProjectID,
+					"work_item_id":   assignment.WorkItemID,
+					"role_id":        assignment.RoleID,
+					"status":         assignment.Status,
+					"claimed_by":     assignment.ClaimedBy,
+					"execution_ref":  assignment.ExecutionRef,
+					"execution_mode": assignment.ExecutionMode,
 				},
 				"work_item": map[string]any{
-					"id":    "work_fixture",
-					"title": "Fixture Work",
+					"id":    assignment.WorkItemID,
+					"title": firstNonEmpty(cairnlineSidecarFixtureWorkItemTitle(state, input.ProjectID, assignment.WorkItemID), "Fixture Work"),
 				},
 				"role": map[string]any{
-					"id":   "role_fixture",
-					"name": "Fixture Reviewer",
+					"id":   assignment.RoleID,
+					"name": firstNonEmpty(cairnlineSidecarFixtureRoleName(state, input.ProjectID, assignment.RoleID), "Fixture Reviewer"),
 				},
 			})
 		}
@@ -330,6 +365,20 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		if input.ProjectID == "" || input.AssignmentID == "" {
 			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing launch packet ids")
 		}
+		assignment := ProjectCairnlineSidecarAssignmentItem{
+			ID:            input.AssignmentID,
+			ProjectID:     input.ProjectID,
+			WorkItemID:    "work_fixture",
+			RoleID:        "role_fixture",
+			ProfileID:     "profile_fixture",
+			ExecutionMode: "mcp_pull",
+			Status:        state.assignmentStatus,
+			ClaimedBy:     state.claimedBy,
+			ExecutionRef:  state.executionRef,
+		}
+		if stored, ok := state.assignments[input.ProjectID][input.AssignmentID]; ok {
+			assignment = stored
+		}
 		result := mcp.CallToolResult{Content: mcp.TextContent("Launch packet launch_fixture for " + input.AssignmentID)}
 		if mode != "text-only" {
 			result.StructuredContent = mustRawJSON(map[string]any{
@@ -340,15 +389,15 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 					"name": "Fixture Project",
 				},
 				"work_item": map[string]any{
-					"id":    "work_fixture",
-					"title": "Fixture Work",
+					"id":    assignment.WorkItemID,
+					"title": firstNonEmpty(cairnlineSidecarFixtureWorkItemTitle(state, input.ProjectID, assignment.WorkItemID), "Fixture Work"),
 				},
 				"role": map[string]any{
-					"id":   "role_fixture",
-					"name": "Fixture Reviewer",
+					"id":   assignment.RoleID,
+					"name": firstNonEmpty(cairnlineSidecarFixtureRoleName(state, input.ProjectID, assignment.RoleID), "Fixture Reviewer"),
 				},
 				"profile": map[string]any{
-					"id":   "profile_fixture",
+					"id":   firstNonEmpty(assignment.ProfileID, "profile_fixture"),
 					"name": "Fixture Profile",
 				},
 				"execution_profile": map[string]any{
@@ -360,13 +409,14 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 					"title": "Fixture Skill",
 				}},
 				"assignment": map[string]any{
-					"id":            input.AssignmentID,
-					"project_id":    input.ProjectID,
-					"work_item_id":  "work_fixture",
-					"role_id":       "role_fixture",
-					"status":        state.assignmentStatus,
-					"claimed_by":    state.claimedBy,
-					"execution_ref": state.executionRef,
+					"id":             assignment.ID,
+					"project_id":     assignment.ProjectID,
+					"work_item_id":   assignment.WorkItemID,
+					"role_id":        assignment.RoleID,
+					"status":         assignment.Status,
+					"claimed_by":     assignment.ClaimedBy,
+					"execution_ref":  assignment.ExecutionRef,
+					"execution_mode": assignment.ExecutionMode,
 				},
 				"artifacts":         []map[string]any{{"id": "artifact_fixture"}},
 				"evidence":          []map[string]any{{"id": "evidence_fixture"}},
@@ -500,7 +550,102 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		state.deletedProjects[input.ID] = struct{}{}
 		delete(state.roots, input.ID)
 		delete(state.contextSources, input.ID)
+		delete(state.roles, input.ID)
+		delete(state.workItems, input.ID)
+		delete(state.assignments, input.ID)
 		return mcp.CallToolResult{Content: mcp.TextContent("Deleted project " + input.ID)}, nil
+	case "roles.create":
+		var input struct {
+			ProjectID                 string   `json:"project_id"`
+			Name                      string   `json:"name"`
+			Description               string   `json:"description"`
+			Instructions              string   `json:"instructions"`
+			DefaultProfileID          string   `json:"default_profile_id"`
+			DefaultExecutionProfileID string   `json:"default_execution_profile_id"`
+			DefaultSkillIDs           []string `json:"default_skill_ids"`
+			DefaultExecutionMode      string   `json:"default_execution_mode"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid roles.create arguments")
+		}
+		if input.ProjectID == "" || input.Name == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing role create arguments")
+		}
+		state.roleSequence++
+		id := fmt.Sprintf("role_write_fixture_%d", state.roleSequence)
+		role := ProjectCairnlineSidecarRoleItem{
+			ProjectID:                 input.ProjectID,
+			ID:                        id,
+			Name:                      input.Name,
+			Description:               input.Description,
+			Instructions:              input.Instructions,
+			DefaultProfileID:          input.DefaultProfileID,
+			DefaultExecutionProfileID: input.DefaultExecutionProfileID,
+			DefaultSkillIDs:           input.DefaultSkillIDs,
+			DefaultExecutionMode:      input.DefaultExecutionMode,
+		}
+		cairnlineSidecarFixtureEnsureRoles(state, input.ProjectID)[id] = role
+		return mcp.CallToolResult{Content: mcp.TextContent("Created role " + id + ": " + input.Name)}, nil
+	case "work_items.create":
+		var input struct {
+			ProjectID   string `json:"project_id"`
+			Title       string `json:"title"`
+			Brief       string `json:"brief"`
+			OwnerRoleID string `json:"owner_role_id"`
+			RootID      string `json:"root_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid work_items.create arguments")
+		}
+		if input.ProjectID == "" || input.Title == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing work item create arguments")
+		}
+		state.workSequence++
+		id := fmt.Sprintf("work_write_fixture_%d", state.workSequence)
+		item := ProjectCairnlineSidecarWorkItem{
+			ProjectID:   input.ProjectID,
+			ID:          id,
+			Title:       input.Title,
+			Brief:       input.Brief,
+			Status:      "open",
+			Priority:    "normal",
+			OwnerRoleID: input.OwnerRoleID,
+			RootID:      input.RootID,
+		}
+		cairnlineSidecarFixtureEnsureWorkItems(state, input.ProjectID)[id] = item
+		return mcp.CallToolResult{Content: mcp.TextContent("Created work item " + id + ": " + input.Title)}, nil
+	case "assignments.create":
+		var input struct {
+			ProjectID          string   `json:"project_id"`
+			WorkItemID         string   `json:"work_item_id"`
+			RoleID             string   `json:"role_id"`
+			RootID             string   `json:"root_id"`
+			ProfileID          string   `json:"profile_id"`
+			ExecutionProfileID string   `json:"execution_profile_id"`
+			ExecutionMode      string   `json:"execution_mode"`
+			DesiredAgentKind   string   `json:"desired_agent_kind"`
+			SkillIDs           []string `json:"skill_ids"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assignments.create arguments")
+		}
+		if input.ProjectID == "" || input.WorkItemID == "" || input.RoleID == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing assignment create arguments")
+		}
+		state.assignmentSequence++
+		id := fmt.Sprintf("asg_write_fixture_%d", state.assignmentSequence)
+		assignment := ProjectCairnlineSidecarAssignmentItem{
+			ProjectID:     input.ProjectID,
+			ID:            id,
+			WorkItemID:    input.WorkItemID,
+			RoleID:        input.RoleID,
+			ProfileID:     input.ProfileID,
+			ExecutionMode: input.ExecutionMode,
+			Status:        "queued",
+			SkillIDs:      input.SkillIDs,
+		}
+		cairnlineSidecarFixtureEnsureAssignments(state, input.ProjectID)[id] = assignment
+		return mcp.CallToolResult{Content: mcp.TextContent("Created assignment " + id)}, nil
 	case "roots.list":
 		var input struct {
 			ProjectID string `json:"project_id"`
@@ -775,6 +920,68 @@ func cairnlineSidecarFixtureProjectSources(state *cairnlineSidecarFixtureState, 
 		sources = append(sources, source)
 	}
 	return sources
+}
+
+func cairnlineSidecarFixtureEnsureRoles(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarRoleItem {
+	if state.roles[projectID] == nil {
+		state.roles[projectID] = make(map[string]ProjectCairnlineSidecarRoleItem)
+	}
+	return state.roles[projectID]
+}
+
+func cairnlineSidecarFixtureProjectRoles(state *cairnlineSidecarFixtureState, projectID string) []ProjectCairnlineSidecarRoleItem {
+	rolesByID := state.roles[projectID]
+	roles := make([]ProjectCairnlineSidecarRoleItem, 0, len(rolesByID))
+	for _, role := range rolesByID {
+		roles = append(roles, role)
+	}
+	return roles
+}
+
+func cairnlineSidecarFixtureRoleName(state *cairnlineSidecarFixtureState, projectID, roleID string) string {
+	if role, ok := state.roles[projectID][roleID]; ok {
+		return role.Name
+	}
+	return ""
+}
+
+func cairnlineSidecarFixtureEnsureWorkItems(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarWorkItem {
+	if state.workItems[projectID] == nil {
+		state.workItems[projectID] = make(map[string]ProjectCairnlineSidecarWorkItem)
+	}
+	return state.workItems[projectID]
+}
+
+func cairnlineSidecarFixtureProjectWorkItems(state *cairnlineSidecarFixtureState, projectID string) []ProjectCairnlineSidecarWorkItem {
+	itemsByID := state.workItems[projectID]
+	items := make([]ProjectCairnlineSidecarWorkItem, 0, len(itemsByID))
+	for _, item := range itemsByID {
+		items = append(items, item)
+	}
+	return items
+}
+
+func cairnlineSidecarFixtureWorkItemTitle(state *cairnlineSidecarFixtureState, projectID, workItemID string) string {
+	if item, ok := state.workItems[projectID][workItemID]; ok {
+		return item.Title
+	}
+	return ""
+}
+
+func cairnlineSidecarFixtureEnsureAssignments(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarAssignmentItem {
+	if state.assignments[projectID] == nil {
+		state.assignments[projectID] = make(map[string]ProjectCairnlineSidecarAssignmentItem)
+	}
+	return state.assignments[projectID]
+}
+
+func cairnlineSidecarFixtureProjectAssignments(state *cairnlineSidecarFixtureState, projectID string) []ProjectCairnlineSidecarAssignmentItem {
+	assignmentsByID := state.assignments[projectID]
+	assignments := make([]ProjectCairnlineSidecarAssignmentItem, 0, len(assignmentsByID))
+	for _, assignment := range assignmentsByID {
+		assignments = append(assignments, assignment)
+	}
+	return assignments
 }
 
 func cairnlineSidecarFixtureListResult(mode, text string, structured any) (mcp.CallToolResult, *mcp.RPCError) {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
@@ -277,6 +277,20 @@ func (h *Handler) HandleProjectCairnlineSidecarSetupSmoke(w http.ResponseWriter,
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarSetupEnvelope{
 		Object: "project_cairnline_sidecar_setup",
 		Data:   h.projectCairnlineSidecarSetupSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarWorkSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar work smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarWorkRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarWorkEnvelope{
+		Object: "project_cairnline_sidecar_work",
+		Data:   h.projectCairnlineSidecarWorkSmoke(r.Context(), req),
 	})
 }
 
@@ -1441,6 +1455,219 @@ func (h *Handler) projectCairnlineSidecarSetupSmoke(ctx context.Context, req Pro
 	return fail("sidecar_setup_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary setup project.")
 }
 
+func (h *Handler) projectCairnlineSidecarWorkSmoke(ctx context.Context, req ProjectCairnlineSidecarWorkRequest) ProjectCairnlineSidecarWorkResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	projectName := strings.TrimSpace(req.ProjectName)
+	if projectName == "" {
+		projectName = "Hecate sidecar work smoke " + time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+	roleName := "Sidecar work smoke operator"
+	workTitle := "Sidecar work smoke task"
+	response := ProjectCairnlineSidecarWorkResponse{
+		Ready:                 false,
+		Status:                "sidecar_work_not_run",
+		Detail:                "Cairnline sidecar work smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ConfirmedMutation:     req.ConfirmMutation,
+		ProjectName:           projectName,
+	}
+	if h == nil {
+		response.Status = "sidecar_work_failed"
+		response.Detail = "Cairnline sidecar work smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this work smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+	if !req.ConfirmMutation {
+		response.Status = "sidecar_work_confirmation_required"
+		response.Detail = "Set confirm_mutation=true to let Hecate create, verify, read context for, and clean up temporary role/work/assignment records in the standalone Cairnline sidecar. Hecate-native Projects stores are not mutated."
+		return response
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := ""
+	cleanup := func() {
+		if projectID == "" || response.CleanupVerified {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+		defer cleanupCancel()
+		cleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_delete_project", "projects.delete", false, map[string]string{"id": projectID})
+		response.Steps = append(response.Steps, cleanupStep)
+		if cleanupStep.Status == "ready" {
+			verifyCleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+			if verifyCleanupStep.Status == "tool_failed" {
+				verifyCleanupStep.Status = "expected_missing"
+				response.CleanupVerified = true
+				response.Warnings = append(response.Warnings, "Hecate deleted and verified removal of the temporary standalone Cairnline work project after the work smoke failed; inspect the reported steps before retrying.")
+			} else {
+				response.Warnings = append(response.Warnings, "Hecate deleted the temporary standalone Cairnline work project after the work smoke failed, but removal could not be verified; inspect the reported steps before retrying.")
+			}
+			response.Steps = append(response.Steps, verifyCleanupStep)
+			return
+		}
+		response.Warnings = append(response.Warnings, "Hecate tried to delete the temporary standalone Cairnline work project after the work smoke failed, but cleanup did not succeed; inspect the standalone Cairnline sidecar before retrying.")
+	}
+	fail := func(status, detail string) ProjectCairnlineSidecarWorkResponse {
+		response.Status = status
+		response.Detail = detail
+		cleanup()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	appendStep := func(step ProjectCairnlineSidecarWriteStep) bool {
+		response.Steps = append(response.Steps, step)
+		if step.Status == "tool_failed" {
+			response.Status = "sidecar_work_tool_failed"
+			response.Detail = "Cairnline sidecar " + step.Tool + " returned a tool-level error. Review the step output before retrying."
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		if step.Status == "failed" {
+			response.Status = "sidecar_work_failed"
+			response.Detail = firstNonEmpty(step.ToolText, "Cairnline sidecar "+step.Tool+" failed.")
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		return true
+	}
+
+	createProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_project", "projects.create", false, map[string]string{
+		"name":        projectName,
+		"description": "Temporary Hecate sidecar work smoke project. It should be deleted by the same diagnostic run.",
+	})
+	if !appendStep(createProject) {
+		return response
+	}
+	listProjects := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_after_project_create", "projects.list", true, map[string]string{})
+	if !appendStep(listProjects) {
+		return response
+	}
+	project, ok := projectCairnlineSidecarProjectByName(listProjects.StructuredProjects, projectName)
+	if !ok || strings.TrimSpace(project.ID) == "" {
+		return fail("sidecar_work_created_project_not_listed", "Cairnline sidecar projects.create succeeded, but projects.list did not return the temporary work project by name.")
+	}
+	projectID = strings.TrimSpace(project.ID)
+	response.SelectedProjectID = projectID
+
+	createRole := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_role", "roles.create", false, map[string]any{
+		"project_id":             projectID,
+		"name":                   roleName,
+		"description":            "Temporary role created by the Hecate sidecar work smoke.",
+		"instructions":           "Coordinate the temporary work smoke assignment.",
+		"default_execution_mode": "mcp_pull",
+	})
+	if !appendStep(createRole) {
+		return response
+	}
+	listRoles := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_roles_after_create", "roles.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listRoles) {
+		return response
+	}
+	role, ok := projectCairnlineSidecarRoleByName(listRoles.StructuredRoles, roleName)
+	if !ok || strings.TrimSpace(role.ID) == "" || role.DefaultExecutionMode != "mcp_pull" {
+		return fail("sidecar_work_role_verification_failed", "Cairnline sidecar roles.list did not return the expected temporary mcp_pull role.")
+	}
+	response.RoleID = strings.TrimSpace(role.ID)
+	response.CreatedRole = role
+
+	createWork := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_work_item", "work_items.create", false, map[string]string{
+		"project_id":    projectID,
+		"title":         workTitle,
+		"brief":         "Temporary reviewable work item created by the Hecate sidecar work smoke.",
+		"owner_role_id": response.RoleID,
+	})
+	if !appendStep(createWork) {
+		return response
+	}
+	listWork := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_work_items_after_create", "work_items.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listWork) {
+		return response
+	}
+	work, ok := projectCairnlineSidecarWorkItemByTitle(listWork.StructuredWorkItems, workTitle)
+	if !ok || strings.TrimSpace(work.ID) == "" || strings.TrimSpace(work.OwnerRoleID) != response.RoleID {
+		return fail("sidecar_work_item_verification_failed", "Cairnline sidecar work_items.list did not return the expected temporary work item.")
+	}
+	response.WorkItemID = strings.TrimSpace(work.ID)
+	response.CreatedWorkItem = work
+
+	createAssignment := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_assignment", "assignments.create", false, map[string]any{
+		"project_id":         projectID,
+		"work_item_id":       response.WorkItemID,
+		"role_id":            response.RoleID,
+		"execution_mode":     "mcp_pull",
+		"desired_agent_kind": "any",
+	})
+	if !appendStep(createAssignment) {
+		return response
+	}
+	listAssignments := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_assignments_after_create", "assignments.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listAssignments) {
+		return response
+	}
+	assignment, ok := projectCairnlineSidecarAssignmentByWorkAndRole(listAssignments.StructuredAssignments, response.WorkItemID, response.RoleID)
+	if !ok || strings.TrimSpace(assignment.ID) == "" || assignment.ExecutionMode != "mcp_pull" {
+		return fail("sidecar_work_assignment_verification_failed", "Cairnline sidecar assignments.list did not return the expected temporary mcp_pull assignment.")
+	}
+	response.AssignmentID = strings.TrimSpace(assignment.ID)
+	response.CreatedAssignment = assignment
+
+	contextStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "read_assignment_context", "assignments.context", true, map[string]string{"project_id": projectID, "assignment_id": response.AssignmentID})
+	if !appendStep(contextStep) {
+		return response
+	}
+	if contextStep.AssignmentContextIDs.AssignmentID != response.AssignmentID || contextStep.AssignmentContextIDs.WorkItemID != response.WorkItemID || contextStep.AssignmentContextIDs.RoleID != response.RoleID {
+		return fail("sidecar_work_context_verification_failed", "Cairnline sidecar assignments.context did not return the expected assignment/work/role ids.")
+	}
+	response.ContextIDs = contextStep.AssignmentContextIDs
+
+	launchStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "read_launch_packet", "assignments.launch_packet", true, map[string]string{"project_id": projectID, "assignment_id": response.AssignmentID})
+	if !appendStep(launchStep) {
+		return response
+	}
+	if launchStep.LaunchPacketIDs.AssignmentID != response.AssignmentID || launchStep.LaunchPacketIDs.WorkItemID != response.WorkItemID || launchStep.LaunchPacketIDs.RoleID != response.RoleID {
+		return fail("sidecar_work_launch_packet_verification_failed", "Cairnline sidecar assignments.launch_packet did not return the expected assignment/work/role ids.")
+	}
+	response.LaunchPacketIDs = launchStep.LaunchPacketIDs
+
+	deleteProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_project", "projects.delete", false, map[string]string{"id": projectID})
+	if !appendStep(deleteProject) {
+		return response
+	}
+	verifyDelete := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+	if verifyDelete.Status == "tool_failed" {
+		verifyDelete.Status = "expected_missing"
+		response.Steps = append(response.Steps, verifyDelete)
+		response.CleanupVerified = true
+		response.Ready = true
+		response.Status = "sidecar_work_ready"
+		response.Detail = "Hecate created and verified temporary standalone Cairnline role, work item, assignment, assignment context, and launch packet metadata through the persistent sidecar client, then deleted the temporary project. Hecate-native Projects stores were not mutated."
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	if !appendStep(verifyDelete) {
+		return response
+	}
+	return fail("sidecar_work_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary work project.")
+}
+
 func projectCairnlineSidecarLifecycleShouldReleaseAfterFailure(steps []ProjectCairnlineSidecarLifecycleStep) bool {
 	claimed := false
 	for _, step := range steps {
@@ -1873,6 +2100,85 @@ func (h *Handler) callProjectCairnlineSidecarWriteTool(ctx context.Context, cfg 
 			step.ToolText = "Cairnline sidecar " + tool + " did not return structuredContent; the setup smoke needs typed context source detail to verify setup mutations."
 			return step
 		}
+	case "roles.list":
+		roles, structuredReady, structuredErr := projectCairnlineSidecarStructuredRoles(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredRoles = roles
+		step.StructuredRoleCount = len(roles)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar roles.list returned structuredContent that Hecate could not parse as a role list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar roles.list did not return structuredContent; the work smoke needs typed roles to verify coordination mutations."
+			return step
+		}
+	case "work_items.list":
+		items, structuredReady, structuredErr := projectCairnlineSidecarStructuredWorkItems(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredWorkItems = items
+		step.StructuredWorkItemCount = len(items)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar work_items.list returned structuredContent that Hecate could not parse as a work item list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar work_items.list did not return structuredContent; the work smoke needs typed work items to verify coordination mutations."
+			return step
+		}
+	case "assignments.list":
+		assignments, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignments(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredAssignments = assignments
+		step.StructuredAssignmentCount = len(assignments)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assignments.list returned structuredContent that Hecate could not parse as an assignment list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assignments.list did not return structuredContent; the work smoke needs typed assignments to verify coordination mutations."
+			return step
+		}
+	case "assignments.context":
+		contextIDs, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignmentContextIDs(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.AssignmentContextIDs = contextIDs
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assignments.context returned structuredContent that Hecate could not parse as assignment context: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assignments.context did not return structuredContent; the work smoke needs typed context metadata."
+			return step
+		}
+	case "assignments.launch_packet":
+		packetIDs, _, warnings, structuredReady, structuredErr := projectCairnlineSidecarStructuredLaunchPacket(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.LaunchPacketIDs = packetIDs
+		step.LaunchPacketWarnings = warnings
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assignments.launch_packet returned structuredContent that Hecate could not parse as a launch packet: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assignments.launch_packet did not return structuredContent; the work smoke needs typed launch-packet metadata."
+			return step
+		}
 	}
 	step.Status = "ready"
 	return step
@@ -1962,6 +2268,37 @@ func projectCairnlineSidecarSourceByID(sources []ProjectCairnlineSidecarSourceIt
 	return ProjectCairnlineSidecarSourceItem{}, false
 }
 
+func projectCairnlineSidecarRoleByName(roles []ProjectCairnlineSidecarRoleItem, name string) (ProjectCairnlineSidecarRoleItem, bool) {
+	name = strings.TrimSpace(name)
+	for _, role := range roles {
+		if strings.TrimSpace(role.Name) == name {
+			return role, true
+		}
+	}
+	return ProjectCairnlineSidecarRoleItem{}, false
+}
+
+func projectCairnlineSidecarWorkItemByTitle(items []ProjectCairnlineSidecarWorkItem, title string) (ProjectCairnlineSidecarWorkItem, bool) {
+	title = strings.TrimSpace(title)
+	for _, item := range items {
+		if strings.TrimSpace(item.Title) == title {
+			return item, true
+		}
+	}
+	return ProjectCairnlineSidecarWorkItem{}, false
+}
+
+func projectCairnlineSidecarAssignmentByWorkAndRole(assignments []ProjectCairnlineSidecarAssignmentItem, workItemID, roleID string) (ProjectCairnlineSidecarAssignmentItem, bool) {
+	workItemID = strings.TrimSpace(workItemID)
+	roleID = strings.TrimSpace(roleID)
+	for _, assignment := range assignments {
+		if strings.TrimSpace(assignment.WorkItemID) == workItemID && strings.TrimSpace(assignment.RoleID) == roleID {
+			return assignment, true
+		}
+	}
+	return ProjectCairnlineSidecarAssignmentItem{}, false
+}
+
 func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairnlineSidecarProjectItem, bool, error) {
 	if len(raw) == 0 {
 		return ProjectCairnlineSidecarProjectItem{}, false, nil
@@ -2047,6 +2384,48 @@ func projectCairnlineSidecarStructuredSource(raw json.RawMessage) (ProjectCairnl
 		return ProjectCairnlineSidecarSourceItem{}, false, err
 	}
 	return source, true, nil
+}
+
+func projectCairnlineSidecarStructuredRoles(raw json.RawMessage) ([]ProjectCairnlineSidecarRoleItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarRoleItem{}, true, nil
+	}
+	var roles []ProjectCairnlineSidecarRoleItem
+	if err := json.Unmarshal(trimmed, &roles); err != nil {
+		return nil, false, err
+	}
+	if roles == nil {
+		roles = []ProjectCairnlineSidecarRoleItem{}
+	}
+	return roles, true, nil
+}
+
+func projectCairnlineSidecarStructuredWorkItems(raw json.RawMessage) ([]ProjectCairnlineSidecarWorkItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarWorkItem{}, true, nil
+	}
+	var items []ProjectCairnlineSidecarWorkItem
+	if err := json.Unmarshal(trimmed, &items); err != nil {
+		return nil, false, err
+	}
+	if items == nil {
+		items = []ProjectCairnlineSidecarWorkItem{}
+	}
+	return items, true, nil
 }
 
 func projectCairnlineSidecarStructuredAssignments(raw json.RawMessage) ([]ProjectCairnlineSidecarAssignmentItem, bool, error) {
@@ -2320,6 +2699,15 @@ func (r *ProjectCairnlineSidecarWriteResponse) setSidecarCacheStats(stats mcpcli
 }
 
 func (r *ProjectCairnlineSidecarSetupResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarWorkResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -1086,6 +1086,99 @@ func TestProjectCairnlineSidecarSetupSmoke_CleansUpAfterRootUpdateFailure(t *tes
 	}
 }
 
+func TestProjectCairnlineSidecarWorkSmoke_RequiresConfirmation(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarWorkSmoke(t.Context(), ProjectCairnlineSidecarWorkRequest{ProjectName: "Fixture work smoke"})
+	if got.Ready || got.Status != "sidecar_work_confirmation_required" || got.ConfirmedMutation {
+		t.Fatalf("work smoke = %+v, want confirmation-required without mutation", got)
+	}
+	if len(got.Steps) != 0 || got.ClientCacheEntries != 0 {
+		t.Fatalf("steps/cache = %d/%d, want no sidecar calls before confirmation", len(got.Steps), got.ClientCacheEntries)
+	}
+}
+
+func TestProjectCairnlineSidecarWorkSmoke_CreatesWorkCoordinationRecords(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarWorkSmoke(t.Context(), ProjectCairnlineSidecarWorkRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture work smoke",
+	})
+	if !got.Ready || got.Status != "sidecar_work_ready" || !got.CleanupVerified {
+		t.Fatalf("work smoke = %+v, want ready with verified cleanup", got)
+	}
+	if got.SelectedProjectID == "" || got.RoleID == "" || got.WorkItemID == "" || got.AssignmentID == "" {
+		t.Fatalf("ids = project:%q role:%q work:%q assignment:%q, want created coordination ids", got.SelectedProjectID, got.RoleID, got.WorkItemID, got.AssignmentID)
+	}
+	if got.CreatedRole.Name != "Sidecar work smoke operator" || got.CreatedRole.DefaultExecutionMode != "mcp_pull" {
+		t.Fatalf("created role = %+v, want mcp_pull work-smoke role", got.CreatedRole)
+	}
+	if got.CreatedWorkItem.Title != "Sidecar work smoke task" || got.CreatedWorkItem.OwnerRoleID != got.RoleID {
+		t.Fatalf("created work item = %+v, want owner role %q", got.CreatedWorkItem, got.RoleID)
+	}
+	if got.CreatedAssignment.WorkItemID != got.WorkItemID || got.CreatedAssignment.RoleID != got.RoleID || got.CreatedAssignment.ExecutionMode != "mcp_pull" || got.CreatedAssignment.Status != "queued" {
+		t.Fatalf("created assignment = %+v, want queued mcp_pull assignment for created work/role", got.CreatedAssignment)
+	}
+	if got.ContextIDs.AssignmentID != got.AssignmentID || got.ContextIDs.WorkItemID != got.WorkItemID || got.ContextIDs.RoleID != got.RoleID {
+		t.Fatalf("context ids = %+v, want created assignment/work/role ids", got.ContextIDs)
+	}
+	if got.LaunchPacketIDs.AssignmentID != got.AssignmentID || got.LaunchPacketIDs.WorkItemID != got.WorkItemID || got.LaunchPacketIDs.RoleID != got.RoleID {
+		t.Fatalf("launch packet ids = %+v, want created assignment/work/role ids", got.LaunchPacketIDs)
+	}
+	if len(got.Steps) != 12 {
+		t.Fatalf("steps = %+v, want project/role/work/assignment/context/launch/delete flow", got.Steps)
+	}
+	if got.Steps[2].Tool != "roles.create" || got.Steps[4].Tool != "work_items.create" || got.Steps[6].Tool != "assignments.create" || got.Steps[8].Tool != "assignments.context" || got.Steps[9].Tool != "assignments.launch_packet" || got.Steps[11].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want work smoke order and missing-after-delete verification", got.Steps)
+	}
+	if len(got.Steps[9].LaunchPacketWarnings) != 1 || got.Steps[9].LaunchPacketWarnings[0] != "fixture warning" {
+		t.Fatalf("launch packet warnings = %+v, want fixture warning evidence", got.Steps[9].LaunchPacketWarnings)
+	}
+}
+
+func TestProjectCairnlineSidecarWorkSmoke_CleansUpAfterContextFailure(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "context-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarWorkSmoke(t.Context(), ProjectCairnlineSidecarWorkRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture work smoke cleanup",
+	})
+	if got.Ready || got.Status != "sidecar_work_tool_failed" || !got.CleanupVerified {
+		t.Fatalf("work smoke = %+v, want context tool failure with verified project cleanup", got)
+	}
+	if len(got.Steps) != 11 || got.Steps[8].Tool != "assignments.context" || !got.Steps[8].ToolIsError || got.Steps[9].Name != "cleanup_delete_project" || got.Steps[10].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want context failure followed by project cleanup delete and verification", got.Steps)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "deleted and verified removal") {
+		t.Fatalf("warnings = %+v, want verified cleanup warning", got.Warnings)
+	}
+}
+
 func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureAfterRunningCannotRelease(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -16,6 +16,7 @@ const projectCoordinationBackendSidecarLaunchPacketURL = "/hecate/v1/projects/ca
 const projectCoordinationBackendSidecarLifecycleURL = "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"
 const projectCoordinationBackendSidecarSetupURL = "/hecate/v1/projects/cairnline/sidecar-setup-smoke"
 const projectCoordinationBackendSidecarWriteURL = "/hecate/v1/projects/cairnline/sidecar-write-smoke"
+const projectCoordinationBackendSidecarWorkURL = "/hecate/v1/projects/cairnline/sidecar-work-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -315,6 +316,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarLifecycleURL:         projectCoordinationBackendSidecarLifecycleURL,
 		CairnlineSidecarSetupURL:             projectCoordinationBackendSidecarSetupURL,
 		CairnlineSidecarWriteURL:             projectCoordinationBackendSidecarWriteURL,
+		CairnlineSidecarWorkURL:              projectCoordinationBackendSidecarWorkURL,
 		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -57,6 +57,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarWriteURL != projectCoordinationBackendSidecarWriteURL {
 		t.Fatalf("sidecar write URL = %q, want %q", status.CairnlineSidecarWriteURL, projectCoordinationBackendSidecarWriteURL)
 	}
+	if status.CairnlineSidecarWorkURL != projectCoordinationBackendSidecarWorkURL {
+		t.Fatalf("sidecar work URL = %q, want %q", status.CairnlineSidecarWorkURL, projectCoordinationBackendSidecarWorkURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -124,7 +127,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.Status != "cairnline_connector_not_ready" || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
 		t.Fatalf("status = %+v, want sidecar connector mode to block live Cairnline routing", status)
 	}
-	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write/setup diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
+	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write/setup/work diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
 		t.Fatalf("connector detail = %q, want full sidecar diagnostic surface", status.CairnlineConnectorDetail)
 	}
 	if handler.projectReadRoutesUseCairnlineReadModel() || handler.projectIdentityWritesUseCairnlineAuthority() || handler.projectMemoryWritesUseCairnlineAuthority() || handler.projectAssignmentWritesUseCairnlineAuthority() {
@@ -160,6 +163,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.CairnlineSidecarWriteURL != projectCoordinationBackendSidecarWriteURL {
 		t.Fatalf("sidecar write URL = %q, want %q", status.CairnlineSidecarWriteURL, projectCoordinationBackendSidecarWriteURL)
 	}
+	if status.CairnlineSidecarWorkURL != projectCoordinationBackendSidecarWorkURL {
+		t.Fatalf("sidecar work URL = %q, want %q", status.CairnlineSidecarWorkURL, projectCoordinationBackendSidecarWorkURL)
+	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)
 	}
@@ -173,7 +179,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 		t.Fatalf("project-identity switchpoint = %+v, want Hecate authority while sidecar routing is not live", point)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
+	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
 		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
 	}
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -585,6 +585,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarLifecycleURL         string                                       `json:"cairnline_sidecar_lifecycle_url,omitempty"`
 	CairnlineSidecarSetupURL             string                                       `json:"cairnline_sidecar_setup_url,omitempty"`
 	CairnlineSidecarWriteURL             string                                       `json:"cairnline_sidecar_write_url,omitempty"`
+	CairnlineSidecarWorkURL              string                                       `json:"cairnline_sidecar_work_url,omitempty"`
 	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
@@ -1721,6 +1722,11 @@ type ProjectCairnlineSidecarSetupEnvelope struct {
 	Data   ProjectCairnlineSidecarSetupResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarWorkEnvelope struct {
+	Object string                              `json:"object"`
+	Data   ProjectCairnlineSidecarWorkResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
@@ -1757,6 +1763,11 @@ type ProjectCairnlineSidecarWriteRequest struct {
 }
 
 type ProjectCairnlineSidecarSetupRequest struct {
+	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
+	ProjectName     string `json:"project_name,omitempty"`
+}
+
+type ProjectCairnlineSidecarWorkRequest struct {
 	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
 	ProjectName     string `json:"project_name,omitempty"`
 }
@@ -2081,26 +2092,64 @@ type ProjectCairnlineSidecarSetupResponse struct {
 	Warnings              []string                           `json:"warnings,omitempty"`
 }
 
+type ProjectCairnlineSidecarWorkResponse struct {
+	Ready                 bool                                        `json:"ready"`
+	Status                string                                      `json:"status"`
+	Detail                string                                      `json:"detail"`
+	Command               string                                      `json:"command"`
+	Args                  []string                                    `json:"args,omitempty"`
+	DatabasePath          string                                      `json:"database_path,omitempty"`
+	ProbeTimeoutMS        int64                                       `json:"probe_timeout_ms"`
+	PersistentClient      bool                                        `json:"persistent_client,omitempty"`
+	ClientCacheConfigured bool                                        `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries    int                                         `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse      int                                         `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle       int                                         `json:"client_cache_idle,omitempty"`
+	ConfirmedMutation     bool                                        `json:"confirmed_mutation"`
+	ProjectName           string                                      `json:"project_name,omitempty"`
+	SelectedProjectID     string                                      `json:"selected_project_id,omitempty"`
+	RoleID                string                                      `json:"role_id,omitempty"`
+	WorkItemID            string                                      `json:"work_item_id,omitempty"`
+	AssignmentID          string                                      `json:"assignment_id,omitempty"`
+	Steps                 []ProjectCairnlineSidecarWriteStep          `json:"steps,omitempty"`
+	CreatedRole           ProjectCairnlineSidecarRoleItem             `json:"created_role,omitempty"`
+	CreatedWorkItem       ProjectCairnlineSidecarWorkItem             `json:"created_work_item,omitempty"`
+	CreatedAssignment     ProjectCairnlineSidecarAssignmentItem       `json:"created_assignment,omitempty"`
+	ContextIDs            ProjectCairnlineSidecarAssignmentContextIDs `json:"context_ids,omitempty"`
+	LaunchPacketIDs       ProjectCairnlineSidecarLaunchPacketIDs      `json:"launch_packet_ids,omitempty"`
+	CleanupVerified       bool                                        `json:"cleanup_verified"`
+	Warnings              []string                                    `json:"warnings,omitempty"`
+}
+
 type ProjectCairnlineSidecarWriteStep struct {
-	Name                   string                               `json:"name"`
-	Tool                   string                               `json:"tool"`
-	ReadOnly               bool                                 `json:"read_only"`
-	Status                 string                               `json:"status"`
-	ToolText               string                               `json:"tool_text,omitempty"`
-	ToolIsError            bool                                 `json:"tool_is_error,omitempty"`
-	StructuredContent      json.RawMessage                      `json:"structured_content,omitempty"`
-	Meta                   json.RawMessage                      `json:"meta,omitempty"`
-	StructuredReady        bool                                 `json:"structured_ready"`
-	StructuredProject      ProjectCairnlineSidecarProjectItem   `json:"structured_project,omitempty"`
-	StructuredProjects     []ProjectCairnlineSidecarProjectItem `json:"structured_projects,omitempty"`
-	StructuredProjectCount int                                  `json:"structured_project_count"`
-	StructuredRoot         ProjectCairnlineSidecarRootItem      `json:"structured_root,omitempty"`
-	StructuredRoots        []ProjectCairnlineSidecarRootItem    `json:"structured_roots,omitempty"`
-	StructuredRootCount    int                                  `json:"structured_root_count"`
-	StructuredSource       ProjectCairnlineSidecarSourceItem    `json:"structured_source,omitempty"`
-	StructuredSources      []ProjectCairnlineSidecarSourceItem  `json:"structured_sources,omitempty"`
-	StructuredSourceCount  int                                  `json:"structured_source_count"`
-	StructuredParseError   string                               `json:"structured_parse_error,omitempty"`
+	Name                      string                                      `json:"name"`
+	Tool                      string                                      `json:"tool"`
+	ReadOnly                  bool                                        `json:"read_only"`
+	Status                    string                                      `json:"status"`
+	ToolText                  string                                      `json:"tool_text,omitempty"`
+	ToolIsError               bool                                        `json:"tool_is_error,omitempty"`
+	StructuredContent         json.RawMessage                             `json:"structured_content,omitempty"`
+	Meta                      json.RawMessage                             `json:"meta,omitempty"`
+	StructuredReady           bool                                        `json:"structured_ready"`
+	StructuredProject         ProjectCairnlineSidecarProjectItem          `json:"structured_project,omitempty"`
+	StructuredProjects        []ProjectCairnlineSidecarProjectItem        `json:"structured_projects,omitempty"`
+	StructuredProjectCount    int                                         `json:"structured_project_count"`
+	StructuredRoot            ProjectCairnlineSidecarRootItem             `json:"structured_root,omitempty"`
+	StructuredRoots           []ProjectCairnlineSidecarRootItem           `json:"structured_roots,omitempty"`
+	StructuredRootCount       int                                         `json:"structured_root_count"`
+	StructuredSource          ProjectCairnlineSidecarSourceItem           `json:"structured_source,omitempty"`
+	StructuredSources         []ProjectCairnlineSidecarSourceItem         `json:"structured_sources,omitempty"`
+	StructuredSourceCount     int                                         `json:"structured_source_count"`
+	StructuredRoles           []ProjectCairnlineSidecarRoleItem           `json:"structured_roles,omitempty"`
+	StructuredRoleCount       int                                         `json:"structured_role_count"`
+	StructuredWorkItems       []ProjectCairnlineSidecarWorkItem           `json:"structured_work_items,omitempty"`
+	StructuredWorkItemCount   int                                         `json:"structured_work_item_count"`
+	StructuredAssignments     []ProjectCairnlineSidecarAssignmentItem     `json:"structured_assignments,omitempty"`
+	StructuredAssignmentCount int                                         `json:"structured_assignment_count"`
+	AssignmentContextIDs      ProjectCairnlineSidecarAssignmentContextIDs `json:"assignment_context_ids,omitempty"`
+	LaunchPacketIDs           ProjectCairnlineSidecarLaunchPacketIDs      `json:"launch_packet_ids,omitempty"`
+	LaunchPacketWarnings      []string                                    `json:"launch_packet_warnings,omitempty"`
+	StructuredParseError      string                                      `json:"structured_parse_error,omitempty"`
 }
 
 type ProjectCairnlineSidecarProjectItem struct {
@@ -2127,6 +2176,30 @@ type ProjectCairnlineSidecarAssignmentItem struct {
 	ClaimedBy     string   `json:"claimed_by,omitempty"`
 	ExecutionRef  string   `json:"execution_ref,omitempty"`
 	SkillIDs      []string `json:"skill_ids,omitempty"`
+}
+
+type ProjectCairnlineSidecarRoleItem struct {
+	ID                        string   `json:"id"`
+	ProjectID                 string   `json:"project_id,omitempty"`
+	Name                      string   `json:"name"`
+	Description               string   `json:"description,omitempty"`
+	Instructions              string   `json:"instructions,omitempty"`
+	DefaultProfileID          string   `json:"default_profile_id,omitempty"`
+	DefaultExecutionProfileID string   `json:"default_execution_profile_id,omitempty"`
+	DefaultExecutionMode      string   `json:"default_execution_mode,omitempty"`
+	DefaultSkillIDs           []string `json:"default_skill_ids,omitempty"`
+}
+
+type ProjectCairnlineSidecarWorkItem struct {
+	ID              string   `json:"id"`
+	ProjectID       string   `json:"project_id,omitempty"`
+	Title           string   `json:"title"`
+	Brief           string   `json:"brief,omitempty"`
+	Status          string   `json:"status,omitempty"`
+	Priority        string   `json:"priority,omitempty"`
+	OwnerRoleID     string   `json:"owner_role_id,omitempty"`
+	ReviewerRoleIDs []string `json:"reviewer_role_ids,omitempty"`
+	RootID          string   `json:"root_id,omitempty"`
 }
 
 type ProjectCairnlineSidecarRootItem struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -33,6 +33,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-setup-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-write-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-work-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -93,6 +93,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-setup-smoke", handler.HandleProjectCairnlineSidecarSetupSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-write-smoke", handler.HandleProjectCairnlineSidecarWriteSmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-work-smoke", handler.HandleProjectCairnlineSidecarWorkSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)


### PR DESCRIPTION
## Summary
- add a local-only Cairnline sidecar work smoke endpoint that creates a temporary project-scoped role, work item, and queued MCP-pull assignment
- verify assignments.context and assignments.launch_packet for the created assignment, then delete the temporary sidecar project and verify removal
- update backend status, remote-runtime classification, fixture coverage, and docs for the new diagnostic rung

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProject(CairnlineSidecar|CoordinationBackendStatus)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/orchestrator ./internal/mcp/client
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...
- just docs-format-check
- just agent-docs-check
- just docs-env-check
- git diff --check