### PR TITLE
Read embedded Cairnline handoffs directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -215,10 +215,11 @@ bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
 project list/detail plus project skill list, project role list, work-item
-list/detail, assignment-list, artifact-list, project memory list, and
-memory-candidate list reads load directly from the embedded Cairnline project,
-skill, role, work-item, assignment, artifact, evidence, review, and memory
-records instead of loading a Hecate-native project snapshot first.
+list/detail, assignment-list, artifact-list, handoff-list, project memory list,
+and memory-candidate list reads load directly from the embedded Cairnline
+project, skill, role, work-item, assignment, artifact, evidence, review,
+handoff, and memory records instead of loading a Hecate-native project snapshot
+first.
 Activity, assignment-list, and operations brief reads render work items,
 assignments, roles, artifacts, and handoffs from the Cairnline service records,
 then overlay Hecate-only runtime refs/timestamps where Hecate still owns
@@ -227,9 +228,9 @@ For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
 project role list, work-item list/detail, assignment-list, artifact-list,
-project memory list, and memory-candidate list reads. The explicit sidecar
-read-source routes remain the broader standalone-process exception for project
-list/detail, setup-readiness,
+handoff-list, project memory list, and memory-candidate list reads. The
+explicit sidecar read-source routes remain the broader standalone-process
+exception for project list/detail, setup-readiness,
 health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -395,16 +395,16 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
   list/detail plus project skill list, project role list, work-item list/detail,
-  assignment-list, artifact-list, project memory list, and memory-candidate list
-  reads can load directly from embedded Cairnline rows without first building a
-  Hecate snapshot.
+  assignment-list, artifact-list, handoff-list, project memory list, and
+  memory-candidate list reads can load directly from embedded Cairnline rows
+  without first building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus skill, role, work-item, assignment-list, artifact-list, and
-  memory lists,
+  list/detail plus skill, role, work-item, assignment-list, artifact-list,
+  handoff-list, and memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -527,10 +527,11 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, project skill list, project role
-  list, work-item list/detail, assignment-list, artifact-list, project memory
-  list, and memory-candidate list reads use the embedded Cairnline project,
-  skill, role, work-item, assignment, artifact, evidence, review, and memory
-  records directly instead of loading a Hecate snapshot first; other
+  list, work-item list/detail, assignment-list, artifact-list, handoff-list,
+  project memory list, and memory-candidate list reads use the embedded
+  Cairnline project, skill, role, work-item, assignment, artifact, evidence,
+  review, handoff, and memory records directly instead of loading a Hecate
+  snapshot first; other
   embedded read routes may still use Hecate snapshot scaffolding until their
   route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
@@ -2424,9 +2425,9 @@ read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, project skill list,
 project role list, work-item list/detail, assignment-list, artifact-list,
-project memory list, and memory-candidate list reads now load directly from the
-embedded Cairnline project, skill, role, work-item, assignment, artifact,
-evidence, review, and memory records. Their
+handoff-list, project memory list, and memory-candidate list reads now load
+directly from the embedded Cairnline project, skill, role, work-item,
+assignment, artifact, evidence, review, handoff, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -1013,11 +1013,17 @@ func (h *Handler) HandleProjectHandoffs(w http.ResponseWriter, r *http.Request) 
 		WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
 		return
 	}
-	if !h.requireProject(w, r, projectID) {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if !strictEmbeddedRead && !h.requireProject(w, r, projectID) {
 		return
 	}
 	data, err := h.renderProjectHandoffs(r.Context(), filter)
-	if !writeProjectWorkError(w, err) {
+	if err != nil {
+		if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		_ = writeProjectWorkError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
@@ -1047,15 +1053,25 @@ func (h *Handler) HandleProjectWorkItemHandoffs(w http.ResponseWriter, r *http.R
 		WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})
 		return
 	}
-	if !h.requireProjectWorkItem(w, r, projectID, workItemID) {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if !strictEmbeddedRead && !h.requireProjectWorkItem(w, r, projectID, workItemID) {
 		return
 	}
-	data, err := h.renderProjectHandoffs(r.Context(), projectwork.HandoffFilter{
+	data, err := h.renderProjectWorkItemHandoffs(r.Context(), projectwork.HandoffFilter{
 		ProjectID:  projectID,
 		WorkItemID: workItemID,
 		Status:     strings.TrimSpace(r.URL.Query().Get("status")),
 	})
-	if !writeProjectWorkError(w, err) {
+	if err != nil {
+		if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		if errors.Is(err, projectwork.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
+			return
+		}
+		_ = writeProjectWorkError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectHandoffsResponse{Object: "project_handoffs", Data: data})

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -88,8 +88,16 @@ func renderCairnlineProjectWorkArtifactResponses(items []projectwork.Collaborati
 }
 
 func (h *Handler) renderProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
+	return h.renderProjectHandoffsWithWorkItemRequirement(ctx, filter, false)
+}
+
+func (h *Handler) renderProjectWorkItemHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
+	return h.renderProjectHandoffsWithWorkItemRequirement(ctx, filter, true)
+}
+
+func (h *Handler) renderProjectHandoffsWithWorkItemRequirement(ctx context.Context, filter projectwork.HandoffFilter, requireWorkItem bool) ([]ProjectHandoffResponse, error) {
 	if h.projectReadRoutesUseCairnlineReadModel() {
-		return h.renderCairnlineProjectHandoffs(ctx, filter)
+		return h.renderCairnlineProjectHandoffs(ctx, filter, requireWorkItem)
 	}
 	items, err := h.projectWork.ListHandoffs(ctx, filter)
 	if err != nil {
@@ -104,7 +112,10 @@ func (h *Handler) renderProjectHandoffs(ctx context.Context, filter projectwork.
 	return data, nil
 }
 
-func (h *Handler) renderCairnlineProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]ProjectHandoffResponse, error) {
+func (h *Handler) renderCairnlineProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter, requireWorkItem bool) ([]ProjectHandoffResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectHandoffs(ctx, filter, requireWorkItem)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, filter.ProjectID)
 	if err != nil {
 		return nil, err
@@ -117,13 +128,52 @@ func (h *Handler) renderCairnlineProjectHandoffs(ctx context.Context, filter pro
 	if err != nil {
 		return nil, err
 	}
+	return renderCairnlineProjectHandoffResponses(items), nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectHandoffs(ctx context.Context, filter projectwork.HandoffFilter, requireWorkItem bool) ([]ProjectHandoffResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, filter.ProjectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return nil, projects.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	workItemID := strings.TrimSpace(filter.WorkItemID)
+	if requireWorkItem {
+		if workItemID == "" {
+			return nil, projectwork.ErrNotFound
+		}
+		if _, err := service.GetWorkItem(ctx, project.ID, workItemID); err != nil {
+			if errors.Is(err, cairnline.ErrNotFound) {
+				return nil, projectwork.ErrNotFound
+			}
+			return nil, err
+		}
+	}
+	items, err := cairnlineProjectHandoffs(ctx, service, project.ID, workItemID, strings.TrimSpace(filter.Status))
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return nil, projectwork.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return renderCairnlineProjectHandoffResponses(items), nil
+}
+
+func renderCairnlineProjectHandoffResponses(items []projectwork.Handoff) []ProjectHandoffResponse {
 	data := make([]ProjectHandoffResponse, 0, len(items))
 	for _, item := range items {
 		projected := renderProjectHandoff(item)
 		projected.ReadBackend = "cairnline"
 		data = append(data, projected)
 	}
-	return data, nil
+	return data
 }
 
 func (h *Handler) renderProjectWorkRoles(ctx context.Context, projectID string) ([]ProjectWorkRoleResponse, error) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2041,6 +2041,144 @@ func TestProjectWorkAPI_HandoffsUseCairnlineSidecarWhenConfigured(t *testing.T) 
 	}
 }
 
+func TestProjectWorkAPI_StrictEmbeddedReadModelReadsHandoffsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_handoffs"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Embedded Handoffs",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_source",
+			ProjectID: projectID,
+			Name:      "Source",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_target",
+			ProjectID: projectID,
+			Name:      "Target",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:        "work_embedded",
+			ProjectID: projectID,
+			Title:     "Read embedded handoffs",
+			Status:    cairnline.WorkStatusReady,
+			Priority:  cairnline.PriorityNormal,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:        "work_other",
+			ProjectID: projectID,
+			Title:     "Other handoffs",
+			Status:    cairnline.WorkStatusReady,
+			Priority:  cairnline.PriorityNormal,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded",
+			RoleID:        "role_source",
+			Status:        cairnline.AssignmentCompleted,
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateHandoff(t.Context(), cairnline.Handoff{
+			ID:                    "handoff_embedded",
+			ProjectID:             projectID,
+			WorkItemID:            "work_embedded",
+			SourceAssignmentID:    "asgn_embedded",
+			FromRoleID:            "role_source",
+			ToRoleID:              "role_target",
+			Title:                 "Continue embedded handoff reads",
+			Body:                  "Pick up the next review step.",
+			RecommendedNextAction: "Review evidence",
+			LinkedArtifactIDs:     []string{"artifact_embedded"},
+			ContextRefs:           []string{"ctx:embedded"},
+			Status:                cairnline.HandoffStatusOpen,
+			TrustLabel:            "operator",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateHandoff(t.Context(), cairnline.Handoff{
+			ID:         "handoff_other",
+			ProjectID:  projectID,
+			WorkItemID: "work_other",
+			Title:      "Other handoff",
+			Body:       "Should not appear in work filter.",
+			Status:     cairnline.HandoffStatusOpen,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline handoffs: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/handoffs?work_item_id=work_embedded&status=pending", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("project handoffs status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectHandoffsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode project handoffs response: %v", err)
+	}
+	if response.Object != "project_handoffs" || len(response.Data) != 1 {
+		t.Fatalf("project handoffs response = %+v, want one filtered embedded handoff", response)
+	}
+	handoff := findProjectHandoffForTest(t, response.Data, "handoff_embedded")
+	if handoff.ReadBackend != "cairnline" || handoff.ProjectID != projectID || handoff.WorkItemID != "work_embedded" || handoff.Status != projectwork.HandoffStatusPending {
+		t.Fatalf("project handoff = %+v, want embedded Cairnline pending handoff", handoff)
+	}
+	if handoff.SourceAssignmentID != "asgn_embedded" || handoff.TargetRoleID != "role_target" || handoff.RecommendedNextAction != "Review evidence" || len(handoff.ContextRefs) != 1 {
+		t.Fatalf("project handoff metadata = %+v, want embedded Cairnline handoff metadata", handoff)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded/handoffs", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("work-item handoffs status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode work-item handoffs response: %v", err)
+	}
+	if len(response.Data) != 1 || response.Data[0].ID != "handoff_embedded" || response.Data[0].ReadBackend != "cairnline" {
+		t.Fatalf("work-item handoffs response = %+v, want embedded Cairnline handoff", response)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/missing/handoffs", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item handoffs status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/handoffs", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project handoffs status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_HandoffsCairnlineSidecarReadRequiresStructuredContent(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "text-only")


### PR DESCRIPTION
## Summary
- route strict embedded Cairnline handoff-list reads directly through the embedded service
- preserve project-level handoff filtering while keeping nested work-item reads scoped to an existing work item
- document handoff-list as a strict embedded direct-read exception

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StrictEmbeddedReadModelReadsHandoffsWithoutHecateProject|HandoffsUseCairnlineSidecarWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...