### PR TITLE
feat(projects): route sidecar activity and operations

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -182,8 +182,9 @@ When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
 routes only project list/detail, setup-readiness, health, project skill list,
 project memory list, memory-candidate list, project role list, work-item
-list/detail, assignment-list, artifact-list, handoff-list, and
-closeout-readiness reads through the cached standalone Cairnline MCP client.
+list/detail, assignment-list, artifact-list, handoff-list, activity,
+closeout-readiness, and operations brief reads through the cached standalone
+Cairnline MCP client.
 Other Projects reads, writes, mirrors, dispatch, approvals, and write-authority
 switchpoints remain Hecate-native or on the embedded dogfood path until
 sidecar-specific adapters exist for those route families.
@@ -212,8 +213,9 @@ In embedded read-source modes, project identity and some compatibility
 scaffolding still come from Hecate until Cairnline becomes authoritative; the
 explicit sidecar read-source routes are the narrow exception for project
 list/detail, setup-readiness, health, project skill list, project memory list,
-memory-candidate list, project role list, work-item list/detail, and
-assignment-list, artifact-list, handoff-list, and closeout-readiness reads.
+memory-candidate list, project role list, work-item list/detail,
+assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and
+operations brief reads.
 Project Assistant draft generation also uses the Cairnline-projected context so
 preview and proposal assembly stay aligned, while the proposal ledger remains
 Hecate-owned unless `project-assistant-proposals` is enabled.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -375,11 +375,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` plus
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
   list/detail, setup-readiness, health, project skill list, project memory
-  list, memory-candidate list, project role list, work-item list/detail, and
-  assignment-list, artifact-list, handoff-list, and closeout-readiness reads
-  through the cached standalone MCP client. Other live Projects reads, writes,
-  mirrors, and write-authority switchpoints do not route through the sidecar
-  yet.
+  list, memory-candidate list, project role list, work-item list/detail,
+  assignment-list, artifact-list, handoff-list, activity, closeout-readiness,
+  and operations brief reads through the cached standalone MCP client. Other
+  live Projects reads, writes, mirrors, and write-authority switchpoints do not
+  route through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -397,9 +397,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the explicit sidecar read-source routes for project
   list/detail, setup-readiness, health, skills, memory, memory candidates, roles,
-  work items, assignment lists, artifact lists, handoff lists, and closeout
-  readiness, project identity and some compatibility scaffolding remain
-  Hecate-owned until Cairnline becomes authoritative.
+  work items, assignment lists, artifact lists, handoff lists, activity,
+  closeout readiness, and operations brief, project identity and some
+  compatibility scaffolding remain Hecate-owned until Cairnline becomes
+  authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -437,18 +437,20 @@ mirror database, project row, or proposal record is missing; run
 reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
-memory-candidate list, project role list, work-item list/detail, and
-assignment-list, artifact-list, handoff-list, and closeout-readiness reads
-through the standalone Cairnline MCP client; all other live Projects read
-routes remain Hecate-native or use the embedded dogfood read model when that is
-configured. Work-item list/detail, assignment-list, artifact-list, handoff-list,
-and closeout-readiness reads render the work graph from Cairnline service
-records and overlay Hecate-only runtime refs/timestamps while Hecate still owns
-execution. Outside the explicit sidecar read-source routes for
-project list/detail, setup-readiness, health, skills, memory, memory candidates,
-roles, work items, assignment lists, artifact lists, handoff lists, and closeout
-readiness, project identity and some compatibility scaffolding remain Hecate-owned
-until Cairnline becomes authoritative. Project identity, metadata/default, root,
+memory-candidate list, project role list, work-item list/detail,
+assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and
+operations brief reads through the standalone Cairnline MCP client; all other
+live Projects read routes remain Hecate-native or use the embedded dogfood read
+model when that is configured. Work-item list/detail, assignment-list,
+artifact-list, handoff-list, activity, closeout-readiness, and operations brief
+reads render the work graph from Cairnline service records and overlay
+Hecate-only runtime refs/timestamps while Hecate still owns execution. Outside
+the explicit sidecar read-source routes for project list/detail,
+setup-readiness, health, skills, memory, memory candidates, roles, work items,
+assignment lists, artifact lists, handoff lists, activity, closeout readiness,
+and operations brief, project identity and some compatibility scaffolding remain
+Hecate-owned until Cairnline becomes authoritative. Project identity,
+metadata/default, root,
 and context-source mutations still write Hecate stores first and then
 best-effort mirror into the embedded Cairnline database through
 their identity/metadata/root/source/default seams unless their explicit

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -511,8 +511,8 @@ sequenceDiagram
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness,
   health, skills, memory, memory candidates, roles, work items, assignment
-  lists, artifact lists, handoff lists, and closeout readiness use the same
-  sidecar source when it is configured.
+  lists, artifact lists, handoff lists, activity, closeout readiness, and
+  operations brief use the same sidecar source when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -528,9 +528,10 @@ sequenceDiagram
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
   project list/detail, setup-readiness, health, project skill list, project
   memory list, memory-candidate list, project role list, work-item list/detail,
-  assignment-list, artifact-list, handoff-list, and closeout-readiness reads
-  through the standalone Cairnline MCP client; all other live Projects read
-  routes stay on Hecate-native or embedded dogfood paths.
+  assignment-list, artifact-list, handoff-list, activity, closeout-readiness,
+  and operations-brief reads through the standalone Cairnline MCP client; all
+  other live Projects read routes stay on Hecate-native or embedded dogfood
+  paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2412,9 +2413,9 @@ fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
-assignment-list, artifact-list, handoff-list, and closeout-readiness reads
-through the standalone Cairnline MCP client; backend status reports those routes
-in `read_routes` while `read_model_switch_ready`
+assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and
+operations-brief reads through the standalone Cairnline MCP client; backend
+status reports those routes in `read_routes` while `read_model_switch_ready`
 remains false because the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
@@ -2853,7 +2854,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3066,7 +3067,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -4878,6 +4879,11 @@ model for the portable assignment activity set and then enriches those rows with
 Hecate runtime, linked chat, artifact, handoff, and cockpit bucket metadata.
 `read_backend` identifies the source of the assignment activity read model, not
 a full Projects backend switch.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, this endpoint reads project
+identity through `projects.get`, reads the portable activity rows through the
+typed `projects.activity` MCP result, and uses typed sidecar list tools only to
+enrich the Hecate cockpit projection. Text-only sidecar output is rejected.
 
 ```json
 {
@@ -5334,6 +5340,12 @@ operator-facing brief through the same Hecate activity projection and cockpit
 action helpers as the native route. Hecate-specific setup/defaults items and
 client actions remain Hecate-owned, so `read_backend` identifies the source of
 the work-operations read model rather than a full Projects backend switch.
+When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, this endpoint reads project
+identity through `projects.get`, reads portable operation rows through the
+typed `projects.operations_brief` MCP result, and uses typed sidecar list tools
+only to render Hecate cockpit action targets. Text-only sidecar output is
+rejected.
 Items are capped after sorting by priority, then an explicit operation-kind
 urgency rank, then recency, then id. This keeps blocked or waiting work ahead of
 setup gaps, handoffs ahead of memory triage, and active/completion hygiene below

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -135,7 +135,7 @@ type cairnlineSidecarFixtureState struct {
 
 func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
 	names := append([]string(nil), projectCairnlineSidecarRequiredTools...)
-	if mode == "missing" {
+	if cairnlineSidecarFixtureModeHas(mode, "missing") {
 		names = []string{"projects.list"}
 	}
 	tools := make([]mcp.Tool, 0, len(names))
@@ -152,14 +152,14 @@ func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
 func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixtureState, params mcp.CallToolParams) (mcp.CallToolResult, *mcp.RPCError) {
 	switch params.Name {
 	case "projects.list":
-		if mode == "tool-error" {
+		if cairnlineSidecarFixtureModeHas(mode, "tool-error") {
 			return mcp.CallToolResult{
 				Content: mcp.TextContent("fixture projects.list failed"),
 				IsError: true,
 			}, nil
 		}
 		result := mcp.CallToolResult{Content: mcp.TextContent("Projects (1):\n- proj_fixture: Fixture Project")}
-		if mode != "text-only" {
+		if !cairnlineSidecarFixtureTextOnly(mode, "projects.list") {
 			result.StructuredContent = mustRawJSON(cairnlineSidecarFixtureProjects(state))
 		}
 		return result, nil
@@ -239,6 +239,22 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			ClaimedBy:     state.claimedBy,
 			ExecutionRef:  state.executionRef,
 		}})
+	case "projects.activity":
+		projectID := cairnlineSidecarFixtureProjectID(params.Arguments)
+		activity := cairnlineSidecarFixtureProjectActivity(state, projectID)
+		result := mcp.CallToolResult{Content: mcp.TextContent("Project activity " + projectID)}
+		if !cairnlineSidecarFixtureTextOnly(mode, "projects.activity") {
+			result.StructuredContent = mustRawJSON(activity)
+		}
+		return result, nil
+	case "projects.operations_brief":
+		projectID := cairnlineSidecarFixtureProjectID(params.Arguments)
+		brief := cairnlineSidecarFixtureProjectOperationsBrief(state, projectID)
+		result := mcp.CallToolResult{Content: mcp.TextContent("Operations brief " + projectID)}
+		if !cairnlineSidecarFixtureTextOnly(mode, "projects.operations_brief") {
+			result.StructuredContent = mustRawJSON(brief)
+		}
+		return result, nil
 	case "assignments.next":
 		if mode == "assignment-list-empty" || state.assignmentStatus != "queued" {
 			return cairnlineSidecarFixtureListResult(mode, "No compatible assignments.", []map[string]any{})
@@ -474,7 +490,7 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		state.executionRef = input.ExecutionRef
 		return mcp.CallToolResult{Content: mcp.TextContent("Updated assignment " + input.AssignmentID + ": " + input.Status)}, nil
 	case "projects.get":
-		if mode == "get-tool-error" {
+		if cairnlineSidecarFixtureModeHas(mode, "get-tool-error") {
 			return mcp.CallToolResult{
 				Content: mcp.TextContent("fixture projects.get failed"),
 				IsError: true,
@@ -495,6 +511,14 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 				IsError: true,
 			}, nil
 		}
+		if cairnlineSidecarFixtureModeHas(mode, "strict-projects") && input.ID != "proj_fixture" {
+			if _, ok := state.projects[input.ID]; !ok {
+				return mcp.CallToolResult{
+					Content: mcp.TextContent("fixture project not found: " + input.ID),
+					IsError: true,
+				}, nil
+			}
+		}
 		project := cairnlineSidecarFixtureProject(input.ID)
 		if stored, ok := state.projects[input.ID]; ok {
 			project = stored
@@ -502,7 +526,7 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			project.ContextSources = cairnlineSidecarFixtureProjectSources(state, input.ID)
 		}
 		result := mcp.CallToolResult{Content: mcp.TextContent("Project " + input.ID + ": " + project.Name)}
-		if mode != "text-only" {
+		if !cairnlineSidecarFixtureTextOnly(mode, "projects.get") {
 			result.StructuredContent = mustRawJSON(project)
 		}
 		return result, nil
@@ -1011,7 +1035,7 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	case "artifacts.list":
 		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
 		items := cairnlineSidecarFixtureProjectArtifacts(state, projectID, workItemID)
-		if len(items) == 0 && mode == "collaboration-fixture" {
+		if len(items) == 0 && cairnlineSidecarFixtureModeHas(mode, "collaboration-fixture") {
 			items = cairnlineSidecarFixtureDefaultArtifacts(projectID, workItemID)
 		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Artifacts for %s (%d)", workItemID, len(items)), items)
@@ -1071,7 +1095,7 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	case "evidence.list":
 		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
 		items := cairnlineSidecarFixtureProjectEvidence(state, projectID, workItemID)
-		if len(items) == 0 && mode == "collaboration-fixture" {
+		if len(items) == 0 && cairnlineSidecarFixtureModeHas(mode, "collaboration-fixture") {
 			items = cairnlineSidecarFixtureDefaultEvidence(projectID, workItemID)
 		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Evidence for %s (%d)", workItemID, len(items)), items)
@@ -1128,7 +1152,7 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	case "reviews.list":
 		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
 		items := cairnlineSidecarFixtureProjectReviews(state, projectID, workItemID)
-		if len(items) == 0 && mode == "collaboration-fixture" {
+		if len(items) == 0 && cairnlineSidecarFixtureModeHas(mode, "collaboration-fixture") {
 			items = cairnlineSidecarFixtureDefaultReviews(projectID, workItemID)
 		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Reviews for %s (%d)", workItemID, len(items)), items)
@@ -1204,7 +1228,7 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	case "handoffs.list":
 		projectID, workItemID := cairnlineSidecarFixtureProjectWorkIDs(params.Arguments)
 		items := cairnlineSidecarFixtureProjectHandoffs(state, projectID, workItemID)
-		if len(items) == 0 && mode == "collaboration-fixture" {
+		if len(items) == 0 && cairnlineSidecarFixtureModeHas(mode, "collaboration-fixture") {
 			items = cairnlineSidecarFixtureDefaultHandoffs(projectID, workItemID)
 		}
 		return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Handoffs for %s (%d)", workItemID, len(items)), items)
@@ -1957,9 +1981,208 @@ func cairnlineSidecarFixtureApplyAssistantProposal(state *cairnlineSidecarFixtur
 	return result
 }
 
+func cairnlineSidecarFixtureProjectActivity(state *cairnlineSidecarFixtureState, projectID string) map[string]any {
+	assignments := cairnlineSidecarFixtureProjectAssignments(state, projectID)
+	if len(assignments) == 0 {
+		assignments = []ProjectCairnlineSidecarAssignmentItem{{
+			ProjectID:     projectID,
+			ID:            "asg_fixture",
+			WorkItemID:    "work_fixture",
+			RoleID:        "role_fixture",
+			ProfileID:     "profile_fixture",
+			ExecutionMode: "mcp_pull",
+			Status:        state.assignmentStatus,
+			ClaimedBy:     state.claimedBy,
+			ExecutionRef:  state.executionRef,
+		}}
+	}
+	items := make([]map[string]any, 0, len(assignments))
+	buckets := map[string][]map[string]any{
+		"active":    {},
+		"blocked":   {},
+		"completed": {},
+		"other":     {},
+		"recent":    {},
+	}
+	counts := map[string]int{"assignments": len(assignments)}
+	for _, assignment := range assignments {
+		bucket := cairnlineSidecarFixtureActivityBucket(assignment.Status)
+		counts[bucket]++
+		counts[assignment.Status]++
+		item := map[string]any{
+			"bucket":             bucket,
+			"assignment_id":      assignment.ID,
+			"work_item_id":       assignment.WorkItemID,
+			"work_item_title":    firstNonEmpty(cairnlineSidecarFixtureWorkItemTitle(state, projectID, assignment.WorkItemID), "Fixture Work"),
+			"role_id":            assignment.RoleID,
+			"role_name":          firstNonEmpty(cairnlineSidecarFixtureRoleName(state, projectID, assignment.RoleID), "Fixture Reviewer"),
+			"root_id":            assignment.RootID,
+			"status":             assignment.Status,
+			"execution_mode":     assignment.ExecutionMode,
+			"desired_agent_kind": "any",
+			"execution_ref":      assignment.ExecutionRef,
+			"created_at":         "2026-06-30T00:00:00Z",
+			"updated_at":         "2026-06-30T00:01:00Z",
+		}
+		items = append(items, item)
+		buckets[bucket] = append(buckets[bucket], item)
+		buckets["recent"] = append(buckets["recent"], item)
+	}
+	return map[string]any{
+		"project_id": projectID,
+		"counts":     counts,
+		"buckets":    buckets,
+		"items":      items,
+		"created_at": "2026-06-30T00:02:00Z",
+	}
+}
+
+func cairnlineSidecarFixtureProjectOperationsBrief(state *cairnlineSidecarFixtureState, projectID string) map[string]any {
+	activity := cairnlineSidecarFixtureProjectActivity(state, projectID)
+	activityItems, _ := activity["items"].([]map[string]any)
+	items := make([]map[string]any, 0, len(activityItems)+2)
+	for _, item := range activityItems {
+		assignmentID, _ := item["assignment_id"].(string)
+		workItemID, _ := item["work_item_id"].(string)
+		status, _ := item["status"].(string)
+		items = append(items, map[string]any{
+			"kind":          "assignment",
+			"severity":      cairnlineSidecarFixtureOperationSeverity(status),
+			"status":        status,
+			"title":         "Review assignment " + assignmentID,
+			"detail":        firstNonEmpty(status, "queued"),
+			"work_item_id":  workItemID,
+			"assignment_id": assignmentID,
+			"updated_at":    "2026-06-30T00:03:00Z",
+		})
+	}
+	handoffs := cairnlineSidecarFixtureProjectHandoffs(state, projectID, "")
+	if len(handoffs) == 0 {
+		handoffs = cairnlineSidecarFixtureDefaultHandoffs(projectID, "")
+	}
+	openHandoffs := 0
+	for _, handoff := range handoffs {
+		if handoff.Status != "pending" {
+			continue
+		}
+		openHandoffs++
+		items = append(items, map[string]any{
+			"kind":         "handoff",
+			"severity":     "action",
+			"status":       handoff.Status,
+			"title":        firstNonEmpty(handoff.Title, "Review handoff"),
+			"detail":       firstNonEmpty(handoff.RecommendedNextAction, handoff.Body),
+			"work_item_id": handoff.WorkItemID,
+			"artifact_id":  handoff.ID,
+			"updated_at":   "2026-06-30T00:04:00Z",
+		})
+	}
+	reviews := cairnlineSidecarFixtureProjectReviews(state, projectID, "")
+	if len(reviews) == 0 {
+		reviews = cairnlineSidecarFixtureDefaultReviews(projectID, "")
+	}
+	reviewFollowUps := 0
+	for _, review := range reviews {
+		if review.Verdict != "changes_requested" {
+			continue
+		}
+		reviewFollowUps++
+		items = append(items, map[string]any{
+			"kind":         "review_follow_up",
+			"severity":     "action",
+			"status":       review.Status,
+			"title":        firstNonEmpty(review.Title, "Review follow-up"),
+			"detail":       firstNonEmpty(review.Body, "Review requested changes."),
+			"work_item_id": review.WorkItemID,
+			"artifact_id":  review.ID,
+			"updated_at":   "2026-06-30T00:05:00Z",
+		})
+	}
+	counts := map[string]any{
+		"work_items":                1,
+		"open_work_items":           1,
+		"assignments":               len(activityItems),
+		"active_assignments":        cairnlineSidecarFixtureInt(activity, "counts", "active"),
+		"blocked_assignments":       cairnlineSidecarFixtureInt(activity, "counts", "blocked"),
+		"pending_memory_candidates": 0,
+		"review_follow_ups":         reviewFollowUps,
+		"missing_evidence":          0,
+		"open_handoffs":             openHandoffs,
+		"closeout_ready":            0,
+	}
+	return map[string]any{
+		"project_id": projectID,
+		"status":     "attention",
+		"title":      "Project operations",
+		"detail":     "Fixture operations brief.",
+		"counts":     counts,
+		"items":      items,
+		"created_at": "2026-06-30T00:06:00Z",
+	}
+}
+
+func cairnlineSidecarFixtureActivityBucket(status string) string {
+	switch status {
+	case "claimed", "running", "awaiting_review":
+		return "active"
+	case "completed":
+		return "completed"
+	case "queued", "failed", "cancelled":
+		return "blocked"
+	default:
+		return "other"
+	}
+}
+
+func cairnlineSidecarFixtureOperationSeverity(status string) string {
+	switch status {
+	case "queued", "failed", "cancelled":
+		return "blocked"
+	case "claimed", "running", "awaiting_review":
+		return "active"
+	default:
+		return "info"
+	}
+}
+
+func cairnlineSidecarFixtureInt(value map[string]any, keys ...string) int {
+	var current any = value
+	for _, key := range keys {
+		next, ok := current.(map[string]int)
+		if ok {
+			return next[key]
+		}
+		generic, ok := current.(map[string]any)
+		if !ok {
+			return 0
+		}
+		current = generic[key]
+	}
+	if v, ok := current.(int); ok {
+		return v
+	}
+	return 0
+}
+
+func cairnlineSidecarFixtureModeHas(mode, flag string) bool {
+	for _, part := range strings.FieldsFunc(mode, func(r rune) bool {
+		return r == '+' || r == ','
+	}) {
+		if strings.TrimSpace(part) == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func cairnlineSidecarFixtureTextOnly(mode, tool string) bool {
+	return cairnlineSidecarFixtureModeHas(mode, "text-only") ||
+		cairnlineSidecarFixtureModeHas(mode, tool+"-text-only")
+}
+
 func cairnlineSidecarFixtureListResult(mode, text string, structured any) (mcp.CallToolResult, *mcp.RPCError) {
 	result := mcp.CallToolResult{Content: mcp.TextContent(text)}
-	if mode != "text-only" {
+	if !cairnlineSidecarFixtureModeHas(mode, "text-only") {
 		result.StructuredContent = mustRawJSON(structured)
 	}
 	return result, nil

--- a/internal/api/handler_project_activity.go
+++ b/internal/api/handler_project_activity.go
@@ -106,6 +106,9 @@ type ProjectActivityHandoffSummaryResponse struct {
 }
 
 func (h *Handler) renderProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectActivity(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectActivity(ctx, projectID)
 	}

--- a/internal/api/handler_project_activity_cairnline.go
+++ b/internal/api/handler_project_activity_cairnline.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
@@ -15,6 +16,120 @@ func (h *Handler) renderCairnlineProjectActivity(ctx context.Context, projectID 
 	}
 	defer view.Close()
 	return h.renderCairnlineProjectActivityFromService(ctx, view.service, view.snapshot)
+}
+
+func (h *Handler) renderCairnlineSidecarProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	if !ok {
+		return ProjectActivityDataResponse{}, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	activity, err := h.cairnlineSidecarProjectActivity(ctx, project.ID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	workItemItems, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	assignmentItems, err := h.cairnlineSidecarProjectAssignments(ctx, project.ID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	roleItems, err := h.cairnlineSidecarProjectRoles(ctx, project.ID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	artifactItems, err := h.cairnlineSidecarProjectArtifacts(ctx, project.ID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	evidenceItems, err := h.cairnlineSidecarProjectEvidence(ctx, project.ID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	reviewItems, err := h.cairnlineSidecarProjectReviews(ctx, project.ID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	handoffItems, err := h.cairnlineSidecarProjectHandoffs(ctx, project.ID)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+
+	workItems := projectWorkItemsFromCairnlineSidecar(workItemItems)
+	assignments := projectAssignmentsFromCairnlineSidecar(assignmentItems)
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	projectedWorkItems := make(map[string]ProjectWorkItemResponse, len(workItems))
+	projectedAssignments := make(map[string]ProjectWorkAssignmentResponse, len(assignments))
+	for _, item := range workItems {
+		projected, err := h.renderProjectedProjectWorkItemWithAssignments(ctx, item, assignmentsByWorkItem[item.ID])
+		if err != nil {
+			return ProjectActivityDataResponse{}, err
+		}
+		projected.ReadBackend = "cairnline"
+		markProjectWorkAssignmentReadBackend(projected.Assignments, "cairnline")
+		projectedWorkItems[item.ID] = projected
+		for _, assignment := range projected.Assignments {
+			projectedAssignments[assignment.ID] = assignment
+		}
+	}
+	rolesByID := projectWorkRolesByID(projectRolesFromCairnlineSidecar(roleItems))
+	linkedChats := h.projectActivityLinkedChats(ctx, project.ID, assignments)
+	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(projectArtifactsFromCairnlineSidecar(artifactItems, evidenceItems, reviewItems))
+	handoffsByAssignment, handoffsByWorkItem := groupProjectActivityHandoffs(projectHandoffsFromCairnlineSidecar(handoffItems))
+
+	items := make([]ProjectActivityItemResponse, 0, len(activity.Items))
+	for _, item := range activity.Items {
+		projectedWorkItem, ok := projectedWorkItems[item.WorkItemID]
+		if !ok {
+			continue
+		}
+		projectedAssignment, ok := projectedAssignments[item.AssignmentID]
+		if !ok {
+			continue
+		}
+		activityArtifacts := artifactsByAssignment[projectedAssignment.ID]
+		if len(activityArtifacts) == 0 {
+			activityArtifacts = artifactsByWorkItem[projectedAssignment.WorkItemID]
+		}
+		activityHandoffs := handoffsByAssignment[projectedAssignment.ID]
+		if len(activityHandoffs) == 0 {
+			activityHandoffs = handoffsByWorkItem[projectedAssignment.WorkItemID]
+		}
+		items = append(items, renderProjectActivityItem(projectedWorkItem, projectedAssignment, rolesByID[projectedAssignment.RoleID], activityArtifacts, activityHandoffs, linkedChats[projectedAssignment.ID]))
+	}
+	sortProjectActivityItems(items)
+
+	response := ProjectActivityDataResponse{
+		ProjectID:   project.ID,
+		ReadBackend: "cairnline",
+		Recent:      boundedProjectActivityItems(items, 20),
+	}
+	response.Summary.WorkItemCount = len(workItems)
+	response.Summary.AssignmentCount = activity.Counts.Assignments
+	for _, item := range items {
+		switch projectActivityBucket(item) {
+		case "active":
+			response.Buckets.Active = append(response.Buckets.Active, item)
+			response.Summary.ActiveCount++
+		case "blocked":
+			response.Buckets.Blocked = append(response.Buckets.Blocked, item)
+			response.Summary.BlockedCount++
+		case "completed":
+			response.Buckets.Completed = append(response.Buckets.Completed, item)
+			response.Summary.CompletedCount++
+		}
+	}
+	response.Buckets.Recent = response.Recent
+	response.Summary.RecentCount = len(response.Recent)
+	response.Buckets.Active = boundedProjectActivityItems(response.Buckets.Active, 20)
+	response.Buckets.Blocked = boundedProjectActivityItems(response.Buckets.Blocked, 20)
+	response.Buckets.Completed = boundedProjectActivityItems(response.Buckets.Completed, 20)
+	return response, nil
 }
 
 func (h *Handler) renderCairnlineProjectActivityFromService(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) (ProjectActivityDataResponse, error) {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/mcp"
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/orchestrator"
@@ -139,7 +140,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, handoff lists, and closeout readiness through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, handoff lists, activity, closeout readiness, and operations brief through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +150,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, handoff lists, and closeout readiness through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, artifact lists, handoff lists, activity, closeout readiness, and operations brief through the sidecar."
 }
 
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
@@ -4030,6 +4031,36 @@ func projectCairnlineSidecarStructuredAssignmentContextAssignment(raw json.RawMe
 		return ProjectCairnlineSidecarAssignmentItem{}, false, err
 	}
 	return context.Assignment, true, nil
+}
+
+func projectCairnlineSidecarStructuredProjectActivity(raw json.RawMessage) (cairnline.ProjectActivity, bool, error) {
+	if len(raw) == 0 {
+		return cairnline.ProjectActivity{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return cairnline.ProjectActivity{}, false, nil
+	}
+	var activity cairnline.ProjectActivity
+	if err := json.Unmarshal(trimmed, &activity); err != nil {
+		return cairnline.ProjectActivity{}, false, err
+	}
+	return activity, true, nil
+}
+
+func projectCairnlineSidecarStructuredProjectOperationsBrief(raw json.RawMessage) (cairnline.ProjectOperationsBrief, bool, error) {
+	if len(raw) == 0 {
+		return cairnline.ProjectOperationsBrief{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return cairnline.ProjectOperationsBrief{}, false, nil
+	}
+	var brief cairnline.ProjectOperationsBrief
+	if err := json.Unmarshal(trimmed, &brief); err != nil {
+		return cairnline.ProjectOperationsBrief{}, false, err
+	}
+	return brief, true, nil
 }
 
 func projectCairnlineSidecarStructuredLaunchPacket(raw json.RawMessage) (ProjectCairnlineSidecarLaunchPacketIDs, ProjectCairnlineSidecarLaunchPacketCounts, []string, bool, error) {

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/memory"
@@ -140,6 +141,42 @@ func (h *Handler) callProjectCairnlineSidecarProjectReadTool(ctx context.Context
 		return nil, projectCairnlineSidecarReadFailure(err.Error())
 	}
 	return result, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectActivity(ctx context.Context, projectID string) (cairnline.ProjectActivity, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "projects.activity", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return cairnline.ProjectActivity{}, err
+	}
+	if result.IsError {
+		return cairnline.ProjectActivity{}, projectCairnlineSidecarReadFailure("projects.activity returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	activity, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjectActivity(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return cairnline.ProjectActivity{}, projectCairnlineSidecarReadFailure("projects.activity structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return cairnline.ProjectActivity{}, projectCairnlineSidecarReadFailure("projects.activity did not return typed structuredContent")
+	}
+	return activity, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectOperationsBrief(ctx context.Context, projectID string) (cairnline.ProjectOperationsBrief, error) {
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "projects.operations_brief", map[string]string{"project_id": strings.TrimSpace(projectID)})
+	if err != nil {
+		return cairnline.ProjectOperationsBrief{}, err
+	}
+	if result.IsError {
+		return cairnline.ProjectOperationsBrief{}, projectCairnlineSidecarReadFailure("projects.operations_brief returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	brief, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjectOperationsBrief(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return cairnline.ProjectOperationsBrief{}, projectCairnlineSidecarReadFailure("projects.operations_brief structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return cairnline.ProjectOperationsBrief{}, projectCairnlineSidecarReadFailure("projects.operations_brief did not return typed structuredContent")
+	}
+	return brief, nil
 }
 
 func renderProjectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectItem) ProjectResponseItem {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -61,7 +61,9 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"assignment-list",
 	"artifact-list",
 	"handoff-list",
+	"activity",
 	"closeout-readiness",
+	"operations-brief",
 }
 
 var projectCairnlineWriteAdapterSeamNames = []string{
@@ -359,13 +361,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignment context/launch, activity, assistant, and operations routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignment context/launch and assistant routes are not wired.",
 				}
 				return response
 			}
@@ -802,7 +804,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -815,7 +817,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, and closeout-readiness") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sort"
 	"strconv"
@@ -81,18 +82,25 @@ type ProjectOperationsBriefTargetResponse struct {
 
 func (h *Handler) HandleProjectOperationsBrief(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	brief, err := h.renderProjectOperationsBrief(r.Context(), projectID)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectOperationsBriefEnvelope{Object: "project_operations_brief", Data: brief})
 }
 
 func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID string) (ProjectOperationsBriefResponse, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.renderCairnlineSidecarProjectOperationsBrief(ctx, projectID)
+	}
 	project, ok, err := h.projects.Get(ctx, projectID)
 	if err != nil {
 		return ProjectOperationsBriefResponse{}, err

--- a/internal/api/handler_project_operations_cairnline.go
+++ b/internal/api/handler_project_operations_cairnline.go
@@ -28,6 +28,102 @@ func (h *Handler) renderCairnlineProjectOperationsBrief(ctx context.Context, pro
 	return h.renderCairnlineProjectOperationsBriefFromService(ctx, project, view.service, view.snapshot)
 }
 
+func (h *Handler) renderCairnlineSidecarProjectOperationsBrief(ctx context.Context, projectID string) (ProjectOperationsBriefResponse, error) {
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	if !ok {
+		return ProjectOperationsBriefResponse{}, projects.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	brief, err := h.cairnlineSidecarProjectOperationsBrief(ctx, project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	workItemItems, err := h.cairnlineSidecarProjectWorkItems(ctx, project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	assignmentItems, err := h.cairnlineSidecarProjectAssignments(ctx, project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	artifactItems, err := h.cairnlineSidecarProjectArtifacts(ctx, project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	evidenceItems, err := h.cairnlineSidecarProjectEvidence(ctx, project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	reviewItems, err := h.cairnlineSidecarProjectReviews(ctx, project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	handoffItems, err := h.cairnlineSidecarProjectHandoffs(ctx, project.ID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+
+	workItems := projectWorkItemsFromCairnlineSidecar(workItemItems)
+	assignments := projectAssignmentsFromCairnlineSidecar(assignmentItems)
+	artifacts := projectArtifactsFromCairnlineSidecar(artifactItems, evidenceItems, reviewItems)
+	handoffs := projectHandoffsFromCairnlineSidecar(handoffItems)
+	workItemsByID := projectOperationsSnapshotWorkItemsByID(workItems)
+	assignmentsByID := projectOperationsSnapshotAssignmentsByID(assignments)
+	assignmentsByWorkItem := groupProjectWorkAssignmentsByWorkItem(assignments)
+	artifactsByID := projectOperationsSnapshotArtifactsByID(artifacts)
+	handoffsByID := projectOperationsSnapshotHandoffsByID(handoffs)
+
+	items := make([]ProjectOperationsBriefItemResponse, 0, len(brief.Items)+1)
+	for _, item := range brief.Items {
+		rendered, ok := projectOperationItemFromCairnline(project.ID, item, workItemsByID, assignmentsByID, assignmentsByWorkItem, artifactsByID, handoffsByID)
+		if ok {
+			items = append(items, rendered)
+		}
+	}
+	if brief.Counts.PendingMemoryCandidates > 0 {
+		items = append(items, memoryCandidateOperationItem(project.ID, brief.Counts.PendingMemoryCandidates))
+	}
+	if len(items) == 0 {
+		if item := latestWorkOperationItem(project.ID, workItems); item != nil {
+			items = append(items, *item)
+		}
+	}
+
+	sortProjectOperationsItems(items)
+	availableItemCount := len(items)
+	items = boundedProjectOperationsItems(items, projectOperationsBriefItemLimit)
+	generatedAt := brief.CreatedAt
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	response := ProjectOperationsBriefResponse{
+		ProjectID:   project.ID,
+		GeneratedAt: formatOptionalTime(generatedAt),
+		ReadBackend: "cairnline",
+		Items:       items,
+	}
+	response.Summary.ItemCount = len(items)
+	response.Summary.AvailableItemCount = availableItemCount
+	response.Summary.OmittedItemCount = availableItemCount - len(items)
+	response.Summary.ItemLimit = projectOperationsBriefItemLimit
+	response.Summary.PendingMemoryCandidateCount = brief.Counts.PendingMemoryCandidates
+	response.Summary.PendingHandoffCount = brief.Counts.OpenHandoffs
+	for _, item := range items {
+		switch item.Priority {
+		case projectOperationsPriorityHigh:
+			response.Summary.HighCount++
+		case projectOperationsPriorityMedium:
+			response.Summary.MediumCount++
+		case projectOperationsPriorityLow:
+			response.Summary.LowCount++
+		}
+	}
+	return response, nil
+}
+
 func (h *Handler) renderCairnlineProjectOperationsBriefFromService(ctx context.Context, project projects.Project, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) (ProjectOperationsBriefResponse, error) {
 	activity, err := h.renderCairnlineProjectActivityFromService(ctx, service, snapshot)
 	if err != nil {

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -260,6 +261,58 @@ func TestProjectOperationsBrief_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	memoryItem := findProjectOperationsItemForTest(t, response.Data.Items, "review_memory_candidates")
 	if memoryItem.Target.Surface != "memory" || memoryItem.Action.Type != projectOperationsActionOpenMemoryReview {
 		t.Fatalf("memory item = %+v, want memory review action", memoryItem)
+	}
+}
+
+func TestProjectOperationsBrief_UsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "collaboration-fixture+strict-projects")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar operations enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/operations/brief", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operations status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectOperationsBriefEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode operations brief: %v", err)
+	}
+	if response.Object != "project_operations_brief" || response.Data.ProjectID != "proj_fixture" || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("operations response = %+v, want sidecar Cairnline operations", response)
+	}
+	start := findProjectOperationsItemForTest(t, response.Data.Items, "start_queued_assignment")
+	if start.Target.WorkItemID != "work_fixture" || start.Target.AssignmentID != "asg_fixture" || start.Action.Type != projectOperationsActionOpenAssignmentPreflight {
+		t.Fatalf("start item = %+v, want queued sidecar assignment preflight action", start)
+	}
+	review := findProjectOperationsItemForTest(t, response.Data.Items, "review_follow_up")
+	if review.Target.WorkItemID != "work_fixture" || review.Action.Type != projectOperationsActionOpenWorkItem {
+		t.Fatalf("review item = %+v, want sidecar review follow-up action", review)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/missing/operations/brief", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project operations status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectOperationsBrief_CairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "projects.operations_brief-text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/operations/brief", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("operations status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
 	}
 }
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -329,12 +329,16 @@ type ProjectHandoffResponse struct {
 
 func (h *Handler) HandleProjectActivity(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	activity, err := h.renderProjectActivity(r.Context(), projectID)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		writeProjectReadRenderError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectActivityEnvelope{Object: "project_activity", Data: activity})

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -4497,6 +4497,60 @@ func TestProjectWorkAPI_ProjectActivityCairnlineConfiguredUsesReadModel(t *testi
 	}
 }
 
+func TestProjectWorkAPI_ProjectActivityUsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "collaboration-fixture+strict-projects")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar activity enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/activity", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("activity status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectActivityEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode activity: %v", err)
+	}
+	if response.Object != "project_activity" || response.Data.ProjectID != "proj_fixture" || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("activity response = %+v, want sidecar Cairnline activity", response)
+	}
+	if response.Data.Summary.WorkItemCount != 1 || response.Data.Summary.AssignmentCount != 1 || response.Data.Summary.BlockedCount != 1 {
+		t.Fatalf("activity summary = %+v, want one blocked sidecar assignment", response.Data.Summary)
+	}
+	item := findProjectActivityItemForTest(t, response.Data.Buckets.Blocked, "asg_fixture")
+	if item.BlockingSignal != "not_started" || item.WorkItem.ID != "work_fixture" || item.Role.ID != "role_fixture" {
+		t.Fatalf("activity item = %+v, want queued sidecar assignment with work and role enrichment", item)
+	}
+	if item.ArtifactSummary.Count == 0 || item.HandoffSummary.Count == 0 {
+		t.Fatalf("activity item = %+v, want sidecar artifact and handoff enrichment", item)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/missing/activity", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project activity status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_ProjectActivityCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "projects.activity-text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/activity", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("activity status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_ProjectActivityCairnlineMatchesHecate(t *testing.T) {
 	t.Parallel()
 	hecateHandler, hecateServer := newProjectWorkProjectionTestServer(t, "memory")


### PR DESCRIPTION
## Summary
- route Project Activity through the Cairnline sidecar read source using typed projects.activity structuredContent
- route Project Operations brief through typed projects.operations_brief and sidecar list-tool enrichment
- update backend status/docs for the expanded sidecar read-route inventory

## Tests
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...
- git diff --check