### PR TITLE
Verify Cairnline sidecar assistant confirmation gate

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -174,9 +174,10 @@ candidate into accepted memory, rejects/deletes another candidate through typed
 An assistant smoke at
 `POST /hecate/v1/projects/cairnline/sidecar-assistant-smoke` requires
 `confirm_mutation=true`, creates and verifies a temporary Project Assistant
-proposal ledger record, applies it with explicit confirmation, verifies the
-created role/work/assignment side effects through typed `structuredContent`,
-then deletes and verifies removal of the temporary project.
+proposal ledger record, verifies unconfirmed apply returns `needs_confirmation`,
+applies it with explicit confirmation, verifies the created role/work/assignment
+side effects through typed `structuredContent`, then deletes and verifies
+removal of the temporary project.
 Hecate does not yet route Projects reads, writes, or mirrors through the sidecar
 client.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -366,12 +366,12 @@ launch agents. Those remain explicit operator or orchestrator actions.
   memory, promotes one memory candidate, rejects/deletes another candidate, and
   cleans up a temporary standalone Cairnline project, plus an explicit
   confirmed Project Assistant smoke that creates and verifies a temporary
-  proposal ledger record, applies it with explicit confirmation, verifies the
+  proposal ledger record, verifies unconfirmed apply returns
+  `needs_confirmation`, applies it with explicit confirmation, verifies the
   created role/work/assignment side effects, and cleans up the temporary
-  standalone Cairnline project. This is contract/client-lifecycle/read-shape
-  and standalone mutation evidence only: Hecate does not yet route live
-  Projects reads, writes, mirrors, or write-authority switchpoints through the
-  sidecar.
+  standalone Cairnline project. This is contract/client-lifecycle/read-shape and
+  standalone mutation evidence only: Hecate does not yet route live Projects
+  reads, writes, mirrors, or write-authority switchpoints through the sidecar.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -400,9 +400,9 @@ candidate, reject/delete another candidate, and clean up the temporary
 standalone Cairnline project. Operators can also run
 `POST /hecate/v1/projects/cairnline/sidecar-assistant-smoke` with
 `confirm_mutation=true` to create and verify a temporary Project Assistant
-proposal ledger record, apply it with explicit confirmation, verify the created
-role/work/assignment side effects, and clean up the temporary standalone
-Cairnline project.
+proposal ledger record, verify unconfirmed apply returns `needs_confirmation`,
+apply it with explicit confirmation, verify the created role/work/assignment
+side effects, and clean up the temporary standalone Cairnline project.
 Those smokes delete their temporary project and verify removal.
 When the embedded Cairnline read adapter is fully wired,
 `GET /hecate/v1/projects/backend-status` reports

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2942,14 +2942,16 @@ Cairnline-specific MCP client cache as `sidecar-connect`.
 
 The smoke creates a temporary rootless project, creates and verifies a
 confirmed-action Project Assistant proposal through `assistant.propose` /
-`assistant.proposals.list` / `assistant.proposals.get`, applies it through
-`assistant.apply` with `confirm=true`, verifies the applied proposal ledger
-state through another `assistant.proposals.get`, verifies the proposal side
-effects through `roles.list`, `work_items.list`, and `assignments.list`, then
-deletes the temporary project and expects a final `projects.get` to return a
-tool-level missing/error result. If a step fails after the temporary project id
-is known, Hecate attempts a best-effort project cleanup delete and verifies
-that cleanup through another `projects.get`.
+`assistant.proposals.list` / `assistant.proposals.get`, first verifies
+`assistant.apply` with `confirm=false` returns a typed `needs_confirmation`
+result without applying side effects, then applies it through `assistant.apply`
+with `confirm=true`. It verifies the applied proposal ledger state through
+another `assistant.proposals.get`, verifies the proposal side effects through
+`roles.list`, `work_items.list`, and `assignments.list`, then deletes the
+temporary project and expects a final `projects.get` to return a tool-level
+missing/error result. If a step fails after the temporary project id is known,
+Hecate attempts a best-effort project cleanup delete and verifies that cleanup
+through another `projects.get`.
 
 Example request:
 
@@ -2994,6 +2996,13 @@ Example response, shortened:
           { "kind": "create_assignment" }
         ]
       }
+    },
+    "unconfirmed_apply_result": {
+      "proposal_id": "prop_proj_123_assistant_smoke",
+      "status": "needs_confirmation",
+      "applied": false,
+      "confirmed": false,
+      "applied_action_count": 0
     },
     "apply_result": {
       "proposal_id": "prop_proj_123_assistant_smoke",

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -625,9 +625,6 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		}
 		return mcp.CallToolResult{Content: mcp.TextContent("Assistant proposal " + input.ID + ": [" + record.Status + "] " + record.Proposal.Title), StructuredContent: mustRawJSON(record)}, nil
 	case "assistant.apply":
-		if mode == "assistant-apply-tool-error" {
-			return mcp.CallToolResult{Content: mcp.TextContent("fixture assistant.apply failed"), IsError: true}, nil
-		}
 		var input struct {
 			ProposalID string                                       `json:"proposal_id"`
 			Proposal   ProjectCairnlineSidecarAssistantProposalItem `json:"proposal"`
@@ -635,6 +632,9 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		}
 		if err := json.Unmarshal(params.Arguments, &input); err != nil {
 			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assistant.apply arguments")
+		}
+		if mode == "assistant-apply-tool-error" && input.Confirm {
+			return mcp.CallToolResult{Content: mcp.TextContent("fixture assistant.apply failed"), IsError: true}, nil
 		}
 		record, ok := state.assistantProposals[input.ProposalID]
 		if !ok && input.Proposal.ID != "" {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -2526,6 +2526,24 @@ func (h *Handler) projectCairnlineSidecarAssistantSmoke(ctx context.Context, req
 		return fail("sidecar_assistant_proposal_get_verification_failed", "Cairnline sidecar assistant.proposals.get did not return the expected proposed assistant record.")
 	}
 
+	unconfirmedApplyStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "check_unconfirmed_assistant_apply", "assistant.apply", false, map[string]any{
+		"proposal_id": response.ProposalID,
+		"confirm":     false,
+	})
+	response.Steps = append(response.Steps, unconfirmedApplyStep)
+	if unconfirmedApplyStep.Status != "tool_failed" || !unconfirmedApplyStep.ToolIsError || !unconfirmedApplyStep.StructuredReady || unconfirmedApplyStep.StructuredAssistantApplyResult.ProposalID != response.ProposalID || unconfirmedApplyStep.StructuredAssistantApplyResult.Status != "needs_confirmation" || unconfirmedApplyStep.StructuredAssistantApplyResult.Applied || unconfirmedApplyStep.StructuredAssistantApplyResult.Confirmed {
+		return fail("sidecar_assistant_unconfirmed_apply_verification_failed", "Cairnline sidecar assistant.apply without confirm=true did not return the expected typed needs_confirmation result before side effects.")
+	}
+	response.UnconfirmedApplyResult = unconfirmedApplyStep.StructuredAssistantApplyResult
+
+	getNeedsConfirmationProposal := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "get_needs_confirmation_assistant_proposal", "assistant.proposals.get", true, map[string]string{"id": response.ProposalID})
+	if !appendStep(getNeedsConfirmationProposal) {
+		return response
+	}
+	if getNeedsConfirmationProposal.StructuredAssistantProposal.ID != response.ProposalID || getNeedsConfirmationProposal.StructuredAssistantProposal.Status != "needs_confirmation" || getNeedsConfirmationProposal.StructuredAssistantProposal.LatestResult == nil || len(getNeedsConfirmationProposal.StructuredAssistantProposal.ApplyAttempts) == 0 {
+		return fail("sidecar_assistant_unconfirmed_apply_ledger_verification_failed", "Cairnline sidecar assistant.proposals.get did not return the expected needs-confirmation proposal ledger state after unconfirmed apply.")
+	}
+
 	applyStep := h.callProjectCairnlineSidecarWriteTool(smokeCtx, cfg, cache, "apply_assistant_proposal", "assistant.apply", false, map[string]any{
 		"proposal_id": response.ProposalID,
 		"confirm":     true,
@@ -2930,6 +2948,17 @@ func (h *Handler) callProjectCairnlineSidecarWriteTool(ctx context.Context, cfg 
 	step.StructuredContent = result.Result.StructuredContent
 	step.Meta = result.Result.Meta
 	if result.IsError {
+		if tool == "assistant.apply" && len(result.Result.StructuredContent) > 0 {
+			applyResult, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssistantApplyResult(result.Result.StructuredContent)
+			step.StructuredReady = structuredReady
+			step.StructuredAssistantApplyResult = applyResult
+			if structuredErr != nil {
+				step.StructuredParseError = structuredErr.Error()
+				step.Status = "failed"
+				step.ToolText = "Cairnline sidecar assistant.apply returned error structuredContent that Hecate could not parse as assistant apply result: " + structuredErr.Error()
+				return step
+			}
+		}
 		step.Status = "tool_failed"
 		return step
 	}

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -1310,20 +1310,23 @@ func TestProjectCairnlineSidecarAssistantSmoke_AppliesProposal(t *testing.T) {
 	if got.CreatedProposal.ID != got.ProposalID || got.CreatedProposal.Status != "proposed" || len(got.CreatedProposal.Proposal.Actions) != 3 {
 		t.Fatalf("created proposal = %+v, want proposed record with three actions", got.CreatedProposal)
 	}
+	if got.UnconfirmedApplyResult.ProposalID != got.ProposalID || got.UnconfirmedApplyResult.Status != "needs_confirmation" || got.UnconfirmedApplyResult.Applied || got.UnconfirmedApplyResult.Confirmed {
+		t.Fatalf("unconfirmed apply result = %+v, want typed needs-confirmation safety result", got.UnconfirmedApplyResult)
+	}
 	if got.ApplyResult.ProposalID != got.ProposalID || got.ApplyResult.Status != "applied" || !got.ApplyResult.Applied || !got.ApplyResult.Confirmed || got.ApplyResult.AppliedActionCount != 3 {
 		t.Fatalf("apply result = %+v, want confirmed applied result for all actions", got.ApplyResult)
 	}
 	if got.AppliedProposal.ID != got.ProposalID || got.AppliedProposal.Status != "applied" || got.AppliedProposal.LatestResult == nil || len(got.AppliedProposal.ApplyAttempts) == 0 {
 		t.Fatalf("applied proposal = %+v, want applied ledger state", got.AppliedProposal)
 	}
-	if len(got.Steps) != 12 {
+	if len(got.Steps) != 14 {
 		t.Fatalf("steps = %+v, want project/proposal/apply/verify/delete flow", got.Steps)
 	}
-	if got.Steps[2].Tool != "assistant.propose" || got.Steps[3].Tool != "assistant.proposals.list" || got.Steps[4].Tool != "assistant.proposals.get" || got.Steps[5].Tool != "assistant.apply" || got.Steps[8].Tool != "work_items.list" || got.Steps[9].Tool != "assignments.list" || got.Steps[11].Status != "expected_missing" {
+	if got.Steps[2].Tool != "assistant.propose" || got.Steps[3].Tool != "assistant.proposals.list" || got.Steps[4].Tool != "assistant.proposals.get" || got.Steps[5].Tool != "assistant.apply" || got.Steps[5].Status != "tool_failed" || got.Steps[5].StructuredAssistantApplyResult.Status != "needs_confirmation" || got.Steps[6].Tool != "assistant.proposals.get" || got.Steps[7].Tool != "assistant.apply" || got.Steps[10].Tool != "work_items.list" || got.Steps[11].Tool != "assignments.list" || got.Steps[13].Status != "expected_missing" {
 		t.Fatalf("steps = %+v, want assistant smoke order and missing-after-delete verification", got.Steps)
 	}
-	if got.Steps[5].StructuredAssistantApplyResult.AppliedActionCount != 3 {
-		t.Fatalf("apply step = %+v, want typed apply result with three applied actions", got.Steps[5])
+	if got.Steps[7].StructuredAssistantApplyResult.AppliedActionCount != 3 {
+		t.Fatalf("apply step = %+v, want typed apply result with three applied actions", got.Steps[7])
 	}
 }
 
@@ -1345,7 +1348,7 @@ func TestProjectCairnlineSidecarAssistantSmoke_CleansUpAfterApplyFailure(t *test
 	if got.Ready || got.Status != "sidecar_assistant_tool_failed" || !got.CleanupVerified {
 		t.Fatalf("assistant smoke = %+v, want apply tool failure with verified project cleanup", got)
 	}
-	if len(got.Steps) != 8 || got.Steps[5].Tool != "assistant.apply" || !got.Steps[5].ToolIsError || got.Steps[6].Name != "cleanup_delete_project" || got.Steps[7].Status != "expected_missing" {
+	if len(got.Steps) != 10 || got.Steps[5].Tool != "assistant.apply" || got.Steps[5].StructuredAssistantApplyResult.Status != "needs_confirmation" || got.Steps[7].Tool != "assistant.apply" || !got.Steps[7].ToolIsError || got.Steps[8].Name != "cleanup_delete_project" || got.Steps[9].Status != "expected_missing" {
 		t.Fatalf("steps = %+v, want apply failure followed by project cleanup delete and verification", got.Steps)
 	}
 	if !strings.Contains(strings.Join(got.Warnings, "\n"), "deleted and verified removal") {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -2215,31 +2215,32 @@ type ProjectCairnlineSidecarMemoryResponse struct {
 }
 
 type ProjectCairnlineSidecarAssistantResponse struct {
-	Ready                 bool                                               `json:"ready"`
-	Status                string                                             `json:"status"`
-	Detail                string                                             `json:"detail"`
-	Command               string                                             `json:"command"`
-	Args                  []string                                           `json:"args,omitempty"`
-	DatabasePath          string                                             `json:"database_path,omitempty"`
-	ProbeTimeoutMS        int64                                              `json:"probe_timeout_ms"`
-	PersistentClient      bool                                               `json:"persistent_client,omitempty"`
-	ClientCacheConfigured bool                                               `json:"client_cache_configured,omitempty"`
-	ClientCacheEntries    int                                                `json:"client_cache_entries,omitempty"`
-	ClientCacheInUse      int                                                `json:"client_cache_in_use,omitempty"`
-	ClientCacheIdle       int                                                `json:"client_cache_idle,omitempty"`
-	ConfirmedMutation     bool                                               `json:"confirmed_mutation"`
-	ProjectName           string                                             `json:"project_name,omitempty"`
-	SelectedProjectID     string                                             `json:"selected_project_id,omitempty"`
-	ProposalID            string                                             `json:"proposal_id,omitempty"`
-	RoleID                string                                             `json:"role_id,omitempty"`
-	WorkItemID            string                                             `json:"work_item_id,omitempty"`
-	AssignmentID          string                                             `json:"assignment_id,omitempty"`
-	Steps                 []ProjectCairnlineSidecarWriteStep                 `json:"steps,omitempty"`
-	CreatedProposal       ProjectCairnlineSidecarAssistantProposalRecordItem `json:"created_proposal,omitempty"`
-	AppliedProposal       ProjectCairnlineSidecarAssistantProposalRecordItem `json:"applied_proposal,omitempty"`
-	ApplyResult           ProjectCairnlineSidecarAssistantApplyResultItem    `json:"apply_result,omitempty"`
-	CleanupVerified       bool                                               `json:"cleanup_verified"`
-	Warnings              []string                                           `json:"warnings,omitempty"`
+	Ready                  bool                                               `json:"ready"`
+	Status                 string                                             `json:"status"`
+	Detail                 string                                             `json:"detail"`
+	Command                string                                             `json:"command"`
+	Args                   []string                                           `json:"args,omitempty"`
+	DatabasePath           string                                             `json:"database_path,omitempty"`
+	ProbeTimeoutMS         int64                                              `json:"probe_timeout_ms"`
+	PersistentClient       bool                                               `json:"persistent_client,omitempty"`
+	ClientCacheConfigured  bool                                               `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries     int                                                `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse       int                                                `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle        int                                                `json:"client_cache_idle,omitempty"`
+	ConfirmedMutation      bool                                               `json:"confirmed_mutation"`
+	ProjectName            string                                             `json:"project_name,omitempty"`
+	SelectedProjectID      string                                             `json:"selected_project_id,omitempty"`
+	ProposalID             string                                             `json:"proposal_id,omitempty"`
+	RoleID                 string                                             `json:"role_id,omitempty"`
+	WorkItemID             string                                             `json:"work_item_id,omitempty"`
+	AssignmentID           string                                             `json:"assignment_id,omitempty"`
+	Steps                  []ProjectCairnlineSidecarWriteStep                 `json:"steps,omitempty"`
+	CreatedProposal        ProjectCairnlineSidecarAssistantProposalRecordItem `json:"created_proposal,omitempty"`
+	UnconfirmedApplyResult ProjectCairnlineSidecarAssistantApplyResultItem    `json:"unconfirmed_apply_result,omitempty"`
+	AppliedProposal        ProjectCairnlineSidecarAssistantProposalRecordItem `json:"applied_proposal,omitempty"`
+	ApplyResult            ProjectCairnlineSidecarAssistantApplyResultItem    `json:"apply_result,omitempty"`
+	CleanupVerified        bool                                               `json:"cleanup_verified"`
+	Warnings               []string                                           `json:"warnings,omitempty"`
 }
 
 type ProjectCairnlineSidecarWriteStep struct {


### PR DESCRIPTION
## Summary
- extend the Cairnline sidecar assistant smoke to call assistant.apply with confirm=false first
- require the typed needs_confirmation result and ledger state before the confirmed apply
- expose the unconfirmed apply result in the smoke response and update docs

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectCairnlineSidecarAssistantSmoke'
- ./ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md docs/operator/deployment.md docs/design/accepted/projects.md docs/design/proposals/cairnline-portable-project-coordination.md
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...