### PR TITLE
feat(projects): route sidecar work items

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -181,11 +181,11 @@ removal of the temporary project.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
 routes only project list/detail, setup-readiness, health, project skill list,
-project memory list, memory-candidate list, and project role list reads through
-the cached standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
-dispatch, approvals, and write-authority switchpoints remain Hecate-native or
-on the embedded dogfood path until sidecar-specific adapters exist for those
-route families.
+project memory list, memory-candidate list, project role list, and work-item
+list/detail reads through the cached standalone Cairnline MCP client. Other
+Projects reads, writes, mirrors, dispatch, approvals, and write-authority
+switchpoints remain Hecate-native or on the embedded dogfood path until
+sidecar-specific adapters exist for those route families.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
@@ -211,10 +211,10 @@ In embedded read-source modes, project identity and some compatibility
 scaffolding still come from Hecate until Cairnline becomes authoritative; the
 explicit sidecar read-source routes are the narrow exception for project
 list/detail, setup-readiness, health, project skill list, project memory list,
-and memory-candidate list reads. Project Assistant draft generation also uses
-the Cairnline-projected context so preview and proposal assembly stay aligned,
-while the proposal ledger remains Hecate-owned unless
-`project-assistant-proposals` is enabled.
+memory-candidate list, project role list, and work-item list/detail reads.
+Project Assistant draft generation also uses the Cairnline-projected context so
+preview and proposal assembly stay aligned, while the proposal ledger remains
+Hecate-owned unless `project-assistant-proposals` is enabled.
 Confirmed Project Assistant apply routes role, work-item, assignment, and
 handoff actions through the same opt-in Cairnline authority switchpoints when
 those switchpoints are enabled; project/default/chat/memory/runtime side

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -375,9 +375,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` plus
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
   list/detail, setup-readiness, health, project skill list, project memory
-  list, memory-candidate list, and project role list reads through the cached
-  standalone MCP client. Other live Projects reads, writes, mirrors, and write-authority
-  switchpoints do not route through the sidecar yet.
+  list, memory-candidate list, project role list, and work-item list/detail
+  reads through the cached standalone MCP client. Other live Projects reads,
+  writes, mirrors, and write-authority switchpoints do not route through the
+  sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -394,9 +395,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the explicit sidecar read-source routes for project
-  list/detail, setup-readiness, health, skills, memory, memory candidates, and
-  roles, project identity and some compatibility scaffolding remain Hecate-owned until
-  Cairnline becomes authoritative.
+  list/detail, setup-readiness, health, skills, memory, memory candidates, roles,
+  and work items, project identity and some compatibility scaffolding remain
+  Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -436,15 +436,16 @@ mirror database, project row, or proposal record is missing; run
 `POST /hecate/v1/projects/cairnline/sync` first when dogfooding strict embedded
 reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
-setup-readiness, health, project skill list, project memory list, and
-memory-candidate list, and project role list reads through the standalone
-Cairnline MCP client; all other live Projects read routes remain Hecate-native
-or use the embedded dogfood read model when that is configured. Activity, work-item list/detail,
-assignment-list, and operations brief reads render the work graph from Cairnline
-service records and overlay Hecate-only runtime refs/timestamps while Hecate
-still owns execution. Outside the explicit sidecar read-source routes for
+setup-readiness, health, project skill list, project memory list,
+memory-candidate list, project role list, and work-item list/detail reads
+through the standalone Cairnline MCP client; all other live Projects read routes
+remain Hecate-native or use the embedded dogfood read model when that is
+configured. Activity, work-item list/detail, assignment-list, and operations
+brief reads render the work graph from Cairnline service records and overlay
+Hecate-only runtime refs/timestamps while Hecate still owns execution. Outside
+the explicit sidecar read-source routes for
 project list/detail, setup-readiness, health, skills, memory, memory candidates,
-and roles, project identity and some compatibility scaffolding remain
+roles, and work items, project identity and some compatibility scaffolding remain
 Hecate-owned until Cairnline becomes authoritative. Project identity,
 metadata/default, root, and context-source mutations still write Hecate stores
 first and then best-effort mirror into the embedded Cairnline database through

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -510,8 +510,8 @@ sequenceDiagram
   temporary project. Live Projects writes still use Hecate-native stores in
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness,
-  health, skills, memory, memory candidates, and roles use the same sidecar
-  source when it is configured.
+  health, skills, memory, memory candidates, roles, and work items use the
+  same sidecar source when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -526,9 +526,9 @@ sequenceDiagram
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
   project list/detail, setup-readiness, health, project skill list, project
-  memory list, memory-candidate list, and project role list reads through the
-  standalone Cairnline MCP client; all other live Projects read routes stay on
-  Hecate-native or embedded dogfood paths.
+  memory list, memory-candidate list, project role list, and work-item
+  list/detail reads through the standalone Cairnline MCP client; all other live
+  Projects read routes stay on Hecate-native or embedded dogfood paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2409,9 +2409,9 @@ requested project row or proposal record to exist so replacement-readiness gaps
 fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
-memory-candidate list, and project role list reads through the standalone
-Cairnline MCP client; backend status reports those routes in `read_routes` while
-`read_model_switch_ready`
+memory-candidate list, project role list, and work-item list/detail reads
+through the standalone Cairnline MCP client; backend status reports those routes
+in `read_routes` while `read_model_switch_ready`
 remains false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
@@ -2850,7 +2850,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, and roles read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3063,7 +3063,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, and roles read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -5532,6 +5532,13 @@ reports `read_model_switch_ready=true`, the work-item set is read from the
 Cairnline read model and then enriched with Hecate runtime assignment
 projection. `read_backend` identifies that read-model source.
 
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, this
+endpoint calls `projects.get`, typed `work_items.list`, and typed
+`assignments.list` through the standalone Cairnline MCP client. Assignment
+summaries remain portable metadata unless their execution refs point at
+Hecate-owned runtime records that can be projected locally.
+
 #### `POST /hecate/v1/projects/{id}/work-items`
 
 Creates a project-scoped work item. `title` is required. `status` defaults to
@@ -5577,6 +5584,10 @@ Returns:
 Returns one work item or `404 not_found`. Under the same Cairnline read-route
 switch described above, the selected work item is read from Cairnline and
 enriched with Hecate assignment runtime projection.
+In sidecar read-source mode, detail is resolved from the typed
+`work_items.list` result for the project plus typed `assignments.list`
+metadata; `work_items.get` remains a sidecar diagnostic/smoke contract rather
+than a live Hecate detail-route dependency.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/readiness`
 

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, and roles through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, and work items through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, and roles through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, and work items through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -57,6 +57,7 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"memory",
 	"memory-candidate",
 	"roles",
+	"work-item",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -354,13 +355,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for work, assignments, activity, assistant, and operations routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignments, collaboration, activity, assistant, and operations routes are not wired.",
 				}
 				return response
 			}
@@ -797,7 +798,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -810,7 +811,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, and roles") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -451,12 +451,16 @@ func (h *Handler) HandleDeleteProjectWorkRole(w http.ResponseWriter, r *http.Req
 
 func (h *Handler) HandleProjectWorkItems(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	data, err := h.renderProjectWorkItems(r.Context(), projectID)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkItemsResponse{Object: "project_work_items", Data: data})
@@ -507,7 +511,24 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 
 func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
+		return
+	}
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		projected, err := h.renderCairnlineSidecarProjectWorkItem(r.Context(), projectID, r.PathValue("work_item_id"))
+		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+				return
+			}
+			if errors.Is(err, projectwork.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+				return
+			}
+			writeProjectReadRenderError(w, err)
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
 		return
 	}
 	if h.projectReadRoutesUseCairnlineReadModel() {

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -158,6 +158,9 @@ func (h *Handler) renderCairnlineProjectWorkRoles(ctx context.Context, projectID
 }
 
 func (h *Handler) renderProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectWorkItems(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectWorkItems(ctx, projectID)
 	}
@@ -185,6 +188,52 @@ func (h *Handler) renderNativeProjectWorkItems(ctx context.Context, projectID st
 		data = append(data, projected)
 	}
 	return data, nil
+}
+
+func (h *Handler) renderCairnlineSidecarProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	items, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	assignments, err := h.cairnlineSidecarProjectAssignments(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	workItems := projectWorkItemsFromCairnlineSidecar(items)
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(projectAssignmentsFromCairnlineSidecar(assignments))
+	data := make([]ProjectWorkItemResponse, 0, len(workItems))
+	for _, item := range workItems {
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
+		if err != nil {
+			return nil, err
+		}
+		projected.ReadBackend = "cairnline"
+		markProjectWorkAssignmentReadBackend(projected.Assignments, "cairnline")
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineSidecarProjectWorkItem(ctx context.Context, projectID, workItemID string) (ProjectWorkItemResponse, error) {
+	items, err := h.renderCairnlineSidecarProjectWorkItems(ctx, projectID)
+	if err != nil {
+		return ProjectWorkItemResponse{}, err
+	}
+	workItemID = strings.TrimSpace(workItemID)
+	for _, item := range items {
+		if item.ID == workItemID {
+			return item, nil
+		}
+	}
+	return ProjectWorkItemResponse{}, projectwork.ErrNotFound
 }
 
 func (h *Handler) renderCairnlineProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1401,6 +1401,73 @@ func TestProjectWorkAPI_RolesCairnlineSidecarReadRequiresStructuredContent(t *te
 	}
 }
 
+func TestProjectWorkAPI_WorkItemsUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar work-item list enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("work-items status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkItemsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode work-items response: %v", err)
+	}
+	if response.Object != "project_work_items" {
+		t.Fatalf("work-items object = %q, want project_work_items", response.Object)
+	}
+	item := findProjectWorkItemForTest(t, response.Data, "work_fixture")
+	if item.ProjectID != "proj_fixture" || item.ReadBackend != "cairnline" || item.Title != "Fixture Work" {
+		t.Fatalf("work item = %+v, want sidecar Cairnline fixture work item", item)
+	}
+	if item.Status != "open" || item.Priority != "normal" {
+		t.Fatalf("work item status/priority = %q/%q, want portable sidecar values", item.Status, item.Priority)
+	}
+	if len(item.Assignments) != 1 || item.Assignments[0].ID != "asg_fixture" || item.Assignments[0].ReadBackend != "cairnline" || item.Assignments[0].RoleID != "role_fixture" {
+		t.Fatalf("work item assignments = %+v, want sidecar assignment summary", item.Assignments)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("work-item detail status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var detail ProjectWorkItemEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode work-item detail response: %v", err)
+	}
+	if detail.Object != "project_work_item" || detail.Data.ID != "work_fixture" || detail.Data.ReadBackend != "cairnline" || len(detail.Data.Assignments) != 1 {
+		t.Fatalf("work-item detail = %+v, want sidecar Cairnline detail", detail)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/missing", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_WorkItemsCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("work-items status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_CreateHandoffGeneratesOpaqueHandoffID(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectWorkTestServer()


### PR DESCRIPTION
## Summary
- route project work-item list/detail reads through the Cairnline sidecar when sidecar read-source mode is enabled
- include sidecar assignment summaries in work-item responses using typed assignments.list metadata
- update backend status and docs to mark work-item list/detail as sidecar-backed while keeping writes and execution Hecate-owned

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(WorkItemsUseCairnlineSidecarWhenConfigured|WorkItemsCairnlineSidecarReadRequiresStructuredContent|RolesUseCairnlineSidecarWhenConfigured|RolesCairnlineSidecarReadRequiresStructuredContent)|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady|TestProjectHealth_ReadsUseCairnlineSidecarWhenConfigured|TestProjectSetupReadiness_ReadsUseCairnlineSidecarWhenConfigured'\n- just agent-docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- git diff --check\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- GOCACHE="$PWD/.gocache" go vet ./...\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n