### PR TITLE
feat(projects): read embedded Cairnline memory directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -213,11 +213,13 @@ the snapshot-seeded in-memory bridge projection.
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot` forces that snapshot-seeded
 bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
-replacement-readiness gaps fail loudly during dogfood. Activity, work-item
-list/detail,
-assignment-list, and operations brief reads render work items, assignments,
-roles, artifacts, and handoffs from the Cairnline service records, then overlay
-Hecate-only runtime refs/timestamps where Hecate still owns execution.
+replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
+memory and memory-candidate list reads load directly from the embedded
+Cairnline project and memory records instead of loading a Hecate-native project
+snapshot first. Activity, work-item list/detail, assignment-list, and
+operations brief reads render work items, assignments, roles, artifacts, and
+handoffs from the Cairnline service records, then overlay Hecate-only runtime
+refs/timestamps where Hecate still owns execution.
 In embedded read-source modes, project identity and some compatibility
 scaffolding still come from Hecate until Cairnline becomes authoritative; the
 explicit sidecar read-source routes are the narrow exception for project

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -526,9 +526,13 @@ sequenceDiagram
   routes require a populated embedded mirror database and fail if the database
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
-  reads. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes
-  project list/detail, setup-readiness, health, project skill list, project
-  memory list, memory-candidate list, project role list, work-item list/detail,
+  reads. Strict embedded memory and memory-candidate list reads use the embedded
+  Cairnline project and memory records directly instead of loading a Hecate
+  snapshot first; other embedded read routes may still use Hecate snapshot
+  scaffolding until their route families are cut over. With
+  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
+  list/detail, setup-readiness, health, project skill list, project memory list,
+  memory-candidate list, project role list, work-item list/detail,
   assignment-list, assignment-context, launch-readiness, assignment preflight, artifact-list,
   handoff-list, Project Assistant context/proposal reads, activity,
   closeout-readiness, and operations-brief reads through the standalone
@@ -2413,9 +2417,11 @@ entries, memory candidates, roles, work items, assignment lists, assignment
 context previews, assignment launch-readiness, assignment preflight, artifact
 lists, handoff lists, Project Assistant context/proposal reads, closeout
 readiness, activity inbox, and operations brief can be served from the Cairnline
-read model, while other live Projects reads still use Hecate. Those
-configured read routes still load Hecate snapshots as bridge scaffolding, but
-their Cairnline service read source is controlled by
+read model, while other live Projects reads still use Hecate. Most of those
+configured embedded read routes still load Hecate snapshots as bridge
+scaffolding, but strict embedded memory and memory-candidate list reads now
+load directly from the embedded Cairnline project and memory records. Their
+Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the
 snapshot-seeded bridge, and `embedded` requires the mirror database and
@@ -4607,6 +4613,9 @@ reports `read_model_switch_ready=true`, this endpoint renders accepted project
 memory from the Cairnline read model and marks each item with
 `read_backend: "cairnline"`. Create, update, and delete requests still mutate
 Hecate's native memory stores until the Cairnline write adapter is ready.
+With `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, this list route reads
+directly from the embedded Cairnline project and memory records; it does not
+require a Hecate-native project or memory-store snapshot.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, this endpoint reads the
 project and memory entries through the standalone Cairnline MCP client and
@@ -4691,6 +4700,9 @@ from the Cairnline read model and marks each item with
 `read_backend: "cairnline"`. Candidate creation, promotion, and rejection still
 mutate Hecate's native memory-candidate store until the Cairnline write adapter
 is ready.
+With `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, this list route reads
+directly from the embedded Cairnline project and memory-candidate records; it
+does not require a Hecate-native project or memory-candidate-store snapshot.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, this endpoint reads the
 project and memory candidates through the standalone Cairnline MCP client and

--- a/internal/api/handler_project_memory.go
+++ b/internal/api/handler_project_memory.go
@@ -61,10 +61,10 @@ type updateProjectMemoryRequest struct {
 
 func (h *Handler) HandleProjectMemoryEntries(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("id"))
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProjectExists(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() && !h.requireProjectExists(w, r, projectID) {
 		return
 	}
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProjectMemoryStore(w) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() && !h.requireProjectMemoryStore(w) {
 		return
 	}
 	includeDisabled := requestBool(r, "include_disabled")
@@ -136,10 +136,10 @@ func (h *Handler) HandleCreateProjectMemoryEntry(w http.ResponseWriter, r *http.
 
 func (h *Handler) HandleProjectMemoryCandidates(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("id"))
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProjectExists(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() && !h.requireProjectExists(w, r, projectID) {
 		return
 	}
-	if !h.projectCairnlineSidecarReadRoutesEnabled() {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() {
 		if _, ok := h.requireProjectMemoryCandidateStore(w); !ok {
 			return
 		}
@@ -480,6 +480,9 @@ func (h *Handler) renderProjectMemoryEntries(ctx context.Context, projectID stri
 }
 
 func (h *Handler) renderCairnlineProjectMemoryEntries(ctx context.Context, projectID string, includeDisabled bool) ([]ProjectMemoryResponseItem, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectMemoryEntries(ctx, projectID, includeDisabled)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -487,6 +490,22 @@ func (h *Handler) renderCairnlineProjectMemoryEntries(ctx context.Context, proje
 	defer view.Close()
 	items, err := view.service.ListMemoryEntries(ctx, view.snapshot.Project.ID, includeDisabled)
 	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectMemoryResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderProjectMemory(projectMemoryFromCairnline(item), "cairnline"))
+	}
+	return out, nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectMemoryEntries(ctx context.Context, projectID string, includeDisabled bool) ([]ProjectMemoryResponseItem, error) {
+	var items []cairnline.MemoryEntry
+	if err := h.withStrictEmbeddedCairnlineProjectRead(ctx, projectID, func(service *cairnline.Service) error {
+		var err error
+		items, err = service.ListMemoryEntries(ctx, projectID, includeDisabled)
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	out := make([]ProjectMemoryResponseItem, 0, len(items))
@@ -533,6 +552,9 @@ func (h *Handler) renderProjectMemoryCandidates(ctx context.Context, projectID, 
 }
 
 func (h *Handler) renderCairnlineProjectMemoryCandidates(ctx context.Context, projectID, status string, includeResolved bool) ([]ProjectMemoryCandidateResponseItem, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectMemoryCandidates(ctx, projectID, status, includeResolved)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -544,6 +566,26 @@ func (h *Handler) renderCairnlineProjectMemoryCandidates(ctx context.Context, pr
 		IncludeResolved: includeResolved,
 	})
 	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectMemoryCandidateResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderProjectMemoryCandidate(projectMemoryCandidateFromCairnline(item), "cairnline"))
+	}
+	return out, nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectMemoryCandidates(ctx context.Context, projectID, status string, includeResolved bool) ([]ProjectMemoryCandidateResponseItem, error) {
+	var items []cairnline.MemoryCandidate
+	if err := h.withStrictEmbeddedCairnlineProjectRead(ctx, projectID, func(service *cairnline.Service) error {
+		var err error
+		items, err = service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+			ProjectID:       projectID,
+			Status:          status,
+			IncludeResolved: includeResolved,
+		})
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	out := make([]ProjectMemoryCandidateResponseItem, 0, len(items))
@@ -567,6 +609,24 @@ func (h *Handler) renderCairnlineSidecarProjectMemoryCandidates(ctx context.Cont
 		return nil, err
 	}
 	return renderProjectMemoryCandidates(projectMemoryCandidatesFromCairnlineSidecar(items), "cairnline"), nil
+}
+
+func (h *Handler) withStrictEmbeddedCairnlineProjectRead(ctx context.Context, projectID string, fn func(*cairnline.Service) error) error {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	if _, err := service.GetProject(ctx, projectID); err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return projects.ErrNotFound
+		}
+		return err
+	}
+	if fn == nil {
+		return nil
+	}
+	return fn(service)
 }
 
 func renderProjectMemoryEntries(items []memory.Entry, readBackend string) []ProjectMemoryResponseItem {

--- a/internal/api/handler_project_memory_test.go
+++ b/internal/api/handler_project_memory_test.go
@@ -746,6 +746,76 @@ func TestProjectMemoryAPI_CandidatesUseCairnlineReadModelWhenConfigured(t *testi
 	assertProjectMemoryCandidateProjectionParity(t, renderProjectMemoryCandidates(nativeCandidates, "hecate"), listed.Data)
 }
 
+func TestProjectMemoryAPI_StrictEmbeddedReadModelReadsMemoryWithoutHecateStores(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+	const projectID = "proj_embedded_memory"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Embedded Memory",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateMemoryEntry(t.Context(), cairnline.MemoryEntry{
+			ID:         "mem_embedded",
+			ProjectID:  projectID,
+			Title:      "Embedded note",
+			Body:       "Read directly from Cairnline.",
+			TrustLabel: memory.TrustLabelOperatorMemory,
+			SourceKind: memory.SourceKindOperator,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateMemoryCandidate(t.Context(), cairnline.MemoryCandidate{
+			ID:                  "memcand_embedded",
+			ProjectID:           projectID,
+			Title:               "Embedded candidate",
+			Body:                "Review directly from Cairnline.",
+			SuggestedKind:       "note",
+			SuggestedTrustLabel: memory.TrustLabelGenerated,
+			SuggestedSourceKind: memory.SourceKindGenerated,
+			SourceRefs: []cairnline.MemoryCandidateSourceRef{{
+				Kind:  "operator",
+				ID:    "seed",
+				Title: "Seed",
+			}},
+		}); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline memory: %v", err)
+	}
+
+	listedMemory := mustRequestJSON[ProjectMemoryListResponse](client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/memory", "")
+	if listedMemory.Object != "project_memory" || len(listedMemory.Data) != 1 {
+		t.Fatalf("memory response = %+v, want one embedded Cairnline entry", listedMemory)
+	}
+	if got := listedMemory.Data[0]; got.ID != "mem_embedded" || got.ProjectID != projectID || got.ReadBackend != "cairnline" || !got.Enabled {
+		t.Fatalf("memory entry = %+v, want embedded Cairnline projection", got)
+	}
+
+	listedCandidates := mustRequestJSON[ProjectMemoryCandidateListResponse](client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/memory/candidates", "")
+	if listedCandidates.Object != "project_memory_candidates" || len(listedCandidates.Data) != 1 {
+		t.Fatalf("candidate response = %+v, want one embedded Cairnline candidate", listedCandidates)
+	}
+	if got := listedCandidates.Data[0]; got.ID != "memcand_embedded" || got.ProjectID != projectID || got.ReadBackend != "cairnline" || got.Status != memory.CandidateStatusPending || len(got.SourceRefs) != 1 {
+		t.Fatalf("memory candidate = %+v, want embedded Cairnline projection with source ref", got)
+	}
+
+	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/proj_missing/memory", "")
+}
+
 func TestProjectMemoryAPI_ListUsesCairnlineSidecarWhenConfigured(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "memory-fixture")


### PR DESCRIPTION
## Summary
- route strict embedded Cairnline memory and memory-candidate list reads directly through the embedded Cairnline service
- avoid requiring Hecate project/memory stores for those strict embedded list routes
- document the narrower direct-read behavior and keep other embedded read routes described as snapshot-scaffolded

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectMemoryAPI_(StrictEmbeddedReadModelReadsMemoryWithoutHecateStores|ListUsesCairnlineReadModelWhenConfigured|CandidatesUseCairnlineReadModelWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...