### PR TITLE
Read embedded Cairnline health directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -214,8 +214,8 @@ the snapshot-seeded in-memory bridge projection.
 bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
-project list/detail plus setup-readiness, project skill list, project role list,
-work-item list/detail, assignment-list, artifact-list, handoff-list,
+project list/detail plus setup-readiness, health, project skill list, project
+role list, work-item list/detail, assignment-list, artifact-list, handoff-list,
 closeout-readiness, project memory list, and memory-candidate list reads load
 directly from the embedded Cairnline project, skill, role, work-item,
 assignment, artifact, evidence, review, handoff, and memory records instead of
@@ -227,7 +227,7 @@ execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
-setup-readiness, project role list, work-item list/detail, assignment-list,
+setup-readiness, health, project role list, work-item list/detail, assignment-list,
 artifact-list, handoff-list, closeout-readiness, project memory list, and
 memory-candidate list reads. The explicit sidecar read-source routes remain the
 broader standalone-process exception for project list/detail, setup-readiness,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -394,7 +394,7 @@ launch agents. Those remain explicit operator or orchestrator actions.
   otherwise uses the snapshot-seeded bridge; `snapshot` forces the bridge; and
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
-  list/detail plus setup-readiness, project skill list, project role list,
+  list/detail plus setup-readiness, health, project skill list, project role list,
   work-item list/detail, assignment-list, artifact-list, handoff-list,
   closeout-readiness, project memory list, and memory-candidate list reads can
   load directly from embedded Cairnline rows without first building a Hecate
@@ -404,8 +404,8 @@ launch agents. Those remain explicit operator or orchestrator actions.
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus setup-readiness, skill, role, work-item, assignment-list,
-  artifact-list, handoff-list, closeout-readiness, and memory lists,
+  list/detail plus setup-readiness, health, skill, role, work-item,
+  assignment-list, artifact-list, handoff-list, closeout-readiness, and memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -526,8 +526,8 @@ sequenceDiagram
   routes require a populated embedded mirror database and fail if the database
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
-  reads. Strict embedded project list/detail, setup-readiness, project skill
-  list, project role list, work-item list/detail, assignment-list,
+  reads. Strict embedded project list/detail, setup-readiness, health, project
+  skill list, project role list, work-item list/detail, assignment-list,
   artifact-list, handoff-list, closeout-readiness, project memory list, and
   memory-candidate list reads use the embedded Cairnline project, skill, role,
   work-item, assignment, artifact, evidence, review, handoff, and memory records
@@ -2423,8 +2423,8 @@ lists, handoff lists, Project Assistant context/proposal reads, closeout
 readiness, activity inbox, and operations brief can be served from the Cairnline
 read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
-scaffolding, but strict embedded project list/detail, setup-readiness, project
-skill list, project role list, work-item list/detail, assignment-list,
+scaffolding, but strict embedded project list/detail, setup-readiness, health,
+project skill list, project role list, work-item list/detail, assignment-list,
 artifact-list, handoff-list, closeout-readiness, project memory list, and
 memory-candidate list reads now load directly from the embedded Cairnline
 project, skill, role, work-item, assignment, artifact, evidence, review,

--- a/internal/api/handler_project_health.go
+++ b/internal/api/handler_project_health.go
@@ -74,7 +74,8 @@ type ProjectHealthAttentionItem struct {
 
 func (h *Handler) HandleProjectHealth(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !strictEmbeddedRead && !h.requireProject(w, r, projectID) {
 		return
 	}
 	health, err := h.renderProjectHealth(r.Context(), projectID)

--- a/internal/api/handler_project_health_cairnline.go
+++ b/internal/api/handler_project_health_cairnline.go
@@ -2,21 +2,52 @@ package api
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 func (h *Handler) renderCairnlineProjectHealth(ctx context.Context, projectID string) (ProjectHealthResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectHealth(ctx, projectID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return ProjectHealthResponse{}, err
 	}
 	defer view.Close()
-	service, snapshot := view.service, view.snapshot
+	return h.renderCairnlineProjectHealthFromService(ctx, view.service, view.snapshot)
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectHealth(ctx context.Context, projectID string) (ProjectHealthResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	defer store.Close()
+	item, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return ProjectHealthResponse{}, projects.ErrNotFound
+	}
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	executionProfile, err := cairnlineExecutionProfileByID(ctx, service, item.DefaultExecutionProfileID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
+	return h.renderCairnlineProjectHealthFromService(ctx, service, cairnlinebridge.Snapshot{
+		Project: projectFromCairnline(item, executionProfile, projects.Project{}),
+	})
+}
+
+func (h *Handler) renderCairnlineProjectHealthFromService(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) (ProjectHealthResponse, error) {
 	activity, err := h.renderCairnlineProjectActivityFromService(ctx, service, snapshot)
 	if err != nil {
 		return ProjectHealthResponse{}, err

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -258,6 +259,202 @@ func TestProjectHealth_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	candidate := findProjectHealthAttentionForTest(t, response.Data.Attention, "Memory candidate pending review")
 	if candidate.CandidateID != "memcand_health" || candidate.Action.CandidateID != "memcand_health" {
 		t.Fatalf("candidate attention = %+v, want Cairnline-backed memory candidate target", candidate)
+	}
+}
+
+func TestProjectHealth_StrictEmbeddedReadModelReadsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_health"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateExecutionProfile(t.Context(), cairnline.ExecutionProfile{
+			ID:           "exec_embedded_health",
+			Name:         "Embedded health runtime",
+			ProviderHint: "openai",
+			ModelHint:    "gpt-5",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAgentProfile(t.Context(), cairnline.AgentProfile{
+			ID:       "profile_embedded_health",
+			Name:     "Embedded Health Profile",
+			SkillIDs: []string{"health"},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:                        projectID,
+			Name:                      "Embedded Health",
+			Description:               "Coordinate health from embedded Cairnline.",
+			DefaultRootID:             "root_embedded_health",
+			DefaultProfileID:          "profile_embedded_health",
+			DefaultExecutionProfileID: "exec_embedded_health",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_health",
+				Path:   "/workspace/embedded-health",
+				Kind:   "git",
+				Active: true,
+			}},
+			ContextSources: []cairnline.Source{{
+				ID:         "ctx_embedded_health",
+				Kind:       "workspace_instruction",
+				Title:      "AGENTS.md",
+				Locator:    "AGENTS.md",
+				Enabled:    true,
+				Format:     "agents_md",
+				TrustLabel: "workspace_guidance",
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:               "role_embedded_health",
+			ProjectID:        projectID,
+			Name:             "Health Reviewer",
+			DefaultProfileID: "profile_embedded_health",
+			DefaultSkillIDs:  []string{"health"},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProjectSkill(t.Context(), cairnline.ProjectSkill{
+			ID:          "health",
+			ProjectID:   projectID,
+			Title:       "Health",
+			Description: "Review project health.",
+			Path:        ".agents/skills/health/SKILL.md",
+			RootID:      "root_embedded_health",
+			Format:      cairnline.SkillFormatMarkdown,
+			Enabled:     true,
+			Status:      cairnline.SkillStatusAvailable,
+			TrustLabel:  cairnline.SkillTrustWorkspace,
+			SourceRefs:  []string{"ctx_embedded_health"},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:              "work_embedded_health",
+			ProjectID:       projectID,
+			Title:           "Review embedded health",
+			Brief:           "Exercise embedded Cairnline health projection.",
+			Status:          cairnline.WorkStatusReady,
+			Priority:        cairnline.PriorityNormal,
+			OwnerRoleID:     "role_embedded_health",
+			ReviewerRoleIDs: []string{"role_embedded_health"},
+			RootID:          "root_embedded_health",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_health",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_health",
+			RoleID:        "role_embedded_health",
+			RootID:        "root_embedded_health",
+			ProfileID:     "profile_embedded_health",
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.ClaimAssignment(t.Context(), projectID, "asgn_embedded_health", "agent-health"); err != nil {
+			return err
+		}
+		if _, err := service.UpdateAssignmentStatus(t.Context(), projectID, "asgn_embedded_health", cairnline.AssignmentRunning, "run_embedded_health"); err != nil {
+			return err
+		}
+		if _, err := service.CreateReview(t.Context(), cairnline.Review{
+			ID:             "review_embedded_health",
+			ProjectID:      projectID,
+			WorkItemID:     "work_embedded_health",
+			AssignmentID:   "asgn_embedded_health",
+			ReviewerRoleID: "role_embedded_health",
+			Title:          "Embedded health review",
+			Body:           "Needs follow-up before closeout.",
+			Verdict:        cairnline.ReviewVerdictChangesRequested,
+			Risk:           cairnline.ReviewRiskMedium,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateHandoff(t.Context(), cairnline.Handoff{
+			ID:                    "handoff_embedded_health",
+			ProjectID:             projectID,
+			WorkItemID:            "work_embedded_health",
+			SourceAssignmentID:    "asgn_embedded_health",
+			FromRoleID:            "role_embedded_health",
+			ToRoleID:              "role_embedded_health",
+			Title:                 "Health follow-up",
+			Body:                  "Create a follow-up assignment.",
+			RecommendedNextAction: "Queue a follow-up review.",
+			Status:                cairnline.HandoffStatusOpen,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateMemoryEntry(t.Context(), cairnline.MemoryEntry{
+			ID:         "mem_embedded_health",
+			ProjectID:  projectID,
+			Title:      "Health note",
+			Body:       "Use embedded health projection.",
+			Enabled:    true,
+			TrustLabel: memory.TrustLabelOperatorMemory,
+			SourceKind: memory.SourceKindOperator,
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateMemoryCandidate(t.Context(), cairnline.MemoryCandidate{
+			ID:                  "memcand_embedded_health",
+			ProjectID:           projectID,
+			Title:               "Health candidate",
+			Body:                "Review this health candidate.",
+			Status:              cairnline.MemoryCandidatePending,
+			SuggestedKind:       "note",
+			SuggestedTrustLabel: memory.TrustLabelGenerated,
+			SuggestedSourceKind: memory.SourceKindGenerated,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline health: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("health status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectHealthEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if response.Object != "project_health" || response.Data.ProjectID != projectID || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("health envelope = %+v, want embedded Cairnline health", response)
+	}
+	summary := response.Data.Summary
+	if summary.MissingDefaults || summary.MissingProjectRoot || summary.EnabledContextSourceCount != 1 || summary.EnabledMemoryCount != 1 || summary.PendingMemoryCandidateCount != 1 || summary.PendingHandoffCount != 1 || summary.ReviewFollowUpCount != 1 || summary.ChangesRequestedReviewCount != 1 {
+		t.Fatalf("health summary = %+v, want embedded defaults/root/context/memory/review/handoff counts", summary)
+	}
+	assertProjectHealthItemsHaveActions(t, response.Data.Attention, projectID)
+	handoff := findProjectHealthAttentionForTest(t, response.Data.Attention, "Pending handoff: Review embedded health")
+	assertProjectHealthActionForTest(t, handoff, projectActionOpenWorkItem, projectID)
+	review := findProjectHealthAttentionForTest(t, response.Data.Attention, "Review follow-up: Review embedded health")
+	assertProjectHealthActionForTest(t, review, projectActionOpenWorkItem, projectID)
+	candidate := findProjectHealthAttentionForTest(t, response.Data.Attention, "Memory candidate pending review")
+	if candidate.CandidateID != "memcand_embedded_health" || candidate.Action.CandidateID != "memcand_embedded_health" {
+		t.Fatalf("candidate attention = %+v, want embedded Cairnline memory candidate target", candidate)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/health", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project health status = %d body=%s, want 404", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- route strict embedded project health reads directly through embedded Cairnline instead of requiring a Hecate project snapshot
- skip the native project guard for strict embedded health while preserving 404s for missing embedded projects
- document health in the strict embedded direct-read route lists

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectHealth_(CairnlineConfiguredUsesReadModel|StrictEmbeddedReadModelReadsWithoutHecateProject|CairnlineMatchesHecateProjectionGraph)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- git diff --check