### PR TITLE
feat(projects): read embedded Cairnline work items directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -214,20 +214,21 @@ the snapshot-seeded in-memory bridge projection.
 bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
-project list/detail plus project skill, project role, memory, and
-memory-candidate list reads load directly from the embedded Cairnline project,
-skill, role, and memory records instead of loading a Hecate-native project
-snapshot first. Activity, work-item list/detail, assignment-list, and operations
-brief reads render work items, assignments, roles, artifacts, and handoffs from
-the Cairnline service records, then overlay Hecate-only runtime refs/timestamps
-where Hecate still owns execution.
+project list/detail plus project skill list, project role list, work-item
+list/detail, project memory list, and memory-candidate list reads load directly
+from the embedded Cairnline project, skill, role, work-item, assignment, and
+memory records instead of loading a Hecate-native project snapshot first.
+Activity, assignment-list, and operations brief reads render work items,
+assignments, roles, artifacts, and handoffs from the Cairnline service records,
+then overlay Hecate-only runtime refs/timestamps where Hecate still owns
+execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
-project role list, project memory list, and memory-candidate list reads. The
-explicit sidecar read-source routes remain the broader standalone-process
-exception for project list/detail, setup-readiness, health, project skill list,
-project memory list,
+project role list, work-item list/detail, project memory list, and
+memory-candidate list reads. The explicit sidecar read-source routes remain the
+broader standalone-process exception for project list/detail, setup-readiness,
+health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,
 artifact-list, handoff-list, activity, closeout-readiness, and operations brief

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -394,19 +394,19 @@ launch agents. Those remain explicit operator or orchestrator actions.
   otherwise uses the snapshot-seeded bridge; `snapshot` forces the bridge; and
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
-  list/detail plus project skill, project role, memory, and memory-candidate
-  list reads can load directly from embedded Cairnline rows without first
-  building a Hecate snapshot.
+  list/detail plus project skill list, project role list, work-item list/detail,
+  project memory list, and memory-candidate list reads can load directly from
+  embedded Cairnline rows without first building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus skill, role, and memory lists, and outside the explicit
-  sidecar read-source routes for project list/detail, setup-readiness, health,
-  skills, memory, memory candidates, roles, work items, assignment lists,
-  assignment context, launch-readiness, assignment preflight, artifact lists,
-  handoff lists, activity, closeout readiness, and operations brief, some project compatibility
+  list/detail plus skill, role, work-item, and memory lists, and outside the
+  explicit sidecar read-source routes for project list/detail, setup-readiness,
+  health, skills, memory, memory candidates, roles, work items, assignment
+  lists, assignment context, launch-readiness, assignment preflight, artifact
+  lists, handoff lists, activity, closeout readiness, and operations brief, some project compatibility
   scaffolding remains Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -527,10 +527,11 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, project skill list, project role
-  list, memory, and memory-candidate list reads use the embedded Cairnline
-  project, skill, role, and memory records directly instead of loading a Hecate
-  snapshot first; other embedded read routes may still use Hecate snapshot
-  scaffolding until their route families are cut over. With
+  list, work-item list/detail, project memory list, and memory-candidate list
+  reads use the embedded Cairnline project, skill, role, work-item, assignment,
+  and memory records directly instead of loading a Hecate snapshot first; other
+  embedded read routes may still use Hecate snapshot scaffolding until their
+  route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
   list/detail, setup-readiness, health, project skill list, project memory list,
   memory-candidate list, project role list, work-item list/detail,
@@ -2421,8 +2422,9 @@ readiness, activity inbox, and operations brief can be served from the Cairnline
 read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, project skill list,
-project role list, memory, and memory-candidate list reads now load directly
-from the embedded Cairnline project, skill, role, and memory records. Their
+project role list, work-item list/detail, project memory list, and
+memory-candidate list reads now load directly from the embedded Cairnline
+project, skill, role, work-item, assignment, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -455,12 +455,12 @@ func (h *Handler) HandleDeleteProjectWorkRole(w http.ResponseWriter, r *http.Req
 
 func (h *Handler) HandleProjectWorkItems(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	data, err := h.renderProjectWorkItems(r.Context(), projectID)
 	if err != nil {
-		if errors.Is(err, projects.ErrNotFound) {
+		if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
 			return
 		}
@@ -515,7 +515,7 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 
 func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requiresEmbeddedCairnlineProjectReads() && !h.requireProject(w, r, projectID) {
 		return
 	}
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
@@ -538,6 +538,10 @@ func (h *Handler) HandleProjectWorkItem(w http.ResponseWriter, r *http.Request) 
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		projected, err := h.renderCairnlineProjectWorkItem(r.Context(), projectID, r.PathValue("work_item_id"))
 		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+				return
+			}
 			if errors.Is(err, projectwork.ErrNotFound) {
 				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
 				return

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -192,6 +192,9 @@ func (h *Handler) renderProjectWorkItems(ctx context.Context, projectID string) 
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		return h.renderCairnlineSidecarProjectWorkItems(ctx, projectID)
 	}
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectWorkItems(ctx, projectID)
+	}
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		return h.renderCairnlineProjectWorkItems(ctx, projectID)
 	}
@@ -219,6 +222,21 @@ func (h *Handler) renderNativeProjectWorkItems(ctx context.Context, projectID st
 		data = append(data, projected)
 	}
 	return data, nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	return h.renderCairnlineProjectWorkItemsFromService(ctx, service, cairnlinebridge.Snapshot{
+		Project: projectFromCairnline(project, nil, projects.Project{}),
+	})
 }
 
 func (h *Handler) renderCairnlineSidecarProjectWorkItems(ctx context.Context, projectID string) ([]ProjectWorkItemResponse, error) {
@@ -465,6 +483,9 @@ func (h *Handler) renderCairnlineProjectWorkItemsFromService(ctx context.Context
 }
 
 func (h *Handler) renderCairnlineProjectWorkItem(ctx context.Context, projectID, workItemID string) (ProjectWorkItemResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectWorkItem(ctx, projectID, workItemID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return ProjectWorkItemResponse{}, err
@@ -492,6 +513,20 @@ func (h *Handler) renderCairnlineProjectWorkItem(ctx context.Context, projectID,
 		projected.ReadBackend = "cairnline"
 		markProjectWorkAssignmentReadBackend(projected.Assignments, "cairnline")
 		return projected, nil
+	}
+	return ProjectWorkItemResponse{}, projectwork.ErrNotFound
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectWorkItem(ctx context.Context, projectID, workItemID string) (ProjectWorkItemResponse, error) {
+	items, err := h.renderStrictEmbeddedCairnlineProjectWorkItems(ctx, projectID)
+	if err != nil {
+		return ProjectWorkItemResponse{}, err
+	}
+	workItemID = strings.TrimSpace(workItemID)
+	for _, item := range items {
+		if item.ID == workItemID {
+			return item, nil
+		}
 	}
 	return ProjectWorkItemResponse{}, projectwork.ErrNotFound
 }

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1549,6 +1549,104 @@ func TestProjectWorkAPI_WorkItemsUseCairnlineSidecarWhenConfigured(t *testing.T)
 	}
 }
 
+func TestProjectWorkAPI_StrictEmbeddedReadModelReadsWorkItemsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_work"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Embedded Work",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_implementer",
+			ProjectID: projectID,
+			Name:      "Implementer",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded",
+			ProjectID:   projectID,
+			Title:       "Wire direct work reads",
+			Brief:       "Exercise embedded Cairnline work-item projection.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_implementer",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded",
+			RoleID:        "role_implementer",
+			Status:        cairnline.AssignmentQueued,
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline work items: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("work-items status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkItemsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode work-items response: %v", err)
+	}
+	item := findProjectWorkItemForTest(t, response.Data, "work_embedded")
+	if item.ProjectID != projectID || item.ReadBackend != "cairnline" || item.Title != "Wire direct work reads" {
+		t.Fatalf("work item = %+v, want embedded Cairnline work item", item)
+	}
+	if item.Status != cairnline.WorkStatusReady || item.Priority != cairnline.PriorityNormal || item.OwnerRoleID != "role_implementer" {
+		t.Fatalf("work item metadata = %+v, want embedded Cairnline metadata", item)
+	}
+	if len(item.Assignments) != 1 || item.Assignments[0].ID != "asgn_embedded" || item.Assignments[0].ReadBackend != "cairnline" || item.Assignments[0].RoleID != "role_implementer" {
+		t.Fatalf("work item assignments = %+v, want embedded Cairnline assignment summary", item.Assignments)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("work-item detail status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var detail ProjectWorkItemEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode work-item detail response: %v", err)
+	}
+	if detail.Object != "project_work_item" || detail.Data.ID != "work_embedded" || detail.Data.ReadBackend != "cairnline" || len(detail.Data.Assignments) != 1 {
+		t.Fatalf("work-item detail = %+v, want embedded Cairnline detail", detail)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/missing", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/work-items", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_WorkItemsCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")


### PR DESCRIPTION
## Summary
- let strict embedded Cairnline mode serve work-item list/detail reads without consulting Hecate project snapshots
- reuse the existing Cairnline work-item/assignment projection helper with an empty Hecate overlay
- update Cairnline replacement docs/status to include work-item list/detail as direct embedded read exceptions

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StrictEmbeddedReadModelReadsWorkItemsWithoutHecateProject|WorkItemsUseCairnlineSidecarWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...