### PR TITLE
feat(projects): route sidecar project roles

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -181,8 +181,8 @@ removal of the temporary project.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
 routes only project list/detail, setup-readiness, health, project skill list,
-project memory list, and memory-candidate list reads through the cached
-standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
+project memory list, memory-candidate list, and project role list reads through
+the cached standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
 dispatch, approvals, and write-authority switchpoints remain Hecate-native or
 on the embedded dogfood path until sidecar-specific adapters exist for those
 route families.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -375,8 +375,8 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` plus
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
   list/detail, setup-readiness, health, project skill list, project memory
-  list, and memory-candidate list reads through the cached standalone MCP
-  client. Other live Projects reads, writes, mirrors, and write-authority
+  list, memory-candidate list, and project role list reads through the cached
+  standalone MCP client. Other live Projects reads, writes, mirrors, and write-authority
   switchpoints do not route through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
@@ -394,8 +394,8 @@ launch agents. Those remain explicit operator or orchestrator actions.
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the explicit sidecar read-source routes for project
-  list/detail, setup-readiness, health, skills, memory, and memory candidates,
-  project identity and some compatibility scaffolding remain Hecate-owned until
+  list/detail, setup-readiness, health, skills, memory, memory candidates, and
+  roles, project identity and some compatibility scaffolding remain Hecate-owned until
   Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -437,14 +437,14 @@ mirror database, project row, or proposal record is missing; run
 reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list, and
-memory-candidate list reads through the standalone Cairnline MCP client; all
-other live Projects read routes remain Hecate-native or use the embedded
-dogfood read model when that is configured. Activity, work-item list/detail,
+memory-candidate list, and project role list reads through the standalone
+Cairnline MCP client; all other live Projects read routes remain Hecate-native
+or use the embedded dogfood read model when that is configured. Activity, work-item list/detail,
 assignment-list, and operations brief reads render the work graph from Cairnline
 service records and overlay Hecate-only runtime refs/timestamps while Hecate
 still owns execution. Outside the explicit sidecar read-source routes for
-project list/detail, setup-readiness, health, skills, memory, and memory
-candidates, project identity and some compatibility scaffolding remain
+project list/detail, setup-readiness, health, skills, memory, memory candidates,
+and roles, project identity and some compatibility scaffolding remain
 Hecate-owned until Cairnline becomes authoritative. Project identity,
 metadata/default, root, and context-source mutations still write Hecate stores
 first and then best-effort mirror into the embedded Cairnline database through

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -509,8 +509,9 @@ sequenceDiagram
   role/work/assignment side effects, then deletes and verifies removal of the
   temporary project. Live Projects writes still use Hecate-native stores in
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
-  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness
-  and health use the same sidecar source when it is configured.
+  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness,
+  health, skills, memory, memory candidates, and roles use the same sidecar
+  source when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -525,9 +526,9 @@ sequenceDiagram
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
   project list/detail, setup-readiness, health, project skill list, project
-  memory list, and memory-candidate list reads through the standalone Cairnline
-  MCP client; all other live Projects read routes stay on Hecate-native or
-  embedded dogfood paths.
+  memory list, memory-candidate list, and project role list reads through the
+  standalone Cairnline MCP client; all other live Projects read routes stay on
+  Hecate-native or embedded dogfood paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2407,9 +2408,10 @@ snapshot-seeded bridge, and `embedded` requires the mirror database and
 requested project row or proposal record to exist so replacement-readiness gaps
 fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
-setup-readiness, health, project skill list, project memory list, and
-memory-candidate list reads through the standalone Cairnline MCP client; backend
-status reports those routes in `read_routes` while `read_model_switch_ready`
+setup-readiness, health, project skill list, project memory list,
+memory-candidate list, and project role list reads through the standalone
+Cairnline MCP client; backend status reports those routes in `read_routes` while
+`read_model_switch_ready`
 remains false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
@@ -2848,7 +2850,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, and memory-candidate read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, and roles read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3061,7 +3063,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, and memory-candidate read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, and roles read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -5437,6 +5439,14 @@ reports `read_model_switch_ready=true`, this endpoint uses the Cairnline read
 model and enriches the portable roles with Hecate built-in flags plus
 role-level provider/model execution defaults. `read_backend` identifies the
 source of the role read model.
+
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, this
+endpoint calls `projects.get` and typed `roles.list` through the standalone
+Cairnline MCP client. Sidecar roles expose portable role metadata such as
+profile, execution-mode, and skill defaults; Hecate-specific provider/model
+defaults remain absent unless they are projected by a Hecate-owned embedded
+read path.
 
 ```json
 {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, and memory candidates through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, and roles through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, and memory candidates through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, and roles through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -56,6 +56,7 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"skills",
 	"memory",
 	"memory-candidate",
+	"roles",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -353,11 +354,11 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
 					"Full Cairnline read-model replacement remains blocked because sidecar adapters for work, assignments, activity, assistant, and operations routes are not wired.",
 				}
@@ -796,7 +797,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -809,7 +810,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, and memory-candidate") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
@@ -341,12 +342,16 @@ func (h *Handler) HandleProjectActivity(w http.ResponseWriter, r *http.Request) 
 
 func (h *Handler) HandleProjectWorkRoles(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	data, err := h.renderProjectWorkRoles(r.Context(), projectID)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkRolesResponse{Object: "project_roles", Data: data})

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
@@ -90,6 +91,9 @@ func (h *Handler) renderCairnlineProjectHandoffs(ctx context.Context, filter pro
 }
 
 func (h *Handler) renderProjectWorkRoles(ctx context.Context, projectID string) ([]ProjectWorkRoleResponse, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectWorkRoles(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectWorkRoles(ctx, projectID)
 	}
@@ -101,6 +105,28 @@ func (h *Handler) renderProjectWorkRoles(ctx context.Context, projectID string) 
 	for _, role := range roles {
 		projected := renderProjectWorkRole(role)
 		projected.ReadBackend = "hecate"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineSidecarProjectWorkRoles(ctx context.Context, projectID string) ([]ProjectWorkRoleResponse, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	roles, err := h.cairnlineSidecarProjectRoles(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]ProjectWorkRoleResponse, 0, len(roles))
+	for _, role := range projectRolesFromCairnlineSidecar(roles) {
+		projected := renderProjectWorkRole(role)
+		projected.ReadBackend = "cairnline"
 		data = append(data, projected)
 	}
 	return data, nil

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1353,6 +1353,54 @@ func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured
 	}
 }
 
+func TestProjectWorkAPI_RolesUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar role list enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/roles", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("roles status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkRolesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode roles response: %v", err)
+	}
+	if response.Object != "project_roles" {
+		t.Fatalf("roles object = %q, want project_roles", response.Object)
+	}
+	role := findProjectWorkRoleForTest(t, response.Data, "role_fixture")
+	if role.ProjectID != "proj_fixture" || role.ReadBackend != "cairnline" || role.BuiltIn {
+		t.Fatalf("role = %+v, want sidecar Cairnline non-built-in fixture role", role)
+	}
+	if role.Name != "Fixture Reviewer" || role.DefaultDriverKind != "mcp_pull" || role.DefaultAgentProfile != "profile_fixture" {
+		t.Fatalf("role defaults = %+v, want portable sidecar role defaults", role)
+	}
+	if !reflect.DeepEqual(role.SkillIDs, []string{"skill_fixture"}) {
+		t.Fatalf("role skill ids = %+v, want fixture skill id", role.SkillIDs)
+	}
+}
+
+func TestProjectWorkAPI_RolesCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/roles", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("roles status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_CreateHandoffGeneratesOpaqueHandoffID(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectWorkTestServer()


### PR DESCRIPTION
## Summary
- route GET /hecate/v1/projects/{id}/roles through the Cairnline sidecar when sidecar read-source mode is enabled
- mark roles in the sidecar read-route backend status and operator/design docs
- add typed structuredContent and text-only failure coverage for the sidecar roles route

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(RolesUseCairnlineSidecarWhenConfigured|RolesCairnlineSidecarReadRequiresStructuredContent)|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady|TestProjectSetupReadiness_ReadsUseCairnlineSidecarWhenConfigured|TestProjectHealth_ReadsUseCairnlineSidecarWhenConfigured|TestProjectSkillsAPI_ListUsesCairnlineSidecarWhenConfigured|TestProjectMemoryAPI_(EntriesUseCairnlineSidecarWhenConfigured|CandidatesUseCairnlineSidecarWhenConfigured)'\n- just agent-docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- GOCACHE="$PWD/.gocache" go vet ./...\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n