### PR TITLE
feat(projects): route sidecar assignment lists

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -181,11 +181,11 @@ removal of the temporary project.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
 routes only project list/detail, setup-readiness, health, project skill list,
-project memory list, memory-candidate list, project role list, and work-item
-list/detail reads through the cached standalone Cairnline MCP client. Other
-Projects reads, writes, mirrors, dispatch, approvals, and write-authority
-switchpoints remain Hecate-native or on the embedded dogfood path until
-sidecar-specific adapters exist for those route families.
+project memory list, memory-candidate list, project role list, work-item
+list/detail, and assignment-list reads through the cached standalone Cairnline
+MCP client. Other Projects reads, writes, mirrors, dispatch, approvals, and
+write-authority switchpoints remain Hecate-native or on the embedded dogfood
+path until sidecar-specific adapters exist for those route families.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
@@ -211,10 +211,11 @@ In embedded read-source modes, project identity and some compatibility
 scaffolding still come from Hecate until Cairnline becomes authoritative; the
 explicit sidecar read-source routes are the narrow exception for project
 list/detail, setup-readiness, health, project skill list, project memory list,
-memory-candidate list, project role list, and work-item list/detail reads.
-Project Assistant draft generation also uses the Cairnline-projected context so
-preview and proposal assembly stay aligned, while the proposal ledger remains
-Hecate-owned unless `project-assistant-proposals` is enabled.
+memory-candidate list, project role list, work-item list/detail, and
+assignment-list reads. Project Assistant draft generation also uses the
+Cairnline-projected context so preview and proposal assembly stay aligned, while
+the proposal ledger remains Hecate-owned unless `project-assistant-proposals` is
+enabled.
 Confirmed Project Assistant apply routes role, work-item, assignment, and
 handoff actions through the same opt-in Cairnline authority switchpoints when
 those switchpoints are enabled; project/default/chat/memory/runtime side

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -375,10 +375,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` plus
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
   list/detail, setup-readiness, health, project skill list, project memory
-  list, memory-candidate list, project role list, and work-item list/detail
-  reads through the cached standalone MCP client. Other live Projects reads,
-  writes, mirrors, and write-authority switchpoints do not route through the
-  sidecar yet.
+  list, memory-candidate list, project role list, work-item list/detail, and
+  assignment-list reads through the cached standalone MCP client. Other live
+  Projects reads, writes, mirrors, and write-authority switchpoints do not route
+  through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -396,8 +396,8 @@ launch agents. Those remain explicit operator or orchestrator actions.
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the explicit sidecar read-source routes for project
   list/detail, setup-readiness, health, skills, memory, memory candidates, roles,
-  and work items, project identity and some compatibility scaffolding remain
-  Hecate-owned until Cairnline becomes authoritative.
+  work items, and assignment lists, project identity and some compatibility
+  scaffolding remain Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -437,18 +437,18 @@ mirror database, project row, or proposal record is missing; run
 reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
-memory-candidate list, project role list, and work-item list/detail reads
-through the standalone Cairnline MCP client; all other live Projects read routes
-remain Hecate-native or use the embedded dogfood read model when that is
-configured. Activity, work-item list/detail, assignment-list, and operations
-brief reads render the work graph from Cairnline service records and overlay
-Hecate-only runtime refs/timestamps while Hecate still owns execution. Outside
-the explicit sidecar read-source routes for
+memory-candidate list, project role list, work-item list/detail, and
+assignment-list reads through the standalone Cairnline MCP client; all other
+live Projects read routes remain Hecate-native or use the embedded dogfood read
+model when that is configured. Work-item list/detail and assignment-list reads
+render the work graph from Cairnline service records and overlay Hecate-only
+runtime refs/timestamps while Hecate still owns execution. Outside the explicit
+sidecar read-source routes for
 project list/detail, setup-readiness, health, skills, memory, memory candidates,
-roles, and work items, project identity and some compatibility scaffolding remain
-Hecate-owned until Cairnline becomes authoritative. Project identity,
-metadata/default, root, and context-source mutations still write Hecate stores
-first and then best-effort mirror into the embedded Cairnline database through
+roles, work items, and assignment lists, project identity and some compatibility
+scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
+identity, metadata/default, root, and context-source mutations still write Hecate
+stores first and then best-effort mirror into the embedded Cairnline database through
 their identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -510,8 +510,8 @@ sequenceDiagram
   temporary project. Live Projects writes still use Hecate-native stores in
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness,
-  health, skills, memory, memory candidates, roles, and work items use the
-  same sidecar source when it is configured.
+  health, skills, memory, memory candidates, roles, work items, and assignment
+  lists use the same sidecar source when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -526,9 +526,10 @@ sequenceDiagram
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
   project list/detail, setup-readiness, health, project skill list, project
-  memory list, memory-candidate list, project role list, and work-item
-  list/detail reads through the standalone Cairnline MCP client; all other live
-  Projects read routes stay on Hecate-native or embedded dogfood paths.
+  memory list, memory-candidate list, project role list, work-item list/detail,
+  and assignment-list reads through the standalone Cairnline MCP client; all
+  other live Projects read routes stay on Hecate-native or embedded dogfood
+  paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2409,9 +2410,9 @@ requested project row or proposal record to exist so replacement-readiness gaps
 fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
-memory-candidate list, project role list, and work-item list/detail reads
-through the standalone Cairnline MCP client; backend status reports those routes
-in `read_routes` while `read_model_switch_ready`
+memory-candidate list, project role list, work-item list/detail, and
+assignment-list reads through the standalone Cairnline MCP client; backend
+status reports those routes in `read_routes` while `read_model_switch_ready`
 remains false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
@@ -2850,7 +2851,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3063,7 +3064,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -5663,6 +5664,12 @@ reports `read_model_switch_ready=true`, the assignment set is read from the
 Cairnline read model and then enriched with Hecate runtime execution projection.
 `read_backend` identifies that read-model source. Assignment context,
 preflight, and start/prepare routes remain Hecate-native.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, this
+endpoint validates the work item through typed `work_items.list` and reads
+assignments through typed `assignments.list` on the standalone Cairnline MCP
+client. Assignment context, launch-readiness, preflight, start/prepare, and
+status mutation routes remain Hecate-owned.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
 

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, and work items through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, and assignment lists through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, and work items through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, and assignment lists through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -58,6 +58,7 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"memory-candidate",
 	"roles",
 	"work-item",
+	"assignment-list",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -355,13 +356,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignments, collaboration, activity, assistant, and operations routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignment context/launch, collaboration, activity, assistant, and operations routes are not wired.",
 				}
 				return response
 			}
@@ -798,7 +799,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -811,7 +812,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, and work-item") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -628,6 +628,23 @@ func (h *Handler) HandleDeleteProjectWorkItem(w http.ResponseWriter, r *http.Req
 func (h *Handler) HandleProjectWorkAssignments(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		data, err := h.renderCairnlineSidecarProjectWorkAssignments(r.Context(), projectID, workItemID)
+		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+				return
+			}
+			if errors.Is(err, projectwork.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+				return
+			}
+			writeProjectReadRenderError(w, err)
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectWorkAssignmentsResponse{Object: "project_assignments", Data: data})
+		return
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		data, err := h.renderCairnlineProjectWorkAssignments(r.Context(), projectID, workItemID)
 		if err != nil {

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -236,6 +236,50 @@ func (h *Handler) renderCairnlineSidecarProjectWorkItem(ctx context.Context, pro
 	return ProjectWorkItemResponse{}, projectwork.ErrNotFound
 }
 
+func (h *Handler) renderCairnlineSidecarProjectWorkAssignments(ctx context.Context, projectID, workItemID string) ([]ProjectWorkAssignmentResponse, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	workItemID = strings.TrimSpace(workItemID)
+	workItems, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	foundWorkItem := false
+	for _, item := range workItems {
+		if item.ID == workItemID {
+			foundWorkItem = true
+			break
+		}
+	}
+	if !foundWorkItem {
+		return nil, projectwork.ErrNotFound
+	}
+	items, err := h.cairnlineSidecarProjectAssignments(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	assignments := projectAssignmentsFromCairnlineSidecar(items)
+	data := make([]ProjectWorkAssignmentResponse, 0, len(assignments))
+	for _, assignment := range assignments {
+		if strings.TrimSpace(assignment.WorkItemID) != workItemID {
+			continue
+		}
+		projected, err := h.renderProjectedProjectWorkAssignment(ctx, assignment)
+		if err != nil {
+			return nil, err
+		}
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
 func (h *Handler) renderCairnlineProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1468,6 +1468,57 @@ func TestProjectWorkAPI_WorkItemsCairnlineSidecarReadRequiresStructuredContent(t
 	}
 }
 
+func TestProjectWorkAPI_AssignmentsUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar assignment list enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assignments status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkAssignmentsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode assignments response: %v", err)
+	}
+	if response.Object != "project_assignments" || len(response.Data) != 1 {
+		t.Fatalf("assignments response = %+v, want one sidecar assignment", response)
+	}
+	assignment := response.Data[0]
+	if assignment.ID != "asg_fixture" || assignment.ProjectID != "proj_fixture" || assignment.WorkItemID != "work_fixture" || assignment.ReadBackend != "cairnline" {
+		t.Fatalf("assignment = %+v, want sidecar Cairnline fixture assignment", assignment)
+	}
+	if assignment.RoleID != "role_fixture" || assignment.DriverKind != projectwork.AssignmentDriverHecateTask || assignment.Status != projectwork.AssignmentStatusQueued {
+		t.Fatalf("assignment defaults = %+v, want portable sidecar assignment metadata", assignment)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/missing/assignments", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item assignments status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_AssignmentsCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("assignments status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_CreateHandoffGeneratesOpaqueHandoffID(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectWorkTestServer()


### PR DESCRIPTION
## Summary

- route project work-item assignment-list reads through the Cairnline sidecar read source
- validate the sidecar work item via typed `work_items.list`, read assignments via typed `assignments.list`, and preserve Hecate projection metadata with `read_backend: cairnline`
- update backend status text and docs while keeping assignment context, launch-readiness, preflight, start/prepare, and status mutations Hecate-owned

## Tests

- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(AssignmentsUseCairnlineSidecarWhenConfigured|AssignmentsCairnlineSidecarReadRequiresStructuredContent|WorkItemsUseCairnlineSidecarWhenConfigured|WorkItemsCairnlineSidecarReadRequiresStructuredContent)|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady|TestProjectHealth_ReadsUseCairnlineSidecarWhenConfigured|TestProjectSetupReadiness_ReadsUseCairnlineSidecarWhenConfigured'`\n- `just agent-docs-check`\n- `GOCACHE="$PWD/.gocache" go vet ./internal/api`\n- `git diff --check`\n- `GOCACHE="$PWD/.gocache" go test ./internal/api`\n- `GOCACHE="$PWD/.gocache" go vet ./...`\n- `GOCACHE="$PWD/.gocache" go test ./...`\n- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`