### PR TITLE
feat(projects): read assignment preflight from Cairnline sidecar

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -182,9 +182,11 @@ When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, Hecate
 routes only project list/detail, setup-readiness, health, project skill list,
 project memory list, memory-candidate list, project role list, work-item
-list/detail, assignment-list, artifact-list, handoff-list, activity,
-closeout-readiness, and operations brief reads through the cached standalone
-Cairnline MCP client.
+list/detail, assignment-list, launch-readiness, assignment preflight,
+artifact-list, handoff-list, activity, closeout-readiness, and operations brief
+reads through the cached standalone Cairnline MCP client. Launch-readiness and
+assignment preflight consume typed `assignments.launch_packet` sidecar data
+before applying Hecate runtime validation.
 Other Projects reads, writes, mirrors, dispatch, approvals, and write-authority
 switchpoints remain Hecate-native or on the embedded dogfood path until
 sidecar-specific adapters exist for those route families.
@@ -214,8 +216,8 @@ scaffolding still come from Hecate until Cairnline becomes authoritative; the
 explicit sidecar read-source routes are the narrow exception for project
 list/detail, setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
-assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and
-operations brief reads.
+assignment-list, launch-readiness, assignment preflight, artifact-list,
+handoff-list, activity, closeout-readiness, and operations brief reads.
 Project Assistant draft generation also uses the Cairnline-projected context so
 preview and proposal assembly stay aligned, while the proposal ledger remains
 Hecate-owned unless `project-assistant-proposals` is enabled.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -376,10 +376,12 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, which routes only project
   list/detail, setup-readiness, health, project skill list, project memory
   list, memory-candidate list, project role list, work-item list/detail,
-  assignment-list, artifact-list, handoff-list, activity, closeout-readiness,
-  and operations brief reads through the cached standalone MCP client. Other
-  live Projects reads, writes, mirrors, and write-authority switchpoints do not
-  route through the sidecar yet.
+  assignment-list, launch-readiness, assignment preflight, artifact-list,
+  handoff-list, activity, closeout-readiness, and operations brief reads through
+  the cached standalone MCP client. Launch-readiness and assignment preflight
+  consume typed sidecar `assignments.launch_packet` data before applying Hecate
+  runtime validation. Other live Projects reads, writes, mirrors, and
+  write-authority switchpoints do not route through the sidecar yet.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,
@@ -397,8 +399,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the explicit sidecar read-source routes for project
   list/detail, setup-readiness, health, skills, memory, memory candidates, roles,
-  work items, assignment lists, artifact lists, handoff lists, activity,
-  closeout readiness, and operations brief, project identity and some
+  work items, assignment lists, launch-readiness, assignment preflight, artifact
+  lists, handoff lists, activity, closeout readiness, and operations brief,
+  project identity and some
   compatibility scaffolding remain Hecate-owned until Cairnline becomes
   authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -438,18 +438,23 @@ reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
-assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and
-operations brief reads through the standalone Cairnline MCP client; all other
-live Projects read routes remain Hecate-native or use the embedded dogfood read
-model when that is configured. Work-item list/detail, assignment-list,
+assignment-list, launch-readiness, assignment preflight, artifact-list,
+handoff-list, activity, closeout-readiness, and operations brief reads through
+the standalone Cairnline MCP client; all other live Projects read routes remain
+Hecate-native or use the embedded dogfood read model when that is configured.
+Launch-readiness and assignment preflight use the typed sidecar
+`assignments.launch_packet` response as their coordination input, then apply
+Hecate runtime validation; assignment start/prepare remains Hecate-owned.
+Work-item list/detail, assignment-list,
 artifact-list, handoff-list, activity, closeout-readiness, and operations brief
 reads render the work graph from Cairnline service records and overlay
 Hecate-only runtime refs/timestamps while Hecate still owns execution. Outside
 the explicit sidecar read-source routes for project list/detail,
 setup-readiness, health, skills, memory, memory candidates, roles, work items,
-assignment lists, artifact lists, handoff lists, activity, closeout readiness,
-and operations brief, project identity and some compatibility scaffolding remain
-Hecate-owned until Cairnline becomes authoritative. Project identity,
+assignment lists, launch-readiness, assignment preflight, artifact lists,
+handoff lists, activity, closeout readiness, and operations brief, project
+identity and some compatibility scaffolding remain Hecate-owned until Cairnline
+becomes authoritative. Project identity,
 metadata/default, root,
 and context-source mutations still write Hecate stores first and then
 best-effort mirror into the embedded Cairnline database through

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -511,8 +511,9 @@ sequenceDiagram
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness,
   health, skills, memory, memory candidates, roles, work items, assignment
-  lists, artifact lists, handoff lists, activity, closeout readiness, and
-  operations brief use the same sidecar source when it is configured.
+  lists, launch-readiness, assignment preflight, artifact lists, handoff lists,
+  activity, closeout readiness, and operations brief use the same sidecar source
+  when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -528,10 +529,10 @@ sequenceDiagram
   reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
   project list/detail, setup-readiness, health, project skill list, project
   memory list, memory-candidate list, project role list, work-item list/detail,
-  assignment-list, artifact-list, handoff-list, activity, closeout-readiness,
-  and operations-brief reads through the standalone Cairnline MCP client; all
-  other live Projects read routes stay on Hecate-native or embedded dogfood
-  paths.
+  assignment-list, launch-readiness, assignment preflight, artifact-list,
+  handoff-list, activity, closeout-readiness, and operations-brief reads through
+  the standalone Cairnline MCP client; all other live Projects read routes stay
+  on Hecate-native or embedded dogfood paths.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2413,10 +2414,11 @@ fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
-assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and
-operations-brief reads through the standalone Cairnline MCP client; backend
-status reports those routes in `read_routes` while `read_model_switch_ready`
-remains false because the broader read model is not sidecar-backed yet.
+assignment-list, launch-readiness, assignment preflight, artifact-list,
+handoff-list, activity, closeout-readiness, and operations-brief reads through
+the standalone Cairnline MCP client; backend status reports those routes in
+`read_routes` while `read_model_switch_ready` remains false because the broader
+read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
@@ -2854,7 +2856,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3067,7 +3069,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -5688,8 +5690,10 @@ When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, this
 endpoint validates the work item through typed `work_items.list` and reads
 assignments through typed `assignments.list` on the standalone Cairnline MCP
-client. Assignment context, launch-readiness, preflight, start/prepare, and
-status mutation routes remain Hecate-owned.
+client. Launch-readiness and assignment preflight read typed
+`assignments.launch_packet` sidecar data before applying Hecate runtime
+validation. Stored assignment context, start/prepare, and status mutation routes
+remain Hecate-owned.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
 

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -160,7 +160,7 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		}
 		result := mcp.CallToolResult{Content: mcp.TextContent("Projects (1):\n- proj_fixture: Fixture Project")}
 		if !cairnlineSidecarFixtureTextOnly(mode, "projects.list") {
-			result.StructuredContent = mustRawJSON(cairnlineSidecarFixtureProjects(state))
+			result.StructuredContent = mustRawJSON(cairnlineSidecarFixtureProjects(mode, state))
 		}
 		return result, nil
 	case "profiles.list":
@@ -415,18 +415,27 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		if stored, ok := state.assignments[input.ProjectID][input.AssignmentID]; ok {
 			assignment = stored
 		}
+		projectID := input.ProjectID
+		if cairnlineSidecarFixtureModeHas(mode, "launch-packet-project-mismatch") {
+			projectID = "proj_other"
+		}
+		workItemID := assignment.WorkItemID
+		if cairnlineSidecarFixtureModeHas(mode, "launch-packet-route-mismatch") {
+			workItemID = "work_other"
+		}
 		result := mcp.CallToolResult{Content: mcp.TextContent("Launch packet launch_fixture for " + input.AssignmentID)}
-		if mode != "text-only" {
+		if !cairnlineSidecarFixtureTextOnly(mode, "assignments.launch_packet") {
 			result.StructuredContent = mustRawJSON(map[string]any{
 				"id":   "launch_fixture",
 				"kind": "assignment_launch_packet",
 				"project": map[string]any{
-					"id":   input.ProjectID,
+					"id":   projectID,
 					"name": "Fixture Project",
 				},
 				"work_item": map[string]any{
-					"id":    assignment.WorkItemID,
-					"title": firstNonEmpty(cairnlineSidecarFixtureWorkItemTitle(state, input.ProjectID, assignment.WorkItemID), "Fixture Work"),
+					"id":         workItemID,
+					"project_id": projectID,
+					"title":      firstNonEmpty(cairnlineSidecarFixtureWorkItemTitle(state, input.ProjectID, workItemID), "Fixture Work"),
 				},
 				"role": map[string]any{
 					"id":   assignment.RoleID,
@@ -437,8 +446,11 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 					"name": "Fixture Profile",
 				},
 				"execution_profile": map[string]any{
-					"id":   "exec_fixture",
-					"name": "Fixture Execution",
+					"id":           "exec_fixture",
+					"name":         "Fixture Execution",
+					"agent_kind":   "any",
+					"model_hint":   "fixture-model",
+					"tools_policy": "readonly",
 				},
 				"skills": []map[string]any{{
 					"id":    "skill_fixture",
@@ -446,8 +458,8 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 				}},
 				"assignment": map[string]any{
 					"id":             assignment.ID,
-					"project_id":     assignment.ProjectID,
-					"work_item_id":   assignment.WorkItemID,
+					"project_id":     projectID,
+					"work_item_id":   workItemID,
 					"role_id":        assignment.RoleID,
 					"status":         assignment.Status,
 					"claimed_by":     assignment.ClaimedBy,
@@ -519,7 +531,10 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 				}, nil
 			}
 		}
-		project := cairnlineSidecarFixtureProject(input.ID)
+		project := cairnlineSidecarFixtureProject(mode, input.ID)
+		if cairnlineSidecarFixtureModeHas(mode, "project-route-mismatch") {
+			project.ID = "proj_other"
+		}
 		if stored, ok := state.projects[input.ID]; ok {
 			project = stored
 			project.Roots = cairnlineSidecarFixtureProjectRoots(state, input.ID)
@@ -1486,11 +1501,12 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 	}
 }
 
-func cairnlineSidecarFixtureProject(id string) ProjectCairnlineSidecarProjectItem {
-	return ProjectCairnlineSidecarProjectItem{
-		ID:          id,
-		Name:        "Fixture Project",
-		Description: "Structured fixture project",
+func cairnlineSidecarFixtureProject(mode, id string) ProjectCairnlineSidecarProjectItem {
+	project := ProjectCairnlineSidecarProjectItem{
+		ID:            id,
+		Name:          "Fixture Project",
+		Description:   "Structured fixture project",
+		DefaultRootID: "root_fixture",
 		Roots: []ProjectCairnlineSidecarRootItem{{
 			ID:     "root_fixture",
 			Path:   "/workspace/fixture",
@@ -1505,10 +1521,16 @@ func cairnlineSidecarFixtureProject(id string) ProjectCairnlineSidecarProjectIte
 			Enabled: true,
 		}},
 	}
+	if cairnlineSidecarFixtureModeHas(mode, "temp-root") {
+		for i := range project.Roots {
+			project.Roots[i].Path = os.TempDir()
+		}
+	}
+	return project
 }
 
-func cairnlineSidecarFixtureProjects(state *cairnlineSidecarFixtureState) []ProjectCairnlineSidecarProjectItem {
-	projects := []ProjectCairnlineSidecarProjectItem{cairnlineSidecarFixtureProject("proj_fixture")}
+func cairnlineSidecarFixtureProjects(mode string, state *cairnlineSidecarFixtureState) []ProjectCairnlineSidecarProjectItem {
+	projects := []ProjectCairnlineSidecarProjectItem{cairnlineSidecarFixtureProject(mode, "proj_fixture")}
 	for _, project := range state.projects {
 		project.Roots = cairnlineSidecarFixtureProjectRoots(state, project.ID)
 		project.ContextSources = cairnlineSidecarFixtureProjectSources(state, project.ID)

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -82,6 +82,15 @@ func (h *Handler) HandleProjectWorkAssignmentLaunchReadiness(w http.ResponseWrit
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
 		return
 	}
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		readiness, err := h.renderCairnlineSidecarProjectAssignmentLaunchReadiness(ctx, projectID, workItemID, assignmentID)
+		if err != nil {
+			WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectAssignmentLaunchReadinessEnvelope{Object: "project_assignment_launch_readiness", Data: readiness})
+		return
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		readiness, err := h.renderCairnlineProjectAssignmentLaunchReadiness(ctx, projectID, workItemID, assignmentID)
 		if err != nil {
@@ -139,6 +148,30 @@ func (h *Handler) HandleProjectWorkAssignmentPreflight(w http.ResponseWriter, r 
 	assignmentID := r.PathValue("assignment_id")
 	if h.projects == nil || h.projectWork == nil {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
+		return
+	}
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		inputs, err := h.cairnlineSidecarProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
+		if err != nil {
+			WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+			return
+		}
+		if !inputs.RoleOK {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment role not found")
+			return
+		}
+		if projectWorkAssignmentIsTerminal(inputs.Assignment.Status) {
+			WriteError(w, http.StatusConflict, errCodeConflict, "terminal assignments cannot be started")
+			return
+		}
+		contextPacket, err := h.projectAssignmentPreflightContext(ctx, inputs.Project, inputs.WorkItem, inputs.Assignment, inputs.Role)
+		if err != nil {
+			WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+			return
+		}
+		appendCairnlineAssignmentLaunchPacketEvidenceItem(&contextPacket, inputs.CairnlineLaunchPacket)
+		contextPacket = chatcontext.Normalize(contextPacket, chatcontext.ProjectAssignmentRefs(inputs.Project.ID, inputs.WorkItem.ID, inputs.Assignment.ID, inputs.Role.ID))
+		writeChatContextPacket(w, contextPacket)
 		return
 	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
@@ -231,6 +264,9 @@ func projectAssignmentPreflightHTTPStatus(err error) int {
 	if errors.As(err, &preflightErr) && preflightErr.status != 0 {
 		return preflightErr.status
 	}
+	if errors.Is(err, errProjectCairnlineSidecarReadFailed) {
+		return http.StatusBadGateway
+	}
 	var launchErr projectworkapp.LaunchPlanError
 	if errors.As(err, &launchErr) {
 		switch launchErr.Kind {
@@ -251,6 +287,9 @@ func projectAssignmentPreflightErrorCode(err error) string {
 	var preflightErr projectAssignmentPreflightError
 	if errors.As(err, &preflightErr) && preflightErr.code != "" {
 		return preflightErr.code
+	}
+	if errors.Is(err, errProjectCairnlineSidecarReadFailed) {
+		return errCodeGatewayError
 	}
 	var launchErr projectworkapp.LaunchPlanError
 	if errors.As(err, &launchErr) {
@@ -359,12 +398,26 @@ func (h *Handler) renderCairnlineProjectAssignmentLaunchReadiness(ctx context.Co
 	return readiness, nil
 }
 
+func (h *Handler) renderCairnlineSidecarProjectAssignmentLaunchReadiness(ctx context.Context, projectID, workItemID, assignmentID string) (ProjectAssignmentLaunchReadinessResponse, error) {
+	inputs, err := h.cairnlineSidecarProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
+	if err != nil {
+		return ProjectAssignmentLaunchReadinessResponse{}, err
+	}
+	readiness, err := h.renderProjectAssignmentLaunchReadiness(ctx, inputs.Project, inputs.WorkItem, inputs.Assignment, inputs.Role, inputs.RoleOK)
+	if err != nil {
+		return ProjectAssignmentLaunchReadinessResponse{}, err
+	}
+	readiness.ReadBackend = "cairnline"
+	return readiness, nil
+}
+
 type projectAssignmentLaunchInputs struct {
-	Project    projects.Project
-	WorkItem   projectwork.WorkItem
-	Assignment projectwork.Assignment
-	Role       projectwork.AgentRoleProfile
-	RoleOK     bool
+	Project               projects.Project
+	WorkItem              projectwork.WorkItem
+	Assignment            projectwork.Assignment
+	Role                  projectwork.AgentRoleProfile
+	RoleOK                bool
+	CairnlineLaunchPacket cairnline.AssignmentLaunchPacket
 }
 
 func (h *Handler) cairnlineProjectAssignmentLaunchInputs(ctx context.Context, projectID, workItemID, assignmentID string) (projectAssignmentLaunchInputs, error) {
@@ -415,6 +468,76 @@ func (h *Handler) cairnlineProjectAssignmentLaunchInputs(ctx context.Context, pr
 	}, nil
 }
 
+func (h *Handler) cairnlineSidecarProjectAssignmentLaunchInputs(ctx context.Context, projectID, workItemID, assignmentID string) (projectAssignmentLaunchInputs, error) {
+	projectID = strings.TrimSpace(projectID)
+	workItemID = strings.TrimSpace(workItemID)
+	assignmentID = strings.TrimSpace(assignmentID)
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if !ok {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "project not found")
+	}
+	if strings.TrimSpace(projectItem.ID) != projectID {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "project not found")
+	}
+	launch, ok, err := h.cairnlineSidecarAssignmentLaunchPacket(ctx, projectID, assignmentID)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if !ok {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
+	}
+	if cairnlineSidecarLaunchPacketRouteMismatch(launch, projectItem.ID, workItemID, assignmentID) {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
+	}
+	nativeProject := projectFromCairnlineSidecar(projectItem)
+	project := projectFromCairnline(launch.Project, launch.ExecutionProfile, nativeProject)
+	if len(project.Roots) == 0 {
+		project.Roots = nativeProject.Roots
+	}
+	if strings.TrimSpace(project.DefaultRootID) == "" {
+		project.DefaultRootID = nativeProject.DefaultRootID
+	}
+	workItem := projectWorkItemFromCairnline(launch.WorkItem)
+	assignment := projectWorkAssignmentFromCairnline(launch.Assignment)
+	role, roleOK := cairnlineSidecarLaunchRole(launch)
+	return projectAssignmentLaunchInputs{
+		Project:               project,
+		WorkItem:              workItem,
+		Assignment:            assignment,
+		Role:                  role,
+		RoleOK:                roleOK,
+		CairnlineLaunchPacket: launch,
+	}, nil
+}
+
+func cairnlineSidecarLaunchPacketRouteMismatch(launch cairnline.AssignmentLaunchPacket, projectID, workItemID, assignmentID string) bool {
+	projectID = strings.TrimSpace(projectID)
+	workItemID = strings.TrimSpace(workItemID)
+	assignmentID = strings.TrimSpace(assignmentID)
+	if strings.TrimSpace(launch.Project.ID) != projectID {
+		return true
+	}
+	if strings.TrimSpace(launch.WorkItem.ID) != workItemID {
+		return true
+	}
+	if strings.TrimSpace(launch.Assignment.ID) != assignmentID {
+		return true
+	}
+	if strings.TrimSpace(launch.WorkItem.ProjectID) != projectID {
+		return true
+	}
+	if strings.TrimSpace(launch.Assignment.ProjectID) != projectID {
+		return true
+	}
+	if strings.TrimSpace(launch.Assignment.WorkItemID) != workItemID {
+		return true
+	}
+	return false
+}
+
 func cairnlineProjectWorkItemExists(ctx context.Context, service *cairnline.Service, projectID, workItemID string) (bool, error) {
 	items, err := service.ListWorkItems(ctx, projectID)
 	if err != nil {
@@ -439,6 +562,39 @@ func cairnlineLaunchRole(ctx context.Context, service *cairnline.Service, snapsh
 	}
 	role := projectWorkRoleFromCairnline(*launch.Role, cairnlineExecutionProfilesByID(executionProfiles), projectWorkRolesByID(snapshot.Roles)[launch.Role.ID])
 	return role, true, nil
+}
+
+func cairnlineSidecarLaunchRole(launch cairnline.AssignmentLaunchPacket) (projectwork.AgentRoleProfile, bool) {
+	if launch.Role == nil {
+		return projectwork.AgentRoleProfile{ID: strings.TrimSpace(launch.Assignment.RoleID)}, false
+	}
+	executionProfiles := map[string]cairnline.ExecutionProfile{}
+	if launch.ExecutionProfile != nil && strings.TrimSpace(launch.ExecutionProfile.ID) != "" {
+		executionProfiles[launch.ExecutionProfile.ID] = *launch.ExecutionProfile
+	}
+	role := projectWorkRoleFromCairnline(*launch.Role, executionProfiles, projectwork.AgentRoleProfile{})
+	if strings.TrimSpace(role.ProjectID) == "" {
+		role.ProjectID = strings.TrimSpace(firstNonEmpty(launch.Role.ProjectID, launch.Assignment.ProjectID, launch.Project.ID))
+	}
+	if strings.TrimSpace(role.DefaultAgentProfile) == "" {
+		profileID := strings.TrimSpace(launch.Assignment.ProfileID)
+		if launch.Profile != nil {
+			profileID = firstNonEmpty(strings.TrimSpace(launch.Profile.ID), profileID)
+		}
+		role.DefaultAgentProfile = profileID
+	}
+	if launch.ExecutionProfile != nil {
+		if strings.TrimSpace(role.DefaultProvider) == "" {
+			role.DefaultProvider = strings.TrimSpace(launch.ExecutionProfile.ProviderHint)
+		}
+		if strings.TrimSpace(role.DefaultModel) == "" {
+			role.DefaultModel = strings.TrimSpace(launch.ExecutionProfile.ModelHint)
+		}
+	}
+	if strings.TrimSpace(role.DefaultDriverKind) == "" {
+		role.DefaultDriverKind = projectWorkAssignmentDriverFromCairnline(launch.Assignment.ExecutionMode)
+	}
+	return role, true
 }
 
 func (h *Handler) populateTaskAssignmentLaunchReadiness(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, readiness *ProjectAssignmentLaunchReadinessResponse) error {

--- a/internal/api/handler_project_assignment_launch_readiness_test.go
+++ b/internal/api/handler_project_assignment_launch_readiness_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/hecatehq/hecate/internal/projects"
@@ -128,6 +130,100 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessUsesCairnlineReadModelWhenConfi
 	}
 	if len(tasks) != 0 {
 		t.Fatalf("tasks = %+v, want no task created by Cairnline launch readiness", tasks)
+	}
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessUsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar launch readiness enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/launch-readiness", "")
+	if readiness.Object != "project_assignment_launch_readiness" {
+		t.Fatalf("object = %q, want project_assignment_launch_readiness", readiness.Object)
+	}
+	if readiness.Data.ReadBackend != "cairnline" {
+		t.Fatalf("read_backend = %q, want cairnline", readiness.Data.ReadBackend)
+	}
+	if !readiness.Data.Ready || readiness.Data.Status != projectAssignmentLaunchReadinessStatusReady {
+		t.Fatalf("readiness = %+v, want sidecar Cairnline-backed ready launch projection", readiness.Data)
+	}
+	if readiness.Data.ProjectID != "proj_fixture" || readiness.Data.WorkItemID != "work_fixture" || readiness.Data.AssignmentID != "asg_fixture" {
+		t.Fatalf("refs = %+v, want sidecar project/work/assignment refs", readiness.Data)
+	}
+	if readiness.Data.DriverKind != projectwork.AssignmentDriverHecateTask || readiness.Data.RootID != "root_fixture" || readiness.Data.Workspace == "" {
+		t.Fatalf("launch target = %+v, want sidecar root plus Hecate runtime validation", readiness.Data)
+	}
+	if readiness.Data.ProfilePosture == nil || readiness.Data.ProfilePosture.ID != "profile_fixture" || !readiness.Data.ProfilePosture.Missing {
+		t.Fatalf("profile_posture = %+v, want missing sidecar profile ref to remain explicit", readiness.Data.ProfilePosture)
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want no task created by sidecar launch readiness", tasks)
+	}
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessCairnlineSidecarRequiresStructuredLaunchPacket(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "assignments.launch_packet-text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/launch-readiness", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("launch readiness status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessCairnlineSidecarRejectsRouteMismatch(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root+launch-packet-route-mismatch")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/launch-readiness", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("launch readiness status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "assignment not found") {
+		t.Fatalf("error body = %s, want scoped assignment not found", rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessCairnlineSidecarRejectsProjectMismatch(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root+project-route-mismatch")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/launch-readiness", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("launch readiness status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "project not found") {
+		t.Fatalf("error body = %s, want scoped project not found", rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessCairnlineSidecarRejectsLaunchPacketProjectMismatch(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root+launch-packet-project-mismatch")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/launch-readiness", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("launch readiness status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "assignment not found") {
+		t.Fatalf("error body = %s, want scoped assignment not found", rec.Body.String())
 	}
 }
 

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -4063,6 +4063,21 @@ func projectCairnlineSidecarStructuredProjectOperationsBrief(raw json.RawMessage
 	return brief, true, nil
 }
 
+func projectCairnlineSidecarStructuredAssignmentLaunchPacket(raw json.RawMessage) (cairnline.AssignmentLaunchPacket, bool, error) {
+	if len(raw) == 0 {
+		return cairnline.AssignmentLaunchPacket{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return cairnline.AssignmentLaunchPacket{}, false, nil
+	}
+	var packet cairnline.AssignmentLaunchPacket
+	if err := json.Unmarshal(trimmed, &packet); err != nil {
+		return cairnline.AssignmentLaunchPacket{}, false, err
+	}
+	return packet, true, nil
+}
+
 func projectCairnlineSidecarStructuredLaunchPacket(raw json.RawMessage) (ProjectCairnlineSidecarLaunchPacketIDs, ProjectCairnlineSidecarLaunchPacketCounts, []string, bool, error) {
 	if len(raw) == 0 {
 		return ProjectCairnlineSidecarLaunchPacketIDs{}, ProjectCairnlineSidecarLaunchPacketCounts{}, nil, false, nil

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -179,6 +179,35 @@ func (h *Handler) cairnlineSidecarProjectOperationsBrief(ctx context.Context, pr
 	return brief, nil
 }
 
+func (h *Handler) cairnlineSidecarAssignmentLaunchPacket(ctx context.Context, projectID, assignmentID string) (cairnline.AssignmentLaunchPacket, bool, error) {
+	projectID = strings.TrimSpace(projectID)
+	assignmentID = strings.TrimSpace(assignmentID)
+	if projectID == "" || assignmentID == "" {
+		return cairnline.AssignmentLaunchPacket{}, false, nil
+	}
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "assignments.launch_packet", map[string]string{
+		"project_id":    projectID,
+		"assignment_id": assignmentID,
+	})
+	if err != nil {
+		return cairnline.AssignmentLaunchPacket{}, false, err
+	}
+	if result.IsError {
+		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
+			return cairnline.AssignmentLaunchPacket{}, false, nil
+		}
+		return cairnline.AssignmentLaunchPacket{}, false, projectCairnlineSidecarReadFailure("assignments.launch_packet returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	packet, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignmentLaunchPacket(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return cairnline.AssignmentLaunchPacket{}, false, projectCairnlineSidecarReadFailure("assignments.launch_packet structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return cairnline.AssignmentLaunchPacket{}, false, projectCairnlineSidecarReadFailure("assignments.launch_packet did not return typed structuredContent")
+	}
+	return packet, true, nil
+}
+
 func renderProjectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectItem) ProjectResponseItem {
 	converted := projectFromCairnlineSidecar(project)
 	return renderProjectWithBackend(converted, "cairnline")

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -59,6 +59,8 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"roles",
 	"work-item",
 	"assignment-list",
+	"launch-readiness",
+	"assignment-preflight",
 	"artifact-list",
 	"handoff-list",
 	"activity",
@@ -361,13 +363,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assignment context/launch and assistant routes are not wired.",
+					"Full Cairnline read-model replacement remains blocked because sidecar adapters for stored assignment context and assistant routes are not wired.",
 				}
 				return response
 			}
@@ -804,7 +806,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -817,7 +819,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief through the standalone Cairnline MCP client; other Cairnline read-model routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief through the standalone Cairnline MCP client; stored assignment context and assistant read routes are not sidecar-backed yet."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,7 +230,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief") || !strings.Contains(warnings, "Full Cairnline read-model replacement remains blocked") {
+	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief") || !strings.Contains(warnings, "stored assignment context and assistant routes are not wired") {
 		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
 	}
 }

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2285,6 +2285,112 @@ func TestProjectWorkAPI_PreflightAndStartIncludeCairnlineLaunchPacketEvidenceWhe
 	assertCairnlineLaunchPacketEvidenceForTest(t, started.Data)
 }
 
+func TestProjectWorkAPI_PreflightAssignmentUsesCairnlineSidecarLaunchPacketWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar preflight enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/preflight", "")
+	if packetResp.Data.ExecutionMode != chat.ExecutionModeHecateTask || packetResp.Data.Model != "fixture-model" {
+		t.Fatalf("sidecar preflight mode/model = %q/%q, want Hecate task fixture-model", packetResp.Data.ExecutionMode, packetResp.Data.Model)
+	}
+	if packetResp.Data.ExecutionProfile != "profile_fixture" || packetResp.Data.Workspace == "" {
+		t.Fatalf("sidecar preflight profile/workspace = %q/%q, want profile_fixture and resolved workspace", packetResp.Data.ExecutionProfile, packetResp.Data.Workspace)
+	}
+	if packetResp.Data.Refs == nil || packetResp.Data.Refs.ProjectID != "proj_fixture" || packetResp.Data.Refs.WorkItemID != "work_fixture" || packetResp.Data.Refs.AssignmentID != "asg_fixture" || packetResp.Data.Refs.RoleID != "role_fixture" {
+		t.Fatalf("sidecar preflight refs = %+v, want project/work/assignment/role refs", packetResp.Data.Refs)
+	}
+	if packetResp.Data.Refs.TaskID != "" || packetResp.Data.Refs.RunID != "" || packetResp.Data.Refs.SessionID != "" {
+		t.Fatalf("sidecar preflight refs = %+v, want no task/run/session side effects", packetResp.Data.Refs)
+	}
+	item := findRenderedContextItemByOrigin(packetResp.Data, "cairnline.assignment_launch_packet")
+	if item == nil || item.Section != contextSectionRuntime || item.Included {
+		t.Fatalf("sidecar launch packet item = %+v, want inspect-only runtime evidence", item)
+	}
+	for _, want := range []string{
+		"Ready: true",
+		"Project: proj_fixture",
+		"Work item: work_fixture",
+		"Assignment: asg_fixture",
+		"Execution mode: mcp_pull",
+		"Skills: 1; artifacts: 1; evidence: 1; reviews: 1; handoffs: 1; memory: 1; memory candidates: 1",
+	} {
+		if !strings.Contains(item.Body, want) {
+			t.Fatalf("sidecar launch packet body = %q, want %q", item.Body, want)
+		}
+	}
+	for key, want := range map[string]string{
+		"read_backend":         "cairnline",
+		"ready":                "true",
+		"project_id":           "proj_fixture",
+		"work_item_id":         "work_fixture",
+		"assignment_id":        "asg_fixture",
+		"role_id":              "role_fixture",
+		"execution_mode":       "mcp_pull",
+		"profile_id":           "profile_fixture",
+		"execution_profile_id": "exec_fixture",
+		"skill_count":          "1",
+	} {
+		if item.Metadata[key] != want {
+			t.Fatalf("sidecar launch packet metadata[%q] = %q, want %q in %+v", key, item.Metadata[key], want, item.Metadata)
+		}
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want no task created by sidecar preflight", tasks)
+	}
+}
+
+func TestProjectWorkAPI_PreflightAssignmentCairnlineSidecarRequiresStructuredLaunchPacket(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "assignments.launch_packet-text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/preflight", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("preflight status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_PreflightAssignmentCairnlineSidecarRejectsRouteMismatch(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root+launch-packet-route-mismatch")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/preflight", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("preflight status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "assignment not found") {
+		t.Fatalf("error body = %s, want scoped assignment not found", rec.Body.String())
+	}
+}
+
+func TestProjectWorkAPI_PreflightAssignmentCairnlineSidecarRejectsProjectMismatch(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root+project-route-mismatch")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/preflight", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("preflight status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "project not found") {
+		t.Fatalf("error body = %s, want scoped project not found", rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_PreflightAndStartSnapshotModelReadiness(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServerWithProviders(&fakeProvider{


### PR DESCRIPTION
## Summary
- route launch readiness and assignment preflight reads through the Cairnline sidecar when sidecar read-source mode is enabled
- consume typed assignments.launch_packet data, add scoped route validation, and keep assignment start/prepare Hecate-owned
- update sidecar readiness/status docs and coverage for structuredContent and mismatched packet failures

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(AssignmentLaunchReadinessUsesCairnlineSidecarWhenConfigured|AssignmentLaunchReadinessCairnlineSidecarRejectsRouteMismatch|PreflightAssignmentUsesCairnlineSidecarLaunchPacketWhenConfigured|WorkItemsUseCairnlineSidecarWhenConfigured)|TestProjectsAPI_ReadsUseCairnlineSidecarWhenConfigured'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-sidecar-client/.gocache" go test -race -timeout 10m ./...
- just agent-docs-check
- git diff --check