### PR TITLE
Read embedded Cairnline operations directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -216,10 +216,10 @@ mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
 project list/detail plus setup-readiness, health, project skill list, project
 role list, work-item list/detail, assignment-list, activity, artifact-list,
-handoff-list, closeout-readiness, project memory list, and memory-candidate list reads load
-directly from the embedded Cairnline project, skill, role, work-item,
-assignment, artifact, evidence, review, handoff, and memory records instead of
-loading a Hecate-native project snapshot first.
+handoff-list, closeout-readiness, operations brief, project memory list, and
+memory-candidate list reads load directly from the embedded Cairnline project,
+skill, role, work-item, assignment, artifact, evidence, review, handoff, and
+memory records instead of loading a Hecate-native project snapshot first.
 Activity, assignment-list, and operations brief reads render work items,
 assignments, roles, artifacts, and handoffs from the Cairnline service records,
 then overlay Hecate-only runtime refs/timestamps where Hecate still owns
@@ -227,11 +227,12 @@ execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
-setup-readiness, health, project role list, work-item list/detail, assignment-list,
-activity, artifact-list, handoff-list, closeout-readiness, project memory list, and
-memory-candidate list reads. The explicit sidecar read-source routes remain the
-broader standalone-process exception for project list/detail, setup-readiness,
-health, project skill list, project memory list,
+setup-readiness, health, project role list, work-item list/detail,
+assignment-list, activity, artifact-list, handoff-list, closeout-readiness,
+operations brief, project memory list, and memory-candidate list reads. The
+explicit sidecar read-source routes remain the broader standalone-process
+exception for project list/detail, setup-readiness, health, project skill list,
+project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,
 artifact-list, handoff-list, activity, closeout-readiness, and operations brief

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -396,16 +396,17 @@ launch agents. Those remain explicit operator or orchestrator actions.
   loudly during replacement-readiness dogfood. In strict embedded mode, project
   list/detail plus setup-readiness, health, project skill list, project role list,
   work-item list/detail, assignment-list, activity, artifact-list, handoff-list,
-  closeout-readiness, project memory list, and memory-candidate list reads can
-  load directly from embedded Cairnline rows without first building a Hecate
-  snapshot.
+  closeout-readiness, operations brief, project memory list, and memory-candidate
+  list reads can load directly from embedded Cairnline rows without first
+  building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, and operations brief reads now render work items,
   assignments, roles, artifacts, and handoffs from Cairnline service records,
   then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
   list/detail plus setup-readiness, health, skill, role, work-item,
-  assignment-list, activity, artifact-list, handoff-list, closeout-readiness, and memory lists,
+  assignment-list, activity, artifact-list, handoff-list, closeout-readiness,
+  operations brief, and memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -528,12 +528,12 @@ sequenceDiagram
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, setup-readiness, health, project
   skill list, project role list, work-item list/detail, assignment-list, activity,
-  artifact-list, handoff-list, closeout-readiness, project memory list, and
-  memory-candidate list reads use the embedded Cairnline project, skill, role,
-  work-item, assignment, artifact, evidence, review, handoff, and memory records
-  directly instead of loading a Hecate snapshot first; other
-  embedded read routes may still use Hecate snapshot scaffolding until their
-  route families are cut over. With
+  artifact-list, handoff-list, closeout-readiness, operations brief, project
+  memory list, and memory-candidate list reads use the embedded Cairnline
+  project, skill, role, work-item, assignment, artifact, evidence, review,
+  handoff, and memory records directly instead of loading a Hecate snapshot
+  first; other embedded read routes may still use Hecate snapshot scaffolding
+  until their route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
   list/detail, setup-readiness, health, project skill list, project memory list,
   memory-candidate list, project role list, work-item list/detail,
@@ -2425,10 +2425,10 @@ read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, setup-readiness, health,
 project skill list, project role list, work-item list/detail, assignment-list,
-activity, artifact-list, handoff-list, closeout-readiness, project memory list, and
-memory-candidate list reads now load directly from the embedded Cairnline
-project, skill, role, work-item, assignment, artifact, evidence, review,
-handoff, and memory records. Their
+activity, artifact-list, handoff-list, closeout-readiness, operations brief,
+project memory list, and memory-candidate list reads now load directly from the
+embedded Cairnline project, skill, role, work-item, assignment, artifact,
+evidence, review, handoff, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the
@@ -5376,6 +5376,9 @@ operator-facing brief through the same Hecate activity projection and cockpit
 action helpers as the native route. Hecate-specific setup/defaults items and
 client actions remain Hecate-owned, so `read_backend` identifies the source of
 the work-operations read model rather than a full Projects backend switch.
+In strict embedded mode, this route verifies project identity in the embedded
+Cairnline database and renders from Cairnline rows without requiring a matching
+Hecate-native project row.
 When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, this endpoint reads project
 identity through `projects.get`, reads portable operation rows through the

--- a/internal/api/handler_project_operations.go
+++ b/internal/api/handler_project_operations.go
@@ -82,7 +82,8 @@ type ProjectOperationsBriefTargetResponse struct {
 
 func (h *Handler) HandleProjectOperationsBrief(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	if !h.projectCairnlineSidecarReadRoutesEnabled() && !h.requireProject(w, r, projectID) {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if !h.projectCairnlineSidecarReadRoutesEnabled() && !strictEmbeddedRead && !h.requireProject(w, r, projectID) {
 		return
 	}
 	brief, err := h.renderProjectOperationsBrief(r.Context(), projectID)
@@ -100,6 +101,9 @@ func (h *Handler) HandleProjectOperationsBrief(w http.ResponseWriter, r *http.Re
 func (h *Handler) renderProjectOperationsBrief(ctx context.Context, projectID string) (ProjectOperationsBriefResponse, error) {
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		return h.renderCairnlineSidecarProjectOperationsBrief(ctx, projectID)
+	}
+	if h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectOperationsBrief(ctx, projectID)
 	}
 	project, ok, err := h.projects.Get(ctx, projectID)
 	if err != nil {

--- a/internal/api/handler_project_operations_cairnline.go
+++ b/internal/api/handler_project_operations_cairnline.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -20,12 +21,38 @@ func (h *Handler) projectReadRoutesUseCairnlineReadModel() bool {
 }
 
 func (h *Handler) renderCairnlineProjectOperationsBrief(ctx context.Context, project projects.Project) (ProjectOperationsBriefResponse, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.renderStrictEmbeddedCairnlineProjectOperationsBrief(ctx, project.ID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, project.ID)
 	if err != nil {
 		return ProjectOperationsBriefResponse{}, err
 	}
 	defer view.Close()
 	return h.renderCairnlineProjectOperationsBriefFromService(ctx, project, view.service, view.snapshot)
+}
+
+func (h *Handler) renderStrictEmbeddedCairnlineProjectOperationsBrief(ctx context.Context, projectID string) (ProjectOperationsBriefResponse, error) {
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	defer store.Close()
+	item, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return ProjectOperationsBriefResponse{}, projects.ErrNotFound
+	}
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	executionProfile, err := cairnlineExecutionProfileByID(ctx, service, item.DefaultExecutionProfileID)
+	if err != nil {
+		return ProjectOperationsBriefResponse{}, err
+	}
+	project := projectFromCairnline(item, executionProfile, projects.Project{})
+	return h.renderCairnlineProjectOperationsBriefFromService(ctx, project, service, cairnlinebridge.Snapshot{
+		Project: project,
+	})
 }
 
 func (h *Handler) renderCairnlineSidecarProjectOperationsBrief(ctx context.Context, projectID string) (ProjectOperationsBriefResponse, error) {

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projects"
@@ -261,6 +262,139 @@ func TestProjectOperationsBrief_CairnlineConfiguredUsesReadModel(t *testing.T) {
 	memoryItem := findProjectOperationsItemForTest(t, response.Data.Items, "review_memory_candidates")
 	if memoryItem.Target.Surface != "memory" || memoryItem.Action.Type != projectOperationsActionOpenMemoryReview {
 		t.Fatalf("memory item = %+v, want memory review action", memoryItem)
+	}
+}
+
+func TestProjectOperationsBrief_StrictEmbeddedReadModelReadsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_operations"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateExecutionProfile(t.Context(), cairnline.ExecutionProfile{
+			ID:           "exec_embedded_operations",
+			Name:         "Embedded operations runtime",
+			ProviderHint: "openai",
+			ModelHint:    "gpt-5",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:                        projectID,
+			Name:                      "Embedded Operations",
+			Description:               "Coordinate operations from embedded Cairnline.",
+			DefaultRootID:             "root_embedded_operations",
+			DefaultExecutionProfileID: "exec_embedded_operations",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_operations",
+				Path:   "/workspace/embedded-operations",
+				Kind:   "git",
+				Active: true,
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_embedded_operations",
+			ProjectID: projectID,
+			Name:      "Operations Reviewer",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded_operations",
+			ProjectID:   projectID,
+			Title:       "Review embedded operations",
+			Brief:       "Exercise embedded Cairnline operations projection.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_embedded_operations",
+			RootID:      "root_embedded_operations",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_operations",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_operations",
+			RoleID:        "role_embedded_operations",
+			RootID:        "root_embedded_operations",
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateHandoff(t.Context(), cairnline.Handoff{
+			ID:                    "handoff_embedded_operations",
+			ProjectID:             projectID,
+			WorkItemID:            "work_embedded_operations",
+			SourceAssignmentID:    "asgn_embedded_operations",
+			FromRoleID:            "role_embedded_operations",
+			ToRoleID:              "role_embedded_operations",
+			Title:                 "Operations follow-up",
+			Body:                  "Keep this handoff visible in operations.",
+			RecommendedNextAction: "Review the queued assignment.",
+			Status:                cairnline.HandoffStatusOpen,
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateMemoryCandidate(t.Context(), cairnline.MemoryCandidate{
+			ID:                  "memcand_embedded_operations",
+			ProjectID:           projectID,
+			Title:               "Operations candidate",
+			Body:                "Review this operations candidate.",
+			Status:              cairnline.MemoryCandidatePending,
+			SuggestedKind:       "note",
+			SuggestedTrustLabel: memory.TrustLabelGenerated,
+			SuggestedSourceKind: memory.SourceKindGenerated,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline operations: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/operations/brief", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("operations brief status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectOperationsBriefEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode operations brief: %v", err)
+	}
+	if response.Object != "project_operations_brief" || response.Data.ProjectID != projectID || response.Data.ReadBackend != "cairnline" {
+		t.Fatalf("operations response = %+v, want embedded Cairnline operations", response)
+	}
+	if response.Data.Summary.PendingMemoryCandidateCount != 1 || response.Data.Summary.PendingHandoffCount != 1 || response.Data.Summary.HighCount != 1 || response.Data.Summary.MediumCount == 0 {
+		t.Fatalf("operations summary = %+v, want queued assignment, memory, and handoff counts", response.Data.Summary)
+	}
+	start := findProjectOperationsItemForTest(t, response.Data.Items, "start_queued_assignment")
+	if start.Target.WorkItemID != "work_embedded_operations" || start.Target.AssignmentID != "asgn_embedded_operations" || start.Action.Type != projectOperationsActionOpenAssignmentPreflight || start.Status != "not_started" {
+		t.Fatalf("start item = %+v, want embedded queued assignment preflight action", start)
+	}
+	handoff := findProjectOperationsItemForTest(t, response.Data.Items, "review_pending_handoff")
+	if handoff.Handoff == nil || handoff.Handoff.ID != "handoff_embedded_operations" || handoff.Action.Type != projectOperationsActionOpenWorkItem {
+		t.Fatalf("handoff item = %+v, want embedded handoff action", handoff)
+	}
+	memoryItem := findProjectOperationsItemForTest(t, response.Data.Items, "review_memory_candidates")
+	if memoryItem.Target.Surface != "memory" || memoryItem.Action.Type != projectOperationsActionOpenMemoryReview {
+		t.Fatalf("memory item = %+v, want embedded memory review action", memoryItem)
+	}
+	requireProjectOperationsItemAbsentForTest(t, response.Data.Items, "configure_project_defaults")
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/operations/brief", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project operations status = %d body=%s, want 404", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- route strict embedded operations brief reads through the embedded Cairnline service without requiring a Hecate project row
- add an embedded-only regression covering queued assignment, handoff, memory candidate, and missing-project behavior
- update runtime and design docs for the operations direct-read exception

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectOperationsBrief_(CairnlineConfiguredUsesReadModel|StrictEmbeddedReadModelReadsWithoutHecateProject|CairnlineMatchesHecateProjectionGraph|UsesCairnlineSidecarWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...