### PR TITLE
feat(projects): cover assistant project create authority

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -228,11 +228,11 @@ handoff-list, activity, closeout-readiness, and operations brief reads.
 Project Assistant draft generation also uses the Cairnline-projected context so
 preview and proposal assembly stay aligned, while the proposal ledger remains
 Hecate-owned unless `project-assistant-proposals` is enabled.
-Confirmed Project Assistant apply routes project metadata/default, root, role,
-work-item, assignment, handoff, and memory-candidate actions through the same
-opt-in Cairnline authority switchpoints when those switchpoints are enabled;
-chat/runtime side effects still keep apply as a mixed-authority replacement
-blocker.
+Confirmed Project Assistant apply routes project create, project
+metadata/default, root, role, work-item, assignment, handoff, and
+memory-candidate actions through the same opt-in Cairnline authority
+switchpoints when those switchpoints are enabled; chat/runtime side effects
+still keep apply as a mixed-authority replacement blocker.
 Project list/detail reconstruct default profile and execution posture from
 Cairnline project/execution-profile records where available. Launch-readiness
 and assignment preflight read
@@ -302,9 +302,9 @@ reconciliation updates are mirrored as replacement evidence.
 Assistant draft/propose/apply-attempt ledger records commit to embedded
 Cairnline first, then best-effort shadow Hecate's proposal store for
 compatibility. Confirmed apply uses the enabled Cairnline authority seams for
-project metadata/default, root, role, work-item, assignment, handoff, and
-memory-candidate actions, but chat/runtime side effects still keep Assistant
-apply as a mixed-authority replacement blocker.
+project create, project metadata/default, root, role, work-item, assignment,
+handoff, and memory-candidate actions, but chat/runtime side effects still keep
+Assistant apply as a mixed-authority replacement blocker.
 Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results and cleanup/conflict states are best-effort mirrored
 for replacement evidence, and other live Projects reads/writes still use the
@@ -413,7 +413,7 @@ execution-profile posture can be shared. Project Assistant draft/propose/apply
 routes mirror the proposal ledger and committed apply side effects after Hecate
 commits proposal records and apply attempts unless `project-assistant-proposals`
 is enabled, in which case the proposal ledger commits to Cairnline first while
-confirmed apply uses enabled project metadata/default, root,
+confirmed apply uses enabled project create, project metadata/default, root,
 role/work-item/assignment/handoff, and memory-candidate authority seams and
 still blocks replacement on the remaining chat/runtime side effects.
 `POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
@@ -486,7 +486,7 @@ memory-candidate records; and
 proposal records, apply-attempt history, and committed apply side effects before
 assignment-start/runtime handoff. `project-assistant-proposals` can make the
 proposal ledger Cairnline-authoritative while confirmed apply uses enabled
-project metadata/default, root, role/work-item/assignment/handoff, and
+project create, project metadata/default, root, role/work-item/assignment/handoff, and
 memory-candidate authority seams and remains blocked on chat/runtime side
 effects. `project-identity` can make project create/delete
 Cairnline-authoritative with snapshot rollback for failed Hecate
@@ -537,7 +537,7 @@ after these gates are met:
   readiness, and operations brief. Draft generation may use the
   Cairnline-projected context, and proposal ledger writes may become
   Cairnline-authoritative with the `project-assistant-proposals` switchpoint.
-  Confirmed apply may use enabled project metadata/default, root,
+  Confirmed apply may use enabled project create, project metadata/default, root,
   role/work-item/assignment/handoff, and memory-candidate Cairnline-authority
   seams, but chat/runtime side effects remain a mixed-authority replacement blocker and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -490,7 +490,7 @@ launch agents. Those remain explicit operator or orchestrator actions.
   Cairnline backend is configured. Hecate still commits first and remains
   authoritative for any mutation family whose opt-in Cairnline write-authority
   switchpoint is not enabled; Project Assistant confirmed apply uses enabled
-  project metadata/default, root, role/work-item/assignment/handoff, and
+  project create, project metadata/default, root, role/work-item/assignment/handoff, and
   memory-candidate authority seams and remains a mixed-authority blocker for
   chat/runtime side effects even when the proposal-ledger switchpoint is
   enabled. Role mirrors also seed referenced agent-profile metadata/execution

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -414,11 +414,12 @@ context/proposal reads, closeout readiness, activity inbox, and operations brief
 can be served from the Cairnline read model. Project Assistant draft generation
 also uses the Cairnline-projected context in this mode, while proposal ledger
 writes remain Hecate-owned unless `project-assistant-proposals` is explicitly
-enabled. Confirmed Project Assistant apply routes project metadata/default,
-root, role, work-item, assignment, handoff, and memory-candidate actions through
-the same opt-in Cairnline authority switchpoints when those switchpoints are
-enabled; chat and runtime side effects remain Hecate-owned and are best-effort
-mirrored into Cairnline as replacement-readiness evidence.
+enabled. Confirmed Project Assistant apply routes project create, project
+metadata/default, root, role, work-item, assignment, handoff, and
+memory-candidate actions through the same opt-in Cairnline authority
+switchpoints when those switchpoints are enabled; chat and runtime side effects
+remain Hecate-owned and are best-effort mirrored into Cairnline as
+replacement-readiness evidence.
 Launch-readiness and assignment preflight read Cairnline coordination records
 before applying Hecate runtime checks.
 Assignment preflight/start context packets may include inspect-only Cairnline
@@ -555,9 +556,9 @@ ledger mutations likewise best-effort mirror proposal records and apply attempts
 after Hecate commits unless `project-assistant-proposals` is enabled, in which
 case the proposal ledger commits to Cairnline first and shadows Hecate's
 proposal store for compatibility. Confirmed apply uses the enabled Cairnline
-authority seams for project metadata/default, root, role, work-item,
-assignment, handoff, and memory-candidate actions, but chat/runtime side effects
-still keep apply as a mixed-authority replacement blocker.
+authority seams for project create, project metadata/default, root, role,
+work-item, assignment, handoff, and memory-candidate actions, but chat/runtime
+side effects still keep apply as a mixed-authority replacement blocker.
 Other live Projects reads/writes still use Hecate-native
 stores until the remaining read routes, write adapter, and migration path are
 ready. Current bridge write experiments cover non-authoritative
@@ -581,7 +582,7 @@ proof seams separately from the live-route `write_adapter_gaps`; only
 and they are mirror-only unless their explicit Cairnline write-authority
 switchpoint is enabled; currently only the proposal-ledger switchpoint can be
 made Cairnline-authoritative, while apply side effects become mixed-authority
-through the enabled project metadata/default, root,
+through the enabled project create, project metadata/default, root,
 role/work-item/assignment/handoff, and memory-candidate switchpoints. It
 also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operators can see the exact

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -573,9 +573,9 @@ sequenceDiagram
   `project-assistant-proposals` makes Project Assistant draft/propose/apply-attempt
   ledger records Cairnline-first, then best-effort shadows Hecate's proposal
   store for compatibility. Confirmed Project Assistant apply uses enabled
-  project metadata/default, root, role/work-item/assignment/handoff, and
-  memory-candidate authority seams and still blocks replacement on the
-  remaining chat/runtime side effects.
+  project create, project metadata/default, root,
+  role/work-item/assignment/handoff, and memory-candidate authority seams and
+  still blocks replacement on the remaining chat/runtime side effects.
   `project-roots` makes project root create/update/delete plus root list
   replacement plus discovery-result replacement and worktree-created root
   record mutations Cairnline-first, then shadows Hecate's compatibility project
@@ -2529,9 +2529,9 @@ history after Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` makes
 those ledger records Cairnline-first. `project-assistant-apply-side-effects-live-mirror`
 mirrors remaining committed apply side effects after Hecate commits; enabled
-project metadata/default, root, role/work-item/assignment/handoff, and
-memory-candidate apply actions use their Cairnline authority seams first.
-Assignment-start dispatch still writes
+project create, project metadata/default, root,
+role/work-item/assignment/handoff, and memory-candidate apply actions use their
+Cairnline authority seams first. Assignment-start dispatch still writes
 Hecate-native runtime stores first, while committed results and cleanup/conflict
 states mirror to Cairnline. Other non-mirrored live mutation routes still write
 only Hecate-native stores.
@@ -6272,9 +6272,10 @@ text-only sidecar output. Draft generation uses the same Cairnline-projected
 context so preview and proposal assembly do not drift, while proposal ledger
 writes remain Hecate-owned unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
-enabled. Confirmed apply uses enabled project metadata/default, root,
-role/work-item/assignment/handoff, and memory-candidate Cairnline-authority
-seams and still blocks replacement on the remaining chat/runtime side effects.
+enabled. Confirmed apply uses enabled project create, project metadata/default,
+root, role/work-item/assignment/handoff, and memory-candidate
+Cairnline-authority seams and still blocks replacement on the remaining
+chat/runtime side effects.
 `GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
 Cairnline read source as the other read routes; strict embedded mode reads the
 proposal record from the embedded mirror instead of falling back to the native

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -134,6 +134,15 @@ type failingUpdateProjectStore struct {
 	err error
 }
 
+type failingCreateProjectStore struct {
+	projects.Store
+	err error
+}
+
+func (s failingCreateProjectStore) Create(context.Context, projects.Project) (projects.Project, error) {
+	return projects.Project{}, s.err
+}
+
 func (s failingUpdateProjectStore) Update(context.Context, string, func(*projects.Project)) (projects.Project, error) {
 	return projects.Project{}, s.err
 }
@@ -1281,6 +1290,68 @@ func TestProjectAssistantAPI_CairnlineApplyMemoryCandidateAuthorityDoesNotBlockO
 	}
 	if _, ok, err := handler.memoryCandidates.GetCandidate(t.Context(), "proj_pa_apply_memory_authority", "memcand_apply_authority"); err != nil || ok {
 		t.Fatalf("shadow memory candidate ok=%v err=%v, want missing after injected shadow failure", ok, err)
+	}
+}
+
+func TestProjectAssistantAPI_CairnlineApplyProjectIdentityAuthorityDoesNotBlockOnShadowFailure(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineWriteAuthority = projectCairnlineWriteAuthorityProjectIdentity
+	baseProjects := projects.NewMemoryStore()
+	handler.SetProjectStore(failingCreateProjectStore{
+		Store: baseProjects,
+		err:   errors.New("shadow project store unavailable"),
+	})
+	if !handler.projectIdentityWritesUseCairnlineAuthority() {
+		t.Fatal("project identity write authority is disabled, want enabled for test")
+	}
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_apply_project_identity_authority",
+		Title:                "Create project through authority",
+		Summary:              "Project Assistant apply should use the Cairnline-first project identity seam.",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{
+			{
+				Kind:   projectassistant.ActionCreateProject,
+				Reason: "Create the project through the authority seam.",
+				Patch: json.RawMessage(`{
+					"id":"proj_pa_apply_project_identity_authority",
+					"name":"Assistant Identity Authority",
+					"description":"Cairnline owns this project create.",
+					"roots":[{"id":"root_main","path":"/workspace/identity","kind":"git","active":true}],
+					"default_provider":"anthropic",
+					"default_model":"claude-sonnet-4-5"
+				}`),
+			},
+		},
+	}
+	applyBody, err := json.Marshal(map[string]any{"proposal": proposal, "confirm": true})
+	if err != nil {
+		t.Fatalf("marshal apply body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/project-assistant/apply", bytes.NewReader(applyBody)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("apply status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var applied projectAssistantApplyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("decode apply response: %v", err)
+	}
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 1 {
+		t.Fatalf("apply response = %+v, want applied project create despite Hecate shadow failure", applied.Data)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, "proj_pa_apply_project_identity_authority")
+	if mirrored.Name != "Assistant Identity Authority" || mirrored.Description != "Cairnline owns this project create." || mirrored.DefaultRootID != "root_main" {
+		t.Fatalf("Cairnline project = %+v, want authoritative project create", mirrored)
+	}
+	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" || mirrored.Roots[0].Path != "/workspace/identity" {
+		t.Fatalf("Cairnline roots = %+v, want root_main", mirrored.Roots)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "anthropic", "claude-sonnet-4-5")
+	if _, ok, err := baseProjects.Get(t.Context(), "proj_pa_apply_project_identity_authority"); err != nil || ok {
+		t.Fatalf("shadow project ok=%v err=%v, want missing after injected shadow failure", ok, err)
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -649,7 +649,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.LiveMirror = true
 			item.BlocksAuthority = true
 			item.Gap = "project-assistant-apply-side-effects"
-			item.Detail = "Project Assistant confirmed apply routes covered portable actions through their enabled Cairnline authority switchpoints: project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime side effects still keep apply as a blocking mixed-authority gap."
+			item.Detail = "Project Assistant confirmed apply routes covered portable actions through their enabled Cairnline authority switchpoints: project create, project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime side effects still keep apply as a blocking mixed-authority gap."
 		}
 		if projectCollaborationAuthoritative && item.Name == "collaboration-artifacts" {
 			item.CurrentAuthority = "cairnline"
@@ -792,13 +792,14 @@ func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []strin
 
 func projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority []string) string {
 	if projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority) {
-		return "Project Assistant confirmed apply uses enabled Cairnline authority seams for the portable actions they cover: project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime side effects still keep apply as a mixed-authority replacement blocker."
+		return "Project Assistant confirmed apply uses enabled Cairnline authority seams for the portable actions they cover: project create, project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime side effects still keep apply as a mixed-authority replacement blocker."
 	}
 	return "Project Assistant confirmed apply side effects still execute through Hecate-owned mutation services, then best-effort mirror committed results into Cairnline."
 }
 
 func projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority []string) bool {
-	return projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectMetadataDefaults) ||
+	return projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectIdentity) ||
+		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectMetadataDefaults) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoots) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoles) ||
 		projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectWorkItems) ||

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -436,11 +436,15 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectIdentityAuthorityConfi
 	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
 		t.Fatalf("project-identity switchpoint = %+v, want opt-in Cairnline authority", point)
 	}
+	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
+	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed authority through project identity switchpoint", applyPoint)
+	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Project create/delete mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "delete restores the Cairnline snapshot") {
+	if !strings.Contains(warnings, "Project create/delete mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "delete restores the Cairnline snapshot") || !strings.Contains(warnings, "chat/runtime") {
 		t.Fatalf("warnings = %+v, want project identity authority plus rollback caveat", status.Warnings)
 	}
 }
@@ -684,6 +688,7 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 			CairnlineReadSource: "embedded",
 			CairnlineWriteAuthority: strings.Join([]string{
 				projectCairnlineWriteAuthorityProjectAssistantProposals,
+				projectCairnlineWriteAuthorityProjectIdentity,
 				projectCairnlineWriteAuthorityProjectMetadataDefaults,
 				projectCairnlineWriteAuthorityProjectRoots,
 				projectCairnlineWriteAuthorityProjectRoles,


### PR DESCRIPTION
## Summary
- add regression coverage proving Project Assistant create-project apply can be Cairnline-authoritative when the Hecate shadow store fails
- mark project identity as one of the portable Project Assistant apply authority switchpoints
- update runtime/operator/design docs to include project create in the covered apply families while preserving the chat/runtime blocker

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_CairnlineApplyProjectIdentityAuthorityDoesNotBlockOnShadowFailure|TestProjectCoordinationBackendStatus_(CairnlineProjectIdentityAuthorityConfigured|CairnlineProjectAssistantApplyPortableAuthorityConfigured)'\n- just docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n