### PR TITLE
Read embedded Cairnline assignments directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -215,9 +215,10 @@ bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
 project list/detail plus project skill list, project role list, work-item
-list/detail, project memory list, and memory-candidate list reads load directly
-from the embedded Cairnline project, skill, role, work-item, assignment, and
-memory records instead of loading a Hecate-native project snapshot first.
+list/detail, assignment-list, project memory list, and memory-candidate list
+reads load directly from the embedded Cairnline project, skill, role, work-item,
+assignment, and memory records instead of loading a Hecate-native project
+snapshot first.
 Activity, assignment-list, and operations brief reads render work items,
 assignments, roles, artifacts, and handoffs from the Cairnline service records,
 then overlay Hecate-only runtime refs/timestamps where Hecate still owns
@@ -225,9 +226,9 @@ execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
-project role list, work-item list/detail, project memory list, and
-memory-candidate list reads. The explicit sidecar read-source routes remain the
-broader standalone-process exception for project list/detail, setup-readiness,
+project role list, work-item list/detail, assignment-list, project memory list,
+and memory-candidate list reads. The explicit sidecar read-source routes remain
+the broader standalone-process exception for project list/detail, setup-readiness,
 health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -395,18 +395,19 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
   list/detail plus project skill list, project role list, work-item list/detail,
-  project memory list, and memory-candidate list reads can load directly from
-  embedded Cairnline rows without first building a Hecate snapshot.
+  assignment-list, project memory list, and memory-candidate list reads can load
+  directly from embedded Cairnline rows without first building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus skill, role, work-item, and memory lists, and outside the
-  explicit sidecar read-source routes for project list/detail, setup-readiness,
-  health, skills, memory, memory candidates, roles, work items, assignment
-  lists, assignment context, launch-readiness, assignment preflight, artifact
-  lists, handoff lists, activity, closeout readiness, and operations brief, some project compatibility
+  list/detail plus skill, role, work-item, assignment-list, and memory lists,
+  and outside the explicit sidecar read-source routes for project list/detail,
+  setup-readiness, health, skills, memory, memory candidates, roles, work items,
+  assignment lists, assignment context, launch-readiness, assignment preflight,
+  artifact lists, handoff lists, activity, closeout readiness, and operations
+  brief, some project compatibility
   scaffolding remains Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
   context as the inspect endpoint, so proposal assembly is exercised against the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -527,9 +527,10 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, project skill list, project role
-  list, work-item list/detail, project memory list, and memory-candidate list
-  reads use the embedded Cairnline project, skill, role, work-item, assignment,
-  and memory records directly instead of loading a Hecate snapshot first; other
+  list, work-item list/detail, assignment-list, project memory list, and
+  memory-candidate list reads use the embedded Cairnline project, skill, role,
+  work-item, assignment, and memory records directly instead of loading a Hecate
+  snapshot first; other
   embedded read routes may still use Hecate snapshot scaffolding until their
   route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
@@ -2422,8 +2423,8 @@ readiness, activity inbox, and operations brief can be served from the Cairnline
 read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, project skill list,
-project role list, work-item list/detail, project memory list, and
-memory-candidate list reads now load directly from the embedded Cairnline
+project role list, work-item list/detail, assignment-list, project memory list,
+and memory-candidate list reads now load directly from the embedded Cairnline
 project, skill, role, work-item, assignment, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -656,6 +656,10 @@ func (h *Handler) HandleProjectWorkAssignments(w http.ResponseWriter, r *http.Re
 	if h.projectReadRoutesUseCairnlineReadModel() {
 		data, err := h.renderCairnlineProjectWorkAssignments(r.Context(), projectID, workItemID)
 		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+				WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+				return
+			}
 			if errors.Is(err, projectwork.ErrNotFound) {
 				WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
 				return

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -644,22 +644,47 @@ func projectHandoffProjectionLess(a, b projectwork.Handoff) bool {
 }
 
 func (h *Handler) renderCairnlineProjectWorkAssignments(ctx context.Context, projectID, workItemID string) ([]ProjectWorkAssignmentResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectWorkAssignments(ctx, projectID, workItemID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 	defer view.Close()
-	if _, err := view.service.GetWorkItem(ctx, view.snapshot.Project.ID, workItemID); err != nil {
+	return h.renderCairnlineProjectWorkAssignmentsFromService(ctx, view.service, view.snapshot, workItemID)
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectWorkAssignments(ctx context.Context, projectID, workItemID string) ([]ProjectWorkAssignmentResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return nil, projects.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return h.renderCairnlineProjectWorkAssignmentsFromService(ctx, service, cairnlinebridge.Snapshot{
+		Project: projectFromCairnline(project, nil, projects.Project{}),
+	}, workItemID)
+}
+
+func (h *Handler) renderCairnlineProjectWorkAssignmentsFromService(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot, workItemID string) ([]ProjectWorkAssignmentResponse, error) {
+	if _, err := service.GetWorkItem(ctx, snapshot.Project.ID, workItemID); err != nil {
 		if errors.Is(err, cairnline.ErrNotFound) {
 			return nil, projectwork.ErrNotFound
 		}
 		return nil, err
 	}
-	items, err := view.service.ListAssignments(ctx, view.snapshot.Project.ID)
+	items, err := service.ListAssignments(ctx, snapshot.Project.ID)
 	if err != nil {
 		return nil, err
 	}
-	assignments := projectWorkAssignmentsFromCairnline(items, view.snapshot.Assignments)
+	assignments := projectWorkAssignmentsFromCairnline(items, snapshot.Assignments)
 	data := make([]ProjectWorkAssignmentResponse, 0, len(items))
 	for _, assignment := range assignments {
 		if strings.TrimSpace(assignment.WorkItemID) != workItemID {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1698,6 +1698,108 @@ func TestProjectWorkAPI_AssignmentsUseCairnlineSidecarWhenConfigured(t *testing.
 	}
 }
 
+func TestProjectWorkAPI_StrictEmbeddedReadModelReadsAssignmentsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_assignments"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Embedded Assignments",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_implementer",
+			ProjectID: projectID,
+			Name:      "Implementer",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:        "work_embedded",
+			ProjectID: projectID,
+			Title:     "Read embedded assignments",
+			Status:    cairnline.WorkStatusReady,
+			Priority:  cairnline.PriorityNormal,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:        "work_other",
+			ProjectID: projectID,
+			Title:     "Other work",
+			Status:    cairnline.WorkStatusReady,
+			Priority:  cairnline.PriorityNormal,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded",
+			RoleID:        "role_implementer",
+			Status:        cairnline.AssignmentQueued,
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_other",
+			ProjectID:     projectID,
+			WorkItemID:    "work_other",
+			RoleID:        "role_implementer",
+			Status:        cairnline.AssignmentQueued,
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline assignments: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded/assignments", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assignments status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkAssignmentsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode assignments response: %v", err)
+	}
+	if response.Object != "project_assignments" || len(response.Data) != 1 {
+		t.Fatalf("assignments response = %+v, want one embedded Cairnline assignment", response)
+	}
+	assignment := response.Data[0]
+	if assignment.ID != "asgn_embedded" || assignment.ProjectID != projectID || assignment.WorkItemID != "work_embedded" || assignment.ReadBackend != "cairnline" {
+		t.Fatalf("assignment = %+v, want embedded Cairnline assignment", assignment)
+	}
+	if assignment.RoleID != "role_implementer" || assignment.DriverKind != projectwork.AssignmentDriverHecateTask || assignment.Status != projectwork.AssignmentStatusQueued {
+		t.Fatalf("assignment defaults = %+v, want embedded Cairnline assignment metadata", assignment)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/missing/assignments", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item assignments status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/work-items/work_embedded/assignments", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project assignments status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_AssignmentsCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")


### PR DESCRIPTION
## Summary
- route strict embedded Cairnline assignment-list reads directly through the embedded service
- preserve distinct project-not-found and work-item-not-found responses
- document assignment-list as a strict embedded direct-read exception

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StrictEmbeddedReadModelReadsAssignmentsWithoutHecateProject|AssignmentsUseCairnlineSidecarWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./... (sandbox blocked httptest local listener; reran with normal permissions and passed)
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...