### PR TITLE
feat(projects): read embedded Cairnline skills directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -214,18 +214,19 @@ the snapshot-seeded in-memory bridge projection.
 bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
-project list/detail plus memory and memory-candidate list reads load directly
-from the embedded Cairnline project and memory records instead of loading a
-Hecate-native project snapshot first. Activity, work-item list/detail,
-assignment-list, and operations brief reads render work items, assignments,
-roles, artifacts, and handoffs from the Cairnline service records, then overlay
-Hecate-only runtime refs/timestamps where Hecate still owns execution.
+project list/detail plus project skill, memory, and memory-candidate list reads
+load directly from the embedded Cairnline project, skill, and memory records
+instead of loading a Hecate-native project snapshot first. Activity, work-item
+list/detail, assignment-list, and operations brief reads render work items,
+assignments, roles, artifacts, and handoffs from the Cairnline service records,
+then overlay Hecate-only runtime refs/timestamps where Hecate still owns
+execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
-direct strict embedded exceptions are project list/detail, project memory list,
-and memory-candidate list reads. The explicit sidecar read-source routes remain
-the broader standalone-process exception for project list/detail,
-setup-readiness, health, project skill list, project memory list,
+direct strict embedded exceptions are project list/detail, project skill list,
+project memory list, and memory-candidate list reads. The explicit sidecar
+read-source routes remain the broader standalone-process exception for project
+list/detail, setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,
 artifact-list, handoff-list, activity, closeout-readiness, and operations brief

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -394,18 +394,19 @@ launch agents. Those remain explicit operator or orchestrator actions.
   otherwise uses the snapshot-seeded bridge; `snapshot` forces the bridge; and
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
-  list/detail plus memory and memory-candidate list reads can load directly from
-  embedded Cairnline rows without first building a Hecate snapshot.
+  list/detail plus project skill, memory, and memory-candidate list reads can
+  load directly from embedded Cairnline rows without first building a Hecate
+  snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus memory lists, and outside the explicit sidecar read-source
-  routes for project list/detail, setup-readiness, health, skills, memory,
-  memory candidates, roles, work items, assignment lists, assignment context,
-  launch-readiness, assignment preflight, artifact lists, handoff lists,
-  activity, closeout readiness, and operations brief, some project compatibility
+  list/detail plus skill and memory lists, and outside the explicit sidecar
+  read-source routes for project list/detail, setup-readiness, health, skills,
+  memory, memory candidates, roles, work items, assignment lists, assignment
+  context, launch-readiness, assignment preflight, artifact lists, handoff
+  lists, activity, closeout readiness, and operations brief, some project compatibility
   scaffolding remains Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -526,10 +526,11 @@ sequenceDiagram
   routes require a populated embedded mirror database and fail if the database
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
-  reads. Strict embedded project list/detail, memory, and memory-candidate list
-  reads use the embedded Cairnline project and memory records directly instead
-  of loading a Hecate snapshot first; other embedded read routes may still use
-  Hecate snapshot scaffolding until their route families are cut over. With
+  reads. Strict embedded project list/detail, project skill list, memory, and
+  memory-candidate list reads use the embedded Cairnline project, skill, and
+  memory records directly instead of loading a Hecate snapshot first; other
+  embedded read routes may still use Hecate snapshot scaffolding until their
+  route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
   list/detail, setup-readiness, health, project skill list, project memory list,
   memory-candidate list, project role list, work-item list/detail,
@@ -2419,14 +2420,15 @@ lists, handoff lists, Project Assistant context/proposal reads, closeout
 readiness, activity inbox, and operations brief can be served from the Cairnline
 read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
-scaffolding, but strict embedded project list/detail, memory, and
-memory-candidate list reads now load directly from the embedded Cairnline
-project and memory records. Their Cairnline service read source is controlled by
-`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
-falls back to the snapshot-seeded bridge, `snapshot` always uses the
-snapshot-seeded bridge, and `embedded` requires the mirror database and
-requested project row or proposal record to exist so replacement-readiness gaps
-fail loudly. With `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
+scaffolding, but strict embedded project list/detail, project skill list,
+memory, and memory-candidate list reads now load directly from the embedded
+Cairnline project, skill, and memory records. Their Cairnline service read
+source is controlled by `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers
+the embedded mirror and falls back to the snapshot-seeded bridge, `snapshot`
+always uses the snapshot-seeded bridge, and `embedded` requires the mirror
+database and requested project row or proposal record to exist so
+replacement-readiness gaps fail loudly. With
+`HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,

--- a/internal/api/handler_project_skills.go
+++ b/internal/api/handler_project_skills.go
@@ -28,16 +28,16 @@ func formatProjectSkillTime(value time.Time) string {
 
 func (h *Handler) HandleProjectSkills(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if h.projectSkills == nil && !h.projectCairnlineSidecarReadRoutesEnabled() {
+	if h.projectSkills == nil && !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project skills store is not configured")
 		return
 	}
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProjectExists(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() && !h.requireProjectExists(w, r, projectID) {
 		return
 	}
 	items, err := h.renderProjectSkills(r.Context(), projectID)
 	if err != nil {
-		if errors.Is(err, projects.ErrNotFound) {
+		if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 			return
 		}
@@ -148,6 +148,9 @@ func (h *Handler) renderProjectSkills(ctx context.Context, projectID string) ([]
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		return h.renderCairnlineSidecarProjectSkills(ctx, projectID)
 	}
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectSkills(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectSkills(ctx, projectID)
 	}
@@ -156,6 +159,27 @@ func (h *Handler) renderProjectSkills(ctx context.Context, projectID string) ([]
 		return nil, err
 	}
 	return renderProjectSkills(items, "hecate"), nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectSkills(ctx context.Context, projectID string) ([]ProjectSkillResponseItem, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := service.ListProjectSkills(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ProjectSkillResponseItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, renderProjectSkill(projectSkillFromCairnline(item, projectskills.Skill{}), "cairnline"))
+	}
+	return out, nil
 }
 
 func (h *Handler) renderCairnlineProjectSkills(ctx context.Context, projectID string) ([]ProjectSkillResponseItem, error) {

--- a/internal/api/handler_project_skills_test.go
+++ b/internal/api/handler_project_skills_test.go
@@ -224,6 +224,107 @@ func TestProjectSkillsAPI_ListUsesCairnlineReadModelWhenConfigured(t *testing.T)
 	assertProjectSkillsProjectionParity(t, renderProjectSkills(nativeSkills, "hecate"), listed.Data)
 }
 
+func TestProjectSkillsAPI_StrictEmbeddedReadModelReadsSkillsWithoutHecateStores(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_skills"
+	tools := true
+	network := false
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Embedded Skills",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_skills",
+				Path:   "/workspace/embedded-skills",
+				Kind:   "git",
+				Active: true,
+			}},
+			ContextSources: []cairnline.Source{{
+				ID:         "ctx_agents",
+				Kind:       "workspace_instruction",
+				Title:      "AGENTS.md",
+				Locator:    "AGENTS.md",
+				Enabled:    true,
+				Format:     "agents_md",
+				TrustLabel: "workspace_guidance",
+			}},
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateProjectSkill(t.Context(), cairnline.ProjectSkill{
+			ID:          "backend",
+			ProjectID:   projectID,
+			Title:       "Backend",
+			Description: "Build backend changes.",
+			Path:        ".agents/skills/backend/SKILL.md",
+			RootID:      "root_embedded_skills",
+			Format:      cairnline.SkillFormatMarkdown,
+			SuggestedTools: []string{
+				"git.diff",
+			},
+			RequiredPermissions: cairnline.RequiredPermissions{
+				Tools:   &tools,
+				Network: &network,
+			},
+			Enabled:    true,
+			Status:     cairnline.SkillStatusAvailable,
+			TrustLabel: cairnline.SkillTrustWorkspace,
+			SourceRefs: []string{"ctx_agents"},
+			Warnings:   []string{"metadata-only skill"},
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline skills: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+	if nativeSkills, err := handler.projectSkills.List(t.Context(), projectID); err != nil || len(nativeSkills) != 0 {
+		t.Fatalf("Hecate skill store rows = %+v err=%v, want none", nativeSkills, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/skills", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var listed ProjectSkillsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	backend := projectSkillResponseFor(listed.Data, "backend")
+	if backend == nil {
+		t.Fatalf("listed skills = %+v, want backend skill", listed.Data)
+	}
+	if backend.ReadBackend != "cairnline" || backend.ProjectID != projectID || backend.Path != ".agents/skills/backend/SKILL.md" || backend.RootID != "root_embedded_skills" {
+		t.Fatalf("backend skill = %+v, want embedded Cairnline skill projection", *backend)
+	}
+	if len(backend.SourceContextSourceIDs) != 1 || backend.SourceContextSourceIDs[0] != "ctx_agents" || len(backend.Warnings) != 1 || backend.Warnings[0] != "metadata-only skill" {
+		t.Fatalf("backend provenance = sources %+v warnings %+v, want embedded Cairnline provenance", backend.SourceContextSourceIDs, backend.Warnings)
+	}
+	if len(backend.SuggestedTools) != 1 || backend.SuggestedTools[0] != "git.diff" {
+		t.Fatalf("backend suggested tools = %+v, want embedded Cairnline suggested tools", backend.SuggestedTools)
+	}
+	if backend.RequiredPermissions == nil || backend.RequiredPermissions.Tools == nil || !*backend.RequiredPermissions.Tools || backend.RequiredPermissions.Network == nil || *backend.RequiredPermissions.Network {
+		t.Fatalf("backend required permissions = %+v, want embedded Cairnline permissions", backend.RequiredPermissions)
+	}
+
+	missingRec := httptest.NewRecorder()
+	server.ServeHTTP(missingRec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/skills", nil))
+	if missingRec.Code != http.StatusNotFound {
+		t.Fatalf("missing status = %d body=%s, want 404", missingRec.Code, missingRec.Body.String())
+	}
+}
+
 func TestProjectSkillsAPI_ListUsesCairnlineSidecarWhenConfigured(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")


### PR DESCRIPTION
## Summary
- let strict embedded Cairnline mode serve project skill lists without consulting Hecate project/skill snapshots
- map missing embedded Cairnline projects to the existing project-skills 404 contract
- update Cairnline replacement docs/status to include project skill list as a direct embedded read exception

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectSkillsAPI_(StrictEmbeddedReadModelReadsSkillsWithoutHecateStores|ListUsesCairnlineReadModelWhenConfigured|ListUsesCairnlineSidecarWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...