### PR TITLE
feat(projects): read assistant state from Cairnline sidecar

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -183,11 +183,17 @@ When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 routes only project list/detail, setup-readiness, health, project skill list,
 project memory list, memory-candidate list, project role list, work-item
 list/detail, assignment-list, assignment-context, launch-readiness, assignment preflight,
-artifact-list, handoff-list, activity, closeout-readiness, and operations brief
-reads through the cached standalone Cairnline MCP client. Assignment-context
-reads consume typed `assignments.context` sidecar data. Launch-readiness and
-assignment preflight consume typed `assignments.launch_packet` sidecar data
-before applying Hecate runtime validation.
+artifact-list, handoff-list, Project Assistant context/proposal record reads,
+activity, closeout-readiness, and operations brief reads through the cached
+standalone Cairnline MCP client. Assignment-context reads consume typed
+`assignments.context` sidecar data. Launch-readiness and assignment preflight
+consume typed `assignments.launch_packet` sidecar data before applying Hecate
+runtime validation. Project Assistant context/proposal reads consume typed
+project, work, skill, memory, and `assistant.proposals.get` sidecar data.
+Proposal-record reads fall back to the Hecate-native proposal ledger only when
+the sidecar reports the proposal is missing, because draft/propose/apply
+mutations remain Hecate-owned unless their explicit write-authority switchpoints
+are enabled.
 Other Projects reads, writes, mirrors, dispatch, approvals, and write-authority
 switchpoints remain Hecate-native or on the embedded dogfood path until
 sidecar-specific adapters exist for those route families.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -439,9 +439,12 @@ reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight, artifact-list,
-handoff-list, activity, closeout-readiness, and operations brief reads through
-the standalone Cairnline MCP client; all other live Projects read routes remain
-Hecate-native or use the embedded dogfood read model when that is configured.
+handoff-list, Project Assistant context/proposal record reads, activity,
+closeout-readiness, and operations brief reads through the standalone Cairnline
+MCP client. Proposal-record reads fall back to the Hecate-native proposal
+ledger only when the sidecar reports the proposal is missing; draft/propose/apply
+mutations remain Hecate-owned unless their explicit write-authority switchpoints
+are enabled.
 Assignment-context reads use typed sidecar `assignments.context` data.
 Launch-readiness and assignment preflight use the typed sidecar
 `assignments.launch_packet` response as their coordination input, then apply
@@ -452,10 +455,11 @@ reads render the work graph from Cairnline service records and overlay
 Hecate-only runtime refs/timestamps while Hecate still owns execution. Outside
 the explicit sidecar read-source routes for project list/detail,
 setup-readiness, health, skills, memory, memory candidates, roles, work items,
-assignment lists, assignment context, launch-readiness, assignment preflight, artifact lists,
-handoff lists, activity, closeout readiness, and operations brief, project
-identity and some compatibility scaffolding remain Hecate-owned until Cairnline
-becomes authoritative. Project identity,
+assignment lists, assignment context, launch-readiness, assignment preflight,
+artifact lists, handoff lists, Project Assistant context/proposal reads,
+activity, closeout readiness, and operations brief, project identity and some
+compatibility scaffolding remain Hecate-owned until Cairnline becomes
+authoritative. Project identity,
 metadata/default, root,
 and context-source mutations still write Hecate stores first and then
 best-effort mirror into the embedded Cairnline database through

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -530,9 +530,10 @@ sequenceDiagram
   project list/detail, setup-readiness, health, project skill list, project
   memory list, memory-candidate list, project role list, work-item list/detail,
   assignment-list, assignment-context, launch-readiness, assignment preflight, artifact-list,
-  handoff-list, activity, closeout-readiness, and operations-brief reads through
-  the standalone Cairnline MCP client; all other live Projects read routes stay
-  on Hecate-native or embedded dogfood paths.
+  handoff-list, Project Assistant context/proposal reads, activity,
+  closeout-readiness, and operations-brief reads through the standalone
+  Cairnline MCP client. Draft/propose/apply mutations remain Hecate-owned
+  unless their explicit write-authority switchpoints are enabled.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2856,7 +2857,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, Project Assistant context/proposal, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3069,7 +3070,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, Project Assistant context/proposal, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3127,7 +3128,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_read_ready",
-    "detail": "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes live project-list reads through this sidecar; writes and other Projects reads stay on Hecate-native stores or embedded dogfood paths.",
+    "detail": "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes the configured Projects read routes through this sidecar; writes stay on Hecate-native stores or embedded dogfood paths.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3203,7 +3204,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_detail_ready",
-    "detail": "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes live project-detail reads through this sidecar; writes and other Projects reads stay on Hecate-native stores or embedded dogfood paths.",
+    "detail": "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes the configured Projects read routes through this sidecar; writes stay on Hecate-native stores or embedded dogfood paths.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -6259,9 +6260,13 @@ Endpoints:
 inspectable Auto role/driver selection that `draft` will use. The response
 includes `read_backend` (`hecate` or `cairnline`). Under
 `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`, this context packet is built
-from the Cairnline read model. Draft generation uses that same
-Cairnline-projected context so preview and proposal assembly do not drift,
-while proposal ledger writes remain Hecate-owned unless
+from the configured Cairnline read source. With
+`HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, the context packet is composed
+from typed sidecar project/work/skill/memory read tools and rejects malformed or
+text-only sidecar output. Draft generation uses the same Cairnline-projected
+context so preview and proposal assembly do not drift, while proposal ledger
+writes remain Hecate-owned unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
 enabled. Confirmed apply uses enabled role/work-item/assignment/handoff
 Cairnline-authority seams and still blocks replacement on the remaining
@@ -6269,7 +6274,11 @@ project/default/chat/memory/runtime side effects.
 `GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
 Cairnline read source as the other read routes; strict embedded mode reads the
 proposal record from the embedded mirror instead of falling back to the native
-proposal store.
+proposal store. Sidecar mode reads typed `assistant.proposals.get` structured
+content from the standalone Cairnline MCP client and falls back to the
+Hecate-native proposal ledger only when the sidecar reports the proposal is
+missing, so freshly drafted/proposed Hecate-owned records remain readable until
+proposal writes move behind their Cairnline authority switchpoint.
 The projection keeps Hecate-owned compatibility details such as native snapshot
 timestamps and Hecate-only metadata where the current UI/model context depends
 on them; Cairnline supplies the portable project graph, not final write

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -685,9 +685,20 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		}
 		record, ok := state.assistantProposals[input.ID]
 		if !ok {
+			record, ok = cairnlineSidecarFixtureDefaultAssistantProposal(input.ID)
+		}
+		if !ok {
 			return mcp.CallToolResult{Content: mcp.TextContent("fixture assistant proposal not found: " + input.ID), IsError: true}, nil
 		}
-		return mcp.CallToolResult{Content: mcp.TextContent("Assistant proposal " + input.ID + ": [" + record.Status + "] " + record.Proposal.Title), StructuredContent: mustRawJSON(record)}, nil
+		if cairnlineSidecarFixtureModeHas(mode, "assistant.proposals.get-id-mismatch") {
+			record.ID = "pa_fixture_other"
+			record.Proposal.ID = "pa_fixture_other"
+		}
+		result := mcp.CallToolResult{Content: mcp.TextContent("Assistant proposal " + input.ID + ": [" + record.Status + "] " + record.Proposal.Title)}
+		if !cairnlineSidecarFixtureTextOnly(mode, "assistant.proposals.get") {
+			result.StructuredContent = mustRawJSON(record)
+		}
+		return result, nil
 	case "assistant.apply":
 		var input struct {
 			ProposalID string                                       `json:"proposal_id"`
@@ -1951,6 +1962,38 @@ func cairnlineSidecarFixtureProjectAssistantProposals(state *cairnlineSidecarFix
 		}
 	}
 	return items
+}
+
+func cairnlineSidecarFixtureDefaultAssistantProposal(id string) (ProjectCairnlineSidecarAssistantProposalRecordItem, bool) {
+	if id != "pa_fixture" {
+		return ProjectCairnlineSidecarAssistantProposalRecordItem{}, false
+	}
+	return ProjectCairnlineSidecarAssistantProposalRecordItem{
+		ID:        "pa_fixture",
+		ProjectID: "proj_fixture",
+		Source:    "assistant",
+		Proposal: ProjectCairnlineSidecarAssistantProposalItem{
+			ID:                   "pa_fixture",
+			ProjectID:            "proj_fixture",
+			Title:                "Queue fixture work",
+			Summary:              "Create one reviewable work item from the sidecar assistant proposal fixture.",
+			RequiresConfirmation: true,
+			Actions: []ProjectCairnlineSidecarAssistantActionItem{{
+				Kind:    "create_work_item",
+				Summary: "Capture the next sidecar-backed project task.",
+				Target:  ProjectCairnlineSidecarAssistantTargetItem{ProjectID: "proj_fixture"},
+				WorkItem: &ProjectCairnlineSidecarWorkItem{
+					ID:        "work_from_sidecar_proposal",
+					ProjectID: "proj_fixture",
+					Title:     "Sidecar proposal work",
+					Brief:     "Read the proposal from the Cairnline sidecar.",
+					Status:    "open",
+					Priority:  "normal",
+				},
+			}},
+		},
+		Status: "proposed",
+	}, true
 }
 
 func cairnlineSidecarFixtureApplyAssistantProposal(state *cairnlineSidecarFixtureState, record ProjectCairnlineSidecarAssistantProposalRecordItem) ProjectCairnlineSidecarAssistantApplyResultItem {

--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -62,7 +62,15 @@ func (h *Handler) HandleProjectAssistantContext(w http.ResponseWriter, r *http.R
 	}
 	var context projectassistant.DraftContext
 	var err error
-	if h.projectReadRoutesUseCairnlineReadModel() {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		context, err = h.cairnlineSidecarProjectAssistantContext(r.Context(), projectassistant.ContextInput{
+			ProjectID:  req.ProjectID,
+			WorkItemID: req.WorkItemID,
+			Request:    req.Request,
+			RoleID:     req.RoleID,
+			DriverKind: req.DriverKind,
+		})
+	} else if h.projectReadRoutesUseCairnlineReadModel() {
 		context, err = h.cairnlineProjectAssistantContext(r.Context(), projectassistant.ContextInput{
 			ProjectID:  req.ProjectID,
 			WorkItemID: req.WorkItemID,
@@ -171,6 +179,9 @@ func (h *Handler) HandleChatProjectAssistantDraft(w http.ResponseWriter, r *http
 }
 
 func (h *Handler) projectAssistantDraft(ctx context.Context, command projectassistantapp.DraftCommand) (projectassistant.Proposal, error) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		return h.cairnlineSidecarProjectAssistantDraft(ctx, command)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.cairnlineProjectAssistantDraft(ctx, command)
 	}
@@ -202,27 +213,45 @@ func (h *Handler) HandleProjectAssistantPropose(w http.ResponseWriter, r *http.R
 }
 
 func (h *Handler) HandleProjectAssistantProposal(w http.ResponseWriter, r *http.Request) {
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		id := r.PathValue("id")
+		record, ok, err := h.cairnlineSidecarProjectAssistantProposal(r.Context(), id)
+		if err != nil {
+			writeProjectAssistantError(w, err)
+			return
+		}
+		if !ok {
+			record, ok, err = h.hecateProjectAssistantProposal(r.Context(), id)
+			if err != nil {
+				writeProjectAssistantError(w, err)
+				return
+			}
+		}
+		writeProjectAssistantProposalRecord(w, record, ok)
+		return
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		record, ok, err := h.cairnlineProjectAssistantProposal(r.Context(), r.PathValue("id"))
 		if err != nil {
 			writeProjectAssistantError(w, err)
 			return
 		}
-		if !ok {
-			WriteError(w, http.StatusNotFound, errCodeNotFound, "project assistant proposal not found")
-			return
-		}
-		WriteJSON(w, http.StatusOK, map[string]any{
-			"object": "project_assistant.proposal_record",
-			"data":   record,
-		})
+		writeProjectAssistantProposalRecord(w, record, ok)
 		return
 	}
-	record, ok, err := h.projectAssistantApplication().Proposal(r.Context(), r.PathValue("id"))
+	record, ok, err := h.hecateProjectAssistantProposal(r.Context(), r.PathValue("id"))
 	if err != nil {
 		writeProjectAssistantError(w, err)
 		return
 	}
+	writeProjectAssistantProposalRecord(w, record, ok)
+}
+
+func (h *Handler) hecateProjectAssistantProposal(ctx context.Context, id string) (projectassistant.ProposalRecord, bool, error) {
+	return h.projectAssistantApplication().Proposal(ctx, id)
+}
+
+func writeProjectAssistantProposalRecord(w http.ResponseWriter, record projectassistant.ProposalRecord, ok bool) {
 	if !ok {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "project assistant proposal not found")
 		return
@@ -259,6 +288,38 @@ func (h *Handler) cairnlineProjectAssistantProposal(ctx context.Context, id stri
 	return cairnlineProjectAssistantProposalFromService(ctx, service, id)
 }
 
+func (h *Handler) cairnlineSidecarProjectAssistantProposal(ctx context.Context, id string) (projectassistant.ProposalRecord, bool, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return projectassistant.ProposalRecord{}, false, nil
+	}
+	result, err := h.callProjectCairnlineSidecarProjectReadTool(ctx, "assistant.proposals.get", map[string]string{"id": id})
+	if err != nil {
+		return projectassistant.ProposalRecord{}, false, err
+	}
+	if result.IsError {
+		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
+			return projectassistant.ProposalRecord{}, false, nil
+		}
+		return projectassistant.ProposalRecord{}, false, projectCairnlineSidecarReadFailure("assistant.proposals.get returned a tool-level error: " + strings.TrimSpace(result.Text))
+	}
+	item, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssistantProposal(result.Result.StructuredContent)
+	if structuredErr != nil {
+		return projectassistant.ProposalRecord{}, false, projectCairnlineSidecarReadFailure("assistant.proposals.get structuredContent parse failed: " + structuredErr.Error())
+	}
+	if !structuredReady {
+		return projectassistant.ProposalRecord{}, false, projectCairnlineSidecarReadFailure("assistant.proposals.get did not return typed structuredContent")
+	}
+	if strings.TrimSpace(item.ID) != id {
+		return projectassistant.ProposalRecord{}, false, projectCairnlineSidecarReadFailure("assistant.proposals.get returned proposal id " + strings.TrimSpace(item.ID) + " for requested id " + id)
+	}
+	record, ok, err := projectAssistantProposalRecordFromCairnlineSidecar(item)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, false, projectCairnlineSidecarReadFailure("assistant.proposals.get conversion failed: " + err.Error())
+	}
+	return record, ok, nil
+}
+
 func cairnlineProjectAssistantProposalFromService(ctx context.Context, service *cairnline.Service, id string) (projectassistant.ProposalRecord, bool, error) {
 	item, err := service.GetAssistantProposal(ctx, id)
 	if errors.Is(err, cairnline.ErrNotFound) {
@@ -269,6 +330,19 @@ func cairnlineProjectAssistantProposalFromService(ctx context.Context, service *
 	}
 	record, ok := cairnlinebridge.ProjectAssistantProposalRecord(item)
 	return record, ok, nil
+}
+
+func projectAssistantProposalRecordFromCairnlineSidecar(item ProjectCairnlineSidecarAssistantProposalRecordItem) (projectassistant.ProposalRecord, bool, error) {
+	raw, err := json.Marshal(item)
+	if err != nil {
+		return projectassistant.ProposalRecord{}, false, err
+	}
+	var record cairnline.AssistantProposalRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		return projectassistant.ProposalRecord{}, false, err
+	}
+	projected, ok := cairnlinebridge.ProjectAssistantProposalRecord(record)
+	return projected, ok, nil
 }
 
 func (h *Handler) HandleProjectAssistantApply(w http.ResponseWriter, r *http.Request) {
@@ -338,6 +412,8 @@ func projectAssistantErrorStatusCode(err error) (int, string) {
 		return http.StatusNotFound, errCodeNotFound
 	case errors.Is(err, projectassistant.ErrConfirmationRequired), errors.Is(err, projectassistant.ErrConflict):
 		return http.StatusConflict, errCodeConflict
+	case errors.Is(err, errProjectCairnlineSidecarReadFailed):
+		return http.StatusBadGateway, errCodeGatewayError
 	default:
 		return http.StatusInternalServerError, errCodeInternalError
 	}

--- a/internal/api/handler_project_assistant_cairnline.go
+++ b/internal/api/handler_project_assistant_cairnline.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
@@ -20,6 +21,25 @@ func (h *Handler) cairnlineProjectAssistantContext(ctx context.Context, input pr
 	}
 	defer view.Close()
 	seed, err := h.cairnlineProjectAssistantContextSeed(ctx, view.service, view.snapshot)
+	if err != nil {
+		return projectassistant.DraftContext{}, err
+	}
+	draftContext, err := projectassistant.NewService(projectassistant.Stores{
+		Projects:         seed.projects,
+		Work:             seed.work,
+		ProjectSkills:    seed.skills,
+		Memory:           seed.memory,
+		MemoryCandidates: seed.memory,
+	}, nil).Context(ctx, input)
+	if err != nil {
+		return projectassistant.DraftContext{}, err
+	}
+	draftContext.ReadBackend = "cairnline"
+	return draftContext, nil
+}
+
+func (h *Handler) cairnlineSidecarProjectAssistantContext(ctx context.Context, input projectassistant.ContextInput) (projectassistant.DraftContext, error) {
+	seed, err := h.cairnlineSidecarProjectAssistantContextSeed(ctx, input.ProjectID)
 	if err != nil {
 		return projectassistant.DraftContext{}, err
 	}
@@ -71,11 +91,77 @@ func (h *Handler) cairnlineProjectAssistantDraft(ctx context.Context, command pr
 	})
 }
 
+func (h *Handler) cairnlineSidecarProjectAssistantDraft(ctx context.Context, command projectassistantapp.DraftCommand) (projectassistant.Proposal, error) {
+	seed, err := h.cairnlineSidecarProjectAssistantContextSeed(ctx, command.ProjectID)
+	if err != nil {
+		return projectassistant.Proposal{}, err
+	}
+	return projectassistant.NewService(projectassistant.Stores{
+		Projects:         seed.projects,
+		Chats:            h.agentChat,
+		Work:             seed.work,
+		ProjectSkills:    seed.skills,
+		Memory:           seed.memory,
+		MemoryCandidates: seed.memory,
+		Proposals:        h.projectAssistantProposalStoreForApplication(),
+		LLM:              gatewayAgentLLMClient{service: h.service},
+	}, newOpaqueTaskResourceID).Draft(ctx, projectassistant.DraftInput{
+		ProjectID:        command.ProjectID,
+		WorkItemID:       command.WorkItemID,
+		Request:          command.Request,
+		RoleID:           command.RoleID,
+		DriverKind:       command.DriverKind,
+		DraftMode:        command.DraftMode,
+		ReviewArtifactID: command.ReviewArtifactID,
+		Provider:         command.Provider,
+		Model:            command.Model,
+		RequestID:        command.RequestID,
+		TraceID:          command.TraceID,
+	})
+}
+
 type cairnlineProjectAssistantContextSeed struct {
 	projects *projects.MemoryStore
 	work     *projectwork.MemoryStore
 	skills   *projectskills.MemoryStore
 	memory   *memory.MemoryStore
+}
+
+func (h *Handler) cairnlineSidecarProjectAssistantContextSeed(ctx context.Context, projectID string) (cairnlineProjectAssistantContextSeed, error) {
+	var seed cairnlineProjectAssistantContextSeed
+	requestedProjectID := strings.TrimSpace(projectID)
+	projectItem, ok, err := h.cairnlineSidecarProject(ctx, requestedProjectID)
+	if err != nil {
+		return seed, err
+	}
+	if !ok {
+		return seed, projectassistant.ErrNotFound
+	}
+	project := projectFromCairnlineSidecar(projectItem)
+	if project.ID != requestedProjectID {
+		return seed, projectassistant.ErrNotFound
+	}
+
+	seed.projects = projects.NewMemoryStore()
+	if _, err := seed.projects.Create(ctx, project); err != nil {
+		return seed, err
+	}
+
+	seed.work = projectwork.NewMemoryStore()
+	if err := h.seedCairnlineSidecarProjectAssistantWork(ctx, seed.work, project.ID); err != nil {
+		return seed, err
+	}
+
+	seed.skills = projectskills.NewMemoryStore()
+	if err := h.seedCairnlineSidecarProjectAssistantSkills(ctx, seed.skills, project.ID); err != nil {
+		return seed, err
+	}
+
+	seed.memory = memory.NewMemoryStore()
+	if err := h.seedCairnlineSidecarProjectAssistantMemory(ctx, seed.memory, project.ID); err != nil {
+		return seed, err
+	}
+	return seed, nil
 }
 
 func (h *Handler) cairnlineProjectAssistantContextSeed(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) (cairnlineProjectAssistantContextSeed, error) {
@@ -109,6 +195,91 @@ func (h *Handler) cairnlineProjectAssistantContextSeed(ctx context.Context, serv
 		return seed, err
 	}
 	return seed, nil
+}
+
+func (h *Handler) seedCairnlineSidecarProjectAssistantWork(ctx context.Context, store *projectwork.MemoryStore, projectID string) error {
+	roleItems, err := h.cairnlineSidecarProjectRoles(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, role := range projectRolesFromCairnlineSidecar(roleItems) {
+		if projectwork.IsBuiltInRoleID(role.ID) {
+			continue
+		}
+		role.DefaultDriverKind = projectWorkAssignmentDriverFromCairnline(role.DefaultDriverKind)
+		if _, err := store.CreateRole(ctx, role); err != nil {
+			return err
+		}
+	}
+
+	workItemItems, err := h.cairnlineSidecarProjectWorkItems(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, item := range projectWorkItemsFromCairnlineSidecar(workItemItems) {
+		item.Status = projectAssistantWorkItemStatusFromCairnline(item.Status)
+		if _, err := store.CreateWorkItem(ctx, item); err != nil {
+			return err
+		}
+	}
+
+	assignmentItems, err := h.cairnlineSidecarProjectAssignments(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, assignment := range projectAssignmentsFromCairnlineSidecar(assignmentItems) {
+		if _, err := store.CreateAssignment(ctx, assignment); err != nil {
+			return err
+		}
+	}
+
+	artifactItems, err := h.cairnlineSidecarProjectArtifacts(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	evidenceItems, err := h.cairnlineSidecarProjectEvidence(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	reviewItems, err := h.cairnlineSidecarProjectReviews(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, artifact := range projectArtifactsFromCairnlineSidecar(artifactItems, evidenceItems, reviewItems) {
+		if _, err := store.CreateArtifact(ctx, artifact); err != nil {
+			return err
+		}
+	}
+
+	handoffItems, err := h.cairnlineSidecarProjectHandoffs(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, handoff := range projectHandoffsFromCairnlineSidecar(handoffItems) {
+		if _, err := store.CreateHandoff(ctx, handoff); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func projectAssistantWorkItemStatusFromCairnline(status string) string {
+	switch strings.TrimSpace(status) {
+	case "running":
+		return projectwork.WorkItemStatusRunning
+	case "review":
+		return projectwork.WorkItemStatusReview
+	case "blocked", "failed":
+		return projectwork.WorkItemStatusBlocked
+	case "completed", "done":
+		return projectwork.WorkItemStatusDone
+	case "cancelled", "canceled":
+		return projectwork.WorkItemStatusCancelled
+	case "ready":
+		return projectwork.WorkItemStatusReady
+	default:
+		return projectwork.WorkItemStatusBacklog
+	}
 }
 
 func seedCairnlineProjectAssistantWork(ctx context.Context, store *projectwork.MemoryStore, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) error {
@@ -184,6 +355,17 @@ func seedCairnlineProjectAssistantWork(ctx context.Context, store *projectwork.M
 	return nil
 }
 
+func (h *Handler) seedCairnlineSidecarProjectAssistantSkills(ctx context.Context, store *projectskills.MemoryStore, projectID string) error {
+	items, err := h.cairnlineSidecarProjectSkills(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	if _, err := store.UpsertDiscovered(ctx, projectID, projectSkillsFromCairnlineSidecar(items)); err != nil {
+		return err
+	}
+	return nil
+}
+
 func seedCairnlineProjectAssistantSkills(ctx context.Context, store *projectskills.MemoryStore, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) error {
 	projectID := snapshot.Project.ID
 	items, err := service.ListProjectSkills(ctx, projectID)
@@ -197,6 +379,28 @@ func seedCairnlineProjectAssistantSkills(ctx context.Context, store *projectskil
 	}
 	if _, err := store.UpsertDiscovered(ctx, projectID, skills); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (h *Handler) seedCairnlineSidecarProjectAssistantMemory(ctx context.Context, store *memory.MemoryStore, projectID string) error {
+	entries, err := h.cairnlineSidecarProjectMemoryEntries(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, item := range projectMemoryEntriesFromCairnlineSidecar(entries) {
+		if _, err := store.Create(ctx, item); err != nil {
+			return err
+		}
+	}
+	candidates, err := h.cairnlineSidecarProjectMemoryCandidates(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	for _, item := range projectMemoryCandidatesFromCairnlineSidecar(candidates) {
+		if _, err := store.CreateCandidate(ctx, item); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -403,6 +403,62 @@ func TestProjectAssistantAPI_ContextUsesCairnlineReadModelWhenConfigured(t *test
 	}
 }
 
+func TestProjectAssistantAPI_ContextUsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "memory-fixture")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar assistant context enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/context", bytes.NewReader([]byte(`{
+		"project_id":"proj_fixture",
+		"work_item_id":"work_fixture",
+		"request":"Queue fixture work",
+		"role_id":"role_fixture"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("context status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response projectAssistantContextResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode context response: %v", err)
+	}
+	if response.Data.ReadBackend != "cairnline" || response.Data.Project.ID != "proj_fixture" {
+		t.Fatalf("context backend/project = %q/%+v, want Cairnline sidecar fixture project", response.Data.ReadBackend, response.Data.Project)
+	}
+	if response.Data.SelectedWork == nil || response.Data.SelectedWork.ID != "work_fixture" || response.Data.Selection.RoleID != "role_fixture" || response.Data.Selection.DriverKind != projectwork.AssignmentDriverHecateTask {
+		t.Fatalf("selected work/selection = %+v/%+v, want sidecar-selected fixture work and role", response.Data.SelectedWork, response.Data.Selection)
+	}
+	if !projectAssistantContextHasRole(response.Data.Roles, "role_fixture") {
+		t.Fatalf("roles = %+v, want sidecar fixture role", response.Data.Roles)
+	}
+	if len(response.Data.Skills) != 1 || response.Data.Skills[0].ID != "skill_fixture" {
+		t.Fatalf("skills = %+v, want sidecar fixture skill", response.Data.Skills)
+	}
+	if len(response.Data.Assignments) != 1 || response.Data.Assignments[0].ID != "asg_fixture" {
+		t.Fatalf("assignments = %+v, want sidecar fixture assignment", response.Data.Assignments)
+	}
+	if len(response.Data.Memory) != 1 || response.Data.Memory[0].ID != "mem_fixture" {
+		t.Fatalf("memory = %+v, want enabled sidecar fixture memory", response.Data.Memory)
+	}
+	if len(response.Data.MemoryCandidates) != 1 || response.Data.MemoryCandidates[0].ID != "memcand_fixture" {
+		t.Fatalf("memory candidates = %+v, want pending sidecar fixture candidate", response.Data.MemoryCandidates)
+	}
+}
+
+func projectAssistantContextHasRole(roles []projectassistant.RoleContext, id string) bool {
+	for _, role := range roles {
+		if role.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
 func TestProjectAssistantAPI_ContextCairnlineMatchesHecate(t *testing.T) {
 	t.Parallel()
 	hecateHandler, hecateServer := newProjectAssistantTestHandler()
@@ -866,6 +922,45 @@ func TestProjectAssistantAPI_DraftUsesCairnlineReadModelWhenConfigured(t *testin
 	}
 	if _, ok, err := handler.projectAssistantProposals.GetProposal(t.Context(), proposed.Data.ID); err != nil || !ok {
 		t.Fatalf("GetProposal(%q) = ok %v err %v, want Cairnline draft stored in Hecate proposal ledger", proposed.Data.ID, ok, err)
+	}
+}
+
+func TestProjectAssistantAPI_DraftUsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "memory-fixture")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar assistant draft enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/draft", bytes.NewReader([]byte(`{
+		"project_id":"proj_fixture",
+		"work_item_id":"work_fixture",
+		"request":"Queue Fixture Reviewer\nRead from the Cairnline sidecar context.",
+		"role_id":"role_fixture"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("draft status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var proposed projectAssistantProposalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &proposed); err != nil {
+		t.Fatalf("decode draft response: %v", err)
+	}
+	if proposed.Object != "project_assistant.proposal" || len(proposed.Data.Actions) != 1 || proposed.Data.Actions[0].Kind != projectassistant.ActionCreateAssignment {
+		t.Fatalf("draft response = %+v, want one sidecar-backed assignment proposal", proposed)
+	}
+	var patch map[string]string
+	if err := json.Unmarshal(proposed.Data.Actions[0].Patch, &patch); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if patch["project_id"] != "proj_fixture" || patch["work_item_id"] != "work_fixture" || patch["role_id"] != "role_fixture" || patch["driver_kind"] != projectwork.AssignmentDriverHecateTask {
+		t.Fatalf("patch = %+v, want sidecar project/work/role with normalized Hecate driver", patch)
+	}
+	if _, ok, err := handler.projectAssistantProposals.GetProposal(t.Context(), proposed.Data.ID); err != nil || !ok {
+		t.Fatalf("GetProposal(%q) = ok %v err %v, want sidecar-context draft stored in Hecate proposal ledger", proposed.Data.ID, ok, err)
 	}
 }
 
@@ -2171,6 +2266,111 @@ func TestProjectAssistantAPI_ProposalReadUsesCairnlineReadModel(t *testing.T) {
 	}
 	if patch["id"] != "work_cairnline_from_proposal" || patch["project_id"] != project.ID {
 		t.Fatalf("projected patch = %+v, want work item patch reconstructed from Cairnline", patch)
+	}
+}
+
+func TestProjectAssistantAPI_ProposalReadUsesCairnlineSidecarWhenConfigured(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if handler.projectReadRoutesUseCairnlineReadModel() {
+		t.Fatal("sidecar assistant proposal enabled embedded Cairnline read-model routes")
+	}
+	if !handler.projectCairnlineSidecarReadRoutesEnabled() {
+		t.Fatal("sidecar read-route predicate = false, want true")
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/project-assistant/proposals/pa_fixture", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get proposal status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response projectAssistantProposalRecordResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode proposal record response: %v", err)
+	}
+	if response.Object != "project_assistant.proposal_record" || response.Data.ID != "pa_fixture" || response.Data.ProjectID != "proj_fixture" {
+		t.Fatalf("proposal response = %+v, want sidecar fixture proposal record", response)
+	}
+	if response.Data.Status != projectassistant.ProposalStatusProposed || response.Data.Proposal.Title != "Queue fixture work" {
+		t.Fatalf("proposal ledger = %+v, want proposed sidecar assistant proposal", response.Data)
+	}
+	if len(response.Data.Proposal.Actions) != 1 || response.Data.Proposal.Actions[0].Kind != projectassistant.ActionCreateWorkItem || response.Data.Proposal.Actions[0].Reason != "Capture the next sidecar-backed project task." {
+		t.Fatalf("proposal actions = %+v, want converted create_work_item action", response.Data.Proposal.Actions)
+	}
+}
+
+func TestProjectAssistantAPI_ProposalReadSidecarFallsBackToNativeLedgerWhenMissing(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/propose", bytes.NewReader([]byte(`{
+		"id":"pa_native_sidecar",
+		"title":"Create native proposal",
+		"summary":"Create a Hecate-owned proposal while sidecar reads are enabled.",
+		"actions":[{
+			"kind":"create_project",
+			"reason":"Exercise native proposal fallback.",
+			"patch":{
+				"id":"proj_native_sidecar",
+				"name":"Native Sidecar Proposal"
+			}
+		}]
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("propose status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/project-assistant/proposals/pa_native_sidecar", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get proposal status = %d body=%s, want 200 native fallback after sidecar miss", rec.Code, rec.Body.String())
+	}
+	var response projectAssistantProposalRecordResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode proposal record response: %v", err)
+	}
+	if response.Data.ID != "pa_native_sidecar" || response.Data.ProjectID != "proj_native_sidecar" || response.Data.Source != projectassistant.ProposalSourceAPI {
+		t.Fatalf("proposal record = %+v, want Hecate-owned API proposal after sidecar miss", response.Data)
+	}
+}
+
+func TestProjectAssistantAPI_ProposalReadCairnlineSidecarRequiresStructuredContent(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "assistant.proposals.get-text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/project-assistant/proposals/pa_fixture", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("get proposal status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "structuredContent") {
+		t.Fatalf("error body = %s, want structuredContent diagnostic", rec.Body.String())
+	}
+}
+
+func TestProjectAssistantAPI_ProposalReadCairnlineSidecarRequiresMatchingID(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "assistant.proposals.get-id-mismatch")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/project-assistant/proposals/pa_fixture", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("get proposal status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "returned proposal id pa_fixture_other for requested id pa_fixture") {
+		t.Fatalf("error body = %s, want proposal id mismatch diagnostic", rec.Body.String())
+	}
+}
+
+func TestProjectAssistantAPI_ProposalReadCairnlineSidecarMissingProposal(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/project-assistant/proposals/pa_missing", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("get proposal status = %d body=%s, want 404", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -140,7 +140,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, assignment context, launch-readiness, assignment preflight, artifact lists, handoff lists, activity, closeout readiness, and operations brief through the standalone Cairnline MCP client; other Projects routes remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project list/detail, setup-readiness, health, skills, memory, memory candidates, roles, work items, assignment lists, assignment context, launch-readiness, assignment preflight, artifact lists, handoff lists, Project Assistant context/proposal reads, activity, closeout readiness, and operations brief through the standalone Cairnline MCP client; writes and migration remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -64,6 +64,8 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"assignment-preflight",
 	"artifact-list",
 	"handoff-list",
+	"project-assistant-context",
+	"project-assistant-proposal",
 	"activity",
 	"closeout-readiness",
 	"operations-brief",
@@ -364,13 +366,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
-				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief routes read through the persistent standalone Cairnline MCP client. Other Projects read routes, all writes, and migration remain on Hecate-native stores or existing embedded dogfood paths."
+				response.Detail = "Cairnline sidecar is configured as the project read source, so project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations-brief routes read through the persistent standalone Cairnline MCP client. Project writes and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
 				response.Warnings = []string{
-					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief use the Cairnline sidecar MCP client in this mode.",
+					"Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations-brief use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
-					"Full Cairnline read-model replacement remains blocked because sidecar adapters for assistant routes are not wired.",
+					"Full Cairnline replacement remains blocked on authoritative write migration.",
 				}
 				return response
 			}
@@ -807,7 +809,7 @@ func projectCairnlineReadSourceDetail(source string) string {
 	case "embedded":
 		return "Configured read routes require the embedded mirror database and requested project row or proposal record; if the mirror is missing or stale, the route fails loudly instead of falling back to a Hecate snapshot."
 	case "sidecar":
-		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief use this source."
+		return "Configured read routes call the standalone Cairnline MCP sidecar through the persistent local client; only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations-brief use this source."
 	case "snapshot":
 		return "Configured read routes use the snapshot-seeded in-memory Cairnline bridge projection and do not attempt the embedded mirror database."
 	default:
@@ -820,7 +822,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief through the standalone Cairnline MCP client; assistant read routes are not sidecar-backed yet."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, activity, closeout-readiness, and operations-brief through the standalone Cairnline MCP client; writes remain Hecate-owned unless a separate write-authority switchpoint is enabled."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -230,8 +230,8 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, activity, closeout-readiness, and operations-brief") || !strings.Contains(warnings, "assistant routes are not wired") {
-		t.Fatalf("warnings = %+v, want partial sidecar read warning", status.Warnings)
+	if !strings.Contains(warnings, "project-assistant-context, project-assistant-proposal") || !strings.Contains(warnings, "authoritative write migration") {
+		t.Fatalf("warnings = %+v, want sidecar read routes with write-migration warning", status.Warnings)
 	}
 }
 

--- a/internal/cairnlinebridge/assistant.go
+++ b/internal/cairnlinebridge/assistant.go
@@ -469,8 +469,10 @@ func ProjectAssistantProposalStatus(status string) string {
 		return projectassistant.ApplyStatusApplied
 	case cairnline.AssistantProposalStatusPartial:
 		return projectassistant.ApplyStatusPartialDueToRuntimeFailure
-	case cairnline.AssistantProposalStatusRejected, cairnline.AssistantProposalStatusNeedsConfirm:
+	case cairnline.AssistantProposalStatusRejected:
 		return projectassistant.ApplyStatusBlockedBeforeApply
+	case cairnline.AssistantProposalStatusNeedsConfirm:
+		return projectassistant.ProposalStatusProposed
 	default:
 		return projectassistant.ProposalStatusProposed
 	}

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -276,6 +276,42 @@ func TestAssistantProposalRecordProjectsCairnlineLedgerBackToHecate(t *testing.T
 	}
 }
 
+func TestProjectAssistantProposalRecordKeepsNeedsConfirmationReviewable(t *testing.T) {
+	now := time.Date(2026, 6, 27, 13, 30, 0, 0, time.UTC)
+	source, ok := AssistantProposalRecord(bridgeAssistantProposalFixture(now))
+	if !ok {
+		t.Fatal("AssistantProposalRecord() ok = false, want portable proposal fixture")
+	}
+	result := cairnline.AssistantApplyResult{
+		ProposalID:       source.ID,
+		Status:           cairnline.AssistantApplyStatusNeedsConfirm,
+		Confirmed:        false,
+		TotalActionCount: len(source.Proposal.Actions),
+	}
+	source.Status = cairnline.AssistantProposalStatusNeedsConfirm
+	source.LatestResult = &result
+	source.ApplyAttempts = []cairnline.AssistantApplyAttempt{{
+		ID:         "paatt_bridge_needs_confirmation",
+		ProposalID: source.ID,
+		Status:     cairnline.AssistantApplyStatusNeedsConfirm,
+		Confirmed:  false,
+		Result:     result,
+		CreatedAt:  now,
+	}}
+	source.AppliedAt = nil
+
+	projected, ok := ProjectAssistantProposalRecord(source)
+	if !ok {
+		t.Fatal("ProjectAssistantProposalRecord() ok = false, want confirmation-required proposal projected")
+	}
+	if projected.Status != projectassistant.ProposalStatusProposed {
+		t.Fatalf("projected status = %q, want proposed so confirmation-required proposals remain reviewable", projected.Status)
+	}
+	if projected.LatestResult == nil || projected.LatestResult.Status != projectassistant.ApplyStatusBlockedBeforeApply || projected.LatestResult.Applied || projected.LatestResult.CommittedActionCount != 0 {
+		t.Fatalf("projected latest result = %+v, want explicit unconfirmed apply gate", projected.LatestResult)
+	}
+}
+
 func TestLoadSnapshotReadsHecateStores(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Summary
- route Project Assistant context reads through the Cairnline sidecar when sidecar read routes are enabled
- route proposal-record reads through typed assistant.proposals.get structuredContent
- keep draft/propose/apply mutations Hecate-owned unless existing write-authority switchpoints are enabled
- update coordination backend readiness docs and runtime/operator docs for the expanded sidecar read route set

Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_(ContextUsesCairnlineSidecarWhenConfigured|ProposalReadUsesCairnlineSidecarWhenConfigured|ProposalReadCairnlineSidecarRequiresStructuredContent|ProposalReadCairnlineSidecarMissingProposal)|TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady'
- just agent-docs-check
- git diff --check
- GOCACHE="$PWD/.gocache" go test ./internal/api
- GOCACHE="$PWD/.gocache" go vet ./internal/api
- GOCACHE="$PWD/.gocache" go vet ./...
- GOCACHE="$PWD/.gocache" go test ./...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...