### PR TITLE
feat(projects): route sidecar project identity reads

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -178,8 +178,12 @@ proposal ledger record, verifies unconfirmed apply returns `needs_confirmation`,
 applies it with explicit confirmation, verifies the created role/work/assignment
 side effects through typed `structuredContent`, then deletes and verifies
 removal of the temporary project.
-Hecate does not yet route Projects reads, writes, or mirrors through the sidecar
-client.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
+routes only project list/detail reads through the cached standalone Cairnline
+MCP client. Other Projects reads, writes, mirrors, dispatch, approvals, and
+write-authority switchpoints remain Hecate-native or on the embedded dogfood
+path until sidecar-specific adapters exist for those route families.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
@@ -201,9 +205,10 @@ list/detail,
 assignment-list, and operations brief reads render work items, assignments,
 roles, artifacts, and handoffs from the Cairnline service records, then overlay
 Hecate-only runtime refs/timestamps where Hecate still owns execution.
-Project identity and some compatibility scaffolding still come from Hecate
-until Cairnline becomes authoritative. Project Assistant draft generation also
-uses the Cairnline-projected
+In embedded read-source modes, project identity and some compatibility
+scaffolding still come from Hecate until Cairnline becomes authoritative; the
+explicit sidecar read source is the narrow exception for project list/detail
+only. Project Assistant draft generation also uses the Cairnline-projected
 context so preview and proposal assembly stay aligned, while the proposal
 ledger remains Hecate-owned unless `project-assistant-proposals` is enabled.
 Confirmed Project Assistant apply routes role, work-item, assignment, and

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -369,9 +369,14 @@ launch agents. Those remain explicit operator or orchestrator actions.
   proposal ledger record, verifies unconfirmed apply returns
   `needs_confirmation`, applies it with explicit confirmation, verifies the
   created role/work/assignment side effects, and cleans up the temporary
-  standalone Cairnline project. This is contract/client-lifecycle/read-shape and
-  standalone mutation evidence only: Hecate does not yet route live Projects
-  reads, writes, mirrors, or write-authority switchpoints through the sidecar.
+  standalone Cairnline project. This remains mostly
+  contract/client-lifecycle/read-shape and standalone mutation evidence. The
+  narrow live-route exception is
+  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` plus
+  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
+  list/detail reads through the cached standalone MCP client. Other live
+  Projects reads, writes, mirrors, and write-authority switchpoints do not route
+  through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -387,8 +392,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
-  execution. Project identity and some compatibility scaffolding remain
-  Hecate-owned until Cairnline becomes authoritative.
+  execution. Outside the explicit sidecar project list/detail read source,
+  project identity and some compatibility scaffolding remain Hecate-owned until
+  Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -434,11 +434,16 @@ read routes require a populated
 `{HECATE_DATA_DIR}/cairnline/embedded/projects.db` and fail loudly when the
 mirror database, project row, or proposal record is missing; run
 `POST /hecate/v1/projects/cairnline/sync` first when dogfooding strict embedded
-reads. Activity, work-item list/detail, assignment-list, and operations brief
-reads render the work graph from Cairnline service records and overlay
-Hecate-only runtime refs/timestamps while Hecate still owns execution. Project
-identity and some compatibility scaffolding remain Hecate-owned until Cairnline
-becomes authoritative. Project identity, metadata/default, root, and
+reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail
+reads through the standalone Cairnline MCP client; all other live Projects read
+routes remain Hecate-native or use the embedded dogfood read model when that is
+configured. Activity, work-item list/detail, assignment-list, and operations
+brief reads render the work graph from Cairnline service records and overlay
+Hecate-only runtime refs/timestamps while Hecate still owns execution. Outside
+the explicit sidecar project list/detail read source, project identity and some
+compatibility scaffolding remain Hecate-owned until Cairnline becomes
+authoritative. Project identity, metadata/default, root, and
 context-source mutations still write Hecate stores first and then best-effort
 mirror into the embedded Cairnline database through their
 identity/metadata/root/source/default seams unless their explicit

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -507,12 +507,13 @@ sequenceDiagram
   standalone Cairnline project, creates and verifies an assistant proposal
   ledger record, applies it with explicit confirmation, verifies the created
   role/work/assignment side effects, then deletes and verifies removal of the
-  temporary project. Live Projects reads and writes still use Hecate-native
-  stores.
-- `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded` controls which
+  temporary project. Live Projects writes still use Hecate-native stores in
+  sidecar mode. Live project list/detail reads use Hecate-native stores unless
+  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set.
+- `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
-  `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
-  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`. The default `auto` prefers the
+  `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
+  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`, the default `auto` prefers the
   embedded mirror database under
   `{HECATE_DATA_DIR}/cairnline/embedded/projects.db` when it already contains
   the requested project or proposal record and otherwise falls back to the
@@ -521,7 +522,10 @@ sequenceDiagram
   routes require a populated embedded mirror database and fail if the database
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
-  reads.
+  reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
+  only `GET /hecate/v1/projects` and `GET /hecate/v1/projects/{id}` through
+  the standalone Cairnline MCP client; all other live Projects read routes stay
+  on Hecate-native or embedded dogfood paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2399,7 +2403,11 @@ their Cairnline service read source is controlled by
 falls back to the snapshot-seeded bridge, `snapshot` always uses the
 snapshot-seeded bridge, and `embedded` requires the mirror database and
 requested project row or proposal record to exist so replacement-readiness gaps
-fail loudly.
+fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail
+through the standalone Cairnline MCP client; backend status reports those two
+routes in `read_routes` while `read_model_switch_ready` remains false because
+the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
@@ -2837,7 +2845,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3050,7 +3058,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3075,9 +3083,11 @@ Local-only standalone Cairnline MCP read smoke. It uses the same sidecar
 command, database, timeout, and Cairnline-specific MCP client cache as
 `sidecar-connect`, then calls the read-only `projects.list` tool with empty
 arguments. This proves Hecate can perform a real MCP tool call through the
-persistent standalone Cairnline sidecar. It is diagnostic only: Hecate still
-keeps live Projects reads, writes, mirrors, dispatch, approvals, and
-write-authority switchpoints on Hecate-native stores in sidecar mode.
+persistent standalone Cairnline sidecar. The smoke endpoint is diagnostic only.
+When `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set, live project
+list reads use the same sidecar tool path; writes, mirrors, dispatch,
+approvals, write-authority switchpoints, and other Projects read routes remain
+on Hecate-native stores or embedded dogfood paths.
 `ready=true` means the MCP tool call succeeded. `structured_ready=true` means
 Hecate also parsed `projects.list` `structuredContent` as typed project-list
 data, which is the contract a future sidecar read adapter would consume.
@@ -3106,7 +3116,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_read_ready",
-    "detail": "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "detail": "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes live project-list reads through this sidecar; writes and other Projects reads stay on Hecate-native stores or embedded dogfood paths.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3154,8 +3164,10 @@ and then calls read-only `projects.get`. With a body such as
 
 This endpoint is diagnostic only. It proves Hecate can read a typed project
 detail record through the standalone Cairnline sidecar, including roots and
-context-source metadata, but it does not switch live Projects routing,
-mirroring, dispatch, approvals, or write authority.
+context-source metadata. When `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`
+is also set, live project-detail reads use the same sidecar tool path; the
+endpoint itself does not switch mirroring, dispatch, approvals, or write
+authority.
 
 The response reports:
 
@@ -3180,7 +3192,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_detail_ready",
-    "detail": "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "detail": "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes live project-detail reads through this sidecar; writes and other Projects reads stay on Hecate-native stores or embedded dogfood paths.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3263,7 +3275,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_coordination_ready",
-    "detail": "Hecate called read-only Cairnline sidecar coordination list tools through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "detail": "Hecate called read-only Cairnline sidecar coordination list tools through the persistent sidecar client. Hecate still keeps live Projects writes and non-project-identity reads on Hecate-native stores or embedded dogfood paths in sidecar mode.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3341,7 +3353,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_assignment_context_ready",
-    "detail": "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "detail": "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. Hecate still keeps live assignment/context reads and writes on Hecate-native stores or embedded dogfood paths in sidecar mode.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3412,7 +3424,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_launch_packet_ready",
-    "detail": "Hecate called the read-only Cairnline sidecar assignments.launch_packet tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode.",
+    "detail": "Hecate called the read-only Cairnline sidecar assignments.launch_packet tool through the persistent sidecar client. Hecate still keeps live assignment launch reads and writes on Hecate-native stores or embedded dogfood paths in sidecar mode.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics, but Hecate does not yet route Projects reads or writes through the standalone Cairnline MCP client."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostic surfaces only; Cairnline read/write routing stays disabled until Hecate has a sidecar Projects backend adapter."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
+	"github.com/hecatehq/hecate/internal/orchestrator"
+)
+
+var errProjectCairnlineSidecarReadFailed = errors.New("cairnline sidecar project read failed")
+
+func (h *Handler) projectCairnlineSidecarProjectReadsEnabled() bool {
+	return h != nil &&
+		h.config.ProjectsCoordinationBackend() == "cairnline" &&
+		h.projectCairnlineConnectorMode() == "sidecar" &&
+		h.config.ProjectsCairnlineReadSource() == "sidecar"
+}
+
+func (h *Handler) renderCairnlineSidecarProjects(ctx context.Context) ([]ProjectResponseItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "projects.list", map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("projects.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	projects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("projects.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("projects.list did not return typed structuredContent")
+	}
+	data := make([]ProjectResponseItem, 0, len(projects))
+	for _, project := range projects {
+		data = append(data, renderProjectFromCairnlineSidecar(project))
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineSidecarProject(ctx context.Context, projectID string) (*ProjectResponseItem, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil, nil
+	}
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "projects.get", map[string]string{"id": projectID})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
+			return nil, nil
+		}
+		return nil, projectCairnlineSidecarReadFailure("projects.get returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	project, structuredReady, structuredErr := projectCairnlineSidecarStructuredProject(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("projects.get structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("projects.get did not return typed structuredContent")
+	}
+	rendered := renderProjectFromCairnlineSidecar(project)
+	return &rendered, nil
+}
+
+func (h *Handler) callProjectCairnlineSidecarProjectReadTool(ctx context.Context, toolName string, args any) (*orchestrator.CachedMCPToolCallResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if h == nil {
+		return nil, projectCairnlineSidecarReadFailure("handler is not configured")
+	}
+	cfg, _, timeout := h.projectCairnlineSidecarMCPConfig()
+	rawArgs, err := json.Marshal(args)
+	if err != nil {
+		return nil, err
+	}
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	readCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := orchestrator.CallCachedMCPServerTool(readCtx, cfg, h.secretCipher, cache, toolName, rawArgs)
+	if err != nil {
+		if projectCairnlineSidecarReadErrShouldEvict(err) {
+			cache.Evict(mcpclient.ServerConfig{
+				Name:    cfg.Name,
+				Command: cfg.Command,
+				Args:    cfg.Args,
+				Env:     cfg.Env,
+				URL:     cfg.URL,
+				Headers: cfg.Headers,
+			})
+			result, err = orchestrator.CallCachedMCPServerTool(readCtx, cfg, h.secretCipher, cache, toolName, rawArgs)
+		}
+	}
+	if err != nil {
+		return nil, projectCairnlineSidecarReadFailure(err.Error())
+	}
+	return result, nil
+}
+
+func renderProjectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectItem) ProjectResponseItem {
+	roots := make([]ProjectRootResponseItem, 0, len(project.Roots))
+	for _, root := range project.Roots {
+		roots = append(roots, ProjectRootResponseItem{
+			ID:        root.ID,
+			Path:      root.Path,
+			Kind:      root.Kind,
+			GitRemote: root.GitRemote,
+			GitBranch: root.GitBranch,
+			Active:    root.Active,
+		})
+	}
+	contextSources := make([]ProjectContextSourceResponseItem, 0, len(project.ContextSources))
+	for _, source := range project.ContextSources {
+		contextSources = append(contextSources, ProjectContextSourceResponseItem{
+			ID:             source.ID,
+			Kind:           source.Kind,
+			Title:          source.Title,
+			Path:           source.Locator,
+			Enabled:        source.Enabled,
+			Format:         source.Format,
+			Scope:          source.Scope,
+			TrustLabel:     source.TrustLabel,
+			SourceCategory: source.SourceCategory,
+			Metadata:       cloneProjectContextMetadata(source.Metadata),
+		})
+	}
+	return ProjectResponseItem{
+		ID:                  project.ID,
+		ReadBackend:         "cairnline",
+		Name:                project.Name,
+		Description:         project.Description,
+		Roots:               roots,
+		ContextSources:      contextSources,
+		DefaultRootID:       project.DefaultRootID,
+		DefaultAgentProfile: project.DefaultProfileID,
+		CreatedAt:           project.CreatedAt,
+		UpdatedAt:           project.UpdatedAt,
+	}
+}
+
+func projectCairnlineSidecarToolErrorIsNotFound(text string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(text)), "not found")
+}
+
+func projectCairnlineSidecarReadErrShouldEvict(err error) bool {
+	return errors.Is(err, mcpclient.ErrClientClosed) || mcpclient.IsTransportClosedErr(err)
+}
+
+func projectCairnlineSidecarReadFailure(message string) error {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "unknown failure"
+	}
+	return fmt.Errorf("%w: %s", errProjectCairnlineSidecarReadFailed, message)
+}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -48,6 +48,11 @@ var projectCairnlineReadRouteNames = []string{
 	"operations-brief",
 }
 
+var projectCairnlineSidecarProjectReadRouteNames = []string{
+	"project-list",
+	"project-detail",
+}
+
 var projectCairnlineWriteAdapterSeamNames = []string{
 	"projects",
 	"roots",
@@ -341,6 +346,18 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
 		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.WriteAdapterGaps)
 		if !connectorReady {
+			if h.projectCairnlineSidecarProjectReadsEnabled() {
+				response.Status = "cairnline_sidecar_project_reads_ready"
+				response.Detail = "Cairnline sidecar is configured as the project identity read source, so project-list and project-detail routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarProjectReadRouteNames...)
+				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
+				response.Warnings = []string{
+					"Only project-list and project-detail use the Cairnline sidecar MCP client in this mode.",
+					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for setup, health, skills, memory, work, assignments, activity, assistant, and operations routes are not wired.",
+				}
+				return response
+			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
 			response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
@@ -773,6 +790,8 @@ func projectCairnlineReadSourceDetail(source string) string {
 	switch source {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
+	case "sidecar":
+		return "Configured project identity read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list and project-detail use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -784,6 +803,8 @@ func projectCairnlineReadSourceWarning(source string) string {
 	switch source {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
+	case "sidecar":
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list and project-detail through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -191,8 +192,46 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 		t.Fatalf("project-identity switchpoint = %+v, want Hecate authority while sidecar routing is not live", point)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration/memory/assistant diagnostic surfaces") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
+	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration/memory/assistant diagnostics") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
 		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_CairnlineSidecarProjectReadsReady(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CoordinationBackend: "cairnline",
+			CairnlineConnector:  "sidecar",
+			CairnlineReadSource: "sidecar",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if status.Status != "cairnline_sidecar_project_reads_ready" {
+		t.Fatalf("status = %+v, want sidecar project-read readiness", status)
+	}
+	if status.CairnlineConnector != "sidecar" || status.CairnlineConnectorReady || status.CairnlineReadSource != "sidecar" {
+		t.Fatalf("connector/read source = %q ready=%t source=%q, want sidecar connector with sidecar read source but no full connector readiness", status.CairnlineConnector, status.CairnlineConnectorReady, status.CairnlineReadSource)
+	}
+	if status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
+		t.Fatalf("status = %+v, want sidecar project reads without full replacement readiness", status)
+	}
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar project reads enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarProjectReadsEnabled() {
+		t.Fatal("projectCairnlineSidecarProjectReadsEnabled() = false, want true")
+	}
+	if !reflect.DeepEqual(status.ReadRoutes, projectCairnlineSidecarProjectReadRouteNames) {
+		t.Fatalf("read routes = %+v, want sidecar project identity routes", status.ReadRoutes)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "read-routes"); gate == nil || gate.Ready || gate.Status != "blocked" {
+		t.Fatalf("read-routes gate = %+v, want blocked because only project identity reads are sidecar-backed", gate)
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "Only project-list and project-detail") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }
 

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -72,7 +72,7 @@ type updateProjectRequest struct {
 func (h *Handler) HandleProjects(w http.ResponseWriter, r *http.Request) {
 	data, err := h.renderProjects(r.Context())
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectsResponse{Object: "projects", Data: data})
@@ -143,7 +143,7 @@ func (h *Handler) HandleCreateProject(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleProject(w http.ResponseWriter, r *http.Request) {
 	project, err := h.renderProject(r.Context(), r.PathValue("id"))
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	if project == nil {
@@ -704,6 +704,9 @@ func parseProjectTime(value string) (time.Time, error) {
 }
 
 func (h *Handler) renderProjects(ctx context.Context) ([]ProjectResponseItem, error) {
+	if h.projectCairnlineSidecarProjectReadsEnabled() {
+		return h.renderCairnlineSidecarProjects(ctx)
+	}
 	items, err := h.projects.List(ctx)
 	if err != nil {
 		return nil, err
@@ -731,6 +734,9 @@ func (h *Handler) renderCairnlineProjects(ctx context.Context, nativeProjects []
 }
 
 func (h *Handler) renderProject(ctx context.Context, projectID string) (*ProjectResponseItem, error) {
+	if h.projectCairnlineSidecarProjectReadsEnabled() {
+		return h.renderCairnlineSidecarProject(ctx, projectID)
+	}
 	project, ok, err := h.projects.Get(ctx, projectID)
 	if err != nil || !ok {
 		return nil, err
@@ -744,6 +750,14 @@ func (h *Handler) renderProject(ctx context.Context, projectID string) (*Project
 	}
 	rendered := renderProject(project)
 	return &rendered, nil
+}
+
+func writeProjectReadRenderError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errProjectCairnlineSidecarReadFailed) {
+		WriteError(w, http.StatusBadGateway, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 }
 
 func (h *Handler) renderCairnlineProject(ctx context.Context, native projects.Project) (ProjectResponseItem, error) {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -33,6 +34,24 @@ func newProjectsCairnlineReadTestServer() http.Handler {
 	}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
 	return NewServer(quietLogger(), handler)
+}
+
+func newProjectsCairnlineSidecarReadTestServer(t *testing.T, mode string) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:          "cairnline",
+			CairnlineConnector:           "sidecar",
+			CairnlineReadSource:          "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + mode},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+	return handler, NewServer(quietLogger(), handler)
 }
 
 func newProjectsCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handler) {
@@ -260,6 +279,56 @@ func TestProjectsAPI_ReadsUseCairnlineReadModelWhenConfigured(t *testing.T) {
 		t.Fatalf("listed projects = %+v, want one project", listed.Data)
 	}
 	assertCairnlineProjectProjectionForTest(t, listed.Data[0], created.Data.ID)
+}
+
+func TestProjectsAPI_ReadsUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar project reads enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarProjectReadsEnabled() {
+		t.Fatal("sidecar project read predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listed ProjectsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed.Data) != 1 {
+		t.Fatalf("listed projects = %+v, want sidecar fixture project", listed.Data)
+	}
+	assertCairnlineSidecarProjectForTest(t, listed.Data[0], "proj_fixture")
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("detail status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var fetched ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &fetched); err != nil {
+		t.Fatalf("decode detail response: %v", err)
+	}
+	assertCairnlineSidecarProjectForTest(t, fetched.Data, "proj_fixture")
+}
+
+func TestProjectsAPI_CairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("list status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
 }
 
 func TestProjectsAPI_CairnlineReadsMatchHecateProjectProjection(t *testing.T) {
@@ -1349,6 +1418,19 @@ func assertCairnlineProjectProjectionForTest(t *testing.T, project ProjectRespon
 	}
 	if source.Metadata["root_id"] != "root_main" {
 		t.Fatalf("context source metadata = %+v, want root_id", source.Metadata)
+	}
+}
+
+func assertCairnlineSidecarProjectForTest(t *testing.T, project ProjectResponseItem, projectID string) {
+	t.Helper()
+	if project.ID != projectID || project.ReadBackend != "cairnline" || project.Name != "Fixture Project" || project.Description != "Structured fixture project" {
+		t.Fatalf("project = %+v, want Cairnline sidecar fixture project %s", project, projectID)
+	}
+	if len(project.Roots) != 1 || project.Roots[0].ID != "root_fixture" || project.Roots[0].Path != "/workspace/fixture" || project.Roots[0].Kind != "local" || !project.Roots[0].Active {
+		t.Fatalf("roots = %+v, want fixture root metadata", project.Roots)
+	}
+	if len(project.ContextSources) != 1 || project.ContextSources[0].ID != "src_fixture" || project.ContextSources[0].Path != "AGENTS.md" || !project.ContextSources[0].Enabled {
+		t.Fatalf("context sources = %+v, want fixture source metadata", project.ContextSources)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -642,7 +642,10 @@ func (c Config) Validate() error {
 	}
 	validateBackend("HECATE_PROJECTS_COORDINATION_BACKEND", c.ProjectsCoordinationBackend(), "hecate", "cairnline")
 	validateBackend("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", c.ProjectsCairnlineConnector(), "embedded", "sidecar")
-	validateBackend("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", c.ProjectsCairnlineReadSource(), "auto", "snapshot", "embedded")
+	validateBackend("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", c.ProjectsCairnlineReadSource(), "auto", "snapshot", "embedded", "sidecar")
+	if c.ProjectsCairnlineReadSource() == "sidecar" && c.ProjectsCairnlineConnector() != "sidecar" {
+		errs = append(errs, errors.New("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar requires HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar"))
+	}
 	for _, item := range c.ProjectsCairnlineWriteAuthority() {
 		validateBackend("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", item, "project-memory", "memory-candidates", "project-collaboration", "project-skills", "project-work-items", "project-roles", "project-assignments", "agent-profiles", "project-metadata-defaults", "project-roots", "project-context-sources", "project-identity", "project-assistant-proposals")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -569,6 +569,16 @@ func TestLoadFromEnvProjectsCairnlineReadSource(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil for embedded Cairnline read source", err)
 	}
+
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "sidecar")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", " Sidecar ")
+	cfg = LoadFromEnv()
+	if got := cfg.ProjectsCairnlineReadSource(); got != "sidecar" {
+		t.Fatalf("ProjectsCairnlineReadSource() = %q, want sidecar", got)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil for sidecar Cairnline read source with sidecar connector", err)
+	}
 }
 
 func TestLoadFromEnvProjectsCairnlineConnector(t *testing.T) {
@@ -702,6 +712,19 @@ func TestValidateRejectsInvalidProjectsCairnlineReadSource(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE") {
 		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", err)
+	}
+}
+
+func TestValidateRejectsSidecarReadSourceWithoutSidecarConnector(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Projects.CairnlineReadSource = "sidecar"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want sidecar read source connector error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") {
+		t.Fatalf("Validate() error = %q, want sidecar connector requirement", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an opt-in Cairnline sidecar read source for GET /hecate/v1/projects and GET /hecate/v1/projects/{id}
- require typed structuredContent from the sidecar and return 502 for sidecar read-shape failures
- report partial sidecar project-read readiness without marking full Cairnline replacement ready
- update runtime, operator, and design docs for the narrow live-read boundary

## Tests
- just agent-docs-check
- GOCACHE="$PWD/.gocache" go test ./internal/config ./internal/api -run 'Test(LoadFromEnvProjectsCairnlineReadSource|ValidateRejectsSidecarReadSourceWithoutSidecarConnector|ValidateRejectsInvalidProjectsCairnlineReadSource|ProjectsAPI_(ReadsUseCairnlineSidecarWhenConfigured|CairnlineSidecarReadRequiresStructuredContent)|ProjectCoordinationBackendStatus_CairnlineSidecar(ProjectReadsReady|ConnectorBlocksEmbeddedRoutes))'
- GOCACHE="$PWD/.gocache" go vet ./internal/config ./internal/api
- git diff --check
- GOCACHE="$PWD/.gocache" go test ./internal/config ./internal/api
- GOCACHE="$PWD/.gocache" go test ./...
- GOCACHE="$PWD/.gocache" go vet ./...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...

## Notes
- sidecar read source requires HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar
- only project-list and project-detail routes use the standalone MCP client in this mode; writes and all other Projects routes remain Hecate-native or embedded dogfood paths