### PR TITLE
feat(projects): route sidecar collaboration lists

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -182,10 +182,11 @@ When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
 routes only project list/detail, setup-readiness, health, project skill list,
 project memory list, memory-candidate list, project role list, work-item
-list/detail, and assignment-list reads through the cached standalone Cairnline
-MCP client. Other Projects reads, writes, mirrors, dispatch, approvals, and
-write-authority switchpoints remain Hecate-native or on the embedded dogfood
-path until sidecar-specific adapters exist for those route families.
+list/detail, assignment-list, artifact-list, and handoff-list reads through the
+cached standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
+dispatch, approvals, and write-authority switchpoints remain Hecate-native or
+on the embedded dogfood path until sidecar-specific adapters exist for those
+route families.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
@@ -212,10 +213,10 @@ scaffolding still come from Hecate until Cairnline becomes authoritative; the
 explicit sidecar read-source routes are the narrow exception for project
 list/detail, setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail, and
-assignment-list reads. Project Assistant draft generation also uses the
-Cairnline-projected context so preview and proposal assembly stay aligned, while
-the proposal ledger remains Hecate-owned unless `project-assistant-proposals` is
-enabled.
+assignment-list, artifact-list, and handoff-list reads. Project Assistant draft
+generation also uses the Cairnline-projected context so preview and proposal
+assembly stay aligned, while the proposal ledger remains Hecate-owned unless
+`project-assistant-proposals` is enabled.
 Confirmed Project Assistant apply routes role, work-item, assignment, and
 handoff actions through the same opt-in Cairnline authority switchpoints when
 those switchpoints are enabled; project/default/chat/memory/runtime side

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -376,9 +376,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
   list/detail, setup-readiness, health, project skill list, project memory
   list, memory-candidate list, project role list, work-item list/detail, and
-  assignment-list reads through the cached standalone MCP client. Other live
-  Projects reads, writes, mirrors, and write-authority switchpoints do not route
-  through the sidecar yet.
+  assignment-list, artifact-list, and handoff-list reads through the cached
+  standalone MCP client. Other live Projects reads, writes, mirrors, and
+  write-authority switchpoints do not route through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -396,8 +396,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the explicit sidecar read-source routes for project
   list/detail, setup-readiness, health, skills, memory, memory candidates, roles,
-  work items, and assignment lists, project identity and some compatibility
-  scaffolding remain Hecate-owned until Cairnline becomes authoritative.
+  work items, assignment lists, artifact lists, and handoff lists, project
+  identity and some compatibility scaffolding remain Hecate-owned until
+  Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -438,17 +438,19 @@ reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail, and
-assignment-list reads through the standalone Cairnline MCP client; all other
-live Projects read routes remain Hecate-native or use the embedded dogfood read
-model when that is configured. Work-item list/detail and assignment-list reads
-render the work graph from Cairnline service records and overlay Hecate-only
-runtime refs/timestamps while Hecate still owns execution. Outside the explicit
-sidecar read-source routes for
+assignment-list, artifact-list, and handoff-list reads through the standalone
+Cairnline MCP client; all other live Projects read routes remain Hecate-native
+or use the embedded dogfood read model when that is configured. Work-item
+list/detail, assignment-list, artifact-list, and handoff-list reads render the
+work graph from Cairnline service records and overlay Hecate-only runtime
+refs/timestamps while Hecate still owns execution. Outside the explicit sidecar
+read-source routes for
 project list/detail, setup-readiness, health, skills, memory, memory candidates,
-roles, work items, and assignment lists, project identity and some compatibility
-scaffolding remain Hecate-owned until Cairnline becomes authoritative. Project
-identity, metadata/default, root, and context-source mutations still write Hecate
-stores first and then best-effort mirror into the embedded Cairnline database through
+roles, work items, assignment lists, artifact lists, and handoff lists, project
+identity and some compatibility scaffolding remain Hecate-owned until Cairnline
+becomes authoritative. Project identity, metadata/default, root, and
+context-source mutations still write Hecate stores first and then best-effort
+mirror into the embedded Cairnline database through
 their identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -510,8 +510,9 @@ sequenceDiagram
   temporary project. Live Projects writes still use Hecate-native stores in
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness,
-  health, skills, memory, memory candidates, roles, work items, and assignment
-  lists use the same sidecar source when it is configured.
+  health, skills, memory, memory candidates, roles, work items, assignment
+  lists, artifact lists, and handoff lists use the same sidecar source when it
+  is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -527,9 +528,9 @@ sequenceDiagram
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
   project list/detail, setup-readiness, health, project skill list, project
   memory list, memory-candidate list, project role list, work-item list/detail,
-  and assignment-list reads through the standalone Cairnline MCP client; all
-  other live Projects read routes stay on Hecate-native or embedded dogfood
-  paths.
+  assignment-list, artifact-list, and handoff-list reads through the standalone
+  Cairnline MCP client; all other live Projects read routes stay on
+  Hecate-native or embedded dogfood paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2410,9 +2411,10 @@ requested project row or proposal record to exist so replacement-readiness gaps
 fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
-memory-candidate list, project role list, work-item list/detail, and
-assignment-list reads through the standalone Cairnline MCP client; backend
-status reports those routes in `read_routes` while `read_model_switch_ready`
+memory-candidate list, project role list, work-item list/detail,
+assignment-list, artifact-list, and handoff-list reads through the standalone
+Cairnline MCP client; backend status reports those routes in `read_routes` while
+`read_model_switch_ready`
 remains false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
@@ -2851,7 +2853,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3064,7 +3066,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -6017,11 +6019,18 @@ Responses use `{ "object": "project_handoffs", "data": [...] }`. When
 reports `read_model_switch_ready=true`, list responses are projected from
 Cairnline and include `read_backend: "cairnline"` on each handoff; writes still
 mutate Hecate's native project-work store.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, project
+handoff lists are read through typed `handoffs.list` on the standalone
+Cairnline MCP client. Handoff create/update/status/delete routes remain
+Hecate-owned unless a separate write-authority switchpoint is enabled.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs`
 
 Lists structured handoff records for one work item. Handoffs are sorted by
-latest update time, newest first.
+latest update time, newest first. In sidecar read-source mode, this endpoint
+first validates the work item through typed `work_items.list`, then reads
+handoffs through typed `handoffs.list`.
 
 ```json
 {
@@ -6115,6 +6124,12 @@ route reports `read_model_switch_ready=true`, this list is projected from
 Cairnline and includes `read_backend: "cairnline"` on each artifact. The
 portable projection includes generic collaboration artifacts plus evidence and
 review records.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, this
+endpoint validates the work item through typed `work_items.list`, then combines
+typed `artifacts.list`, `evidence.list`, and `reviews.list` from the standalone
+Cairnline MCP client. Collaboration artifact creation remains Hecate-owned
+unless a separate write-authority switchpoint is enabled.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts`
 

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -1011,6 +1011,9 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	case "artifacts.list":
 		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
 		items := cairnlineSidecarFixtureProjectArtifacts(state, projectID, workItemID)
+		if len(items) == 0 && mode == "collaboration-fixture" {
+			items = cairnlineSidecarFixtureDefaultArtifacts(projectID, workItemID)
+		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Artifacts for %s (%d)", workItemID, len(items)), items)
 	case "artifacts.get":
 		var input struct {
@@ -1068,6 +1071,9 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	case "evidence.list":
 		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
 		items := cairnlineSidecarFixtureProjectEvidence(state, projectID, workItemID)
+		if len(items) == 0 && mode == "collaboration-fixture" {
+			items = cairnlineSidecarFixtureDefaultEvidence(projectID, workItemID)
+		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Evidence for %s (%d)", workItemID, len(items)), items)
 	case "evidence.get":
 		var input struct {
@@ -1122,6 +1128,9 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	case "reviews.list":
 		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
 		items := cairnlineSidecarFixtureProjectReviews(state, projectID, workItemID)
+		if len(items) == 0 && mode == "collaboration-fixture" {
+			items = cairnlineSidecarFixtureDefaultReviews(projectID, workItemID)
+		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Reviews for %s (%d)", workItemID, len(items)), items)
 	case "reviews.get":
 		var input struct {
@@ -1195,6 +1204,9 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	case "handoffs.list":
 		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
 		items := cairnlineSidecarFixtureProjectHandoffs(state, projectID, workItemID)
+		if len(items) == 0 && mode == "collaboration-fixture" {
+			items = cairnlineSidecarFixtureDefaultHandoffs(projectID, workItemID)
+		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Handoffs for %s (%d)", workItemID, len(items)), items)
 	case "handoffs.get":
 		var input struct {
@@ -1582,6 +1594,25 @@ func cairnlineSidecarFixtureEnsureArtifacts(state *cairnlineSidecarFixtureState,
 	return state.artifacts[projectID]
 }
 
+func cairnlineSidecarFixtureDefaultArtifacts(projectID, workItemID string) []ProjectCairnlineSidecarArtifactItem {
+	workItemID, ok := cairnlineSidecarFixtureDefaultWorkItemID(workItemID)
+	if !ok {
+		return nil
+	}
+	return []ProjectCairnlineSidecarArtifactItem{{
+		ProjectID:    projectID,
+		ID:           "artifact_fixture",
+		WorkItemID:   workItemID,
+		AssignmentID: "asg_fixture",
+		Kind:         "decision_note",
+		Title:        "Fixture decision",
+		Body:         "Portable fixture artifact.",
+		AuthorRoleID: "role_fixture",
+		CreatedAt:    "2026-06-01T10:00:00Z",
+		UpdatedAt:    "2026-06-01T10:00:00Z",
+	}}
+}
+
 func cairnlineSidecarFixtureProjectArtifacts(state *cairnlineSidecarFixtureState, projectID, workItemID string) []ProjectCairnlineSidecarArtifactItem {
 	artifactsByID := state.artifacts[projectID]
 	artifacts := make([]ProjectCairnlineSidecarArtifactItem, 0, len(artifactsByID))
@@ -1598,6 +1629,28 @@ func cairnlineSidecarFixtureEnsureEvidence(state *cairnlineSidecarFixtureState, 
 		state.evidence[projectID] = make(map[string]ProjectCairnlineSidecarEvidenceItem)
 	}
 	return state.evidence[projectID]
+}
+
+func cairnlineSidecarFixtureDefaultEvidence(projectID, workItemID string) []ProjectCairnlineSidecarEvidenceItem {
+	workItemID, ok := cairnlineSidecarFixtureDefaultWorkItemID(workItemID)
+	if !ok {
+		return nil
+	}
+	return []ProjectCairnlineSidecarEvidenceItem{{
+		ProjectID:    projectID,
+		ID:           "evidence_fixture",
+		WorkItemID:   workItemID,
+		AssignmentID: "asg_fixture",
+		Title:        "Fixture evidence",
+		Body:         "Portable fixture evidence.",
+		Locator:      "https://example.com/evidence",
+		SourceKind:   "pull_request",
+		ExternalID:   "PR 632",
+		Provider:     "github",
+		TrustLabel:   "operator_provided",
+		CreatedAt:    "2026-06-01T11:00:00Z",
+		UpdatedAt:    "2026-06-01T11:00:00Z",
+	}}
 }
 
 func cairnlineSidecarFixtureProjectEvidence(state *cairnlineSidecarFixtureState, projectID, workItemID string) []ProjectCairnlineSidecarEvidenceItem {
@@ -1618,6 +1671,27 @@ func cairnlineSidecarFixtureEnsureReviews(state *cairnlineSidecarFixtureState, p
 	return state.reviews[projectID]
 }
 
+func cairnlineSidecarFixtureDefaultReviews(projectID, workItemID string) []ProjectCairnlineSidecarReviewItem {
+	workItemID, ok := cairnlineSidecarFixtureDefaultWorkItemID(workItemID)
+	if !ok {
+		return nil
+	}
+	return []ProjectCairnlineSidecarReviewItem{{
+		ProjectID:      projectID,
+		ID:             "review_fixture",
+		WorkItemID:     workItemID,
+		AssignmentID:   "asg_fixture",
+		ReviewerRoleID: "role_fixture",
+		Title:          "Fixture review",
+		Body:           "Portable fixture review.",
+		Verdict:        "changes_requested",
+		Risk:           "medium",
+		Status:         "open",
+		CreatedAt:      "2026-06-01T12:00:00Z",
+		UpdatedAt:      "2026-06-01T12:00:00Z",
+	}}
+}
+
 func cairnlineSidecarFixtureProjectReviews(state *cairnlineSidecarFixtureState, projectID, workItemID string) []ProjectCairnlineSidecarReviewItem {
 	reviewsByID := state.reviews[projectID]
 	reviews := make([]ProjectCairnlineSidecarReviewItem, 0, len(reviewsByID))
@@ -1634,6 +1708,42 @@ func cairnlineSidecarFixtureEnsureHandoffs(state *cairnlineSidecarFixtureState, 
 		state.handoffs[projectID] = make(map[string]ProjectCairnlineSidecarHandoffItem)
 	}
 	return state.handoffs[projectID]
+}
+
+func cairnlineSidecarFixtureDefaultHandoffs(projectID, workItemID string) []ProjectCairnlineSidecarHandoffItem {
+	workItemID, ok := cairnlineSidecarFixtureDefaultWorkItemID(workItemID)
+	if !ok {
+		return nil
+	}
+	return []ProjectCairnlineSidecarHandoffItem{{
+		ProjectID:             projectID,
+		ID:                    "handoff_fixture",
+		WorkItemID:            workItemID,
+		SourceAssignmentID:    "asg_fixture",
+		FromRoleID:            "role_fixture",
+		ToRoleID:              "role_fixture",
+		Title:                 "Fixture handoff",
+		Body:                  "Portable fixture handoff.",
+		RecommendedNextAction: "Review fixture follow-up.",
+		LinkedArtifactIDs:     []string{"artifact_fixture"},
+		Status:                "open",
+		ProvenanceKind:        "agent_draft",
+		TrustLabel:            "operator_reviewed",
+		CreatedAt:             "2026-06-01T13:00:00Z",
+		UpdatedAt:             "2026-06-01T13:00:00Z",
+		StatusChangedAt:       "2026-06-01T13:00:00Z",
+	}}
+}
+
+func cairnlineSidecarFixtureDefaultWorkItemID(workItemID string) (string, bool) {
+	workItemID = strings.TrimSpace(workItemID)
+	if workItemID == "" {
+		return "work_fixture", true
+	}
+	if workItemID == "work_fixture" {
+		return workItemID, true
+	}
+	return "", false
 }
 
 func cairnlineSidecarFixtureProjectHandoffs(state *cairnlineSidecarFixtureState, projectID, workItemID string) []ProjectCairnlineSidecarHandoffItem {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, and assignment lists through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, and handoff lists through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, and assignment lists through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, and handoff lists through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_cairnline_sidecar_health.go
+++ b/internal/api/handler_project_cairnline_sidecar_health.go
@@ -122,7 +122,11 @@ func (h *Handler) cairnlineSidecarProjectAssignments(ctx context.Context, projec
 }
 
 func (h *Handler) cairnlineSidecarProjectArtifacts(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarArtifactItem, error) {
-	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "artifacts.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	return h.cairnlineSidecarProjectArtifactList(ctx, projectID, "")
+}
+
+func (h *Handler) cairnlineSidecarProjectArtifactList(ctx context.Context, projectID, workItemID string) ([]ProjectCairnlineSidecarArtifactItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "artifacts.list", projectCairnlineSidecarProjectWorkListArgs(projectID, workItemID))
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +144,11 @@ func (h *Handler) cairnlineSidecarProjectArtifacts(ctx context.Context, projectI
 }
 
 func (h *Handler) cairnlineSidecarProjectEvidence(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarEvidenceItem, error) {
-	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "evidence.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	return h.cairnlineSidecarProjectEvidenceList(ctx, projectID, "")
+}
+
+func (h *Handler) cairnlineSidecarProjectEvidenceList(ctx context.Context, projectID, workItemID string) ([]ProjectCairnlineSidecarEvidenceItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "evidence.list", projectCairnlineSidecarProjectWorkListArgs(projectID, workItemID))
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +166,11 @@ func (h *Handler) cairnlineSidecarProjectEvidence(ctx context.Context, projectID
 }
 
 func (h *Handler) cairnlineSidecarProjectReviews(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarReviewItem, error) {
-	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "reviews.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	return h.cairnlineSidecarProjectReviewList(ctx, projectID, "")
+}
+
+func (h *Handler) cairnlineSidecarProjectReviewList(ctx context.Context, projectID, workItemID string) ([]ProjectCairnlineSidecarReviewItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "reviews.list", projectCairnlineSidecarProjectWorkListArgs(projectID, workItemID))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +188,11 @@ func (h *Handler) cairnlineSidecarProjectReviews(ctx context.Context, projectID 
 }
 
 func (h *Handler) cairnlineSidecarProjectHandoffs(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarHandoffItem, error) {
-	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "handoffs.list", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	return h.cairnlineSidecarProjectHandoffList(ctx, projectID, "")
+}
+
+func (h *Handler) cairnlineSidecarProjectHandoffList(ctx context.Context, projectID, workItemID string) ([]ProjectCairnlineSidecarHandoffItem, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "handoffs.list", projectCairnlineSidecarProjectWorkListArgs(projectID, workItemID))
 	if err != nil {
 		return nil, err
 	}
@@ -191,6 +207,14 @@ func (h *Handler) cairnlineSidecarProjectHandoffs(ctx context.Context, projectID
 		return nil, projectCairnlineSidecarReadFailure("handoffs.list did not return typed structuredContent")
 	}
 	return handoffs, nil
+}
+
+func projectCairnlineSidecarProjectWorkListArgs(projectID, workItemID string) map[string]string {
+	args := map[string]string{"project_id": strings.TrimSpace(projectID)}
+	if workItemID = strings.TrimSpace(workItemID); workItemID != "" {
+		args["work_item_id"] = workItemID
+	}
+	return args
 }
 
 func (h *Handler) cairnlineSidecarProjectMemoryCandidates(ctx context.Context, projectID string) ([]ProjectCairnlineSidecarMemoryCandidateItem, error) {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -59,6 +59,8 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"roles",
 	"work-item",
 	"assignment-list",
+	"artifact-list",
+	"handoff-list",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -356,13 +358,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignment context/launch, collaboration, activity, assistant, and operations routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignment context/launch, activity, assistant, and operations routes are not wired.",
 				}
 				return response
 			}
@@ -799,7 +801,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -812,7 +814,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, and assignment-list") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -901,6 +901,23 @@ func projectWorkAssignmentStatusFromRun(status string) string {
 func (h *Handler) HandleProjectWorkArtifacts(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		data, err := h.renderCairnlineSidecarProjectWorkArtifacts(r.Context(), projectID, workItemID)
+		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+				return
+			}
+			if errors.Is(err, projectwork.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+				return
+			}
+			writeProjectReadRenderError(w, err)
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectWorkArtifactsResponse{Object: "project_collaboration_artifacts", Data: data})
+		return
+	}
 	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
@@ -956,13 +973,26 @@ func (h *Handler) HandleCreateProjectWorkArtifact(w http.ResponseWriter, r *http
 
 func (h *Handler) HandleProjectHandoffs(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.requireProject(w, r, projectID) {
-		return
-	}
 	filter := projectwork.HandoffFilter{
 		ProjectID:  projectID,
 		WorkItemID: strings.TrimSpace(r.URL.Query().Get("work_item_id")),
 		Status:     strings.TrimSpace(r.URL.Query().Get("status")),
+	}
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		data, err := h.renderCairnlineSidecarProjectHandoffs(r.Context(), filter)
+		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+				return
+			}
+			writeProjectReadRenderError(w, err)
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
+		return
+	}
+	if !h.requireProject(w, r, projectID) {
+		return
 	}
 	data, err := h.renderProjectHandoffs(r.Context(), filter)
 	if !writeProjectWorkError(w, err) {
@@ -974,6 +1004,27 @@ func (h *Handler) HandleProjectHandoffs(w http.ResponseWriter, r *http.Request) 
 func (h *Handler) HandleProjectWorkItemHandoffs(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		data, err := h.renderCairnlineSidecarProjectWorkItemHandoffs(r.Context(), projectwork.HandoffFilter{
+			ProjectID:  projectID,
+			WorkItemID: workItemID,
+			Status:     strings.TrimSpace(r.URL.Query().Get("status")),
+		})
+		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+				return
+			}
+			if errors.Is(err, projectwork.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+				return
+			}
+			writeProjectReadRenderError(w, err)
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
+		return
+	}
 	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -237,29 +237,11 @@ func (h *Handler) renderCairnlineSidecarProjectWorkItem(ctx context.Context, pro
 }
 
 func (h *Handler) renderCairnlineSidecarProjectWorkAssignments(ctx context.Context, projectID, workItemID string) ([]ProjectWorkAssignmentResponse, error) {
-	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	project, err := h.cairnlineSidecarProjectWithRequiredWorkItem(ctx, projectID, workItemID)
 	if err != nil {
 		return nil, err
 	}
-	if !ok {
-		return nil, projects.ErrNotFound
-	}
-	project := projectFromCairnlineSidecar(projectItem)
 	workItemID = strings.TrimSpace(workItemID)
-	workItems, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
-	if err != nil {
-		return nil, err
-	}
-	foundWorkItem := false
-	for _, item := range workItems {
-		if item.ID == workItemID {
-			foundWorkItem = true
-			break
-		}
-	}
-	if !foundWorkItem {
-		return nil, projectwork.ErrNotFound
-	}
 	items, err := h.cairnlineSidecarProjectAssignments(ctx, project.ID)
 	if err != nil {
 		return nil, err
@@ -278,6 +260,100 @@ func (h *Handler) renderCairnlineSidecarProjectWorkAssignments(ctx context.Conte
 		data = append(data, projected)
 	}
 	return data, nil
+}
+
+func (h *Handler) renderCairnlineSidecarProjectWorkArtifacts(ctx context.Context, projectID, workItemID string) ([]ProjectWorkArtifactResponse, error) {
+	project, err := h.cairnlineSidecarProjectWithRequiredWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	workItemID = strings.TrimSpace(workItemID)
+	artifacts, err := h.cairnlineSidecarProjectArtifactList(ctx, project.ID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	evidence, err := h.cairnlineSidecarProjectEvidenceList(ctx, project.ID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	reviews, err := h.cairnlineSidecarProjectReviewList(ctx, project.ID, workItemID)
+	if err != nil {
+		return nil, err
+	}
+	items := projectArtifactsFromCairnlineSidecar(artifacts, evidence, reviews)
+	sortProjectWorkArtifactsForProjection(items)
+	data := make([]ProjectWorkArtifactResponse, 0, len(items))
+	for _, item := range items {
+		projected := renderProjectWorkArtifact(item)
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderCairnlineSidecarProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, filter.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	return h.renderCairnlineSidecarProjectHandoffsForProject(ctx, project.ID, filter)
+}
+
+func (h *Handler) renderCairnlineSidecarProjectWorkItemHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
+	project, err := h.cairnlineSidecarProjectWithRequiredWorkItem(ctx, filter.ProjectID, filter.WorkItemID)
+	if err != nil {
+		return nil, err
+	}
+	return h.renderCairnlineSidecarProjectHandoffsForProject(ctx, project.ID, filter)
+}
+
+func (h *Handler) renderCairnlineSidecarProjectHandoffsForProject(ctx context.Context, projectID string, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
+	items, err := h.cairnlineSidecarProjectHandoffList(ctx, projectID, filter.WorkItemID)
+	if err != nil {
+		return nil, err
+	}
+	handoffs := projectHandoffsFromCairnlineSidecar(items)
+	status := strings.TrimSpace(filter.Status)
+	sortProjectHandoffsForProjection(handoffs)
+	data := make([]ProjectHandoffResponse, 0, len(handoffs))
+	for _, handoff := range handoffs {
+		if status != "" && handoff.Status != status {
+			continue
+		}
+		projected := renderProjectHandoff(handoff)
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectWithRequiredWorkItem(ctx context.Context, projectID, workItemID string) (projects.Project, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return projects.Project{}, err
+	}
+	if !ok {
+		return projects.Project{}, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	workItemID = strings.TrimSpace(workItemID)
+	if workItemID == "" {
+		return projects.Project{}, projectwork.ErrNotFound
+	}
+	workItems, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
+	if err != nil {
+		return projects.Project{}, err
+	}
+	for _, item := range workItems {
+		if item.ID == workItemID {
+			return project, nil
+		}
+	}
+	return projects.Project{}, projectwork.ErrNotFound
 }
 
 func (h *Handler) renderCairnlineProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
@@ -370,10 +446,7 @@ func cairnlineProjectWorkArtifacts(ctx context.Context, service *cairnline.Servi
 		out = append(out, projectHealthReviewFromCairnline(item))
 	}
 	sort.SliceStable(out, func(i, j int) bool {
-		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
-			return out[i].CreatedAt.Before(out[j].CreatedAt)
-		}
-		return out[i].ID < out[j].ID
+		return projectWorkArtifactProjectionLess(out[i], out[j])
 	})
 	return out, nil
 }
@@ -416,15 +489,38 @@ func cairnlineProjectHandoffs(ctx context.Context, service *cairnline.Service, p
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool {
-		if !out[i].UpdatedAt.Equal(out[j].UpdatedAt) {
-			return out[i].UpdatedAt.After(out[j].UpdatedAt)
-		}
-		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
-			return out[i].CreatedAt.After(out[j].CreatedAt)
-		}
-		return out[i].ID < out[j].ID
+		return projectHandoffProjectionLess(out[i], out[j])
 	})
 	return out, nil
+}
+
+func sortProjectWorkArtifactsForProjection(items []projectwork.CollaborationArtifact) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return projectWorkArtifactProjectionLess(items[i], items[j])
+	})
+}
+
+func projectWorkArtifactProjectionLess(a, b projectwork.CollaborationArtifact) bool {
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.Before(b.CreatedAt)
+	}
+	return a.ID < b.ID
+}
+
+func sortProjectHandoffsForProjection(items []projectwork.Handoff) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return projectHandoffProjectionLess(items[i], items[j])
+	})
+}
+
+func projectHandoffProjectionLess(a, b projectwork.Handoff) bool {
+	if !a.UpdatedAt.Equal(b.UpdatedAt) {
+		return a.UpdatedAt.After(b.UpdatedAt)
+	}
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.After(b.CreatedAt)
+	}
+	return a.ID < b.ID
 }
 
 func (h *Handler) renderCairnlineProjectWorkAssignments(ctx context.Context, projectID, workItemID string) ([]ProjectWorkAssignmentResponse, error) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1519,6 +1519,119 @@ func TestProjectWorkAPI_AssignmentsCairnlineSidecarReadRequiresStructuredContent
 	}
 }
 
+func TestProjectWorkAPI_ArtifactsUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "collaboration-fixture")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar artifact list enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/artifacts", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("artifacts status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkArtifactsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode artifacts response: %v", err)
+	}
+	if response.Object != "project_collaboration_artifacts" || len(response.Data) != 3 {
+		t.Fatalf("artifacts response = %+v, want generic artifact, evidence, and review", response)
+	}
+	if response.Data[0].ID != "artifact_fixture" || response.Data[0].Kind != projectwork.ArtifactKindDecisionNote || response.Data[0].ReadBackend != "cairnline" {
+		t.Fatalf("generic artifact = %+v, want Cairnline-backed decision note", response.Data[0])
+	}
+	if response.Data[1].ID != "evidence_fixture" || response.Data[1].Kind != projectwork.ArtifactKindEvidenceLink || response.Data[1].EvidenceURL == "" || response.Data[1].ReadBackend != "cairnline" {
+		t.Fatalf("evidence artifact = %+v, want Cairnline-backed evidence link", response.Data[1])
+	}
+	if response.Data[2].ID != "review_fixture" || response.Data[2].Kind != projectwork.ArtifactKindReview || response.Data[2].ReviewVerdict != projectwork.ReviewVerdictChangesRequested || !response.Data[2].ReviewFollowUpRequired || response.Data[2].ReadBackend != "cairnline" {
+		t.Fatalf("review artifact = %+v, want Cairnline-backed review", response.Data[2])
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/missing/artifacts", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item artifacts status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_ArtifactsCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/artifacts", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("artifacts status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_HandoffsUseCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "collaboration-fixture")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar handoff list enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/handoffs?work_item_id=work_fixture&status=pending", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("project handoffs status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectHandoffsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode project handoffs response: %v", err)
+	}
+	if response.Object != "project_handoffs" || len(response.Data) != 1 {
+		t.Fatalf("project handoffs response = %+v, want one filtered handoff", response)
+	}
+	handoff := response.Data[0]
+	if handoff.ID != "handoff_fixture" || handoff.ProjectID != "proj_fixture" || handoff.WorkItemID != "work_fixture" || handoff.Status != projectwork.HandoffStatusPending || handoff.ReadBackend != "cairnline" {
+		t.Fatalf("project handoff = %+v, want sidecar Cairnline fixture handoff", handoff)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/handoffs", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("work-item handoffs status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode work-item handoffs response: %v", err)
+	}
+	if len(response.Data) != 1 || response.Data[0].ID != "handoff_fixture" || response.Data[0].ReadBackend != "cairnline" {
+		t.Fatalf("work-item handoffs response = %+v, want sidecar handoff", response)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/missing/handoffs", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item handoffs status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_HandoffsCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/handoffs", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("handoffs status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_CreateHandoffGeneratesOpaqueHandoffID(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectWorkTestServer()


### PR DESCRIPTION
## Summary

- route collaboration artifact and handoff list reads through the Cairnline sidecar read source
- combine typed `artifacts.list`, `evidence.list`, and `reviews.list` into existing Hecate artifact projections, and read handoffs through typed `handoffs.list`
- keep create/update/delete/status mutations Hecate-owned while updating backend status, docs, and sidecar fixture coverage

## Tests

- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(ArtifactsUseCairnlineSidecarWhenConfigured|ArtifactsCairnlineSidecarReadRequiresStructuredContent|HandoffsUseCairnlineSidecarWhenConfigured|HandoffsCairnlineSidecarReadRequiresStructuredContent|AssignmentsUseCairnlineSidecarWhenConfigured|AssignmentsCairnlineSidecarReadRequiresStructuredContent)|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady|TestProjectHealth_ReadsUseCairnlineSidecarWhenConfigured'`\n- `just agent-docs-check`\n- `GOCACHE="$PWD/.gocache" go vet ./internal/api`\n- `git diff --check`\n- `GOCACHE="$PWD/.gocache" go test ./internal/api`\n- `GOCACHE="$PWD/.gocache" go vet ./...`\n- `GOCACHE="$PWD/.gocache" go test ./...`\n- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`