### PR TITLE
feat(projects): route sidecar project health

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -180,8 +180,8 @@ side effects through typed `structuredContent`, then deletes and verifies
 removal of the temporary project.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
-routes only project list/detail and setup-readiness reads through the cached
-standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
+routes only project list/detail, setup-readiness, and health reads through the
+cached standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
 dispatch, approvals, and write-authority switchpoints remain Hecate-native or
 on the embedded dogfood path until sidecar-specific adapters exist for those
 route families.
@@ -208,8 +208,8 @@ roles, artifacts, and handoffs from the Cairnline service records, then overlay
 Hecate-only runtime refs/timestamps where Hecate still owns execution.
 In embedded read-source modes, project identity and some compatibility
 scaffolding still come from Hecate until Cairnline becomes authoritative; the
-explicit sidecar read source is the narrow exception for project list/detail and
-setup-readiness. Project Assistant draft generation also uses the
+explicit sidecar read source is the narrow exception for project list/detail,
+setup-readiness, and health. Project Assistant draft generation also uses the
 Cairnline-projected context so preview and proposal assembly stay aligned,
 while the proposal ledger remains Hecate-owned unless
 `project-assistant-proposals` is enabled.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -374,9 +374,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   narrow live-route exception is
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` plus
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
-  list/detail reads through the cached standalone MCP client. Other live
-  Projects reads, writes, mirrors, and write-authority switchpoints do not route
-  through the sidecar yet.
+  list/detail, setup-readiness, and health reads through the cached standalone
+  MCP client. Other live Projects reads, writes, mirrors, and write-authority
+  switchpoints do not route through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -392,8 +392,8 @@ launch agents. Those remain explicit operator or orchestrator actions.
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
-  execution. Outside the explicit sidecar project list/detail and
-  setup-readiness read source, project identity and some compatibility
+  execution. Outside the explicit sidecar project list/detail, setup-readiness,
+  and health read source, project identity and some compatibility
   scaffolding remain Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -435,14 +435,14 @@ read routes require a populated
 mirror database, project row, or proposal record is missing; run
 `POST /hecate/v1/projects/cairnline/sync` first when dogfooding strict embedded
 reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
-`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail
-and setup-readiness reads through the standalone Cairnline MCP client; all other
-live Projects read routes remain Hecate-native or use the embedded dogfood read
-model when that is configured. Activity, work-item list/detail,
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
+setup-readiness, and health reads through the standalone Cairnline MCP client;
+all other live Projects read routes remain Hecate-native or use the embedded
+dogfood read model when that is configured. Activity, work-item list/detail,
 assignment-list, and operations brief reads render the work graph from
 Cairnline service records and overlay Hecate-only runtime refs/timestamps while
-Hecate still owns execution. Outside the explicit sidecar project list/detail
-and setup-readiness read source, project identity and some compatibility
+Hecate still owns execution. Outside the explicit sidecar project list/detail,
+setup-readiness, and health read source, project identity and some compatibility
 scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
 identity, metadata/default, root, and
 context-source mutations still write Hecate stores first and then best-effort

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -510,7 +510,7 @@ sequenceDiagram
   temporary project. Live Projects writes still use Hecate-native stores in
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness
-  uses the same sidecar source when it is configured.
+  and health use the same sidecar source when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -2405,10 +2405,10 @@ falls back to the snapshot-seeded bridge, `snapshot` always uses the
 snapshot-seeded bridge, and `embedded` requires the mirror database and
 requested project row or proposal record to exist so replacement-readiness gaps
 fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
-`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail
-and setup-readiness through the standalone Cairnline MCP client; backend status
-reports those routes in `read_routes` while `read_model_switch_ready` remains
-false because the broader read model is not sidecar-backed yet.
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
+setup-readiness, and health through the standalone Cairnline MCP client; backend
+status reports those routes in `read_routes` while `read_model_switch_ready`
+remains false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
@@ -2846,7 +2846,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail and setup-readiness read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, and health read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3059,7 +3059,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail and setup-readiness read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, and health read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -5044,6 +5044,12 @@ reports `read_model_switch_ready=true`, portable health inputs are read from
 the Cairnline read model and then projected into Hecate's health/attention
 contract. Hecate still owns Hecate-specific provider/model default checks and
 action shapes. `read_backend` identifies the health-state read-model source.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, this route
+instead composes typed read-only Cairnline MCP sidecar calls for project detail,
+roles, work items, assignments, collaboration artifacts, handoffs, memory,
+profiles, and skills. The sidecar path requires typed `structuredContent`;
+malformed or text-only sidecar responses fail loudly with `502 gateway_error`.
 
 The five-item cap is applied after the server's attention derivation order. The
 summary reports returned, available, omitted, and limit counts so clients can

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail and setup-readiness through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, and health through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail and setup-readiness through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, and health through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_cairnline_sidecar_health.go
+++ b/internal/api/handler_project_cairnline_sidecar_health.go
@@ -1,0 +1,233 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+func (h *Handler) renderCairnlineSidecarProjectHealth(ctx context.Context, projectID string) (ProjectHealthResponse, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	if !ok {
+		return ProjectHealthResponse{}, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	roles, err := h.cairnlineSidecarProjectRoles(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	workItems, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	assignments, err := h.cairnlineSidecarProjectAssignments(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	artifacts, err := h.cairnlineSidecarProjectArtifacts(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	evidence, err := h.cairnlineSidecarProjectEvidence(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	reviews, err := h.cairnlineSidecarProjectReviews(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	handoffs, err := h.cairnlineSidecarProjectHandoffs(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	memoryEntries, err := h.cairnlineSidecarProjectMemoryEntries(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	memoryCandidates, err := h.cairnlineSidecarProjectMemoryCandidates(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	profiles, err := h.cairnlineSidecarAgentProfiles(ctx)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	skills, err := h.cairnlineSidecarProjectSkills(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+
+	now := time.Now().UTC()
+	activity := ProjectActivityDataResponse{
+		ProjectID:   project.ID,
+		ReadBackend: "cairnline",
+	}
+	convertedWorkItems := projectWorkItemsFromCairnlineSidecar(workItems)
+	convertedAssignments := projectAssignmentsFromCairnlineSidecar(assignments)
+	convertedHandoffs := projectHandoffsFromCairnlineSidecar(handoffs)
+	convertedArtifacts := projectArtifactsFromCairnlineSidecar(artifacts, evidence, reviews)
+	convertedMemoryEntries := projectMemoryEntriesFromCairnlineSidecar(memoryEntries)
+	convertedMemoryCandidates := projectMemoryCandidatesFromCairnlineSidecar(memoryCandidates)
+	staleAssignments := projectHealthStaleAssignments(project, activity, convertedWorkItems, convertedAssignments, now)
+	summary := projectHealthSummary(project, convertedMemoryEntries, convertedMemoryCandidates, convertedHandoffs, convertedArtifacts, staleAssignments)
+	attention := projectHealthAttentionItems(
+		project,
+		activity,
+		convertedWorkItems,
+		projectRolesFromCairnlineSidecar(roles),
+		convertedHandoffs,
+		convertedArtifacts,
+		convertedMemoryEntries,
+		convertedMemoryCandidates,
+		projectAgentProfilesFromCairnlineSidecar(profiles),
+		projectSkillsFromCairnlineSidecar(skills),
+		staleAssignments,
+	)
+	availableAttentionCount := len(attention)
+	attention = boundedProjectHealthAttention(attention, projectHealthAttentionLimit)
+	summary.AttentionCount = len(attention)
+	summary.AvailableAttentionCount = availableAttentionCount
+	summary.OmittedAttentionCount = availableAttentionCount - len(attention)
+	summary.AttentionLimit = projectHealthAttentionLimit
+	return ProjectHealthResponse{
+		ProjectID:   project.ID,
+		GeneratedAt: formatOptionalTime(now),
+		ReadBackend: "cairnline",
+		Summary:     summary,
+		Attention:   attention,
+	}, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectAssignments(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarAssignmentItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "assignments.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("assignments.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	assignments, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignments(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("assignments.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("assignments.list did not return typed structuredContent")
+	}
+	return assignments, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectArtifacts(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarArtifactItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "artifacts.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("artifacts.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	artifacts, structuredReady, structuredErr := projectCairnlineSidecarStructuredArtifacts(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("artifacts.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("artifacts.list did not return typed structuredContent")
+	}
+	return artifacts, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectEvidence(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarEvidenceItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "evidence.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("evidence.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	evidence, structuredReady, structuredErr := projectCairnlineSidecarStructuredEvidence(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("evidence.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("evidence.list did not return typed structuredContent")
+	}
+	return evidence, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectReviews(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarReviewItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "reviews.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("reviews.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	reviews, structuredReady, structuredErr := projectCairnlineSidecarStructuredReviews(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("reviews.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("reviews.list did not return typed structuredContent")
+	}
+	return reviews, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectHandoffs(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarHandoffItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "handoffs.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("handoffs.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	handoffs, structuredReady, structuredErr := projectCairnlineSidecarStructuredHandoffs(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("handoffs.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("handoffs.list did not return typed structuredContent")
+	}
+	return handoffs, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectMemoryCandidates(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarMemoryCandidateItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "memory_candidates.list", map[string]any{
+		"project_id":       strings.TrimSpace(projectID),
+		"include_resolved": true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	candidates, structuredReady, structuredErr := projectCairnlineSidecarStructuredMemoryCandidates(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list did not return typed structuredContent")
+	}
+	return candidates, nil
+}
+
+func (h *Handler) cairnlineSidecarAgentProfiles(ctx context.Context) ([]ProjectCairnlineSidecarAgentProfileItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "profiles.list", map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError {
+		return nil, projectCairnlineSidecarReadFailure("profiles.list returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	profiles, structuredReady, structuredErr := projectCairnlineSidecarStructuredAgentProfiles(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return nil, projectCairnlineSidecarReadFailure("profiles.list structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return nil, projectCairnlineSidecarReadFailure("profiles.list did not return typed structuredContent")
+	}
+	return profiles, nil
+}

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/orchestrator"
@@ -229,6 +230,141 @@ func projectWorkItemsFromCairnlineSidecar(items []ProjectCairnlineSidecarWorkIte
 	return out
 }
 
+func projectAssignmentsFromCairnlineSidecar(items []ProjectCairnlineSidecarAssignmentItem) []projectwork.Assignment {
+	out := make([]projectwork.Assignment, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectwork.Assignment{
+			ID:         item.ID,
+			ProjectID:  item.ProjectID,
+			WorkItemID: item.WorkItemID,
+			RoleID:     item.RoleID,
+			RootID:     item.RootID,
+			DriverKind: projectWorkAssignmentDriverFromCairnline(item.ExecutionMode),
+			Status:     projectWorkAssignmentStatusFromCairnline(item.Status),
+			ExecutionRef: projectwork.NormalizeAssignmentExecutionRef(projectwork.AssignmentExecutionRef{
+				ContextSnapshotID: item.ContextSnapshotID,
+			}),
+			CreatedAt:   projectCairnlineSidecarTime(item.CreatedAt),
+			UpdatedAt:   projectCairnlineSidecarTime(item.UpdatedAt),
+			StartedAt:   projectCairnlineSidecarTime(item.StartedAt),
+			CompletedAt: projectCairnlineSidecarTime(item.CompletedAt),
+		})
+	}
+	return out
+}
+
+func projectArtifactsFromCairnlineSidecar(artifacts []ProjectCairnlineSidecarArtifactItem, evidence []ProjectCairnlineSidecarEvidenceItem, reviews []ProjectCairnlineSidecarReviewItem) []projectwork.CollaborationArtifact {
+	out := make([]projectwork.CollaborationArtifact, 0, len(artifacts))
+	for _, item := range artifacts {
+		out = append(out, projectGenericArtifactFromCairnlineSidecar(item))
+	}
+	for _, item := range evidence {
+		out = append(out, projectEvidenceFromCairnlineSidecar(item))
+	}
+	for _, item := range reviews {
+		out = append(out, projectReviewFromCairnlineSidecar(item))
+	}
+	return out
+}
+
+func projectGenericArtifactFromCairnlineSidecar(item ProjectCairnlineSidecarArtifactItem) projectwork.CollaborationArtifact {
+	return projectwork.CollaborationArtifact{
+		ID:           item.ID,
+		ProjectID:    item.ProjectID,
+		WorkItemID:   item.WorkItemID,
+		AssignmentID: item.AssignmentID,
+		Kind:         item.Kind,
+		Title:        item.Title,
+		Body:         item.Body,
+		AuthorRoleID: item.AuthorRoleID,
+		CreatedAt:    projectCairnlineSidecarTime(item.CreatedAt),
+		UpdatedAt:    projectCairnlineSidecarTime(item.UpdatedAt),
+	}
+}
+
+func projectEvidenceFromCairnlineSidecar(item ProjectCairnlineSidecarEvidenceItem) projectwork.CollaborationArtifact {
+	return projectwork.CollaborationArtifact{
+		ID:                 item.ID,
+		ProjectID:          item.ProjectID,
+		WorkItemID:         item.WorkItemID,
+		AssignmentID:       item.AssignmentID,
+		Kind:               projectwork.ArtifactKindEvidenceLink,
+		Title:              item.Title,
+		Body:               item.Body,
+		EvidenceSourceKind: firstNonEmptyString(strings.TrimSpace(item.SourceKind), projectwork.EvidenceSourceExternal),
+		EvidenceURL:        item.Locator,
+		EvidenceExternalID: item.ExternalID,
+		EvidenceProvider:   item.Provider,
+		EvidenceTrustLabel: item.TrustLabel,
+		CreatedAt:          projectCairnlineSidecarTime(item.CreatedAt),
+		UpdatedAt:          projectCairnlineSidecarTime(item.UpdatedAt),
+	}
+}
+
+func projectReviewFromCairnlineSidecar(item ProjectCairnlineSidecarReviewItem) projectwork.CollaborationArtifact {
+	return projectwork.CollaborationArtifact{
+		ID:                     item.ID,
+		ProjectID:              item.ProjectID,
+		WorkItemID:             item.WorkItemID,
+		AssignmentID:           item.AssignmentID,
+		Kind:                   projectwork.ArtifactKindReview,
+		Title:                  item.Title,
+		Body:                   item.Body,
+		AuthorRoleID:           item.ReviewerRoleID,
+		ReviewedAssignmentID:   item.AssignmentID,
+		ReviewVerdict:          projectHealthReviewVerdictFromCairnline(item.Verdict),
+		ReviewRisk:             projectHealthReviewRiskFromCairnline(item.Risk),
+		ReviewFollowUpRequired: projectHealthReviewRequiresFollowUpFromCairnline(item.Verdict),
+		CreatedAt:              projectCairnlineSidecarTime(item.CreatedAt),
+		UpdatedAt:              projectCairnlineSidecarTime(item.UpdatedAt),
+	}
+}
+
+func projectHandoffsFromCairnlineSidecar(items []ProjectCairnlineSidecarHandoffItem) []projectwork.Handoff {
+	out := make([]projectwork.Handoff, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectwork.Handoff{
+			ID:                    item.ID,
+			ProjectID:             item.ProjectID,
+			WorkItemID:            item.WorkItemID,
+			SourceAssignmentID:    item.SourceAssignmentID,
+			SourceRunID:           item.SourceRunID,
+			SourceChatSessionID:   item.SourceChatSessionID,
+			SourceMessageID:       item.SourceMessageID,
+			TargetRoleID:          item.ToRoleID,
+			TargetAssignmentID:    item.TargetAssignmentID,
+			TargetWorkItemID:      item.TargetWorkItemID,
+			Title:                 item.Title,
+			Summary:               item.Body,
+			RecommendedNextAction: item.RecommendedNextAction,
+			LinkedArtifactIDs:     append([]string(nil), item.LinkedArtifactIDs...),
+			LinkedMemoryIDs:       append([]string(nil), item.LinkedMemoryIDs...),
+			ContextRefs:           append([]string(nil), item.ContextRefs...),
+			Status:                projectHealthHandoffStatusFromCairnline(item.Status),
+			ProvenanceKind:        item.ProvenanceKind,
+			TrustLabel:            item.TrustLabel,
+			CreatedByRoleID:       item.FromRoleID,
+			CreatedAt:             projectCairnlineSidecarTime(item.CreatedAt),
+			UpdatedAt:             projectCairnlineSidecarTime(item.UpdatedAt),
+			StatusChangedAt:       projectworkTime(projectCairnlineSidecarTime(item.StatusChangedAt), projectCairnlineSidecarTime(item.UpdatedAt)),
+		})
+	}
+	return out
+}
+
+func projectAgentProfilesFromCairnlineSidecar(items []ProjectCairnlineSidecarAgentProfileItem) []agentprofiles.Profile {
+	out := make([]agentprofiles.Profile, 0, len(items))
+	for _, item := range items {
+		out = append(out, agentprofiles.Profile{
+			ID:          item.ID,
+			Name:        item.Name,
+			Description: item.Description,
+			SkillIDs:    append([]string(nil), item.SkillIDs...),
+		})
+	}
+	return out
+}
+
 func projectSkillsFromCairnlineSidecar(items []ProjectCairnlineSidecarSkillItem) []projectskills.Skill {
 	out := make([]projectskills.Skill, 0, len(items))
 	for _, item := range items {
@@ -336,6 +472,27 @@ func projectCairnlineSidecarTime(value string) time.Time {
 		return time.Time{}
 	}
 	return parsed.UTC()
+}
+
+func projectCairnlineSidecarStructuredAgentProfiles(raw json.RawMessage) ([]ProjectCairnlineSidecarAgentProfileItem, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return []ProjectCairnlineSidecarAgentProfileItem{}, true, nil
+	}
+	var profiles []ProjectCairnlineSidecarAgentProfileItem
+	if err := json.Unmarshal(trimmed, &profiles); err != nil {
+		return nil, false, err
+	}
+	if profiles == nil {
+		profiles = []ProjectCairnlineSidecarAgentProfileItem{}
+	}
+	return profiles, true, nil
 }
 
 func projectCairnlineSidecarStructuredSkills(raw json.RawMessage) ([]ProjectCairnlineSidecarSkillItem, bool, error) {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -52,6 +52,7 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"project-list",
 	"project-detail",
 	"setup-readiness",
+	"health",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -349,13 +350,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, and setup-readiness routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, and health routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, and setup-readiness use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, and health use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for health, skills, memory, work, assignments, activity, assistant, and operations routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for skills, memory, work, assignments, activity, assistant, and operations routes are not wired.",
 				}
 				return response
 			}
@@ -792,7 +793,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, and setup-readiness use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, and health use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -805,7 +806,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, and setup-readiness through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, and health through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, and setup-readiness") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, and health") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_health.go
+++ b/internal/api/handler_project_health.go
@@ -74,7 +74,7 @@ type ProjectHealthAttentionItem struct {
 
 func (h *Handler) HandleProjectHealth(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	health, err := h.renderProjectHealth(r.Context(), projectID)
@@ -83,13 +83,16 @@ func (h *Handler) HandleProjectHealth(w http.ResponseWriter, r *http.Request) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 			return
 		}
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectHealthEnvelope{Object: "project_health", Data: health})
 }
 
 func (h *Handler) renderProjectHealth(ctx context.Context, projectID string) (ProjectHealthResponse, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectHealth(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectHealth(ctx, projectID)
 	}

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -261,6 +261,65 @@ func TestProjectHealth_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	}
 }
 
+func TestProjectHealth_ReadsUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar health enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("health status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectHealthEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if response.Object != "project_health" || response.Data.ProjectID != "proj_fixture" || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("health envelope = %+v, want sidecar Cairnline project health", response)
+	}
+	summary := response.Data.Summary
+	if !summary.MissingDefaults || summary.MissingProjectRoot || summary.EnabledContextSourceCount != 1 || summary.SavedMemoryCount != 0 || summary.PendingMemoryCandidateCount != 0 {
+		t.Fatalf("health summary = %+v, want sidecar root/source/defaults projection", summary)
+	}
+	assertProjectHealthItemsHaveActions(t, response.Data.Attention, "proj_fixture")
+	defaults := findProjectHealthAttentionForTest(t, response.Data.Attention, "Provider/model defaults missing")
+	assertProjectHealthActionForTest(t, defaults, projectActionOpenProjectSettings, "proj_fixture")
+	if _, ok := findProjectHealthAttention(response.Data.Attention, "No project root configured"); ok {
+		t.Fatalf("attention = %+v, want no missing root item for sidecar active root", response.Data.Attention)
+	}
+	if _, ok := findProjectHealthAttention(response.Data.Attention, "Project skills need review"); ok {
+		t.Fatalf("attention = %+v, want sidecar role/profile/skill references to resolve", response.Data.Attention)
+	}
+}
+
+func TestProjectHealth_CairnlineSidecarRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/health", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("health status = %d body=%s, want 502 for text-only sidecar", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(response.Error.Message, "projects.get did not return typed structuredContent") {
+		t.Fatalf("error = %+v, want structuredContent failure", response.Error)
+	}
+}
+
 func TestProjectHealth_CairnlineMatchesHecateProjectionGraph(t *testing.T) {
 	t.Parallel()
 	hecateHandler, hecateServer := newProjectWorkProjectionTestServer(t, "memory")
@@ -472,13 +531,20 @@ func TestProjectHealth_AttentionCapReportsOmittedItems(t *testing.T) {
 
 func findProjectHealthAttentionForTest(t *testing.T, items []ProjectHealthAttentionItem, title string) ProjectHealthAttentionItem {
 	t.Helper()
-	for _, item := range items {
-		if item.Title == title {
-			return item
-		}
+	if item, ok := findProjectHealthAttention(items, title); ok {
+		return item
 	}
 	t.Fatalf("project health attention %q not found in %+v", title, items)
 	return ProjectHealthAttentionItem{}
+}
+
+func findProjectHealthAttention(items []ProjectHealthAttentionItem, title string) (ProjectHealthAttentionItem, bool) {
+	for _, item := range items {
+		if item.Title == title {
+			return item, true
+		}
+	}
+	return ProjectHealthAttentionItem{}, false
 }
 
 func assertProjectHealthItemsHaveActions(t *testing.T, items []ProjectHealthAttentionItem, projectID string) {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -2310,16 +2310,23 @@ type ProjectCairnlineSidecarProjectItem struct {
 }
 
 type ProjectCairnlineSidecarAssignmentItem struct {
-	ID            string   `json:"id"`
-	ProjectID     string   `json:"project_id,omitempty"`
-	WorkItemID    string   `json:"work_item_id,omitempty"`
-	RoleID        string   `json:"role_id,omitempty"`
-	ProfileID     string   `json:"profile_id,omitempty"`
-	ExecutionMode string   `json:"execution_mode,omitempty"`
-	Status        string   `json:"status,omitempty"`
-	ClaimedBy     string   `json:"claimed_by,omitempty"`
-	ExecutionRef  string   `json:"execution_ref,omitempty"`
-	SkillIDs      []string `json:"skill_ids,omitempty"`
+	ID                 string   `json:"id"`
+	ProjectID          string   `json:"project_id,omitempty"`
+	WorkItemID         string   `json:"work_item_id,omitempty"`
+	RoleID             string   `json:"role_id,omitempty"`
+	RootID             string   `json:"root_id,omitempty"`
+	ProfileID          string   `json:"profile_id,omitempty"`
+	ExecutionProfileID string   `json:"execution_profile_id,omitempty"`
+	ExecutionMode      string   `json:"execution_mode,omitempty"`
+	Status             string   `json:"status,omitempty"`
+	ClaimedBy          string   `json:"claimed_by,omitempty"`
+	ExecutionRef       string   `json:"execution_ref,omitempty"`
+	ContextSnapshotID  string   `json:"context_snapshot_id,omitempty"`
+	SkillIDs           []string `json:"skill_ids,omitempty"`
+	CreatedAt          string   `json:"created_at,omitempty"`
+	UpdatedAt          string   `json:"updated_at,omitempty"`
+	StartedAt          string   `json:"started_at,omitempty"`
+	CompletedAt        string   `json:"completed_at,omitempty"`
 }
 
 type ProjectCairnlineSidecarRoleItem struct {
@@ -2468,6 +2475,13 @@ type ProjectCairnlineSidecarMemoryCandidateItem struct {
 	PromotedMemoryID    string                                            `json:"promoted_memory_id,omitempty"`
 	CreatedAt           string                                            `json:"created_at,omitempty"`
 	UpdatedAt           string                                            `json:"updated_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarAgentProfileItem struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	SkillIDs    []string `json:"skill_ids,omitempty"`
 }
 
 type ProjectCairnlineSidecarMemoryCandidateSourceRef struct {


### PR DESCRIPTION
## Summary
- route project health through the Cairnline sidecar read source when configured
- compose health from typed sidecar project, role, work, assignment, collaboration, memory, profile, and skill reads
- update backend status/docs to include health in the sidecar read-route set

## Tests
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectHealth_(ReadsUseCairnlineSidecarWhenConfigured|CairnlineSidecarRequiresStructuredContent)|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...