### PR TITLE
feat(projects): route sidecar setup readiness

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -180,10 +180,11 @@ side effects through typed `structuredContent`, then deletes and verifies
 removal of the temporary project.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
-routes only project list/detail reads through the cached standalone Cairnline
-MCP client. Other Projects reads, writes, mirrors, dispatch, approvals, and
-write-authority switchpoints remain Hecate-native or on the embedded dogfood
-path until sidecar-specific adapters exist for those route families.
+routes only project list/detail and setup-readiness reads through the cached
+standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
+dispatch, approvals, and write-authority switchpoints remain Hecate-native or
+on the embedded dogfood path until sidecar-specific adapters exist for those
+route families.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
@@ -207,10 +208,11 @@ roles, artifacts, and handoffs from the Cairnline service records, then overlay
 Hecate-only runtime refs/timestamps where Hecate still owns execution.
 In embedded read-source modes, project identity and some compatibility
 scaffolding still come from Hecate until Cairnline becomes authoritative; the
-explicit sidecar read source is the narrow exception for project list/detail
-only. Project Assistant draft generation also uses the Cairnline-projected
-context so preview and proposal assembly stay aligned, while the proposal
-ledger remains Hecate-owned unless `project-assistant-proposals` is enabled.
+explicit sidecar read source is the narrow exception for project list/detail and
+setup-readiness. Project Assistant draft generation also uses the
+Cairnline-projected context so preview and proposal assembly stay aligned,
+while the proposal ledger remains Hecate-owned unless
+`project-assistant-proposals` is enabled.
 Confirmed Project Assistant apply routes role, work-item, assignment, and
 handoff actions through the same opt-in Cairnline authority switchpoints when
 those switchpoints are enabled; project/default/chat/memory/runtime side

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -392,9 +392,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
-  execution. Outside the explicit sidecar project list/detail read source,
-  project identity and some compatibility scaffolding remain Hecate-owned until
-  Cairnline becomes authoritative.
+  execution. Outside the explicit sidecar project list/detail and
+  setup-readiness read source, project identity and some compatibility
+  scaffolding remain Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -436,14 +436,15 @@ mirror database, project row, or proposal record is missing; run
 `POST /hecate/v1/projects/cairnline/sync` first when dogfooding strict embedded
 reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail
-reads through the standalone Cairnline MCP client; all other live Projects read
-routes remain Hecate-native or use the embedded dogfood read model when that is
-configured. Activity, work-item list/detail, assignment-list, and operations
-brief reads render the work graph from Cairnline service records and overlay
-Hecate-only runtime refs/timestamps while Hecate still owns execution. Outside
-the explicit sidecar project list/detail read source, project identity and some
-compatibility scaffolding remain Hecate-owned until Cairnline becomes
-authoritative. Project identity, metadata/default, root, and
+and setup-readiness reads through the standalone Cairnline MCP client; all other
+live Projects read routes remain Hecate-native or use the embedded dogfood read
+model when that is configured. Activity, work-item list/detail,
+assignment-list, and operations brief reads render the work graph from
+Cairnline service records and overlay Hecate-only runtime refs/timestamps while
+Hecate still owns execution. Outside the explicit sidecar project list/detail
+and setup-readiness read source, project identity and some compatibility
+scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
+identity, metadata/default, root, and
 context-source mutations still write Hecate stores first and then best-effort
 mirror into the embedded Cairnline database through their
 identity/metadata/root/source/default seams unless their explicit

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -509,7 +509,8 @@ sequenceDiagram
   role/work/assignment side effects, then deletes and verifies removal of the
   temporary project. Live Projects writes still use Hecate-native stores in
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
-  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set.
+  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness
+  uses the same sidecar source when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -2405,9 +2406,9 @@ snapshot-seeded bridge, and `embedded` requires the mirror database and
 requested project row or proposal record to exist so replacement-readiness gaps
 fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail
-through the standalone Cairnline MCP client; backend status reports those two
-routes in `read_routes` while `read_model_switch_ready` remains false because
-the broader read model is not sidecar-backed yet.
+and setup-readiness through the standalone Cairnline MCP client; backend status
+reports those routes in `read_routes` while `read_model_switch_ready` remains
+false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
@@ -2845,7 +2846,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail and setup-readiness read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3058,7 +3059,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail and setup-readiness read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -5134,6 +5135,12 @@ When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
 reports `read_model_switch_ready=true`, the portable setup counts are read from
 the Cairnline read model and then projected into Hecate's setup checklist/action
 contract. Hecate still owns Hecate-specific provider/model default checks.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, this route
+instead composes typed read-only Cairnline MCP sidecar calls for project detail,
+roles, work items, skills, accepted memory, and pending memory candidates. The
+sidecar path requires typed `structuredContent`; malformed or text-only sidecar
+responses fail loudly with `502 gateway_error`.
 `read_backend` identifies the setup-state read-model source.
 
 ```json

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail and setup-readiness through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail and setup-readiness through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -1,19 +1,46 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
+	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 var errProjectCairnlineSidecarReadFailed = errors.New("cairnline sidecar project read failed")
 
-func (h *Handler) projectCairnlineSidecarProjectReadsEnabled() bool {
+type ProjectCairnlineSidecarSkillItem struct {
+	ID                     string                                       `json:"id"`
+	ProjectID              string                                       `json:"project_id,omitempty"`
+	Title                  string                                       `json:"title,omitempty"`
+	Description            string                                       `json:"description,omitempty"`
+	Path                   string                                       `json:"path,omitempty"`
+	RootID                 string                                       `json:"root_id,omitempty"`
+	Format                 string                                       `json:"format,omitempty"`
+	SuggestedTools         []string                                     `json:"suggested_tools,omitempty"`
+	RequiredPermissions    *ProjectSkillRequiredPermissionsResponseItem `json:"required_permissions,omitempty"`
+	Enabled                bool                                         `json:"enabled"`
+	Status                 string                                       `json:"status,omitempty"`
+	TrustLabel             string                                       `json:"trust_label,omitempty"`
+	SourceContextSourceIDs []string                                     `json:"source_context_source_ids,omitempty"`
+	SourceRefs             []string                                     `json:"source_refs,omitempty"`
+	Warnings               []string                                     `json:"warnings,omitempty"`
+	DiscoveredAt           string                                       `json:"discovered_at,omitempty"`
+	CreatedAt              string                                       `json:"created_at,omitempty"`
+	UpdatedAt              string                                       `json:"updated_at,omitempty"`
+}
+
+func (h *Handler) projectCairnlineSidecarReadRoutesEnabled() bool {
 	return h != nil &&
 		h.config.ProjectsCoordinationBackend() == "cairnline" &&
 		h.projectCairnlineConnectorMode() == "sidecar" &&
@@ -43,29 +70,40 @@ func (h *Handler) renderCairnlineSidecarProjects(ctx context.Context) ([]Project
 }
 
 func (h *Handler) renderCairnlineSidecarProject(ctx context.Context, projectID string) (*ProjectResponseItem, error) {
-	projectID = strings.TrimSpace(projectID)
-	if projectID == "" {
-		return nil, nil
-	}
-	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "projects.get", map[string]string{"id": projectID})
+	project, ok, err := h.cairnlineSidecarProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
-	if result.IsError {
-		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
-			return nil, nil
-		}
-		return nil, projectCairnlineSidecarReadFailure("projects.get returned a tool-level error: " + strings.TrimSpace(result.Text))
-	}
-	project, structuredReady, structuredErr := projectCairnlineSidecarStructuredProject(result.Result.StructuredContent)
-	if structuredErr != nil {
-		return nil, projectCairnlineSidecarReadFailure("projects.get structuredContent parse failed: " + structuredErr.Error())
-	}
-	if !structuredReady {
-		return nil, projectCairnlineSidecarReadFailure("projects.get did not return typed structuredContent")
+	if !ok {
+		return nil, nil
 	}
 	rendered := renderProjectFromCairnlineSidecar(project)
 	return &rendered, nil
+}
+
+func (h *Handler) cairnlineSidecarProject(ctx context.Context, projectID string) (ProjectCairnlineSidecarProjectItem, bool, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return ProjectCairnlineSidecarProjectItem{}, false, nil
+	}
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "projects.get", map[string]string{"id": projectID})
+	if err != nil {
+		return ProjectCairnlineSidecarProjectItem{}, false, err
+	}
+	if result.IsError {
+		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
+			return ProjectCairnlineSidecarProjectItem{}, false, nil
+		}
+		return ProjectCairnlineSidecarProjectItem{}, false, projectCairnlineSidecarReadFailure("projects.get returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	project, structuredReady, structuredErr := projectCairnlineSidecarStructuredProject(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return ProjectCairnlineSidecarProjectItem{}, false, projectCairnlineSidecarReadFailure("projects.get structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return ProjectCairnlineSidecarProjectItem{}, false, projectCairnlineSidecarReadFailure("projects.get did not return typed structuredContent")
+	}
+	return project, true, nil
 }
 
 func (h *Handler) callProjectCairnlineSidecarProjectReadTool(ctx context.Context, toolName string, args any) (*orchestrator.CachedMCPToolCallResult, error) {
@@ -104,9 +142,28 @@ func (h *Handler) callProjectCairnlineSidecarProjectReadTool(ctx context.Context
 }
 
 func renderProjectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectItem) ProjectResponseItem {
-	roots := make([]ProjectRootResponseItem, 0, len(project.Roots))
-	for _, root := range project.Roots {
-		roots = append(roots, ProjectRootResponseItem{
+	converted := projectFromCairnlineSidecar(project)
+	return renderProjectWithBackend(converted, "cairnline")
+}
+
+func projectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectItem) projects.Project {
+	return projects.Project{
+		ID:                  project.ID,
+		Name:                project.Name,
+		Description:         project.Description,
+		Roots:               projectRootsFromCairnlineSidecar(project.Roots),
+		ContextSources:      projectContextSourcesFromCairnlineSidecar(project.ContextSources),
+		DefaultRootID:       project.DefaultRootID,
+		DefaultAgentProfile: project.DefaultProfileID,
+		CreatedAt:           projectCairnlineSidecarTime(project.CreatedAt),
+		UpdatedAt:           projectCairnlineSidecarTime(project.UpdatedAt),
+	}
+}
+
+func projectRootsFromCairnlineSidecar(items []ProjectCairnlineSidecarRootItem) []projects.Root {
+	out := make([]projects.Root, 0, len(items))
+	for _, root := range items {
+		out = append(out, projects.Root{
 			ID:        root.ID,
 			Path:      root.Path,
 			Kind:      root.Kind,
@@ -115,9 +172,13 @@ func renderProjectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectIte
 			Active:    root.Active,
 		})
 	}
-	contextSources := make([]ProjectContextSourceResponseItem, 0, len(project.ContextSources))
-	for _, source := range project.ContextSources {
-		contextSources = append(contextSources, ProjectContextSourceResponseItem{
+	return out
+}
+
+func projectContextSourcesFromCairnlineSidecar(items []ProjectCairnlineSidecarSourceItem) []projects.ContextSource {
+	out := make([]projects.ContextSource, 0, len(items))
+	for _, source := range items {
+		out = append(out, projects.ContextSource{
 			ID:             source.ID,
 			Kind:           source.Kind,
 			Title:          source.Title,
@@ -130,18 +191,172 @@ func renderProjectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectIte
 			Metadata:       cloneProjectContextMetadata(source.Metadata),
 		})
 	}
-	return ProjectResponseItem{
-		ID:                  project.ID,
-		ReadBackend:         "cairnline",
-		Name:                project.Name,
-		Description:         project.Description,
-		Roots:               roots,
-		ContextSources:      contextSources,
-		DefaultRootID:       project.DefaultRootID,
-		DefaultAgentProfile: project.DefaultProfileID,
-		CreatedAt:           project.CreatedAt,
-		UpdatedAt:           project.UpdatedAt,
+	return out
+}
+
+func projectRolesFromCairnlineSidecar(items []ProjectCairnlineSidecarRoleItem) []projectwork.AgentRoleProfile {
+	out := make([]projectwork.AgentRoleProfile, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectwork.AgentRoleProfile{
+			ID:                  item.ID,
+			ProjectID:           item.ProjectID,
+			Name:                item.Name,
+			Description:         item.Description,
+			Instructions:        item.Instructions,
+			DefaultDriverKind:   item.DefaultExecutionMode,
+			DefaultAgentProfile: item.DefaultProfileID,
+			SkillIDs:            append([]string(nil), item.DefaultSkillIDs...),
+		})
 	}
+	return out
+}
+
+func projectWorkItemsFromCairnlineSidecar(items []ProjectCairnlineSidecarWorkItem) []projectwork.WorkItem {
+	out := make([]projectwork.WorkItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectwork.WorkItem{
+			ID:              item.ID,
+			ProjectID:       item.ProjectID,
+			Title:           item.Title,
+			Brief:           item.Brief,
+			Status:          item.Status,
+			Priority:        item.Priority,
+			OwnerRoleID:     item.OwnerRoleID,
+			RootID:          item.RootID,
+			ReviewerRoleIDs: append([]string(nil), item.ReviewerRoleIDs...),
+		})
+	}
+	return out
+}
+
+func projectSkillsFromCairnlineSidecar(items []ProjectCairnlineSidecarSkillItem) []projectskills.Skill {
+	out := make([]projectskills.Skill, 0, len(items))
+	for _, item := range items {
+		sourceIDs := append([]string(nil), item.SourceContextSourceIDs...)
+		if len(sourceIDs) == 0 {
+			sourceIDs = append(sourceIDs, item.SourceRefs...)
+		}
+		out = append(out, projectskills.Skill{
+			ID:                     item.ID,
+			ProjectID:              item.ProjectID,
+			Title:                  item.Title,
+			Description:            item.Description,
+			Path:                   item.Path,
+			RootID:                 item.RootID,
+			Format:                 item.Format,
+			SuggestedTools:         append([]string(nil), item.SuggestedTools...),
+			RequiredPermissions:    projectSkillRequiredPermissionsFromResponse(item.RequiredPermissions),
+			Enabled:                item.Enabled,
+			Status:                 item.Status,
+			TrustLabel:             item.TrustLabel,
+			SourceContextSourceIDs: sourceIDs,
+			Warnings:               append([]string(nil), item.Warnings...),
+			DiscoveredAt:           projectCairnlineSidecarTime(item.DiscoveredAt),
+			CreatedAt:              projectCairnlineSidecarTime(item.CreatedAt),
+			UpdatedAt:              projectCairnlineSidecarTime(item.UpdatedAt),
+		})
+	}
+	return out
+}
+
+func projectMemoryEntriesFromCairnlineSidecar(items []ProjectCairnlineSidecarMemoryEntryItem) []memory.Entry {
+	out := make([]memory.Entry, 0, len(items))
+	for _, item := range items {
+		out = append(out, memory.Entry{
+			ID:         item.ID,
+			Scope:      memory.ScopeProject,
+			ProjectID:  item.ProjectID,
+			Title:      item.Title,
+			Body:       item.Body,
+			TrustLabel: item.TrustLabel,
+			SourceKind: item.SourceKind,
+			SourceID:   item.SourceID,
+			Enabled:    item.Enabled,
+			CreatedAt:  projectCairnlineSidecarTime(item.CreatedAt),
+			UpdatedAt:  projectCairnlineSidecarTime(item.UpdatedAt),
+		})
+	}
+	return out
+}
+
+func projectMemoryCandidatesFromCairnlineSidecar(items []ProjectCairnlineSidecarMemoryCandidateItem) []memory.Candidate {
+	out := make([]memory.Candidate, 0, len(items))
+	for _, item := range items {
+		out = append(out, memory.Candidate{
+			ID:                  item.ID,
+			ProjectID:           item.ProjectID,
+			Title:               item.Title,
+			Body:                item.Body,
+			SuggestedKind:       item.SuggestedKind,
+			SuggestedTrustLabel: item.SuggestedTrustLabel,
+			SuggestedSourceKind: item.SuggestedSourceKind,
+			SuggestedSourceID:   item.SuggestedSourceID,
+			SourceRefs:          projectMemoryCandidateSourceRefsFromCairnlineSidecar(item.SourceRefs),
+			Status:              item.Status,
+			StatusReason:        item.StatusReason,
+			PromotedMemoryID:    item.PromotedMemoryID,
+			CreatedAt:           projectCairnlineSidecarTime(item.CreatedAt),
+			UpdatedAt:           projectCairnlineSidecarTime(item.UpdatedAt),
+		})
+	}
+	return out
+}
+
+func projectMemoryCandidateSourceRefsFromCairnlineSidecar(items []ProjectCairnlineSidecarMemoryCandidateSourceRef) []memory.CandidateSourceRef {
+	out := make([]memory.CandidateSourceRef, 0, len(items))
+	for _, item := range items {
+		out = append(out, memory.CandidateSourceRef{
+			Kind:  item.Kind,
+			ID:    item.ID,
+			Title: item.Title,
+			URL:   item.URL,
+		})
+	}
+	return out
+}
+
+func projectSkillRequiredPermissionsFromResponse(item *ProjectSkillRequiredPermissionsResponseItem) projectskills.RequiredPermissions {
+	if item == nil {
+		return projectskills.RequiredPermissions{}
+	}
+	return projectskills.RequiredPermissions{
+		Tools:   item.Tools,
+		Writes:  item.Writes,
+		Network: item.Network,
+	}
+}
+
+func projectCairnlineSidecarTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
+func projectCairnlineSidecarStructuredSkills(raw json.RawMessage) ([]ProjectCairnlineSidecarSkillItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarSkillItem{}, true, nil
+	}
+	var skills []ProjectCairnlineSidecarSkillItem
+	if err := json.Unmarshal(trimmed, &skills); err != nil {
+		return nil, false, err
+	}
+	if skills == nil {
+		skills = []ProjectCairnlineSidecarSkillItem{}
+	}
+	return skills, true, nil
 }
 
 func projectCairnlineSidecarToolErrorIsNotFound(text string) bool {

--- a/internal/api/handler_project_cairnline_sidecar_setup_readiness.go
+++ b/internal/api/handler_project_cairnline_sidecar_setup_readiness.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+func (h *Handler) renderCairnlineSidecarProjectSetupReadiness(ctx context.Context, projectID string) (ProjectSetupReadinessResponse, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	if !ok {
+		return ProjectSetupReadinessResponse{}, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	roles, err := h.cairnlineSidecarProjectRoles(ctx, project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	workItems, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	skills, err := h.cairnlineSidecarProjectSkills(ctx, project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	entries, err := h.cairnlineSidecarProjectMemoryEntries(ctx, project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	candidates, err := h.cairnlineSidecarProjectPendingMemoryCandidates(ctx, project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+
+	summary := projectSetupReadinessSummary(
+		project,
+		projectWorkItemsFromCairnlineSidecar(workItems),
+		projectRolesFromCairnlineSidecar(roles),
+		projectSkillsFromCairnlineSidecar(skills),
+		projectMemoryEntriesFromCairnlineSidecar(entries),
+		projectMemoryCandidatesFromCairnlineSidecar(candidates),
+	)
+	setupStarted := summary.EnabledContextSourceCount > 0 ||
+		summary.RoleCount > 0 ||
+		summary.SkillCount > 0 ||
+		summary.SavedMemoryCount > 0 ||
+		summary.PendingMemoryCandidateCount > 0
+	firstWorkReady := summary.WorkItemCount == 0 && setupStarted
+	return ProjectSetupReadinessResponse{
+		ProjectID:      project.ID,
+		GeneratedAt:    formatOptionalTime(time.Now().UTC()),
+		ReadBackend:    "cairnline",
+		ShowOnboarding: summary.WorkItemCount == 0 && !setupStarted,
+		SetupStarted:   setupStarted,
+		FirstWorkReady: firstWorkReady,
+		Summary:        summary,
+		PrimaryAction:  projectSetupReadinessAction(projectSetupReadinessActionBootstrap, project.ID, "Set up project"),
+		Checks:         projectSetupReadinessChecks(project, summary),
+	}, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectRoles(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarRoleItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "roles.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("roles.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	roles, structuredReady, structuredErr := projectCairnlineSidecarStructuredRoles(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("roles.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("roles.list did not return typed structuredContent")
+	}
+	return roles, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectWorkItems(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarWorkItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "work_items.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("work_items.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	items, structuredReady, structuredErr := projectCairnlineSidecarStructuredWorkItems(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("work_items.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("work_items.list did not return typed structuredContent")
+	}
+	return items, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectSkills(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarSkillItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "skills.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("skills.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	skills, structuredReady, structuredErr := projectCairnlineSidecarStructuredSkills(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("skills.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("skills.list did not return typed structuredContent")
+	}
+	return skills, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectMemoryEntries(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarMemoryEntryItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "memory_entries.list", map[string]any{
+		"project_id":       strings.TrimSpace(projectID),
+		"include_disabled": true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("memory_entries.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	entries, structuredReady, structuredErr := projectCairnlineSidecarStructuredMemoryEntries(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("memory_entries.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("memory_entries.list did not return typed structuredContent")
+	}
+	return entries, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectPendingMemoryCandidates(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarMemoryCandidateItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "memory_candidates.list", map[string]string{
+		"project_id": strings.TrimSpace(projectID),
+		"status":     "pending",
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	candidates, structuredReady, structuredErr := projectCairnlineSidecarStructuredMemoryCandidates(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list did not return typed structuredContent")
+	}
+	return candidates, nil
+}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -48,9 +48,10 @@ var projectCairnlineReadRouteNames = []string{
 	"operations-brief",
 }
 
-var projectCairnlineSidecarProjectReadRouteNames = []string{
+var projectCairnlineSidecarReadRouteNames = []string{
 	"project-list",
 	"project-detail",
+	"setup-readiness",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -346,15 +347,15 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
 		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.WriteAdapterGaps)
 		if !connectorReady {
-			if h.projectCairnlineSidecarProjectReadsEnabled() {
-				response.Status = "cairnline_sidecar_project_reads_ready"
-				response.Detail = "Cairnline sidecar is configured as the project identity read source, so project-list and project-detail routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
-				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarProjectReadRouteNames...)
+			if h.projectCairnlineSidecarReadRoutesEnabled() {
+				response.Status = "cairnline_sidecar_read_routes_ready"
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, and setup-readiness routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list and project-detail use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, and setup-readiness use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for setup, health, skills, memory, work, assignments, activity, assistant, and operations routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for health, skills, memory, work, assignments, activity, assistant, and operations routes are not wired.",
 				}
 				return response
 			}
@@ -791,7 +792,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured project identity read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list and project-detail use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, and setup-readiness use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -804,7 +805,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list and project-detail through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, and setup-readiness through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -197,7 +197,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	}
 }
 
-func TestProjectCoordinationBackendStatus_CairnlineSidecarProjectReadsReady(t *testing.T) {
+func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{
 			Backend:             "sqlite",
@@ -208,8 +208,8 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarProjectReadsReady(t *t
 	}, quietLogger(), nil, nil, nil, nil)
 
 	status := handler.projectCoordinationBackendStatus()
-	if status.Status != "cairnline_sidecar_project_reads_ready" {
-		t.Fatalf("status = %+v, want sidecar project-read readiness", status)
+	if status.Status != "cairnline_sidecar_read_routes_ready" {
+		t.Fatalf("status = %+v, want sidecar read-route readiness", status)
 	}
 	if status.CairnlineConnector != "sidecar" || status.CairnlineConnectorReady || status.CairnlineReadSource != "sidecar" {
 		t.Fatalf("connector/read source = %q ready=%t source=%q, want sidecar connector with sidecar read source but no full connector readiness", status.CairnlineConnector, status.CairnlineConnectorReady, status.CairnlineReadSource)
@@ -220,17 +220,17 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarProjectReadsReady(t *t
 	if handler.projectReadRoutesUseCairnlineReadModel() {
 		t.Fatal("sidecar project reads enabled embedded Cairnline read-model routes")
 	}
-	if !handler.projectCairnlineSidecarProjectReadsEnabled() {
-		t.Fatal("projectCairnlineSidecarProjectReadsEnabled() = false, want true")
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("projectCairnlineSidecarReadRoutesEnabled() = false, want true")
 	}
-	if !reflect.DeepEqual(status.ReadRoutes, projectCairnlineSidecarProjectReadRouteNames) {
-		t.Fatalf("read routes = %+v, want sidecar project identity routes", status.ReadRoutes)
+	if !reflect.DeepEqual(status.ReadRoutes, projectCairnlineSidecarReadRouteNames) {
+		t.Fatalf("read routes = %+v, want sidecar read routes", status.ReadRoutes)
 	}
 	if gate := findReplacementGate(status.ReplacementGates, "read-routes"); gate == nil || gate.Ready || gate.Status != "blocked" {
-		t.Fatalf("read-routes gate = %+v, want blocked because only project identity reads are sidecar-backed", gate)
+		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list and project-detail") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, and setup-readiness") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_setup_readiness.go
+++ b/internal/api/handler_project_setup_readiness.go
@@ -69,7 +69,7 @@ type ProjectSetupReadinessActionResponse struct {
 
 func (h *Handler) HandleProjectSetupReadiness(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	readiness, err := h.renderProjectSetupReadiness(r.Context(), projectID)
@@ -78,13 +78,16 @@ func (h *Handler) HandleProjectSetupReadiness(w http.ResponseWriter, r *http.Req
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 			return
 		}
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectSetupReadinessEnvelope{Object: "project_setup_readiness", Data: readiness})
 }
 
 func (h *Handler) renderProjectSetupReadiness(ctx context.Context, projectID string) (ProjectSetupReadinessResponse, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectSetupReadiness(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectSetupReadiness(ctx, projectID)
 	}

--- a/internal/api/handler_project_setup_readiness_test.go
+++ b/internal/api/handler_project_setup_readiness_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/config"
@@ -255,6 +256,67 @@ func TestProjectSetupReadiness_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	}
 	if response.Data.Summary.MissingDefaults || !response.Data.Summary.HasPurpose || !response.Data.Summary.HasActiveRoot {
 		t.Fatalf("setup readiness summary = %+v, want Hecate defaults/purpose/root over Cairnline setup counts", response.Data.Summary)
+	}
+}
+
+func TestProjectSetupReadiness_ReadsUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar setup readiness enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/setup-readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("setup readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectSetupReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode setup readiness: %v", err)
+	}
+	if response.Data.ReadBackend != "cairnline" || response.Data.ProjectID != "proj_fixture" {
+		t.Fatalf("setup readiness = %+v, want Cairnline fixture project", response.Data)
+	}
+	if response.Data.ShowOnboarding || !response.Data.SetupStarted || response.Data.FirstWorkReady {
+		t.Fatalf("setup readiness flags = %+v, want sidecar setup started with existing work", response.Data)
+	}
+	summary := response.Data.Summary
+	if summary.WorkItemCount != 1 || summary.RoleCount != 1 || summary.SkillCount != 1 || summary.EnabledContextSourceCount != 1 {
+		t.Fatalf("setup readiness summary = %+v, want sidecar work/role/skill/source counts", summary)
+	}
+	if summary.SavedMemoryCount != 0 || summary.PendingMemoryCandidateCount != 0 {
+		t.Fatalf("setup readiness summary = %+v, want no fixture memory", summary)
+	}
+	if !summary.HasPurpose || !summary.HasActiveRoot || !summary.MissingDefaults {
+		t.Fatalf("setup readiness summary = %+v, want portable project with Hecate execution defaults missing", summary)
+	}
+	for _, id := range []string{"purpose", "workspace_source", "sources_memory", "roles", "first_work_item"} {
+		check := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, id)
+		if check.Status != projectSetupReadinessStatusReady || check.Action != nil {
+			t.Fatalf("check %s = %+v, want ready without action", id, check)
+		}
+	}
+	defaults := findProjectSetupReadinessCheckForTest(t, response.Data.Checks, "launch_defaults")
+	if defaults.Status != projectSetupReadinessStatusTodo || defaults.Action == nil || defaults.Action.Type != projectSetupReadinessActionProjectSettings {
+		t.Fatalf("launch defaults check = %+v, want settings todo", defaults)
+	}
+}
+
+func TestProjectSetupReadiness_CairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/setup-readiness", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("setup readiness status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
 	}
 }
 

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -704,7 +704,7 @@ func parseProjectTime(value string) (time.Time, error) {
 }
 
 func (h *Handler) renderProjects(ctx context.Context) ([]ProjectResponseItem, error) {
-	if h.projectCairnlineSidecarProjectReadsEnabled() {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		return h.renderCairnlineSidecarProjects(ctx)
 	}
 	items, err := h.projects.List(ctx)
@@ -734,7 +734,7 @@ func (h *Handler) renderCairnlineProjects(ctx context.Context, nativeProjects []
 }
 
 func (h *Handler) renderProject(ctx context.Context, projectID string) (*ProjectResponseItem, error) {
-	if h.projectCairnlineSidecarProjectReadsEnabled() {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		return h.renderCairnlineSidecarProject(ctx, projectID)
 	}
 	project, ok, err := h.projects.Get(ctx, projectID)

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -287,7 +287,7 @@ func TestProjectsAPI_ReadsUseCairnlineSidecarWhenConfigured(t *testing.T) {
 	if handler.projectReadRoutesUseCairnlineReadModel() {
 		t.Fatal("sidecar project reads enabled embedded Cairnline read-model routes")
 	}
-	if !handler.projectCairnlineSidecarProjectReadsEnabled() {
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
 		t.Fatal("sidecar project read predicate = false, want true")
 	}
 

--- a/internal/mcp/client/cache.go
+++ b/internal/mcp/client/cache.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sort"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/mcp"
@@ -776,5 +777,7 @@ func IsTransportClosedErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errors.Is(err, ErrTransportClosed)
+	return errors.Is(err, ErrTransportClosed) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET)
 }

--- a/internal/mcp/client/cache_test.go
+++ b/internal/mcp/client/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -58,6 +59,21 @@ func newCacheTestCache(t *testing.T, ttl, reaper time.Duration) *SharedClientCac
 	c := newSharedClientCacheWithReaper(ttl, reaper, mcp.ClientInfo{Name: "hecate-cache-test", Version: "0.0.0"})
 	t.Cleanup(func() { _ = c.Close() })
 	return c
+}
+
+func TestIsTransportClosedErrRecognizesOSClosedPipe(t *testing.T) {
+	t.Parallel()
+	for _, err := range []error{
+		fmt.Errorf("write frame: %w", syscall.EPIPE),
+		fmt.Errorf("write frame: %w", syscall.ECONNRESET),
+	} {
+		if !IsTransportClosedErr(err) {
+			t.Fatalf("IsTransportClosedErr(%v) = false, want true", err)
+		}
+	}
+	if IsTransportClosedErr(fmt.Errorf("write frame: permission denied")) {
+		t.Fatal("IsTransportClosedErr(non-transport error) = true, want false")
+	}
 }
 
 // TestCache_Acquire_HitsAndMisses pins the core caching invariant: a


### PR DESCRIPTION
## Summary
- route project setup-readiness through the Cairnline sidecar read source when configured
- compose typed sidecar project, role, work-item, skill, and memory reads into the existing Hecate setup-readiness contract
- harden cached MCP stale-client detection for broken pipe / connection reset retries
- update Projects/Cairnline docs and backend status wording for the expanded sidecar read-route set

## Verification
- just agent-docs-check
- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/mcp/client
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectSetupReadiness|TestProjectsAPI_ReadsUseCairnlineSidecarWhenConfigured|TestProjectsAPI_CairnlineSidecarReadRequiresStructuredContent|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady'\n- GOCACHE="$PWD/.gocache" go test ./internal/mcp/client -run TestIsTransportClosedErrRecognizesOSClosedPipe\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./internal/mcp/client\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...