### PR TITLE
fix(projects): preserve Cairnline assignment runtime shadows

### DIFF
--- a/internal/api/handler_project_assignment_authority.go
+++ b/internal/api/handler_project_assignment_authority.go
@@ -81,7 +81,7 @@ func (h *Handler) updateProjectWorkAssignmentWithCairnlineAuthority(ctx context.
 		if shadow, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID); err != nil {
 			return err
 		} else if ok {
-			assignment.ExecutionRef = shadow.ExecutionRef
+			overlayProjectAssignmentRuntimeShadow(&assignment, shadow)
 		}
 		applyProjectAssignmentUpdate(&assignment, cmd)
 		if err := validateProjectAssignmentForCairnlineAuthority(assignment); err != nil {
@@ -235,13 +235,27 @@ func applyProjectAssignmentUpdate(item *projectwork.Assignment, cmd projectworka
 
 func projectWorkAssignmentFromCairnlineAuthority(item cairnline.Assignment, native projectwork.Assignment) projectwork.Assignment {
 	out := projectWorkAssignmentFromCairnline(item)
-	if ref := projectwork.NormalizeAssignmentExecutionRef(native.ExecutionRef); !projectAssignmentExecutionRefEmpty(ref) {
-		out.ExecutionRef = ref
-	}
+	overlayProjectAssignmentRuntimeShadow(&out, native)
 	if out.ExecutionRef.ContextSnapshotID == "" {
 		out.ExecutionRef.ContextSnapshotID = strings.TrimSpace(item.ContextSnapshotID)
 	}
 	return out
+}
+
+func overlayProjectAssignmentRuntimeShadow(item *projectwork.Assignment, shadow projectwork.Assignment) {
+	if item == nil {
+		return
+	}
+	if ref := projectwork.NormalizeAssignmentExecutionRef(shadow.ExecutionRef); !projectAssignmentExecutionRefEmpty(ref) {
+		item.ExecutionRef = ref
+	}
+	item.ContextPacket = append([]byte(nil), shadow.ContextPacket...)
+	if !shadow.StartedAt.IsZero() {
+		item.StartedAt = shadow.StartedAt
+	}
+	if !shadow.CompletedAt.IsZero() {
+		item.CompletedAt = shadow.CompletedAt
+	}
 }
 
 func projectAssignmentExecutionRefEmpty(ref projectwork.AssignmentExecutionRef) bool {
@@ -274,6 +288,7 @@ func (h *Handler) shadowProjectAssignmentToHecate(ctx context.Context, operation
 		item.DriverKind = assignment.DriverKind
 		item.Status = assignment.Status
 		item.ExecutionRef = assignment.ExecutionRef
+		item.ContextPacket = append([]byte(nil), assignment.ContextPacket...)
 		item.StartedAt = assignment.StartedAt
 		item.CompletedAt = assignment.CompletedAt
 	})

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1057,6 +1057,16 @@ func TestProjectWorkAPI_CairnlineAssignmentAuthorityWritesCairnlineAndShadowsHec
 	if shadow.DriverKind != projectwork.AssignmentDriverHecateTask || shadow.Status != projectwork.AssignmentStatusQueued || shadow.ExecutionRef.ContextSnapshotID != "ctx_authority" {
 		t.Fatalf("Hecate shadow assignment = %+v, want compatibility shadow", shadow)
 	}
+	startedAt := time.Date(2026, 6, 30, 10, 30, 0, 0, time.UTC)
+	completedAt := startedAt.Add(2 * time.Minute)
+	contextPacket := []byte(`{"id":"ctx_authority","items":[{"kind":"project_work","body":"persisted"}]}`)
+	if _, err := handler.projectWork.UpdateAssignment(t.Context(), projectID, "asgn_authority", func(item *projectwork.Assignment) {
+		item.ContextPacket = append([]byte(nil), contextPacket...)
+		item.StartedAt = startedAt
+		item.CompletedAt = completedAt
+	}); err != nil {
+		t.Fatalf("seed assignment runtime shadow: %v", err)
+	}
 
 	updated := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments/asgn_authority", projectJourneyJSON(t, map[string]any{
 		"driver_kind": projectwork.AssignmentDriverExternalAgent,
@@ -1081,6 +1091,9 @@ func TestProjectWorkAPI_CairnlineAssignmentAuthorityWritesCairnlineAndShadowsHec
 	shadow = getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_authority", "asgn_authority")
 	if shadow.DriverKind != projectwork.AssignmentDriverExternalAgent || shadow.Status != projectwork.AssignmentStatusCompleted || shadow.ExecutionRef.ChatSessionID != "chat_authority" {
 		t.Fatalf("updated Hecate shadow assignment = %+v, want compatibility shadow update", shadow)
+	}
+	if string(shadow.ContextPacket) != string(contextPacket) || !shadow.StartedAt.Equal(startedAt) || !shadow.CompletedAt.Equal(completedAt) {
+		t.Fatalf("updated Hecate shadow runtime fields = packet %s started %v completed %v, want preserved packet/timestamps", string(shadow.ContextPacket), shadow.StartedAt, shadow.CompletedAt)
 	}
 
 	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/assignments/asgn_authority", "")


### PR DESCRIPTION
## Summary
- preserve Hecate runtime shadow fields when Cairnline-authoritative assignments are updated
- keep persisted context packets, execution refs, and start/complete timestamps across compatibility shadow writes
- add regression coverage for runtime shadow preservation

## Tests
- `git diff --check`
- `just agent-docs-check`
- `GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_CairnlineAssignmentAuthorityWritesCairnlineAndShadowsHecate'`\n- `GOCACHE="$PWD/.gocache" go build ./...`\n- `GOCACHE="$PWD/.gocache" go vet ./...`\n- `GOCACHE="$PWD/.gocache" go test ./...`\n- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`\n\n## Docs\n- unchanged; this is internal Cairnline/Hecate assignment-shadow persistence behavior, with no operator workflow or public API contract change.