### PR TITLE
Read embedded Cairnline assignment context directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -215,24 +215,25 @@ bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
 project list/detail plus setup-readiness, health, project skill list, project
-role list, work-item list/detail, assignment-list, activity, artifact-list,
-handoff-list, closeout-readiness, operations brief, project memory list, and
-memory-candidate list reads load directly from the embedded Cairnline project,
-skill, role, work-item, assignment, artifact, evidence, review, handoff, and
-memory records instead of loading a Hecate-native project snapshot first.
-Activity, assignment-list, and operations brief reads render work items,
-assignments, roles, artifacts, and handoffs from the Cairnline service records,
-then overlay Hecate-only runtime refs/timestamps where Hecate still owns
-execution.
+role list, work-item list/detail, assignment-list, assignment-context, activity,
+artifact-list, handoff-list, closeout-readiness, operations brief, project
+memory list, and memory-candidate list reads load directly from the embedded
+Cairnline project, skill, role, work-item, assignment, artifact, evidence,
+review, handoff, and memory records instead of loading a Hecate-native project
+snapshot first.
+Activity, assignment-list, assignment-context, and operations brief reads render
+work items, assignments, roles, artifacts, and handoffs from the Cairnline
+service records, then overlay Hecate-only runtime refs/timestamps where Hecate
+still owns execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
 setup-readiness, health, project role list, work-item list/detail,
-assignment-list, activity, artifact-list, handoff-list, closeout-readiness,
-operations brief, project memory list, and memory-candidate list reads. The
-explicit sidecar read-source routes remain the broader standalone-process
-exception for project list/detail, setup-readiness, health, project skill list,
-project memory list,
+assignment-list, assignment-context, activity, artifact-list, handoff-list,
+closeout-readiness, operations brief, project memory list, and memory-candidate
+list reads. The explicit sidecar read-source routes remain the broader
+standalone-process exception for project list/detail, setup-readiness, health,
+project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,
 artifact-list, handoff-list, activity, closeout-readiness, and operations brief

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -395,18 +395,18 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
   list/detail plus setup-readiness, health, project skill list, project role list,
-  work-item list/detail, assignment-list, activity, artifact-list, handoff-list,
-  closeout-readiness, operations brief, project memory list, and memory-candidate
-  list reads can load directly from embedded Cairnline rows without first
-  building a Hecate snapshot.
+  work-item list/detail, assignment-list, assignment-context, activity,
+  artifact-list, handoff-list, closeout-readiness, operations brief, project
+  memory list, and memory-candidate list reads can load directly from embedded
+  Cairnline rows without first building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
-  assignment-list, and operations brief reads now render work items,
-  assignments, roles, artifacts, and handoffs from Cairnline service records,
-  then overlay Hecate-only runtime refs/timestamps while Hecate still owns
+  assignment-list, assignment-context, and operations brief reads now render work
+  items, assignments, roles, artifacts, and handoffs from Cairnline service
+  records, then overlay Hecate-only runtime refs/timestamps while Hecate still owns
   execution. Outside the strict embedded direct-read exceptions for project
   list/detail plus setup-readiness, health, skill, role, work-item,
-  assignment-list, activity, artifact-list, handoff-list, closeout-readiness,
-  operations brief, and memory lists,
+  assignment-list, assignment-context, activity, artifact-list, handoff-list,
+  closeout-readiness, operations brief, and memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -527,13 +527,13 @@ sequenceDiagram
   or requested project row/proposal record is missing. Run
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, setup-readiness, health, project
-  skill list, project role list, work-item list/detail, assignment-list, activity,
-  artifact-list, handoff-list, closeout-readiness, operations brief, project
-  memory list, and memory-candidate list reads use the embedded Cairnline
-  project, skill, role, work-item, assignment, artifact, evidence, review,
-  handoff, and memory records directly instead of loading a Hecate snapshot
-  first; other embedded read routes may still use Hecate snapshot scaffolding
-  until their route families are cut over. With
+  skill list, project role list, work-item list/detail, assignment-list,
+  assignment-context, activity, artifact-list, handoff-list, closeout-readiness,
+  operations brief, project memory list, and memory-candidate list reads use the
+  embedded Cairnline project, skill, role, work-item, assignment, artifact,
+  evidence, review, handoff, and memory records directly instead of loading a
+  Hecate snapshot first; other embedded read routes may still use Hecate
+  snapshot scaffolding until their route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
   list/detail, setup-readiness, health, project skill list, project memory list,
   memory-candidate list, project role list, work-item list/detail,
@@ -2425,10 +2425,10 @@ read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, setup-readiness, health,
 project skill list, project role list, work-item list/detail, assignment-list,
-activity, artifact-list, handoff-list, closeout-readiness, operations brief,
-project memory list, and memory-candidate list reads now load directly from the
-embedded Cairnline project, skill, role, work-item, assignment, artifact,
-evidence, review, handoff, and memory records. Their
+assignment-context, activity, artifact-list, handoff-list, closeout-readiness,
+operations brief, project memory list, and memory-candidate list reads now load
+directly from the embedded Cairnline project, skill, role, work-item,
+assignment, artifact, evidence, review, handoff, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the
@@ -5811,6 +5811,10 @@ does not create a Task, Run, Chat session, external-agent execution, memory
 entry, artifact, or assignment update. It shows portable project/work/role,
 profile, skill, source, memory, evidence, review, and handoff metadata so the
 operator can inspect what Cairnline would hand to a compatible orchestrator.
+
+In strict embedded mode, the endpoint reads the assignment context directly
+from the embedded Cairnline database and does not require a matching
+Hecate-native project or assignment row.
 
 With the default Hecate backend, unstarted assignments, rows without a stored
 packet or execution link, or older runs that predate snapshots return

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -134,6 +134,23 @@ func (h *Handler) HandleProjectWorkAssignmentContext(w http.ResponseWriter, r *h
 		writeChatContextPacket(w, chatcontext.Normalize(packet, chatcontext.ProjectAssignmentRefs(projectID, workItemID, assignmentID, roleID)))
 		return
 	}
+	if h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads() {
+		packet, ok, err := h.contextPacketForStrictEmbeddedCairnlineProjectAssignment(ctx, projectID, workItemID, assignmentID)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		if !ok {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project assignment context packet not found")
+			return
+		}
+		roleID := ""
+		if packet.Refs != nil {
+			roleID = packet.Refs.RoleID
+		}
+		writeChatContextPacket(w, chatcontext.Normalize(packet, chatcontext.ProjectAssignmentRefs(projectID, workItemID, assignmentID, roleID)))
+		return
+	}
 	if h.projectWork == nil {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project work store is not configured")
 		return

--- a/internal/api/handler_chat_context_cairnline.go
+++ b/internal/api/handler_chat_context_cairnline.go
@@ -40,6 +40,28 @@ func (h *Handler) cairnlineAssignmentLaunchPacket(ctx context.Context, assignmen
 	return view.service.AssignmentLaunchPacket(ctx, view.snapshot.Project.ID, assignment.ID)
 }
 
+func (h *Handler) contextPacketForStrictEmbeddedCairnlineProjectAssignment(ctx context.Context, projectID, workItemID, assignmentID string) (chat.ContextPacket, bool, error) {
+	projectID = strings.TrimSpace(projectID)
+	workItemID = strings.TrimSpace(workItemID)
+	assignmentID = strings.TrimSpace(assignmentID)
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return chat.ContextPacket{}, false, err
+	}
+	defer store.Close()
+	context, err := service.AssignmentContext(ctx, projectID, assignmentID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return chat.ContextPacket{}, false, nil
+	}
+	if err != nil {
+		return chat.ContextPacket{}, false, err
+	}
+	if cairnlineSidecarAssignmentContextRouteMismatch(context, projectID, workItemID, assignmentID) {
+		return chat.ContextPacket{}, false, nil
+	}
+	return cairnlineAssignmentContextPacket(context), true, nil
+}
+
 func (h *Handler) contextPacketForCairnlineSidecarProjectAssignment(ctx context.Context, projectID, workItemID, assignmentID string) (chat.ContextPacket, bool, error) {
 	projectID = strings.TrimSpace(projectID)
 	workItemID = strings.TrimSpace(workItemID)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3091,6 +3091,100 @@ func TestProjectWorkAPI_AssignmentContextUsesCairnlineSidecarWhenConfigured(t *t
 	}
 }
 
+func TestProjectWorkAPI_AssignmentContextStrictEmbeddedReadModelReadsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_assignment_context"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:            projectID,
+			Name:          "Embedded Assignment Context",
+			Description:   "Coordinate assignment context from embedded Cairnline.",
+			DefaultRootID: "root_embedded_assignment_context",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_assignment_context",
+				Path:   "/workspace/embedded-assignment-context",
+				Kind:   "git",
+				Active: true,
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:        "role_embedded_assignment_context",
+			ProjectID: projectID,
+			Name:      "Context Reviewer",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded_assignment_context",
+			ProjectID:   projectID,
+			Title:       "Review embedded assignment context",
+			Brief:       "Exercise embedded Cairnline assignment context projection.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_embedded_assignment_context",
+			RootID:      "root_embedded_assignment_context",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_assignment_context",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_assignment_context",
+			RoleID:        "role_embedded_assignment_context",
+			RootID:        "root_embedded_assignment_context",
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline assignment context: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_assignment_context/assignments/asgn_embedded_assignment_context/context", "")
+	if packetResp.Data.ExecutionMode != cairnline.ExecutionMCPPull {
+		t.Fatalf("assignment context execution mode = %q, want mcp_pull", packetResp.Data.ExecutionMode)
+	}
+	if packetResp.Data.Refs == nil || packetResp.Data.Refs.ProjectID != projectID || packetResp.Data.Refs.WorkItemID != "work_embedded_assignment_context" || packetResp.Data.Refs.AssignmentID != "asgn_embedded_assignment_context" || packetResp.Data.Refs.RoleID != "role_embedded_assignment_context" {
+		t.Fatalf("assignment context refs = %+v, want embedded project/work/assignment/role refs", packetResp.Data.Refs)
+	}
+	if packetResp.Data.Refs.TaskID != "" || packetResp.Data.Refs.RunID != "" || packetResp.Data.Refs.SessionID != "" {
+		t.Fatalf("assignment context refs = %+v, want no task/run/session side effects", packetResp.Data.Refs)
+	}
+	item := findRenderedContextItemByOrigin(packetResp.Data, "cairnline.assignments.context")
+	if item == nil || item.Section != contextSectionRuntime || item.Included || item.Metadata["read_backend"] != "cairnline" || item.Metadata["source_tool"] != "assignments.context" {
+		t.Fatalf("embedded assignment context runtime item = %+v, want inspect-only assignments.context metadata", item)
+	}
+	workItem := findRenderedContextItemByOrigin(packetResp.Data, "work_embedded_assignment_context")
+	if workItem == nil || workItem.Section != contextSectionProjectWork || !workItem.Included {
+		t.Fatalf("embedded assignment work item = %+v, want included project-work metadata", workItem)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_other/assignments/asgn_embedded_assignment_context/context", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("route-mismatched assignment context status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_missing/work-items/work_embedded_assignment_context/assignments/asgn_embedded_assignment_context/context", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing project assignment context status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_AssignmentContextCairnlineSidecarRequiresStructuredContent(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "assignments.context-text-only")


### PR DESCRIPTION
## Summary
- route strict embedded assignment context reads through the embedded Cairnline service without requiring Hecate-native project/work/assignment rows
- preserve assignment route mismatch checks and normalized project/work/assignment refs
- document assignment-context as a direct strict embedded read route

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_AssignmentContext(UsesCairnlineSidecarWhenConfigured|StrictEmbeddedReadModelReadsWithoutHecateProject|CairnlineSidecarRejectsRouteMismatch|CairnlineSidecarRejectsProjectMismatch|CairnlineSidecarRejectsContextProjectMismatch)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...