### PR TITLE
Report partial Cairnline write gates

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2409,7 +2409,10 @@ Cairnline-backed yet and therefore still block authority switch.
 `replacement_ready` stays `false` until read parity, strict embedded mirror
 probes, write-authority switchpoints, and migration/rollback gates are all
 ready. `replacement_gates` reports those high-level gates as structured
-checklist items so clients do not need to parse warning prose.
+checklist items so clients do not need to parse warning prose. The
+`write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
+it ignores the separate `migration-cutover` gap because migration and rollback
+are reported by the `migration-and-rollback` gate.
 `write_switchpoints` maps each live mutation family to the current authority,
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
 `snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -339,11 +339,11 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.WriteAdapterSeams = append([]string(nil), projectCairnlineWriteAdapterSeamNames...)
 		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsSnapshot(effectiveWriteAuthority)
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
-		response.ReplacementGates = projectCairnlineReplacementGates(readReady)
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.WriteAdapterGaps)
 		if !connectorReady {
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
-			response.ReplacementGates = projectCairnlineReplacementGates(false)
+			response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
 				"Project reads and writes still use Hecate-native stores.",
@@ -388,7 +388,8 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 	return response
 }
 
-func projectCairnlineReplacementGates(readRoutesReady bool) []ProjectCoordinationBackendReplacementGate {
+func projectCairnlineReplacementGates(readRoutesReady bool, writeGaps []string) []ProjectCoordinationBackendReplacementGate {
+	writeGate := projectCairnlineWriteAuthorityReplacementGate(writeGaps)
 	return []ProjectCoordinationBackendReplacementGate{
 		{
 			ID:     "read-routes",
@@ -402,12 +403,7 @@ func projectCairnlineReplacementGates(readRoutesReady bool) []ProjectCoordinatio
 			Status: "operator_probe_required",
 			Detail: "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
 		},
-		{
-			ID:     "write-authority-switchpoints",
-			Ready:  false,
-			Status: "blocked",
-			Detail: "Live mutation routes still commit to Hecate-native stores first; Cairnline mirrors are replacement evidence, not write authority.",
-		},
+		writeGate,
 		{
 			ID:     "migration-and-rollback",
 			Ready:  false,
@@ -415,6 +411,41 @@ func projectCairnlineReplacementGates(readRoutesReady bool) []ProjectCoordinatio
 			Detail: "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet.",
 		},
 	}
+}
+
+func projectCairnlineWriteAuthorityReplacementGate(writeGaps []string) ProjectCoordinationBackendReplacementGate {
+	remaining := projectCairnlineWriteSwitchpointGaps(writeGaps)
+	gate := ProjectCoordinationBackendReplacementGate{
+		ID:     "write-authority-switchpoints",
+		Ready:  false,
+		Status: "blocked",
+		Detail: "Live mutation routes still commit to Hecate-native stores first; Cairnline mirrors are replacement evidence, not write authority.",
+	}
+	switch {
+	case len(remaining) == 0:
+		gate.Ready = true
+		gate.Status = "ready"
+		gate.Detail = "All live mutation switchpoints that have landed are Cairnline-authoritative; migration, rollback, and final cutover still have separate gates."
+	case len(remaining) < projectCairnlineWriteSwitchpointGapCount():
+		gate.Status = "partial"
+		gate.Detail = "Some live mutation switchpoints are Cairnline-authoritative; remaining write gaps: " + strings.Join(remaining, ", ") + "."
+	}
+	return gate
+}
+
+func projectCairnlineWriteSwitchpointGaps(writeGaps []string) []string {
+	out := make([]string, 0, len(writeGaps))
+	for _, gap := range writeGaps {
+		if gap == "migration-cutover" {
+			continue
+		}
+		out = append(out, gap)
+	}
+	return out
+}
+
+func projectCairnlineWriteSwitchpointGapCount() int {
+	return len(projectCairnlineWriteAdapterGapNames) - 1
 }
 
 func projectReplacementGateStatus(ready bool) string {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -280,8 +280,8 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectMemoryAuthorityConfigu
 	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
 		t.Fatalf("project-memory switchpoint = %+v, want opt-in Cairnline authority", point)
 	}
-	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "blocked" {
-		t.Fatalf("write-authority gate = %+v, want full replacement still blocked", gate)
+	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "partial" || strings.Contains(gate.Detail, "memory,") || !strings.Contains(gate.Detail, "memory-candidates") {
+		t.Fatalf("write-authority gate = %+v, want partial write authority with remaining candidate gap", gate)
 	}
 	if !strings.Contains(strings.Join(status.Warnings, "\n"), "Accepted project memory entry mutations are opt-in Cairnline-authoritative") {
 		t.Fatalf("warnings = %+v, want project-memory authority warning", status.Warnings)
@@ -668,6 +668,16 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyWorkAuth
 	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "project-assistant-apply-side-effects") {
+		t.Fatalf("write-authority gate = %+v, want partial write authority with mixed assistant apply gap", gate)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_WriteAuthorityGateIgnoresMigrationGap(t *testing.T) {
+	gate := projectCairnlineWriteAuthorityReplacementGate([]string{"migration-cutover"})
+	if !gate.Ready || gate.Status != "ready" || !strings.Contains(gate.Detail, "migration, rollback, and final cutover still have separate gates") {
+		t.Fatalf("write-authority gate = %+v, want ready when only migration gate remains", gate)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make the backend-status write-authority gate reflect computed Cairnline write gaps
- report partial write authority when some switchpoints are enabled, and ready when only migration/cutover remains
- document the write gate status contract

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'
- ./ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md
- git diff --check
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api