### PR TITLE
Add Cairnline sidecar memory smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -166,7 +166,11 @@ removal of the temporary project. A collaboration smoke at
 `confirm_mutation=true`, creates temporary role/work/assignment scaffolding,
 records and verifies artifact, evidence, review, and handoff metadata through
 typed `structuredContent`, then deletes and verifies removal of the temporary
-project.
+project. A memory smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-memory-smoke` requires
+`confirm_mutation=true`, creates and verifies accepted memory, promotes one
+candidate into accepted memory, rejects/deletes another candidate through typed
+`structuredContent`, then deletes and verifies removal of the temporary project.
 Hecate does not yet route Projects reads, writes, or mirrors through the sidecar
 client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -361,8 +361,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   role, work-item, assignment, assignment-context, and launch-packet metadata on
   a temporary standalone Cairnline project, plus an explicit confirmed
   collaboration smoke that records and verifies typed artifact, evidence,
-  review, and handoff metadata on a temporary standalone Cairnline project. This
-  is
+  review, and handoff metadata on a temporary standalone Cairnline project,
+  plus an explicit confirmed memory smoke that creates and verifies accepted
+  memory, promotes one memory candidate, rejects/deletes another candidate, and
+  cleans up a temporary standalone Cairnline project. This is
   contract/client-lifecycle/read-shape and standalone mutation evidence only:
   Hecate does not yet route live Projects reads, writes, mirrors, or
   write-authority switchpoints through the sidecar.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -393,6 +393,11 @@ respectively. Operators can also run
 `POST /hecate/v1/projects/cairnline/sidecar-collaboration-smoke` with
 `confirm_mutation=true` to record and verify temporary artifact, evidence,
 review, and handoff metadata in the standalone Cairnline sidecar database.
+Operators can also run
+`POST /hecate/v1/projects/cairnline/sidecar-memory-smoke` with
+`confirm_mutation=true` to create and verify accepted memory, promote one memory
+candidate, reject/delete another candidate, and clean up the temporary
+standalone Cairnline project.
 Those smokes delete their temporary project and verify removal.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
@@ -446,11 +451,12 @@ Cairnline-specific MCP client cache. `sidecar-read-smoke`,
 cached client to call read-only Cairnline MCP tools and return diagnostic
 evidence. `sidecar-lifecycle-smoke` is opt-in mutation evidence for the
 standalone sidecar assignment lifecycle. `sidecar-write-smoke`,
-`sidecar-setup-smoke`, `sidecar-work-smoke`, and
-`sidecar-collaboration-smoke` are opt-in mutation evidence for standalone
+`sidecar-setup-smoke`, `sidecar-work-smoke`,
+`sidecar-collaboration-smoke`, and `sidecar-memory-smoke` are opt-in mutation
+evidence for standalone
 sidecar project identity, project setup metadata, project work coordination
-records, and collaboration metadata records. None of these routes operator
-project reads or writes through the sidecar backend.
+records, collaboration metadata records, and memory/candidate records. None of
+these routes operator project reads or writes through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -496,8 +496,12 @@ sequenceDiagram
   collaboration mutation smoke: after `confirm_mutation=true`, it creates a
   temporary standalone Cairnline project, role/work/assignment scaffolding, then
   records and verifies artifact, evidence, review, and handoff metadata before
-  deleting and verifying removal of the temporary project. Live Projects reads
-  and writes still use Hecate-native stores.
+  deleting and verifying removal of the temporary project.
+  `sidecar-memory-smoke` is the memory mutation smoke: after
+  `confirm_mutation=true`, it creates and verifies an accepted memory entry,
+  creates and promotes one memory candidate into accepted memory, rejects and
+  deletes another candidate, then deletes and verifies removal of the temporary
+  project. Live Projects reads and writes still use Hecate-native stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2705,7 +2709,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_setup_url": "/hecate/v1/projects/cairnline/sidecar-setup-smoke",
     "cairnline_sidecar_write_url": "/hecate/v1/projects/cairnline/sidecar-write-smoke",
     "cairnline_sidecar_work_url": "/hecate/v1/projects/cairnline/sidecar-work-smoke",
-    "cairnline_sidecar_collaboration_url": "/hecate/v1/projects/cairnline/sidecar-collaboration-smoke"
+    "cairnline_sidecar_collaboration_url": "/hecate/v1/projects/cairnline/sidecar-collaboration-smoke",
+    "cairnline_sidecar_memory_url": "/hecate/v1/projects/cairnline/sidecar-memory-smoke"
   }
 }
 ```
@@ -2829,6 +2834,85 @@ Example response, shortened:
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
     "tools": [{ "name": "projects.list" }],
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-memory-smoke`
+
+Local-only standalone Cairnline MCP memory lifecycle smoke. This endpoint
+mutates only the standalone Cairnline sidecar database after explicit
+confirmation. It does not mutate Hecate-native Projects stores, does not start
+a Hecate Task, does not launch an External Agent, and does not make Cairnline
+authoritative for live Projects routes.
+
+Without `confirm_mutation=true`, the endpoint returns
+`sidecar_memory_confirmation_required` and makes no sidecar tool calls. With
+confirmation, Hecate uses the same sidecar command, database, timeout, and
+Cairnline-specific MCP client cache as `sidecar-connect`.
+
+The smoke creates a temporary rootless project, creates and verifies one
+accepted memory entry through `memory_entries.create` / `memory_entries.list` /
+`memory_entries.get` / `memory_entries.update`, creates and verifies one
+pending memory candidate through `memory_candidates.create` /
+`memory_candidates.list` / `memory_candidates.get`, promotes that candidate
+through `memory_candidates.promote` and verifies the promoted accepted memory
+entry through `memory_entries.get`, creates a second candidate, rejects it
+through `memory_candidates.reject`, deletes the rejected candidate through
+`memory_candidates.delete`, then deletes the temporary project and expects a
+final `projects.get` to return a tool-level missing/error result. If a step
+fails after the temporary project id is known, Hecate attempts a best-effort
+project cleanup delete and verifies that cleanup through another
+`projects.get`.
+
+Example request:
+
+```json
+{
+  "confirm_mutation": true,
+  "project_name": "Hecate sidecar memory smoke"
+}
+```
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_memory",
+  "data": {
+    "ready": true,
+    "status": "sidecar_memory_ready",
+    "detail": "Hecate created and verified temporary standalone Cairnline accepted memory, promoted one memory candidate, rejected and deleted another, then deleted the temporary project. Hecate-native Projects stores were not mutated.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "confirmed_mutation": true,
+    "project_name": "Hecate sidecar memory smoke",
+    "selected_project_id": "proj_123",
+    "memory_entry_id": "mem_123",
+    "promote_candidate_id": "memcand_123",
+    "promoted_memory_entry_id": "mem_456",
+    "reject_candidate_id": "memcand_456",
+    "created_memory_entry": {
+      "id": "mem_123",
+      "title": "Sidecar memory entry",
+      "trust_label": "operator_memory",
+      "enabled": true
+    },
+    "promoted_memory_candidate": {
+      "id": "memcand_123",
+      "status": "promoted",
+      "promoted_memory_id": "mem_456"
+    },
+    "rejected_memory_candidate": {
+      "id": "memcand_456",
+      "status": "rejected"
+    },
+    "cleanup_verified": true,
     "warnings": []
   }
 }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -41,6 +41,8 @@ func cairnlineSidecarFixtureMain(mode string) {
 		evidence:         make(map[string]map[string]ProjectCairnlineSidecarEvidenceItem),
 		reviews:          make(map[string]map[string]ProjectCairnlineSidecarReviewItem),
 		handoffs:         make(map[string]map[string]ProjectCairnlineSidecarHandoffItem),
+		memoryEntries:    make(map[string]map[string]ProjectCairnlineSidecarMemoryEntryItem),
+		memoryCandidates: make(map[string]map[string]ProjectCairnlineSidecarMemoryCandidateItem),
 	}
 	for {
 		line, err := in.ReadBytes('\n')
@@ -116,6 +118,8 @@ type cairnlineSidecarFixtureState struct {
 	evidenceSequence   int
 	reviewSequence     int
 	handoffSequence    int
+	memorySequence     int
+	candidateSequence  int
 	roles              map[string]map[string]ProjectCairnlineSidecarRoleItem
 	workItems          map[string]map[string]ProjectCairnlineSidecarWorkItem
 	assignments        map[string]map[string]ProjectCairnlineSidecarAssignmentItem
@@ -123,6 +127,8 @@ type cairnlineSidecarFixtureState struct {
 	evidence           map[string]map[string]ProjectCairnlineSidecarEvidenceItem
 	reviews            map[string]map[string]ProjectCairnlineSidecarReviewItem
 	handoffs           map[string]map[string]ProjectCairnlineSidecarHandoffItem
+	memoryEntries      map[string]map[string]ProjectCairnlineSidecarMemoryEntryItem
+	memoryCandidates   map[string]map[string]ProjectCairnlineSidecarMemoryCandidateItem
 }
 
 func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
@@ -569,6 +575,8 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		delete(state.evidence, input.ID)
 		delete(state.reviews, input.ID)
 		delete(state.handoffs, input.ID)
+		delete(state.memoryEntries, input.ID)
+		delete(state.memoryCandidates, input.ID)
 		return mcp.CallToolResult{Content: mcp.TextContent("Deleted project " + input.ID)}, nil
 	case "roles.create":
 		var input struct {
@@ -1106,6 +1114,235 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			return mcp.CallToolResult{Content: mcp.TextContent("fixture handoff not found: " + input.HandoffID), IsError: true}, nil
 		}
 		return mcp.CallToolResult{Content: mcp.TextContent("Handoff " + input.HandoffID), StructuredContent: mustRawJSON(handoff)}, nil
+	case "memory_entries.create":
+		var input struct {
+			ProjectID  string `json:"project_id"`
+			Title      string `json:"title"`
+			Body       string `json:"body"`
+			TrustLabel string `json:"trust_label"`
+			SourceKind string `json:"source_kind"`
+			SourceID   string `json:"source_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_entries.create arguments")
+		}
+		if input.ProjectID == "" || input.Title == "" || input.Body == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing memory entry create arguments")
+		}
+		state.memorySequence++
+		id := fmt.Sprintf("mem_write_fixture_%d", state.memorySequence)
+		entry := ProjectCairnlineSidecarMemoryEntryItem{
+			ProjectID:  input.ProjectID,
+			ID:         id,
+			Title:      input.Title,
+			Body:       input.Body,
+			TrustLabel: firstNonEmpty(input.TrustLabel, "operator_memory"),
+			SourceKind: input.SourceKind,
+			SourceID:   input.SourceID,
+			Enabled:    true,
+		}
+		cairnlineSidecarFixtureEnsureMemoryEntries(state, input.ProjectID)[id] = entry
+		return mcp.CallToolResult{Content: mcp.TextContent("Created memory entry " + id + ": " + input.Title)}, nil
+	case "memory_entries.list":
+		var input struct {
+			ProjectID       string `json:"project_id"`
+			IncludeDisabled bool   `json:"include_disabled"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_entries.list arguments")
+		}
+		items := cairnlineSidecarFixtureProjectMemoryEntries(state, input.ProjectID, input.IncludeDisabled)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Memory entries for %s (%d)", input.ProjectID, len(items)), items)
+	case "memory_entries.get":
+		var input struct {
+			ProjectID string `json:"project_id"`
+			MemoryID  string `json:"memory_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_entries.get arguments")
+		}
+		entry, ok := state.memoryEntries[input.ProjectID][input.MemoryID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture memory entry not found: " + input.MemoryID), IsError: true}, nil
+		}
+		return mcp.CallToolResult{Content: mcp.TextContent("Memory entry " + input.MemoryID), StructuredContent: mustRawJSON(entry)}, nil
+	case "memory_entries.update":
+		var input struct {
+			ProjectID  string  `json:"project_id"`
+			MemoryID   string  `json:"memory_id"`
+			Title      *string `json:"title"`
+			Body       *string `json:"body"`
+			TrustLabel *string `json:"trust_label"`
+			SourceKind *string `json:"source_kind"`
+			SourceID   *string `json:"source_id"`
+			Enabled    *bool   `json:"enabled"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_entries.update arguments")
+		}
+		entries := cairnlineSidecarFixtureEnsureMemoryEntries(state, input.ProjectID)
+		entry, ok := entries[input.MemoryID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture memory entry not found: " + input.MemoryID), IsError: true}, nil
+		}
+		if input.Title != nil {
+			entry.Title = *input.Title
+		}
+		if input.Body != nil {
+			entry.Body = *input.Body
+		}
+		if input.TrustLabel != nil {
+			entry.TrustLabel = *input.TrustLabel
+		}
+		if input.SourceKind != nil {
+			entry.SourceKind = *input.SourceKind
+		}
+		if input.SourceID != nil {
+			entry.SourceID = *input.SourceID
+		}
+		if input.Enabled != nil {
+			entry.Enabled = *input.Enabled
+		}
+		entries[input.MemoryID] = entry
+		return mcp.CallToolResult{Content: mcp.TextContent("Updated memory entry " + input.MemoryID + ": " + entry.Title)}, nil
+	case "memory_entries.delete":
+		var input struct {
+			ProjectID string `json:"project_id"`
+			MemoryID  string `json:"memory_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_entries.delete arguments")
+		}
+		delete(cairnlineSidecarFixtureEnsureMemoryEntries(state, input.ProjectID), input.MemoryID)
+		return mcp.CallToolResult{Content: mcp.TextContent("Deleted memory entry " + input.MemoryID)}, nil
+	case "memory_candidates.create":
+		var input struct {
+			ProjectID           string                                            `json:"project_id"`
+			Title               string                                            `json:"title"`
+			Body                string                                            `json:"body"`
+			SuggestedKind       string                                            `json:"suggested_kind"`
+			SuggestedTrustLabel string                                            `json:"suggested_trust_label"`
+			SuggestedSourceKind string                                            `json:"suggested_source_kind"`
+			SuggestedSourceID   string                                            `json:"suggested_source_id"`
+			SourceRefs          []ProjectCairnlineSidecarMemoryCandidateSourceRef `json:"source_refs"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_candidates.create arguments")
+		}
+		if input.ProjectID == "" || input.Title == "" || input.Body == "" {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing memory candidate create arguments")
+		}
+		state.candidateSequence++
+		id := fmt.Sprintf("memcand_write_fixture_%d", state.candidateSequence)
+		candidate := ProjectCairnlineSidecarMemoryCandidateItem{
+			ProjectID:           input.ProjectID,
+			ID:                  id,
+			Title:               input.Title,
+			Body:                input.Body,
+			SuggestedKind:       input.SuggestedKind,
+			SuggestedTrustLabel: firstNonEmpty(input.SuggestedTrustLabel, "generated_summary"),
+			SuggestedSourceKind: firstNonEmpty(input.SuggestedSourceKind, "generated"),
+			SuggestedSourceID:   input.SuggestedSourceID,
+			SourceRefs:          input.SourceRefs,
+			Status:              "pending",
+		}
+		cairnlineSidecarFixtureEnsureMemoryCandidates(state, input.ProjectID)[id] = candidate
+		return mcp.CallToolResult{Content: mcp.TextContent("Created memory candidate " + id + ": " + input.Title)}, nil
+	case "memory_candidates.list":
+		var input struct {
+			ProjectID       string `json:"project_id"`
+			IncludeResolved bool   `json:"include_resolved"`
+			Status          string `json:"status"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_candidates.list arguments")
+		}
+		items := cairnlineSidecarFixtureProjectMemoryCandidates(state, input.ProjectID, input.IncludeResolved, input.Status)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Memory candidates for %s (%d)", input.ProjectID, len(items)), items)
+	case "memory_candidates.get":
+		var input struct {
+			ProjectID   string `json:"project_id"`
+			CandidateID string `json:"candidate_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_candidates.get arguments")
+		}
+		candidate, ok := state.memoryCandidates[input.ProjectID][input.CandidateID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture memory candidate not found: " + input.CandidateID), IsError: true}, nil
+		}
+		return mcp.CallToolResult{Content: mcp.TextContent("Memory candidate " + input.CandidateID), StructuredContent: mustRawJSON(candidate)}, nil
+	case "memory_candidates.promote":
+		if mode == "memory-candidate-promote-tool-error" {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture memory_candidates.promote failed"), IsError: true}, nil
+		}
+		var input struct {
+			ProjectID   string `json:"project_id"`
+			CandidateID string `json:"candidate_id"`
+			Title       string `json:"title"`
+			Body        string `json:"body"`
+			TrustLabel  string `json:"trust_label"`
+			SourceKind  string `json:"source_kind"`
+			SourceID    string `json:"source_id"`
+			Enabled     *bool  `json:"enabled"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_candidates.promote arguments")
+		}
+		candidates := cairnlineSidecarFixtureEnsureMemoryCandidates(state, input.ProjectID)
+		candidate, ok := candidates[input.CandidateID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture memory candidate not found: " + input.CandidateID), IsError: true}, nil
+		}
+		enabled := true
+		if input.Enabled != nil {
+			enabled = *input.Enabled
+		}
+		state.memorySequence++
+		entryID := fmt.Sprintf("mem_write_fixture_%d", state.memorySequence)
+		entry := ProjectCairnlineSidecarMemoryEntryItem{
+			ProjectID:  input.ProjectID,
+			ID:         entryID,
+			Title:      firstNonEmpty(input.Title, candidate.Title),
+			Body:       firstNonEmpty(input.Body, candidate.Body),
+			TrustLabel: firstNonEmpty(input.TrustLabel, candidate.SuggestedTrustLabel, "generated_summary"),
+			SourceKind: firstNonEmpty(input.SourceKind, candidate.SuggestedSourceKind, "generated"),
+			SourceID:   firstNonEmpty(input.SourceID, candidate.SuggestedSourceID),
+			Enabled:    enabled,
+		}
+		cairnlineSidecarFixtureEnsureMemoryEntries(state, input.ProjectID)[entryID] = entry
+		candidate.Status = "promoted"
+		candidate.PromotedMemoryID = entryID
+		candidates[input.CandidateID] = candidate
+		return mcp.CallToolResult{Content: mcp.TextContent("Promoted memory candidate " + input.CandidateID + " to memory entry " + entryID), StructuredContent: mustRawJSON(candidate)}, nil
+	case "memory_candidates.reject":
+		var input struct {
+			ProjectID   string `json:"project_id"`
+			CandidateID string `json:"candidate_id"`
+			Reason      string `json:"reason"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_candidates.reject arguments")
+		}
+		candidates := cairnlineSidecarFixtureEnsureMemoryCandidates(state, input.ProjectID)
+		candidate, ok := candidates[input.CandidateID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture memory candidate not found: " + input.CandidateID), IsError: true}, nil
+		}
+		candidate.Status = "rejected"
+		candidate.StatusReason = input.Reason
+		candidates[input.CandidateID] = candidate
+		return mcp.CallToolResult{Content: mcp.TextContent("Rejected memory candidate " + input.CandidateID), StructuredContent: mustRawJSON(candidate)}, nil
+	case "memory_candidates.delete":
+		var input struct {
+			ProjectID   string `json:"project_id"`
+			CandidateID string `json:"candidate_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_candidates.delete arguments")
+		}
+		delete(cairnlineSidecarFixtureEnsureMemoryCandidates(state, input.ProjectID), input.CandidateID)
+		return mcp.CallToolResult{Content: mcp.TextContent("Deleted memory candidate " + input.CandidateID)}, nil
 	default:
 		return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeMethodNotFound, params.Name)
 	}
@@ -1306,6 +1543,47 @@ func cairnlineSidecarFixtureProjectHandoffs(state *cairnlineSidecarFixtureState,
 		}
 	}
 	return handoffs
+}
+
+func cairnlineSidecarFixtureEnsureMemoryEntries(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarMemoryEntryItem {
+	if state.memoryEntries[projectID] == nil {
+		state.memoryEntries[projectID] = make(map[string]ProjectCairnlineSidecarMemoryEntryItem)
+	}
+	return state.memoryEntries[projectID]
+}
+
+func cairnlineSidecarFixtureProjectMemoryEntries(state *cairnlineSidecarFixtureState, projectID string, includeDisabled bool) []ProjectCairnlineSidecarMemoryEntryItem {
+	entriesByID := state.memoryEntries[projectID]
+	entries := make([]ProjectCairnlineSidecarMemoryEntryItem, 0, len(entriesByID))
+	for _, entry := range entriesByID {
+		if !includeDisabled && !entry.Enabled {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func cairnlineSidecarFixtureEnsureMemoryCandidates(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarMemoryCandidateItem {
+	if state.memoryCandidates[projectID] == nil {
+		state.memoryCandidates[projectID] = make(map[string]ProjectCairnlineSidecarMemoryCandidateItem)
+	}
+	return state.memoryCandidates[projectID]
+}
+
+func cairnlineSidecarFixtureProjectMemoryCandidates(state *cairnlineSidecarFixtureState, projectID string, includeResolved bool, status string) []ProjectCairnlineSidecarMemoryCandidateItem {
+	candidatesByID := state.memoryCandidates[projectID]
+	candidates := make([]ProjectCairnlineSidecarMemoryCandidateItem, 0, len(candidatesByID))
+	for _, candidate := range candidatesByID {
+		if status != "" && candidate.Status != status {
+			continue
+		}
+		if status == "" && !includeResolved && candidate.Status != "pending" {
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+	return candidates
 }
 
 func cairnlineSidecarFixtureListResult(mode, text string, structured any) (mcp.CallToolResult, *mcp.RPCError) {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
@@ -305,6 +305,20 @@ func (h *Handler) HandleProjectCairnlineSidecarCollaborationSmoke(w http.Respons
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarCollaborationEnvelope{
 		Object: "project_cairnline_sidecar_collaboration",
 		Data:   h.projectCairnlineSidecarCollaborationSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarMemorySmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar memory smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarMemoryRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarMemoryEnvelope{
+		Object: "project_cairnline_sidecar_memory",
+		Data:   h.projectCairnlineSidecarMemorySmoke(r.Context(), req),
 	})
 }
 
@@ -2026,6 +2040,294 @@ func (h *Handler) projectCairnlineSidecarCollaborationSmoke(ctx context.Context,
 	return fail("sidecar_collaboration_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary collaboration project.")
 }
 
+func (h *Handler) projectCairnlineSidecarMemorySmoke(ctx context.Context, req ProjectCairnlineSidecarMemoryRequest) ProjectCairnlineSidecarMemoryResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	projectName := strings.TrimSpace(req.ProjectName)
+	if projectName == "" {
+		projectName = "Hecate sidecar memory smoke " + time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+	const (
+		memoryTitle          = "Sidecar memory entry"
+		updatedMemoryTitle   = "Sidecar memory entry updated"
+		candidateTitle       = "Sidecar memory candidate"
+		promotedMemoryTitle  = "Sidecar promoted memory"
+		rejectCandidateTitle = "Sidecar rejected memory candidate"
+	)
+	response := ProjectCairnlineSidecarMemoryResponse{
+		Ready:                 false,
+		Status:                "sidecar_memory_not_run",
+		Detail:                "Cairnline sidecar memory smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ConfirmedMutation:     req.ConfirmMutation,
+		ProjectName:           projectName,
+	}
+	if h == nil {
+		response.Status = "sidecar_memory_failed"
+		response.Detail = "Cairnline sidecar memory smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this memory smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+	if !req.ConfirmMutation {
+		response.Status = "sidecar_memory_confirmation_required"
+		response.Detail = "Set confirm_mutation=true to let Hecate create, verify, promote, reject, delete, and clean up temporary memory records in the standalone Cairnline sidecar. Hecate-native Projects stores are not mutated."
+		return response
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := ""
+	cleanup := func() {
+		if projectID == "" || response.CleanupVerified {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+		defer cleanupCancel()
+		cleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_delete_project", "projects.delete", false, map[string]string{"id": projectID})
+		response.Steps = append(response.Steps, cleanupStep)
+		if cleanupStep.Status == "ready" {
+			verifyCleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+			if verifyCleanupStep.Status == "tool_failed" {
+				verifyCleanupStep.Status = "expected_missing"
+				response.CleanupVerified = true
+				response.Warnings = append(response.Warnings, "Hecate deleted and verified removal of the temporary standalone Cairnline memory project after the memory smoke failed; inspect the reported steps before retrying.")
+			} else {
+				response.Warnings = append(response.Warnings, "Hecate deleted the temporary standalone Cairnline memory project after the memory smoke failed, but removal could not be verified; inspect the reported steps before retrying.")
+			}
+			response.Steps = append(response.Steps, verifyCleanupStep)
+			return
+		}
+		response.Warnings = append(response.Warnings, "Hecate tried to delete the temporary standalone Cairnline memory project after the memory smoke failed, but cleanup did not succeed; inspect the standalone Cairnline sidecar before retrying.")
+	}
+	fail := func(status, detail string) ProjectCairnlineSidecarMemoryResponse {
+		response.Status = status
+		response.Detail = detail
+		cleanup()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	appendStep := func(step ProjectCairnlineSidecarWriteStep) bool {
+		response.Steps = append(response.Steps, step)
+		if step.Status == "tool_failed" {
+			response.Status = "sidecar_memory_tool_failed"
+			response.Detail = "Cairnline sidecar " + step.Tool + " returned a tool-level error. Review the step output before retrying."
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		if step.Status == "failed" {
+			response.Status = "sidecar_memory_failed"
+			response.Detail = firstNonEmpty(step.ToolText, "Cairnline sidecar "+step.Tool+" failed.")
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		return true
+	}
+
+	createProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_project", "projects.create", false, map[string]string{
+		"name":        projectName,
+		"description": "Temporary Hecate sidecar memory smoke project. It should be deleted by the same diagnostic run.",
+	})
+	if !appendStep(createProject) {
+		return response
+	}
+	listProjects := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_after_project_create", "projects.list", true, map[string]string{})
+	if !appendStep(listProjects) {
+		return response
+	}
+	project, ok := projectCairnlineSidecarProjectByName(listProjects.StructuredProjects, projectName)
+	if !ok || strings.TrimSpace(project.ID) == "" {
+		return fail("sidecar_memory_created_project_not_listed", "Cairnline sidecar projects.create succeeded, but projects.list did not return the temporary memory project by name.")
+	}
+	projectID = strings.TrimSpace(project.ID)
+	response.SelectedProjectID = projectID
+
+	createMemory := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_memory_entry", "memory_entries.create", false, map[string]string{
+		"project_id":  projectID,
+		"title":       memoryTitle,
+		"body":        "Temporary accepted memory created by the Hecate sidecar memory smoke.",
+		"trust_label": "operator_memory",
+		"source_kind": "operator",
+		"source_id":   "hecate-sidecar-memory-smoke",
+	})
+	if !appendStep(createMemory) {
+		return response
+	}
+	listMemory := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_memory_entries_after_create", "memory_entries.list", true, map[string]any{"project_id": projectID, "include_disabled": true})
+	if !appendStep(listMemory) {
+		return response
+	}
+	memoryEntry, ok := projectCairnlineSidecarMemoryEntryByTitle(listMemory.StructuredMemoryEntries, memoryTitle)
+	if !ok || strings.TrimSpace(memoryEntry.ID) == "" || !memoryEntry.Enabled || memoryEntry.TrustLabel != "operator_memory" {
+		return fail("sidecar_memory_entry_create_verification_failed", "Cairnline sidecar memory_entries.list did not return the expected temporary accepted memory entry.")
+	}
+	response.MemoryEntryID = strings.TrimSpace(memoryEntry.ID)
+	response.CreatedMemoryEntry = memoryEntry
+
+	getMemory := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_memory_entry", "memory_entries.get", true, map[string]string{"project_id": projectID, "memory_id": response.MemoryEntryID})
+	if !appendStep(getMemory) {
+		return response
+	}
+	if getMemory.StructuredMemoryEntry.ID != response.MemoryEntryID || getMemory.StructuredMemoryEntry.Title != memoryTitle {
+		return fail("sidecar_memory_entry_get_verification_failed", "Cairnline sidecar memory_entries.get did not return the expected temporary accepted memory entry.")
+	}
+
+	updateMemory := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "update_memory_entry", "memory_entries.update", false, map[string]any{
+		"project_id": projectID,
+		"memory_id":  response.MemoryEntryID,
+		"title":      updatedMemoryTitle,
+		"body":       "Temporary accepted memory updated by the Hecate sidecar memory smoke.",
+		"enabled":    true,
+	})
+	if !appendStep(updateMemory) {
+		return response
+	}
+	getUpdatedMemory := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_updated_memory_entry", "memory_entries.get", true, map[string]string{"project_id": projectID, "memory_id": response.MemoryEntryID})
+	if !appendStep(getUpdatedMemory) {
+		return response
+	}
+	if getUpdatedMemory.StructuredMemoryEntry.ID != response.MemoryEntryID || getUpdatedMemory.StructuredMemoryEntry.Title != updatedMemoryTitle || !getUpdatedMemory.StructuredMemoryEntry.Enabled {
+		return fail("sidecar_memory_entry_update_verification_failed", "Cairnline sidecar memory_entries.get did not return the expected updated accepted memory entry.")
+	}
+	response.UpdatedMemoryEntry = getUpdatedMemory.StructuredMemoryEntry
+
+	createCandidate := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_memory_candidate", "memory_candidates.create", false, map[string]any{
+		"project_id":            projectID,
+		"title":                 candidateTitle,
+		"body":                  "Temporary memory candidate created by the Hecate sidecar memory smoke.",
+		"suggested_kind":        "diagnostic_note",
+		"suggested_trust_label": "generated_summary",
+		"suggested_source_kind": "generated",
+		"suggested_source_id":   response.MemoryEntryID,
+		"source_refs":           []map[string]string{{"kind": "memory_entry", "id": response.MemoryEntryID, "title": updatedMemoryTitle}},
+	})
+	if !appendStep(createCandidate) {
+		return response
+	}
+	listCandidates := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_memory_candidates_after_create", "memory_candidates.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listCandidates) {
+		return response
+	}
+	candidate, ok := projectCairnlineSidecarMemoryCandidateByTitle(listCandidates.StructuredMemoryCandidates, candidateTitle)
+	if !ok || strings.TrimSpace(candidate.ID) == "" || candidate.Status != "pending" || len(candidate.SourceRefs) != 1 {
+		return fail("sidecar_memory_candidate_create_verification_failed", "Cairnline sidecar memory_candidates.list did not return the expected pending memory candidate with source provenance.")
+	}
+	response.PromoteCandidateID = strings.TrimSpace(candidate.ID)
+	response.CreatedMemoryCandidate = candidate
+
+	getCandidate := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_memory_candidate", "memory_candidates.get", true, map[string]string{"project_id": projectID, "candidate_id": response.PromoteCandidateID})
+	if !appendStep(getCandidate) {
+		return response
+	}
+	if getCandidate.StructuredMemoryCandidate.ID != response.PromoteCandidateID || getCandidate.StructuredMemoryCandidate.Status != "pending" {
+		return fail("sidecar_memory_candidate_get_verification_failed", "Cairnline sidecar memory_candidates.get did not return the expected pending memory candidate.")
+	}
+
+	promoteCandidate := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "promote_memory_candidate", "memory_candidates.promote", false, map[string]string{
+		"project_id":   projectID,
+		"candidate_id": response.PromoteCandidateID,
+		"title":        promotedMemoryTitle,
+		"trust_label":  "operator_memory",
+		"source_kind":  "operator",
+		"source_id":    response.MemoryEntryID,
+	})
+	if !appendStep(promoteCandidate) {
+		return response
+	}
+	if promoteCandidate.StructuredMemoryCandidate.ID != response.PromoteCandidateID || promoteCandidate.StructuredMemoryCandidate.Status != "promoted" || strings.TrimSpace(promoteCandidate.StructuredMemoryCandidate.PromotedMemoryID) == "" {
+		return fail("sidecar_memory_candidate_promote_verification_failed", "Cairnline sidecar memory_candidates.promote did not return the expected promoted candidate with promoted memory id.")
+	}
+	response.PromotedMemoryCandidate = promoteCandidate.StructuredMemoryCandidate
+	response.PromotedMemoryEntryID = strings.TrimSpace(promoteCandidate.StructuredMemoryCandidate.PromotedMemoryID)
+
+	getPromotedMemory := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_promoted_memory_entry", "memory_entries.get", true, map[string]string{"project_id": projectID, "memory_id": response.PromotedMemoryEntryID})
+	if !appendStep(getPromotedMemory) {
+		return response
+	}
+	if getPromotedMemory.StructuredMemoryEntry.ID != response.PromotedMemoryEntryID || getPromotedMemory.StructuredMemoryEntry.Title != promotedMemoryTitle || getPromotedMemory.StructuredMemoryEntry.TrustLabel != "operator_memory" {
+		return fail("sidecar_memory_candidate_promoted_entry_verification_failed", "Cairnline sidecar memory_entries.get did not return the expected accepted memory entry created by promotion.")
+	}
+	response.PromotedMemoryEntry = getPromotedMemory.StructuredMemoryEntry
+
+	createRejectCandidate := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_reject_memory_candidate", "memory_candidates.create", false, map[string]string{
+		"project_id": projectID,
+		"title":      rejectCandidateTitle,
+		"body":       "Temporary memory candidate that should be rejected by the Hecate sidecar memory smoke.",
+	})
+	if !appendStep(createRejectCandidate) {
+		return response
+	}
+	listRejectCandidates := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_reject_memory_candidates", "memory_candidates.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listRejectCandidates) {
+		return response
+	}
+	rejectCandidate, ok := projectCairnlineSidecarMemoryCandidateByTitle(listRejectCandidates.StructuredMemoryCandidates, rejectCandidateTitle)
+	if !ok || strings.TrimSpace(rejectCandidate.ID) == "" || rejectCandidate.Status != "pending" {
+		return fail("sidecar_memory_reject_candidate_create_verification_failed", "Cairnline sidecar memory_candidates.list did not return the expected pending candidate to reject.")
+	}
+	response.RejectCandidateID = strings.TrimSpace(rejectCandidate.ID)
+
+	rejectStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "reject_memory_candidate", "memory_candidates.reject", false, map[string]string{
+		"project_id":   projectID,
+		"candidate_id": response.RejectCandidateID,
+		"reason":       "Temporary smoke candidate is not durable project memory.",
+	})
+	if !appendStep(rejectStep) {
+		return response
+	}
+	if rejectStep.StructuredMemoryCandidate.ID != response.RejectCandidateID || rejectStep.StructuredMemoryCandidate.Status != "rejected" || rejectStep.StructuredMemoryCandidate.StatusReason == "" {
+		return fail("sidecar_memory_candidate_reject_verification_failed", "Cairnline sidecar memory_candidates.reject did not return the expected rejected candidate.")
+	}
+	response.RejectedMemoryCandidate = rejectStep.StructuredMemoryCandidate
+
+	deleteRejectCandidate := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_rejected_memory_candidate", "memory_candidates.delete", false, map[string]string{"project_id": projectID, "candidate_id": response.RejectCandidateID})
+	if !appendStep(deleteRejectCandidate) {
+		return response
+	}
+	listAfterRejectDelete := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_memory_candidates_after_reject_delete", "memory_candidates.list", true, map[string]any{"project_id": projectID, "include_resolved": true})
+	if !appendStep(listAfterRejectDelete) {
+		return response
+	}
+	if _, ok := projectCairnlineSidecarMemoryCandidateByID(listAfterRejectDelete.StructuredMemoryCandidates, response.RejectCandidateID); ok {
+		return fail("sidecar_memory_candidate_delete_verification_failed", "Cairnline sidecar memory_candidates.delete succeeded, but memory_candidates.list still returned the rejected temporary candidate.")
+	}
+
+	deleteProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_project", "projects.delete", false, map[string]string{"id": projectID})
+	if !appendStep(deleteProject) {
+		return response
+	}
+	verifyDelete := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+	if verifyDelete.Status == "tool_failed" {
+		verifyDelete.Status = "expected_missing"
+		response.Steps = append(response.Steps, verifyDelete)
+		response.CleanupVerified = true
+		response.Ready = true
+		response.Status = "sidecar_memory_ready"
+		response.Detail = "Hecate created and verified temporary standalone Cairnline accepted memory, promoted one memory candidate, rejected and deleted another, then deleted the temporary project. Hecate-native Projects stores were not mutated."
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	if !appendStep(verifyDelete) {
+		return response
+	}
+	return fail("sidecar_memory_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary memory project.")
+}
+
 func projectCairnlineSidecarLifecycleShouldReleaseAfterFailure(steps []ProjectCairnlineSidecarLifecycleStep) bool {
 	claimed := false
 	for _, step := range steps {
@@ -2630,6 +2932,68 @@ func (h *Handler) callProjectCairnlineSidecarWriteTool(ctx context.Context, cfg 
 			step.ToolText = "Cairnline sidecar handoffs.get did not return structuredContent; the collaboration smoke needs typed handoff detail to verify collaboration mutations."
 			return step
 		}
+	case "memory_entries.list":
+		entries, structuredReady, structuredErr := projectCairnlineSidecarStructuredMemoryEntries(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredMemoryEntries = entries
+		step.StructuredMemoryEntryCount = len(entries)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar memory_entries.list returned structuredContent that Hecate could not parse as memory entries: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar memory_entries.list did not return structuredContent; the memory smoke needs typed memory entries to verify memory mutations."
+			return step
+		}
+	case "memory_entries.get":
+		entry, structuredReady, structuredErr := projectCairnlineSidecarStructuredMemoryEntry(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredMemoryEntry = entry
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar memory_entries.get returned structuredContent that Hecate could not parse as memory: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar memory_entries.get did not return structuredContent; the memory smoke needs typed memory detail to verify memory mutations."
+			return step
+		}
+	case "memory_candidates.list":
+		candidates, structuredReady, structuredErr := projectCairnlineSidecarStructuredMemoryCandidates(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredMemoryCandidates = candidates
+		step.StructuredMemoryCandidateCount = len(candidates)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar memory_candidates.list returned structuredContent that Hecate could not parse as memory candidates: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar memory_candidates.list did not return structuredContent; the memory smoke needs typed memory candidates to verify candidate mutations."
+			return step
+		}
+	case "memory_candidates.get", "memory_candidates.promote", "memory_candidates.reject":
+		candidate, structuredReady, structuredErr := projectCairnlineSidecarStructuredMemoryCandidate(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredMemoryCandidate = candidate
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " returned structuredContent that Hecate could not parse as memory candidate: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " did not return structuredContent; the memory smoke needs typed memory candidate detail to verify candidate mutations."
+			return step
+		}
 	case "assignments.context":
 		contextIDs, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignmentContextIDs(result.Result.StructuredContent)
 		step.StructuredReady = structuredReady
@@ -2819,6 +3183,36 @@ func projectCairnlineSidecarHandoffByTitle(handoffs []ProjectCairnlineSidecarHan
 		}
 	}
 	return ProjectCairnlineSidecarHandoffItem{}, false
+}
+
+func projectCairnlineSidecarMemoryEntryByTitle(entries []ProjectCairnlineSidecarMemoryEntryItem, title string) (ProjectCairnlineSidecarMemoryEntryItem, bool) {
+	title = strings.TrimSpace(title)
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.Title) == title {
+			return entry, true
+		}
+	}
+	return ProjectCairnlineSidecarMemoryEntryItem{}, false
+}
+
+func projectCairnlineSidecarMemoryCandidateByTitle(candidates []ProjectCairnlineSidecarMemoryCandidateItem, title string) (ProjectCairnlineSidecarMemoryCandidateItem, bool) {
+	title = strings.TrimSpace(title)
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate.Title) == title {
+			return candidate, true
+		}
+	}
+	return ProjectCairnlineSidecarMemoryCandidateItem{}, false
+}
+
+func projectCairnlineSidecarMemoryCandidateByID(candidates []ProjectCairnlineSidecarMemoryCandidateItem, id string) (ProjectCairnlineSidecarMemoryCandidateItem, bool) {
+	id = strings.TrimSpace(id)
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate.ID) == id {
+			return candidate, true
+		}
+	}
+	return ProjectCairnlineSidecarMemoryCandidateItem{}, false
 }
 
 func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairnlineSidecarProjectItem, bool, error) {
@@ -3115,6 +3509,78 @@ func projectCairnlineSidecarStructuredHandoff(raw json.RawMessage) (ProjectCairn
 	return handoff, true, nil
 }
 
+func projectCairnlineSidecarStructuredMemoryEntries(raw json.RawMessage) ([]ProjectCairnlineSidecarMemoryEntryItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarMemoryEntryItem{}, true, nil
+	}
+	var entries []ProjectCairnlineSidecarMemoryEntryItem
+	if err := json.Unmarshal(trimmed, &entries); err != nil {
+		return nil, false, err
+	}
+	if entries == nil {
+		entries = []ProjectCairnlineSidecarMemoryEntryItem{}
+	}
+	return entries, true, nil
+}
+
+func projectCairnlineSidecarStructuredMemoryEntry(raw json.RawMessage) (ProjectCairnlineSidecarMemoryEntryItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarMemoryEntryItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarMemoryEntryItem{}, false, nil
+	}
+	var entry ProjectCairnlineSidecarMemoryEntryItem
+	if err := json.Unmarshal(trimmed, &entry); err != nil {
+		return ProjectCairnlineSidecarMemoryEntryItem{}, false, err
+	}
+	return entry, true, nil
+}
+
+func projectCairnlineSidecarStructuredMemoryCandidates(raw json.RawMessage) ([]ProjectCairnlineSidecarMemoryCandidateItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarMemoryCandidateItem{}, true, nil
+	}
+	var candidates []ProjectCairnlineSidecarMemoryCandidateItem
+	if err := json.Unmarshal(trimmed, &candidates); err != nil {
+		return nil, false, err
+	}
+	if candidates == nil {
+		candidates = []ProjectCairnlineSidecarMemoryCandidateItem{}
+	}
+	return candidates, true, nil
+}
+
+func projectCairnlineSidecarStructuredMemoryCandidate(raw json.RawMessage) (ProjectCairnlineSidecarMemoryCandidateItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarMemoryCandidateItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarMemoryCandidateItem{}, false, nil
+	}
+	var candidate ProjectCairnlineSidecarMemoryCandidateItem
+	if err := json.Unmarshal(trimmed, &candidate); err != nil {
+		return ProjectCairnlineSidecarMemoryCandidateItem{}, false, err
+	}
+	return candidate, true, nil
+}
+
 func projectCairnlineSidecarStructuredAssignmentContextIDs(raw json.RawMessage) (ProjectCairnlineSidecarAssignmentContextIDs, bool, error) {
 	if len(raw) == 0 {
 		return ProjectCairnlineSidecarAssignmentContextIDs{}, false, nil
@@ -3383,6 +3849,15 @@ func (r *ProjectCairnlineSidecarWorkResponse) setSidecarCacheStats(stats mcpclie
 }
 
 func (r *ProjectCairnlineSidecarCollaborationResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarMemoryResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -1266,6 +1266,99 @@ func TestProjectCairnlineSidecarCollaborationSmoke_CleansUpAfterReviewFailure(t 
 	}
 }
 
+func TestProjectCairnlineSidecarMemorySmoke_RequiresConfirmation(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarMemorySmoke(t.Context(), ProjectCairnlineSidecarMemoryRequest{ProjectName: "Fixture memory smoke"})
+	if got.Ready || got.Status != "sidecar_memory_confirmation_required" || got.ConfirmedMutation {
+		t.Fatalf("memory smoke = %+v, want confirmation-required without mutation", got)
+	}
+	if len(got.Steps) != 0 || got.ClientCacheEntries != 0 {
+		t.Fatalf("steps/cache = %d/%d, want no sidecar calls before confirmation", len(got.Steps), got.ClientCacheEntries)
+	}
+}
+
+func TestProjectCairnlineSidecarMemorySmoke_CreatesMemoryRecords(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarMemorySmoke(t.Context(), ProjectCairnlineSidecarMemoryRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture memory smoke",
+	})
+	if !got.Ready || got.Status != "sidecar_memory_ready" || !got.CleanupVerified {
+		t.Fatalf("memory smoke = %+v, want ready with verified cleanup", got)
+	}
+	if got.SelectedProjectID == "" || got.MemoryEntryID == "" || got.PromoteCandidateID == "" || got.PromotedMemoryEntryID == "" || got.RejectCandidateID == "" {
+		t.Fatalf("ids = project:%q memory:%q promote-candidate:%q promoted-memory:%q reject-candidate:%q, want memory ids", got.SelectedProjectID, got.MemoryEntryID, got.PromoteCandidateID, got.PromotedMemoryEntryID, got.RejectCandidateID)
+	}
+	if got.CreatedMemoryEntry.Title != "Sidecar memory entry" || !got.CreatedMemoryEntry.Enabled || got.CreatedMemoryEntry.TrustLabel != "operator_memory" {
+		t.Fatalf("created memory = %+v, want operator accepted memory", got.CreatedMemoryEntry)
+	}
+	if got.UpdatedMemoryEntry.ID != got.MemoryEntryID || got.UpdatedMemoryEntry.Title != "Sidecar memory entry updated" || !got.UpdatedMemoryEntry.Enabled {
+		t.Fatalf("updated memory = %+v, want updated accepted memory id %q", got.UpdatedMemoryEntry, got.MemoryEntryID)
+	}
+	if got.CreatedMemoryCandidate.ID != got.PromoteCandidateID || got.CreatedMemoryCandidate.Status != "pending" || len(got.CreatedMemoryCandidate.SourceRefs) != 1 {
+		t.Fatalf("created candidate = %+v, want pending candidate with source ref", got.CreatedMemoryCandidate)
+	}
+	if got.PromotedMemoryCandidate.ID != got.PromoteCandidateID || got.PromotedMemoryCandidate.Status != "promoted" || got.PromotedMemoryCandidate.PromotedMemoryID != got.PromotedMemoryEntryID {
+		t.Fatalf("promoted candidate = %+v, want promoted candidate linked to memory %q", got.PromotedMemoryCandidate, got.PromotedMemoryEntryID)
+	}
+	if got.PromotedMemoryEntry.ID != got.PromotedMemoryEntryID || got.PromotedMemoryEntry.Title != "Sidecar promoted memory" || got.PromotedMemoryEntry.TrustLabel != "operator_memory" {
+		t.Fatalf("promoted memory = %+v, want accepted promoted memory", got.PromotedMemoryEntry)
+	}
+	if got.RejectedMemoryCandidate.ID != got.RejectCandidateID || got.RejectedMemoryCandidate.Status != "rejected" || got.RejectedMemoryCandidate.StatusReason == "" {
+		t.Fatalf("rejected candidate = %+v, want rejected candidate with reason", got.RejectedMemoryCandidate)
+	}
+	if len(got.Steps) != 19 {
+		t.Fatalf("steps = %+v, want project/memory/candidate/delete flow", got.Steps)
+	}
+	if got.Steps[2].Tool != "memory_entries.create" || got.Steps[7].Tool != "memory_candidates.create" || got.Steps[10].Tool != "memory_candidates.promote" || got.Steps[14].Tool != "memory_candidates.reject" || got.Steps[18].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want memory smoke order and missing-after-delete verification", got.Steps)
+	}
+}
+
+func TestProjectCairnlineSidecarMemorySmoke_CleansUpAfterPromoteFailure(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "memory-candidate-promote-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarMemorySmoke(t.Context(), ProjectCairnlineSidecarMemoryRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture memory smoke cleanup",
+	})
+	if got.Ready || got.Status != "sidecar_memory_tool_failed" || !got.CleanupVerified {
+		t.Fatalf("memory smoke = %+v, want promote tool failure with verified project cleanup", got)
+	}
+	if len(got.Steps) != 13 || got.Steps[10].Tool != "memory_candidates.promote" || !got.Steps[10].ToolIsError || got.Steps[11].Name != "cleanup_delete_project" || got.Steps[12].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want promote failure followed by project cleanup delete and verification", got.Steps)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "deleted and verified removal") {
+		t.Fatalf("warnings = %+v, want verified cleanup warning", got.Warnings)
+	}
+}
+
 func TestProjectCairnlineSidecarLifecycleSmoke_WarnsWhenFailureAfterRunningCannotRelease(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -18,6 +18,7 @@ const projectCoordinationBackendSidecarSetupURL = "/hecate/v1/projects/cairnline
 const projectCoordinationBackendSidecarWriteURL = "/hecate/v1/projects/cairnline/sidecar-write-smoke"
 const projectCoordinationBackendSidecarWorkURL = "/hecate/v1/projects/cairnline/sidecar-work-smoke"
 const projectCoordinationBackendSidecarCollaborationURL = "/hecate/v1/projects/cairnline/sidecar-collaboration-smoke"
+const projectCoordinationBackendSidecarMemoryURL = "/hecate/v1/projects/cairnline/sidecar-memory-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -319,6 +320,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarWriteURL:             projectCoordinationBackendSidecarWriteURL,
 		CairnlineSidecarWorkURL:              projectCoordinationBackendSidecarWorkURL,
 		CairnlineSidecarCollaborationURL:     projectCoordinationBackendSidecarCollaborationURL,
+		CairnlineSidecarMemoryURL:            projectCoordinationBackendSidecarMemoryURL,
 		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -63,6 +63,12 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarCollaborationURL != projectCoordinationBackendSidecarCollaborationURL {
 		t.Fatalf("sidecar collaboration URL = %q, want %q", status.CairnlineSidecarCollaborationURL, projectCoordinationBackendSidecarCollaborationURL)
 	}
+	if status.CairnlineSidecarMemoryURL != projectCoordinationBackendSidecarMemoryURL {
+		t.Fatalf("sidecar memory URL = %q, want %q", status.CairnlineSidecarMemoryURL, projectCoordinationBackendSidecarMemoryURL)
+	}
+	if status.CairnlineSidecarMemoryURL != projectCoordinationBackendSidecarMemoryURL {
+		t.Fatalf("sidecar memory URL = %q, want %q", status.CairnlineSidecarMemoryURL, projectCoordinationBackendSidecarMemoryURL)
+	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
@@ -130,7 +136,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.Status != "cairnline_connector_not_ready" || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
 		t.Fatalf("status = %+v, want sidecar connector mode to block live Cairnline routing", status)
 	}
-	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write/setup/work/collaboration diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
+	if !strings.Contains(status.CairnlineConnectorDetail, "lifecycle/write/setup/work/collaboration/memory diagnostics") || strings.Contains(status.CairnlineConnectorDetail, "read-smoke surfaces only") {
 		t.Fatalf("connector detail = %q, want full sidecar diagnostic surface", status.CairnlineConnectorDetail)
 	}
 	if handler.projectReadRoutesUseCairnlineReadModel() || handler.projectIdentityWritesUseCairnlineAuthority() || handler.projectMemoryWritesUseCairnlineAuthority() || handler.projectAssignmentWritesUseCairnlineAuthority() {
@@ -185,7 +191,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 		t.Fatalf("project-identity switchpoint = %+v, want Hecate authority while sidecar routing is not live", point)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
+	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration/memory diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
 		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
 	}
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -587,6 +587,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarWriteURL             string                                       `json:"cairnline_sidecar_write_url,omitempty"`
 	CairnlineSidecarWorkURL              string                                       `json:"cairnline_sidecar_work_url,omitempty"`
 	CairnlineSidecarCollaborationURL     string                                       `json:"cairnline_sidecar_collaboration_url,omitempty"`
+	CairnlineSidecarMemoryURL            string                                       `json:"cairnline_sidecar_memory_url,omitempty"`
 	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
@@ -1733,6 +1734,11 @@ type ProjectCairnlineSidecarCollaborationEnvelope struct {
 	Data   ProjectCairnlineSidecarCollaborationResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarMemoryEnvelope struct {
+	Object string                                `json:"object"`
+	Data   ProjectCairnlineSidecarMemoryResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
@@ -1779,6 +1785,11 @@ type ProjectCairnlineSidecarWorkRequest struct {
 }
 
 type ProjectCairnlineSidecarCollaborationRequest struct {
+	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
+	ProjectName     string `json:"project_name,omitempty"`
+}
+
+type ProjectCairnlineSidecarMemoryRequest struct {
 	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
 	ProjectName     string `json:"project_name,omitempty"`
 }
@@ -2161,47 +2172,84 @@ type ProjectCairnlineSidecarCollaborationResponse struct {
 	Warnings              []string                            `json:"warnings,omitempty"`
 }
 
+type ProjectCairnlineSidecarMemoryResponse struct {
+	Ready                   bool                                       `json:"ready"`
+	Status                  string                                     `json:"status"`
+	Detail                  string                                     `json:"detail"`
+	Command                 string                                     `json:"command"`
+	Args                    []string                                   `json:"args,omitempty"`
+	DatabasePath            string                                     `json:"database_path,omitempty"`
+	ProbeTimeoutMS          int64                                      `json:"probe_timeout_ms"`
+	PersistentClient        bool                                       `json:"persistent_client,omitempty"`
+	ClientCacheConfigured   bool                                       `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries      int                                        `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse        int                                        `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle         int                                        `json:"client_cache_idle,omitempty"`
+	ConfirmedMutation       bool                                       `json:"confirmed_mutation"`
+	ProjectName             string                                     `json:"project_name,omitempty"`
+	SelectedProjectID       string                                     `json:"selected_project_id,omitempty"`
+	MemoryEntryID           string                                     `json:"memory_entry_id,omitempty"`
+	PromoteCandidateID      string                                     `json:"promote_candidate_id,omitempty"`
+	PromotedMemoryEntryID   string                                     `json:"promoted_memory_entry_id,omitempty"`
+	RejectCandidateID       string                                     `json:"reject_candidate_id,omitempty"`
+	Steps                   []ProjectCairnlineSidecarWriteStep         `json:"steps,omitempty"`
+	CreatedMemoryEntry      ProjectCairnlineSidecarMemoryEntryItem     `json:"created_memory_entry,omitempty"`
+	UpdatedMemoryEntry      ProjectCairnlineSidecarMemoryEntryItem     `json:"updated_memory_entry,omitempty"`
+	CreatedMemoryCandidate  ProjectCairnlineSidecarMemoryCandidateItem `json:"created_memory_candidate,omitempty"`
+	PromotedMemoryCandidate ProjectCairnlineSidecarMemoryCandidateItem `json:"promoted_memory_candidate,omitempty"`
+	PromotedMemoryEntry     ProjectCairnlineSidecarMemoryEntryItem     `json:"promoted_memory_entry,omitempty"`
+	RejectedMemoryCandidate ProjectCairnlineSidecarMemoryCandidateItem `json:"rejected_memory_candidate,omitempty"`
+	CleanupVerified         bool                                       `json:"cleanup_verified"`
+	Warnings                []string                                   `json:"warnings,omitempty"`
+}
+
 type ProjectCairnlineSidecarWriteStep struct {
-	Name                      string                                      `json:"name"`
-	Tool                      string                                      `json:"tool"`
-	ReadOnly                  bool                                        `json:"read_only"`
-	Status                    string                                      `json:"status"`
-	ToolText                  string                                      `json:"tool_text,omitempty"`
-	ToolIsError               bool                                        `json:"tool_is_error,omitempty"`
-	StructuredContent         json.RawMessage                             `json:"structured_content,omitempty"`
-	Meta                      json.RawMessage                             `json:"meta,omitempty"`
-	StructuredReady           bool                                        `json:"structured_ready"`
-	StructuredProject         ProjectCairnlineSidecarProjectItem          `json:"structured_project,omitempty"`
-	StructuredProjects        []ProjectCairnlineSidecarProjectItem        `json:"structured_projects,omitempty"`
-	StructuredProjectCount    int                                         `json:"structured_project_count"`
-	StructuredRoot            ProjectCairnlineSidecarRootItem             `json:"structured_root,omitempty"`
-	StructuredRoots           []ProjectCairnlineSidecarRootItem           `json:"structured_roots,omitempty"`
-	StructuredRootCount       int                                         `json:"structured_root_count"`
-	StructuredSource          ProjectCairnlineSidecarSourceItem           `json:"structured_source,omitempty"`
-	StructuredSources         []ProjectCairnlineSidecarSourceItem         `json:"structured_sources,omitempty"`
-	StructuredSourceCount     int                                         `json:"structured_source_count"`
-	StructuredRoles           []ProjectCairnlineSidecarRoleItem           `json:"structured_roles,omitempty"`
-	StructuredRoleCount       int                                         `json:"structured_role_count"`
-	StructuredWorkItems       []ProjectCairnlineSidecarWorkItem           `json:"structured_work_items,omitempty"`
-	StructuredWorkItemCount   int                                         `json:"structured_work_item_count"`
-	StructuredAssignments     []ProjectCairnlineSidecarAssignmentItem     `json:"structured_assignments,omitempty"`
-	StructuredAssignmentCount int                                         `json:"structured_assignment_count"`
-	StructuredArtifact        ProjectCairnlineSidecarArtifactItem         `json:"structured_artifact,omitempty"`
-	StructuredArtifacts       []ProjectCairnlineSidecarArtifactItem       `json:"structured_artifacts,omitempty"`
-	StructuredArtifactCount   int                                         `json:"structured_artifact_count"`
-	StructuredEvidenceItem    ProjectCairnlineSidecarEvidenceItem         `json:"structured_evidence_item,omitempty"`
-	StructuredEvidence        []ProjectCairnlineSidecarEvidenceItem       `json:"structured_evidence,omitempty"`
-	StructuredEvidenceCount   int                                         `json:"structured_evidence_count"`
-	StructuredReview          ProjectCairnlineSidecarReviewItem           `json:"structured_review,omitempty"`
-	StructuredReviews         []ProjectCairnlineSidecarReviewItem         `json:"structured_reviews,omitempty"`
-	StructuredReviewCount     int                                         `json:"structured_review_count"`
-	StructuredHandoff         ProjectCairnlineSidecarHandoffItem          `json:"structured_handoff,omitempty"`
-	StructuredHandoffs        []ProjectCairnlineSidecarHandoffItem        `json:"structured_handoffs,omitempty"`
-	StructuredHandoffCount    int                                         `json:"structured_handoff_count"`
-	AssignmentContextIDs      ProjectCairnlineSidecarAssignmentContextIDs `json:"assignment_context_ids,omitempty"`
-	LaunchPacketIDs           ProjectCairnlineSidecarLaunchPacketIDs      `json:"launch_packet_ids,omitempty"`
-	LaunchPacketWarnings      []string                                    `json:"launch_packet_warnings,omitempty"`
-	StructuredParseError      string                                      `json:"structured_parse_error,omitempty"`
+	Name                           string                                       `json:"name"`
+	Tool                           string                                       `json:"tool"`
+	ReadOnly                       bool                                         `json:"read_only"`
+	Status                         string                                       `json:"status"`
+	ToolText                       string                                       `json:"tool_text,omitempty"`
+	ToolIsError                    bool                                         `json:"tool_is_error,omitempty"`
+	StructuredContent              json.RawMessage                              `json:"structured_content,omitempty"`
+	Meta                           json.RawMessage                              `json:"meta,omitempty"`
+	StructuredReady                bool                                         `json:"structured_ready"`
+	StructuredProject              ProjectCairnlineSidecarProjectItem           `json:"structured_project,omitempty"`
+	StructuredProjects             []ProjectCairnlineSidecarProjectItem         `json:"structured_projects,omitempty"`
+	StructuredProjectCount         int                                          `json:"structured_project_count"`
+	StructuredRoot                 ProjectCairnlineSidecarRootItem              `json:"structured_root,omitempty"`
+	StructuredRoots                []ProjectCairnlineSidecarRootItem            `json:"structured_roots,omitempty"`
+	StructuredRootCount            int                                          `json:"structured_root_count"`
+	StructuredSource               ProjectCairnlineSidecarSourceItem            `json:"structured_source,omitempty"`
+	StructuredSources              []ProjectCairnlineSidecarSourceItem          `json:"structured_sources,omitempty"`
+	StructuredSourceCount          int                                          `json:"structured_source_count"`
+	StructuredRoles                []ProjectCairnlineSidecarRoleItem            `json:"structured_roles,omitempty"`
+	StructuredRoleCount            int                                          `json:"structured_role_count"`
+	StructuredWorkItems            []ProjectCairnlineSidecarWorkItem            `json:"structured_work_items,omitempty"`
+	StructuredWorkItemCount        int                                          `json:"structured_work_item_count"`
+	StructuredAssignments          []ProjectCairnlineSidecarAssignmentItem      `json:"structured_assignments,omitempty"`
+	StructuredAssignmentCount      int                                          `json:"structured_assignment_count"`
+	StructuredArtifact             ProjectCairnlineSidecarArtifactItem          `json:"structured_artifact,omitempty"`
+	StructuredArtifacts            []ProjectCairnlineSidecarArtifactItem        `json:"structured_artifacts,omitempty"`
+	StructuredArtifactCount        int                                          `json:"structured_artifact_count"`
+	StructuredEvidenceItem         ProjectCairnlineSidecarEvidenceItem          `json:"structured_evidence_item,omitempty"`
+	StructuredEvidence             []ProjectCairnlineSidecarEvidenceItem        `json:"structured_evidence,omitempty"`
+	StructuredEvidenceCount        int                                          `json:"structured_evidence_count"`
+	StructuredReview               ProjectCairnlineSidecarReviewItem            `json:"structured_review,omitempty"`
+	StructuredReviews              []ProjectCairnlineSidecarReviewItem          `json:"structured_reviews,omitempty"`
+	StructuredReviewCount          int                                          `json:"structured_review_count"`
+	StructuredHandoff              ProjectCairnlineSidecarHandoffItem           `json:"structured_handoff,omitempty"`
+	StructuredHandoffs             []ProjectCairnlineSidecarHandoffItem         `json:"structured_handoffs,omitempty"`
+	StructuredHandoffCount         int                                          `json:"structured_handoff_count"`
+	StructuredMemoryEntry          ProjectCairnlineSidecarMemoryEntryItem       `json:"structured_memory_entry,omitempty"`
+	StructuredMemoryEntries        []ProjectCairnlineSidecarMemoryEntryItem     `json:"structured_memory_entries,omitempty"`
+	StructuredMemoryEntryCount     int                                          `json:"structured_memory_entry_count"`
+	StructuredMemoryCandidate      ProjectCairnlineSidecarMemoryCandidateItem   `json:"structured_memory_candidate,omitempty"`
+	StructuredMemoryCandidates     []ProjectCairnlineSidecarMemoryCandidateItem `json:"structured_memory_candidates,omitempty"`
+	StructuredMemoryCandidateCount int                                          `json:"structured_memory_candidate_count"`
+	AssignmentContextIDs           ProjectCairnlineSidecarAssignmentContextIDs  `json:"assignment_context_ids,omitempty"`
+	LaunchPacketIDs                ProjectCairnlineSidecarLaunchPacketIDs       `json:"launch_packet_ids,omitempty"`
+	LaunchPacketWarnings           []string                                     `json:"launch_packet_warnings,omitempty"`
+	StructuredParseError           string                                       `json:"structured_parse_error,omitempty"`
 }
 
 type ProjectCairnlineSidecarProjectItem struct {
@@ -2346,6 +2394,43 @@ type ProjectCairnlineSidecarHandoffItem struct {
 	CreatedAt             string   `json:"created_at,omitempty"`
 	UpdatedAt             string   `json:"updated_at,omitempty"`
 	StatusChangedAt       string   `json:"status_changed_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarMemoryEntryItem struct {
+	ID         string `json:"id"`
+	ProjectID  string `json:"project_id,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Body       string `json:"body,omitempty"`
+	TrustLabel string `json:"trust_label,omitempty"`
+	SourceKind string `json:"source_kind,omitempty"`
+	SourceID   string `json:"source_id,omitempty"`
+	Enabled    bool   `json:"enabled"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	UpdatedAt  string `json:"updated_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarMemoryCandidateItem struct {
+	ID                  string                                            `json:"id"`
+	ProjectID           string                                            `json:"project_id,omitempty"`
+	Title               string                                            `json:"title,omitempty"`
+	Body                string                                            `json:"body,omitempty"`
+	SuggestedKind       string                                            `json:"suggested_kind,omitempty"`
+	SuggestedTrustLabel string                                            `json:"suggested_trust_label,omitempty"`
+	SuggestedSourceKind string                                            `json:"suggested_source_kind,omitempty"`
+	SuggestedSourceID   string                                            `json:"suggested_source_id,omitempty"`
+	SourceRefs          []ProjectCairnlineSidecarMemoryCandidateSourceRef `json:"source_refs,omitempty"`
+	Status              string                                            `json:"status,omitempty"`
+	StatusReason        string                                            `json:"status_reason,omitempty"`
+	PromotedMemoryID    string                                            `json:"promoted_memory_id,omitempty"`
+	CreatedAt           string                                            `json:"created_at,omitempty"`
+	UpdatedAt           string                                            `json:"updated_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarMemoryCandidateSourceRef struct {
+	Kind  string `json:"kind"`
+	ID    string `json:"id"`
+	Title string `json:"title,omitempty"`
+	URL   string `json:"url,omitempty"`
 }
 
 // MCPCacheStatsResponse is the wire shape for GET /hecate/v1/system/mcp/cache.

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -30,6 +30,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-detail-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-memory-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-setup-smoke"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -89,6 +89,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-detail-smoke", handler.HandleProjectCairnlineSidecarDetailSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke", handler.HandleProjectCairnlineSidecarLaunchPacketSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke", handler.HandleProjectCairnlineSidecarLifecycleSmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-memory-smoke", handler.HandleProjectCairnlineSidecarMemorySmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-setup-smoke", handler.HandleProjectCairnlineSidecarSetupSmoke)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4340,6 +4340,22 @@ func TestProjectCairnlineSidecarLifecycleSmokeRejectsNonLoopbackClientsBeforeCom
 	}
 }
 
+func TestProjectCairnlineSidecarMemorySmokeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-memory-smoke", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a local-only opt-in Cairnline sidecar memory smoke endpoint
- verify accepted memory create/list/get/update plus memory candidate create/get/promote/reject/delete through typed structuredContent
- clean up the temporary standalone Cairnline project and document the new diagnostic route

## Tests
- just go-format-check
- just docs-check
- GOCACHE="$PWD/.gocache" go build ./...
- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/orchestrator ./internal/mcp/client
- GOCACHE="$PWD/.gocache" go vet ./...
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProject(CairnlineSidecar|CoordinationBackendStatus)|TestProjectCairnlineSidecarMemorySmoke|TestProjectCairnlineSidecar.*RejectsNonLoopback'\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n\nNote: the sandboxed `go test ./...` run hit the local httptest loopback bind restriction; the same command passed with normal local loopback access.