### PR TITLE
feat(projects): route sidecar closeout readiness

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -182,11 +182,11 @@ When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
 routes only project list/detail, setup-readiness, health, project skill list,
 project memory list, memory-candidate list, project role list, work-item
-list/detail, assignment-list, artifact-list, and handoff-list reads through the
-cached standalone Cairnline MCP client. Other Projects reads, writes, mirrors,
-dispatch, approvals, and write-authority switchpoints remain Hecate-native or
-on the embedded dogfood path until sidecar-specific adapters exist for those
-route families.
+list/detail, assignment-list, artifact-list, handoff-list, and
+closeout-readiness reads through the cached standalone Cairnline MCP client.
+Other Projects reads, writes, mirrors, dispatch, approvals, and write-authority
+switchpoints remain Hecate-native or on the embedded dogfood path until
+sidecar-specific adapters exist for those route families.
 Today, `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` is a
 replacement-readiness intent flag only: when the current stores are fully wired
 and the embedded connector is selected, it reports `cairnline_read_routes_ready`,
@@ -213,10 +213,10 @@ scaffolding still come from Hecate until Cairnline becomes authoritative; the
 explicit sidecar read-source routes are the narrow exception for project
 list/detail, setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail, and
-assignment-list, artifact-list, and handoff-list reads. Project Assistant draft
-generation also uses the Cairnline-projected context so preview and proposal
-assembly stay aligned, while the proposal ledger remains Hecate-owned unless
-`project-assistant-proposals` is enabled.
+assignment-list, artifact-list, handoff-list, and closeout-readiness reads.
+Project Assistant draft generation also uses the Cairnline-projected context so
+preview and proposal assembly stay aligned, while the proposal ledger remains
+Hecate-owned unless `project-assistant-proposals` is enabled.
 Confirmed Project Assistant apply routes role, work-item, assignment, and
 handoff actions through the same opt-in Cairnline authority switchpoints when
 those switchpoints are enabled; project/default/chat/memory/runtime side

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -376,9 +376,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
   list/detail, setup-readiness, health, project skill list, project memory
   list, memory-candidate list, project role list, work-item list/detail, and
-  assignment-list, artifact-list, and handoff-list reads through the cached
-  standalone MCP client. Other live Projects reads, writes, mirrors, and
-  write-authority switchpoints do not route through the sidecar yet.
+  assignment-list, artifact-list, handoff-list, and closeout-readiness reads
+  through the cached standalone MCP client. Other live Projects reads, writes,
+  mirrors, and write-authority switchpoints do not route through the sidecar
+  yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -396,9 +397,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the explicit sidecar read-source routes for project
   list/detail, setup-readiness, health, skills, memory, memory candidates, roles,
-  work items, assignment lists, artifact lists, and handoff lists, project
-  identity and some compatibility scaffolding remain Hecate-owned until
-  Cairnline becomes authoritative.
+  work items, assignment lists, artifact lists, handoff lists, and closeout
+  readiness, project identity and some compatibility scaffolding remain
+  Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -438,19 +438,19 @@ reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail, and
-assignment-list, artifact-list, and handoff-list reads through the standalone
-Cairnline MCP client; all other live Projects read routes remain Hecate-native
-or use the embedded dogfood read model when that is configured. Work-item
-list/detail, assignment-list, artifact-list, and handoff-list reads render the
-work graph from Cairnline service records and overlay Hecate-only runtime
-refs/timestamps while Hecate still owns execution. Outside the explicit sidecar
-read-source routes for
+assignment-list, artifact-list, handoff-list, and closeout-readiness reads
+through the standalone Cairnline MCP client; all other live Projects read
+routes remain Hecate-native or use the embedded dogfood read model when that is
+configured. Work-item list/detail, assignment-list, artifact-list, handoff-list,
+and closeout-readiness reads render the work graph from Cairnline service
+records and overlay Hecate-only runtime refs/timestamps while Hecate still owns
+execution. Outside the explicit sidecar read-source routes for
 project list/detail, setup-readiness, health, skills, memory, memory candidates,
-roles, work items, assignment lists, artifact lists, and handoff lists, project
-identity and some compatibility scaffolding remain Hecate-owned until Cairnline
-becomes authoritative. Project identity, metadata/default, root, and
-context-source mutations still write Hecate stores first and then best-effort
-mirror into the embedded Cairnline database through
+roles, work items, assignment lists, artifact lists, handoff lists, and closeout
+readiness, project identity and some compatibility scaffolding remain Hecate-owned
+until Cairnline becomes authoritative. Project identity, metadata/default, root,
+and context-source mutations still write Hecate stores first and then
+best-effort mirror into the embedded Cairnline database through
 their identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -511,8 +511,8 @@ sequenceDiagram
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness,
   health, skills, memory, memory candidates, roles, work items, assignment
-  lists, artifact lists, and handoff lists use the same sidecar source when it
-  is configured.
+  lists, artifact lists, handoff lists, and closeout readiness use the same
+  sidecar source when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -528,9 +528,9 @@ sequenceDiagram
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
   project list/detail, setup-readiness, health, project skill list, project
   memory list, memory-candidate list, project role list, work-item list/detail,
-  assignment-list, artifact-list, and handoff-list reads through the standalone
-  Cairnline MCP client; all other live Projects read routes stay on
-  Hecate-native or embedded dogfood paths.
+  assignment-list, artifact-list, handoff-list, and closeout-readiness reads
+  through the standalone Cairnline MCP client; all other live Projects read
+  routes stay on Hecate-native or embedded dogfood paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2412,9 +2412,9 @@ fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
-assignment-list, artifact-list, and handoff-list reads through the standalone
-Cairnline MCP client; backend status reports those routes in `read_routes` while
-`read_model_switch_ready`
+assignment-list, artifact-list, handoff-list, and closeout-readiness reads
+through the standalone Cairnline MCP client; backend status reports those routes
+in `read_routes` while `read_model_switch_ready`
 remains false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
@@ -2853,7 +2853,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3066,7 +3066,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -5602,6 +5602,12 @@ The response does not create, update, or delete project records. `ready=true`
 means the selected-work detail may enable the guided Mark done action; the
 operator still applies the durable `status="done"` mutation through
 `PATCH /hecate/v1/projects/{id}/work-items/{work_item_id}`.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, this
+endpoint validates the work item through typed `work_items.list`, reads typed
+`assignments.list`, `artifacts.list`, `evidence.list`, `reviews.list`, and
+`handoffs.list`, then runs the same Hecate closeout evaluator over the
+converted portable records. The closeout mutation path remains Hecate-owned.
 
 ```json
 {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, and handoff lists through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, handoff lists, and closeout readiness through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, and handoff lists through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, handoff lists, and closeout readiness through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -61,6 +61,7 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"assignment-list",
 	"artifact-list",
 	"handoff-list",
+	"closeout-readiness",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -358,11 +359,11 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
 					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignment context/launch, activity, assistant, and operations routes are not wired.",
 				}
@@ -801,7 +802,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -814,7 +815,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, and handoff-list") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -291,6 +291,44 @@ func (h *Handler) renderCairnlineSidecarProjectWorkArtifacts(ctx context.Context
 	return data, nil
 }
 
+func (h *Handler) renderCairnlineSidecarProjectWorkItemReadiness(ctx context.Context, projectID, workItemID string) (ProjectWorkItemReadinessResponse, error) {
+	project, workItem, err := h.cairnlineSidecarProjectAndRequiredWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	workItemID = strings.TrimSpace(workItemID)
+	assignmentItems, err := h.cairnlineSidecarProjectAssignments(ctx, project.ID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	assignments := filterProjectWorkAssignments(projectAssignmentsFromCairnlineSidecar(assignmentItems), workItemID)
+	artifactItems, err := h.cairnlineSidecarProjectArtifactList(ctx, project.ID, workItemID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	evidenceItems, err := h.cairnlineSidecarProjectEvidenceList(ctx, project.ID, workItemID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	reviewItems, err := h.cairnlineSidecarProjectReviewList(ctx, project.ID, workItemID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	handoffItems, err := h.cairnlineSidecarProjectHandoffList(ctx, project.ID, workItemID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	readiness := projectwork.EvaluateWorkItemReadiness(
+		workItem,
+		assignments,
+		projectArtifactsFromCairnlineSidecar(artifactItems, evidenceItems, reviewItems),
+		projectHandoffsFromCairnlineSidecar(handoffItems),
+	)
+	rendered := renderProjectWorkItemReadiness(readiness)
+	rendered.ReadBackend = "cairnline"
+	return rendered, nil
+}
+
 func (h *Handler) renderCairnlineSidecarProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
 	projectItem, ok, err := h.cairnlineSidecarProject(ctx, filter.ProjectID)
 	if err != nil {
@@ -332,28 +370,33 @@ func (h *Handler) renderCairnlineSidecarProjectHandoffsForProject(ctx context.Co
 }
 
 func (h *Handler) cairnlineSidecarProjectWithRequiredWorkItem(ctx context.Context, projectID, workItemID string) (projects.Project, error) {
+	project, _, err := h.cairnlineSidecarProjectAndRequiredWorkItem(ctx, projectID, workItemID)
+	return project, err
+}
+
+func (h *Handler) cairnlineSidecarProjectAndRequiredWorkItem(ctx context.Context, projectID, workItemID string) (projects.Project, projectwork.WorkItem, error) {
 	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
 	if err != nil {
-		return projects.Project{}, err
+		return projects.Project{}, projectwork.WorkItem{}, err
 	}
 	if !ok {
-		return projects.Project{}, projects.ErrNotFound
+		return projects.Project{}, projectwork.WorkItem{}, projects.ErrNotFound
 	}
 	project := projectFromCairnlineSidecar(projectItem)
 	workItemID = strings.TrimSpace(workItemID)
 	if workItemID == "" {
-		return projects.Project{}, projectwork.ErrNotFound
+		return projects.Project{}, projectwork.WorkItem{}, projectwork.ErrNotFound
 	}
 	workItems, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
 	if err != nil {
-		return projects.Project{}, err
+		return projects.Project{}, projectwork.WorkItem{}, err
 	}
-	for _, item := range workItems {
+	for _, item := range projectWorkItemsFromCairnlineSidecar(workItems) {
 		if item.ID == workItemID {
-			return project, nil
+			return project, item, nil
 		}
 	}
-	return projects.Project{}, projectwork.ErrNotFound
+	return projects.Project{}, projectwork.WorkItem{}, projectwork.ErrNotFound
 }
 
 func (h *Handler) renderCairnlineProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
@@ -498,6 +541,17 @@ func sortProjectWorkArtifactsForProjection(items []projectwork.CollaborationArti
 	sort.SliceStable(items, func(i, j int) bool {
 		return projectWorkArtifactProjectionLess(items[i], items[j])
 	})
+}
+
+func filterProjectWorkAssignments(items []projectwork.Assignment, workItemID string) []projectwork.Assignment {
+	workItemID = strings.TrimSpace(workItemID)
+	out := make([]projectwork.Assignment, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item.WorkItemID) == workItemID {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 func projectWorkArtifactProjectionLess(a, b projectwork.CollaborationArtifact) bool {

--- a/internal/api/handler_project_work_readiness.go
+++ b/internal/api/handler_project_work_readiness.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
@@ -44,6 +45,23 @@ type ProjectWorkItemReviewFollowUpResponse struct {
 
 func (h *Handler) HandleProjectWorkItemReadiness(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		readiness, err := h.renderCairnlineSidecarProjectWorkItemReadiness(r.Context(), projectID, r.PathValue("work_item_id"))
+		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+				return
+			}
+			if errors.Is(err, projectwork.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+				return
+			}
+			writeProjectReadRenderError(w, err)
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectWorkItemReadinessEnvelope{Object: "project_work_item_readiness", Data: readiness})
+		return
+	}
 	if !h.requireProject(w, r, projectID) {
 		return
 	}

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1632,6 +1632,59 @@ func TestProjectWorkAPI_HandoffsCairnlineSidecarReadRequiresStructuredContent(t 
 	}
 }
 
+func TestProjectWorkAPI_CloseoutReadinessUsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "collaboration-fixture")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar closeout readiness enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkItemReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode readiness response: %v", err)
+	}
+	if response.Object != "project_work_item_readiness" || response.Data.ProjectID != "proj_fixture" || response.Data.WorkItemID != "work_fixture" || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("readiness response = %+v, want sidecar Cairnline readiness", response)
+	}
+	if response.Data.Ready || response.Data.Status != "blocked" || response.Data.AssignmentCount != 1 || response.Data.CompletedAssignments != 0 {
+		t.Fatalf("readiness = %+v, want blocked sidecar closeout state", response.Data)
+	}
+	if !containsString(response.Data.Blockers, "1 assignment is still active") || !containsString(response.Data.Blockers, "1 handoff is pending") || response.Data.ReviewFollowUpCount != 1 {
+		t.Fatalf("readiness blockers = %+v follow-ups=%d, want active assignment, pending handoff, and review follow-up", response.Data.Blockers, response.Data.ReviewFollowUpCount)
+	}
+	if len(response.Data.ReviewFollowUps) != 1 || response.Data.ReviewFollowUps[0].ArtifactID != "review_fixture" || response.Data.ReviewFollowUps[0].ReviewVerdict != projectwork.ReviewVerdictChangesRequested {
+		t.Fatalf("review follow-ups = %+v, want sidecar review follow-up", response.Data.ReviewFollowUps)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/missing/readiness", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item readiness status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_CloseoutReadinessCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/readiness", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("readiness status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_CreateHandoffGeneratesOpaqueHandoffID(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectWorkTestServer()


### PR DESCRIPTION
Summary
- route work-item closeout readiness through the Cairnline sidecar read source
- derive sidecar readiness from typed work_items.list, assignments.list, artifacts.list, evidence.list, reviews.list, and handoffs.list calls
- reuse the Hecate closeout evaluator and keep closeout mutation Hecate-owned
- update sidecar route status and operator/runtime/design docs

Validation
- GOCACHE="$PWD/.gocache" go vet ./...
- GOCACHE="$PWD/.gocache" go test ./...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...
- just agent-docs-check
- git diff --check