### PR TITLE
Read embedded Cairnline setup readiness directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -214,12 +214,12 @@ the snapshot-seeded in-memory bridge projection.
 bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
-project list/detail plus project skill list, project role list, work-item
-list/detail, assignment-list, artifact-list, handoff-list, closeout-readiness,
-project memory list, and memory-candidate list reads load directly from the
-embedded Cairnline project, skill, role, work-item, assignment, artifact,
-evidence, review, handoff, and memory records instead of loading a
-Hecate-native project snapshot first.
+project list/detail plus setup-readiness, project skill list, project role list,
+work-item list/detail, assignment-list, artifact-list, handoff-list,
+closeout-readiness, project memory list, and memory-candidate list reads load
+directly from the embedded Cairnline project, skill, role, work-item,
+assignment, artifact, evidence, review, handoff, and memory records instead of
+loading a Hecate-native project snapshot first.
 Activity, assignment-list, and operations brief reads render work items,
 assignments, roles, artifacts, and handoffs from the Cairnline service records,
 then overlay Hecate-only runtime refs/timestamps where Hecate still owns
@@ -227,10 +227,10 @@ execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
-project role list, work-item list/detail, assignment-list, artifact-list,
-handoff-list, closeout-readiness, project memory list, and memory-candidate
-list reads. The explicit sidecar read-source routes remain the broader
-standalone-process exception for project list/detail, setup-readiness,
+setup-readiness, project role list, work-item list/detail, assignment-list,
+artifact-list, handoff-list, closeout-readiness, project memory list, and
+memory-candidate list reads. The explicit sidecar read-source routes remain the
+broader standalone-process exception for project list/detail, setup-readiness,
 health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -394,17 +394,18 @@ launch agents. Those remain explicit operator or orchestrator actions.
   otherwise uses the snapshot-seeded bridge; `snapshot` forces the bridge; and
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
-  list/detail plus project skill list, project role list, work-item list/detail,
-  assignment-list, artifact-list, handoff-list, closeout-readiness, project
-  memory list, and memory-candidate list reads can load directly from embedded
-  Cairnline rows without first building a Hecate snapshot.
+  list/detail plus setup-readiness, project skill list, project role list,
+  work-item list/detail, assignment-list, artifact-list, handoff-list,
+  closeout-readiness, project memory list, and memory-candidate list reads can
+  load directly from embedded Cairnline rows without first building a Hecate
+  snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus skill, role, work-item, assignment-list, artifact-list,
-  handoff-list, closeout-readiness, and memory lists,
+  list/detail plus setup-readiness, skill, role, work-item, assignment-list,
+  artifact-list, handoff-list, closeout-readiness, and memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -526,12 +526,12 @@ sequenceDiagram
   routes require a populated embedded mirror database and fail if the database
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
-  reads. Strict embedded project list/detail, project skill list, project role
-  list, work-item list/detail, assignment-list, artifact-list, handoff-list,
-  closeout-readiness, project memory list, and memory-candidate list reads use
-  the embedded Cairnline project, skill, role, work-item, assignment, artifact,
-  evidence, review, handoff, and memory records directly instead of loading a
-  Hecate snapshot first; other
+  reads. Strict embedded project list/detail, setup-readiness, project skill
+  list, project role list, work-item list/detail, assignment-list,
+  artifact-list, handoff-list, closeout-readiness, project memory list, and
+  memory-candidate list reads use the embedded Cairnline project, skill, role,
+  work-item, assignment, artifact, evidence, review, handoff, and memory records
+  directly instead of loading a Hecate snapshot first; other
   embedded read routes may still use Hecate snapshot scaffolding until their
   route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
@@ -2423,11 +2423,12 @@ lists, handoff lists, Project Assistant context/proposal reads, closeout
 readiness, activity inbox, and operations brief can be served from the Cairnline
 read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
-scaffolding, but strict embedded project list/detail, project skill list,
-project role list, work-item list/detail, assignment-list, artifact-list,
-handoff-list, closeout-readiness, project memory list, and memory-candidate list
-reads now load directly from the embedded Cairnline project, skill, role,
-work-item, assignment, artifact, evidence, review, handoff, and memory records. Their
+scaffolding, but strict embedded project list/detail, setup-readiness, project
+skill list, project role list, work-item list/detail, assignment-list,
+artifact-list, handoff-list, closeout-readiness, project memory list, and
+memory-candidate list reads now load directly from the embedded Cairnline
+project, skill, role, work-item, assignment, artifact, evidence, review,
+handoff, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the

--- a/internal/api/handler_project_setup_readiness.go
+++ b/internal/api/handler_project_setup_readiness.go
@@ -69,7 +69,8 @@ type ProjectSetupReadinessActionResponse struct {
 
 func (h *Handler) HandleProjectSetupReadiness(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !strictEmbeddedRead && !h.requireProject(w, r, projectID) {
 		return
 	}
 	readiness, err := h.renderProjectSetupReadiness(r.Context(), projectID)

--- a/internal/api/handler_project_setup_readiness_cairnline.go
+++ b/internal/api/handler_project_setup_readiness_cairnline.go
@@ -2,15 +2,20 @@ package api
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 func (h *Handler) renderCairnlineProjectSetupReadiness(ctx context.Context, projectID string) (ProjectSetupReadinessResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectSetupReadiness(ctx, projectID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return ProjectSetupReadinessResponse{}, err
@@ -40,7 +45,54 @@ func (h *Handler) renderCairnlineProjectSetupReadiness(ctx context.Context, proj
 		return ProjectSetupReadinessResponse{}, err
 	}
 
-	project := view.snapshot.Project
+	return renderCairnlineProjectSetupReadinessFromRows(view.snapshot.Project, roles, workItems, entries, candidates, skills), nil
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectSetupReadiness(ctx context.Context, projectID string) (ProjectSetupReadinessResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	defer store.Close()
+	item, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return ProjectSetupReadinessResponse{}, projects.ErrNotFound
+	}
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	executionProfile, err := cairnlineExecutionProfileByID(ctx, service, item.DefaultExecutionProfileID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	project := projectFromCairnline(item, executionProfile, projects.Project{})
+	roles, err := service.ListRoles(ctx, project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	workItems, err := service.ListWorkItems(ctx, project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	entries, err := service.ListMemoryEntries(ctx, project.ID, true)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	candidates, err := service.ListMemoryCandidates(ctx, cairnline.MemoryCandidateFilter{
+		ProjectID: project.ID,
+		Status:    cairnline.MemoryCandidatePending,
+	})
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	skills, err := service.ListProjectSkills(ctx, project.ID)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
+	return renderCairnlineProjectSetupReadinessFromRows(project, roles, workItems, entries, candidates, skills), nil
+}
+
+func renderCairnlineProjectSetupReadinessFromRows(project projects.Project, roles []cairnline.Role, workItems []cairnline.WorkItem, entries []cairnline.MemoryEntry, candidates []cairnline.MemoryCandidate, skills []cairnline.ProjectSkill) ProjectSetupReadinessResponse {
 	summary := projectSetupReadinessSummary(
 		project,
 		projectWorkItemsFromCairnline(workItems),
@@ -65,7 +117,7 @@ func (h *Handler) renderCairnlineProjectSetupReadiness(ctx context.Context, proj
 		Summary:        summary,
 		PrimaryAction:  projectSetupReadinessAction(projectSetupReadinessActionBootstrap, project.ID, "Set up project"),
 		Checks:         projectSetupReadinessChecks(project, summary),
-	}, nil
+	}
 }
 
 func projectWorkItemsFromCairnline(items []cairnline.WorkItem) []projectwork.WorkItem {

--- a/internal/api/handler_project_setup_readiness_test.go
+++ b/internal/api/handler_project_setup_readiness_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -256,6 +257,132 @@ func TestProjectSetupReadiness_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	}
 	if response.Data.Summary.MissingDefaults || !response.Data.Summary.HasPurpose || !response.Data.Summary.HasActiveRoot {
 		t.Fatalf("setup readiness summary = %+v, want Hecate defaults/purpose/root over Cairnline setup counts", response.Data.Summary)
+	}
+}
+
+func TestProjectSetupReadiness_StrictEmbeddedReadModelReadsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_setup"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateExecutionProfile(t.Context(), cairnline.ExecutionProfile{
+			ID:           "exec_embedded_setup",
+			Name:         "Embedded setup runtime",
+			ProviderHint: "openai",
+			ModelHint:    "gpt-5",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:                        projectID,
+			Name:                      "Embedded Setup",
+			Description:               "Coordinate setup from embedded Cairnline.",
+			DefaultRootID:             "root_embedded_setup",
+			DefaultExecutionProfileID: "exec_embedded_setup",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_setup",
+				Path:   "/workspace/embedded-setup",
+				Kind:   "git",
+				Active: true,
+			}},
+			ContextSources: []cairnline.Source{{
+				ID:         "ctx_embedded_setup",
+				Kind:       "workspace_instruction",
+				Title:      "AGENTS.md",
+				Locator:    "AGENTS.md",
+				Enabled:    true,
+				Format:     "agents_md",
+				TrustLabel: "workspace_guidance",
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_embedded_setup",
+			ProjectID: projectID,
+			Name:      "Coordinator",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProjectSkill(t.Context(), cairnline.ProjectSkill{
+			ID:          "setup",
+			ProjectID:   projectID,
+			Title:       "Setup",
+			Description: "Coordinate project setup.",
+			Path:        ".agents/skills/setup/SKILL.md",
+			RootID:      "root_embedded_setup",
+			Format:      cairnline.SkillFormatMarkdown,
+			Enabled:     true,
+			Status:      cairnline.SkillStatusAvailable,
+			TrustLabel:  cairnline.SkillTrustWorkspace,
+			SourceRefs:  []string{"ctx_embedded_setup"},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateMemoryEntry(t.Context(), cairnline.MemoryEntry{
+			ID:         "mem_embedded_setup",
+			ProjectID:  projectID,
+			Title:      "Setup note",
+			Body:       "Use explicit setup guidance.",
+			Enabled:    true,
+			TrustLabel: memory.TrustLabelOperatorMemory,
+			SourceKind: memory.SourceKindOperator,
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateMemoryCandidate(t.Context(), cairnline.MemoryCandidate{
+			ID:                  "memcand_embedded_setup",
+			ProjectID:           projectID,
+			Title:               "Setup candidate",
+			Body:                "Review this setup candidate.",
+			Status:              cairnline.MemoryCandidatePending,
+			SuggestedKind:       "note",
+			SuggestedTrustLabel: memory.TrustLabelGenerated,
+			SuggestedSourceKind: memory.SourceKindGenerated,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline setup readiness: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/setup-readiness", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("setup readiness status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectSetupReadinessEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode setup readiness: %v", err)
+	}
+	if response.Object != "project_setup_readiness" || response.Data.ProjectID != projectID || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("setup readiness envelope = %+v, want embedded Cairnline setup readiness", response)
+	}
+	if response.Data.ShowOnboarding || !response.Data.SetupStarted || !response.Data.FirstWorkReady {
+		t.Fatalf("setup readiness flags = %+v, want setup started and first work ready", response.Data)
+	}
+	summary := response.Data.Summary
+	if summary.WorkItemCount != 0 || summary.RoleCount != 1 || summary.SkillCount != 1 || summary.EnabledContextSourceCount != 1 || summary.SavedMemoryCount != 1 || summary.PendingMemoryCandidateCount != 1 {
+		t.Fatalf("setup readiness summary = %+v, want embedded setup counts", summary)
+	}
+	if summary.MissingDefaults || !summary.HasPurpose || !summary.HasActiveRoot {
+		t.Fatalf("setup readiness summary = %+v, want embedded purpose/root/defaults", summary)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/setup-readiness", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project setup readiness status = %d body=%s, want 404", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- route strict embedded Cairnline setup-readiness reads directly through the embedded service
- let setup-readiness work without a Hecate-native project row while preserving missing-project 404s
- share the Cairnline setup-readiness row renderer between snapshot and strict embedded paths
- document setup-readiness as a strict embedded direct-read exception

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectSetupReadiness_(StrictEmbeddedReadModelReadsWithoutHecateProject|CairnlineConfiguredUsesReadModel|ReadsUseCairnlineSidecarWhenConfigured|CairnlineMatchesHecate)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline.*Strict|TestProjectCairnline.*Embedded|TestProjectSetupReadiness_(StrictEmbeddedReadModelReadsWithoutHecateProject|CairnlineConfiguredUsesReadModel|ReadsUseCairnlineSidecarWhenConfigured|CairnlineMatchesHecate)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...