### PR TITLE
feat(projects): route assistant project defaults through Cairnline authority

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -228,10 +228,11 @@ handoff-list, activity, closeout-readiness, and operations brief reads.
 Project Assistant draft generation also uses the Cairnline-projected context so
 preview and proposal assembly stay aligned, while the proposal ledger remains
 Hecate-owned unless `project-assistant-proposals` is enabled.
-Confirmed Project Assistant apply routes role, work-item, assignment, handoff,
-and memory-candidate actions through the same opt-in Cairnline authority
-switchpoints when those switchpoints are enabled; project/default/chat/runtime
-side effects still keep apply as a mixed-authority replacement blocker.
+Confirmed Project Assistant apply routes project metadata/default, role,
+work-item, assignment, handoff, and memory-candidate actions through the same
+opt-in Cairnline authority switchpoints when those switchpoints are enabled;
+root/chat/runtime side effects still keep apply as a mixed-authority
+replacement blocker.
 Project list/detail reconstruct default profile and execution posture from
 Cairnline project/execution-profile records where available. Launch-readiness
 and assignment preflight read
@@ -301,9 +302,9 @@ reconciliation updates are mirrored as replacement evidence.
 Assistant draft/propose/apply-attempt ledger records commit to embedded
 Cairnline first, then best-effort shadow Hecate's proposal store for
 compatibility. Confirmed apply uses the enabled Cairnline authority seams for
-role, work-item, assignment, handoff, and memory-candidate actions, but
-project/default/chat/runtime side effects still keep Assistant apply as a
-mixed-authority replacement blocker.
+project metadata/default, role, work-item, assignment, handoff, and
+memory-candidate actions, but root/chat/runtime side effects still keep
+Assistant apply as a mixed-authority replacement blocker.
 Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results and cleanup/conflict states are best-effort mirrored
 for replacement evidence, and other live Projects reads/writes still use the
@@ -412,9 +413,9 @@ execution-profile posture can be shared. Project Assistant draft/propose/apply
 routes mirror the proposal ledger and committed apply side effects after Hecate
 commits proposal records and apply attempts unless `project-assistant-proposals`
 is enabled, in which case the proposal ledger commits to Cairnline first while
-confirmed apply uses enabled role/work-item/assignment/handoff and
-memory-candidate authority seams and still blocks replacement on the remaining
-project/default/chat/runtime side effects.
+confirmed apply uses enabled project metadata/default,
+role/work-item/assignment/handoff, and memory-candidate authority seams and still
+blocks replacement on the remaining root/chat/runtime side effects.
 `POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
 SQLite export under Hecate's data directory and returns the same
 `migration_rehearsal` evidence for the single-project database. Both sync and
@@ -485,9 +486,10 @@ memory-candidate records; and
 proposal records, apply-attempt history, and committed apply side effects before
 assignment-start/runtime handoff. `project-assistant-proposals` can make the
 proposal ledger Cairnline-authoritative while confirmed apply uses enabled
-role/work-item/assignment/handoff and memory-candidate authority seams and
-remains blocked on project/default/chat/runtime side effects. `project-identity` can make project
-create/delete Cairnline-authoritative with snapshot rollback for failed Hecate
+project metadata/default, role/work-item/assignment/handoff, and
+memory-candidate authority seams and remains blocked on root/chat/runtime side
+effects. `project-identity` can make project create/delete
+Cairnline-authoritative with snapshot rollback for failed Hecate
 compatibility cleanup;
 `project-metadata-defaults` can make
 metadata/default-only PATCHes Cairnline-authoritative; `project-roots` and
@@ -535,9 +537,9 @@ after these gates are met:
   readiness, and operations brief. Draft generation may use the
   Cairnline-projected context, and proposal ledger writes may become
   Cairnline-authoritative with the `project-assistant-proposals` switchpoint.
-  Confirmed apply may use enabled role/work-item/assignment/handoff and
-  memory-candidate Cairnline-authority seams, but project/default/chat/runtime
-  side effects remain a mixed-authority replacement blocker and are mirrored as
+  Confirmed apply may use enabled project metadata/default,
+  role/work-item/assignment/handoff, and memory-candidate Cairnline-authority
+  seams, but root/chat/runtime side effects remain a mixed-authority replacement blocker and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative
   Cairnline launch-packet evidence, but assignment-start remains a Hecate-owned

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -490,11 +490,11 @@ launch agents. Those remain explicit operator or orchestrator actions.
   Cairnline backend is configured. Hecate still commits first and remains
   authoritative for any mutation family whose opt-in Cairnline write-authority
   switchpoint is not enabled; Project Assistant confirmed apply uses enabled
-  role/work-item/assignment/handoff and memory-candidate authority seams and
-  remains a mixed-authority blocker for project/default/chat/runtime side
-  effects even when the proposal-ledger switchpoint is enabled. Role mirrors
-  also seed referenced agent-profile metadata/execution posture when the
-  profile store is available.
+  project metadata/default, role/work-item/assignment/handoff, and
+  memory-candidate authority seams and remains a mixed-authority blocker for
+  root/chat/runtime side effects even when the proposal-ledger switchpoint is
+  enabled. Role mirrors also seed referenced agent-profile metadata/execution
+  posture when the profile store is available.
   Assignment-start dispatch is still a Hecate-owned write
   gap. Artifact/evidence/review update/delete semantics are absent because
   Hecate currently records those as immutable collaboration artifacts. Route

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -415,9 +415,9 @@ can be served from the Cairnline read model. Project Assistant draft generation
 also uses the Cairnline-projected context in this mode, while proposal ledger
 writes remain Hecate-owned unless `project-assistant-proposals` is explicitly
 enabled. Confirmed Project Assistant apply routes role, work-item, assignment,
-handoff, and memory-candidate actions through the same opt-in Cairnline
-authority switchpoints when those switchpoints are enabled; other apply side effects remain
-Hecate-owned and are best-effort mirrored into Cairnline as
+handoff, memory-candidate, and project metadata/default actions through the same
+opt-in Cairnline authority switchpoints when those switchpoints are enabled; root,
+chat, and runtime side effects remain Hecate-owned and are best-effort mirrored into Cairnline as
 replacement-readiness evidence.
 Launch-readiness and assignment preflight read Cairnline coordination records
 before applying Hecate runtime checks.
@@ -555,9 +555,9 @@ ledger mutations likewise best-effort mirror proposal records and apply attempts
 after Hecate commits unless `project-assistant-proposals` is enabled, in which
 case the proposal ledger commits to Cairnline first and shadows Hecate's
 proposal store for compatibility. Confirmed apply uses the enabled Cairnline
-authority seams for role, work-item, assignment, handoff, and memory-candidate
-actions, but project/default/chat/runtime side effects still keep apply as a
-mixed-authority replacement blocker.
+authority seams for project metadata/default, role, work-item, assignment,
+handoff, and memory-candidate actions, but root/chat/runtime side effects still
+keep apply as a mixed-authority replacement blocker.
 Other live Projects reads/writes still use Hecate-native
 stores until the remaining read routes, write adapter, and migration path are
 ready. Current bridge write experiments cover non-authoritative
@@ -581,8 +581,8 @@ proof seams separately from the live-route `write_adapter_gaps`; only
 and they are mirror-only unless their explicit Cairnline write-authority
 switchpoint is enabled; currently only the proposal-ledger switchpoint can be
 made Cairnline-authoritative, while apply side effects become mixed-authority
-through the enabled role/work-item/assignment/handoff and memory-candidate
-switchpoints. It
+through the enabled project metadata/default, role/work-item/assignment/handoff,
+and memory-candidate switchpoints. It
 also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operators can see the exact
 read-route, strict-embedded-probe, write-authority, and migration blockers

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -573,9 +573,9 @@ sequenceDiagram
   `project-assistant-proposals` makes Project Assistant draft/propose/apply-attempt
   ledger records Cairnline-first, then best-effort shadows Hecate's proposal
   store for compatibility. Confirmed Project Assistant apply uses enabled
-  role/work-item/assignment/handoff and memory-candidate authority seams and
-  still blocks replacement on the remaining project/default/chat/runtime side
-  effects.
+  project-metadata/default, role/work-item/assignment/handoff, and
+  memory-candidate authority seams and still blocks replacement on the
+  remaining root/chat/runtime side effects.
   `project-roots` makes project root create/update/delete plus root list
   replacement plus discovery-result replacement and worktree-created root
   record mutations Cairnline-first, then shadows Hecate's compatibility project
@@ -2529,8 +2529,8 @@ history after Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` makes
 those ledger records Cairnline-first. `project-assistant-apply-side-effects-live-mirror`
 mirrors remaining committed apply side effects after Hecate commits; enabled
-role/work-item/assignment/handoff and memory-candidate apply actions use their
-Cairnline authority seams first. Assignment-start dispatch still writes
+project metadata/default, role/work-item/assignment/handoff, and memory-candidate
+apply actions use their Cairnline authority seams first. Assignment-start dispatch still writes
 Hecate-native runtime stores first, while committed results and cleanup/conflict
 states mirror to Cairnline. Other non-mirrored live mutation routes still write
 only Hecate-native stores.
@@ -6272,8 +6272,8 @@ context so preview and proposal assembly do not drift, while proposal ledger
 writes remain Hecate-owned unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
 enabled. Confirmed apply uses enabled role/work-item/assignment/handoff and
-memory-candidate Cairnline-authority seams and still blocks replacement on the
-remaining project/default/chat/runtime side effects.
+memory-candidate plus project metadata/default Cairnline-authority seams and
+still blocks replacement on the remaining root/chat/runtime side effects.
 `GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
 Cairnline read source as the other read routes; strict embedded mode reads the
 proposal record from the embedded mirror instead of falling back to the native

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -97,6 +97,7 @@ func (h *Handler) projectAssistantApplication() *projectassistantapp.Application
 	if h.projectAssistant == nil {
 		h.projectAssistant = projectassistantapp.New(projectassistantapp.Options{
 			Projects:                 h.projects,
+			ProjectAuthority:         h.projectAssistantProjectAuthorityForApplication(),
 			Chats:                    h.agentChat,
 			Work:                     h.projectWork,
 			WorkAuthority:            h.projectAssistantWorkAuthorityForApplication(),

--- a/internal/api/handler_project_assistant_apply_authority.go
+++ b/internal/api/handler_project_assistant_apply_authority.go
@@ -4,16 +4,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectapp"
 	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
+type projectAssistantProjectAuthority struct {
+	handler *Handler
+}
+
 type projectAssistantWorkAuthority struct {
 	handler *Handler
+}
+
+func (h *Handler) projectAssistantProjectAuthorityForApplication() projectassistant.ProjectAuthority {
+	if h == nil {
+		return nil
+	}
+	return projectAssistantProjectAuthority{handler: h}
 }
 
 func (h *Handler) projectAssistantWorkAuthorityForApplication() projectassistant.WorkAuthority {
@@ -28,6 +42,119 @@ func (h *Handler) projectAssistantMemoryCandidateAuthorityForApplication() proje
 		return nil
 	}
 	return projectAssistantMemoryCandidateAuthority{handler: h}
+}
+
+func (authority projectAssistantProjectAuthority) CreateProject(ctx context.Context, project projects.Project) (projects.Project, error) {
+	h := authority.handler
+	if h == nil || h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
+	}
+	if h.projectIdentityWritesUseCairnlineAuthority() {
+		created, err := h.createProjectWithCairnlineAuthority(ctx, project)
+		return created, projectAssistantApplyProjectError(err)
+	}
+	created, err := h.projects.Create(ctx, project)
+	return created, projectAssistantApplyProjectError(err)
+}
+
+func (authority projectAssistantProjectAuthority) UpdateProject(ctx context.Context, projectID string, cmd projectassistant.ProjectUpdateCommand) (projects.Project, error) {
+	h := authority.handler
+	if h == nil || h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
+	}
+	req := updateProjectRequest{Name: cmd.Name, Description: cmd.Description}
+	if h.projectMetadataDefaultsWritesUseCairnlineAuthority() && projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req) {
+		updated, err := h.updateProjectMetadataDefaultsWithCairnlineAuthority(ctx, projectID, req)
+		return updated, projectAssistantApplyProjectError(err)
+	}
+	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
+		if cmd.Name != nil {
+			project.Name = strings.TrimSpace(*cmd.Name)
+		}
+		if cmd.Description != nil {
+			project.Description = strings.TrimSpace(*cmd.Description)
+		}
+	})
+	return updated, projectAssistantApplyProjectError(err)
+}
+
+func (authority projectAssistantProjectAuthority) AttachProjectRoot(ctx context.Context, projectID string, root projects.Root) (projects.Project, error) {
+	h := authority.handler
+	if h == nil || h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
+	}
+	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
+		project.Roots = append(project.Roots, root)
+	})
+	return updated, projectAssistantApplyProjectError(err)
+}
+
+func (authority projectAssistantProjectAuthority) RemoveProjectRoot(ctx context.Context, projectID, rootID string) (projects.Project, error) {
+	h := authority.handler
+	if h == nil || h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
+	}
+	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
+		roots := project.Roots[:0]
+		for _, root := range project.Roots {
+			if root.ID != rootID {
+				roots = append(roots, root)
+			}
+		}
+		project.Roots = roots
+		if project.DefaultRootID == rootID {
+			project.DefaultRootID = ""
+		}
+	})
+	return updated, projectAssistantApplyProjectError(err)
+}
+
+func (authority projectAssistantProjectAuthority) SetProjectDefaults(ctx context.Context, projectID string, cmd projectassistant.ProjectDefaultsCommand) (projects.Project, error) {
+	h := authority.handler
+	if h == nil || h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
+	}
+	req := updateProjectRequest{
+		DefaultRootID:            cmd.DefaultRootID,
+		DefaultProvider:          cmd.DefaultProvider,
+		DefaultModel:             cmd.DefaultModel,
+		DefaultAgentProfile:      cmd.DefaultAgentProfile,
+		DefaultToolsEnabled:      cmd.DefaultToolsEnabled,
+		DefaultWorkspaceMode:     cmd.DefaultWorkspaceMode,
+		DefaultSystemPrompt:      cmd.DefaultSystemPrompt,
+		DefaultCompactToolOutput: cmd.DefaultCompactToolOutput,
+	}
+	if h.projectMetadataDefaultsWritesUseCairnlineAuthority() && projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req) {
+		updated, err := h.updateProjectMetadataDefaultsWithCairnlineAuthority(ctx, projectID, req)
+		return updated, projectAssistantApplyProjectError(err)
+	}
+	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
+		if cmd.DefaultRootID != nil {
+			project.DefaultRootID = strings.TrimSpace(*cmd.DefaultRootID)
+		}
+		if cmd.DefaultProvider != nil {
+			project.DefaultProvider = strings.TrimSpace(*cmd.DefaultProvider)
+		}
+		if cmd.DefaultModel != nil {
+			project.DefaultModel = strings.TrimSpace(*cmd.DefaultModel)
+		}
+		if cmd.DefaultAgentProfile != nil {
+			project.DefaultAgentProfile = strings.TrimSpace(*cmd.DefaultAgentProfile)
+		}
+		if cmd.DefaultToolsEnabled != nil {
+			project.DefaultToolsEnabled = cloneBool(cmd.DefaultToolsEnabled)
+		}
+		if cmd.DefaultWorkspaceMode != nil {
+			project.DefaultWorkspaceMode = strings.TrimSpace(*cmd.DefaultWorkspaceMode)
+		}
+		if cmd.DefaultSystemPrompt != nil {
+			project.DefaultSystemPrompt = strings.TrimSpace(*cmd.DefaultSystemPrompt)
+		}
+		if cmd.DefaultCompactToolOutput != nil {
+			project.DefaultCompactToolOutput = cloneBool(cmd.DefaultCompactToolOutput)
+		}
+	})
+	return updated, projectAssistantApplyProjectError(err)
 }
 
 func (authority projectAssistantWorkAuthority) CreateRole(ctx context.Context, projectID string, cmd projectassistant.WorkRoleCommand) (projectwork.AgentRoleProfile, error) {
@@ -203,6 +330,26 @@ func projectAssistantApplyWorkError(err error) error {
 		return fmt.Errorf("%w: %w", projectassistant.ErrConflict, err)
 	}
 	return err
+}
+
+func projectAssistantApplyProjectError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, projectapp.ErrProjectNotFound),
+		errors.Is(err, projectapp.ErrProjectRootNotFound),
+		errors.Is(err, cairnline.ErrNotFound):
+		return fmt.Errorf("%w: %w", projects.ErrNotFound, err)
+	case errors.Is(err, projectapp.ErrProjectRootConflict),
+		errors.Is(err, projectapp.ErrProjectContextSourceConflict),
+		errors.Is(err, cairnline.ErrDuplicate),
+		errors.Is(err, cairnline.ErrConflict):
+		return fmt.Errorf("%w: %w", projects.ErrAlreadyExists, err)
+	case errors.Is(err, cairnline.ErrInvalid):
+		return fmt.Errorf("%w: %w", projects.ErrInvalid, err)
+	default:
+		return err
+	}
 }
 
 type projectAssistantMemoryCandidateAuthority struct {

--- a/internal/api/handler_project_assistant_authority.go
+++ b/internal/api/handler_project_assistant_authority.go
@@ -212,17 +212,8 @@ func (s cairnlineProjectAssistantProposalAuthorityStore) writeRecord(ctx context
 	}
 	var written projectassistant.ProposalRecord
 	err := s.handler.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
-		projectID := strings.TrimSpace(record.ProjectID)
-		if projectID != "" && s.handler.projects != nil {
-			project, ok, err := s.handler.projects.Get(ctx, projectID)
-			if err != nil {
-				return err
-			}
-			if ok {
-				if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
-					return err
-				}
-			}
+		if err := s.handler.seedProjectMetadataForAssistantProposalRecord(ctx, service, record.ProjectID); err != nil {
+			return err
 		}
 		item, ok := cairnlinebridge.AssistantProposalRecord(record)
 		if !ok {

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -129,6 +129,15 @@ func (s failingCreateRoleProjectWorkStore) CreateRole(context.Context, projectwo
 	return projectwork.AgentRoleProfile{}, s.err
 }
 
+type failingUpdateProjectStore struct {
+	projects.Store
+	err error
+}
+
+func (s failingUpdateProjectStore) Update(context.Context, string, func(*projects.Project)) (projects.Project, error) {
+	return projects.Project{}, s.err
+}
+
 type failingCreateMemoryCandidateStore struct {
 	*memory.MemoryStore
 	err error
@@ -1272,6 +1281,83 @@ func TestProjectAssistantAPI_CairnlineApplyMemoryCandidateAuthorityDoesNotBlockO
 	}
 	if _, ok, err := handler.memoryCandidates.GetCandidate(t.Context(), "proj_pa_apply_memory_authority", "memcand_apply_authority"); err != nil || ok {
 		t.Fatalf("shadow memory candidate ok=%v err=%v, want missing after injected shadow failure", ok, err)
+	}
+}
+
+func TestProjectAssistantAPI_CairnlineApplyProjectMetadataAuthorityDoesNotBlockOnShadowFailure(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineWriteAuthority = projectCairnlineWriteAuthorityProjectMetadataDefaults
+	baseProjects := projects.NewMemoryStore()
+	project, err := baseProjects.Create(t.Context(), projects.Project{
+		ID:            "proj_pa_apply_project_authority",
+		Name:          "Assistant Project Authority",
+		DefaultRootID: "root_main",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   "/workspace/main",
+			Kind:   "git",
+			Active: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	handler.SetProjectStore(failingUpdateProjectStore{
+		Store: baseProjects,
+		err:   errors.New("shadow project store unavailable"),
+	})
+	if !handler.projectMetadataDefaultsWritesUseCairnlineAuthority() {
+		t.Fatal("metadata/default write authority is disabled, want enabled for test")
+	}
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_apply_project_authority",
+		Title:                "Update project through authority",
+		Summary:              "Project Assistant apply should use the Cairnline-first metadata/default authority seam.",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{
+			{
+				Kind:   projectassistant.ActionUpdateProject,
+				Reason: "Rename the project through the authority seam.",
+				Target: map[string]string{"project_id": "proj_pa_apply_project_authority"},
+				Patch:  json.RawMessage(`{"name":"Assistant Project Authority Updated","description":"Cairnline owns this metadata update."}`),
+			},
+			{
+				Kind:   projectassistant.ActionSetProjectDefaults,
+				Reason: "Set launch defaults through the authority seam.",
+				Target: map[string]string{"project_id": "proj_pa_apply_project_authority"},
+				Patch:  json.RawMessage(`{"default_root_id":"root_main","default_provider":"anthropic","default_model":"claude-sonnet-4-5"}`),
+			},
+		},
+	}
+	applyBody, err := json.Marshal(map[string]any{"proposal": proposal, "confirm": true})
+	if err != nil {
+		t.Fatalf("marshal apply body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("apply status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var applied projectAssistantApplyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("decode apply response: %v", err)
+	}
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 2 {
+		t.Fatalf("apply response = %+v, want applied project metadata/default actions despite Hecate shadow failure", applied.Data)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, project.ID)
+	if mirrored.Name != "Assistant Project Authority Updated" || mirrored.Description != "Cairnline owns this metadata update." || mirrored.DefaultRootID != "root_main" {
+		t.Fatalf("Cairnline project = %+v, want authoritative metadata/default update", mirrored)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "anthropic", "claude-sonnet-4-5")
+	native, ok, err := baseProjects.Get(t.Context(), project.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get native project ok=%v err=%v", ok, err)
+	}
+	if native.Name != "Assistant Project Authority" || native.DefaultModel != "" {
+		t.Fatalf("native shadow project = %+v, want unchanged after injected shadow failure", native)
 	}
 }
 

--- a/internal/api/handler_project_cairnline_mirror.go
+++ b/internal/api/handler_project_cairnline_mirror.go
@@ -347,12 +347,18 @@ func (h *Handler) writeProjectAssistantActionResultToCairnline(ctx context.Conte
 	projectID := projectAssistantActionResultProjectID(result)
 	switch strings.TrimSpace(result.Kind) {
 	case projectassistant.ActionCreateProject:
+		if h.projectIdentityWritesUseCairnlineAuthority() {
+			return nil
+		}
 		project, ok := h.projectForCairnlineMirror(ctx, "project_assistant_apply_result", projectID)
 		if !ok {
 			return nil
 		}
 		return h.writeProjectIdentityToCairnline(ctx, project)
 	case projectassistant.ActionUpdateProject:
+		if h.projectMetadataDefaultsWritesUseCairnlineAuthority() {
+			return nil
+		}
 		project, ok := h.projectForCairnlineMirror(ctx, "project_assistant_apply_result", projectID)
 		if !ok {
 			return nil
@@ -380,6 +386,9 @@ func (h *Handler) writeProjectAssistantActionResultToCairnline(ctx context.Conte
 		}
 		return h.writeProjectDefaultsToCairnline(ctx, project)
 	case projectassistant.ActionSetProjectDefaults:
+		if h.projectMetadataDefaultsWritesUseCairnlineAuthority() {
+			return nil
+		}
 		project, ok := h.projectForCairnlineMirror(ctx, "project_assistant_apply_result", projectID)
 		if !ok {
 			return nil
@@ -810,23 +819,34 @@ func (h *Handler) deleteAgentProfileFromCairnline(ctx context.Context, profileID
 
 func (h *Handler) writeProjectAssistantProposalRecordToCairnline(ctx context.Context, record projectassistant.ProposalRecord) error {
 	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
-		projectID := strings.TrimSpace(record.ProjectID)
-		if projectID != "" && h != nil && h.projects != nil {
-			project, ok, err := h.projects.Get(ctx, projectID)
-			if err != nil {
-				return err
-			}
-			if ok {
-				// Proposal records only need the project row to exist; avoid
-				// replacing Cairnline-owned roots or sources while writing the ledger.
-				if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
-					return err
-				}
-			}
+		if err := h.seedProjectMetadataForAssistantProposalRecord(ctx, service, record.ProjectID); err != nil {
+			return err
 		}
 		_, _, err := cairnlinebridge.UpsertAssistantProposalRecord(ctx, service, record)
 		return err
 	})
+}
+
+func (h *Handler) seedProjectMetadataForAssistantProposalRecord(ctx context.Context, service *cairnline.Service, projectID string) error {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" || h == nil || h.projects == nil {
+		return nil
+	}
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil || !ok {
+		return err
+	}
+	if h.projectIdentityWritesUseCairnlineAuthority() || h.projectMetadataDefaultsWritesUseCairnlineAuthority() {
+		if _, err := service.GetProject(ctx, projectID); err == nil {
+			return nil
+		} else if !errors.Is(err, cairnline.ErrNotFound) {
+			return err
+		}
+	}
+	// Proposal records only need the project row to exist; avoid replacing
+	// Cairnline-owned roots or sources while writing the ledger.
+	_, err = cairnlinebridge.UpsertProjectMetadata(ctx, service, project)
+	return err
 }
 
 func (h *Handler) writeProjectSkillsToCairnline(ctx context.Context, project projects.Project, skills []projectskills.Skill) error {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -649,7 +649,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.LiveMirror = true
 			item.BlocksAuthority = true
 			item.Gap = "project-assistant-apply-side-effects"
-			item.Detail = "Project Assistant confirmed apply routes role, work-item, assignment, handoff, and memory-candidate actions through their opt-in Cairnline authority switchpoints when enabled; project/default/chat/runtime side effects still keep apply as a blocking mixed-authority gap."
+			item.Detail = "Project Assistant confirmed apply routes project metadata/default, role, work-item, assignment, handoff, and memory-candidate actions through their opt-in Cairnline authority switchpoints when enabled; root/chat/runtime side effects still keep apply as a blocking mixed-authority gap."
 		}
 		if projectCollaborationAuthoritative && item.Name == "collaboration-artifacts" {
 			item.CurrentAuthority = "cairnline"
@@ -792,13 +792,14 @@ func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []strin
 
 func projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority []string) string {
 	if projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority) {
-		return "Project Assistant confirmed apply uses the enabled Cairnline authority seams for role, work-item, assignment, handoff, and memory-candidate actions, but project/default/chat/runtime side effects still keep apply as a mixed-authority replacement blocker."
+		return "Project Assistant confirmed apply uses the enabled Cairnline authority seams for project metadata/default, role, work-item, assignment, handoff, and memory-candidate actions, but root/chat/runtime side effects still keep apply as a mixed-authority replacement blocker."
 	}
 	return "Project Assistant confirmed apply side effects still execute through Hecate-owned mutation services, then best-effort mirror committed results into Cairnline."
 }
 
 func projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority []string) bool {
-	return projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles) ||
+	return projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectMetadataDefaults) ||
+		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectCollaboration) ||

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -405,11 +405,15 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectMetadataDefaultsAuthor
 	if identityPoint == nil || identityPoint.CurrentAuthority != "hecate" || !identityPoint.BlocksAuthority || identityPoint.Gap != "projects" {
 		t.Fatalf("project-identity switchpoint = %+v, want create/delete to remain Hecate-owned and blocking", identityPoint)
 	}
+	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
+	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed authority through metadata/default switchpoint", applyPoint)
+	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Project metadata/default-only update mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "controlled by separate switchpoints") {
+	if !strings.Contains(warnings, "Project metadata/default-only update mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "controlled by separate switchpoints") || !strings.Contains(warnings, "root/chat/runtime") {
 		t.Fatalf("warnings = %+v, want metadata/default authority plus separate-switchpoint caveat", status.Warnings)
 	}
 }
@@ -680,6 +684,7 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 			CairnlineReadSource: "embedded",
 			CairnlineWriteAuthority: strings.Join([]string{
 				projectCairnlineWriteAuthorityProjectAssistantProposals,
+				projectCairnlineWriteAuthorityProjectMetadataDefaults,
 				projectCairnlineWriteAuthorityProjectRoles,
 				projectCairnlineWriteAuthorityProjectWorkItems,
 				projectCairnlineWriteAuthorityProjectAssignments,
@@ -704,8 +709,8 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 		}
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "confirmed apply is mixed-authority") || !strings.Contains(warnings, "Project Assistant confirmed apply uses the enabled Cairnline authority seams") {
-		t.Fatalf("warnings = %+v, want assistant proposal authority and mixed apply-work authority caveats", status.Warnings)
+	if !strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "confirmed apply is mixed-authority") || !strings.Contains(warnings, "Project Assistant confirmed apply uses the enabled Cairnline authority seams") || !strings.Contains(warnings, "root/chat/runtime") {
+		t.Fatalf("warnings = %+v, want assistant proposal authority and mixed apply authority caveats", status.Warnings)
 	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")

--- a/internal/projectassistant/action_handlers.go
+++ b/internal/projectassistant/action_handlers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Service) applyCreateProject(ctx context.Context, action Action) (ActionResult, error) {
-	if s.projects == nil {
+	if s.projectAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
 	var patch projectPatch
@@ -24,10 +24,14 @@ func (s *Service) applyCreateProject(ctx context.Context, action Action) (Action
 	id := strings.TrimSpace(patch.ID)
 	if id == "" {
 		id = s.idgen("proj")
-	} else if _, ok, err := s.projects.Get(ctx, id); err != nil {
-		return ActionResult{}, err
-	} else if ok {
-		return ActionResult{}, fmt.Errorf("%w: project %q already exists", ErrConflict, id)
+	} else if s.projects != nil {
+		_, ok, err := s.projects.Get(ctx, id)
+		if err != nil {
+			return ActionResult{}, err
+		}
+		if ok {
+			return ActionResult{}, fmt.Errorf("%w: project %q already exists", ErrConflict, id)
+		}
 	}
 	roots, err := rootsForProjectPatch(patch, s.idgen)
 	if err != nil {
@@ -46,7 +50,7 @@ func (s *Service) applyCreateProject(ctx context.Context, action Action) (Action
 		DefaultSystemPrompt:      patch.DefaultSystemPrompt,
 		DefaultCompactToolOutput: patch.DefaultCompactToolOutput,
 	}
-	created, err := s.projects.Create(ctx, project)
+	created, err := s.projectAuthority.CreateProject(ctx, project)
 	if err != nil {
 		return ActionResult{}, mapProjectErr(err)
 	}
@@ -54,6 +58,9 @@ func (s *Service) applyCreateProject(ctx context.Context, action Action) (Action
 }
 
 func (s *Service) applyUpdateProject(ctx context.Context, action Action) (ActionResult, error) {
+	if s.projectAuthority == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
 	projectID := targetValue(action, "project_id")
 	if projectID == "" {
 		return ActionResult{}, fmt.Errorf("%w: target.project_id is required", ErrInvalid)
@@ -65,13 +72,9 @@ func (s *Service) applyUpdateProject(ctx context.Context, action Action) (Action
 	if err := decodePatch(action, &patch); err != nil {
 		return ActionResult{}, err
 	}
-	updated, err := s.projects.Update(ctx, projectID, func(project *projects.Project) {
-		if patch.Name != nil {
-			project.Name = *patch.Name
-		}
-		if patch.Description != nil {
-			project.Description = *patch.Description
-		}
+	updated, err := s.projectAuthority.UpdateProject(ctx, projectID, ProjectUpdateCommand{
+		Name:        patch.Name,
+		Description: patch.Description,
 	})
 	if err != nil {
 		return ActionResult{}, mapProjectErr(err)
@@ -80,6 +83,9 @@ func (s *Service) applyUpdateProject(ctx context.Context, action Action) (Action
 }
 
 func (s *Service) applyAttachProjectRoot(ctx context.Context, action Action) (ActionResult, error) {
+	if s.projectAuthority == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
 	projectID := targetValue(action, "project_id")
 	if projectID == "" {
 		return ActionResult{}, fmt.Errorf("%w: target.project_id is required", ErrInvalid)
@@ -92,9 +98,7 @@ func (s *Service) applyAttachProjectRoot(ctx context.Context, action Action) (Ac
 		return ActionResult{}, err
 	}
 	root := rootFromPatch(patch, s.idgen)
-	updated, err := s.projects.Update(ctx, projectID, func(project *projects.Project) {
-		project.Roots = append(project.Roots, root)
-	})
+	updated, err := s.projectAuthority.AttachProjectRoot(ctx, projectID, root)
 	if err != nil {
 		return ActionResult{}, mapProjectErr(err)
 	}
@@ -102,6 +106,9 @@ func (s *Service) applyAttachProjectRoot(ctx context.Context, action Action) (Ac
 }
 
 func (s *Service) applyRemoveProjectRoot(ctx context.Context, action Action) (ActionResult, error) {
+	if s.projectAuthority == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
 	projectID := targetValue(action, "project_id")
 	rootID := targetValue(action, "root_id")
 	if projectID == "" || rootID == "" {
@@ -114,18 +121,7 @@ func (s *Service) applyRemoveProjectRoot(ctx context.Context, action Action) (Ac
 	if !projectHasRoot(project, rootID) {
 		return ActionResult{}, fmt.Errorf("%w: root %q", ErrNotFound, rootID)
 	}
-	updated, err := s.projects.Update(ctx, projectID, func(project *projects.Project) {
-		roots := project.Roots[:0]
-		for _, root := range project.Roots {
-			if root.ID != rootID {
-				roots = append(roots, root)
-			}
-		}
-		project.Roots = roots
-		if project.DefaultRootID == rootID {
-			project.DefaultRootID = ""
-		}
-	})
+	updated, err := s.projectAuthority.RemoveProjectRoot(ctx, projectID, rootID)
 	if err != nil {
 		return ActionResult{}, mapProjectErr(err)
 	}
@@ -133,6 +129,9 @@ func (s *Service) applyRemoveProjectRoot(ctx context.Context, action Action) (Ac
 }
 
 func (s *Service) applySetProjectDefaults(ctx context.Context, action Action) (ActionResult, error) {
+	if s.projectAuthority == nil {
+		return ActionResult{}, ErrStoreNotConfigured
+	}
 	projectID := targetValue(action, "project_id")
 	if projectID == "" {
 		return ActionResult{}, fmt.Errorf("%w: target.project_id is required", ErrInvalid)
@@ -148,31 +147,15 @@ func (s *Service) applySetProjectDefaults(ctx context.Context, action Action) (A
 	if patch.DefaultRootID != nil && *patch.DefaultRootID != "" && !projectHasRoot(project, *patch.DefaultRootID) {
 		return ActionResult{}, fmt.Errorf("%w: root %q", ErrNotFound, *patch.DefaultRootID)
 	}
-	updated, err := s.projects.Update(ctx, projectID, func(project *projects.Project) {
-		if patch.DefaultRootID != nil {
-			project.DefaultRootID = *patch.DefaultRootID
-		}
-		if patch.DefaultProvider != nil {
-			project.DefaultProvider = *patch.DefaultProvider
-		}
-		if patch.DefaultModel != nil {
-			project.DefaultModel = *patch.DefaultModel
-		}
-		if patch.DefaultAgentProfile != nil {
-			project.DefaultAgentProfile = *patch.DefaultAgentProfile
-		}
-		if patch.DefaultToolsEnabled != nil {
-			project.DefaultToolsEnabled = patch.DefaultToolsEnabled
-		}
-		if patch.DefaultWorkspaceMode != nil {
-			project.DefaultWorkspaceMode = *patch.DefaultWorkspaceMode
-		}
-		if patch.DefaultSystemPrompt != nil {
-			project.DefaultSystemPrompt = *patch.DefaultSystemPrompt
-		}
-		if patch.DefaultCompactToolOutput != nil {
-			project.DefaultCompactToolOutput = patch.DefaultCompactToolOutput
-		}
+	updated, err := s.projectAuthority.SetProjectDefaults(ctx, projectID, ProjectDefaultsCommand{
+		DefaultRootID:            patch.DefaultRootID,
+		DefaultProvider:          patch.DefaultProvider,
+		DefaultModel:             patch.DefaultModel,
+		DefaultAgentProfile:      patch.DefaultAgentProfile,
+		DefaultToolsEnabled:      patch.DefaultToolsEnabled,
+		DefaultWorkspaceMode:     patch.DefaultWorkspaceMode,
+		DefaultSystemPrompt:      patch.DefaultSystemPrompt,
+		DefaultCompactToolOutput: patch.DefaultCompactToolOutput,
 	})
 	if err != nil {
 		return ActionResult{}, mapProjectErr(err)

--- a/internal/projectassistant/project_authority.go
+++ b/internal/projectassistant/project_authority.go
@@ -1,0 +1,110 @@
+package projectassistant
+
+import (
+	"context"
+
+	"github.com/hecatehq/hecate/internal/projects"
+)
+
+type ProjectAuthority interface {
+	CreateProject(ctx context.Context, project projects.Project) (projects.Project, error)
+	UpdateProject(ctx context.Context, projectID string, cmd ProjectUpdateCommand) (projects.Project, error)
+	AttachProjectRoot(ctx context.Context, projectID string, root projects.Root) (projects.Project, error)
+	RemoveProjectRoot(ctx context.Context, projectID, rootID string) (projects.Project, error)
+	SetProjectDefaults(ctx context.Context, projectID string, cmd ProjectDefaultsCommand) (projects.Project, error)
+}
+
+type ProjectUpdateCommand struct {
+	Name        *string
+	Description *string
+}
+
+type ProjectDefaultsCommand struct {
+	DefaultRootID            *string
+	DefaultProvider          *string
+	DefaultModel             *string
+	DefaultAgentProfile      *string
+	DefaultToolsEnabled      *bool
+	DefaultWorkspaceMode     *string
+	DefaultSystemPrompt      *string
+	DefaultCompactToolOutput *bool
+}
+
+func projectAuthorityForStores(stores Stores) ProjectAuthority {
+	if stores.ProjectAuthority != nil {
+		return stores.ProjectAuthority
+	}
+	if stores.Projects == nil {
+		return nil
+	}
+	return storeProjectAuthority{store: stores.Projects}
+}
+
+type storeProjectAuthority struct {
+	store projects.Store
+}
+
+func (authority storeProjectAuthority) CreateProject(ctx context.Context, project projects.Project) (projects.Project, error) {
+	return authority.store.Create(ctx, project)
+}
+
+func (authority storeProjectAuthority) UpdateProject(ctx context.Context, projectID string, cmd ProjectUpdateCommand) (projects.Project, error) {
+	return authority.store.Update(ctx, projectID, func(project *projects.Project) {
+		if cmd.Name != nil {
+			project.Name = *cmd.Name
+		}
+		if cmd.Description != nil {
+			project.Description = *cmd.Description
+		}
+	})
+}
+
+func (authority storeProjectAuthority) AttachProjectRoot(ctx context.Context, projectID string, root projects.Root) (projects.Project, error) {
+	return authority.store.Update(ctx, projectID, func(project *projects.Project) {
+		project.Roots = append(project.Roots, root)
+	})
+}
+
+func (authority storeProjectAuthority) RemoveProjectRoot(ctx context.Context, projectID, rootID string) (projects.Project, error) {
+	return authority.store.Update(ctx, projectID, func(project *projects.Project) {
+		roots := project.Roots[:0]
+		for _, root := range project.Roots {
+			if root.ID != rootID {
+				roots = append(roots, root)
+			}
+		}
+		project.Roots = roots
+		if project.DefaultRootID == rootID {
+			project.DefaultRootID = ""
+		}
+	})
+}
+
+func (authority storeProjectAuthority) SetProjectDefaults(ctx context.Context, projectID string, cmd ProjectDefaultsCommand) (projects.Project, error) {
+	return authority.store.Update(ctx, projectID, func(project *projects.Project) {
+		if cmd.DefaultRootID != nil {
+			project.DefaultRootID = *cmd.DefaultRootID
+		}
+		if cmd.DefaultProvider != nil {
+			project.DefaultProvider = *cmd.DefaultProvider
+		}
+		if cmd.DefaultModel != nil {
+			project.DefaultModel = *cmd.DefaultModel
+		}
+		if cmd.DefaultAgentProfile != nil {
+			project.DefaultAgentProfile = *cmd.DefaultAgentProfile
+		}
+		if cmd.DefaultToolsEnabled != nil {
+			project.DefaultToolsEnabled = cmd.DefaultToolsEnabled
+		}
+		if cmd.DefaultWorkspaceMode != nil {
+			project.DefaultWorkspaceMode = *cmd.DefaultWorkspaceMode
+		}
+		if cmd.DefaultSystemPrompt != nil {
+			project.DefaultSystemPrompt = *cmd.DefaultSystemPrompt
+		}
+		if cmd.DefaultCompactToolOutput != nil {
+			project.DefaultCompactToolOutput = cmd.DefaultCompactToolOutput
+		}
+	})
+}

--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -52,6 +52,7 @@ type IDGenerator func(prefix string) string
 type Service struct {
 	mu                       sync.Mutex
 	projects                 projects.Store
+	projectAuthority         ProjectAuthority
 	chats                    chat.Store
 	work                     projectwork.Store
 	workAuthority            WorkAuthority
@@ -66,6 +67,7 @@ type Service struct {
 
 type Stores struct {
 	Projects                 projects.Store
+	ProjectAuthority         ProjectAuthority
 	Chats                    chat.Store
 	Work                     projectwork.Store
 	WorkAuthority            WorkAuthority
@@ -190,6 +192,7 @@ func NewService(stores Stores, idgen IDGenerator) *Service {
 	}
 	return &Service{
 		projects:                 stores.Projects,
+		projectAuthority:         projectAuthorityForStores(stores),
 		chats:                    stores.Chats,
 		work:                     stores.Work,
 		workAuthority:            workAuthorityForStores(stores),

--- a/internal/projectassistantapp/application.go
+++ b/internal/projectassistantapp/application.go
@@ -18,6 +18,7 @@ type Application struct {
 
 type Options struct {
 	Projects                 projects.Store
+	ProjectAuthority         projectassistant.ProjectAuthority
 	Chats                    chat.Store
 	Work                     projectwork.Store
 	WorkAuthority            projectassistant.WorkAuthority
@@ -76,6 +77,7 @@ func New(options Options) *Application {
 	return &Application{
 		service: projectassistant.NewService(projectassistant.Stores{
 			Projects:                 options.Projects,
+			ProjectAuthority:         options.ProjectAuthority,
 			Chats:                    options.Chats,
 			Work:                     options.Work,
 			WorkAuthority:            workAuthority,


### PR DESCRIPTION
## Summary
- add a Project Assistant project-authority seam and wire Hecate's Cairnline-first project metadata/default authority into confirmed apply
- prevent proposal-ledger writes from reseeding stale Hecate project metadata over Cairnline-authoritative project updates
- update backend-status/docs to describe Assistant apply as mixed authority with metadata/default actions covered and root/chat/runtime still blocking replacement

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus_(CairnlineProjectAssistantProposalAuthorityConfigured|CairnlineProjectAssistantApplyPortableAuthorityConfigured|CairnlineProjectMetadataDefaultsAuthorityConfigured)|TestProjectAssistantAPI_(CairnlineApplyProjectMetadataAuthorityDoesNotBlockOnShadowFailure|ProjectSideEffectsMirrorThroughNarrowCairnlineSeams|CairnlineApplyMemoryCandidateAuthorityDoesNotBlockOnShadowFailure)'\n- GOCACHE="$PWD/.gocache" go test ./internal/projectassistant ./internal/projectassistantapp\n- just docs-format-check\n- just agent-docs-check\n- just docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api ./internal/projectassistant ./internal/projectassistantapp\n- GOCACHE="$PWD/.gocache" go test ./internal/api ./internal/projectassistant ./internal/projectassistantapp\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...