### PR TITLE
Read embedded Cairnline closeout readiness directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -215,11 +215,11 @@ bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
 project list/detail plus project skill list, project role list, work-item
-list/detail, assignment-list, artifact-list, handoff-list, project memory list,
-and memory-candidate list reads load directly from the embedded Cairnline
-project, skill, role, work-item, assignment, artifact, evidence, review,
-handoff, and memory records instead of loading a Hecate-native project snapshot
-first.
+list/detail, assignment-list, artifact-list, handoff-list, closeout-readiness,
+project memory list, and memory-candidate list reads load directly from the
+embedded Cairnline project, skill, role, work-item, assignment, artifact,
+evidence, review, handoff, and memory records instead of loading a
+Hecate-native project snapshot first.
 Activity, assignment-list, and operations brief reads render work items,
 assignments, roles, artifacts, and handoffs from the Cairnline service records,
 then overlay Hecate-only runtime refs/timestamps where Hecate still owns
@@ -228,9 +228,9 @@ For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
 project role list, work-item list/detail, assignment-list, artifact-list,
-handoff-list, project memory list, and memory-candidate list reads. The
-explicit sidecar read-source routes remain the broader standalone-process
-exception for project list/detail, setup-readiness,
+handoff-list, closeout-readiness, project memory list, and memory-candidate
+list reads. The explicit sidecar read-source routes remain the broader
+standalone-process exception for project list/detail, setup-readiness,
 health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -395,16 +395,16 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
   list/detail plus project skill list, project role list, work-item list/detail,
-  assignment-list, artifact-list, handoff-list, project memory list, and
-  memory-candidate list reads can load directly from embedded Cairnline rows
-  without first building a Hecate snapshot.
+  assignment-list, artifact-list, handoff-list, closeout-readiness, project
+  memory list, and memory-candidate list reads can load directly from embedded
+  Cairnline rows without first building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
   list/detail plus skill, role, work-item, assignment-list, artifact-list,
-  handoff-list, and memory lists,
+  handoff-list, closeout-readiness, and memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -528,10 +528,10 @@ sequenceDiagram
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, project skill list, project role
   list, work-item list/detail, assignment-list, artifact-list, handoff-list,
-  project memory list, and memory-candidate list reads use the embedded
-  Cairnline project, skill, role, work-item, assignment, artifact, evidence,
-  review, handoff, and memory records directly instead of loading a Hecate
-  snapshot first; other
+  closeout-readiness, project memory list, and memory-candidate list reads use
+  the embedded Cairnline project, skill, role, work-item, assignment, artifact,
+  evidence, review, handoff, and memory records directly instead of loading a
+  Hecate snapshot first; other
   embedded read routes may still use Hecate snapshot scaffolding until their
   route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
@@ -2425,9 +2425,9 @@ read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, project skill list,
 project role list, work-item list/detail, assignment-list, artifact-list,
-handoff-list, project memory list, and memory-candidate list reads now load
-directly from the embedded Cairnline project, skill, role, work-item,
-assignment, artifact, evidence, review, handoff, and memory records. Their
+handoff-list, closeout-readiness, project memory list, and memory-candidate list
+reads now load directly from the embedded Cairnline project, skill, role,
+work-item, assignment, artifact, evidence, review, handoff, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -793,6 +793,9 @@ func markProjectWorkAssignmentReadBackend(items []ProjectWorkAssignmentResponse,
 }
 
 func (h *Handler) renderCairnlineProjectWorkItemReadiness(ctx context.Context, projectID, workItemID string) (ProjectWorkItemReadinessResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectWorkItemReadiness(ctx, projectID, workItemID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return ProjectWorkItemReadinessResponse{}, err
@@ -806,6 +809,50 @@ func (h *Handler) renderCairnlineProjectWorkItemReadiness(ctx context.Context, p
 		return ProjectWorkItemReadinessResponse{}, err
 	}
 	return renderCairnlineProjectWorkItemReadiness(readiness), nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectWorkItemReadiness(ctx context.Context, projectID, workItemID string) (ProjectWorkItemReadinessResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return ProjectWorkItemReadinessResponse{}, projects.ErrNotFound
+	}
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	workItemID = strings.TrimSpace(workItemID)
+	workItem, err := service.GetWorkItem(ctx, project.ID, workItemID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return ProjectWorkItemReadinessResponse{}, projectwork.ErrNotFound
+	}
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	assignments, err := service.ListAssignments(ctx, project.ID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	artifacts, err := cairnlineProjectWorkArtifacts(ctx, service, project.ID, workItemID)
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	handoffs, err := cairnlineProjectHandoffs(ctx, service, project.ID, workItemID, "")
+	if err != nil {
+		return ProjectWorkItemReadinessResponse{}, err
+	}
+	readiness := projectwork.EvaluateWorkItemReadiness(
+		projectWorkItemFromCairnline(workItem),
+		filterProjectWorkAssignments(projectWorkAssignmentsFromCairnline(assignments, nil), workItemID),
+		artifacts,
+		handoffs,
+	)
+	rendered := renderProjectWorkItemReadiness(readiness)
+	rendered.ReadBackend = "cairnline"
+	return rendered, nil
 }
 
 type cairnlineProjectWorkView struct {

--- a/internal/api/handler_project_work_readiness.go
+++ b/internal/api/handler_project_work_readiness.go
@@ -62,11 +62,16 @@ func (h *Handler) HandleProjectWorkItemReadiness(w http.ResponseWriter, r *http.
 		WriteJSON(w, http.StatusOK, ProjectWorkItemReadinessEnvelope{Object: "project_work_item_readiness", Data: readiness})
 		return
 	}
-	if !h.requireProject(w, r, projectID) {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if !strictEmbeddedRead && !h.requireProject(w, r, projectID) {
 		return
 	}
 	readiness, err := h.renderProjectWorkItemReadiness(r.Context(), projectID, r.PathValue("work_item_id"))
 	if err != nil {
+		if errors.Is(err, projects.ErrNotFound) {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
 		if errors.Is(err, projectwork.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
 			return

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2193,6 +2193,103 @@ func TestProjectWorkAPI_HandoffsCairnlineSidecarReadRequiresStructuredContent(t 
 	}
 }
 
+func TestProjectWorkAPI_StrictEmbeddedReadModelReadsCloseoutReadinessWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_readiness"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Embedded Readiness",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_owner",
+			ProjectID: projectID,
+			Name:      "Owner",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:        "work_embedded",
+			ProjectID: projectID,
+			Title:     "Read embedded closeout readiness",
+			Status:    cairnline.WorkStatusReady,
+			Priority:  cairnline.PriorityNormal,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded",
+			RoleID:        "role_owner",
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CompleteAssignment(t.Context(), projectID, "asgn_embedded", cairnline.AssignmentCompleted, "run_embedded"); err != nil {
+			return err
+		}
+		_, err := service.CreateHandoff(t.Context(), cairnline.Handoff{
+			ID:                 "handoff_embedded",
+			ProjectID:          projectID,
+			WorkItemID:         "work_embedded",
+			SourceAssignmentID: "asgn_embedded",
+			FromRoleID:         "role_owner",
+			ToRoleID:           "role_owner",
+			Title:              "Follow up before closeout",
+			Body:               "Keep this work item open until reviewed.",
+			Status:             cairnline.HandoffStatusOpen,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline readiness: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded/readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkItemReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode readiness response: %v", err)
+	}
+	if response.Object != "project_work_item_readiness" || response.Data.ProjectID != projectID || response.Data.WorkItemID != "work_embedded" || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("readiness response = %+v, want embedded Cairnline readiness", response)
+	}
+	if response.Data.Ready || response.Data.Status != "blocked" || response.Data.AssignmentCount != 1 || response.Data.CompletedAssignments != 1 {
+		t.Fatalf("readiness = %+v, want blocked embedded closeout state", response.Data)
+	}
+	if !containsString(response.Data.MissingEvidenceAssignmentIDs, "asgn_embedded") || !containsString(response.Data.Blockers, "1 completed assignment is missing evidence") || !containsString(response.Data.Blockers, "1 handoff is pending") {
+		t.Fatalf("readiness blockers = %+v missing=%+v, want missing evidence and pending handoff blockers", response.Data.Blockers, response.Data.MissingEvidenceAssignmentIDs)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/missing/readiness", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing work-item readiness status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/work-items/work_embedded/readiness", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project readiness status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_CloseoutReadinessUsesCairnlineSidecarWhenConfigured(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "collaboration-fixture")


### PR DESCRIPTION
## Summary
- route strict embedded Cairnline closeout-readiness reads directly through the embedded service
- let closeout readiness work without a Hecate-native project row while preserving missing project/work-item 404s
- document closeout-readiness as a strict embedded direct-read exception

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StrictEmbeddedReadModelReadsCloseoutReadinessWithoutHecateProject|CloseoutReadinessUsesCairnlineSidecarWhenConfigured)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline.*Strict|TestProjectCairnline.*Embedded|TestProjectWorkAPI_(StrictEmbeddedReadModelReadsCloseoutReadinessWithoutHecateProject|CloseoutReadinessUsesCairnlineSidecarWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...