### PR TITLE
Add Cairnline sidecar assistant smoke

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -171,6 +171,12 @@ project. A memory smoke at
 `confirm_mutation=true`, creates and verifies accepted memory, promotes one
 candidate into accepted memory, rejects/deletes another candidate through typed
 `structuredContent`, then deletes and verifies removal of the temporary project.
+An assistant smoke at
+`POST /hecate/v1/projects/cairnline/sidecar-assistant-smoke` requires
+`confirm_mutation=true`, creates and verifies a temporary Project Assistant
+proposal ledger record, applies it with explicit confirmation, verifies the
+created role/work/assignment side effects through typed `structuredContent`,
+then deletes and verifies removal of the temporary project.
 Hecate does not yet route Projects reads, writes, or mirrors through the sidecar
 client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -364,10 +364,14 @@ launch agents. Those remain explicit operator or orchestrator actions.
   review, and handoff metadata on a temporary standalone Cairnline project,
   plus an explicit confirmed memory smoke that creates and verifies accepted
   memory, promotes one memory candidate, rejects/deletes another candidate, and
-  cleans up a temporary standalone Cairnline project. This is
-  contract/client-lifecycle/read-shape and standalone mutation evidence only:
-  Hecate does not yet route live Projects reads, writes, mirrors, or
-  write-authority switchpoints through the sidecar.
+  cleans up a temporary standalone Cairnline project, plus an explicit
+  confirmed Project Assistant smoke that creates and verifies a temporary
+  proposal ledger record, applies it with explicit confirmation, verifies the
+  created role/work/assignment side effects, and cleans up the temporary
+  standalone Cairnline project. This is contract/client-lifecycle/read-shape
+  and standalone mutation evidence only: Hecate does not yet route live
+  Projects reads, writes, mirrors, or write-authority switchpoints through the
+  sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -397,7 +397,12 @@ Operators can also run
 `POST /hecate/v1/projects/cairnline/sidecar-memory-smoke` with
 `confirm_mutation=true` to create and verify accepted memory, promote one memory
 candidate, reject/delete another candidate, and clean up the temporary
-standalone Cairnline project.
+standalone Cairnline project. Operators can also run
+`POST /hecate/v1/projects/cairnline/sidecar-assistant-smoke` with
+`confirm_mutation=true` to create and verify a temporary Project Assistant
+proposal ledger record, apply it with explicit confirmation, verify the created
+role/work/assignment side effects, and clean up the temporary standalone
+Cairnline project.
 Those smokes delete their temporary project and verify removal.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports
@@ -452,11 +457,12 @@ cached client to call read-only Cairnline MCP tools and return diagnostic
 evidence. `sidecar-lifecycle-smoke` is opt-in mutation evidence for the
 standalone sidecar assignment lifecycle. `sidecar-write-smoke`,
 `sidecar-setup-smoke`, `sidecar-work-smoke`,
-`sidecar-collaboration-smoke`, and `sidecar-memory-smoke` are opt-in mutation
-evidence for standalone
-sidecar project identity, project setup metadata, project work coordination
-records, collaboration metadata records, and memory/candidate records. None of
-these routes operator project reads or writes through the sidecar backend.
+`sidecar-collaboration-smoke`, `sidecar-memory-smoke`, and
+`sidecar-assistant-smoke` are opt-in mutation evidence for standalone sidecar
+project identity, project setup metadata, project work coordination records,
+collaboration metadata records, memory/candidate records, and Project Assistant
+proposal/apply records. None of these routes operator project reads or writes
+through the sidecar backend.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -48,11 +48,12 @@ context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added t
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
 workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar
-probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work
-smoke, plugin-registry management, agent-adapter authenticate, and local
-provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are explicitly
-classified for remote mode, and route coverage tests fail when a new registered
-route is not marked remote-safe or local-only.
+probe/connect/read/detail/coordination/assignment-context/launch-packet,
+Cairnline sidecar lifecycle/write/setup/work/collaboration/memory/assistant
+smokes, plugin-registry management, agent-adapter authenticate, and local
+provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are
+explicitly classified for remote mode, and route coverage tests fail when a new
+registered route is not marked remote-safe or local-only.
 
 Remote mode disables local model providers by default. In that default posture,
 local presets are omitted, `kind=local` provider creates/updates are rejected,
@@ -501,7 +502,13 @@ sequenceDiagram
   `confirm_mutation=true`, it creates and verifies an accepted memory entry,
   creates and promotes one memory candidate into accepted memory, rejects and
   deletes another candidate, then deletes and verifies removal of the temporary
-  project. Live Projects reads and writes still use Hecate-native stores.
+  project. `sidecar-assistant-smoke` is the Project Assistant proposal/apply
+  smoke: after `confirm_mutation=true`, it creates a temporary rootless
+  standalone Cairnline project, creates and verifies an assistant proposal
+  ledger record, applies it with explicit confirmation, verifies the created
+  role/work/assignment side effects, then deletes and verifies removal of the
+  temporary project. Live Projects reads and writes still use Hecate-native
+  stores.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2517,7 +2524,8 @@ tools, assignment context, launch packets, the explicitly confirmed standalone
 assignment lifecycle, the explicitly confirmed temporary-project write smoke,
 the explicitly confirmed temporary root/context-source setup smoke, and the
 explicitly confirmed temporary role/work/assignment/context/launch-packet work
-smoke. None of these changes live route authority.
+smoke, plus confirmed collaboration, memory, and Project Assistant
+proposal/apply smokes. None of these changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -2710,7 +2718,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_write_url": "/hecate/v1/projects/cairnline/sidecar-write-smoke",
     "cairnline_sidecar_work_url": "/hecate/v1/projects/cairnline/sidecar-work-smoke",
     "cairnline_sidecar_collaboration_url": "/hecate/v1/projects/cairnline/sidecar-collaboration-smoke",
-    "cairnline_sidecar_memory_url": "/hecate/v1/projects/cairnline/sidecar-memory-smoke"
+    "cairnline_sidecar_memory_url": "/hecate/v1/projects/cairnline/sidecar-memory-smoke",
+    "cairnline_sidecar_assistant_url": "/hecate/v1/projects/cairnline/sidecar-assistant-smoke"
   }
 }
 ```
@@ -2911,6 +2920,91 @@ Example response, shortened:
     "rejected_memory_candidate": {
       "id": "memcand_456",
       "status": "rejected"
+    },
+    "cleanup_verified": true,
+    "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-assistant-smoke`
+
+Local-only standalone Cairnline MCP Project Assistant proposal/apply smoke.
+This endpoint mutates only the standalone Cairnline sidecar database after
+explicit confirmation. It does not mutate Hecate-native Projects stores, does
+not start a Hecate Task, does not launch an External Agent, and does not make
+Cairnline authoritative for live Projects routes.
+
+Without `confirm_mutation=true`, the endpoint returns
+`sidecar_assistant_confirmation_required` and makes no sidecar tool calls. With
+confirmation, Hecate uses the same sidecar command, database, timeout, and
+Cairnline-specific MCP client cache as `sidecar-connect`.
+
+The smoke creates a temporary rootless project, creates and verifies a
+confirmed-action Project Assistant proposal through `assistant.propose` /
+`assistant.proposals.list` / `assistant.proposals.get`, applies it through
+`assistant.apply` with `confirm=true`, verifies the applied proposal ledger
+state through another `assistant.proposals.get`, verifies the proposal side
+effects through `roles.list`, `work_items.list`, and `assignments.list`, then
+deletes the temporary project and expects a final `projects.get` to return a
+tool-level missing/error result. If a step fails after the temporary project id
+is known, Hecate attempts a best-effort project cleanup delete and verifies
+that cleanup through another `projects.get`.
+
+Example request:
+
+```json
+{
+  "confirm_mutation": true,
+  "project_name": "Hecate sidecar assistant smoke"
+}
+```
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_assistant",
+  "data": {
+    "ready": true,
+    "status": "sidecar_assistant_ready",
+    "detail": "Hecate created, listed, fetched, applied, and verified a temporary standalone Cairnline Project Assistant proposal, then deleted the temporary project. Hecate-native Projects stores were not mutated.",
+    "command": "cairnline",
+    "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
+    "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
+    "probe_timeout_ms": 10000,
+    "persistent_client": true,
+    "client_cache_configured": true,
+    "confirmed_mutation": true,
+    "project_name": "Hecate sidecar assistant smoke",
+    "selected_project_id": "proj_123",
+    "proposal_id": "prop_proj_123_assistant_smoke",
+    "role_id": "role_proj_123_assistant",
+    "work_item_id": "work_proj_123_assistant",
+    "assignment_id": "asgn_proj_123_assistant",
+    "created_proposal": {
+      "id": "prop_proj_123_assistant_smoke",
+      "status": "proposed",
+      "proposal": {
+        "title": "Queue sidecar assistant assignment",
+        "requires_confirmation": true,
+        "actions": [
+          { "kind": "create_role" },
+          { "kind": "create_work_item" },
+          { "kind": "create_assignment" }
+        ]
+      }
+    },
+    "apply_result": {
+      "proposal_id": "prop_proj_123_assistant_smoke",
+      "status": "applied",
+      "applied": true,
+      "confirmed": true,
+      "applied_action_count": 3
+    },
+    "applied_proposal": {
+      "id": "prop_proj_123_assistant_smoke",
+      "status": "applied"
     },
     "cleanup_verified": true,
     "warnings": []

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -29,20 +29,21 @@ func cairnlineSidecarFixtureMain(mode string) {
 	in := bufio.NewReader(os.Stdin)
 	enc := json.NewEncoder(os.Stdout)
 	state := &cairnlineSidecarFixtureState{
-		assignmentStatus: "queued",
-		projects:         make(map[string]ProjectCairnlineSidecarProjectItem),
-		deletedProjects:  make(map[string]struct{}),
-		roots:            make(map[string]map[string]ProjectCairnlineSidecarRootItem),
-		contextSources:   make(map[string]map[string]ProjectCairnlineSidecarSourceItem),
-		roles:            make(map[string]map[string]ProjectCairnlineSidecarRoleItem),
-		workItems:        make(map[string]map[string]ProjectCairnlineSidecarWorkItem),
-		assignments:      make(map[string]map[string]ProjectCairnlineSidecarAssignmentItem),
-		artifacts:        make(map[string]map[string]ProjectCairnlineSidecarArtifactItem),
-		evidence:         make(map[string]map[string]ProjectCairnlineSidecarEvidenceItem),
-		reviews:          make(map[string]map[string]ProjectCairnlineSidecarReviewItem),
-		handoffs:         make(map[string]map[string]ProjectCairnlineSidecarHandoffItem),
-		memoryEntries:    make(map[string]map[string]ProjectCairnlineSidecarMemoryEntryItem),
-		memoryCandidates: make(map[string]map[string]ProjectCairnlineSidecarMemoryCandidateItem),
+		assignmentStatus:   "queued",
+		projects:           make(map[string]ProjectCairnlineSidecarProjectItem),
+		deletedProjects:    make(map[string]struct{}),
+		roots:              make(map[string]map[string]ProjectCairnlineSidecarRootItem),
+		contextSources:     make(map[string]map[string]ProjectCairnlineSidecarSourceItem),
+		roles:              make(map[string]map[string]ProjectCairnlineSidecarRoleItem),
+		workItems:          make(map[string]map[string]ProjectCairnlineSidecarWorkItem),
+		assignments:        make(map[string]map[string]ProjectCairnlineSidecarAssignmentItem),
+		artifacts:          make(map[string]map[string]ProjectCairnlineSidecarArtifactItem),
+		evidence:           make(map[string]map[string]ProjectCairnlineSidecarEvidenceItem),
+		reviews:            make(map[string]map[string]ProjectCairnlineSidecarReviewItem),
+		handoffs:           make(map[string]map[string]ProjectCairnlineSidecarHandoffItem),
+		memoryEntries:      make(map[string]map[string]ProjectCairnlineSidecarMemoryEntryItem),
+		memoryCandidates:   make(map[string]map[string]ProjectCairnlineSidecarMemoryCandidateItem),
+		assistantProposals: make(map[string]ProjectCairnlineSidecarAssistantProposalRecordItem),
 	}
 	for {
 		line, err := in.ReadBytes('\n')
@@ -129,6 +130,7 @@ type cairnlineSidecarFixtureState struct {
 	handoffs           map[string]map[string]ProjectCairnlineSidecarHandoffItem
 	memoryEntries      map[string]map[string]ProjectCairnlineSidecarMemoryEntryItem
 	memoryCandidates   map[string]map[string]ProjectCairnlineSidecarMemoryCandidateItem
+	assistantProposals map[string]ProjectCairnlineSidecarAssistantProposalRecordItem
 }
 
 func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
@@ -577,7 +579,101 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		delete(state.handoffs, input.ID)
 		delete(state.memoryEntries, input.ID)
 		delete(state.memoryCandidates, input.ID)
+		for proposalID, proposal := range state.assistantProposals {
+			if proposal.ProjectID == input.ID {
+				delete(state.assistantProposals, proposalID)
+			}
+		}
 		return mcp.CallToolResult{Content: mcp.TextContent("Deleted project " + input.ID)}, nil
+	case "assistant.propose":
+		var input ProjectCairnlineSidecarAssistantProposalItem
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assistant.propose arguments")
+		}
+		if input.ID == "" || input.ProjectID == "" || input.Title == "" || len(input.Actions) == 0 {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "missing assistant proposal arguments")
+		}
+		input.RequiresConfirmation = true
+		record := ProjectCairnlineSidecarAssistantProposalRecordItem{
+			ID:        input.ID,
+			ProjectID: input.ProjectID,
+			Source:    firstNonEmpty(input.Source, "assistant"),
+			Proposal:  input,
+			Status:    "proposed",
+		}
+		state.assistantProposals[record.ID] = record
+		return mcp.CallToolResult{Content: mcp.TextContent("Assistant proposal " + record.ID + ": [proposed] " + input.Title), StructuredContent: mustRawJSON(record)}, nil
+	case "assistant.proposals.list":
+		var input struct {
+			ProjectID string `json:"project_id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assistant.proposals.list arguments")
+		}
+		items := cairnlineSidecarFixtureProjectAssistantProposals(state, input.ProjectID)
+		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Assistant proposals (%d)", len(items)), items)
+	case "assistant.proposals.get":
+		var input struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assistant.proposals.get arguments")
+		}
+		record, ok := state.assistantProposals[input.ID]
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture assistant proposal not found: " + input.ID), IsError: true}, nil
+		}
+		return mcp.CallToolResult{Content: mcp.TextContent("Assistant proposal " + input.ID + ": [" + record.Status + "] " + record.Proposal.Title), StructuredContent: mustRawJSON(record)}, nil
+	case "assistant.apply":
+		if mode == "assistant-apply-tool-error" {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture assistant.apply failed"), IsError: true}, nil
+		}
+		var input struct {
+			ProposalID string                                       `json:"proposal_id"`
+			Proposal   ProjectCairnlineSidecarAssistantProposalItem `json:"proposal"`
+			Confirm    bool                                         `json:"confirm"`
+		}
+		if err := json.Unmarshal(params.Arguments, &input); err != nil {
+			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assistant.apply arguments")
+		}
+		record, ok := state.assistantProposals[input.ProposalID]
+		if !ok && input.Proposal.ID != "" {
+			record = ProjectCairnlineSidecarAssistantProposalRecordItem{
+				ID:        input.Proposal.ID,
+				ProjectID: input.Proposal.ProjectID,
+				Source:    firstNonEmpty(input.Proposal.Source, "assistant"),
+				Proposal:  input.Proposal,
+				Status:    "proposed",
+			}
+			input.ProposalID = record.ID
+			ok = true
+		}
+		if !ok {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture assistant proposal not found: " + input.ProposalID), IsError: true}, nil
+		}
+		if !input.Confirm {
+			result := ProjectCairnlineSidecarAssistantApplyResultItem{
+				ProposalID:       record.ID,
+				Status:           "needs_confirmation",
+				Applied:          false,
+				Confirmed:        false,
+				TotalActionCount: len(record.Proposal.Actions),
+			}
+			record.Status = "needs_confirmation"
+			record.LatestResult = &result
+			record.ApplyAttempts = append(record.ApplyAttempts, ProjectCairnlineSidecarAssistantApplyAttemptItem{ID: "attempt_" + record.ID + "_needs_confirmation", ProposalID: record.ID, Status: result.Status, Confirmed: false, Result: result})
+			state.assistantProposals[record.ID] = record
+			return mcp.CallToolResult{Content: mcp.TextContent("Assistant apply " + record.ID + ": needs_confirmation"), StructuredContent: mustRawJSON(result), IsError: true}, nil
+		}
+		result := cairnlineSidecarFixtureApplyAssistantProposal(state, record)
+		record.Status = result.Status
+		record.LatestResult = &result
+		record.ApplyAttempts = append(record.ApplyAttempts, ProjectCairnlineSidecarAssistantApplyAttemptItem{ID: "attempt_" + record.ID + "_applied", ProposalID: record.ID, Status: result.Status, Confirmed: true, Result: result})
+		if result.Applied {
+			record.AppliedAt = "fixture-applied-at"
+		}
+		state.assistantProposals[record.ID] = record
+		return mcp.CallToolResult{Content: mcp.TextContent(fmt.Sprintf("Assistant apply %s: %s actions=%d/%d", record.ID, result.Status, result.AppliedActionCount, result.TotalActionCount)), StructuredContent: mustRawJSON(result)}, nil
 	case "roles.create":
 		var input struct {
 			ProjectID                 string   `json:"project_id"`
@@ -1584,6 +1680,91 @@ func cairnlineSidecarFixtureProjectMemoryCandidates(state *cairnlineSidecarFixtu
 		candidates = append(candidates, candidate)
 	}
 	return candidates
+}
+
+func cairnlineSidecarFixtureProjectAssistantProposals(state *cairnlineSidecarFixtureState, projectID string) []ProjectCairnlineSidecarAssistantProposalRecordItem {
+	items := make([]ProjectCairnlineSidecarAssistantProposalRecordItem, 0, len(state.assistantProposals))
+	for _, item := range state.assistantProposals {
+		if projectID == "" || item.ProjectID == projectID {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func cairnlineSidecarFixtureApplyAssistantProposal(state *cairnlineSidecarFixtureState, record ProjectCairnlineSidecarAssistantProposalRecordItem) ProjectCairnlineSidecarAssistantApplyResultItem {
+	result := ProjectCairnlineSidecarAssistantApplyResultItem{
+		ProposalID:       record.ID,
+		Status:           "applied",
+		Applied:          true,
+		Confirmed:        true,
+		TotalActionCount: len(record.Proposal.Actions),
+		Actions:          make([]ProjectCairnlineSidecarAssistantActionResultItem, 0, len(record.Proposal.Actions)),
+	}
+	for idx, action := range record.Proposal.Actions {
+		actionResult := ProjectCairnlineSidecarAssistantActionResultItem{
+			Kind:   action.Kind,
+			Status: "applied",
+		}
+		switch action.Kind {
+		case "create_role":
+			if action.Role == nil || action.Role.ProjectID == "" || action.Role.ID == "" {
+				result.Status = "partial"
+				result.Applied = false
+				result.FailedActionIndex = &idx
+				actionResult.Status = "failed"
+				actionResult.Error = "missing role payload"
+				result.Actions = append(result.Actions, actionResult)
+				return result
+			}
+			cairnlineSidecarFixtureEnsureRoles(state, action.Role.ProjectID)[action.Role.ID] = *action.Role
+			actionResult.ProjectID = action.Role.ProjectID
+			actionResult.RoleID = action.Role.ID
+		case "create_work_item":
+			if action.WorkItem == nil || action.WorkItem.ProjectID == "" || action.WorkItem.ID == "" {
+				result.Status = "partial"
+				result.Applied = false
+				result.FailedActionIndex = &idx
+				actionResult.Status = "failed"
+				actionResult.Error = "missing work item payload"
+				result.Actions = append(result.Actions, actionResult)
+				return result
+			}
+			cairnlineSidecarFixtureEnsureWorkItems(state, action.WorkItem.ProjectID)[action.WorkItem.ID] = *action.WorkItem
+			actionResult.ProjectID = action.WorkItem.ProjectID
+			actionResult.WorkItemID = action.WorkItem.ID
+		case "create_assignment":
+			if action.Assignment == nil || action.Assignment.ProjectID == "" || action.Assignment.ID == "" {
+				result.Status = "partial"
+				result.Applied = false
+				result.FailedActionIndex = &idx
+				actionResult.Status = "failed"
+				actionResult.Error = "missing assignment payload"
+				result.Actions = append(result.Actions, actionResult)
+				return result
+			}
+			assignment := *action.Assignment
+			if assignment.Status == "" {
+				assignment.Status = "queued"
+			}
+			cairnlineSidecarFixtureEnsureAssignments(state, assignment.ProjectID)[assignment.ID] = assignment
+			actionResult.ProjectID = assignment.ProjectID
+			actionResult.WorkItemID = assignment.WorkItemID
+			actionResult.RoleID = assignment.RoleID
+			actionResult.AssignmentID = assignment.ID
+		default:
+			result.Status = "partial"
+			result.Applied = false
+			result.FailedActionIndex = &idx
+			actionResult.Status = "failed"
+			actionResult.Error = "unsupported action kind"
+			result.Actions = append(result.Actions, actionResult)
+			return result
+		}
+		result.AppliedActionCount++
+		result.Actions = append(result.Actions, actionResult)
+	}
+	return result
 }
 
 func cairnlineSidecarFixtureListResult(mode, text string, structured any) (mcp.CallToolResult, *mcp.RPCError) {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -322,6 +322,20 @@ func (h *Handler) HandleProjectCairnlineSidecarMemorySmoke(w http.ResponseWriter
 	})
 }
 
+func (h *Handler) HandleProjectCairnlineSidecarAssistantSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar assistant smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarAssistantRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarAssistantEnvelope{
+		Object: "project_cairnline_sidecar_assistant",
+		Data:   h.projectCairnlineSidecarAssistantSmoke(r.Context(), req),
+	})
+}
+
 func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairnlineSidecarProbeResponse {
 	if ctx == nil {
 		ctx = context.Background()
@@ -2328,6 +2342,259 @@ func (h *Handler) projectCairnlineSidecarMemorySmoke(ctx context.Context, req Pr
 	return fail("sidecar_memory_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary memory project.")
 }
 
+func (h *Handler) projectCairnlineSidecarAssistantSmoke(ctx context.Context, req ProjectCairnlineSidecarAssistantRequest) ProjectCairnlineSidecarAssistantResponse {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	projectName := strings.TrimSpace(req.ProjectName)
+	if projectName == "" {
+		projectName = "Hecate sidecar assistant smoke " + time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+	const (
+		roleName  = "Sidecar assistant operator"
+		workTitle = "Sidecar assistant proposed work"
+	)
+	response := ProjectCairnlineSidecarAssistantResponse{
+		Ready:                 false,
+		Status:                "sidecar_assistant_not_run",
+		Detail:                "Cairnline sidecar assistant smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ConfirmedMutation:     req.ConfirmMutation,
+		ProjectName:           projectName,
+	}
+	if h == nil {
+		response.Status = "sidecar_assistant_failed"
+		response.Detail = "Cairnline sidecar assistant smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this assistant smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+	if !req.ConfirmMutation {
+		response.Status = "sidecar_assistant_confirmation_required"
+		response.Detail = "Set confirm_mutation=true to let Hecate create, verify, apply, and clean up a temporary Project Assistant proposal in the standalone Cairnline sidecar. Hecate-native Projects stores are not mutated."
+		return response
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	smokeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	projectID := ""
+	cleanup := func() {
+		if projectID == "" || response.CleanupVerified {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+		defer cleanupCancel()
+		cleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_delete_project", "projects.delete", false, map[string]string{"id": projectID})
+		response.Steps = append(response.Steps, cleanupStep)
+		if cleanupStep.Status == "ready" {
+			verifyCleanupStep := h.callProjectCairnlineSidecarWriteTool(cleanupCtx, cfg, cache, "cleanup_get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+			if verifyCleanupStep.Status == "tool_failed" {
+				verifyCleanupStep.Status = "expected_missing"
+				response.CleanupVerified = true
+				response.Warnings = append(response.Warnings, "Hecate deleted and verified removal of the temporary standalone Cairnline assistant project after the assistant smoke failed; inspect the reported steps before retrying.")
+			} else {
+				response.Warnings = append(response.Warnings, "Hecate deleted the temporary standalone Cairnline assistant project after the assistant smoke failed, but removal could not be verified; inspect the reported steps before retrying.")
+			}
+			response.Steps = append(response.Steps, verifyCleanupStep)
+			return
+		}
+		response.Warnings = append(response.Warnings, "Hecate tried to delete the temporary standalone Cairnline assistant project after the assistant smoke failed, but cleanup did not succeed; inspect the standalone Cairnline sidecar before retrying.")
+	}
+	fail := func(status, detail string) ProjectCairnlineSidecarAssistantResponse {
+		response.Status = status
+		response.Detail = detail
+		cleanup()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	appendStep := func(step ProjectCairnlineSidecarWriteStep) bool {
+		response.Steps = append(response.Steps, step)
+		if step.Status == "tool_failed" {
+			response.Status = "sidecar_assistant_tool_failed"
+			response.Detail = "Cairnline sidecar " + step.Tool + " returned a tool-level error. Review the step output before retrying."
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		if step.Status == "failed" {
+			response.Status = "sidecar_assistant_failed"
+			response.Detail = firstNonEmpty(step.ToolText, "Cairnline sidecar "+step.Tool+" failed.")
+			cleanup()
+			response.setSidecarCacheStats(cache.Stats())
+			return false
+		}
+		return true
+	}
+
+	createProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_project", "projects.create", false, map[string]string{
+		"name":        projectName,
+		"description": "Temporary Hecate sidecar assistant smoke project. It should be deleted by the same diagnostic run.",
+	})
+	if !appendStep(createProject) {
+		return response
+	}
+	listProjects := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_after_project_create", "projects.list", true, map[string]string{})
+	if !appendStep(listProjects) {
+		return response
+	}
+	project, ok := projectCairnlineSidecarProjectByName(listProjects.StructuredProjects, projectName)
+	if !ok || strings.TrimSpace(project.ID) == "" {
+		return fail("sidecar_assistant_created_project_not_listed", "Cairnline sidecar projects.create succeeded, but projects.list did not return the temporary assistant project by name.")
+	}
+	projectID = strings.TrimSpace(project.ID)
+	response.SelectedProjectID = projectID
+	response.ProposalID = "prop_" + projectID + "_assistant_smoke"
+	response.RoleID = "role_" + projectID + "_assistant"
+	response.WorkItemID = "work_" + projectID + "_assistant"
+	response.AssignmentID = "asgn_" + projectID + "_assistant"
+
+	proposal := map[string]any{
+		"id":                    response.ProposalID,
+		"project_id":            projectID,
+		"title":                 "Queue sidecar assistant assignment",
+		"summary":               "Temporary Project Assistant proposal created by the Hecate sidecar assistant smoke.",
+		"source":                "assistant",
+		"requires_confirmation": true,
+		"warnings":              []string{"Temporary diagnostic proposal; it should be applied and cleaned up by the same smoke run."},
+		"actions": []map[string]any{
+			{
+				"kind": "create_role",
+				"role": map[string]any{
+					"id":                     response.RoleID,
+					"project_id":             projectID,
+					"name":                   roleName,
+					"description":            "Temporary role from the sidecar assistant smoke.",
+					"default_execution_mode": "mcp_pull",
+				},
+			},
+			{
+				"kind": "create_work_item",
+				"work_item": map[string]any{
+					"id":            response.WorkItemID,
+					"project_id":    projectID,
+					"title":         workTitle,
+					"brief":         "Temporary work item from the sidecar assistant smoke.",
+					"owner_role_id": response.RoleID,
+				},
+			},
+			{
+				"kind": "create_assignment",
+				"assignment": map[string]any{
+					"id":             response.AssignmentID,
+					"project_id":     projectID,
+					"work_item_id":   response.WorkItemID,
+					"role_id":        response.RoleID,
+					"execution_mode": "mcp_pull",
+				},
+			},
+		},
+	}
+	proposeStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "create_assistant_proposal", "assistant.propose", false, proposal)
+	if !appendStep(proposeStep) {
+		return response
+	}
+	if proposeStep.StructuredAssistantProposal.ID != response.ProposalID || proposeStep.StructuredAssistantProposal.Status != "proposed" || len(proposeStep.StructuredAssistantProposal.Proposal.Actions) != 3 {
+		return fail("sidecar_assistant_proposal_create_verification_failed", "Cairnline sidecar assistant.propose did not return the expected proposed assistant record with three actions.")
+	}
+	response.CreatedProposal = proposeStep.StructuredAssistantProposal
+
+	listProposals := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_assistant_proposals_after_create", "assistant.proposals.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listProposals) {
+		return response
+	}
+	if _, ok := projectCairnlineSidecarAssistantProposalByID(listProposals.StructuredAssistantProposals, response.ProposalID); !ok {
+		return fail("sidecar_assistant_proposal_list_verification_failed", "Cairnline sidecar assistant.proposals.list did not return the expected proposed assistant record.")
+	}
+
+	getProposal := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_assistant_proposal", "assistant.proposals.get", true, map[string]string{"id": response.ProposalID})
+	if !appendStep(getProposal) {
+		return response
+	}
+	if getProposal.StructuredAssistantProposal.ID != response.ProposalID || getProposal.StructuredAssistantProposal.ProjectID != projectID {
+		return fail("sidecar_assistant_proposal_get_verification_failed", "Cairnline sidecar assistant.proposals.get did not return the expected proposed assistant record.")
+	}
+
+	applyStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "apply_assistant_proposal", "assistant.apply", false, map[string]any{
+		"proposal_id": response.ProposalID,
+		"confirm":     true,
+	})
+	if !appendStep(applyStep) {
+		return response
+	}
+	if applyStep.StructuredAssistantApplyResult.ProposalID != response.ProposalID || applyStep.StructuredAssistantApplyResult.Status != "applied" || !applyStep.StructuredAssistantApplyResult.Applied || applyStep.StructuredAssistantApplyResult.AppliedActionCount != 3 {
+		return fail("sidecar_assistant_apply_verification_failed", "Cairnline sidecar assistant.apply did not return the expected applied result for all three proposal actions.")
+	}
+	response.ApplyResult = applyStep.StructuredAssistantApplyResult
+
+	getAppliedProposal := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_applied_assistant_proposal", "assistant.proposals.get", true, map[string]string{"id": response.ProposalID})
+	if !appendStep(getAppliedProposal) {
+		return response
+	}
+	if getAppliedProposal.StructuredAssistantProposal.ID != response.ProposalID || getAppliedProposal.StructuredAssistantProposal.Status != "applied" || getAppliedProposal.StructuredAssistantProposal.LatestResult == nil || len(getAppliedProposal.StructuredAssistantProposal.ApplyAttempts) == 0 {
+		return fail("sidecar_assistant_applied_proposal_get_verification_failed", "Cairnline sidecar assistant.proposals.get did not return the applied proposal ledger state with latest result and apply attempt.")
+	}
+	response.AppliedProposal = getAppliedProposal.StructuredAssistantProposal
+
+	listRoles := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_roles_after_apply", "roles.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listRoles) {
+		return response
+	}
+	role, ok := projectCairnlineSidecarRoleByName(listRoles.StructuredRoles, roleName)
+	if !ok || role.ID != response.RoleID {
+		return fail("sidecar_assistant_role_apply_verification_failed", "Cairnline sidecar roles.list did not return the role created by assistant.apply.")
+	}
+
+	listWork := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_work_items_after_apply", "work_items.list", true, map[string]string{"project_id": projectID})
+	if !appendStep(listWork) {
+		return response
+	}
+	work, ok := projectCairnlineSidecarWorkItemByTitle(listWork.StructuredWorkItems, workTitle)
+	if !ok || work.ID != response.WorkItemID || work.OwnerRoleID != response.RoleID {
+		return fail("sidecar_assistant_work_apply_verification_failed", "Cairnline sidecar work_items.list did not return the work item created by assistant.apply.")
+	}
+
+	listAssignments := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "list_assignments_after_apply", "assignments.list", true, map[string]string{"project_id": projectID, "work_item_id": response.WorkItemID})
+	if !appendStep(listAssignments) {
+		return response
+	}
+	assignment, ok := projectCairnlineSidecarAssignmentByWorkAndRole(listAssignments.StructuredAssignments, response.WorkItemID, response.RoleID)
+	if !ok || assignment.ID != response.AssignmentID || assignment.ExecutionMode != "mcp_pull" {
+		return fail("sidecar_assistant_assignment_apply_verification_failed", "Cairnline sidecar assignments.list did not return the queued MCP-pull assignment created by assistant.apply.")
+	}
+
+	deleteProject := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "delete_project", "projects.delete", false, map[string]string{"id": projectID})
+	if !appendStep(deleteProject) {
+		return response
+	}
+	verifyDelete := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_after_project_delete", "projects.get", true, map[string]string{"id": projectID})
+	if verifyDelete.Status == "tool_failed" {
+		verifyDelete.Status = "expected_missing"
+		response.Steps = append(response.Steps, verifyDelete)
+		response.CleanupVerified = true
+		response.Ready = true
+		response.Status = "sidecar_assistant_ready"
+		response.Detail = "Hecate created, listed, fetched, applied, and verified a temporary standalone Cairnline Project Assistant proposal, then deleted the temporary project. Hecate-native Projects stores were not mutated."
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	if !appendStep(verifyDelete) {
+		return response
+	}
+	return fail("sidecar_assistant_project_delete_verification_failed", "Cairnline sidecar projects.delete succeeded, but projects.get still returned the temporary assistant project.")
+}
+
 func projectCairnlineSidecarLifecycleShouldReleaseAfterFailure(steps []ProjectCairnlineSidecarLifecycleStep) bool {
 	claimed := false
 	for _, step := range steps {
@@ -2994,6 +3261,52 @@ func (h *Handler) callProjectCairnlineSidecarWriteTool(ctx context.Context, cfg 
 			step.ToolText = "Cairnline sidecar " + tool + " did not return structuredContent; the memory smoke needs typed memory candidate detail to verify candidate mutations."
 			return step
 		}
+	case "assistant.propose", "assistant.proposals.get":
+		proposal, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssistantProposal(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredAssistantProposal = proposal
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " returned structuredContent that Hecate could not parse as assistant proposal: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar " + tool + " did not return structuredContent; the assistant smoke needs typed proposal detail to verify proposal ledger mutations."
+			return step
+		}
+	case "assistant.proposals.list":
+		proposals, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssistantProposals(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredAssistantProposals = proposals
+		step.StructuredAssistantProposalCount = len(proposals)
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assistant.proposals.list returned structuredContent that Hecate could not parse as assistant proposals: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assistant.proposals.list did not return structuredContent; the assistant smoke needs typed proposal records to verify proposal ledger mutations."
+			return step
+		}
+	case "assistant.apply":
+		applyResult, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssistantApplyResult(result.Result.StructuredContent)
+		step.StructuredReady = structuredReady
+		step.StructuredAssistantApplyResult = applyResult
+		if structuredErr != nil {
+			step.StructuredParseError = structuredErr.Error()
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assistant.apply returned structuredContent that Hecate could not parse as assistant apply result: " + structuredErr.Error()
+			return step
+		}
+		if !structuredReady {
+			step.Status = "failed"
+			step.ToolText = "Cairnline sidecar assistant.apply did not return structuredContent; the assistant smoke needs typed apply result to verify confirmed apply."
+			return step
+		}
 	case "assignments.context":
 		contextIDs, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignmentContextIDs(result.Result.StructuredContent)
 		step.StructuredReady = structuredReady
@@ -3213,6 +3526,16 @@ func projectCairnlineSidecarMemoryCandidateByID(candidates []ProjectCairnlineSid
 		}
 	}
 	return ProjectCairnlineSidecarMemoryCandidateItem{}, false
+}
+
+func projectCairnlineSidecarAssistantProposalByID(proposals []ProjectCairnlineSidecarAssistantProposalRecordItem, id string) (ProjectCairnlineSidecarAssistantProposalRecordItem, bool) {
+	id = strings.TrimSpace(id)
+	for _, proposal := range proposals {
+		if strings.TrimSpace(proposal.ID) == id {
+			return proposal, true
+		}
+	}
+	return ProjectCairnlineSidecarAssistantProposalRecordItem{}, false
 }
 
 func projectCairnlineSidecarStructuredProject(raw json.RawMessage) (ProjectCairnlineSidecarProjectItem, bool, error) {
@@ -3581,6 +3904,57 @@ func projectCairnlineSidecarStructuredMemoryCandidate(raw json.RawMessage) (Proj
 	return candidate, true, nil
 }
 
+func projectCairnlineSidecarStructuredAssistantProposals(raw json.RawMessage) ([]ProjectCairnlineSidecarAssistantProposalRecordItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarAssistantProposalRecordItem{}, true, nil
+	}
+	var proposals []ProjectCairnlineSidecarAssistantProposalRecordItem
+	if err := json.Unmarshal(trimmed, &proposals); err != nil {
+		return nil, false, err
+	}
+	if proposals == nil {
+		proposals = []ProjectCairnlineSidecarAssistantProposalRecordItem{}
+	}
+	return proposals, true, nil
+}
+
+func projectCairnlineSidecarStructuredAssistantProposal(raw json.RawMessage) (ProjectCairnlineSidecarAssistantProposalRecordItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarAssistantProposalRecordItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarAssistantProposalRecordItem{}, false, nil
+	}
+	var proposal ProjectCairnlineSidecarAssistantProposalRecordItem
+	if err := json.Unmarshal(trimmed, &proposal); err != nil {
+		return ProjectCairnlineSidecarAssistantProposalRecordItem{}, false, err
+	}
+	return proposal, true, nil
+}
+
+func projectCairnlineSidecarStructuredAssistantApplyResult(raw json.RawMessage) (ProjectCairnlineSidecarAssistantApplyResultItem, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineSidecarAssistantApplyResultItem{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineSidecarAssistantApplyResultItem{}, false, nil
+	}
+	var result ProjectCairnlineSidecarAssistantApplyResultItem
+	if err := json.Unmarshal(trimmed, &result); err != nil {
+		return ProjectCairnlineSidecarAssistantApplyResultItem{}, false, err
+	}
+	return result, true, nil
+}
+
 func projectCairnlineSidecarStructuredAssignmentContextIDs(raw json.RawMessage) (ProjectCairnlineSidecarAssignmentContextIDs, bool, error) {
 	if len(raw) == 0 {
 		return ProjectCairnlineSidecarAssignmentContextIDs{}, false, nil
@@ -3858,6 +4232,15 @@ func (r *ProjectCairnlineSidecarCollaborationResponse) setSidecarCacheStats(stat
 }
 
 func (r *ProjectCairnlineSidecarMemoryResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
+func (r *ProjectCairnlineSidecarAssistantResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -1266,6 +1266,93 @@ func TestProjectCairnlineSidecarCollaborationSmoke_CleansUpAfterReviewFailure(t 
 	}
 }
 
+func TestProjectCairnlineSidecarAssistantSmoke_RequiresConfirmation(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarAssistantSmoke(t.Context(), ProjectCairnlineSidecarAssistantRequest{ProjectName: "Fixture assistant smoke"})
+	if got.Ready || got.Status != "sidecar_assistant_confirmation_required" || got.ConfirmedMutation {
+		t.Fatalf("assistant smoke = %+v, want confirmation-required without mutation", got)
+	}
+	if len(got.Steps) != 0 || got.ClientCacheEntries != 0 {
+		t.Fatalf("steps/cache = %d/%d, want no sidecar calls before confirmation", len(got.Steps), got.ClientCacheEntries)
+	}
+}
+
+func TestProjectCairnlineSidecarAssistantSmoke_AppliesProposal(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarAssistantSmoke(t.Context(), ProjectCairnlineSidecarAssistantRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture assistant smoke",
+	})
+	if !got.Ready || got.Status != "sidecar_assistant_ready" || !got.CleanupVerified {
+		t.Fatalf("assistant smoke = %+v, want ready with verified cleanup", got)
+	}
+	if got.SelectedProjectID == "" || got.ProposalID == "" || got.RoleID == "" || got.WorkItemID == "" || got.AssignmentID == "" {
+		t.Fatalf("ids = project:%q proposal:%q role:%q work:%q assignment:%q, want created assistant ids", got.SelectedProjectID, got.ProposalID, got.RoleID, got.WorkItemID, got.AssignmentID)
+	}
+	if got.CreatedProposal.ID != got.ProposalID || got.CreatedProposal.Status != "proposed" || len(got.CreatedProposal.Proposal.Actions) != 3 {
+		t.Fatalf("created proposal = %+v, want proposed record with three actions", got.CreatedProposal)
+	}
+	if got.ApplyResult.ProposalID != got.ProposalID || got.ApplyResult.Status != "applied" || !got.ApplyResult.Applied || !got.ApplyResult.Confirmed || got.ApplyResult.AppliedActionCount != 3 {
+		t.Fatalf("apply result = %+v, want confirmed applied result for all actions", got.ApplyResult)
+	}
+	if got.AppliedProposal.ID != got.ProposalID || got.AppliedProposal.Status != "applied" || got.AppliedProposal.LatestResult == nil || len(got.AppliedProposal.ApplyAttempts) == 0 {
+		t.Fatalf("applied proposal = %+v, want applied ledger state", got.AppliedProposal)
+	}
+	if len(got.Steps) != 12 {
+		t.Fatalf("steps = %+v, want project/proposal/apply/verify/delete flow", got.Steps)
+	}
+	if got.Steps[2].Tool != "assistant.propose" || got.Steps[3].Tool != "assistant.proposals.list" || got.Steps[4].Tool != "assistant.proposals.get" || got.Steps[5].Tool != "assistant.apply" || got.Steps[8].Tool != "work_items.list" || got.Steps[9].Tool != "assignments.list" || got.Steps[11].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want assistant smoke order and missing-after-delete verification", got.Steps)
+	}
+	if got.Steps[5].StructuredAssistantApplyResult.AppliedActionCount != 3 {
+		t.Fatalf("apply step = %+v, want typed apply result with three applied actions", got.Steps[5])
+	}
+}
+
+func TestProjectCairnlineSidecarAssistantSmoke_CleansUpAfterApplyFailure(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "assistant-apply-tool-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarAssistantSmoke(t.Context(), ProjectCairnlineSidecarAssistantRequest{
+		ConfirmMutation: true,
+		ProjectName:     "Fixture assistant smoke cleanup",
+	})
+	if got.Ready || got.Status != "sidecar_assistant_tool_failed" || !got.CleanupVerified {
+		t.Fatalf("assistant smoke = %+v, want apply tool failure with verified project cleanup", got)
+	}
+	if len(got.Steps) != 8 || got.Steps[5].Tool != "assistant.apply" || !got.Steps[5].ToolIsError || got.Steps[6].Name != "cleanup_delete_project" || got.Steps[7].Status != "expected_missing" {
+		t.Fatalf("steps = %+v, want apply failure followed by project cleanup delete and verification", got.Steps)
+	}
+	if !strings.Contains(strings.Join(got.Warnings, "\n"), "deleted and verified removal") {
+		t.Fatalf("warnings = %+v, want verified cleanup warning", got.Warnings)
+	}
+}
+
 func TestProjectCairnlineSidecarMemorySmoke_RequiresConfirmation(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -19,6 +19,7 @@ const projectCoordinationBackendSidecarWriteURL = "/hecate/v1/projects/cairnline
 const projectCoordinationBackendSidecarWorkURL = "/hecate/v1/projects/cairnline/sidecar-work-smoke"
 const projectCoordinationBackendSidecarCollaborationURL = "/hecate/v1/projects/cairnline/sidecar-collaboration-smoke"
 const projectCoordinationBackendSidecarMemoryURL = "/hecate/v1/projects/cairnline/sidecar-memory-smoke"
+const projectCoordinationBackendSidecarAssistantURL = "/hecate/v1/projects/cairnline/sidecar-assistant-smoke"
 const projectCoordinationBackendEmbeddedReadModelURL = "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
 const projectCoordinationBackendEmbeddedParityReportURL = "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
 const projectCoordinationBackendSyncReadinessURL = "/hecate/v1/projects/cairnline/sync"
@@ -321,6 +322,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineSidecarWorkURL:              projectCoordinationBackendSidecarWorkURL,
 		CairnlineSidecarCollaborationURL:     projectCoordinationBackendSidecarCollaborationURL,
 		CairnlineSidecarMemoryURL:            projectCoordinationBackendSidecarMemoryURL,
+		CairnlineSidecarAssistantURL:         projectCoordinationBackendSidecarAssistantURL,
 		EmbeddedReadModelURL:                 projectCoordinationBackendEmbeddedReadModelURL,
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -66,8 +66,8 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.CairnlineSidecarMemoryURL != projectCoordinationBackendSidecarMemoryURL {
 		t.Fatalf("sidecar memory URL = %q, want %q", status.CairnlineSidecarMemoryURL, projectCoordinationBackendSidecarMemoryURL)
 	}
-	if status.CairnlineSidecarMemoryURL != projectCoordinationBackendSidecarMemoryURL {
-		t.Fatalf("sidecar memory URL = %q, want %q", status.CairnlineSidecarMemoryURL, projectCoordinationBackendSidecarMemoryURL)
+	if status.CairnlineSidecarAssistantURL != projectCoordinationBackendSidecarAssistantURL {
+		t.Fatalf("sidecar assistant URL = %q, want %q", status.CairnlineSidecarAssistantURL, projectCoordinationBackendSidecarAssistantURL)
 	}
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -588,6 +588,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarWorkURL              string                                       `json:"cairnline_sidecar_work_url,omitempty"`
 	CairnlineSidecarCollaborationURL     string                                       `json:"cairnline_sidecar_collaboration_url,omitempty"`
 	CairnlineSidecarMemoryURL            string                                       `json:"cairnline_sidecar_memory_url,omitempty"`
+	CairnlineSidecarAssistantURL         string                                       `json:"cairnline_sidecar_assistant_url,omitempty"`
 	EmbeddedReadModelURL                 string                                       `json:"embedded_read_model_url,omitempty"`
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
@@ -1739,6 +1740,11 @@ type ProjectCairnlineSidecarMemoryEnvelope struct {
 	Data   ProjectCairnlineSidecarMemoryResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarAssistantEnvelope struct {
+	Object string                                   `json:"object"`
+	Data   ProjectCairnlineSidecarAssistantResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
 }
@@ -1790,6 +1796,11 @@ type ProjectCairnlineSidecarCollaborationRequest struct {
 }
 
 type ProjectCairnlineSidecarMemoryRequest struct {
+	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
+	ProjectName     string `json:"project_name,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssistantRequest struct {
 	ConfirmMutation bool   `json:"confirm_mutation,omitempty"`
 	ProjectName     string `json:"project_name,omitempty"`
 }
@@ -2203,53 +2214,85 @@ type ProjectCairnlineSidecarMemoryResponse struct {
 	Warnings                []string                                   `json:"warnings,omitempty"`
 }
 
+type ProjectCairnlineSidecarAssistantResponse struct {
+	Ready                 bool                                               `json:"ready"`
+	Status                string                                             `json:"status"`
+	Detail                string                                             `json:"detail"`
+	Command               string                                             `json:"command"`
+	Args                  []string                                           `json:"args,omitempty"`
+	DatabasePath          string                                             `json:"database_path,omitempty"`
+	ProbeTimeoutMS        int64                                              `json:"probe_timeout_ms"`
+	PersistentClient      bool                                               `json:"persistent_client,omitempty"`
+	ClientCacheConfigured bool                                               `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries    int                                                `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse      int                                                `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle       int                                                `json:"client_cache_idle,omitempty"`
+	ConfirmedMutation     bool                                               `json:"confirmed_mutation"`
+	ProjectName           string                                             `json:"project_name,omitempty"`
+	SelectedProjectID     string                                             `json:"selected_project_id,omitempty"`
+	ProposalID            string                                             `json:"proposal_id,omitempty"`
+	RoleID                string                                             `json:"role_id,omitempty"`
+	WorkItemID            string                                             `json:"work_item_id,omitempty"`
+	AssignmentID          string                                             `json:"assignment_id,omitempty"`
+	Steps                 []ProjectCairnlineSidecarWriteStep                 `json:"steps,omitempty"`
+	CreatedProposal       ProjectCairnlineSidecarAssistantProposalRecordItem `json:"created_proposal,omitempty"`
+	AppliedProposal       ProjectCairnlineSidecarAssistantProposalRecordItem `json:"applied_proposal,omitempty"`
+	ApplyResult           ProjectCairnlineSidecarAssistantApplyResultItem    `json:"apply_result,omitempty"`
+	CleanupVerified       bool                                               `json:"cleanup_verified"`
+	Warnings              []string                                           `json:"warnings,omitempty"`
+}
+
 type ProjectCairnlineSidecarWriteStep struct {
-	Name                           string                                       `json:"name"`
-	Tool                           string                                       `json:"tool"`
-	ReadOnly                       bool                                         `json:"read_only"`
-	Status                         string                                       `json:"status"`
-	ToolText                       string                                       `json:"tool_text,omitempty"`
-	ToolIsError                    bool                                         `json:"tool_is_error,omitempty"`
-	StructuredContent              json.RawMessage                              `json:"structured_content,omitempty"`
-	Meta                           json.RawMessage                              `json:"meta,omitempty"`
-	StructuredReady                bool                                         `json:"structured_ready"`
-	StructuredProject              ProjectCairnlineSidecarProjectItem           `json:"structured_project,omitempty"`
-	StructuredProjects             []ProjectCairnlineSidecarProjectItem         `json:"structured_projects,omitempty"`
-	StructuredProjectCount         int                                          `json:"structured_project_count"`
-	StructuredRoot                 ProjectCairnlineSidecarRootItem              `json:"structured_root,omitempty"`
-	StructuredRoots                []ProjectCairnlineSidecarRootItem            `json:"structured_roots,omitempty"`
-	StructuredRootCount            int                                          `json:"structured_root_count"`
-	StructuredSource               ProjectCairnlineSidecarSourceItem            `json:"structured_source,omitempty"`
-	StructuredSources              []ProjectCairnlineSidecarSourceItem          `json:"structured_sources,omitempty"`
-	StructuredSourceCount          int                                          `json:"structured_source_count"`
-	StructuredRoles                []ProjectCairnlineSidecarRoleItem            `json:"structured_roles,omitempty"`
-	StructuredRoleCount            int                                          `json:"structured_role_count"`
-	StructuredWorkItems            []ProjectCairnlineSidecarWorkItem            `json:"structured_work_items,omitempty"`
-	StructuredWorkItemCount        int                                          `json:"structured_work_item_count"`
-	StructuredAssignments          []ProjectCairnlineSidecarAssignmentItem      `json:"structured_assignments,omitempty"`
-	StructuredAssignmentCount      int                                          `json:"structured_assignment_count"`
-	StructuredArtifact             ProjectCairnlineSidecarArtifactItem          `json:"structured_artifact,omitempty"`
-	StructuredArtifacts            []ProjectCairnlineSidecarArtifactItem        `json:"structured_artifacts,omitempty"`
-	StructuredArtifactCount        int                                          `json:"structured_artifact_count"`
-	StructuredEvidenceItem         ProjectCairnlineSidecarEvidenceItem          `json:"structured_evidence_item,omitempty"`
-	StructuredEvidence             []ProjectCairnlineSidecarEvidenceItem        `json:"structured_evidence,omitempty"`
-	StructuredEvidenceCount        int                                          `json:"structured_evidence_count"`
-	StructuredReview               ProjectCairnlineSidecarReviewItem            `json:"structured_review,omitempty"`
-	StructuredReviews              []ProjectCairnlineSidecarReviewItem          `json:"structured_reviews,omitempty"`
-	StructuredReviewCount          int                                          `json:"structured_review_count"`
-	StructuredHandoff              ProjectCairnlineSidecarHandoffItem           `json:"structured_handoff,omitempty"`
-	StructuredHandoffs             []ProjectCairnlineSidecarHandoffItem         `json:"structured_handoffs,omitempty"`
-	StructuredHandoffCount         int                                          `json:"structured_handoff_count"`
-	StructuredMemoryEntry          ProjectCairnlineSidecarMemoryEntryItem       `json:"structured_memory_entry,omitempty"`
-	StructuredMemoryEntries        []ProjectCairnlineSidecarMemoryEntryItem     `json:"structured_memory_entries,omitempty"`
-	StructuredMemoryEntryCount     int                                          `json:"structured_memory_entry_count"`
-	StructuredMemoryCandidate      ProjectCairnlineSidecarMemoryCandidateItem   `json:"structured_memory_candidate,omitempty"`
-	StructuredMemoryCandidates     []ProjectCairnlineSidecarMemoryCandidateItem `json:"structured_memory_candidates,omitempty"`
-	StructuredMemoryCandidateCount int                                          `json:"structured_memory_candidate_count"`
-	AssignmentContextIDs           ProjectCairnlineSidecarAssignmentContextIDs  `json:"assignment_context_ids,omitempty"`
-	LaunchPacketIDs                ProjectCairnlineSidecarLaunchPacketIDs       `json:"launch_packet_ids,omitempty"`
-	LaunchPacketWarnings           []string                                     `json:"launch_packet_warnings,omitempty"`
-	StructuredParseError           string                                       `json:"structured_parse_error,omitempty"`
+	Name                             string                                               `json:"name"`
+	Tool                             string                                               `json:"tool"`
+	ReadOnly                         bool                                                 `json:"read_only"`
+	Status                           string                                               `json:"status"`
+	ToolText                         string                                               `json:"tool_text,omitempty"`
+	ToolIsError                      bool                                                 `json:"tool_is_error,omitempty"`
+	StructuredContent                json.RawMessage                                      `json:"structured_content,omitempty"`
+	Meta                             json.RawMessage                                      `json:"meta,omitempty"`
+	StructuredReady                  bool                                                 `json:"structured_ready"`
+	StructuredProject                ProjectCairnlineSidecarProjectItem                   `json:"structured_project,omitempty"`
+	StructuredProjects               []ProjectCairnlineSidecarProjectItem                 `json:"structured_projects,omitempty"`
+	StructuredProjectCount           int                                                  `json:"structured_project_count"`
+	StructuredRoot                   ProjectCairnlineSidecarRootItem                      `json:"structured_root,omitempty"`
+	StructuredRoots                  []ProjectCairnlineSidecarRootItem                    `json:"structured_roots,omitempty"`
+	StructuredRootCount              int                                                  `json:"structured_root_count"`
+	StructuredSource                 ProjectCairnlineSidecarSourceItem                    `json:"structured_source,omitempty"`
+	StructuredSources                []ProjectCairnlineSidecarSourceItem                  `json:"structured_sources,omitempty"`
+	StructuredSourceCount            int                                                  `json:"structured_source_count"`
+	StructuredRoles                  []ProjectCairnlineSidecarRoleItem                    `json:"structured_roles,omitempty"`
+	StructuredRoleCount              int                                                  `json:"structured_role_count"`
+	StructuredWorkItems              []ProjectCairnlineSidecarWorkItem                    `json:"structured_work_items,omitempty"`
+	StructuredWorkItemCount          int                                                  `json:"structured_work_item_count"`
+	StructuredAssignments            []ProjectCairnlineSidecarAssignmentItem              `json:"structured_assignments,omitempty"`
+	StructuredAssignmentCount        int                                                  `json:"structured_assignment_count"`
+	StructuredArtifact               ProjectCairnlineSidecarArtifactItem                  `json:"structured_artifact,omitempty"`
+	StructuredArtifacts              []ProjectCairnlineSidecarArtifactItem                `json:"structured_artifacts,omitempty"`
+	StructuredArtifactCount          int                                                  `json:"structured_artifact_count"`
+	StructuredEvidenceItem           ProjectCairnlineSidecarEvidenceItem                  `json:"structured_evidence_item,omitempty"`
+	StructuredEvidence               []ProjectCairnlineSidecarEvidenceItem                `json:"structured_evidence,omitempty"`
+	StructuredEvidenceCount          int                                                  `json:"structured_evidence_count"`
+	StructuredReview                 ProjectCairnlineSidecarReviewItem                    `json:"structured_review,omitempty"`
+	StructuredReviews                []ProjectCairnlineSidecarReviewItem                  `json:"structured_reviews,omitempty"`
+	StructuredReviewCount            int                                                  `json:"structured_review_count"`
+	StructuredHandoff                ProjectCairnlineSidecarHandoffItem                   `json:"structured_handoff,omitempty"`
+	StructuredHandoffs               []ProjectCairnlineSidecarHandoffItem                 `json:"structured_handoffs,omitempty"`
+	StructuredHandoffCount           int                                                  `json:"structured_handoff_count"`
+	StructuredMemoryEntry            ProjectCairnlineSidecarMemoryEntryItem               `json:"structured_memory_entry,omitempty"`
+	StructuredMemoryEntries          []ProjectCairnlineSidecarMemoryEntryItem             `json:"structured_memory_entries,omitempty"`
+	StructuredMemoryEntryCount       int                                                  `json:"structured_memory_entry_count"`
+	StructuredMemoryCandidate        ProjectCairnlineSidecarMemoryCandidateItem           `json:"structured_memory_candidate,omitempty"`
+	StructuredMemoryCandidates       []ProjectCairnlineSidecarMemoryCandidateItem         `json:"structured_memory_candidates,omitempty"`
+	StructuredMemoryCandidateCount   int                                                  `json:"structured_memory_candidate_count"`
+	StructuredAssistantProposal      ProjectCairnlineSidecarAssistantProposalRecordItem   `json:"structured_assistant_proposal,omitempty"`
+	StructuredAssistantProposals     []ProjectCairnlineSidecarAssistantProposalRecordItem `json:"structured_assistant_proposals,omitempty"`
+	StructuredAssistantProposalCount int                                                  `json:"structured_assistant_proposal_count"`
+	StructuredAssistantApplyResult   ProjectCairnlineSidecarAssistantApplyResultItem      `json:"structured_assistant_apply_result,omitempty"`
+	AssignmentContextIDs             ProjectCairnlineSidecarAssignmentContextIDs          `json:"assignment_context_ids,omitempty"`
+	LaunchPacketIDs                  ProjectCairnlineSidecarLaunchPacketIDs               `json:"launch_packet_ids,omitempty"`
+	LaunchPacketWarnings             []string                                             `json:"launch_packet_warnings,omitempty"`
+	StructuredParseError             string                                               `json:"structured_parse_error,omitempty"`
 }
 
 type ProjectCairnlineSidecarProjectItem struct {
@@ -2431,6 +2474,93 @@ type ProjectCairnlineSidecarMemoryCandidateSourceRef struct {
 	ID    string `json:"id"`
 	Title string `json:"title,omitempty"`
 	URL   string `json:"url,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssistantProposalRecordItem struct {
+	ID            string                                             `json:"id"`
+	ProjectID     string                                             `json:"project_id,omitempty"`
+	Source        string                                             `json:"source,omitempty"`
+	SourceID      string                                             `json:"source_id,omitempty"`
+	Proposal      ProjectCairnlineSidecarAssistantProposalItem       `json:"proposal"`
+	Status        string                                             `json:"status"`
+	LatestResult  *ProjectCairnlineSidecarAssistantApplyResultItem   `json:"latest_result,omitempty"`
+	ApplyAttempts []ProjectCairnlineSidecarAssistantApplyAttemptItem `json:"apply_attempts,omitempty"`
+	CreatedAt     string                                             `json:"created_at,omitempty"`
+	UpdatedAt     string                                             `json:"updated_at,omitempty"`
+	AppliedAt     string                                             `json:"applied_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssistantProposalItem struct {
+	ID                   string                                       `json:"id"`
+	ProjectID            string                                       `json:"project_id,omitempty"`
+	Title                string                                       `json:"title"`
+	Summary              string                                       `json:"summary,omitempty"`
+	Warnings             []string                                     `json:"warnings,omitempty"`
+	Source               string                                       `json:"source,omitempty"`
+	RequiresConfirmation bool                                         `json:"requires_confirmation"`
+	Actions              []ProjectCairnlineSidecarAssistantActionItem `json:"actions,omitempty"`
+	CreatedAt            string                                       `json:"created_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssistantActionItem struct {
+	Kind            string                                      `json:"kind"`
+	Title           string                                      `json:"title,omitempty"`
+	Summary         string                                      `json:"summary,omitempty"`
+	Target          ProjectCairnlineSidecarAssistantTargetItem  `json:"target,omitempty"`
+	Project         *ProjectCairnlineSidecarProjectItem         `json:"project,omitempty"`
+	Root            *ProjectCairnlineSidecarRootItem            `json:"root,omitempty"`
+	Role            *ProjectCairnlineSidecarRoleItem            `json:"role,omitempty"`
+	WorkItem        *ProjectCairnlineSidecarWorkItem            `json:"work_item,omitempty"`
+	Assignment      *ProjectCairnlineSidecarAssignmentItem      `json:"assignment,omitempty"`
+	Evidence        *ProjectCairnlineSidecarEvidenceItem        `json:"evidence,omitempty"`
+	Review          *ProjectCairnlineSidecarReviewItem          `json:"review,omitempty"`
+	Handoff         *ProjectCairnlineSidecarHandoffItem         `json:"handoff,omitempty"`
+	MemoryCandidate *ProjectCairnlineSidecarMemoryCandidateItem `json:"memory_candidate,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssistantTargetItem struct {
+	ProjectID    string `json:"project_id,omitempty"`
+	RootID       string `json:"root_id,omitempty"`
+	RoleID       string `json:"role_id,omitempty"`
+	WorkItemID   string `json:"work_item_id,omitempty"`
+	AssignmentID string `json:"assignment_id,omitempty"`
+	ArtifactID   string `json:"artifact_id,omitempty"`
+	HandoffID    string `json:"handoff_id,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssistantApplyResultItem struct {
+	ProposalID         string                                             `json:"proposal_id"`
+	Status             string                                             `json:"status"`
+	Applied            bool                                               `json:"applied"`
+	Confirmed          bool                                               `json:"confirmed"`
+	TotalActionCount   int                                                `json:"total_action_count"`
+	AppliedActionCount int                                                `json:"applied_action_count"`
+	FailedActionIndex  *int                                               `json:"failed_action_index,omitempty"`
+	Actions            []ProjectCairnlineSidecarAssistantActionResultItem `json:"actions,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssistantActionResultItem struct {
+	Kind              string `json:"kind"`
+	Status            string `json:"status"`
+	ProjectID         string `json:"project_id,omitempty"`
+	RootID            string `json:"root_id,omitempty"`
+	RoleID            string `json:"role_id,omitempty"`
+	WorkItemID        string `json:"work_item_id,omitempty"`
+	AssignmentID      string `json:"assignment_id,omitempty"`
+	ArtifactID        string `json:"artifact_id,omitempty"`
+	HandoffID         string `json:"handoff_id,omitempty"`
+	MemoryCandidateID string `json:"memory_candidate_id,omitempty"`
+	Error             string `json:"error,omitempty"`
+}
+
+type ProjectCairnlineSidecarAssistantApplyAttemptItem struct {
+	ID           string                                          `json:"id"`
+	ProposalID   string                                          `json:"proposal_id"`
+	Status       string                                          `json:"status"`
+	Confirmed    bool                                            `json:"confirmed"`
+	Result       ProjectCairnlineSidecarAssistantApplyResultItem `json:"result"`
+	ErrorMessage string                                          `json:"error_message,omitempty"`
+	CreatedAt    string                                          `json:"created_at,omitempty"`
 }
 
 // MCPCacheStatsResponse is the wire shape for GET /hecate/v1/system/mcp/cache.

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -30,6 +30,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-detail-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-lifecycle-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-assistant-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-memory-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -90,6 +90,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-launch-packet-smoke", handler.HandleProjectCairnlineSidecarLaunchPacketSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-lifecycle-smoke", handler.HandleProjectCairnlineSidecarLifecycleSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-memory-smoke", handler.HandleProjectCairnlineSidecarMemorySmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-assistant-smoke", handler.HandleProjectCairnlineSidecarAssistantSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-setup-smoke", handler.HandleProjectCairnlineSidecarSetupSmoke)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4356,6 +4356,22 @@ func TestProjectCairnlineSidecarMemorySmokeRejectsNonLoopbackClientsBeforeComman
 	}
 }
 
+func TestProjectCairnlineSidecarAssistantSmokeRejectsNonLoopbackClientsBeforeCommandHandling(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	h := NewHandler(config.Config{}, logger, nil, nil, nil, nil)
+	server := NewServer(logger, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/cairnline/sidecar-assistant-smoke", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestMCPRegistryServersDiscoversCustomRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a local-only Cairnline sidecar Project Assistant smoke endpoint
- verify assistant.propose, proposal list/get, confirmed assistant.apply, side-effect reads, and cleanup against the standalone sidecar database
- document the new smoke in runtime, deployment, and Projects design docs

## Validation
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProject(CairnlineSidecar|CoordinationBackendStatus)|TestProjectCairnlineSidecarAssistantSmoke|TestProjectCairnlineSidecar.*RejectsNonLoopback'\n- just agent-docs-check\n- git diff --check\n- GOCACHE="$PWD/.gocache" go vet ./...\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...