### PR TITLE
feat(projects): route assistant memory candidates through Cairnline authority

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -228,10 +228,10 @@ handoff-list, activity, closeout-readiness, and operations brief reads.
 Project Assistant draft generation also uses the Cairnline-projected context so
 preview and proposal assembly stay aligned, while the proposal ledger remains
 Hecate-owned unless `project-assistant-proposals` is enabled.
-Confirmed Project Assistant apply routes role, work-item, assignment, and
-handoff actions through the same opt-in Cairnline authority switchpoints when
-those switchpoints are enabled; project/default/chat/memory/runtime side
-effects still keep apply as a mixed-authority replacement blocker.
+Confirmed Project Assistant apply routes role, work-item, assignment, handoff,
+and memory-candidate actions through the same opt-in Cairnline authority
+switchpoints when those switchpoints are enabled; project/default/chat/runtime
+side effects still keep apply as a mixed-authority replacement blocker.
 Project list/detail reconstruct default profile and execution posture from
 Cairnline project/execution-profile records where available. Launch-readiness
 and assignment preflight read
@@ -301,9 +301,9 @@ reconciliation updates are mirrored as replacement evidence.
 Assistant draft/propose/apply-attempt ledger records commit to embedded
 Cairnline first, then best-effort shadow Hecate's proposal store for
 compatibility. Confirmed apply uses the enabled Cairnline authority seams for
-role, work-item, assignment, and handoff actions, but
-project/default/chat/memory/runtime side effects still keep Assistant apply as
-a mixed-authority replacement blocker.
+role, work-item, assignment, handoff, and memory-candidate actions, but
+project/default/chat/runtime side effects still keep Assistant apply as a
+mixed-authority replacement blocker.
 Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results and cleanup/conflict states are best-effort mirrored
 for replacement evidence, and other live Projects reads/writes still use the
@@ -412,9 +412,9 @@ execution-profile posture can be shared. Project Assistant draft/propose/apply
 routes mirror the proposal ledger and committed apply side effects after Hecate
 commits proposal records and apply attempts unless `project-assistant-proposals`
 is enabled, in which case the proposal ledger commits to Cairnline first while
-confirmed apply uses enabled role/work-item/assignment/handoff authority seams
-and still blocks replacement on the remaining project/default/chat/memory/runtime
-side effects.
+confirmed apply uses enabled role/work-item/assignment/handoff and
+memory-candidate authority seams and still blocks replacement on the remaining
+project/default/chat/runtime side effects.
 `POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
 SQLite export under Hecate's data directory and returns the same
 `migration_rehearsal` evidence for the single-project database. Both sync and
@@ -485,8 +485,8 @@ memory-candidate records; and
 proposal records, apply-attempt history, and committed apply side effects before
 assignment-start/runtime handoff. `project-assistant-proposals` can make the
 proposal ledger Cairnline-authoritative while confirmed apply uses enabled
-role/work-item/assignment/handoff authority seams and remains blocked on
-project/default/chat/memory/runtime side effects. `project-identity` can make project
+role/work-item/assignment/handoff and memory-candidate authority seams and
+remains blocked on project/default/chat/runtime side effects. `project-identity` can make project
 create/delete Cairnline-authoritative with snapshot rollback for failed Hecate
 compatibility cleanup;
 `project-metadata-defaults` can make
@@ -535,9 +535,9 @@ after these gates are met:
   readiness, and operations brief. Draft generation may use the
   Cairnline-projected context, and proposal ledger writes may become
   Cairnline-authoritative with the `project-assistant-proposals` switchpoint.
-  Confirmed apply may use enabled role/work-item/assignment/handoff
-  Cairnline-authority seams, but project/default/chat/memory/runtime side
-  effects remain a mixed-authority replacement blocker and are mirrored as
+  Confirmed apply may use enabled role/work-item/assignment/handoff and
+  memory-candidate Cairnline-authority seams, but project/default/chat/runtime
+  side effects remain a mixed-authority replacement blocker and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative
   Cairnline launch-packet evidence, but assignment-start remains a Hecate-owned

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -490,10 +490,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   Cairnline backend is configured. Hecate still commits first and remains
   authoritative for any mutation family whose opt-in Cairnline write-authority
   switchpoint is not enabled; Project Assistant confirmed apply uses enabled
-  role/work-item/assignment/handoff authority seams and remains a
-  mixed-authority blocker for project/default/chat/memory/runtime side effects
-  even when the proposal-ledger switchpoint is enabled. Role
-  mirrors also seed referenced agent-profile metadata/execution posture when the
+  role/work-item/assignment/handoff and memory-candidate authority seams and
+  remains a mixed-authority blocker for project/default/chat/runtime side
+  effects even when the proposal-ledger switchpoint is enabled. Role mirrors
+  also seed referenced agent-profile metadata/execution posture when the
   profile store is available.
   Assignment-start dispatch is still a Hecate-owned write
   gap. Artifact/evidence/review update/delete semantics are absent because

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -415,8 +415,8 @@ can be served from the Cairnline read model. Project Assistant draft generation
 also uses the Cairnline-projected context in this mode, while proposal ledger
 writes remain Hecate-owned unless `project-assistant-proposals` is explicitly
 enabled. Confirmed Project Assistant apply routes role, work-item, assignment,
-and handoff actions through the same opt-in Cairnline authority switchpoints
-when those switchpoints are enabled; other apply side effects remain
+handoff, and memory-candidate actions through the same opt-in Cairnline
+authority switchpoints when those switchpoints are enabled; other apply side effects remain
 Hecate-owned and are best-effort mirrored into Cairnline as
 replacement-readiness evidence.
 Launch-readiness and assignment preflight read Cairnline coordination records
@@ -555,8 +555,8 @@ ledger mutations likewise best-effort mirror proposal records and apply attempts
 after Hecate commits unless `project-assistant-proposals` is enabled, in which
 case the proposal ledger commits to Cairnline first and shadows Hecate's
 proposal store for compatibility. Confirmed apply uses the enabled Cairnline
-authority seams for role, work-item, assignment, and handoff actions, but
-project/default/chat/memory/runtime side effects still keep apply as a
+authority seams for role, work-item, assignment, handoff, and memory-candidate
+actions, but project/default/chat/runtime side effects still keep apply as a
 mixed-authority replacement blocker.
 Other live Projects reads/writes still use Hecate-native
 stores until the remaining read routes, write adapter, and migration path are
@@ -581,7 +581,8 @@ proof seams separately from the live-route `write_adapter_gaps`; only
 and they are mirror-only unless their explicit Cairnline write-authority
 switchpoint is enabled; currently only the proposal-ledger switchpoint can be
 made Cairnline-authoritative, while apply side effects become mixed-authority
-only through the enabled role/work-item/assignment/handoff switchpoints. It
+through the enabled role/work-item/assignment/handoff and memory-candidate
+switchpoints. It
 also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operators can see the exact
 read-route, strict-embedded-probe, write-authority, and migration blockers

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -573,8 +573,9 @@ sequenceDiagram
   `project-assistant-proposals` makes Project Assistant draft/propose/apply-attempt
   ledger records Cairnline-first, then best-effort shadows Hecate's proposal
   store for compatibility. Confirmed Project Assistant apply uses enabled
-  role/work-item/assignment/handoff authority seams and still blocks replacement
-  on the remaining project/default/chat/memory/runtime side effects.
+  role/work-item/assignment/handoff and memory-candidate authority seams and
+  still blocks replacement on the remaining project/default/chat/runtime side
+  effects.
   `project-roots` makes project root create/update/delete plus root list
   replacement plus discovery-result replacement and worktree-created root
   record mutations Cairnline-first, then shadows Hecate's compatibility project
@@ -2527,10 +2528,12 @@ mirrors Project Assistant draft/propose/apply proposal records and apply-attempt
 history after Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` makes
 those ledger records Cairnline-first. `project-assistant-apply-side-effects-live-mirror`
-mirrors committed apply side effects after Hecate commits. Assignment-start
-dispatch still writes Hecate-native runtime stores first, while committed
-results and cleanup/conflict states mirror to Cairnline. Other non-mirrored live
-mutation routes still write only Hecate-native stores.
+mirrors remaining committed apply side effects after Hecate commits; enabled
+role/work-item/assignment/handoff and memory-candidate apply actions use their
+Cairnline authority seams first. Assignment-start dispatch still writes
+Hecate-native runtime stores first, while committed results and cleanup/conflict
+states mirror to Cairnline. Other non-mirrored live mutation routes still write
+only Hecate-native stores.
 `mirror_parity_url` points at a read-only check that compares Hecate's current
 project stores with the existing embedded Cairnline mirror database without
 creating or repairing it. `sync_readiness_url` points at the all-project
@@ -6268,9 +6271,9 @@ text-only sidecar output. Draft generation uses the same Cairnline-projected
 context so preview and proposal assembly do not drift, while proposal ledger
 writes remain Hecate-owned unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
-enabled. Confirmed apply uses enabled role/work-item/assignment/handoff
-Cairnline-authority seams and still blocks replacement on the remaining
-project/default/chat/memory/runtime side effects.
+enabled. Confirmed apply uses enabled role/work-item/assignment/handoff and
+memory-candidate Cairnline-authority seams and still blocks replacement on the
+remaining project/default/chat/runtime side effects.
 `GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
 Cairnline read source as the other read routes; strict embedded mode reads the
 proposal record from the embedded mirror instead of falling back to the native

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -96,17 +96,18 @@ func (h *Handler) projectAssistantApplication() *projectassistantapp.Application
 	defer h.projectAssistantMu.Unlock()
 	if h.projectAssistant == nil {
 		h.projectAssistant = projectassistantapp.New(projectassistantapp.Options{
-			Projects:         h.projects,
-			Chats:            h.agentChat,
-			Work:             h.projectWork,
-			WorkAuthority:    h.projectAssistantWorkAuthorityForApplication(),
-			WorkApplication:  h.projectWorkApplication(),
-			ProjectSkills:    h.projectSkills,
-			Memory:           h.memory,
-			MemoryCandidates: h.memoryCandidates,
-			Proposals:        h.projectAssistantProposalStoreForApplication(),
-			LLM:              gatewayAgentLLMClient{service: h.service},
-			IDGenerator:      newOpaqueTaskResourceID,
+			Projects:                 h.projects,
+			Chats:                    h.agentChat,
+			Work:                     h.projectWork,
+			WorkAuthority:            h.projectAssistantWorkAuthorityForApplication(),
+			WorkApplication:          h.projectWorkApplication(),
+			ProjectSkills:            h.projectSkills,
+			Memory:                   h.memory,
+			MemoryCandidates:         h.memoryCandidates,
+			MemoryCandidateAuthority: h.projectAssistantMemoryCandidateAuthorityForApplication(),
+			Proposals:                h.projectAssistantProposalStoreForApplication(),
+			LLM:                      gatewayAgentLLMClient{service: h.service},
+			IDGenerator:              newOpaqueTaskResourceID,
 		})
 	}
 	return h.projectAssistant

--- a/internal/api/handler_project_assistant_apply_authority.go
+++ b/internal/api/handler_project_assistant_apply_authority.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
@@ -19,6 +21,13 @@ func (h *Handler) projectAssistantWorkAuthorityForApplication() projectassistant
 		return nil
 	}
 	return projectAssistantWorkAuthority{handler: h}
+}
+
+func (h *Handler) projectAssistantMemoryCandidateAuthorityForApplication() projectassistant.MemoryCandidateAuthority {
+	if h == nil {
+		return nil
+	}
+	return projectAssistantMemoryCandidateAuthority{handler: h}
 }
 
 func (authority projectAssistantWorkAuthority) CreateRole(ctx context.Context, projectID string, cmd projectassistant.WorkRoleCommand) (projectwork.AgentRoleProfile, error) {
@@ -194,4 +203,57 @@ func projectAssistantApplyWorkError(err error) error {
 		return fmt.Errorf("%w: %w", projectassistant.ErrConflict, err)
 	}
 	return err
+}
+
+type projectAssistantMemoryCandidateAuthority struct {
+	handler *Handler
+}
+
+func (authority projectAssistantMemoryCandidateAuthority) CreateMemoryCandidate(ctx context.Context, projectID string, cmd projectassistant.MemoryCandidateCommand) (memory.Candidate, error) {
+	h := authority.handler
+	if h == nil {
+		return memory.Candidate{}, projectassistant.ErrStoreNotConfigured
+	}
+	candidate := memory.Candidate{
+		ID:                  cmd.ID,
+		ProjectID:           projectID,
+		Title:               cmd.Title,
+		Body:                cmd.Body,
+		SuggestedKind:       cmd.SuggestedKind,
+		SuggestedTrustLabel: cmd.SuggestedTrustLabel,
+		SuggestedSourceKind: cmd.SuggestedSourceKind,
+		SuggestedSourceID:   cmd.SuggestedSourceID,
+		SourceRefs:          append([]memory.CandidateSourceRef(nil), cmd.SourceRefs...),
+		Status:              memory.CandidateStatusPending,
+	}
+	if h.projectMemoryCandidatesWriteUseCairnlineAuthority() {
+		created, err := h.createProjectMemoryCandidateWithCairnlineAuthority(ctx, projectID, candidate)
+		if err != nil {
+			return memory.Candidate{}, projectAssistantApplyMemoryCandidateError(err)
+		}
+		h.shadowProjectMemoryCandidateToHecate(ctx, "project_assistant_memory_candidate_authority_create_shadow", created)
+		return created, nil
+	}
+	if h.memoryCandidates == nil {
+		return memory.Candidate{}, projectassistant.ErrStoreNotConfigured
+	}
+	created, err := h.memoryCandidates.CreateCandidate(ctx, candidate)
+	return created, projectAssistantApplyMemoryCandidateError(err)
+}
+
+func projectAssistantApplyMemoryCandidateError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, cairnline.ErrNotFound):
+		return fmt.Errorf("%w: %w", memory.ErrNotFound, err)
+	case errors.Is(err, cairnline.ErrInvalid):
+		return fmt.Errorf("%w: %w", memory.ErrInvalid, err)
+	case errors.Is(err, cairnline.ErrDuplicate):
+		return fmt.Errorf("%w: %w", memory.ErrAlreadyExists, err)
+	case errors.Is(err, cairnline.ErrConflict):
+		return fmt.Errorf("%w: %w", memory.ErrConflict, err)
+	default:
+		return err
+	}
 }

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -129,6 +129,15 @@ func (s failingCreateRoleProjectWorkStore) CreateRole(context.Context, projectwo
 	return projectwork.AgentRoleProfile{}, s.err
 }
 
+type failingCreateMemoryCandidateStore struct {
+	*memory.MemoryStore
+	err error
+}
+
+func (s failingCreateMemoryCandidateStore) CreateCandidate(context.Context, memory.Candidate) (memory.Candidate, error) {
+	return memory.Candidate{}, s.err
+}
+
 type failingProposalUpsertStore struct {
 	projectassistant.ProposalStore
 	err error
@@ -1199,6 +1208,70 @@ func TestProjectAssistantAPI_CairnlineApplyWorkAuthorityDoesNotBlockOnRoleShadow
 		if role.ID == "role_apply_authority" {
 			t.Fatalf("shadow role store unexpectedly contains %+v, want Cairnline authority to survive failed Hecate shadow", role)
 		}
+	}
+}
+
+func TestProjectAssistantAPI_CairnlineApplyMemoryCandidateAuthorityDoesNotBlockOnShadowFailure(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineWriteAuthority = strings.Join([]string{
+		"project-memory",
+		"memory-candidates",
+	}, ",")
+	handler.SetMemoryStore(failingCreateMemoryCandidateStore{
+		MemoryStore: memory.NewMemoryStore(),
+		err:         errors.New("shadow memory candidate store unavailable"),
+	})
+	client := newAPITestClient(t, server)
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_pa_apply_memory_authority",
+		Name: "Assistant Apply Memory Authority",
+	}); err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	proposed := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/propose", `{
+		"id":"pa_apply_memory_authority",
+		"title":"Create memory candidate through authority",
+		"summary":"Project Assistant apply should use the Cairnline-first memory candidate authority seam.",
+		"actions":[{
+			"kind":"create_memory_candidate",
+			"reason":"Capture a reviewable project lesson.",
+			"patch":{
+				"id":"memcand_apply_authority",
+				"project_id":"proj_pa_apply_memory_authority",
+				"title":"Authority-backed memory candidate",
+				"body":"Assistant memory-candidate apply should commit through Cairnline when candidate authority is enabled.",
+				"suggested_kind":"process",
+				"suggested_trust_label":"operator_reviewed",
+				"suggested_source_kind":"project_assistant",
+				"suggested_source_id":"pa_apply_memory_authority",
+				"source_refs":[{"kind":"proposal","id":"pa_apply_memory_authority","title":"Create memory candidate through authority"}]
+			}
+		}]
+	}`)
+	applied := mustRequestJSON[projectAssistantApplyResponse](client, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposed.Data,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 1 {
+		t.Fatalf("apply response = %+v, want applied memory-candidate action despite Hecate shadow failure", applied.Data)
+	}
+
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror: %v", err)
+	}
+	defer store.Close()
+	candidate, err := service.GetMemoryCandidate(t.Context(), "proj_pa_apply_memory_authority", "memcand_apply_authority")
+	if err != nil {
+		t.Fatalf("GetMemoryCandidate from Cairnline: %v", err)
+	}
+	if candidate.Status != cairnline.MemoryCandidatePending || candidate.SuggestedSourceKind != "project_assistant" || candidate.SuggestedSourceID != "pa_apply_memory_authority" || len(candidate.SourceRefs) != 1 || candidate.SourceRefs[0].ID != "pa_apply_memory_authority" {
+		t.Fatalf("Cairnline memory candidate = %+v, want authoritative assistant-sourced pending candidate", candidate)
+	}
+	if _, ok, err := handler.memoryCandidates.GetCandidate(t.Context(), "proj_pa_apply_memory_authority", "memcand_apply_authority"); err != nil || ok {
+		t.Fatalf("shadow memory candidate ok=%v err=%v, want missing after injected shadow failure", ok, err)
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -558,7 +558,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 	projectWorkItemsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems)
 	projectAssignmentsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments)
 	projectAssistantProposalsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssistantProposals)
-	projectAssistantWorkEffectsAuthoritative := projectCairnlineAssistantApplyWorkEffectsAuthoritative(writeAuthority)
+	projectAssistantPortableEffectsAuthoritative := projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority)
 	for _, item := range projectCairnlineWriteSwitchpoints {
 		if projectIdentityAuthoritative && item.Name == "project-identity" {
 			item.CurrentAuthority = "cairnline"
@@ -639,17 +639,17 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.BlocksAuthority = false
 			item.Gap = ""
 			item.Detail = "Project Assistant draft/propose/apply-attempt ledger records commit to the embedded Cairnline database first, then best-effort shadow Hecate's proposal store for compatibility; confirmed apply side effects remain Hecate-owned."
-			if projectAssistantWorkEffectsAuthoritative {
-				item.Detail = "Project Assistant draft/propose/apply-attempt ledger records commit to the embedded Cairnline database first, then best-effort shadow Hecate's proposal store for compatibility; confirmed apply is mixed-authority when enabled work-family actions route through Cairnline."
+			if projectAssistantPortableEffectsAuthoritative {
+				item.Detail = "Project Assistant draft/propose/apply-attempt ledger records commit to the embedded Cairnline database first, then best-effort shadow Hecate's proposal store for compatibility; confirmed apply is mixed-authority when enabled portable actions route through Cairnline."
 			}
 		}
-		if projectAssistantWorkEffectsAuthoritative && item.Name == "project-assistant-apply-side-effects" {
+		if projectAssistantPortableEffectsAuthoritative && item.Name == "project-assistant-apply-side-effects" {
 			item.CurrentAuthority = "mixed"
-			item.CairnlineState = "partial_authoritative_via_work_switchpoints"
+			item.CairnlineState = "partial_authoritative_via_portable_switchpoints"
 			item.LiveMirror = true
 			item.BlocksAuthority = true
 			item.Gap = "project-assistant-apply-side-effects"
-			item.Detail = "Project Assistant confirmed apply routes role, work-item, assignment, and handoff actions through the same opt-in Cairnline authority switchpoints when enabled; project/default/chat/memory/runtime side effects still keep apply as a blocking mixed-authority gap."
+			item.Detail = "Project Assistant confirmed apply routes role, work-item, assignment, handoff, and memory-candidate actions through their opt-in Cairnline authority switchpoints when enabled; project/default/chat/runtime side effects still keep apply as a blocking mixed-authority gap."
 		}
 		if projectCollaborationAuthoritative && item.Name == "collaboration-artifacts" {
 			item.CurrentAuthority = "cairnline"
@@ -782,8 +782,8 @@ func projectCairnlineProjectAssignmentWriteWarning(writeAuthority []string) stri
 
 func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []string) string {
 	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssistantProposals) {
-		if projectCairnlineAssistantApplyWorkEffectsAuthoritative(writeAuthority) {
-			return "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; confirmed apply is mixed-authority when enabled work-family actions route through Cairnline."
+		if projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority) {
+			return "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; confirmed apply is mixed-authority when enabled portable actions route through Cairnline."
 		}
 		return "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; confirmed apply side effects still execute through Hecate-owned project mutation services."
 	}
@@ -791,17 +791,19 @@ func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []strin
 }
 
 func projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority []string) string {
-	if projectCairnlineAssistantApplyWorkEffectsAuthoritative(writeAuthority) {
-		return "Project Assistant confirmed apply uses the enabled Cairnline authority seams for role, work-item, assignment, and handoff actions, but project/default/chat/memory/runtime side effects still keep apply as a mixed-authority replacement blocker."
+	if projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority) {
+		return "Project Assistant confirmed apply uses the enabled Cairnline authority seams for role, work-item, assignment, handoff, and memory-candidate actions, but project/default/chat/runtime side effects still keep apply as a mixed-authority replacement blocker."
 	}
 	return "Project Assistant confirmed apply side effects still execute through Hecate-owned mutation services, then best-effort mirror committed results into Cairnline."
 }
 
-func projectCairnlineAssistantApplyWorkEffectsAuthoritative(writeAuthority []string) bool {
+func projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority []string) bool {
 	return projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments) ||
-		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectCollaboration)
+		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectCollaboration) ||
+		(projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory") &&
+			projectCairnlineWriteAuthorityEnabled(writeAuthority, "memory-candidates"))
 }
 
 func projectCairnlineReadSourceDetail(source string) string {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -672,7 +672,7 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantProposalAutho
 	}
 }
 
-func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyWorkAuthorityConfigured(t *testing.T) {
+func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortableAuthorityConfigured(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{
 			Backend:             "sqlite",
@@ -684,6 +684,8 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyWorkAuth
 				projectCairnlineWriteAuthorityProjectWorkItems,
 				projectCairnlineWriteAuthorityProjectAssignments,
 				projectCairnlineWriteAuthorityProjectCollaboration,
+				"project-memory",
+				"memory-candidates",
 			}, ","),
 		},
 	}, quietLogger(), nil, nil, nil, nil)
@@ -693,10 +695,10 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyWorkAuth
 		t.Fatalf("write gaps = %+v, want assistant apply side effects to remain a blocking mixed-authority gap", status.WriteAdapterGaps)
 	}
 	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
-	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_work_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
-		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed authority through enabled work switchpoints", applyPoint)
+	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed authority through enabled portable switchpoints", applyPoint)
 	}
-	for _, name := range []string{"roles", "work-items", "assignments", "artifacts", "handoffs", "project-assistant-proposals"} {
+	for _, name := range []string{"roles", "work-items", "assignments", "artifacts", "handoffs", "memory", "memory-candidates", "project-assistant-proposals"} {
 		if containsString(status.WriteAdapterGaps, name) {
 			t.Fatalf("write gaps = %+v, did not expect %q when underlying work/proposal switchpoints are enabled", status.WriteAdapterGaps, name)
 		}

--- a/internal/projectassistant/action_handlers.go
+++ b/internal/projectassistant/action_handlers.go
@@ -446,7 +446,7 @@ func (s *Service) applyUpdateHandoff(ctx context.Context, action Action) (Action
 }
 
 func (s *Service) applyCreateMemoryCandidate(ctx context.Context, action Action) (ActionResult, error) {
-	if s.memoryCandidates == nil {
+	if s.memoryCandidateAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
 	var patch memoryCandidatePatch
@@ -464,9 +464,8 @@ func (s *Service) applyCreateMemoryCandidate(ctx context.Context, action Action)
 	if id == "" {
 		id = s.idgen("memcand")
 	}
-	candidate, err := s.memoryCandidates.CreateCandidate(ctx, memory.Candidate{
+	candidate, err := s.memoryCandidateAuthority.CreateMemoryCandidate(ctx, projectID, MemoryCandidateCommand{
 		ID:                  id,
-		ProjectID:           projectID,
 		Title:               patch.Title,
 		Body:                patch.Body,
 		SuggestedKind:       patch.SuggestedKind,

--- a/internal/projectassistant/memory_authority.go
+++ b/internal/projectassistant/memory_authority.go
@@ -1,0 +1,51 @@
+package projectassistant
+
+import (
+	"context"
+
+	"github.com/hecatehq/hecate/internal/memory"
+)
+
+type MemoryCandidateAuthority interface {
+	CreateMemoryCandidate(ctx context.Context, projectID string, cmd MemoryCandidateCommand) (memory.Candidate, error)
+}
+
+type MemoryCandidateCommand struct {
+	ID                  string
+	Title               string
+	Body                string
+	SuggestedKind       string
+	SuggestedTrustLabel string
+	SuggestedSourceKind string
+	SuggestedSourceID   string
+	SourceRefs          []memory.CandidateSourceRef
+}
+
+func memoryCandidateAuthorityForStores(stores Stores) MemoryCandidateAuthority {
+	if stores.MemoryCandidateAuthority != nil {
+		return stores.MemoryCandidateAuthority
+	}
+	if stores.MemoryCandidates == nil {
+		return nil
+	}
+	return storeMemoryCandidateAuthority{store: stores.MemoryCandidates}
+}
+
+type storeMemoryCandidateAuthority struct {
+	store memory.CandidateStore
+}
+
+func (authority storeMemoryCandidateAuthority) CreateMemoryCandidate(ctx context.Context, projectID string, cmd MemoryCandidateCommand) (memory.Candidate, error) {
+	return authority.store.CreateCandidate(ctx, memory.Candidate{
+		ID:                  cmd.ID,
+		ProjectID:           projectID,
+		Title:               cmd.Title,
+		Body:                cmd.Body,
+		SuggestedKind:       cmd.SuggestedKind,
+		SuggestedTrustLabel: cmd.SuggestedTrustLabel,
+		SuggestedSourceKind: cmd.SuggestedSourceKind,
+		SuggestedSourceID:   cmd.SuggestedSourceID,
+		SourceRefs:          append([]memory.CandidateSourceRef(nil), cmd.SourceRefs...),
+		Status:              memory.CandidateStatusPending,
+	})
+}

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -50,29 +50,31 @@ var (
 type IDGenerator func(prefix string) string
 
 type Service struct {
-	mu               sync.Mutex
-	projects         projects.Store
-	chats            chat.Store
-	work             projectwork.Store
-	workAuthority    WorkAuthority
-	projectSkills    projectskills.Store
-	memory           memory.Store
-	memoryCandidates memory.CandidateStore
-	proposals        ProposalStore
-	llm              LLMClient
-	idgen            IDGenerator
+	mu                       sync.Mutex
+	projects                 projects.Store
+	chats                    chat.Store
+	work                     projectwork.Store
+	workAuthority            WorkAuthority
+	projectSkills            projectskills.Store
+	memory                   memory.Store
+	memoryCandidates         memory.CandidateStore
+	memoryCandidateAuthority MemoryCandidateAuthority
+	proposals                ProposalStore
+	llm                      LLMClient
+	idgen                    IDGenerator
 }
 
 type Stores struct {
-	Projects         projects.Store
-	Chats            chat.Store
-	Work             projectwork.Store
-	WorkAuthority    WorkAuthority
-	ProjectSkills    projectskills.Store
-	Memory           memory.Store
-	MemoryCandidates memory.CandidateStore
-	Proposals        ProposalStore
-	LLM              LLMClient
+	Projects                 projects.Store
+	Chats                    chat.Store
+	Work                     projectwork.Store
+	WorkAuthority            WorkAuthority
+	ProjectSkills            projectskills.Store
+	Memory                   memory.Store
+	MemoryCandidates         memory.CandidateStore
+	MemoryCandidateAuthority MemoryCandidateAuthority
+	Proposals                ProposalStore
+	LLM                      LLMClient
 }
 
 type ProposalInput struct {
@@ -187,16 +189,17 @@ func NewService(stores Stores, idgen IDGenerator) *Service {
 		proposals = NewMemoryProposalStore()
 	}
 	return &Service{
-		projects:         stores.Projects,
-		chats:            stores.Chats,
-		work:             stores.Work,
-		workAuthority:    workAuthorityForStores(stores),
-		projectSkills:    stores.ProjectSkills,
-		memory:           stores.Memory,
-		memoryCandidates: stores.MemoryCandidates,
-		proposals:        proposals,
-		llm:              stores.LLM,
-		idgen:            idgen,
+		projects:                 stores.Projects,
+		chats:                    stores.Chats,
+		work:                     stores.Work,
+		workAuthority:            workAuthorityForStores(stores),
+		projectSkills:            stores.ProjectSkills,
+		memory:                   stores.Memory,
+		memoryCandidates:         stores.MemoryCandidates,
+		memoryCandidateAuthority: memoryCandidateAuthorityForStores(stores),
+		proposals:                proposals,
+		llm:                      stores.LLM,
+		idgen:                    idgen,
 	}
 }
 

--- a/internal/projectassistantapp/application.go
+++ b/internal/projectassistantapp/application.go
@@ -17,17 +17,18 @@ type Application struct {
 }
 
 type Options struct {
-	Projects         projects.Store
-	Chats            chat.Store
-	Work             projectwork.Store
-	WorkAuthority    projectassistant.WorkAuthority
-	WorkApplication  *projectworkapp.Application
-	ProjectSkills    projectskills.Store
-	Memory           memory.Store
-	MemoryCandidates memory.CandidateStore
-	Proposals        projectassistant.ProposalStore
-	LLM              projectassistant.LLMClient
-	IDGenerator      projectassistant.IDGenerator
+	Projects                 projects.Store
+	Chats                    chat.Store
+	Work                     projectwork.Store
+	WorkAuthority            projectassistant.WorkAuthority
+	WorkApplication          *projectworkapp.Application
+	ProjectSkills            projectskills.Store
+	Memory                   memory.Store
+	MemoryCandidates         memory.CandidateStore
+	MemoryCandidateAuthority projectassistant.MemoryCandidateAuthority
+	Proposals                projectassistant.ProposalStore
+	LLM                      projectassistant.LLMClient
+	IDGenerator              projectassistant.IDGenerator
 }
 
 type ContextCommand struct {
@@ -74,15 +75,16 @@ func New(options Options) *Application {
 	}
 	return &Application{
 		service: projectassistant.NewService(projectassistant.Stores{
-			Projects:         options.Projects,
-			Chats:            options.Chats,
-			Work:             options.Work,
-			WorkAuthority:    workAuthority,
-			ProjectSkills:    options.ProjectSkills,
-			Memory:           options.Memory,
-			MemoryCandidates: options.MemoryCandidates,
-			Proposals:        options.Proposals,
-			LLM:              options.LLM,
+			Projects:                 options.Projects,
+			Chats:                    options.Chats,
+			Work:                     options.Work,
+			WorkAuthority:            workAuthority,
+			ProjectSkills:            options.ProjectSkills,
+			Memory:                   options.Memory,
+			MemoryCandidates:         options.MemoryCandidates,
+			MemoryCandidateAuthority: options.MemoryCandidateAuthority,
+			Proposals:                options.Proposals,
+			LLM:                      options.LLM,
 		}, options.IDGenerator),
 	}
 }


### PR DESCRIPTION
## Summary
- add a Project Assistant memory-candidate authority seam with store-backed fallback
- route confirmed create_memory_candidate apply actions through Cairnline-first authority when project-memory,memory-candidates write authority is enabled
- update coordination backend status/docs so memory-candidate apply is counted with portable authority switchpoints

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_(CairnlineApplyMemoryCandidateAuthorityDoesNotBlockOnShadowFailure|CairnlineApplyWorkAuthorityDoesNotBlockOnRoleShadowFailure|ApplyMirrorsCoordinationGraphToCairnlineWhenConfigured|ProjectSideEffectsMirrorThroughNarrowCairnlineSeams)'\n- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus_CairnlineProjectMemoryCandidateAuthorityConfigured|TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortableAuthorityConfigured'\n- GOCACHE="$PWD/.gocache" go test ./internal/projectassistant ./internal/projectassistantapp\n- just docs-format-check\n- just agent-docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/projectassistant ./internal/projectassistantapp\n- GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/projectassistant ./internal/projectassistantapp\n- just docs-check\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n\n## Notes\n- The first sandboxed package test hit a local-listener permission error from httptest, then passed unsandboxed.