### PR TITLE
feat(projects): route sidecar project memory

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -180,11 +180,12 @@ side effects through typed `structuredContent`, then deletes and verifies
 removal of the temporary project.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
-routes only project list/detail, setup-readiness, health, and project skill
-list reads through the cached standalone Cairnline MCP client. Other Projects
-reads, writes, mirrors, dispatch, approvals, and write-authority switchpoints
-remain Hecate-native or on the embedded dogfood path until sidecar-specific
-adapters exist for those route families.
+routes only project list/detail, setup-readiness, health, project skill list,
+project memory list, and memory-candidate list reads through the cached
+standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
+dispatch, approvals, and write-authority switchpoints remain Hecate-native or
+on the embedded dogfood path until sidecar-specific adapters exist for those
+route families.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
@@ -208,10 +209,11 @@ roles, artifacts, and handoffs from the Cairnline service records, then overlay
 Hecate-only runtime refs/timestamps where Hecate still owns execution.
 In embedded read-source modes, project identity and some compatibility
 scaffolding still come from Hecate until Cairnline becomes authoritative; the
-explicit sidecar read source is the narrow exception for project list/detail,
-setup-readiness, health, and project skill list reads. Project Assistant draft
-generation also uses the Cairnline-projected context so preview and proposal
-assembly stay aligned, while the proposal ledger remains Hecate-owned unless
+explicit sidecar read-source routes are the narrow exception for project
+list/detail, setup-readiness, health, project skill list, project memory list,
+and memory-candidate list reads. Project Assistant draft generation also uses
+the Cairnline-projected context so preview and proposal assembly stay aligned,
+while the proposal ledger remains Hecate-owned unless
 `project-assistant-proposals` is enabled.
 Confirmed Project Assistant apply routes role, work-item, assignment, and
 handoff actions through the same opt-in Cairnline authority switchpoints when

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -374,9 +374,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   narrow live-route exception is
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` plus
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
-  list/detail, setup-readiness, health, and project skill list reads through
-  the cached standalone MCP client. Other live Projects reads, writes, mirrors,
-  and write-authority switchpoints do not route through the sidecar yet.
+  list/detail, setup-readiness, health, project skill list, project memory
+  list, and memory-candidate list reads through the cached standalone MCP
+  client. Other live Projects reads, writes, mirrors, and write-authority
+  switchpoints do not route through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -392,10 +393,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
-  execution. Outside the explicit sidecar project list/detail, setup-readiness,
-  health, and project skill list read source, project identity and some
-  compatibility scaffolding remain Hecate-owned until Cairnline becomes
-  authoritative.
+  execution. Outside the explicit sidecar read-source routes for project
+  list/detail, setup-readiness, health, skills, memory, and memory candidates,
+  project identity and some compatibility scaffolding remain Hecate-owned until
+  Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -436,18 +436,19 @@ mirror database, project row, or proposal record is missing; run
 `POST /hecate/v1/projects/cairnline/sync` first when dogfooding strict embedded
 reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
-setup-readiness, health, and project skill list reads through the standalone
-Cairnline MCP client; all other live Projects read routes remain Hecate-native
-or use the embedded dogfood read model when that is configured. Activity,
-work-item list/detail, assignment-list, and operations brief reads render the
-work graph from Cairnline service records and overlay Hecate-only runtime
-refs/timestamps while Hecate still owns execution. Outside the explicit sidecar
-project list/detail, setup-readiness, health, and project skill list read
-source, project identity and some compatibility scaffolding remain Hecate-owned
-until Cairnline becomes authoritative. Project identity, metadata/default, root,
-and context-source mutations still write Hecate stores first and then
-best-effort mirror into the embedded Cairnline database through their
-identity/metadata/root/source/default seams unless their explicit
+setup-readiness, health, project skill list, project memory list, and
+memory-candidate list reads through the standalone Cairnline MCP client; all
+other live Projects read routes remain Hecate-native or use the embedded
+dogfood read model when that is configured. Activity, work-item list/detail,
+assignment-list, and operations brief reads render the work graph from Cairnline
+service records and overlay Hecate-only runtime refs/timestamps while Hecate
+still owns execution. Outside the explicit sidecar read-source routes for
+project list/detail, setup-readiness, health, skills, memory, and memory
+candidates, project identity and some compatibility scaffolding remain
+Hecate-owned until Cairnline becomes authoritative. Project identity,
+metadata/default, root, and context-source mutations still write Hecate stores
+first and then best-effort mirror into the embedded Cairnline database through
+their identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.
 The sidecar probe/connect surfaces are configured with

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -524,9 +524,10 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
-  project list/detail, setup-readiness, health, and project skill list reads
-  through the standalone Cairnline MCP client; all other live Projects read
-  routes stay on Hecate-native or embedded dogfood paths.
+  project list/detail, setup-readiness, health, project skill list, project
+  memory list, and memory-candidate list reads through the standalone Cairnline
+  MCP client; all other live Projects read routes stay on Hecate-native or
+  embedded dogfood paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2406,10 +2407,10 @@ snapshot-seeded bridge, and `embedded` requires the mirror database and
 requested project row or proposal record to exist so replacement-readiness gaps
 fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
-setup-readiness, health, and project skill list reads through the standalone
-Cairnline MCP client; backend status reports those routes in `read_routes`
-while `read_model_switch_ready` remains false because the broader read model is
-not sidecar-backed yet.
+setup-readiness, health, project skill list, project memory list, and
+memory-candidate list reads through the standalone Cairnline MCP client; backend
+status reports those routes in `read_routes` while `read_model_switch_ready`
+remains false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
@@ -2847,7 +2848,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, and skills read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, and memory-candidate read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3060,7 +3061,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, and skills read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, and memory-candidate read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -4585,6 +4586,10 @@ reports `read_model_switch_ready=true`, this endpoint renders accepted project
 memory from the Cairnline read model and marks each item with
 `read_backend: "cairnline"`. Create, update, and delete requests still mutate
 Hecate's native memory stores until the Cairnline write adapter is ready.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, this endpoint reads the
+project and memory entries through the standalone Cairnline MCP client and
+requires typed `structuredContent`; text-only sidecar output is rejected.
 
 ```json
 GET /hecate/v1/projects/proj_.../memory?include_disabled=true
@@ -4665,6 +4670,10 @@ from the Cairnline read model and marks each item with
 `read_backend: "cairnline"`. Candidate creation, promotion, and rejection still
 mutate Hecate's native memory-candidate store until the Cairnline write adapter
 is ready.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, this endpoint reads the
+project and memory candidates through the standalone Cairnline MCP client and
+requires typed `structuredContent`; text-only sidecar output is rejected.
 
 Candidates are review artifacts, not durable memory. Operators should inspect
 the candidate body, suggested trust/source fields, and `source_refs` before

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -1248,6 +1248,9 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_entries.list arguments")
 		}
 		items := cairnlineSidecarFixtureProjectMemoryEntries(state, input.ProjectID, input.IncludeDisabled)
+		if mode == "memory-fixture" && len(items) == 0 {
+			items = cairnlineSidecarFixtureDefaultMemoryEntries(input.ProjectID, input.IncludeDisabled)
+		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Memory entries for %s (%d)", input.ProjectID, len(items)), items)
 	case "memory_entries.get":
 		var input struct {
@@ -1354,6 +1357,9 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid memory_candidates.list arguments")
 		}
 		items := cairnlineSidecarFixtureProjectMemoryCandidates(state, input.ProjectID, input.IncludeResolved, input.Status)
+		if mode == "memory-fixture" && len(items) == 0 {
+			items = cairnlineSidecarFixtureDefaultMemoryCandidates(input.ProjectID, input.IncludeResolved, input.Status)
+		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Memory candidates for %s (%d)", input.ProjectID, len(items)), items)
 	case "memory_candidates.get":
 		var input struct {
@@ -1660,6 +1666,35 @@ func cairnlineSidecarFixtureProjectMemoryEntries(state *cairnlineSidecarFixtureS
 	return entries
 }
 
+func cairnlineSidecarFixtureDefaultMemoryEntries(projectID string, includeDisabled bool) []ProjectCairnlineSidecarMemoryEntryItem {
+	entries := []ProjectCairnlineSidecarMemoryEntryItem{
+		{
+			ProjectID:  projectID,
+			ID:         "mem_fixture",
+			Title:      "Fixture memory",
+			Body:       "Remember the fixture sidecar memory contract.",
+			TrustLabel: "operator_memory",
+			SourceKind: "test_fixture",
+			SourceID:   "fixture-memory",
+			Enabled:    true,
+		},
+		{
+			ProjectID:  projectID,
+			ID:         "mem_disabled_fixture",
+			Title:      "Disabled fixture memory",
+			Body:       "This memory entry is disabled.",
+			TrustLabel: "operator_memory",
+			SourceKind: "test_fixture",
+			SourceID:   "fixture-memory-disabled",
+			Enabled:    false,
+		},
+	}
+	if includeDisabled {
+		return entries
+	}
+	return entries[:1]
+}
+
 func cairnlineSidecarFixtureEnsureMemoryCandidates(state *cairnlineSidecarFixtureState, projectID string) map[string]ProjectCairnlineSidecarMemoryCandidateItem {
 	if state.memoryCandidates[projectID] == nil {
 		state.memoryCandidates[projectID] = make(map[string]ProjectCairnlineSidecarMemoryCandidateItem)
@@ -1680,6 +1715,51 @@ func cairnlineSidecarFixtureProjectMemoryCandidates(state *cairnlineSidecarFixtu
 		candidates = append(candidates, candidate)
 	}
 	return candidates
+}
+
+func cairnlineSidecarFixtureDefaultMemoryCandidates(projectID string, includeResolved bool, status string) []ProjectCairnlineSidecarMemoryCandidateItem {
+	candidates := []ProjectCairnlineSidecarMemoryCandidateItem{
+		{
+			ProjectID:           projectID,
+			ID:                  "memcand_fixture",
+			Title:               "Fixture candidate",
+			Body:                "Promote this fixture candidate when it becomes durable.",
+			SuggestedKind:       "project_guidance",
+			SuggestedTrustLabel: "generated_summary",
+			SuggestedSourceKind: "test_fixture",
+			SuggestedSourceID:   "fixture-candidate",
+			SourceRefs: []ProjectCairnlineSidecarMemoryCandidateSourceRef{{
+				Kind:  "evidence",
+				ID:    "evidence_fixture",
+				Title: "Fixture evidence",
+				URL:   "https://example.test/evidence",
+			}},
+			Status: "pending",
+		},
+		{
+			ProjectID:           projectID,
+			ID:                  "memcand_rejected_fixture",
+			Title:               "Rejected fixture candidate",
+			Body:                "This candidate was rejected.",
+			SuggestedKind:       "project_guidance",
+			SuggestedTrustLabel: "generated_summary",
+			SuggestedSourceKind: "test_fixture",
+			SuggestedSourceID:   "fixture-candidate-rejected",
+			Status:              "rejected",
+			StatusReason:        "Not durable.",
+		},
+	}
+	out := make([]ProjectCairnlineSidecarMemoryCandidateItem, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strings.TrimSpace(status) != "" && candidate.Status != status {
+			continue
+		}
+		if strings.TrimSpace(status) == "" && !includeResolved && candidate.Status != "pending" {
+			continue
+		}
+		out = append(out, candidate)
+	}
+	return out
 }
 
 func cairnlineSidecarFixtureProjectAssistantProposals(state *cairnlineSidecarFixtureState, projectID string) []ProjectCairnlineSidecarAssistantProposalRecordItem {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, and skills through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, and memory candidates through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, and skills through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, and memory candidates through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_cairnline_sidecar_health.go
+++ b/internal/api/handler_project_cairnline_sidecar_health.go
@@ -194,24 +194,7 @@ func (h *Handler) cairnlineSidecarProjectHandoffs(ctx context.Context, projectID
 }
 
 func (h *Handler) cairnlineSidecarProjectMemoryCandidates(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarMemoryCandidateItem, error) {
-	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "memory_candidates.list", map[string]any{
-		"project_id":       strings.TrimSpace(projectID),
-		"include_resolved": true,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if result.IsError {
-		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list returned a tool-level error: " + strings.TrimSpace(result.Text))
-	}
-	candidates, structuredReady, structuredErr := projectCairnlineSidecarStructuredMemoryCandidates(result.Result.StructuredContent)
-	if structuredErr != nil {
-		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list structuredContent parse failed: " + structuredErr.Error())
-	}
-	if !structuredReady {
-		return nil, projectCairnlineSidecarReadFailure("memory_candidates.list did not return typed structuredContent")
-	}
-	return candidates, nil
+	return h.cairnlineSidecarProjectMemoryCandidateList(ctx, projectID, "", true)
 }
 
 func (h *Handler) cairnlineSidecarAgentProfiles(ctx context.Context) ([]ProjectCairnlineSidecarAgentProfileItem, error) {

--- a/internal/api/handler_project_cairnline_sidecar_setup_readiness.go
+++ b/internal/api/handler_project_cairnline_sidecar_setup_readiness.go
@@ -120,9 +120,13 @@ func (h *Handler) cairnlineSidecarProjectSkills(ctx context.Context, projectID s
 }
 
 func (h *Handler) cairnlineSidecarProjectMemoryEntries(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarMemoryEntryItem, error) {
+	return h.cairnlineSidecarProjectMemoryEntryList(ctx, projectID, true)
+}
+
+func (h *Handler) cairnlineSidecarProjectMemoryEntryList(ctx context.Context, projectID string, includeDisabled bool) ([]ProjectCairnlineSidecarMemoryEntryItem, error) {
 	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "memory_entries.list", map[string]any{
 		"project_id":       strings.TrimSpace(projectID),
-		"include_disabled": true,
+		"include_disabled": includeDisabled,
 	})
 	if err != nil {
 		return nil, err
@@ -141,10 +145,20 @@ func (h *Handler) cairnlineSidecarProjectMemoryEntries(ctx context.Context, proj
 }
 
 func (h *Handler) cairnlineSidecarProjectPendingMemoryCandidates(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarMemoryCandidateItem, error) {
-	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "memory_candidates.list", map[string]string{
+	return h.cairnlineSidecarProjectMemoryCandidateList(ctx, projectID, "pending", false)
+}
+
+func (h *Handler) cairnlineSidecarProjectMemoryCandidateList(ctx context.Context, projectID, status string, includeResolved bool) ([]ProjectCairnlineSidecarMemoryCandidateItem, error) {
+	args := map[string]any{
 		"project_id": strings.TrimSpace(projectID),
-		"status":     "pending",
-	})
+	}
+	if strings.TrimSpace(status) != "" {
+		args["status"] = strings.TrimSpace(status)
+	}
+	if includeResolved {
+		args["include_resolved"] = true
+	}
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "memory_candidates.list", args)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -54,6 +54,8 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"setup-readiness",
 	"health",
 	"skills",
+	"memory",
+	"memory-candidate",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -351,13 +353,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, and skills routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, and skills use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for memory, work, assignments, activity, assistant, and operations routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for work, assignments, activity, assistant, and operations routes are not wired.",
 				}
 				return response
 			}
@@ -794,7 +796,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, and skills use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -807,7 +809,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, and skills through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, and skills") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_memory.go
+++ b/internal/api/handler_project_memory.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
 )
 
 type createProjectMemoryRequest struct {
@@ -60,16 +61,20 @@ type updateProjectMemoryRequest struct {
 
 func (h *Handler) HandleProjectMemoryEntries(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("id"))
-	if !h.requireProjectExists(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProjectExists(w, r, projectID) {
 		return
 	}
-	if !h.requireProjectMemoryStore(w) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProjectMemoryStore(w) {
 		return
 	}
 	includeDisabled := requestBool(r, "include_disabled")
 	items, err := h.renderProjectMemoryEntries(r.Context(), projectID, includeDisabled)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectMemoryListResponse{Object: "project_memory", Data: items})
@@ -131,11 +136,13 @@ func (h *Handler) HandleCreateProjectMemoryEntry(w http.ResponseWriter, r *http.
 
 func (h *Handler) HandleProjectMemoryCandidates(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("id"))
-	if !h.requireProjectExists(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProjectExists(w, r, projectID) {
 		return
 	}
-	if _, ok := h.requireProjectMemoryCandidateStore(w); !ok {
-		return
+	if !h.projectCairnlineSidecarReadRoutesEnabled() {
+		if _, ok := h.requireProjectMemoryCandidateStore(w); !ok {
+			return
+		}
 	}
 	status := strings.TrimSpace(r.URL.Query().Get("status"))
 	if status == "" && !requestBool(r, "include_resolved") {
@@ -143,7 +150,11 @@ func (h *Handler) HandleProjectMemoryCandidates(w http.ResponseWriter, r *http.R
 	}
 	items, err := h.renderProjectMemoryCandidates(r.Context(), projectID, status, requestBool(r, "include_resolved"))
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectMemoryCandidateListResponse{Object: "project_memory_candidates", Data: items})
@@ -452,6 +463,9 @@ func (h *Handler) requireProjectMemoryCandidateStore(w http.ResponseWriter) (mem
 }
 
 func (h *Handler) renderProjectMemoryEntries(ctx context.Context, projectID string, includeDisabled bool) ([]ProjectMemoryResponseItem, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectMemoryEntries(ctx, projectID, includeDisabled)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectMemoryEntries(ctx, projectID, includeDisabled)
 	}
@@ -482,7 +496,26 @@ func (h *Handler) renderCairnlineProjectMemoryEntries(ctx context.Context, proje
 	return out, nil
 }
 
+func (h *Handler) renderCairnlineSidecarProjectMemoryEntries(ctx context.Context, projectID string, includeDisabled bool) ([]ProjectMemoryResponseItem, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	items, err := h.cairnlineSidecarProjectMemoryEntryList(ctx, project.ID, includeDisabled)
+	if err != nil {
+		return nil, err
+	}
+	return renderProjectMemoryEntries(projectMemoryEntriesFromCairnlineSidecar(items), "cairnline"), nil
+}
+
 func (h *Handler) renderProjectMemoryCandidates(ctx context.Context, projectID, status string, includeResolved bool) ([]ProjectMemoryCandidateResponseItem, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectMemoryCandidates(ctx, projectID, status, includeResolved)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectMemoryCandidates(ctx, projectID, status, includeResolved)
 	}
@@ -518,6 +551,22 @@ func (h *Handler) renderCairnlineProjectMemoryCandidates(ctx context.Context, pr
 		out = append(out, renderProjectMemoryCandidate(projectMemoryCandidateFromCairnline(item), "cairnline"))
 	}
 	return out, nil
+}
+
+func (h *Handler) renderCairnlineSidecarProjectMemoryCandidates(ctx context.Context, projectID, status string, includeResolved bool) ([]ProjectMemoryCandidateResponseItem, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	items, err := h.cairnlineSidecarProjectMemoryCandidateList(ctx, project.ID, status, includeResolved)
+	if err != nil {
+		return nil, err
+	}
+	return renderProjectMemoryCandidates(projectMemoryCandidatesFromCairnlineSidecar(items), "cairnline"), nil
 }
 
 func renderProjectMemoryEntries(items []memory.Entry, readBackend string) []ProjectMemoryResponseItem {

--- a/internal/api/handler_project_memory_test.go
+++ b/internal/api/handler_project_memory_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hecatehq/cairnline"
@@ -743,6 +744,106 @@ func TestProjectMemoryAPI_CandidatesUseCairnlineReadModelWhenConfigured(t *testi
 		t.Fatalf("List native memory candidates: %v", err)
 	}
 	assertProjectMemoryCandidateProjectionParity(t, renderProjectMemoryCandidates(nativeCandidates, "hecate"), listed.Data)
+}
+
+func TestProjectMemoryAPI_ListUsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "memory-fixture")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar memory list enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/memory", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("memory status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectMemoryListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode memory response: %v", err)
+	}
+	if response.Object != "project_memory" || len(response.Data) != 1 {
+		t.Fatalf("memory response = %+v, want one enabled fixture entry", response)
+	}
+	entry := projectMemoryResponseForTest(response.Data, "mem_fixture")
+	if entry == nil || entry.ReadBackend != "cairnline" || entry.ProjectID != "proj_fixture" || !entry.Enabled || entry.Title != "Fixture memory" {
+		t.Fatalf("memory entry = %+v, want sidecar Cairnline fixture memory", entry)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/memory?include_disabled=true", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("memory include-disabled status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	response = ProjectMemoryListResponse{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode include-disabled memory response: %v", err)
+	}
+	disabled := projectMemoryResponseForTest(response.Data, "mem_disabled_fixture")
+	if len(response.Data) != 2 || disabled == nil || disabled.ReadBackend != "cairnline" || disabled.Enabled {
+		t.Fatalf("memory entries = %+v, want disabled sidecar fixture included", response.Data)
+	}
+}
+
+func TestProjectMemoryAPI_CandidatesUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "memory-fixture")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar memory candidates enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/memory/candidates", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("memory candidates status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectMemoryCandidateListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode memory candidates response: %v", err)
+	}
+	pending := projectMemoryCandidateResponseForTest(response.Data, "memcand_fixture")
+	if len(response.Data) != 1 || pending == nil || pending.ReadBackend != "cairnline" || pending.ProjectID != "proj_fixture" || pending.Status != memory.CandidateStatusPending || len(pending.SourceRefs) != 1 {
+		t.Fatalf("memory candidates = %+v, want one pending sidecar fixture candidate", response.Data)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/memory/candidates?include_resolved=true", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("memory candidates include-resolved status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	response = ProjectMemoryCandidateListResponse{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode include-resolved memory candidates response: %v", err)
+	}
+	rejected := projectMemoryCandidateResponseForTest(response.Data, "memcand_rejected_fixture")
+	if len(response.Data) != 2 || rejected == nil || rejected.ReadBackend != "cairnline" || rejected.Status != memory.CandidateStatusRejected || rejected.StatusReason != "Not durable." {
+		t.Fatalf("memory candidates = %+v, want rejected sidecar fixture candidate included", response.Data)
+	}
+}
+
+func TestProjectMemoryAPI_CairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	for _, endpoint := range []string{
+		"/hecate/v1/projects/proj_fixture/memory",
+		"/hecate/v1/projects/proj_fixture/memory/candidates",
+	} {
+		rec := httptest.NewRecorder()
+		server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, endpoint, nil))
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("%s status = %d body=%s, want 502", endpoint, rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "structuredContent") {
+			t.Fatalf("%s error body = %s, want structuredContent diagnostic", endpoint, rec.Body.String())
+		}
+	}
 }
 
 func TestProjectMemoryAPI_ValidationAndScoping(t *testing.T) {


### PR DESCRIPTION
## Summary
- route project memory and memory-candidate list reads through the configured Cairnline sidecar read source
- keep setup/health sidecar memory behavior intact while sharing the typed list helpers
- update backend-status route lists and operator/design/runtime docs for the expanded sidecar read boundary

## Tests
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectMemoryAPI_(ListUsesCairnlineSidecarWhenConfigured|CandidatesUseCairnlineSidecarWhenConfigured|CairnlineSidecarReadRequiresStructuredContent|ListUsesCairnlineReadModelWhenConfigured|CandidatesUseCairnlineReadModelWhenConfigured)|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady|TestProjectSetupReadiness_ReadsUseCairnlineSidecarWhenConfigured|TestProjectHealth_ReadsUseCairnlineSidecarWhenConfigured'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...