### PR TITLE
feat(projects): read embedded Cairnline roles directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -214,19 +214,20 @@ the snapshot-seeded in-memory bridge projection.
 bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
-project list/detail plus project skill, memory, and memory-candidate list reads
-load directly from the embedded Cairnline project, skill, and memory records
-instead of loading a Hecate-native project snapshot first. Activity, work-item
-list/detail, assignment-list, and operations brief reads render work items,
-assignments, roles, artifacts, and handoffs from the Cairnline service records,
-then overlay Hecate-only runtime refs/timestamps where Hecate still owns
-execution.
+project list/detail plus project skill, project role, memory, and
+memory-candidate list reads load directly from the embedded Cairnline project,
+skill, role, and memory records instead of loading a Hecate-native project
+snapshot first. Activity, work-item list/detail, assignment-list, and operations
+brief reads render work items, assignments, roles, artifacts, and handoffs from
+the Cairnline service records, then overlay Hecate-only runtime refs/timestamps
+where Hecate still owns execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
-project memory list, and memory-candidate list reads. The explicit sidecar
-read-source routes remain the broader standalone-process exception for project
-list/detail, setup-readiness, health, project skill list, project memory list,
+project role list, project memory list, and memory-candidate list reads. The
+explicit sidecar read-source routes remain the broader standalone-process
+exception for project list/detail, setup-readiness, health, project skill list,
+project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,
 artifact-list, handoff-list, activity, closeout-readiness, and operations brief

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -394,19 +394,19 @@ launch agents. Those remain explicit operator or orchestrator actions.
   otherwise uses the snapshot-seeded bridge; `snapshot` forces the bridge; and
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
-  list/detail plus project skill, memory, and memory-candidate list reads can
-  load directly from embedded Cairnline rows without first building a Hecate
-  snapshot.
+  list/detail plus project skill, project role, memory, and memory-candidate
+  list reads can load directly from embedded Cairnline rows without first
+  building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus skill and memory lists, and outside the explicit sidecar
-  read-source routes for project list/detail, setup-readiness, health, skills,
-  memory, memory candidates, roles, work items, assignment lists, assignment
-  context, launch-readiness, assignment preflight, artifact lists, handoff
-  lists, activity, closeout readiness, and operations brief, some project compatibility
+  list/detail plus skill, role, and memory lists, and outside the explicit
+  sidecar read-source routes for project list/detail, setup-readiness, health,
+  skills, memory, memory candidates, roles, work items, assignment lists,
+  assignment context, launch-readiness, assignment preflight, artifact lists,
+  handoff lists, activity, closeout readiness, and operations brief, some project compatibility
   scaffolding remains Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -526,11 +526,11 @@ sequenceDiagram
   routes require a populated embedded mirror database and fail if the database
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
-  reads. Strict embedded project list/detail, project skill list, memory, and
-  memory-candidate list reads use the embedded Cairnline project, skill, and
-  memory records directly instead of loading a Hecate snapshot first; other
-  embedded read routes may still use Hecate snapshot scaffolding until their
-  route families are cut over. With
+  reads. Strict embedded project list/detail, project skill list, project role
+  list, memory, and memory-candidate list reads use the embedded Cairnline
+  project, skill, role, and memory records directly instead of loading a Hecate
+  snapshot first; other embedded read routes may still use Hecate snapshot
+  scaffolding until their route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
   list/detail, setup-readiness, health, project skill list, project memory list,
   memory-candidate list, project role list, work-item list/detail,
@@ -2421,13 +2421,14 @@ readiness, activity inbox, and operations brief can be served from the Cairnline
 read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, project skill list,
-memory, and memory-candidate list reads now load directly from the embedded
-Cairnline project, skill, and memory records. Their Cairnline service read
-source is controlled by `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers
-the embedded mirror and falls back to the snapshot-seeded bridge, `snapshot`
-always uses the snapshot-seeded bridge, and `embedded` requires the mirror
-database and requested project row or proposal record to exist so
-replacement-readiness gaps fail loudly. With
+project role list, memory, and memory-candidate list reads now load directly
+from the embedded Cairnline project, skill, role, and memory records. Their
+Cairnline service read source is controlled by
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
+falls back to the snapshot-seeded bridge, `snapshot` always uses the
+snapshot-seeded bridge, and `embedded` requires the mirror database and
+requested project row or proposal record to exist so replacement-readiness gaps
+fail loudly. With
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -346,12 +346,12 @@ func (h *Handler) HandleProjectActivity(w http.ResponseWriter, r *http.Request) 
 
 func (h *Handler) HandleProjectWorkRoles(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	data, err := h.renderProjectWorkRoles(r.Context(), projectID)
 	if err != nil {
-		if errors.Is(err, projects.ErrNotFound) {
+		if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 			return
 		}

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -94,6 +94,9 @@ func (h *Handler) renderProjectWorkRoles(ctx context.Context, projectID string) 
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		return h.renderCairnlineSidecarProjectWorkRoles(ctx, projectID)
 	}
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectWorkRoles(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectWorkRoles(ctx, projectID)
 	}
@@ -126,6 +129,34 @@ func (h *Handler) renderCairnlineSidecarProjectWorkRoles(ctx context.Context, pr
 	data := make([]ProjectWorkRoleResponse, 0, len(roles))
 	for _, role := range projectRolesFromCairnlineSidecar(roles) {
 		projected := renderProjectWorkRole(role)
+		projected.ReadBackend = "cairnline"
+		data = append(data, projected)
+	}
+	return data, nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectWorkRoles(ctx context.Context, projectID string) ([]ProjectWorkRoleResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	roles, err := service.ListRoles(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+	executionProfilesByID := cairnlineExecutionProfilesByID(executionProfiles)
+	data := make([]ProjectWorkRoleResponse, 0, len(roles))
+	for _, role := range roles {
+		projected := renderProjectWorkRole(projectWorkRoleFromCairnline(role, executionProfilesByID, projectwork.AgentRoleProfile{}))
 		projected.ReadBackend = "cairnline"
 		data = append(data, projected)
 	}

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1400,6 +1400,88 @@ func TestProjectWorkAPI_RolesUseCairnlineSidecarWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_StrictEmbeddedReadModelReadsRolesWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_roles"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateExecutionProfile(t.Context(), cairnline.ExecutionProfile{
+			ID:           "exec_external",
+			Name:         "External adapter",
+			ProviderHint: "anthropic",
+			ModelHint:    "claude-sonnet-4-5",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAgentProfile(t.Context(), cairnline.AgentProfile{
+			ID:   "profile_review",
+			Name: "Review profile",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Embedded Roles",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:                        "role_reviewer",
+			ProjectID:                 projectID,
+			Name:                      "Reviewer",
+			Description:               "Reviews completed assignments.",
+			Instructions:              "Inspect evidence before approving.",
+			DefaultProfileID:          "profile_review",
+			DefaultExecutionProfileID: "exec_external",
+			DefaultSkillIDs:           []string{"review"},
+			DefaultExecutionMode:      cairnline.ExecutionExternalAdapter,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline roles: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/roles", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("roles status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkRolesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode roles response: %v", err)
+	}
+	role := findProjectWorkRoleForTest(t, response.Data, "role_reviewer")
+	if role.ProjectID != projectID || role.ReadBackend != "cairnline" || role.BuiltIn {
+		t.Fatalf("role = %+v, want embedded Cairnline non-built-in role", role)
+	}
+	if role.Name != "Reviewer" || role.DefaultDriverKind != projectwork.AssignmentDriverExternalAgent || role.DefaultAgentProfile != "profile_review" {
+		t.Fatalf("role defaults = %+v, want embedded Cairnline role defaults", role)
+	}
+	if role.DefaultProvider != "anthropic" || role.DefaultModel != "claude-sonnet-4-5" {
+		t.Fatalf("role provider/model = %q/%q, want execution profile hints", role.DefaultProvider, role.DefaultModel)
+	}
+	if !reflect.DeepEqual(role.SkillIDs, []string{"review"}) {
+		t.Fatalf("role skill ids = %+v, want review skill id", role.SkillIDs)
+	}
+
+	missingRec := httptest.NewRecorder()
+	server.ServeHTTP(missingRec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/roles", nil))
+	if missingRec.Code != http.StatusNotFound {
+		t.Fatalf("missing status = %d body=%s, want 404", missingRec.Code, missingRec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_RolesCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")


### PR DESCRIPTION
## Summary
- let strict embedded Cairnline mode serve project role lists without consulting Hecate project snapshots
- preserve Cairnline role projection with execution-profile provider/model hints
- update Cairnline replacement docs/status to include project role list as a direct embedded read exception

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StrictEmbeddedReadModelReadsRolesWithoutHecateProject|RolesUseCairnlineSidecarWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...