### PR TITLE
Read embedded Cairnline activity directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -215,8 +215,8 @@ bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
 project list/detail plus setup-readiness, health, project skill list, project
-role list, work-item list/detail, assignment-list, artifact-list, handoff-list,
-closeout-readiness, project memory list, and memory-candidate list reads load
+role list, work-item list/detail, assignment-list, activity, artifact-list,
+handoff-list, closeout-readiness, project memory list, and memory-candidate list reads load
 directly from the embedded Cairnline project, skill, role, work-item,
 assignment, artifact, evidence, review, handoff, and memory records instead of
 loading a Hecate-native project snapshot first.
@@ -228,7 +228,7 @@ For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
 setup-readiness, health, project role list, work-item list/detail, assignment-list,
-artifact-list, handoff-list, closeout-readiness, project memory list, and
+activity, artifact-list, handoff-list, closeout-readiness, project memory list, and
 memory-candidate list reads. The explicit sidecar read-source routes remain the
 broader standalone-process exception for project list/detail, setup-readiness,
 health, project skill list, project memory list,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -395,7 +395,7 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
   list/detail plus setup-readiness, health, project skill list, project role list,
-  work-item list/detail, assignment-list, artifact-list, handoff-list,
+  work-item list/detail, assignment-list, activity, artifact-list, handoff-list,
   closeout-readiness, project memory list, and memory-candidate list reads can
   load directly from embedded Cairnline rows without first building a Hecate
   snapshot.
@@ -405,7 +405,7 @@ launch agents. Those remain explicit operator or orchestrator actions.
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
   list/detail plus setup-readiness, health, skill, role, work-item,
-  assignment-list, artifact-list, handoff-list, closeout-readiness, and memory lists,
+  assignment-list, activity, artifact-list, handoff-list, closeout-readiness, and memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -527,7 +527,7 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, setup-readiness, health, project
-  skill list, project role list, work-item list/detail, assignment-list,
+  skill list, project role list, work-item list/detail, assignment-list, activity,
   artifact-list, handoff-list, closeout-readiness, project memory list, and
   memory-candidate list reads use the embedded Cairnline project, skill, role,
   work-item, assignment, artifact, evidence, review, handoff, and memory records
@@ -2425,7 +2425,7 @@ read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, setup-readiness, health,
 project skill list, project role list, work-item list/detail, assignment-list,
-artifact-list, handoff-list, closeout-readiness, project memory list, and
+activity, artifact-list, handoff-list, closeout-readiness, project memory list, and
 memory-candidate list reads now load directly from the embedded Cairnline
 project, skill, role, work-item, assignment, artifact, evidence, review,
 handoff, and memory records. Their

--- a/internal/api/handler_project_activity_cairnline.go
+++ b/internal/api/handler_project_activity_cairnline.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
@@ -10,12 +11,33 @@ import (
 )
 
 func (h *Handler) renderCairnlineProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectActivity(ctx, projectID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if err != nil {
 		return ProjectActivityDataResponse{}, err
 	}
 	defer view.Close()
 	return h.renderCairnlineProjectActivityFromService(ctx, view.service, view.snapshot)
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return ProjectActivityDataResponse{}, projects.ErrNotFound
+	}
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	return h.renderCairnlineProjectActivityFromService(ctx, service, cairnlinebridge.Snapshot{
+		Project: projectFromCairnline(project, nil, projects.Project{}),
+	})
 }
 
 func (h *Handler) renderCairnlineSidecarProjectActivity(ctx context.Context, projectID string) (ProjectActivityDataResponse, error) {

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -329,7 +329,8 @@ type ProjectHandoffResponse struct {
 
 func (h *Handler) HandleProjectActivity(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !strictEmbeddedRead && !h.requireProject(w, r, projectID) {
 		return
 	}
 	activity, err := h.renderProjectActivity(r.Context(), projectID)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -5359,6 +5359,127 @@ func TestProjectWorkAPI_ProjectActivityCairnlineConfiguredUsesReadModel(t *testi
 	}
 }
 
+func TestProjectWorkAPI_ProjectActivityStrictEmbeddedReadModelReadsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_activity"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:            projectID,
+			Name:          "Embedded Activity",
+			DefaultRootID: "root_embedded_activity",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_activity",
+				Path:   "/workspace/embedded-activity",
+				Kind:   "git",
+				Active: true,
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_embedded_activity",
+			ProjectID: projectID,
+			Name:      "Activity Reviewer",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded_activity",
+			ProjectID:   projectID,
+			Title:       "Review embedded activity",
+			Brief:       "Exercise embedded Cairnline activity projection.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_embedded_activity",
+			RootID:      "root_embedded_activity",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_activity",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_activity",
+			RoleID:        "role_embedded_activity",
+			RootID:        "root_embedded_activity",
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.ClaimAssignment(t.Context(), projectID, "asgn_embedded_activity", "agent-activity"); err != nil {
+			return err
+		}
+		if _, err := service.UpdateAssignmentStatus(t.Context(), projectID, "asgn_embedded_activity", cairnline.AssignmentRunning, "run_embedded_activity"); err != nil {
+			return err
+		}
+		if _, err := service.CreateEvidence(t.Context(), cairnline.Evidence{
+			ID:           "ev_embedded_activity",
+			ProjectID:    projectID,
+			WorkItemID:   "work_embedded_activity",
+			AssignmentID: "asgn_embedded_activity",
+			Title:        "Embedded activity evidence",
+			Body:         "Activity can render from embedded Cairnline rows.",
+			SourceKind:   "operator_note",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateHandoff(t.Context(), cairnline.Handoff{
+			ID:                 "handoff_embedded_activity",
+			ProjectID:          projectID,
+			WorkItemID:         "work_embedded_activity",
+			SourceAssignmentID: "asgn_embedded_activity",
+			FromRoleID:         "role_embedded_activity",
+			ToRoleID:           "role_embedded_activity",
+			Title:              "Activity follow-up",
+			Body:               "Keep this handoff visible in activity.",
+			Status:             cairnline.HandoffStatusOpen,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline activity: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/activity", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("activity status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectActivityEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode activity: %v", err)
+	}
+	if response.Object != "project_activity" || response.Data.ProjectID != projectID || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("activity response = %+v, want embedded Cairnline activity", response)
+	}
+	if response.Data.Summary.WorkItemCount != 1 || response.Data.Summary.AssignmentCount != 1 || response.Data.Summary.ActiveCount != 1 || response.Data.Summary.RecentCount != 1 {
+		t.Fatalf("activity summary = %+v, want one active embedded assignment", response.Data.Summary)
+	}
+	item := findProjectActivityItemForTest(t, response.Data.Buckets.Active, "asgn_embedded_activity")
+	if item.BlockingSignal != "running" || item.WorkItem.ID != "work_embedded_activity" || item.Role.ID != "role_embedded_activity" {
+		t.Fatalf("activity item = %+v, want running embedded assignment with work and role enrichment", item)
+	}
+	if item.ArtifactSummary.Count != 1 || item.HandoffSummary.Count != 1 {
+		t.Fatalf("activity item = %+v, want embedded artifact and handoff enrichment", item)
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/activity", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project activity status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_ProjectActivityUsesCairnlineSidecarWhenConfigured(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "collaboration-fixture+strict-projects")


### PR DESCRIPTION
## Summary
- route strict embedded project activity reads directly through embedded Cairnline instead of loading a Hecate project snapshot
- skip the native project guard for strict embedded activity while preserving 404s for missing embedded projects
- document activity in the strict embedded direct-read route lists

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_ProjectActivity(CairnlineConfiguredUsesReadModel|StrictEmbeddedReadModelReadsWithoutHecateProject|CairnlineMatchesHecate)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- git diff --check