### PR TITLE
feat(projects): route sidecar project skills

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -180,11 +180,11 @@ side effects through typed `structuredContent`, then deletes and verifies
 removal of the temporary project.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
-routes only project list/detail, setup-readiness, and health reads through the
-cached standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
-dispatch, approvals, and write-authority switchpoints remain Hecate-native or
-on the embedded dogfood path until sidecar-specific adapters exist for those
-route families.
+routes only project list/detail, setup-readiness, health, and project skill
+list reads through the cached standalone Cairnline MCP client. Other Projects
+reads, writes, mirrors, dispatch, approvals, and write-authority switchpoints
+remain Hecate-native or on the embedded dogfood path until sidecar-specific
+adapters exist for those route families.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
@@ -209,9 +209,9 @@ Hecate-only runtime refs/timestamps where Hecate still owns execution.
 In embedded read-source modes, project identity and some compatibility
 scaffolding still come from Hecate until Cairnline becomes authoritative; the
 explicit sidecar read source is the narrow exception for project list/detail,
-setup-readiness, and health. Project Assistant draft generation also uses the
-Cairnline-projected context so preview and proposal assembly stay aligned,
-while the proposal ledger remains Hecate-owned unless
+setup-readiness, health, and project skill list reads. Project Assistant draft
+generation also uses the Cairnline-projected context so preview and proposal
+assembly stay aligned, while the proposal ledger remains Hecate-owned unless
 `project-assistant-proposals` is enabled.
 Confirmed Project Assistant apply routes role, work-item, assignment, and
 handoff actions through the same opt-in Cairnline authority switchpoints when

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -374,9 +374,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   narrow live-route exception is
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` plus
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
-  list/detail, setup-readiness, and health reads through the cached standalone
-  MCP client. Other live Projects reads, writes, mirrors, and write-authority
-  switchpoints do not route through the sidecar yet.
+  list/detail, setup-readiness, health, and project skill list reads through
+  the cached standalone MCP client. Other live Projects reads, writes, mirrors,
+  and write-authority switchpoints do not route through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -393,8 +393,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the explicit sidecar project list/detail, setup-readiness,
-  and health read source, project identity and some compatibility
-  scaffolding remain Hecate-owned until Cairnline becomes authoritative.
+  health, and project skill list read source, project identity and some
+  compatibility scaffolding remain Hecate-owned until Cairnline becomes
+  authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -436,17 +436,17 @@ mirror database, project row, or proposal record is missing; run
 `POST /hecate/v1/projects/cairnline/sync` first when dogfooding strict embedded
 reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
-setup-readiness, and health reads through the standalone Cairnline MCP client;
-all other live Projects read routes remain Hecate-native or use the embedded
-dogfood read model when that is configured. Activity, work-item list/detail,
-assignment-list, and operations brief reads render the work graph from
-Cairnline service records and overlay Hecate-only runtime refs/timestamps while
-Hecate still owns execution. Outside the explicit sidecar project list/detail,
-setup-readiness, and health read source, project identity and some compatibility
-scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
-identity, metadata/default, root, and
-context-source mutations still write Hecate stores first and then best-effort
-mirror into the embedded Cairnline database through their
+setup-readiness, health, and project skill list reads through the standalone
+Cairnline MCP client; all other live Projects read routes remain Hecate-native
+or use the embedded dogfood read model when that is configured. Activity,
+work-item list/detail, assignment-list, and operations brief reads render the
+work graph from Cairnline service records and overlay Hecate-only runtime
+refs/timestamps while Hecate still owns execution. Outside the explicit sidecar
+project list/detail, setup-readiness, health, and project skill list read
+source, project identity and some compatibility scaffolding remain Hecate-owned
+until Cairnline becomes authoritative. Project identity, metadata/default, root,
+and context-source mutations still write Hecate stores first and then
+best-effort mirror into the embedded Cairnline database through their
 identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -524,9 +524,9 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
-  only `GET /hecate/v1/projects` and `GET /hecate/v1/projects/{id}` through
-  the standalone Cairnline MCP client; all other live Projects read routes stay
-  on Hecate-native or embedded dogfood paths.
+  project list/detail, setup-readiness, health, and project skill list reads
+  through the standalone Cairnline MCP client; all other live Projects read
+  routes stay on Hecate-native or embedded dogfood paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2406,9 +2406,10 @@ snapshot-seeded bridge, and `embedded` requires the mirror database and
 requested project row or proposal record to exist so replacement-readiness gaps
 fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
-setup-readiness, and health through the standalone Cairnline MCP client; backend
-status reports those routes in `read_routes` while `read_model_switch_ready`
-remains false because the broader read model is not sidecar-backed yet.
+setup-readiness, health, and project skill list reads through the standalone
+Cairnline MCP client; backend status reports those routes in `read_routes`
+while `read_model_switch_ready` remains false because the broader read model is
+not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
@@ -2846,7 +2847,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, and health read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, and skills read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3059,7 +3060,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, and health read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, and skills read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -5334,6 +5335,10 @@ registry from the Cairnline read model and marks each item with
 `read_backend: "cairnline"`. Hecate-only advisory fields such as
 `suggested_tools` and `required_permissions` are still enriched from the Hecate
 snapshot because they are not part of Cairnline's portable core skill contract.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, this endpoint reads the
+project and skill registry through the standalone Cairnline MCP client and
+requires typed `structuredContent`; text-only sidecar output is rejected.
 
 ```json
 {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, and health through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, and skills through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, and health through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, and skills through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -53,6 +53,7 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"project-detail",
 	"setup-readiness",
 	"health",
+	"skills",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -350,13 +351,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, and health routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, and skills routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, and health use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, and skills use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for skills, memory, work, assignments, activity, assistant, and operations routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for memory, work, assignments, activity, assistant, and operations routes are not wired.",
 				}
 				return response
 			}
@@ -793,7 +794,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, and health use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, and skills use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -806,7 +807,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, and health through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, and skills through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, and health") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, and skills") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_skills.go
+++ b/internal/api/handler_project_skills.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 )
 
@@ -26,16 +27,21 @@ func formatProjectSkillTime(value time.Time) string {
 }
 
 func (h *Handler) HandleProjectSkills(w http.ResponseWriter, r *http.Request) {
-	if h.projectSkills == nil {
+	projectID := r.PathValue("id")
+	if h.projectSkills == nil && !h.projectCairnlineSidecarReadRoutesEnabled() {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project skills store is not configured")
 		return
 	}
-	if !h.requireProjectExists(w, r, r.PathValue("id")) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProjectExists(w, r, projectID) {
 		return
 	}
-	items, err := h.renderProjectSkills(r.Context(), r.PathValue("id"))
+	items, err := h.renderProjectSkills(r.Context(), projectID)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectSkillsResponse{Object: "project_skills", Data: items})
@@ -139,6 +145,9 @@ func (h *Handler) HandleUpdateProjectSkill(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *Handler) renderProjectSkills(ctx context.Context, projectID string) ([]ProjectSkillResponseItem, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectSkills(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectSkills(ctx, projectID)
 	}
@@ -165,6 +174,22 @@ func (h *Handler) renderCairnlineProjectSkills(ctx context.Context, projectID st
 		out = append(out, renderProjectSkill(projectSkillFromCairnline(item, nativeByID[item.ID]), "cairnline"))
 	}
 	return out, nil
+}
+
+func (h *Handler) renderCairnlineSidecarProjectSkills(ctx context.Context, projectID string) ([]ProjectSkillResponseItem, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	items, err := h.cairnlineSidecarProjectSkills(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	return renderProjectSkills(projectSkillsFromCairnlineSidecar(items), "cairnline"), nil
 }
 
 func renderProjectSkills(items []projectskills.Skill, readBackend string) []ProjectSkillResponseItem {

--- a/internal/api/handler_project_skills_test.go
+++ b/internal/api/handler_project_skills_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hecatehq/cairnline"
@@ -221,6 +222,54 @@ func TestProjectSkillsAPI_ListUsesCairnlineReadModelWhenConfigured(t *testing.T)
 		t.Fatalf("List native skills: %v", err)
 	}
 	assertProjectSkillsProjectionParity(t, renderProjectSkills(nativeSkills, "hecate"), listed.Data)
+}
+
+func TestProjectSkillsAPI_ListUsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar skills list enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/skills", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("skills status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectSkillsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode skills response: %v", err)
+	}
+	if response.Object != "project_skills" {
+		t.Fatalf("skills object = %q, want project_skills", response.Object)
+	}
+	skill := projectSkillResponseFor(response.Data, "skill_fixture")
+	if skill == nil {
+		t.Fatalf("skills = %+v, want fixture skill", response.Data)
+	}
+	if skill.ReadBackend != "cairnline" || skill.ProjectID != "proj_fixture" || skill.Title != "Fixture Skill" {
+		t.Fatalf("skill = %+v, want sidecar Cairnline fixture skill", *skill)
+	}
+	if skill.Path != ".agents/skills/fixture/SKILL.md" || !skill.Enabled || skill.Status != projectskills.StatusAvailable || skill.TrustLabel != projectskills.TrustWorkspaceSkill {
+		t.Fatalf("skill metadata = %+v, want portable sidecar skill metadata", *skill)
+	}
+}
+
+func TestProjectSkillsAPI_CairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/skills", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("skills status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
 }
 
 func TestProjectSkillsAPI_MirrorsMutationsToCairnlineWhenConfigured(t *testing.T) {


### PR DESCRIPTION
## Summary
- route project skills list reads through the Cairnline sidecar read source when configured
- preserve strict typed structuredContent handling for sidecar skill data
- update backend-status route lists and operator/design/runtime docs for the expanded sidecar read boundary

## Tests
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectSkillsAPI_(ListUsesCairnlineSidecarWhenConfigured|CairnlineSidecarReadRequiresStructuredContent|ListUsesCairnlineReadModelWhenConfigured)|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...