### PR TITLE
Read embedded Cairnline artifacts directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -215,10 +215,10 @@ bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
 project list/detail plus project skill list, project role list, work-item
-list/detail, assignment-list, project memory list, and memory-candidate list
-reads load directly from the embedded Cairnline project, skill, role, work-item,
-assignment, and memory records instead of loading a Hecate-native project
-snapshot first.
+list/detail, assignment-list, artifact-list, project memory list, and
+memory-candidate list reads load directly from the embedded Cairnline project,
+skill, role, work-item, assignment, artifact, evidence, review, and memory
+records instead of loading a Hecate-native project snapshot first.
 Activity, assignment-list, and operations brief reads render work items,
 assignments, roles, artifacts, and handoffs from the Cairnline service records,
 then overlay Hecate-only runtime refs/timestamps where Hecate still owns
@@ -226,9 +226,10 @@ execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
-project role list, work-item list/detail, assignment-list, project memory list,
-and memory-candidate list reads. The explicit sidecar read-source routes remain
-the broader standalone-process exception for project list/detail, setup-readiness,
+project role list, work-item list/detail, assignment-list, artifact-list,
+project memory list, and memory-candidate list reads. The explicit sidecar
+read-source routes remain the broader standalone-process exception for project
+list/detail, setup-readiness,
 health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -395,14 +395,16 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
   list/detail plus project skill list, project role list, work-item list/detail,
-  assignment-list, project memory list, and memory-candidate list reads can load
-  directly from embedded Cairnline rows without first building a Hecate snapshot.
+  assignment-list, artifact-list, project memory list, and memory-candidate list
+  reads can load directly from embedded Cairnline rows without first building a
+  Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus skill, role, work-item, assignment-list, and memory lists,
+  list/detail plus skill, role, work-item, assignment-list, artifact-list, and
+  memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -527,10 +527,10 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, project skill list, project role
-  list, work-item list/detail, assignment-list, project memory list, and
-  memory-candidate list reads use the embedded Cairnline project, skill, role,
-  work-item, assignment, and memory records directly instead of loading a Hecate
-  snapshot first; other
+  list, work-item list/detail, assignment-list, artifact-list, project memory
+  list, and memory-candidate list reads use the embedded Cairnline project,
+  skill, role, work-item, assignment, artifact, evidence, review, and memory
+  records directly instead of loading a Hecate snapshot first; other
   embedded read routes may still use Hecate snapshot scaffolding until their
   route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
@@ -2423,9 +2423,10 @@ readiness, activity inbox, and operations brief can be served from the Cairnline
 read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, project skill list,
-project role list, work-item list/detail, assignment-list, project memory list,
-and memory-candidate list reads now load directly from the embedded Cairnline
-project, skill, role, work-item, assignment, and memory records. Their
+project role list, work-item list/detail, assignment-list, artifact-list,
+project memory list, and memory-candidate list reads now load directly from the
+embedded Cairnline project, skill, role, work-item, assignment, artifact,
+evidence, review, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -930,11 +930,21 @@ func (h *Handler) HandleProjectWorkArtifacts(w http.ResponseWriter, r *http.Requ
 		WriteJSON(w, http.StatusOK, ProjectWorkArtifactsResponse{Object: "project_collaboration_artifacts", Data: data})
 		return
 	}
-	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if !strictEmbeddedRead && !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
 	data, err := h.renderProjectWorkArtifacts(r.Context(), projectID, workItemID)
-	if !writeProjectWorkError(w, err) {
+	if err != nil {
+		if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		if errors.Is(err, projectwork.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+			return
+		}
+		_ = writeProjectWorkError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkArtifactsResponse{Object: "project_collaboration_artifacts", Data: data})

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -30,6 +30,9 @@ func (h *Handler) renderProjectWorkArtifacts(ctx context.Context, projectID, wor
 }
 
 func (h *Handler) renderCairnlineProjectWorkArtifacts(ctx context.Context, projectID, workItemID string) ([]ProjectWorkArtifactResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectWorkArtifacts(ctx, projectID, workItemID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -42,13 +45,46 @@ func (h *Handler) renderCairnlineProjectWorkArtifacts(ctx context.Context, proje
 	if err != nil {
 		return nil, err
 	}
+	return renderCairnlineProjectWorkArtifactResponses(items), nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectWorkArtifacts(ctx context.Context, projectID, workItemID string) ([]ProjectWorkArtifactResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return nil, projects.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if _, err := service.GetWorkItem(ctx, project.ID, workItemID); err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return nil, projectwork.ErrNotFound
+		}
+		return nil, err
+	}
+	items, err := cairnlineProjectWorkArtifacts(ctx, service, project.ID, workItemID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return nil, projectwork.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return renderCairnlineProjectWorkArtifactResponses(items), nil
+}
+
+func renderCairnlineProjectWorkArtifactResponses(items []projectwork.CollaborationArtifact) []ProjectWorkArtifactResponse {
 	data := make([]ProjectWorkArtifactResponse, 0, len(items))
 	for _, item := range items {
 		projected := renderProjectWorkArtifact(item)
 		projected.ReadBackend = "cairnline"
 		data = append(data, projected)
 	}
-	return data, nil
+	return data
 }
 
 func (h *Handler) renderProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1853,6 +1853,134 @@ func TestProjectWorkAPI_ArtifactsUseCairnlineSidecarWhenConfigured(t *testing.T)
 	}
 }
 
+func TestProjectWorkAPI_StrictEmbeddedReadModelReadsArtifactsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_artifacts"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Embedded Artifacts",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_reviewer",
+			ProjectID: projectID,
+			Name:      "Reviewer",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:        "work_embedded",
+			ProjectID: projectID,
+			Title:     "Read embedded artifacts",
+			Status:    cairnline.WorkStatusReady,
+			Priority:  cairnline.PriorityNormal,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded",
+			RoleID:        "role_reviewer",
+			Status:        cairnline.AssignmentCompleted,
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateArtifact(t.Context(), cairnline.Artifact{
+			ID:           "artifact_embedded",
+			ProjectID:    projectID,
+			WorkItemID:   "work_embedded",
+			AssignmentID: "asgn_embedded",
+			Kind:         projectwork.ArtifactKindDecisionNote,
+			Title:        "Decision",
+			Body:         "Use direct embedded artifact reads.",
+			AuthorRoleID: "role_reviewer",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateEvidence(t.Context(), cairnline.Evidence{
+			ID:           "evidence_embedded",
+			ProjectID:    projectID,
+			WorkItemID:   "work_embedded",
+			AssignmentID: "asgn_embedded",
+			Title:        "Evidence",
+			Body:         "Runtime evidence.",
+			Locator:      "https://example.test/evidence",
+			ExternalID:   "EVID-1",
+			Provider:     "test",
+			TrustLabel:   cairnline.EvidenceTrustOperator,
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateReview(t.Context(), cairnline.Review{
+			ID:             "review_embedded",
+			ProjectID:      projectID,
+			WorkItemID:     "work_embedded",
+			AssignmentID:   "asgn_embedded",
+			ReviewerRoleID: "role_reviewer",
+			Title:          "Review",
+			Body:           "Needs a follow-up.",
+			Verdict:        cairnline.ReviewVerdictChangesRequested,
+			Risk:           cairnline.ReviewRiskMedium,
+			Status:         cairnline.ReviewStatusRecorded,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline artifacts: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded/artifacts", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("artifacts status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkArtifactsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode artifacts response: %v", err)
+	}
+	if response.Object != "project_collaboration_artifacts" || len(response.Data) != 3 {
+		t.Fatalf("artifacts response = %+v, want embedded generic artifact, evidence, and review", response)
+	}
+	artifact := findProjectWorkArtifactForTest(t, response.Data, "artifact_embedded")
+	if artifact.ReadBackend != "cairnline" || artifact.Kind != projectwork.ArtifactKindDecisionNote || artifact.AssignmentID != "asgn_embedded" {
+		t.Fatalf("generic artifact = %+v, want embedded Cairnline decision artifact", artifact)
+	}
+	evidence := findProjectWorkArtifactForTest(t, response.Data, "evidence_embedded")
+	if evidence.ReadBackend != "cairnline" || evidence.Kind != projectwork.ArtifactKindEvidenceLink || evidence.EvidenceURL != "https://example.test/evidence" || evidence.EvidenceExternalID != "EVID-1" || evidence.EvidenceProvider != "test" {
+		t.Fatalf("evidence artifact = %+v, want embedded Cairnline evidence artifact", evidence)
+	}
+	review := findProjectWorkArtifactForTest(t, response.Data, "review_embedded")
+	if review.ReadBackend != "cairnline" || review.Kind != projectwork.ArtifactKindReview || review.ReviewedAssignmentID != "asgn_embedded" || review.ReviewVerdict != projectwork.ReviewVerdictChangesRequested || review.ReviewRisk != projectwork.ReviewRiskMedium || !review.ReviewFollowUpRequired {
+		t.Fatalf("review artifact = %+v, want embedded Cairnline review artifact", review)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/missing/artifacts", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item artifacts status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/work-items/work_embedded/artifacts", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project artifacts status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_ArtifactsCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")


### PR DESCRIPTION
## Summary
- route strict embedded Cairnline artifact-list reads directly through the embedded service
- preserve distinct project-not-found and work-item-not-found responses without requiring a Hecate project row
- document artifact-list as a strict embedded direct-read exception

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StrictEmbeddedReadModelReadsArtifactsWithoutHecateProject|ArtifactsUseCairnlineSidecarWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...