### PR TITLE
feat(projects): add Cairnline portable authority alias

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -252,6 +252,9 @@ Cairnline first, then best-effort shadows the entry into Hecate-native memory
 stores for compatibility. Adding `memory-candidates` to that setting makes
 memory-candidate create/promote/reject Cairnline-first too; it requires
 `project-memory` because promotion creates accepted project memory.
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable` expands to every
+current portable write-authority switchpoint for embedded dogfooding; Hecate
+runtime side effects and migration cutover remain separate gates.
 `project-metadata-defaults` is a scoped opt-in authority slice: project
 metadata/default-only PATCHes commit portable project metadata and launch
 defaults to embedded Cairnline first, then best-effort shadow Hecate's

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -432,6 +432,10 @@ launch agents. Those remain explicit operator or orchestrator actions.
   first disabled-by-default Cairnline write-authority switchpoint: accepted
   project memory entry create/update/delete commits to embedded Cairnline first
   and then shadows back into Hecate-native memory stores.
+  `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable` expands to every
+  current portable write-authority switchpoint for embedded dogfooding, but it
+  does not make Hecate runtime side effects or migration cutover
+  Cairnline-owned.
   `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory,memory-candidates`
   also makes memory-candidate create/promote/reject Cairnline-first; the
   `memory-candidates` switch requires `project-memory` because promotion creates

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -486,6 +486,11 @@ project identity, project setup metadata, project work coordination records,
 collaboration metadata records, memory/candidate records, and Project Assistant
 proposal/apply records. None of these routes operator project reads or writes
 through the sidecar backend.
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable` expands to every
+current portable write-authority dogfood switchpoint. It does not make Hecate
+runtime side effects or migration cutover Cairnline-owned: root
+scan/worktree creation, assignment-start dispatch, Project Assistant
+chat/runtime side effects, and migration/rollback remain separate gates.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an alpha
 write-authority dogfood switch for accepted project memory entries:
 create/update/delete commits to the embedded Cairnline database first and then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -534,10 +534,13 @@ sequenceDiagram
   closeout-readiness, and operations-brief reads through the standalone
   Cairnline MCP client. Draft/propose/apply mutations remain Hecate-owned
   unless their explicit write-authority switchpoints are enabled.
-- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
+- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|all-portable|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`. The default is `none`.
+  `all-portable` expands to every current portable write-authority switchpoint
+  for dogfooding; it does not make Hecate runtime side effects or migration
+  cutover Cairnline-owned.
   `project-memory` makes accepted project memory entry create/update/delete
   commit to the embedded Cairnline database first and then best-effort shadow
   the row back into Hecate-native memory stores. `memory-candidates` requires
@@ -2351,6 +2354,11 @@ today. `sidecar` exposes standalone MCP contract probe/connect surfaces and
 reports `cairnline_connector_ready=false`, so read/write routing and
 write-authority switchpoints stay disabled.
 `cairnline_read_source` reflects `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`.
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable` expands to every
+current portable write-authority switchpoint for dogfooding the embedded
+Cairnline authority path. It is not a migration or runtime cutover switch:
+Hecate-owned root scan/worktree, assignment-start, Project Assistant chat/runtime
+side effects, and migration/rollback gates still remain separate.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables the first
 disabled-by-default write authority switchpoint: accepted project memory entries
 commit to embedded Cairnline first and are then shadowed back into Hecate-native

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -726,6 +726,45 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 	}
 }
 
+func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAliasConfigured(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "all-portable",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	for _, name := range []string{
+		"projects",
+		"context-sources",
+		"agent-profiles",
+		"skills",
+		"memory",
+		"memory-candidates",
+		"roles",
+		"work-items",
+		"assignments",
+		"artifacts",
+		"handoffs",
+		"project-assistant-proposals",
+	} {
+		if containsString(status.WriteAdapterGaps, name) {
+			t.Fatalf("write gaps = %+v, did not expect portable gap %q with all-portable authority alias", status.WriteAdapterGaps, name)
+		}
+	}
+	for _, name := range []string{"roots", "assignment-start", "project-assistant-apply-side-effects", "migration-cutover"} {
+		if !containsString(status.WriteAdapterGaps, name) {
+			t.Fatalf("write gaps = %+v, want remaining non-portable/migration gap %q with all-portable authority alias", status.WriteAdapterGaps, name)
+		}
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "roots") || !strings.Contains(gate.Detail, "assignment-start") || !strings.Contains(gate.Detail, "project-assistant-apply-side-effects") {
+		t.Fatalf("write-authority gate = %+v, want partial write authority with remaining side-effect gaps", gate)
+	}
+}
+
 func TestProjectCoordinationBackendStatus_WriteAuthorityGateIgnoresMigrationGap(t *testing.T) {
 	gate := projectCairnlineWriteAuthorityReplacementGate([]string{"migration-cutover"})
 	if !gate.Ready || gate.Status != "ready" || !strings.Contains(gate.Detail, "migration, rollback, and final cutover still have separate gates") {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1277,6 +1277,22 @@ func normalizeProjectsCairnlineReadSource(value string) string {
 	return value
 }
 
+var projectsCairnlineAllPortableWriteAuthority = []string{
+	"project-memory",
+	"memory-candidates",
+	"project-collaboration",
+	"project-skills",
+	"project-work-items",
+	"project-roles",
+	"project-assignments",
+	"agent-profiles",
+	"project-metadata-defaults",
+	"project-roots",
+	"project-context-sources",
+	"project-identity",
+	"project-assistant-proposals",
+}
+
 func normalizeProjectsCairnlineWriteAuthority(value string) []string {
 	value = strings.ToLower(strings.TrimSpace(value))
 	if value == "" || value == "none" {
@@ -1285,16 +1301,25 @@ func normalizeProjectsCairnlineWriteAuthority(value string) []string {
 	parts := strings.Split(value, ",")
 	out := make([]string, 0, len(parts))
 	seen := make(map[string]struct{}, len(parts))
+	appendValue := func(part string) {
+		if _, exists := seen[part]; exists {
+			return
+		}
+		seen[part] = struct{}{}
+		out = append(out, part)
+	}
 	for _, part := range parts {
 		part = strings.ToLower(strings.TrimSpace(part))
 		if part == "" || part == "none" {
 			continue
 		}
-		if _, exists := seen[part]; exists {
+		if part == "all-portable" {
+			for _, expanded := range projectsCairnlineAllPortableWriteAuthority {
+				appendValue(expanded)
+			}
 			continue
 		}
-		seen[part] = struct{}{}
-		out = append(out, part)
+		appendValue(part)
 	}
 	return out
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -687,6 +687,18 @@ func TestLoadFromEnvProjectsCairnlineWriteAuthority(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil for project memory, candidate, collaboration, skills, role, work-item, assignment, agent-profile, project metadata/default, root, context-source, identity, and assistant proposal Cairnline write authority opt-ins", err)
 	}
+
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", " all-portable, project-memory ")
+	cfg = LoadFromEnv()
+	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 13 || got[0] != "project-memory" || got[1] != "memory-candidates" || got[12] != "project-assistant-proposals" {
+		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want all-portable expansion with duplicate project-memory removed", got)
+	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-context-sources") || !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-identity") {
+		t.Fatalf("ProjectsCairnlineWriteAuthorityEnabled() did not include all-portable expansion: %+v", cfg.ProjectsCairnlineWriteAuthority())
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil for all-portable Cairnline write authority alias", err)
+	}
 }
 
 func TestValidateRejectsInvalidProjectsCoordinationBackend(t *testing.T) {


### PR DESCRIPTION
## Summary
- add HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable as a dogfood alias for every current portable Cairnline write-authority switchpoint
- keep validation/status using concrete switchpoints after normalization
- document that the alias does not cover Hecate runtime side effects or migration cutover

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/config ./internal/api -run 'TestLoadFromEnvProjectsCairnlineWriteAuthority|TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAliasConfigured'\n- just docs-format-check\n- just docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/config ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./internal/config ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...\n