### PR TITLE
feat(projects): route assistant root actions through Cairnline authority

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -228,11 +228,11 @@ handoff-list, activity, closeout-readiness, and operations brief reads.
 Project Assistant draft generation also uses the Cairnline-projected context so
 preview and proposal assembly stay aligned, while the proposal ledger remains
 Hecate-owned unless `project-assistant-proposals` is enabled.
-Confirmed Project Assistant apply routes project metadata/default, role,
+Confirmed Project Assistant apply routes project metadata/default, root, role,
 work-item, assignment, handoff, and memory-candidate actions through the same
 opt-in Cairnline authority switchpoints when those switchpoints are enabled;
-root/chat/runtime side effects still keep apply as a mixed-authority
-replacement blocker.
+chat/runtime side effects still keep apply as a mixed-authority replacement
+blocker.
 Project list/detail reconstruct default profile and execution posture from
 Cairnline project/execution-profile records where available. Launch-readiness
 and assignment preflight read
@@ -302,9 +302,9 @@ reconciliation updates are mirrored as replacement evidence.
 Assistant draft/propose/apply-attempt ledger records commit to embedded
 Cairnline first, then best-effort shadow Hecate's proposal store for
 compatibility. Confirmed apply uses the enabled Cairnline authority seams for
-project metadata/default, role, work-item, assignment, handoff, and
-memory-candidate actions, but root/chat/runtime side effects still keep
-Assistant apply as a mixed-authority replacement blocker.
+project metadata/default, root, role, work-item, assignment, handoff, and
+memory-candidate actions, but chat/runtime side effects still keep Assistant
+apply as a mixed-authority replacement blocker.
 Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results and cleanup/conflict states are best-effort mirrored
 for replacement evidence, and other live Projects reads/writes still use the
@@ -413,9 +413,9 @@ execution-profile posture can be shared. Project Assistant draft/propose/apply
 routes mirror the proposal ledger and committed apply side effects after Hecate
 commits proposal records and apply attempts unless `project-assistant-proposals`
 is enabled, in which case the proposal ledger commits to Cairnline first while
-confirmed apply uses enabled project metadata/default,
-role/work-item/assignment/handoff, and memory-candidate authority seams and still
-blocks replacement on the remaining root/chat/runtime side effects.
+confirmed apply uses enabled project metadata/default, root,
+role/work-item/assignment/handoff, and memory-candidate authority seams and
+still blocks replacement on the remaining chat/runtime side effects.
 `POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
 SQLite export under Hecate's data directory and returns the same
 `migration_rehearsal` evidence for the single-project database. Both sync and
@@ -486,8 +486,8 @@ memory-candidate records; and
 proposal records, apply-attempt history, and committed apply side effects before
 assignment-start/runtime handoff. `project-assistant-proposals` can make the
 proposal ledger Cairnline-authoritative while confirmed apply uses enabled
-project metadata/default, role/work-item/assignment/handoff, and
-memory-candidate authority seams and remains blocked on root/chat/runtime side
+project metadata/default, root, role/work-item/assignment/handoff, and
+memory-candidate authority seams and remains blocked on chat/runtime side
 effects. `project-identity` can make project create/delete
 Cairnline-authoritative with snapshot rollback for failed Hecate
 compatibility cleanup;
@@ -537,9 +537,9 @@ after these gates are met:
   readiness, and operations brief. Draft generation may use the
   Cairnline-projected context, and proposal ledger writes may become
   Cairnline-authoritative with the `project-assistant-proposals` switchpoint.
-  Confirmed apply may use enabled project metadata/default,
+  Confirmed apply may use enabled project metadata/default, root,
   role/work-item/assignment/handoff, and memory-candidate Cairnline-authority
-  seams, but root/chat/runtime side effects remain a mixed-authority replacement blocker and are mirrored as
+  seams, but chat/runtime side effects remain a mixed-authority replacement blocker and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative
   Cairnline launch-packet evidence, but assignment-start remains a Hecate-owned

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -490,9 +490,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   Cairnline backend is configured. Hecate still commits first and remains
   authoritative for any mutation family whose opt-in Cairnline write-authority
   switchpoint is not enabled; Project Assistant confirmed apply uses enabled
-  project metadata/default, role/work-item/assignment/handoff, and
+  project metadata/default, root, role/work-item/assignment/handoff, and
   memory-candidate authority seams and remains a mixed-authority blocker for
-  root/chat/runtime side effects even when the proposal-ledger switchpoint is
+  chat/runtime side effects even when the proposal-ledger switchpoint is
   enabled. Role mirrors also seed referenced agent-profile metadata/execution
   posture when the profile store is available.
   Assignment-start dispatch is still a Hecate-owned write

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -414,11 +414,11 @@ context/proposal reads, closeout readiness, activity inbox, and operations brief
 can be served from the Cairnline read model. Project Assistant draft generation
 also uses the Cairnline-projected context in this mode, while proposal ledger
 writes remain Hecate-owned unless `project-assistant-proposals` is explicitly
-enabled. Confirmed Project Assistant apply routes role, work-item, assignment,
-handoff, memory-candidate, and project metadata/default actions through the same
-opt-in Cairnline authority switchpoints when those switchpoints are enabled; root,
-chat, and runtime side effects remain Hecate-owned and are best-effort mirrored into Cairnline as
-replacement-readiness evidence.
+enabled. Confirmed Project Assistant apply routes project metadata/default,
+root, role, work-item, assignment, handoff, and memory-candidate actions through
+the same opt-in Cairnline authority switchpoints when those switchpoints are
+enabled; chat and runtime side effects remain Hecate-owned and are best-effort
+mirrored into Cairnline as replacement-readiness evidence.
 Launch-readiness and assignment preflight read Cairnline coordination records
 before applying Hecate runtime checks.
 Assignment preflight/start context packets may include inspect-only Cairnline
@@ -555,9 +555,9 @@ ledger mutations likewise best-effort mirror proposal records and apply attempts
 after Hecate commits unless `project-assistant-proposals` is enabled, in which
 case the proposal ledger commits to Cairnline first and shadows Hecate's
 proposal store for compatibility. Confirmed apply uses the enabled Cairnline
-authority seams for project metadata/default, role, work-item, assignment,
-handoff, and memory-candidate actions, but root/chat/runtime side effects still
-keep apply as a mixed-authority replacement blocker.
+authority seams for project metadata/default, root, role, work-item,
+assignment, handoff, and memory-candidate actions, but chat/runtime side effects
+still keep apply as a mixed-authority replacement blocker.
 Other live Projects reads/writes still use Hecate-native
 stores until the remaining read routes, write adapter, and migration path are
 ready. Current bridge write experiments cover non-authoritative
@@ -581,8 +581,8 @@ proof seams separately from the live-route `write_adapter_gaps`; only
 and they are mirror-only unless their explicit Cairnline write-authority
 switchpoint is enabled; currently only the proposal-ledger switchpoint can be
 made Cairnline-authoritative, while apply side effects become mixed-authority
-through the enabled project metadata/default, role/work-item/assignment/handoff,
-and memory-candidate switchpoints. It
+through the enabled project metadata/default, root,
+role/work-item/assignment/handoff, and memory-candidate switchpoints. It
 also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operators can see the exact
 read-route, strict-embedded-probe, write-authority, and migration blockers

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -573,9 +573,9 @@ sequenceDiagram
   `project-assistant-proposals` makes Project Assistant draft/propose/apply-attempt
   ledger records Cairnline-first, then best-effort shadows Hecate's proposal
   store for compatibility. Confirmed Project Assistant apply uses enabled
-  project-metadata/default, role/work-item/assignment/handoff, and
+  project metadata/default, root, role/work-item/assignment/handoff, and
   memory-candidate authority seams and still blocks replacement on the
-  remaining root/chat/runtime side effects.
+  remaining chat/runtime side effects.
   `project-roots` makes project root create/update/delete plus root list
   replacement plus discovery-result replacement and worktree-created root
   record mutations Cairnline-first, then shadows Hecate's compatibility project
@@ -2529,8 +2529,9 @@ history after Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` makes
 those ledger records Cairnline-first. `project-assistant-apply-side-effects-live-mirror`
 mirrors remaining committed apply side effects after Hecate commits; enabled
-project metadata/default, role/work-item/assignment/handoff, and memory-candidate
-apply actions use their Cairnline authority seams first. Assignment-start dispatch still writes
+project metadata/default, root, role/work-item/assignment/handoff, and
+memory-candidate apply actions use their Cairnline authority seams first.
+Assignment-start dispatch still writes
 Hecate-native runtime stores first, while committed results and cleanup/conflict
 states mirror to Cairnline. Other non-mirrored live mutation routes still write
 only Hecate-native stores.
@@ -6271,9 +6272,9 @@ text-only sidecar output. Draft generation uses the same Cairnline-projected
 context so preview and proposal assembly do not drift, while proposal ledger
 writes remain Hecate-owned unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
-enabled. Confirmed apply uses enabled role/work-item/assignment/handoff and
-memory-candidate plus project metadata/default Cairnline-authority seams and
-still blocks replacement on the remaining root/chat/runtime side effects.
+enabled. Confirmed apply uses enabled project metadata/default, root,
+role/work-item/assignment/handoff, and memory-candidate Cairnline-authority
+seams and still blocks replacement on the remaining chat/runtime side effects.
 `GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
 Cairnline read source as the other read routes; strict embedded mode reads the
 proposal record from the embedded mirror instead of falling back to the native

--- a/internal/api/handler_project_assistant_apply_authority.go
+++ b/internal/api/handler_project_assistant_apply_authority.go
@@ -83,6 +83,10 @@ func (authority projectAssistantProjectAuthority) AttachProjectRoot(ctx context.
 	if h == nil || h.projects == nil {
 		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
+	if h.projectRootWritesUseCairnlineAuthority() {
+		updated, _, err := h.createProjectRootWithCairnlineAuthority(ctx, projectID, root)
+		return updated, projectAssistantApplyProjectError(err)
+	}
 	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
 		project.Roots = append(project.Roots, root)
 	})
@@ -93,6 +97,10 @@ func (authority projectAssistantProjectAuthority) RemoveProjectRoot(ctx context.
 	h := authority.handler
 	if h == nil || h.projects == nil {
 		return projects.Project{}, projectassistant.ErrStoreNotConfigured
+	}
+	if h.projectRootWritesUseCairnlineAuthority() {
+		updated, _, err := h.deleteProjectRootWithCairnlineAuthority(ctx, projectID, rootID)
+		return updated, projectAssistantApplyProjectError(err)
 	}
 	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
 		roots := project.Roots[:0]

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -1361,6 +1361,94 @@ func TestProjectAssistantAPI_CairnlineApplyProjectMetadataAuthorityDoesNotBlockO
 	}
 }
 
+func TestProjectAssistantAPI_CairnlineApplyProjectRootAuthorityDoesNotBlockOnShadowFailure(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineWriteAuthority = projectCairnlineWriteAuthorityProjectRoots
+	baseProjects := projects.NewMemoryStore()
+	project, err := baseProjects.Create(t.Context(), projects.Project{
+		ID:            "proj_pa_apply_root_authority",
+		Name:          "Assistant Root Authority",
+		DefaultRootID: "root_main",
+		Roots: []projects.Root{{
+			ID:     "root_main",
+			Path:   "/workspace/main",
+			Kind:   "git",
+			Active: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+	if err := handler.writeProjectIdentityToCairnline(t.Context(), project); err != nil {
+		t.Fatalf("write initial Cairnline project: %v", err)
+	}
+	seedCairnlineOnlyProjectGraphForTest(t, handler, project.ID)
+	handler.SetProjectStore(failingUpdateProjectStore{
+		Store: baseProjects,
+		err:   errors.New("shadow project store unavailable"),
+	})
+	if !handler.projectRootWritesUseCairnlineAuthority() {
+		t.Fatal("root write authority is disabled, want enabled for test")
+	}
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_apply_root_authority",
+		Title:                "Update roots through authority",
+		Summary:              "Project Assistant apply should use the Cairnline-first root authority seam.",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{
+			{
+				Kind:   projectassistant.ActionAttachProjectRoot,
+				Reason: "Attach a root through the authority seam.",
+				Target: map[string]string{"project_id": project.ID},
+				Patch:  json.RawMessage(`{"id":"root_attached","path":"/workspace/attached","kind":"git_worktree","active":true}`),
+			},
+			{
+				Kind:   projectassistant.ActionRemoveProjectRoot,
+				Reason: "Remove the original root through the authority seam.",
+				Target: map[string]string{"project_id": project.ID, "root_id": "root_main"},
+			},
+		},
+	}
+	applyBody, err := json.Marshal(map[string]any{"proposal": proposal, "confirm": true})
+	if err != nil {
+		t.Fatalf("marshal apply body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("apply status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var applied projectAssistantApplyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("decode apply response: %v", err)
+	}
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 2 {
+		t.Fatalf("apply response = %+v, want applied root actions despite Hecate shadow failure", applied.Data)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, project.ID)
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_attached") == nil {
+		t.Fatalf("Cairnline roots = %+v, want attached root", mirrored.Roots)
+	}
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_main") != nil {
+		t.Fatalf("Cairnline roots = %+v, want removed root_main absent", mirrored.Roots)
+	}
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_cairnline_only") == nil {
+		t.Fatalf("Cairnline roots = %+v, want Cairnline-only root preserved", mirrored.Roots)
+	}
+	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
+		t.Fatalf("Cairnline sources = %+v, want Cairnline-only source preserved", mirrored.ContextSources)
+	}
+	native, ok, err := baseProjects.Get(t.Context(), project.ID)
+	if err != nil || !ok {
+		t.Fatalf("Get native project ok=%v err=%v", ok, err)
+	}
+	if len(native.Roots) != 1 || native.Roots[0].ID != "root_main" || native.DefaultRootID != "root_main" {
+		t.Fatalf("native shadow project = %+v, want unchanged after injected shadow failure", native)
+	}
+}
+
 func TestProjectAssistantAPI_ProposalRouteUsesStrictEmbeddedReadSource(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)

--- a/internal/api/handler_project_cairnline_mirror.go
+++ b/internal/api/handler_project_cairnline_mirror.go
@@ -365,6 +365,9 @@ func (h *Handler) writeProjectAssistantActionResultToCairnline(ctx context.Conte
 		}
 		return h.writeProjectMetadataToCairnline(ctx, project)
 	case projectassistant.ActionAttachProjectRoot:
+		if h.projectRootWritesUseCairnlineAuthority() {
+			return nil
+		}
 		project, ok := h.projectForCairnlineMirror(ctx, "project_assistant_apply_result", projectID)
 		if !ok {
 			return nil
@@ -376,6 +379,9 @@ func (h *Handler) writeProjectAssistantActionResultToCairnline(ctx context.Conte
 		}
 		return h.writeProjectRootToCairnline(ctx, project, root)
 	case projectassistant.ActionRemoveProjectRoot:
+		if h.projectRootWritesUseCairnlineAuthority() {
+			return nil
+		}
 		project, ok := h.projectForCairnlineMirror(ctx, "project_assistant_apply_result", projectID)
 		if !ok {
 			return nil

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -649,7 +649,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.LiveMirror = true
 			item.BlocksAuthority = true
 			item.Gap = "project-assistant-apply-side-effects"
-			item.Detail = "Project Assistant confirmed apply routes project metadata/default, role, work-item, assignment, handoff, and memory-candidate actions through their opt-in Cairnline authority switchpoints when enabled; root/chat/runtime side effects still keep apply as a blocking mixed-authority gap."
+			item.Detail = "Project Assistant confirmed apply routes covered portable actions through their enabled Cairnline authority switchpoints: project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime side effects still keep apply as a blocking mixed-authority gap."
 		}
 		if projectCollaborationAuthoritative && item.Name == "collaboration-artifacts" {
 			item.CurrentAuthority = "cairnline"
@@ -792,13 +792,14 @@ func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []strin
 
 func projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority []string) string {
 	if projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority) {
-		return "Project Assistant confirmed apply uses the enabled Cairnline authority seams for project metadata/default, role, work-item, assignment, handoff, and memory-candidate actions, but root/chat/runtime side effects still keep apply as a mixed-authority replacement blocker."
+		return "Project Assistant confirmed apply uses enabled Cairnline authority seams for the portable actions they cover: project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime side effects still keep apply as a mixed-authority replacement blocker."
 	}
 	return "Project Assistant confirmed apply side effects still execute through Hecate-owned mutation services, then best-effort mirror committed results into Cairnline."
 }
 
 func projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority []string) bool {
 	return projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectMetadataDefaults) ||
+		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoots) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments) ||

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -413,7 +413,7 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectMetadataDefaultsAuthor
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Project metadata/default-only update mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "controlled by separate switchpoints") || !strings.Contains(warnings, "root/chat/runtime") {
+	if !strings.Contains(warnings, "Project metadata/default-only update mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "controlled by separate switchpoints") || !strings.Contains(warnings, "chat/runtime") {
 		t.Fatalf("warnings = %+v, want metadata/default authority plus separate-switchpoint caveat", status.Warnings)
 	}
 }
@@ -685,6 +685,7 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 			CairnlineWriteAuthority: strings.Join([]string{
 				projectCairnlineWriteAuthorityProjectAssistantProposals,
 				projectCairnlineWriteAuthorityProjectMetadataDefaults,
+				projectCairnlineWriteAuthorityProjectRoots,
 				projectCairnlineWriteAuthorityProjectRoles,
 				projectCairnlineWriteAuthorityProjectWorkItems,
 				projectCairnlineWriteAuthorityProjectAssignments,
@@ -709,7 +710,7 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 		}
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "confirmed apply is mixed-authority") || !strings.Contains(warnings, "Project Assistant confirmed apply uses the enabled Cairnline authority seams") || !strings.Contains(warnings, "root/chat/runtime") {
+	if !strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "confirmed apply is mixed-authority") || !strings.Contains(warnings, "Project Assistant confirmed apply uses enabled Cairnline authority seams") || !strings.Contains(warnings, "chat/runtime") {
 		t.Fatalf("warnings = %+v, want assistant proposal authority and mixed apply authority caveats", status.Warnings)
 	}
 	if status.ReplacementReady {


### PR DESCRIPTION
## Summary
- route Project Assistant attach/remove root actions through the Cairnline root authority seam when `project-roots` is enabled
- skip the old committed-side-effect root mirror for already-authoritative Assistant root actions
- update replacement-readiness wording to include Assistant root actions and keep chat/runtime as the remaining Assistant apply blocker

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_(CairnlineApplyProjectRootAuthorityDoesNotBlockOnShadowFailure|ProjectSideEffectsMirrorThroughNarrowCairnlineSeams|CairnlineApplyProjectMetadataAuthorityDoesNotBlockOnShadowFailure)|TestProjectCoordinationBackendStatus_(CairnlineProjectAssistantApplyPortableAuthorityConfigured|CairnlineProjectMetadataDefaultsAuthorityConfigured|CairnlineDirectRootSourceAuthorityConfigured)'\n- just docs-format-check\n- just agent-docs-check\n- just docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...