### PR TITLE
feat(projects): read embedded Cairnline projects directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -214,19 +214,22 @@ the snapshot-seeded in-memory bridge projection.
 bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
-memory and memory-candidate list reads load directly from the embedded
-Cairnline project and memory records instead of loading a Hecate-native project
-snapshot first. Activity, work-item list/detail, assignment-list, and
-operations brief reads render work items, assignments, roles, artifacts, and
-handoffs from the Cairnline service records, then overlay Hecate-only runtime
-refs/timestamps where Hecate still owns execution.
-In embedded read-source modes, project identity and some compatibility
-scaffolding still come from Hecate until Cairnline becomes authoritative; the
-explicit sidecar read-source routes are the narrow exception for project
-list/detail, setup-readiness, health, project skill list, project memory list,
+project list/detail plus memory and memory-candidate list reads load directly
+from the embedded Cairnline project and memory records instead of loading a
+Hecate-native project snapshot first. Activity, work-item list/detail,
+assignment-list, and operations brief reads render work items, assignments,
+roles, artifacts, and handoffs from the Cairnline service records, then overlay
+Hecate-only runtime refs/timestamps where Hecate still owns execution.
+For remaining embedded read-route families, some project compatibility
+scaffolding still comes from Hecate until Cairnline becomes authoritative. The
+direct strict embedded exceptions are project list/detail, project memory list,
+and memory-candidate list reads. The explicit sidecar read-source routes remain
+the broader standalone-process exception for project list/detail,
+setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
-assignment-list, assignment-context, launch-readiness, assignment preflight, artifact-list,
-handoff-list, activity, closeout-readiness, and operations brief reads.
+assignment-list, assignment-context, launch-readiness, assignment preflight,
+artifact-list, handoff-list, activity, closeout-readiness, and operations brief
+reads.
 Project Assistant draft generation also uses the Cairnline-projected context so
 preview and proposal assembly stay aligned, while the proposal ledger remains
 Hecate-owned unless `project-assistant-proposals` is enabled.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -393,18 +393,20 @@ launch agents. Those remain explicit operator or orchestrator actions.
   embedded mirror database when it already contains the requested project and
   otherwise uses the snapshot-seeded bridge; `snapshot` forces the bridge; and
   `embedded` requires a populated embedded mirror so read-route drift fails
-  loudly during replacement-readiness dogfood.
+  loudly during replacement-readiness dogfood. In strict embedded mode, project
+  list/detail plus memory and memory-candidate list reads can load directly from
+  embedded Cairnline rows without first building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
-  execution. Outside the explicit sidecar read-source routes for project
-  list/detail, setup-readiness, health, skills, memory, memory candidates, roles,
-  work items, assignment lists, assignment context, launch-readiness, assignment preflight, artifact
-  lists, handoff lists, activity, closeout readiness, and operations brief,
-  project identity and some
-  compatibility scaffolding remain Hecate-owned until Cairnline becomes
-  authoritative.
+  execution. Outside the strict embedded direct-read exceptions for project
+  list/detail plus memory lists, and outside the explicit sidecar read-source
+  routes for project list/detail, setup-readiness, health, skills, memory,
+  memory candidates, roles, work items, assignment lists, assignment context,
+  launch-readiness, assignment preflight, artifact lists, handoff lists,
+  activity, closeout readiness, and operations brief, some project compatibility
+  scaffolding remains Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the
   portable read model while proposal persistence and apply remain Hecate-owned.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -526,10 +526,10 @@ sequenceDiagram
   routes require a populated embedded mirror database and fail if the database
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
-  reads. Strict embedded memory and memory-candidate list reads use the embedded
-  Cairnline project and memory records directly instead of loading a Hecate
-  snapshot first; other embedded read routes may still use Hecate snapshot
-  scaffolding until their route families are cut over. With
+  reads. Strict embedded project list/detail, memory, and memory-candidate list
+  reads use the embedded Cairnline project and memory records directly instead
+  of loading a Hecate snapshot first; other embedded read routes may still use
+  Hecate snapshot scaffolding until their route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
   list/detail, setup-readiness, health, project skill list, project memory list,
   memory-candidate list, project role list, work-item list/detail,
@@ -2419,9 +2419,9 @@ lists, handoff lists, Project Assistant context/proposal reads, closeout
 readiness, activity inbox, and operations brief can be served from the Cairnline
 read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
-scaffolding, but strict embedded memory and memory-candidate list reads now
-load directly from the embedded Cairnline project and memory records. Their
-Cairnline service read source is controlled by
+scaffolding, but strict embedded project list/detail, memory, and
+memory-candidate list reads now load directly from the embedded Cairnline
+project and memory records. Their Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the
 snapshot-seeded bridge, and `embedded` requires the mirror database and

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -707,6 +707,9 @@ func (h *Handler) renderProjects(ctx context.Context) ([]ProjectResponseItem, er
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		return h.renderCairnlineSidecarProjects(ctx)
 	}
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjects(ctx)
+	}
 	items, err := h.projects.List(ctx)
 	if err != nil {
 		return nil, err
@@ -717,6 +720,27 @@ func (h *Handler) renderProjects(ctx context.Context) ([]ProjectResponseItem, er
 	data := make([]ProjectResponseItem, 0, len(items))
 	for _, item := range items {
 		data = append(data, renderProject(item))
+	}
+	return data, nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjects(ctx context.Context) ([]ProjectResponseItem, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	items, err := service.ListProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]ProjectResponseItem, 0, len(items))
+	for _, item := range items {
+		project, err := h.renderCairnlineProjectFromService(ctx, service, item, projects.Project{})
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, project)
 	}
 	return data, nil
 }
@@ -737,6 +761,9 @@ func (h *Handler) renderProject(ctx context.Context, projectID string) (*Project
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		return h.renderCairnlineSidecarProject(ctx, projectID)
 	}
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProject(ctx, projectID)
+	}
 	project, ok, err := h.projects.Get(ctx, projectID)
 	if err != nil || !ok {
 		return nil, err
@@ -750,6 +777,26 @@ func (h *Handler) renderProject(ctx context.Context, projectID string) (*Project
 	}
 	rendered := renderProject(project)
 	return &rendered, nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProject(ctx context.Context, projectID string) (*ProjectResponseItem, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	item, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	project, err := h.renderCairnlineProjectFromService(ctx, service, item, projects.Project{})
+	if err != nil {
+		return nil, err
+	}
+	return &project, nil
 }
 
 func writeProjectReadRenderError(w http.ResponseWriter, err error) {
@@ -770,7 +817,11 @@ func (h *Handler) renderCairnlineProject(ctx context.Context, native projects.Pr
 	if err != nil {
 		return ProjectResponseItem{}, err
 	}
-	executionProfile, err := cairnlineExecutionProfileByID(ctx, view.service, project.DefaultExecutionProfileID)
+	return h.renderCairnlineProjectFromService(ctx, view.service, project, native)
+}
+
+func (h *Handler) renderCairnlineProjectFromService(ctx context.Context, service *cairnline.Service, project cairnline.Project, native projects.Project) (ProjectResponseItem, error) {
+	executionProfile, err := cairnlineExecutionProfileByID(ctx, service, project.DefaultExecutionProfileID)
 	if err != nil {
 		return ProjectResponseItem{}, err
 	}
@@ -850,8 +901,8 @@ func projectFromCairnline(item cairnline.Project, executionProfile *cairnline.Ex
 		DefaultWorkspaceMode:     native.DefaultWorkspaceMode,
 		DefaultSystemPrompt:      native.DefaultSystemPrompt,
 		DefaultCompactToolOutput: cloneBool(native.DefaultCompactToolOutput),
-		CreatedAt:                native.CreatedAt,
-		UpdatedAt:                native.UpdatedAt,
+		CreatedAt:                firstNonZeroTime(native.CreatedAt, item.CreatedAt),
+		UpdatedAt:                firstNonZeroTime(native.UpdatedAt, item.UpdatedAt),
 		LastOpenedAt:             native.LastOpenedAt,
 	}
 	if executionProfile != nil {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -400,6 +400,72 @@ func TestProjectsAPI_CairnlineConfiguredProjectDetailReadsEmbeddedMirror(t *test
 	}
 }
 
+func TestProjectsAPI_StrictEmbeddedReadModelReadsProjectsWithoutHecateStore(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+	const projectID = "proj_embedded_project"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateExecutionProfile(t.Context(), cairnline.ExecutionProfile{
+			ID:             "exec_embedded",
+			Name:           "Embedded runtime",
+			ProviderHint:   "openai",
+			ModelHint:      "gpt-5",
+			ToolsPolicy:    "block",
+			AdapterOptions: map[string]any{"workspace_mode": "worktree", "compact_tool_output": true},
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:                        projectID,
+			Name:                      "Embedded Project",
+			Description:               "Read directly from Cairnline.",
+			DefaultRootID:             "root_main",
+			DefaultProfileID:          "profile_architect",
+			DefaultExecutionProfileID: "exec_embedded",
+			Roots: []cairnline.Root{{
+				ID:        "root_main",
+				Path:      "/workspace/embedded",
+				Kind:      "git",
+				GitBranch: "main",
+				Active:    true,
+			}},
+			ContextSources: []cairnline.Source{{
+				ID:         "ctx_agents",
+				Kind:       "workspace_instruction",
+				Title:      "AGENTS.md",
+				Locator:    "AGENTS.md",
+				Enabled:    true,
+				Format:     "agents_md",
+				TrustLabel: "workspace_guidance",
+				Metadata:   map[string]string{"root_id": "root_main"},
+			}},
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline project: %v", err)
+	}
+
+	listed := mustRequestJSON[ProjectsResponse](client, http.MethodGet, "/hecate/v1/projects", "")
+	if listed.Object != "projects" || len(listed.Data) != 1 {
+		t.Fatalf("projects response = %+v, want one embedded Cairnline project", listed)
+	}
+	assertStrictEmbeddedProjectProjectionForTest(t, listed.Data[0], projectID)
+
+	detail := mustRequestJSON[ProjectResponse](client, http.MethodGet, "/hecate/v1/projects/"+projectID, "")
+	assertStrictEmbeddedProjectProjectionForTest(t, detail.Data, projectID)
+
+	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/proj_missing", "")
+}
+
 func TestProjectsAPI_MirrorsIdentityMutationsToCairnlineWhenConfigured(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineMirrorTestServer(t)
@@ -1418,6 +1484,31 @@ func assertCairnlineProjectProjectionForTest(t *testing.T, project ProjectRespon
 	}
 	if source.Metadata["root_id"] != "root_main" {
 		t.Fatalf("context source metadata = %+v, want root_id", source.Metadata)
+	}
+}
+
+func assertStrictEmbeddedProjectProjectionForTest(t *testing.T, project ProjectResponseItem, projectID string) {
+	t.Helper()
+	if project.ID != projectID || project.ReadBackend != "cairnline" || project.Name != "Embedded Project" || project.Description != "Read directly from Cairnline." {
+		t.Fatalf("project = %+v, want direct embedded Cairnline project %s", project, projectID)
+	}
+	if project.DefaultRootID != "root_main" || project.DefaultAgentProfile != "profile_architect" || project.DefaultProvider != "openai" || project.DefaultModel != "gpt-5" || project.DefaultWorkspaceMode != "worktree" {
+		t.Fatalf("project defaults = %+v, want Cairnline project/execution-profile defaults", project)
+	}
+	if project.DefaultToolsEnabled == nil || *project.DefaultToolsEnabled {
+		t.Fatalf("default_tools_enabled = %v, want false from Cairnline execution profile", project.DefaultToolsEnabled)
+	}
+	if project.DefaultCompactToolOutput == nil || !*project.DefaultCompactToolOutput {
+		t.Fatalf("default_compact_tool_output = %v, want true from Cairnline execution profile", project.DefaultCompactToolOutput)
+	}
+	if project.CreatedAt == "" || project.UpdatedAt == "" {
+		t.Fatalf("project timestamps = created %q updated %q, want Cairnline timestamps", project.CreatedAt, project.UpdatedAt)
+	}
+	if len(project.Roots) != 1 || project.Roots[0].ID != "root_main" || project.Roots[0].Path != "/workspace/embedded" || project.Roots[0].Kind != "git" || project.Roots[0].GitBranch != "main" || !project.Roots[0].Active {
+		t.Fatalf("project roots = %+v, want embedded Cairnline root metadata", project.Roots)
+	}
+	if len(project.ContextSources) != 1 || project.ContextSources[0].ID != "ctx_agents" || project.ContextSources[0].Path != "AGENTS.md" || project.ContextSources[0].TrustLabel != "workspace_guidance" || project.ContextSources[0].Metadata["root_id"] != "root_main" {
+		t.Fatalf("project context sources = %+v, want embedded Cairnline source metadata", project.ContextSources)
 	}
 }
 


### PR DESCRIPTION
## Summary
- route strict embedded Cairnline project list/detail reads directly through the embedded Cairnline service
- preserve Cairnline project timestamps and execution-profile defaults when no Hecate project snapshot exists
- document the strict embedded direct-read foothold for project identity plus memory/candidate lists

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectsAPI_(StrictEmbeddedReadModelReadsProjectsWithoutHecateStore|CairnlineConfiguredProjectDetailReadsEmbeddedMirror|CairnlineReadsMatchHecateProjectProjection)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...