### PR TITLE
Add Cairnline sidecar collaboration smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -161,7 +161,12 @@ requires `confirm_mutation=true`, creates a temporary rootless Cairnline
 project, creates a role, work item, and queued `mcp_pull` assignment through
 typed `structuredContent`, verifies `assignments.context` and
 `assignments.launch_packet` for that assignment, then deletes and verifies
-removal of the temporary project.
+removal of the temporary project. A collaboration smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-collaboration-smoke` requires
+`confirm_mutation=true`, creates temporary role/work/assignment scaffolding,
+records and verifies artifact, evidence, review, and handoff metadata through
+typed `structuredContent`, then deletes and verifies removal of the temporary
+project.
 Hecate does not yet route Projects reads, writes, or mirrors through the sidecar
 client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -359,7 +359,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   verifies typed root and context-source metadata on a temporary standalone
   Cairnline project, plus an explicit confirmed work smoke that creates typed
   role, work-item, assignment, assignment-context, and launch-packet metadata on
-  a temporary standalone Cairnline project. This is
+  a temporary standalone Cairnline project, plus an explicit confirmed
+  collaboration smoke that records and verifies typed artifact, evidence,
+  review, and handoff metadata on a temporary standalone Cairnline project. This
+  is
   contract/client-lifecycle/read-shape and standalone mutation evidence only:
   Hecate does not yet route live Projects reads, writes, mirrors, or
   write-authority switchpoints through the sidecar.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -389,7 +389,11 @@ authoritative and are not mutated by that smoke. Operators can also run
 `POST /hecate/v1/projects/cairnline/sidecar-work-smoke`, each with
 `confirm_mutation=true`, to prove temporary standalone Cairnline project
 identity, setup metadata, and role/work/assignment/context/launch-packet writes
-respectively. Those smokes delete their temporary project and verify removal.
+respectively. Operators can also run
+`POST /hecate/v1/projects/cairnline/sidecar-collaboration-smoke` with
+`confirm_mutation=true` to record and verify temporary artifact, evidence,
+review, and handoff metadata in the standalone Cairnline sidecar database.
+Those smokes delete their temporary project and verify removal.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
 `read_model_switch_ready=true`, and project list/detail, setup readiness,
@@ -442,10 +446,11 @@ Cairnline-specific MCP client cache. `sidecar-read-smoke`,
 cached client to call read-only Cairnline MCP tools and return diagnostic
 evidence. `sidecar-lifecycle-smoke` is opt-in mutation evidence for the
 standalone sidecar assignment lifecycle. `sidecar-write-smoke`,
-`sidecar-setup-smoke`, and `sidecar-work-smoke` are opt-in mutation evidence for
-standalone sidecar project identity, project setup metadata, and project work
-coordination records. None of these routes operator project reads or writes
-through the sidecar backend.
+`sidecar-setup-smoke`, `sidecar-work-smoke`, and
+`sidecar-collaboration-smoke` are opt-in mutation evidence for standalone
+sidecar project identity, project setup metadata, project work coordination
+records, and collaboration metadata records. None of these routes operator
+project reads or writes through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -492,8 +492,12 @@ sequenceDiagram
   creates a temporary standalone Cairnline project, role, work item, and queued
   MCP-pull assignment, verifies `assignments.context` and
   `assignments.launch_packet` for that assignment, then deletes and verifies
-  removal of the temporary project. Live Projects reads and writes still use
-  Hecate-native stores.
+  removal of the temporary project. `sidecar-collaboration-smoke` is the
+  collaboration mutation smoke: after `confirm_mutation=true`, it creates a
+  temporary standalone Cairnline project, role/work/assignment scaffolding, then
+  records and verifies artifact, evidence, review, and handoff metadata before
+  deleting and verifying removal of the temporary project. Live Projects reads
+  and writes still use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2700,7 +2704,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_lifecycle_url": "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke",
     "cairnline_sidecar_setup_url": "/hecate/v1/projects/cairnline/sidecar-setup-smoke",
     "cairnline_sidecar_write_url": "/hecate/v1/projects/cairnline/sidecar-write-smoke",
-    "cairnline_sidecar_work_url": "/hecate/v1/projects/cairnline/sidecar-work-smoke"
+    "cairnline_sidecar_work_url": "/hecate/v1/projects/cairnline/sidecar-work-smoke",
+    "cairnline_sidecar_collaboration_url": "/hecate/v1/projects/cairnline/sidecar-collaboration-smoke"
   }
 }
 ```
@@ -3565,6 +3570,88 @@ Example request:
 {
   "confirm_mutation": true,
   "project_name": "Hecate sidecar work smoke"
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-collaboration-smoke`
+
+Local-only standalone Cairnline MCP collaboration metadata smoke. This endpoint
+mutates only the standalone Cairnline sidecar database after explicit
+confirmation. It does not mutate Hecate-native Projects stores, does not start
+a Hecate Task, does not launch an External Agent, and does not make Cairnline
+authoritative for live Projects routes.
+
+Without `confirm_mutation=true`, the endpoint returns
+`sidecar_collaboration_confirmation_required` and makes no sidecar tool calls.
+With confirmation, Hecate uses the same sidecar command, database, timeout, and
+Cairnline-specific MCP client cache as `sidecar-connect`.
+
+The smoke creates a temporary rootless project, two roles, a work item, and a
+queued `mcp_pull` assignment, then records and verifies one generic artifact,
+one evidence record, one structured review, and one handoff through
+`artifacts.create` / `artifacts.list` / `artifacts.get`,
+`evidence.record` / `evidence.list` / `evidence.get`, `reviews.record` /
+`reviews.list` / `reviews.get`, and `handoffs.create` / `handoffs.list` /
+`handoffs.get`. It then deletes the temporary project and expects a final
+`projects.get` to return a tool-level missing/error result. If a step fails
+after the temporary project id is known, Hecate attempts a best-effort project
+cleanup delete and verifies that cleanup through another `projects.get`.
+
+Example request:
+
+```json
+{
+  "confirm_mutation": true,
+  "project_name": "Hecate sidecar collaboration smoke"
+}
+```
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_collaboration",
+  "data": {
+    "ready": true,
+    "status": "sidecar_collaboration_ready",
+    "detail": "Hecate created and verified temporary standalone Cairnline artifact, evidence, review, and handoff metadata through the persistent sidecar client, then deleted the temporary project. Hecate-native Projects stores were not mutated.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "confirmed_mutation": true,
+    "project_name": "Hecate sidecar collaboration smoke",
+    "selected_project_id": "proj_123",
+    "author_role_id": "role_author",
+    "reviewer_role_id": "role_reviewer",
+    "work_item_id": "work_123",
+    "assignment_id": "asg_123",
+    "created_artifact": {
+      "id": "artifact_123",
+      "kind": "diagnostic_note",
+      "title": "Sidecar collaboration artifact"
+    },
+    "created_evidence": {
+      "id": "evidence_123",
+      "title": "Sidecar collaboration evidence",
+      "locator": "file://hecate-sidecar-collaboration-smoke.md"
+    },
+    "created_review": {
+      "id": "review_123",
+      "title": "Sidecar collaboration review",
+      "verdict": "approved",
+      "risk": "low"
+    },
+    "created_handoff": {
+      "id": "handoff_123",
+      "title": "Sidecar collaboration handoff",
+      "status": "open"
+    },
+    "cleanup_verified": true,
+    "warnings": []
+  }
 }
 ```
 

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -37,6 +37,10 @@ func cairnlineSidecarFixtureMain(mode string) {
 		roles:            make(map[string]map[string]ProjectCairnlineSidecarRoleItem),
 		workItems:        make(map[string]map[string]ProjectCairnlineSidecarWorkItem),
 		assignments:      make(map[string]map[string]ProjectCairnlineSidecarAssignmentItem),
+		artifacts:        make(map[string]map[string]ProjectCairnlineSidecarArtifactItem),
+		evidence:         make(map[string]map[string]ProjectCairnlineSidecarEvidenceItem),
+		reviews:          make(map[string]map[string]ProjectCairnlineSidecarReviewItem),
+		handoffs:         make(map[string]map[string]ProjectCairnlineSidecarHandoffItem),
 	}
 	for {
 		line, err := in.ReadBytes('\n')
@@ -108,9 +112,17 @@ type cairnlineSidecarFixtureState struct {
 	roleSequence       int
 	workSequence       int
 	assignmentSequence int
+	artifactSequence   int
+	evidenceSequence   int
+	reviewSequence     int
+	handoffSequence    int
 	roles              map[string]map[string]ProjectCairnlineSidecarRoleItem
 	workItems          map[string]map[string]ProjectCairnlineSidecarWorkItem
 	assignments        map[string]map[string]ProjectCairnlineSidecarAssignmentItem
+	artifacts          map[string]map[string]ProjectCairnlineSidecarArtifactItem
+	evidence           map[string]map[string]ProjectCairnlineSidecarEvidenceItem
+	reviews            map[string]map[string]ProjectCairnlineSidecarReviewItem
+	handoffs           map[string]map[string]ProjectCairnlineSidecarHandoffItem
 }
 
 func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
@@ -553,6 +565,10 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		delete(state.roles, input.ID)
 		delete(state.workItems, input.ID)
 		delete(state.assignments, input.ID)
+		delete(state.artifacts, input.ID)
+		delete(state.evidence, input.ID)
+		delete(state.reviews, input.ID)
+		delete(state.handoffs, input.ID)
 		return mcp.CallToolResult{Content: mcp.TextContent("Deleted project " + input.ID)}, nil
 	case "roles.create":
 		var input struct {
@@ -854,6 +870,242 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		}
 		delete(sources, input.SourceID)
 		return mcp.CallToolResult{Content: mcp.TextContent("Deleted context source " + input.SourceID), StructuredContent: mustRawJSON(source)}, nil
+	case "artifacts.create":
+		var input struct {
+			ProjectID      string `json:"project_id"`
+			WorkItemID     string `json:"work_item_id"`
+			AssignmentID   string `json:"assignment_id"`
+			Kind           string `json:"kind"`
+			Title          string `json:"title"`
+			Body           string `json:"body"`
+			AuthorRoleID   string `json:"author_role_id"`
+			ProvenanceKind string `json:"provenance_kind"`
+			TrustLabel     string `json:"trust_label"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid artifacts.create arguments")
+		}
+		if input.ProjectID == "" || input.WorkItemID == "" || input.Kind == "" || input.Body == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing artifact create arguments")
+		}
+		state.artifactSequence++
+		id := fmt.Sprintf("artifact_write_fixture_%d", state.artifactSequence)
+		artifact := ProjectCairnlineSidecarArtifactItem{
+			ProjectID:      input.ProjectID,
+			ID:             id,
+			WorkItemID:     input.WorkItemID,
+			AssignmentID:   input.AssignmentID,
+			Kind:           input.Kind,
+			Title:          input.Title,
+			Body:           input.Body,
+			AuthorRoleID:   input.AuthorRoleID,
+			ProvenanceKind: input.ProvenanceKind,
+			TrustLabel:     input.TrustLabel,
+		}
+		cairnlineSidecarFixtureEnsureArtifacts(state, input.ProjectID)[id] = artifact
+		return mcp.CallToolResult{Content: mcp.TextContent("Created artifact " + id), StructuredContent: mustRawJSON(artifact)}, nil
+	case "artifacts.list":
+		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
+		items := cairnlineSidecarFixtureProjectArtifacts(state, projectID, workItemID)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Artifacts for %s (%d)", workItemID, len(items)), items)
+	case "artifacts.get":
+		var input struct {
+			ProjectID  string `json:"project_id"`
+			WorkItemID string `json:"work_item_id"`
+			ArtifactID string `json:"artifact_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid artifacts.get arguments")
+		}
+		artifact, ok := state.artifacts[input.ProjectID][input.ArtifactID]
+		if !ok || artifact.WorkItemID != input.WorkItemID {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture artifact not found: " + input.ArtifactID), IsError: true}, nil
+		}
+		return mcp.CallToolResult{Content: mcp.TextContent("Artifact " + input.ArtifactID), StructuredContent: mustRawJSON(artifact)}, nil
+	case "evidence.record":
+		if mode == "evidence-record-tool-error" {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture evidence.record failed"), IsError: true}, nil
+		}
+		var input struct {
+			ProjectID    string `json:"project_id"`
+			WorkItemID   string `json:"work_item_id"`
+			AssignmentID string `json:"assignment_id"`
+			Title        string `json:"title"`
+			Body         string `json:"body"`
+			Locator      string `json:"locator"`
+			SourceKind   string `json:"source_kind"`
+			ExternalID   string `json:"external_id"`
+			Provider     string `json:"provider"`
+			TrustLabel   string `json:"trust_label"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid evidence.record arguments")
+		}
+		if input.ProjectID == "" || input.WorkItemID == "" || input.Title == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing evidence record arguments")
+		}
+		state.evidenceSequence++
+		id := fmt.Sprintf("evidence_write_fixture_%d", state.evidenceSequence)
+		item := ProjectCairnlineSidecarEvidenceItem{
+			ProjectID:    input.ProjectID,
+			ID:           id,
+			WorkItemID:   input.WorkItemID,
+			AssignmentID: input.AssignmentID,
+			Title:        input.Title,
+			Body:         input.Body,
+			Locator:      input.Locator,
+			SourceKind:   input.SourceKind,
+			ExternalID:   input.ExternalID,
+			Provider:     input.Provider,
+			TrustLabel:   input.TrustLabel,
+		}
+		cairnlineSidecarFixtureEnsureEvidence(state, input.ProjectID)[id] = item
+		return mcp.CallToolResult{Content: mcp.TextContent("Recorded evidence " + id)}, nil
+	case "evidence.list":
+		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
+		items := cairnlineSidecarFixtureProjectEvidence(state, projectID, workItemID)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Evidence for %s (%d)", workItemID, len(items)), items)
+	case "evidence.get":
+		var input struct {
+			ProjectID  string `json:"project_id"`
+			WorkItemID string `json:"work_item_id"`
+			EvidenceID string `json:"evidence_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid evidence.get arguments")
+		}
+		item, ok := state.evidence[input.ProjectID][input.EvidenceID]
+		if !ok || item.WorkItemID != input.WorkItemID {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture evidence not found: " + input.EvidenceID), IsError: true}, nil
+		}
+		return mcp.CallToolResult{Content: mcp.TextContent("Evidence " + input.EvidenceID), StructuredContent: mustRawJSON(item)}, nil
+	case "reviews.record":
+		if mode == "review-record-tool-error" {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture reviews.record failed"), IsError: true}, nil
+		}
+		var input struct {
+			ProjectID      string `json:"project_id"`
+			WorkItemID     string `json:"work_item_id"`
+			AssignmentID   string `json:"assignment_id"`
+			ReviewerRoleID string `json:"reviewer_role_id"`
+			Title          string `json:"title"`
+			Body           string `json:"body"`
+			Verdict        string `json:"verdict"`
+			Risk           string `json:"risk"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid reviews.record arguments")
+		}
+		if input.ProjectID == "" || input.WorkItemID == "" || input.Body == "" || input.Verdict == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing review record arguments")
+		}
+		state.reviewSequence++
+		id := fmt.Sprintf("review_write_fixture_%d", state.reviewSequence)
+		review := ProjectCairnlineSidecarReviewItem{
+			ProjectID:      input.ProjectID,
+			ID:             id,
+			WorkItemID:     input.WorkItemID,
+			AssignmentID:   input.AssignmentID,
+			ReviewerRoleID: input.ReviewerRoleID,
+			Title:          input.Title,
+			Body:           input.Body,
+			Verdict:        input.Verdict,
+			Risk:           input.Risk,
+			Status:         "open",
+		}
+		cairnlineSidecarFixtureEnsureReviews(state, input.ProjectID)[id] = review
+		return mcp.CallToolResult{Content: mcp.TextContent("Recorded review " + id)}, nil
+	case "reviews.list":
+		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
+		items := cairnlineSidecarFixtureProjectReviews(state, projectID, workItemID)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Reviews for %s (%d)", workItemID, len(items)), items)
+	case "reviews.get":
+		var input struct {
+			ProjectID  string `json:"project_id"`
+			WorkItemID string `json:"work_item_id"`
+			ReviewID   string `json:"review_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid reviews.get arguments")
+		}
+		review, ok := state.reviews[input.ProjectID][input.ReviewID]
+		if !ok || review.WorkItemID != input.WorkItemID {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture review not found: " + input.ReviewID), IsError: true}, nil
+		}
+		return mcp.CallToolResult{Content: mcp.TextContent("Review " + input.ReviewID), StructuredContent: mustRawJSON(review)}, nil
+	case "handoffs.create":
+		var input struct {
+			ProjectID             string   `json:"project_id"`
+			WorkItemID            string   `json:"work_item_id"`
+			SourceAssignmentID    string   `json:"source_assignment_id"`
+			SourceRunID           string   `json:"source_run_id"`
+			SourceChatSessionID   string   `json:"source_chat_session_id"`
+			SourceMessageID       string   `json:"source_message_id"`
+			FromRoleID            string   `json:"from_role_id"`
+			ToRoleID              string   `json:"to_role_id"`
+			TargetAssignmentID    string   `json:"target_assignment_id"`
+			TargetWorkItemID      string   `json:"target_work_item_id"`
+			Title                 string   `json:"title"`
+			Body                  string   `json:"body"`
+			RecommendedNextAction string   `json:"recommended_next_action"`
+			LinkedArtifactIDs     []string `json:"linked_artifact_ids"`
+			LinkedMemoryIDs       []string `json:"linked_memory_ids"`
+			ContextRefs           []string `json:"context_refs"`
+			Status                string   `json:"status"`
+			ProvenanceKind        string   `json:"provenance_kind"`
+			TrustLabel            string   `json:"trust_label"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid handoffs.create arguments")
+		}
+		if input.ProjectID == "" || input.WorkItemID == "" || input.Title == "" || input.Body == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing handoff create arguments")
+		}
+		state.handoffSequence++
+		id := fmt.Sprintf("handoff_write_fixture_%d", state.handoffSequence)
+		status := firstNonEmpty(input.Status, "open")
+		handoff := ProjectCairnlineSidecarHandoffItem{
+			ProjectID:             input.ProjectID,
+			ID:                    id,
+			WorkItemID:            input.WorkItemID,
+			SourceAssignmentID:    input.SourceAssignmentID,
+			SourceRunID:           input.SourceRunID,
+			SourceChatSessionID:   input.SourceChatSessionID,
+			SourceMessageID:       input.SourceMessageID,
+			FromRoleID:            input.FromRoleID,
+			ToRoleID:              input.ToRoleID,
+			TargetAssignmentID:    input.TargetAssignmentID,
+			TargetWorkItemID:      input.TargetWorkItemID,
+			Title:                 input.Title,
+			Body:                  input.Body,
+			RecommendedNextAction: input.RecommendedNextAction,
+			LinkedArtifactIDs:     input.LinkedArtifactIDs,
+			LinkedMemoryIDs:       input.LinkedMemoryIDs,
+			ContextRefs:           input.ContextRefs,
+			Status:                status,
+			ProvenanceKind:        input.ProvenanceKind,
+			TrustLabel:            input.TrustLabel,
+		}
+		cairnlineSidecarFixtureEnsureHandoffs(state, input.ProjectID)[id] = handoff
+		return mcp.CallToolResult{Content: mcp.TextContent("Created handoff " + id)}, nil
+	case "handoffs.list":
+		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
+		items := cairnlineSidecarFixtureProjectHandoffs(state, projectID, workItemID)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Handoffs for %s (%d)", workItemID, len(items)), items)
+	case "handoffs.get":
+		var input struct {
+			ProjectID  string `json:"project_id"`
+			WorkItemID string `json:"work_item_id"`
+			HandoffID  string `json:"handoff_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid handoffs.get arguments")
+		}
+		handoff, ok := state.handoffs[input.ProjectID][input.HandoffID]
+		if !ok || handoff.WorkItemID != input.WorkItemID {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture handoff not found: " + input.HandoffID), IsError: true}, nil
+		}
+		return mcp.CallToolResult{Content: mcp.TextContent("Handoff " + input.HandoffID), StructuredContent: mustRawJSON(handoff)}, nil
 	default:
 		return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeMethodNotFound, params.Name)
 	}
@@ -984,6 +1236,78 @@ func cairnlineSidecarFixtureProjectAssignments(state *cairnlineSidecarFixtureSta
 	return assignments
 }
 
+func cairnlineSidecarFixtureEnsureArtifacts(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarArtifactItem {
+	if state.artifacts[projectID] == nil {
+		state.artifacts[projectID] = make(map[string]ProjectCairnlineSidecarArtifactItem)
+	}
+	return state.artifacts[projectID]
+}
+
+func cairnlineSidecarFixtureProjectArtifacts(state *cairnlineSidecarFixtureState, projectID, workItemID string) []ProjectCairnlineSidecarArtifactItem {
+	artifactsByID := state.artifacts[projectID]
+	artifacts := make([]ProjectCairnlineSidecarArtifactItem, 0, len(artifactsByID))
+	for _, artifact := range artifactsByID {
+		if workItemID == "" || artifact.WorkItemID == workItemID {
+			artifacts = append(artifacts, artifact)
+		}
+	}
+	return artifacts
+}
+
+func cairnlineSidecarFixtureEnsureEvidence(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarEvidenceItem {
+	if state.evidence[projectID] == nil {
+		state.evidence[projectID] = make(map[string]ProjectCairnlineSidecarEvidenceItem)
+	}
+	return state.evidence[projectID]
+}
+
+func cairnlineSidecarFixtureProjectEvidence(state *cairnlineSidecarFixtureState, projectID, workItemID string) []ProjectCairnlineSidecarEvidenceItem {
+	evidenceByID := state.evidence[projectID]
+	items := make([]ProjectCairnlineSidecarEvidenceItem, 0, len(evidenceByID))
+	for _, item := range evidenceByID {
+		if workItemID == "" || item.WorkItemID == workItemID {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func cairnlineSidecarFixtureEnsureReviews(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarReviewItem {
+	if state.reviews[projectID] == nil {
+		state.reviews[projectID] = make(map[string]ProjectCairnlineSidecarReviewItem)
+	}
+	return state.reviews[projectID]
+}
+
+func cairnlineSidecarFixtureProjectReviews(state *cairnlineSidecarFixtureState, projectID, workItemID string) []ProjectCairnlineSidecarReviewItem {
+	reviewsByID := state.reviews[projectID]
+	reviews := make([]ProjectCairnlineSidecarReviewItem, 0, len(reviewsByID))
+	for _, review := range reviewsByID {
+		if workItemID == "" || review.WorkItemID == workItemID {
+			reviews = append(reviews, review)
+		}
+	}
+	return reviews
+}
+
+func cairnlineSidecarFixtureEnsureHandoffs(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarHandoffItem {
+	if state.handoffs[projectID] == nil {
+		state.handoffs[projectID] = make(map[string]ProjectCairnlineSidecarHandoffItem)
+	}
+	return state.handoffs[projectID]
+}
+
+func cairnlineSidecarFixtureProjectHandoffs(state *cairnlineSidecarFixtureState, projectID, workItemID string) []ProjectCairnlineSidecarHandoffItem {
+	handoffsByID := state.handoffs[projectID]
+	handoffs := make([]ProjectCairnlineSidecarHandoffItem, 0, len(handoffsByID))
+	for _, handoff := range handoffsByID {
+		if workItemID == "" || handoff.WorkItemID == workItemID {
+			handoffs = append(handoffs, handoff)
+		}
+	}
+	return handoffs
+}
+
 func cairnlineSidecarFixtureListResult(mode, text string, structured any) (mcp.CallToolResult, *mcp.RPCError) {
 	result := mcp.CallToolResult{Content: mcp.TextContent(text)}
 	if mode != "text-only" {
@@ -998,6 +1322,15 @@ func cairnlineSidecarFixtureProjectID(raw json.RawMessage) string {
 	}
 	_ = json.Unmarshal(raw, &input)
 	return input.ProjectID
+}
+
+func cairnlineSidecarFixtureProjectWorkIDs(raw json.RawMessage) (string, string) {
+	var input struct {
+		ProjectID  string `json:"project_id"`
+		WorkItemID string `json:"work_item_id"`
+	}
+	_ = json.Unmarshal(raw, &input)
+	return input.ProjectID, input.WorkItemID
 }
 
 func mustRawJSON(value any) json.RawMessage {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
@@ -291,6 +291,20 @@ func (h *Handler) HandleProjectCairnlineSidecarWorkSmoke(w http.ResponseWriter, 
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarWorkEnvelope{
 		Object: "project_cairnline_sidecar_work",
 		Data:   h.projectCairnlineSidecarWorkSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarCollaborationSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar collaboration smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarCollaborationRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarCollaborationEnvelope{
+		Object: "project_cairnline_sidecar_collaboration",
+		Data:   h.projectCairnlineSidecarCollaborationSmoke(r.Context(), req),
 	})
 }
 
@@ -1668,6 +1682,350 @@ func (h *Handler) projectCairnlineSidecarWorkSmoke(ctx context.Context, req Proj
 	return fail("sidecar_work_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary work project.")
 }
 
+func (h *Handler) projectCairnlineSidecarCollaborationSmoke(ctx context.Context, req ProjectCairnlineSidecarCollaborationRequest) ProjectCairnlineSidecarCollaborationResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	projectName := strings.TrimSpace(req.ProjectName)
+	if projectName == "" {
+		projectName = "Hecate sidecar collaboration smoke " + time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+	const (
+		authorRoleName   = "Sidecar collaboration author"
+		reviewerRoleName = "Sidecar collaboration reviewer"
+		workTitle        = "Sidecar collaboration smoke task"
+		artifactTitle    = "Sidecar collaboration artifact"
+		evidenceTitle    = "Sidecar collaboration evidence"
+		reviewTitle      = "Sidecar collaboration review"
+		handoffTitle     = "Sidecar collaboration handoff"
+	)
+	response := ProjectCairnlineSidecarCollaborationResponse{
+		Ready:                 false,
+		Status:                "sidecar_collaboration_not_run",
+		Detail:                "Cairnline sidecar collaboration smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ConfirmedMutation:     req.ConfirmMutation,
+		ProjectName:           projectName,
+	}
+	if h == nil {
+		response.Status = "sidecar_collaboration_failed"
+		response.Detail = "Cairnline sidecar collaboration smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this collaboration smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+	if !req.ConfirmMutation {
+		response.Status = "sidecar_collaboration_confirmation_required"
+		response.Detail = "Set confirm_mutation=true to let Hecate create, verify, and clean up temporary collaboration artifact, evidence, review, and handoff records in the standalone Cairnline sidecar. Hecate-native Projects stores are not mutated."
+		return response
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := ""
+	cleanup := func() {
+		if projectID == "" || response.CleanupVerified {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+		defer cleanupCancel()
+		cleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_delete_project", "projects.delete", false, map[string]string{"id": projectID})
+		response.Steps = append(response.Steps, cleanupStep)
+		if cleanupStep.Status == "ready" {
+			verifyCleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+			if verifyCleanupStep.Status == "tool_failed" {
+				verifyCleanupStep.Status = "expected_missing"
+				response.CleanupVerified = true
+				response.Warnings = append(response.Warnings, "Hecate deleted and verified removal of the temporary standalone Cairnline collaboration project after the collaboration smoke failed; inspect the reported steps before retrying.")
+			} else {
+				response.Warnings = append(response.Warnings, "Hecate deleted the temporary standalone Cairnline collaboration project after the collaboration smoke failed, but removal could not be verified; inspect the reported steps before retrying.")
+			}
+			response.Steps = append(response.Steps, verifyCleanupStep)
+			return
+		}
+		response.Warnings = append(response.Warnings, "Hecate tried to delete the temporary standalone Cairnline collaboration project after the collaboration smoke failed, but cleanup did not succeed; inspect the standalone Cairnline sidecar before retrying.")
+	}
+	fail := func(status, detail string) ProjectCairnlineSidecarCollaborationResponse {
+		response.Status = status
+		response.Detail = detail
+		cleanup()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	appendStep := func(step ProjectCairnlineSidecarWriteStep) bool {
+		response.Steps = append(response.Steps, step)
+		if step.Status == "tool_failed" {
+			response.Status = "sidecar_collaboration_tool_failed"
+			response.Detail = "Cairnline sidecar " + step.Tool + " returned a tool-level error. Review the step output before retrying."
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		if step.Status == "failed" {
+			response.Status = "sidecar_collaboration_failed"
+			response.Detail = firstNonEmpty(step.ToolText, "Cairnline sidecar "+step.Tool+" failed.")
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		return true
+	}
+
+	createProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_project", "projects.create", false, map[string]string{
+		"name":        projectName,
+		"description": "Temporary Hecate sidecar collaboration smoke project. It should be deleted by the same diagnostic run.",
+	})
+	if !appendStep(createProject) {
+		return response
+	}
+	listProjects := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_after_project_create", "projects.list", true, map[string]string{})
+	if !appendStep(listProjects) {
+		return response
+	}
+	project, ok := projectCairnlineSidecarProjectByName(listProjects.StructuredProjects, projectName)
+	if !ok || strings.TrimSpace(project.ID) == "" {
+		return fail("sidecar_collaboration_created_project_not_listed", "Cairnline sidecar projects.create succeeded, but projects.list did not return the temporary collaboration project by name.")
+	}
+	projectID = strings.TrimSpace(project.ID)
+	response.SelectedProjectID = projectID
+
+	createAuthorRole := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_author_role", "roles.create", false, map[string]any{
+		"project_id":             projectID,
+		"name":                   authorRoleName,
+		"description":            "Temporary author role created by the Hecate sidecar collaboration smoke.",
+		"instructions":           "Produce collaboration evidence for the temporary smoke.",
+		"default_execution_mode": "mcp_pull",
+	})
+	if !appendStep(createAuthorRole) {
+		return response
+	}
+	createReviewerRole := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_reviewer_role", "roles.create", false, map[string]any{
+		"project_id":             projectID,
+		"name":                   reviewerRoleName,
+		"description":            "Temporary reviewer role created by the Hecate sidecar collaboration smoke.",
+		"instructions":           "Review collaboration evidence for the temporary smoke.",
+		"default_execution_mode": "manual",
+	})
+	if !appendStep(createReviewerRole) {
+		return response
+	}
+	listRoles := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_roles_after_create", "roles.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listRoles) {
+		return response
+	}
+	authorRole, ok := projectCairnlineSidecarRoleByName(listRoles.StructuredRoles, authorRoleName)
+	if !ok || strings.TrimSpace(authorRole.ID) == "" || authorRole.DefaultExecutionMode != "mcp_pull" {
+		return fail("sidecar_collaboration_author_role_verification_failed", "Cairnline sidecar roles.list did not return the expected temporary author role.")
+	}
+	reviewerRole, ok := projectCairnlineSidecarRoleByName(listRoles.StructuredRoles, reviewerRoleName)
+	if !ok || strings.TrimSpace(reviewerRole.ID) == "" || reviewerRole.DefaultExecutionMode != "manual" {
+		return fail("sidecar_collaboration_reviewer_role_verification_failed", "Cairnline sidecar roles.list did not return the expected temporary reviewer role.")
+	}
+	response.AuthorRoleID = strings.TrimSpace(authorRole.ID)
+	response.ReviewerRoleID = strings.TrimSpace(reviewerRole.ID)
+
+	createWork := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_work_item", "work_items.create", false, map[string]string{
+		"project_id":    projectID,
+		"title":         workTitle,
+		"brief":         "Temporary collaboration work item created by the Hecate sidecar collaboration smoke.",
+		"owner_role_id": response.AuthorRoleID,
+	})
+	if !appendStep(createWork) {
+		return response
+	}
+	listWork := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_work_items_after_create", "work_items.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listWork) {
+		return response
+	}
+	work, ok := projectCairnlineSidecarWorkItemByTitle(listWork.StructuredWorkItems, workTitle)
+	if !ok || strings.TrimSpace(work.ID) == "" || strings.TrimSpace(work.OwnerRoleID) != response.AuthorRoleID {
+		return fail("sidecar_collaboration_work_item_verification_failed", "Cairnline sidecar work_items.list did not return the expected temporary collaboration work item.")
+	}
+	response.WorkItemID = strings.TrimSpace(work.ID)
+
+	createAssignment := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_assignment", "assignments.create", false, map[string]any{
+		"project_id":         projectID,
+		"work_item_id":       response.WorkItemID,
+		"role_id":            response.AuthorRoleID,
+		"execution_mode":     "mcp_pull",
+		"desired_agent_kind": "any",
+	})
+	if !appendStep(createAssignment) {
+		return response
+	}
+	listAssignments := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_assignments_after_create", "assignments.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listAssignments) {
+		return response
+	}
+	assignment, ok := projectCairnlineSidecarAssignmentByWorkAndRole(listAssignments.StructuredAssignments, response.WorkItemID, response.AuthorRoleID)
+	if !ok || strings.TrimSpace(assignment.ID) == "" || assignment.ExecutionMode != "mcp_pull" {
+		return fail("sidecar_collaboration_assignment_verification_failed", "Cairnline sidecar assignments.list did not return the expected temporary collaboration assignment.")
+	}
+	response.AssignmentID = strings.TrimSpace(assignment.ID)
+
+	createArtifact := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_artifact", "artifacts.create", false, map[string]string{
+		"project_id":      projectID,
+		"work_item_id":    response.WorkItemID,
+		"assignment_id":   response.AssignmentID,
+		"kind":            "diagnostic_note",
+		"title":           artifactTitle,
+		"body":            "Temporary artifact created by the Hecate sidecar collaboration smoke.",
+		"author_role_id":  response.AuthorRoleID,
+		"provenance_kind": "hecate_sidecar_smoke",
+		"trust_label":     "diagnostic",
+	})
+	if !appendStep(createArtifact) {
+		return response
+	}
+	if createArtifact.StructuredArtifact.Title != artifactTitle || createArtifact.StructuredArtifact.AssignmentID != response.AssignmentID {
+		return fail("sidecar_collaboration_artifact_create_verification_failed", "Cairnline sidecar artifacts.create did not return the expected temporary artifact.")
+	}
+	listArtifacts := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_artifacts_after_create", "artifacts.list", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID})
+	if !appendStep(listArtifacts) {
+		return response
+	}
+	artifact, ok := projectCairnlineSidecarArtifactByTitle(listArtifacts.StructuredArtifacts, artifactTitle)
+	if !ok || strings.TrimSpace(artifact.ID) == "" || artifact.AssignmentID != response.AssignmentID || artifact.Kind != "diagnostic_note" {
+		return fail("sidecar_collaboration_artifact_list_verification_failed", "Cairnline sidecar artifacts.list did not return the expected temporary artifact.")
+	}
+	getArtifact := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_artifact", "artifacts.get", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID, "artifact_id": artifact.ID})
+	if !appendStep(getArtifact) {
+		return response
+	}
+	if getArtifact.StructuredArtifact.ID != artifact.ID || getArtifact.StructuredArtifact.Title != artifactTitle {
+		return fail("sidecar_collaboration_artifact_get_verification_failed", "Cairnline sidecar artifacts.get did not return the expected temporary artifact.")
+	}
+	response.CreatedArtifact = getArtifact.StructuredArtifact
+
+	recordEvidence := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "record_evidence", "evidence.record", false, map[string]string{
+		"project_id":    projectID,
+		"work_item_id":  response.WorkItemID,
+		"assignment_id": response.AssignmentID,
+		"title":         evidenceTitle,
+		"body":          "Temporary evidence created by the Hecate sidecar collaboration smoke.",
+		"locator":       "file://hecate-sidecar-collaboration-smoke.md",
+		"source_kind":   "diagnostic",
+		"provider":      "hecate",
+		"trust_label":   "diagnostic",
+	})
+	if !appendStep(recordEvidence) {
+		return response
+	}
+	listEvidence := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_evidence_after_record", "evidence.list", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID})
+	if !appendStep(listEvidence) {
+		return response
+	}
+	evidence, ok := projectCairnlineSidecarEvidenceByTitle(listEvidence.StructuredEvidence, evidenceTitle)
+	if !ok || strings.TrimSpace(evidence.ID) == "" || evidence.AssignmentID != response.AssignmentID || evidence.Locator == "" {
+		return fail("sidecar_collaboration_evidence_list_verification_failed", "Cairnline sidecar evidence.list did not return the expected temporary evidence.")
+	}
+	getEvidence := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_evidence", "evidence.get", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID, "evidence_id": evidence.ID})
+	if !appendStep(getEvidence) {
+		return response
+	}
+	if getEvidence.StructuredEvidenceItem.ID != evidence.ID || getEvidence.StructuredEvidenceItem.Title != evidenceTitle {
+		return fail("sidecar_collaboration_evidence_get_verification_failed", "Cairnline sidecar evidence.get did not return the expected temporary evidence.")
+	}
+	response.CreatedEvidence = getEvidence.StructuredEvidenceItem
+
+	recordReview := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "record_review", "reviews.record", false, map[string]string{
+		"project_id":       projectID,
+		"work_item_id":     response.WorkItemID,
+		"assignment_id":    response.AssignmentID,
+		"reviewer_role_id": response.ReviewerRoleID,
+		"title":            reviewTitle,
+		"body":             "Temporary review created by the Hecate sidecar collaboration smoke.",
+		"verdict":          "approved",
+		"risk":             "low",
+	})
+	if !appendStep(recordReview) {
+		return response
+	}
+	listReviews := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_reviews_after_record", "reviews.list", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID})
+	if !appendStep(listReviews) {
+		return response
+	}
+	review, ok := projectCairnlineSidecarReviewByTitle(listReviews.StructuredReviews, reviewTitle)
+	if !ok || strings.TrimSpace(review.ID) == "" || review.AssignmentID != response.AssignmentID || review.ReviewerRoleID != response.ReviewerRoleID || review.Verdict != "approved" {
+		return fail("sidecar_collaboration_review_list_verification_failed", "Cairnline sidecar reviews.list did not return the expected temporary review.")
+	}
+	getReview := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_review", "reviews.get", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID, "review_id": review.ID})
+	if !appendStep(getReview) {
+		return response
+	}
+	if getReview.StructuredReview.ID != review.ID || getReview.StructuredReview.Title != reviewTitle || getReview.StructuredReview.Verdict != "approved" {
+		return fail("sidecar_collaboration_review_get_verification_failed", "Cairnline sidecar reviews.get did not return the expected temporary review.")
+	}
+	response.CreatedReview = getReview.StructuredReview
+
+	createHandoff := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_handoff", "handoffs.create", false, map[string]any{
+		"project_id":              projectID,
+		"work_item_id":            response.WorkItemID,
+		"source_assignment_id":    response.AssignmentID,
+		"from_role_id":            response.AuthorRoleID,
+		"to_role_id":              response.ReviewerRoleID,
+		"title":                   handoffTitle,
+		"body":                    "Temporary handoff created by the Hecate sidecar collaboration smoke.",
+		"recommended_next_action": "Delete this smoke project after verification.",
+		"linked_artifact_ids":     []string{response.CreatedArtifact.ID},
+		"context_refs":            []string{response.CreatedEvidence.ID, response.CreatedReview.ID},
+		"status":                  "open",
+		"provenance_kind":         "hecate_sidecar_smoke",
+		"trust_label":             "diagnostic",
+	})
+	if !appendStep(createHandoff) {
+		return response
+	}
+	listHandoffs := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_handoffs_after_create", "handoffs.list", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID})
+	if !appendStep(listHandoffs) {
+		return response
+	}
+	handoff, ok := projectCairnlineSidecarHandoffByTitle(listHandoffs.StructuredHandoffs, handoffTitle)
+	if !ok || strings.TrimSpace(handoff.ID) == "" || handoff.SourceAssignmentID != response.AssignmentID || handoff.FromRoleID != response.AuthorRoleID || handoff.ToRoleID != response.ReviewerRoleID || handoff.Status != "open" {
+		return fail("sidecar_collaboration_handoff_list_verification_failed", "Cairnline sidecar handoffs.list did not return the expected temporary handoff.")
+	}
+	getHandoff := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_handoff", "handoffs.get", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID, "handoff_id": handoff.ID})
+	if !appendStep(getHandoff) {
+		return response
+	}
+	if getHandoff.StructuredHandoff.ID != handoff.ID || getHandoff.StructuredHandoff.Title != handoffTitle || getHandoff.StructuredHandoff.Status != "open" {
+		return fail("sidecar_collaboration_handoff_get_verification_failed", "Cairnline sidecar handoffs.get did not return the expected temporary handoff.")
+	}
+	response.CreatedHandoff = getHandoff.StructuredHandoff
+
+	deleteProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_project", "projects.delete", false, map[string]string{"id": projectID})
+	if !appendStep(deleteProject) {
+		return response
+	}
+	verifyDelete := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+	if verifyDelete.Status == "tool_failed" {
+		verifyDelete.Status = "expected_missing"
+		response.Steps = append(response.Steps, verifyDelete)
+		response.CleanupVerified = true
+		response.Ready = true
+		response.Status = "sidecar_collaboration_ready"
+		response.Detail = "Hecate created and verified temporary standalone Cairnline artifact, evidence, review, and handoff metadata through the persistent sidecar client, then deleted the temporary project. Hecate-native Projects stores were not mutated."
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	if !appendStep(verifyDelete) {
+		return response
+	}
+	return fail("sidecar_collaboration_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary collaboration project.")
+}
+
 func projectCairnlineSidecarLifecycleShouldReleaseAfterFailure(steps []ProjectCairnlineSidecarLifecycleStep) bool {
 	claimed := false
 	for _, step := range steps {
@@ -2148,6 +2506,130 @@ func (h *Handler) callProjectCairnlineSidecarWriteTool(ctx context.Context, cfg 
 			step.ToolText = "Cairnline sidecar assignments.list did not return structuredContent; the work smoke needs typed assignments to verify coordination mutations."
 			return step
 		}
+	case "artifacts.list":
+		artifacts, structuredReady, structuredErr := projectCairnlineSidecarStructuredArtifacts(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredArtifacts = artifacts
+		step.StructuredArtifactCount = len(artifacts)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar artifacts.list returned structuredContent that Hecate could not parse as an artifact list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar artifacts.list did not return structuredContent; the collaboration smoke needs typed artifacts to verify collaboration mutations."
+			return step
+		}
+	case "artifacts.create", "artifacts.get":
+		artifact, structuredReady, structuredErr := projectCairnlineSidecarStructuredArtifact(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredArtifact = artifact
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " returned structuredContent that Hecate could not parse as an artifact: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " did not return structuredContent; the collaboration smoke needs typed artifact detail to verify collaboration mutations."
+			return step
+		}
+	case "evidence.list":
+		evidence, structuredReady, structuredErr := projectCairnlineSidecarStructuredEvidence(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredEvidence = evidence
+		step.StructuredEvidenceCount = len(evidence)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar evidence.list returned structuredContent that Hecate could not parse as an evidence list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar evidence.list did not return structuredContent; the collaboration smoke needs typed evidence to verify collaboration mutations."
+			return step
+		}
+	case "evidence.get":
+		evidence, structuredReady, structuredErr := projectCairnlineSidecarStructuredEvidenceItem(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredEvidenceItem = evidence
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar evidence.get returned structuredContent that Hecate could not parse as evidence: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar evidence.get did not return structuredContent; the collaboration smoke needs typed evidence detail to verify collaboration mutations."
+			return step
+		}
+	case "reviews.list":
+		reviews, structuredReady, structuredErr := projectCairnlineSidecarStructuredReviews(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredReviews = reviews
+		step.StructuredReviewCount = len(reviews)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar reviews.list returned structuredContent that Hecate could not parse as a review list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar reviews.list did not return structuredContent; the collaboration smoke needs typed reviews to verify collaboration mutations."
+			return step
+		}
+	case "reviews.get":
+		review, structuredReady, structuredErr := projectCairnlineSidecarStructuredReview(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredReview = review
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar reviews.get returned structuredContent that Hecate could not parse as a review: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar reviews.get did not return structuredContent; the collaboration smoke needs typed review detail to verify collaboration mutations."
+			return step
+		}
+	case "handoffs.list":
+		handoffs, structuredReady, structuredErr := projectCairnlineSidecarStructuredHandoffs(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredHandoffs = handoffs
+		step.StructuredHandoffCount = len(handoffs)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar handoffs.list returned structuredContent that Hecate could not parse as a handoff list: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar handoffs.list did not return structuredContent; the collaboration smoke needs typed handoffs to verify collaboration mutations."
+			return step
+		}
+	case "handoffs.get":
+		handoff, structuredReady, structuredErr := projectCairnlineSidecarStructuredHandoff(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredHandoff = handoff
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar handoffs.get returned structuredContent that Hecate could not parse as a handoff: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar handoffs.get did not return structuredContent; the collaboration smoke needs typed handoff detail to verify collaboration mutations."
+			return step
+		}
 	case "assignments.context":
 		contextIDs, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignmentContextIDs(result.Result.StructuredContent)
 		step.StructuredReady = structuredReady
@@ -2299,6 +2781,46 @@ func projectCairnlineSidecarAssignmentByWorkAndRole(assignments []ProjectCairnli
 	return ProjectCairnlineSidecarAssignmentItem{}, false
 }
 
+func projectCairnlineSidecarArtifactByTitle(artifacts []ProjectCairnlineSidecarArtifactItem, title string) (ProjectCairnlineSidecarArtifactItem, bool) {
+	title = strings.TrimSpace(title)
+	for _, artifact := range artifacts {
+		if strings.TrimSpace(artifact.Title) == title {
+			return artifact, true
+		}
+	}
+	return ProjectCairnlineSidecarArtifactItem{}, false
+}
+
+func projectCairnlineSidecarEvidenceByTitle(items []ProjectCairnlineSidecarEvidenceItem, title string) (ProjectCairnlineSidecarEvidenceItem, bool) {
+	title = strings.TrimSpace(title)
+	for _, item := range items {
+		if strings.TrimSpace(item.Title) == title {
+			return item, true
+		}
+	}
+	return ProjectCairnlineSidecarEvidenceItem{}, false
+}
+
+func projectCairnlineSidecarReviewByTitle(reviews []ProjectCairnlineSidecarReviewItem, title string) (ProjectCairnlineSidecarReviewItem, bool) {
+	title = strings.TrimSpace(title)
+	for _, review := range reviews {
+		if strings.TrimSpace(review.Title) == title {
+			return review, true
+		}
+	}
+	return ProjectCairnlineSidecarReviewItem{}, false
+}
+
+func projectCairnlineSidecarHandoffByTitle(handoffs []ProjectCairnlineSidecarHandoffItem, title string) (ProjectCairnlineSidecarHandoffItem, bool) {
+	title = strings.TrimSpace(title)
+	for _, handoff := range handoffs {
+		if strings.TrimSpace(handoff.Title) == title {
+			return handoff, true
+		}
+	}
+	return ProjectCairnlineSidecarHandoffItem{}, false
+}
+
 func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairnlineSidecarProjectItem, bool, error) {
 	if len(raw) == 0 {
 		return ProjectCairnlineSidecarProjectItem{}, false, nil
@@ -2447,6 +2969,150 @@ func projectCairnlineSidecarStructuredAssignments(raw json.RawMessage) ([]Projec
 		assignments = []ProjectCairnlineSidecarAssignmentItem{}
 	}
 	return assignments, true, nil
+}
+
+func projectCairnlineSidecarStructuredArtifacts(raw json.RawMessage) ([]ProjectCairnlineSidecarArtifactItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarArtifactItem{}, true, nil
+	}
+	var artifacts []ProjectCairnlineSidecarArtifactItem
+	if err := json.Unmarshal(trimmed, &artifacts); err != nil {
+		return nil, false, err
+	}
+	if artifacts == nil {
+		artifacts = []ProjectCairnlineSidecarArtifactItem{}
+	}
+	return artifacts, true, nil
+}
+
+func projectCairnlineSidecarStructuredArtifact(raw json.RawMessage) (ProjectCairnlineSidecarArtifactItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarArtifactItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarArtifactItem{}, false, nil
+	}
+	var artifact ProjectCairnlineSidecarArtifactItem
+	if err := json.Unmarshal(trimmed, &artifact); err != nil {
+		return ProjectCairnlineSidecarArtifactItem{}, false, err
+	}
+	return artifact, true, nil
+}
+
+func projectCairnlineSidecarStructuredEvidence(raw json.RawMessage) ([]ProjectCairnlineSidecarEvidenceItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarEvidenceItem{}, true, nil
+	}
+	var items []ProjectCairnlineSidecarEvidenceItem
+	if err := json.Unmarshal(trimmed, &items); err != nil {
+		return nil, false, err
+	}
+	if items == nil {
+		items = []ProjectCairnlineSidecarEvidenceItem{}
+	}
+	return items, true, nil
+}
+
+func projectCairnlineSidecarStructuredEvidenceItem(raw json.RawMessage) (ProjectCairnlineSidecarEvidenceItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarEvidenceItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarEvidenceItem{}, false, nil
+	}
+	var item ProjectCairnlineSidecarEvidenceItem
+	if err := json.Unmarshal(trimmed, &item); err != nil {
+		return ProjectCairnlineSidecarEvidenceItem{}, false, err
+	}
+	return item, true, nil
+}
+
+func projectCairnlineSidecarStructuredReviews(raw json.RawMessage) ([]ProjectCairnlineSidecarReviewItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarReviewItem{}, true, nil
+	}
+	var reviews []ProjectCairnlineSidecarReviewItem
+	if err := json.Unmarshal(trimmed, &reviews); err != nil {
+		return nil, false, err
+	}
+	if reviews == nil {
+		reviews = []ProjectCairnlineSidecarReviewItem{}
+	}
+	return reviews, true, nil
+}
+
+func projectCairnlineSidecarStructuredReview(raw json.RawMessage) (ProjectCairnlineSidecarReviewItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarReviewItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarReviewItem{}, false, nil
+	}
+	var review ProjectCairnlineSidecarReviewItem
+	if err := json.Unmarshal(trimmed, &review); err != nil {
+		return ProjectCairnlineSidecarReviewItem{}, false, err
+	}
+	return review, true, nil
+}
+
+func projectCairnlineSidecarStructuredHandoffs(raw json.RawMessage) ([]ProjectCairnlineSidecarHandoffItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarHandoffItem{}, true, nil
+	}
+	var handoffs []ProjectCairnlineSidecarHandoffItem
+	if err := json.Unmarshal(trimmed, &handoffs); err != nil {
+		return nil, false, err
+	}
+	if handoffs == nil {
+		handoffs = []ProjectCairnlineSidecarHandoffItem{}
+	}
+	return handoffs, true, nil
+}
+
+func projectCairnlineSidecarStructuredHandoff(raw json.RawMessage) (ProjectCairnlineSidecarHandoffItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarHandoffItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarHandoffItem{}, false, nil
+	}
+	var handoff ProjectCairnlineSidecarHandoffItem
+	if err := json.Unmarshal(trimmed, &handoff); err != nil {
+		return ProjectCairnlineSidecarHandoffItem{}, false, err
+	}
+	return handoff, true, nil
 }
 
 func projectCairnlineSidecarStructuredAssignmentContextIDs(raw json.RawMessage) (ProjectCairnlineSidecarAssignmentContextIDs, bool, error) {
@@ -2708,6 +3374,15 @@ func (r *ProjectCairnlineSidecarSetupResponse) setSidecarCacheStats(stats mcpcli
 }
 
 func (r *ProjectCairnlineSidecarWorkResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarCollaborationResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -1179,6 +1179,93 @@ func TestProjectCairnlineSidecarWorkSmoke_CleansUpAfterContextFailure(t *testing
 	}
 }
 
+func TestProjectCairnlineSidecarCollaborationSmoke_RequiresConfirmation(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarCollaborationSmoke(t.Context(), ProjectCairnlineSidecarCollaborationRequest{ProjectName: "Fixture collaboration smoke"})
+	if got.Ready || got.Status != "sidecar_collaboration_confirmation_required" || got.ConfirmedMutation {
+		t.Fatalf("collaboration smoke = %+v, want confirmation-required without mutation", got)
+	}
+	if len(got.Steps) != 0 || got.ClientCacheEntries != 0 {
+		t.Fatalf("steps/cache = %d/%d, want no sidecar calls before confirmation", len(got.Steps), got.ClientCacheEntries)
+	}
+}
+
+func TestProjectCairnlineSidecarCollaborationSmoke_CreatesCollaborationRecords(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarCollaborationSmoke(t.Context(), ProjectCairnlineSidecarCollaborationRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture collaboration smoke",
+	})
+	if !got.Ready || got.Status != "sidecar_collaboration_ready" || !got.CleanupVerified {
+		t.Fatalf("collaboration smoke = %+v, want ready with verified cleanup", got)
+	}
+	if got.SelectedProjectID == "" || got.AuthorRoleID == "" || got.ReviewerRoleID == "" || got.WorkItemID == "" || got.AssignmentID == "" {
+		t.Fatalf("ids = project:%q author:%q reviewer:%q work:%q assignment:%q, want created collaboration ids", got.SelectedProjectID, got.AuthorRoleID, got.ReviewerRoleID, got.WorkItemID, got.AssignmentID)
+	}
+	if got.CreatedArtifact.Title != "Sidecar collaboration artifact" || got.CreatedArtifact.AssignmentID != got.AssignmentID || got.CreatedArtifact.Kind != "diagnostic_note" {
+		t.Fatalf("created artifact = %+v, want verified diagnostic artifact for assignment %q", got.CreatedArtifact, got.AssignmentID)
+	}
+	if got.CreatedEvidence.Title != "Sidecar collaboration evidence" || got.CreatedEvidence.AssignmentID != got.AssignmentID || got.CreatedEvidence.Locator == "" {
+		t.Fatalf("created evidence = %+v, want verified evidence for assignment %q", got.CreatedEvidence, got.AssignmentID)
+	}
+	if got.CreatedReview.Title != "Sidecar collaboration review" || got.CreatedReview.AssignmentID != got.AssignmentID || got.CreatedReview.ReviewerRoleID != got.ReviewerRoleID || got.CreatedReview.Verdict != "approved" {
+		t.Fatalf("created review = %+v, want verified approved review by reviewer role %q", got.CreatedReview, got.ReviewerRoleID)
+	}
+	if got.CreatedHandoff.Title != "Sidecar collaboration handoff" || got.CreatedHandoff.SourceAssignmentID != got.AssignmentID || got.CreatedHandoff.FromRoleID != got.AuthorRoleID || got.CreatedHandoff.ToRoleID != got.ReviewerRoleID || got.CreatedHandoff.Status != "open" {
+		t.Fatalf("created handoff = %+v, want verified open handoff from author to reviewer", got.CreatedHandoff)
+	}
+	if len(got.Steps) != 23 {
+		t.Fatalf("steps = %+v, want project/role/work/assignment/collaboration/delete flow", got.Steps)
+	}
+	if got.Steps[9].Tool != "artifacts.create" || got.Steps[12].Tool != "evidence.record" || got.Steps[15].Tool != "reviews.record" || got.Steps[18].Tool != "handoffs.create" || got.Steps[22].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want collaboration smoke order and missing-after-delete verification", got.Steps)
+	}
+}
+
+func TestProjectCairnlineSidecarCollaborationSmoke_CleansUpAfterReviewFailure(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "review-record-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarCollaborationSmoke(t.Context(), ProjectCairnlineSidecarCollaborationRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture collaboration smoke cleanup",
+	})
+	if got.Ready || got.Status != "sidecar_collaboration_tool_failed" || !got.CleanupVerified {
+		t.Fatalf("collaboration smoke = %+v, want review tool failure with verified project cleanup", got)
+	}
+	if len(got.Steps) != 18 || got.Steps[15].Tool != "reviews.record" || !got.Steps[15].ToolIsError || got.Steps[16].Name != "cleanup_delete_project" || got.Steps[17].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want review failure followed by project cleanup delete and verification", got.Steps)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "deleted and verified removal") {
+		t.Fatalf("warnings = %+v, want verified cleanup warning", got.Warnings)
+	}
+}
+
 func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureAfterRunningCannotRelease(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -17,6 +17,7 @@ const projectCoordinationBackendSidecarLifecycleURL = "/hecate/v1/projects/cairn
 const projectCoordinationBackendSidecarSetupURL = "/hecate/v1/projects/cairnline/sidecar-setup-smoke"
 const projectCoordinationBackendSidecarWriteURL = "/hecate/v1/projects/cairnline/sidecar-write-smoke"
 const projectCoordinationBackendSidecarWorkURL = "/hecate/v1/projects/cairnline/sidecar-work-smoke"
+const projectCoordinationBackendSidecarCollaborationURL = "/hecate/v1/projects/cairnline/sidecar-collaboration-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -317,6 +318,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarSetupURL:             projectCoordinationBackendSidecarSetupURL,
 		CairnlineSidecarWriteURL:             projectCoordinationBackendSidecarWriteURL,
 		CairnlineSidecarWorkURL:              projectCoordinationBackendSidecarWorkURL,
+		CairnlineSidecarCollaborationURL:     projectCoordinationBackendSidecarCollaborationURL,
 		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -60,6 +60,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarWorkURL != projectCoordinationBackendSidecarWorkURL {
 		t.Fatalf("sidecar work URL = %q, want %q", status.CairnlineSidecarWorkURL, projectCoordinationBackendSidecarWorkURL)
 	}
+	if status.CairnlineSidecarCollaborationURL != projectCoordinationBackendSidecarCollaborationURL {
+		t.Fatalf("sidecar collaboration URL = %q, want %q", status.CairnlineSidecarCollaborationURL, projectCoordinationBackendSidecarCollaborationURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -127,7 +130,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.Status != "cairnline_connector_not_ready" || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
 		t.Fatalf("status = %+v, want sidecar connector mode to block live Cairnline routing", status)
 	}
-	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write/setup/work diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
+	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write/setup/work/collaboration diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
 		t.Fatalf("connector detail = %q, want full sidecar diagnostic surface", status.CairnlineConnectorDetail)
 	}
 	if handler.projectReadRoutesUseCairnlineReadModel() || handler.projectIdentityWritesUseCairnlineAuthority() || handler.projectMemoryWritesUseCairnlineAuthority() || handler.projectAssignmentWritesUseCairnlineAuthority() {
@@ -166,6 +169,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.CairnlineSidecarWorkURL != projectCoordinationBackendSidecarWorkURL {
 		t.Fatalf("sidecar work URL = %q, want %q", status.CairnlineSidecarWorkURL, projectCoordinationBackendSidecarWorkURL)
 	}
+	if status.CairnlineSidecarCollaborationURL != projectCoordinationBackendSidecarCollaborationURL {
+		t.Fatalf("sidecar collaboration URL = %q, want %q", status.CairnlineSidecarCollaborationURL, projectCoordinationBackendSidecarCollaborationURL)
+	}
 	if len(status.ReadRoutes) != 0 {
 		t.Fatalf("read routes = %+v, want none in sidecar connector mode", status.ReadRoutes)
 	}
@@ -179,7 +185,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 		t.Fatalf("project-identity switchpoint = %+v, want Hecate authority while sidecar routing is not live", point)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
+	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
 		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
 	}
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -586,6 +586,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarSetupURL             string                                       `json:"cairnline_sidecar_setup_url,omitempty"`
 	CairnlineSidecarWriteURL             string                                       `json:"cairnline_sidecar_write_url,omitempty"`
 	CairnlineSidecarWorkURL              string                                       `json:"cairnline_sidecar_work_url,omitempty"`
+	CairnlineSidecarCollaborationURL     string                                       `json:"cairnline_sidecar_collaboration_url,omitempty"`
 	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
@@ -1727,6 +1728,11 @@ type ProjectCairnlineSidecarWorkEnvelope struct {
 	Data   ProjectCairnlineSidecarWorkResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarCollaborationEnvelope struct {
+	Object string                                       `json:"object"`
+	Data   ProjectCairnlineSidecarCollaborationResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
@@ -1768,6 +1774,11 @@ type ProjectCairnlineSidecarSetupRequest struct {
 }
 
 type ProjectCairnlineSidecarWorkRequest struct {
+	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
+	ProjectName     string `json:"project_name,omitempty"`
+}
+
+type ProjectCairnlineSidecarCollaborationRequest struct {
 	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
 	ProjectName     string `json:"project_name,omitempty"`
 }
@@ -2121,6 +2132,35 @@ type ProjectCairnlineSidecarWorkResponse struct {
 	Warnings              []string                                    `json:"warnings,omitempty"`
 }
 
+type ProjectCairnlineSidecarCollaborationResponse struct {
+	Ready                 bool                                `json:"ready"`
+	Status                string                              `json:"status"`
+	Detail                string                              `json:"detail"`
+	Command               string                              `json:"command"`
+	Args                  []string                            `json:"args,omitempty"`
+	DatabasePath          string                              `json:"database_path,omitempty"`
+	ProbeTimeoutMS        int64                               `json:"probe_timeout_ms"`
+	PersistentClient      bool                                `json:"persistent_client,omitempty"`
+	ClientCacheConfigured bool                                `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries    int                                 `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse      int                                 `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle       int                                 `json:"client_cache_idle,omitempty"`
+	ConfirmedMutation     bool                                `json:"confirmed_mutation"`
+	ProjectName           string                              `json:"project_name,omitempty"`
+	SelectedProjectID     string                              `json:"selected_project_id,omitempty"`
+	AuthorRoleID          string                              `json:"author_role_id,omitempty"`
+	ReviewerRoleID        string                              `json:"reviewer_role_id,omitempty"`
+	WorkItemID            string                              `json:"work_item_id,omitempty"`
+	AssignmentID          string                              `json:"assignment_id,omitempty"`
+	Steps                 []ProjectCairnlineSidecarWriteStep  `json:"steps,omitempty"`
+	CreatedArtifact       ProjectCairnlineSidecarArtifactItem `json:"created_artifact,omitempty"`
+	CreatedEvidence       ProjectCairnlineSidecarEvidenceItem `json:"created_evidence,omitempty"`
+	CreatedReview         ProjectCairnlineSidecarReviewItem   `json:"created_review,omitempty"`
+	CreatedHandoff        ProjectCairnlineSidecarHandoffItem  `json:"created_handoff,omitempty"`
+	CleanupVerified       bool                                `json:"cleanup_verified"`
+	Warnings              []string                            `json:"warnings,omitempty"`
+}
+
 type ProjectCairnlineSidecarWriteStep struct {
 	Name                      string                                      `json:"name"`
 	Tool                      string                                      `json:"tool"`
@@ -2146,6 +2186,18 @@ type ProjectCairnlineSidecarWriteStep struct {
 	StructuredWorkItemCount   int                                         `json:"structured_work_item_count"`
 	StructuredAssignments     []ProjectCairnlineSidecarAssignmentItem     `json:"structured_assignments,omitempty"`
 	StructuredAssignmentCount int                                         `json:"structured_assignment_count"`
+	StructuredArtifact        ProjectCairnlineSidecarArtifactItem         `json:"structured_artifact,omitempty"`
+	StructuredArtifacts       []ProjectCairnlineSidecarArtifactItem       `json:"structured_artifacts,omitempty"`
+	StructuredArtifactCount   int                                         `json:"structured_artifact_count"`
+	StructuredEvidenceItem    ProjectCairnlineSidecarEvidenceItem         `json:"structured_evidence_item,omitempty"`
+	StructuredEvidence        []ProjectCairnlineSidecarEvidenceItem       `json:"structured_evidence,omitempty"`
+	StructuredEvidenceCount   int                                         `json:"structured_evidence_count"`
+	StructuredReview          ProjectCairnlineSidecarReviewItem           `json:"structured_review,omitempty"`
+	StructuredReviews         []ProjectCairnlineSidecarReviewItem         `json:"structured_reviews,omitempty"`
+	StructuredReviewCount     int                                         `json:"structured_review_count"`
+	StructuredHandoff         ProjectCairnlineSidecarHandoffItem          `json:"structured_handoff,omitempty"`
+	StructuredHandoffs        []ProjectCairnlineSidecarHandoffItem        `json:"structured_handoffs,omitempty"`
+	StructuredHandoffCount    int                                         `json:"structured_handoff_count"`
 	AssignmentContextIDs      ProjectCairnlineSidecarAssignmentContextIDs `json:"assignment_context_ids,omitempty"`
 	LaunchPacketIDs           ProjectCairnlineSidecarLaunchPacketIDs      `json:"launch_packet_ids,omitempty"`
 	LaunchPacketWarnings      []string                                    `json:"launch_packet_warnings,omitempty"`
@@ -2222,6 +2274,78 @@ type ProjectCairnlineSidecarSourceItem struct {
 	TrustLabel     string            `json:"trust_label,omitempty"`
 	SourceCategory string            `json:"source_category,omitempty"`
 	Metadata       map[string]string `json:"metadata,omitempty"`
+}
+
+type ProjectCairnlineSidecarArtifactItem struct {
+	ID             string `json:"id"`
+	ProjectID      string `json:"project_id,omitempty"`
+	WorkItemID     string `json:"work_item_id,omitempty"`
+	AssignmentID   string `json:"assignment_id,omitempty"`
+	Kind           string `json:"kind,omitempty"`
+	Title          string `json:"title,omitempty"`
+	Body           string `json:"body,omitempty"`
+	AuthorRoleID   string `json:"author_role_id,omitempty"`
+	ProvenanceKind string `json:"provenance_kind,omitempty"`
+	TrustLabel     string `json:"trust_label,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+	UpdatedAt      string `json:"updated_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarEvidenceItem struct {
+	ID           string `json:"id"`
+	ProjectID    string `json:"project_id,omitempty"`
+	WorkItemID   string `json:"work_item_id,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+	Title        string `json:"title,omitempty"`
+	Body         string `json:"body,omitempty"`
+	Locator      string `json:"locator,omitempty"`
+	SourceKind   string `json:"source_kind,omitempty"`
+	ExternalID   string `json:"external_id,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	TrustLabel   string `json:"trust_label,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarReviewItem struct {
+	ID             string `json:"id"`
+	ProjectID      string `json:"project_id,omitempty"`
+	WorkItemID     string `json:"work_item_id,omitempty"`
+	AssignmentID   string `json:"assignment_id,omitempty"`
+	ReviewerRoleID string `json:"reviewer_role_id,omitempty"`
+	Title          string `json:"title,omitempty"`
+	Body           string `json:"body,omitempty"`
+	Verdict        string `json:"verdict,omitempty"`
+	Risk           string `json:"risk,omitempty"`
+	Status         string `json:"status,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+	UpdatedAt      string `json:"updated_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarHandoffItem struct {
+	ID                    string   `json:"id"`
+	ProjectID             string   `json:"project_id,omitempty"`
+	WorkItemID            string   `json:"work_item_id,omitempty"`
+	SourceAssignmentID    string   `json:"source_assignment_id,omitempty"`
+	SourceRunID           string   `json:"source_run_id,omitempty"`
+	SourceChatSessionID   string   `json:"source_chat_session_id,omitempty"`
+	SourceMessageID       string   `json:"source_message_id,omitempty"`
+	FromRoleID            string   `json:"from_role_id,omitempty"`
+	ToRoleID              string   `json:"to_role_id,omitempty"`
+	TargetAssignmentID    string   `json:"target_assignment_id,omitempty"`
+	TargetWorkItemID      string   `json:"target_work_item_id,omitempty"`
+	Title                 string   `json:"title,omitempty"`
+	Body                  string   `json:"body,omitempty"`
+	RecommendedNextAction string   `json:"recommended_next_action,omitempty"`
+	LinkedArtifactIDs     []string `json:"linked_artifact_ids,omitempty"`
+	LinkedMemoryIDs       []string `json:"linked_memory_ids,omitempty"`
+	ContextRefs           []string `json:"context_refs,omitempty"`
+	Status                string   `json:"status,omitempty"`
+	ProvenanceKind        string   `json:"provenance_kind,omitempty"`
+	TrustLabel            string   `json:"trust_label,omitempty"`
+	CreatedAt             string   `json:"created_at,omitempty"`
+	UpdatedAt             string   `json:"updated_at,omitempty"`
+	StatusChangedAt       string   `json:"status_changed_at,omitempty"`
 }
 
 // MCPCacheStatsResponse is the wire shape for GET /hecate/v1/system/mcp/cache.

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -24,6 +24,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/projects/backend-status"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/cairnline/mirror-parity"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-collaboration-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-connect"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-detail-smoke"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -94,6 +94,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-setup-smoke", handler.HandleProjectCairnlineSidecarSetupSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-write-smoke", handler.HandleProjectCairnlineSidecarWriteSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-work-smoke", handler.HandleProjectCairnlineSidecarWorkSmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-collaboration-smoke", handler.HandleProjectCairnlineSidecarCollaborationSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)


### PR DESCRIPTION
## Summary
- add a local-only confirmed Cairnline sidecar collaboration smoke endpoint
- verify temporary artifact, evidence, review, and handoff records through typed MCP structuredContent
- expose the new smoke URL in backend status and document the sidecar diagnostic boundary

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProject(CairnlineSidecar|CoordinationBackendStatus)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api ./internal/orchestrator ./internal/mcp/client
- just docs-format-check
- git diff --check
- just agent-docs-check
- just docs-env-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...