### PR TITLE
Read embedded Cairnline launch preflight directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -215,23 +215,26 @@ bridge; `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` requires the embedded
 mirror database and requested project row or proposal record so
 replacement-readiness gaps fail loudly during dogfood. In strict embedded mode,
 project list/detail plus setup-readiness, health, project skill list, project
-role list, work-item list/detail, assignment-list, assignment-context, activity,
-artifact-list, handoff-list, closeout-readiness, operations brief, project
-memory list, and memory-candidate list reads load directly from the embedded
-Cairnline project, skill, role, work-item, assignment, artifact, evidence,
-review, handoff, and memory records instead of loading a Hecate-native project
-snapshot first.
-Activity, assignment-list, assignment-context, and operations brief reads render
-work items, assignments, roles, artifacts, and handoffs from the Cairnline
-service records, then overlay Hecate-only runtime refs/timestamps where Hecate
+role list, work-item list/detail, assignment-list, assignment-context,
+launch-readiness, assignment preflight, activity, artifact-list, handoff-list,
+closeout-readiness, operations brief, project memory list, and
+memory-candidate list reads load directly from the embedded Cairnline project,
+skill, role, work-item, assignment, launch-packet, artifact, evidence, review,
+handoff, and memory records instead of loading a Hecate-native project snapshot
+first.
+Activity, assignment-list, assignment-context, launch-readiness, assignment
+preflight, and operations brief reads render work items, assignments, roles,
+artifacts, and handoffs from the Cairnline service records, then overlay
+Hecate-only runtime refs/timestamps and runtime launch validation where Hecate
 still owns execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
 setup-readiness, health, project role list, work-item list/detail,
-assignment-list, assignment-context, activity, artifact-list, handoff-list,
-closeout-readiness, operations brief, project memory list, and memory-candidate
-list reads. The explicit sidecar read-source routes remain the broader
+assignment-list, assignment-context, launch-readiness, assignment preflight,
+activity, artifact-list, handoff-list, closeout-readiness, operations brief,
+project memory list, and memory-candidate list reads. The explicit sidecar
+read-source routes remain the broader
 standalone-process exception for project list/detail, setup-readiness, health,
 project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -395,18 +395,21 @@ launch agents. Those remain explicit operator or orchestrator actions.
   `embedded` requires a populated embedded mirror so read-route drift fails
   loudly during replacement-readiness dogfood. In strict embedded mode, project
   list/detail plus setup-readiness, health, project skill list, project role list,
-  work-item list/detail, assignment-list, assignment-context, activity,
-  artifact-list, handoff-list, closeout-readiness, operations brief, project
-  memory list, and memory-candidate list reads can load directly from embedded
-  Cairnline rows without first building a Hecate snapshot.
+  work-item list/detail, assignment-list, assignment-context, launch-readiness,
+  assignment preflight, activity, artifact-list, handoff-list,
+  closeout-readiness, operations brief, project memory list, and
+  memory-candidate list reads can load directly from embedded Cairnline rows
+  without first building a Hecate snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
-  assignment-list, assignment-context, and operations brief reads now render work
-  items, assignments, roles, artifacts, and handoffs from Cairnline service
-  records, then overlay Hecate-only runtime refs/timestamps while Hecate still owns
-  execution. Outside the strict embedded direct-read exceptions for project
+  assignment-list, assignment-context, launch-readiness, assignment preflight,
+  and operations brief reads now render work items, assignments, roles,
+  artifacts, and handoffs from Cairnline service records, then overlay
+  Hecate-only runtime refs/timestamps and runtime launch validation while Hecate
+  still owns execution. Outside the strict embedded direct-read exceptions for project
   list/detail plus setup-readiness, health, skill, role, work-item,
-  assignment-list, assignment-context, activity, artifact-list, handoff-list,
-  closeout-readiness, operations brief, and memory lists,
+  assignment-list, assignment-context, launch-readiness, assignment preflight,
+  activity, artifact-list, handoff-list, closeout-readiness, operations brief,
+  and memory lists,
   and outside the explicit sidecar read-source routes for project list/detail,
   setup-readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -528,9 +528,10 @@ sequenceDiagram
   `POST /hecate/v1/projects/cairnline/sync` first when testing strict embedded
   reads. Strict embedded project list/detail, setup-readiness, health, project
   skill list, project role list, work-item list/detail, assignment-list,
-  assignment-context, activity, artifact-list, handoff-list, closeout-readiness,
-  operations brief, project memory list, and memory-candidate list reads use the
-  embedded Cairnline project, skill, role, work-item, assignment, artifact,
+  assignment-context, launch-readiness, assignment preflight, activity,
+  artifact-list, handoff-list, closeout-readiness, operations brief, project
+  memory list, and memory-candidate list reads use the embedded Cairnline
+  project, skill, role, work-item, assignment, launch-packet, artifact,
   evidence, review, handoff, and memory records directly instead of loading a
   Hecate snapshot first; other embedded read routes may still use Hecate
   snapshot scaffolding until their route families are cut over. With
@@ -2425,10 +2426,11 @@ read model, while other live Projects reads still use Hecate. Most of those
 configured embedded read routes still load Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, setup-readiness, health,
 project skill list, project role list, work-item list/detail, assignment-list,
-assignment-context, activity, artifact-list, handoff-list, closeout-readiness,
-operations brief, project memory list, and memory-candidate list reads now load
-directly from the embedded Cairnline project, skill, role, work-item,
-assignment, artifact, evidence, review, handoff, and memory records. Their
+assignment-context, launch-readiness, assignment preflight, activity,
+artifact-list, handoff-list, closeout-readiness, operations brief, project
+memory list, and memory-candidate list reads now load directly from the embedded
+Cairnline project, skill, role, work-item, assignment, launch-packet, artifact,
+evidence, review, handoff, and memory records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the
@@ -5840,6 +5842,10 @@ read from the Cairnline read model and the response includes
 task-store/runner availability, active execution lookup, workspace validation,
 provider/model readiness, and External Agent adapter validation.
 
+In strict embedded mode, the endpoint reads the launch packet directly from the
+embedded Cairnline database and does not require a matching Hecate-native
+project, work item, assignment, or role row.
+
 The response envelope is:
 
 ```json
@@ -5924,6 +5930,10 @@ portable assignment launch packet and summarizes portable project/work/root,
 role, profile, execution profile, skills, evidence, reviews, handoffs, memory,
 and memory-candidate counts. It is replacement-readiness evidence only; Hecate
 still owns dispatch validation and the subsequent start/prepare mutation.
+
+In strict embedded mode, preflight reads the launch packet directly from the
+embedded Cairnline database and does not require a matching Hecate-native
+project, work item, assignment, or role row.
 
 The Projects cockpit uses this endpoint before `Start assignment`, `Prepare
 chat`, and `Start from handoff` so the operator can review the effective launch

--- a/internal/api/handler_chat_context_cairnline.go
+++ b/internal/api/handler_chat_context_cairnline.go
@@ -32,6 +32,14 @@ func (h *Handler) contextPacketForCairnlineProjectAssignment(ctx context.Context
 }
 
 func (h *Handler) cairnlineAssignmentLaunchPacket(ctx context.Context, assignment projectwork.Assignment) (cairnline.AssignmentLaunchPacket, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+		if err != nil {
+			return cairnline.AssignmentLaunchPacket{}, err
+		}
+		defer store.Close()
+		return service.AssignmentLaunchPacket(ctx, assignment.ProjectID, assignment.ID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, assignment.ProjectID)
 	if err != nil {
 		return cairnline.AssignmentLaunchPacket{}, err

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -421,6 +421,9 @@ type projectAssignmentLaunchInputs struct {
 }
 
 func (h *Handler) cairnlineProjectAssignmentLaunchInputs(ctx context.Context, projectID, workItemID, assignmentID string) (projectAssignmentLaunchInputs, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.strictEmbeddedCairnlineProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, projectID)
 	if errors.Is(err, projects.ErrNotFound) {
 		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "project not found")
@@ -465,6 +468,65 @@ func (h *Handler) cairnlineProjectAssignmentLaunchInputs(ctx context.Context, pr
 		Assignment: assignment,
 		Role:       role,
 		RoleOK:     roleOK,
+	}, nil
+}
+
+func (h *Handler) strictEmbeddedCairnlineProjectAssignmentLaunchInputs(ctx context.Context, projectID, workItemID, assignmentID string) (projectAssignmentLaunchInputs, error) {
+	projectID = strings.TrimSpace(projectID)
+	workItemID = strings.TrimSpace(workItemID)
+	assignmentID = strings.TrimSpace(assignmentID)
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	defer store.Close()
+	if _, err := service.GetProject(ctx, projectID); err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "project not found")
+		}
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if _, err := service.GetWorkItem(ctx, projectID, workItemID); err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "work item not found")
+		}
+		return projectAssignmentLaunchInputs{}, err
+	}
+	launch, err := service.AssignmentLaunchPacket(ctx, projectID, assignmentID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
+	}
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if cairnlineSidecarLaunchPacketRouteMismatch(launch, projectID, workItemID, assignmentID) {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
+	}
+	projectExecutionProfile, err := cairnlineExecutionProfileByID(ctx, service, launch.Project.DefaultExecutionProfileID)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	project := projectFromCairnline(launch.Project, projectExecutionProfile, projects.Project{})
+	workItem := projectWorkItemFromCairnline(launch.WorkItem)
+	assignment := projectWorkAssignmentFromCairnline(launch.Assignment)
+	if h.projectWork != nil {
+		if native, ok, err := h.loadProjectWorkAssignmentForCairnlineMirror(ctx, project.ID, assignment.ID); err != nil {
+			return projectAssignmentLaunchInputs{}, err
+		} else if ok {
+			assignment.ExecutionRef = native.ExecutionRef
+		}
+	}
+	role, roleOK, err := cairnlineLaunchRole(ctx, service, cairnlinebridge.Snapshot{}, launch)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	return projectAssignmentLaunchInputs{
+		Project:               project,
+		WorkItem:              workItem,
+		Assignment:            assignment,
+		Role:                  role,
+		RoleOK:                roleOK,
+		CairnlineLaunchPacket: launch,
 	}, nil
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3007,6 +3007,144 @@ func TestProjectWorkAPI_PreflightAssignmentUsesCairnlineSidecarLaunchPacketWhenC
 	}
 }
 
+func TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_launch_preflight"
+	workspace := t.TempDir()
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateExecutionProfile(t.Context(), cairnline.ExecutionProfile{
+			ID:           "exec_embedded_launch_preflight",
+			Name:         "Embedded launch preflight",
+			ProviderHint: "anthropic",
+			ModelHint:    "claude-sonnet-4",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:                        projectID,
+			Name:                      "Embedded Launch Preflight",
+			Description:               "Coordinate launch preflight from embedded Cairnline.",
+			DefaultRootID:             "root_embedded_launch_preflight",
+			DefaultExecutionProfileID: "exec_embedded_launch_preflight",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_launch_preflight",
+				Path:   workspace,
+				Kind:   "git",
+				Active: true,
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:                        "role_embedded_launch_preflight",
+			ProjectID:                 projectID,
+			Name:                      "Launch Reviewer",
+			DefaultExecutionProfileID: "exec_embedded_launch_preflight",
+			DefaultExecutionMode:      cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded_launch_preflight",
+			ProjectID:   projectID,
+			Title:       "Review embedded launch preflight",
+			Brief:       "Exercise embedded Cairnline launch readiness and preflight projection.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_embedded_launch_preflight",
+			RootID:      "root_embedded_launch_preflight",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_launch_preflight",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_launch_preflight",
+			RoleID:        "role_embedded_launch_preflight",
+			RootID:        "root_embedded_launch_preflight",
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline launch preflight: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	client := newAPITestClient(t, server)
+	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_launch_preflight/assignments/asgn_embedded_launch_preflight/launch-readiness", "")
+	if readiness.Data.ReadBackend != "cairnline" || !readiness.Data.Ready || readiness.Data.Status != projectAssignmentLaunchReadinessStatusReady {
+		t.Fatalf("embedded launch readiness = %+v, want ready Cairnline read", readiness.Data)
+	}
+	if readiness.Data.Workspace != workspace || readiness.Data.RootID != "root_embedded_launch_preflight" || readiness.Data.Provider != "anthropic" || readiness.Data.Model != "claude-sonnet-4" {
+		t.Fatalf("embedded launch readiness target = workspace/provider/model/root %q/%q/%q/%q, want %q/anthropic/claude-sonnet-4/root", readiness.Data.Workspace, readiness.Data.Provider, readiness.Data.Model, readiness.Data.RootID, workspace)
+	}
+
+	packetResp := mustRequestJSON[ChatContextPacketResponse](client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_launch_preflight/assignments/asgn_embedded_launch_preflight/preflight", "")
+	if packetResp.Data.ExecutionMode != chat.ExecutionModeHecateTask || packetResp.Data.Provider != "anthropic" || packetResp.Data.Model != "claude-sonnet-4" || packetResp.Data.Workspace != workspace {
+		t.Fatalf("embedded preflight launch shape = mode/provider/model/workspace %q/%q/%q/%q, want hecate_task/anthropic/claude-sonnet-4/%q", packetResp.Data.ExecutionMode, packetResp.Data.Provider, packetResp.Data.Model, packetResp.Data.Workspace, workspace)
+	}
+	if packetResp.Data.Refs == nil || packetResp.Data.Refs.ProjectID != projectID || packetResp.Data.Refs.WorkItemID != "work_embedded_launch_preflight" || packetResp.Data.Refs.AssignmentID != "asgn_embedded_launch_preflight" || packetResp.Data.Refs.RoleID != "role_embedded_launch_preflight" {
+		t.Fatalf("embedded preflight refs = %+v, want embedded project/work/assignment/role refs", packetResp.Data.Refs)
+	}
+	if packetResp.Data.Refs.TaskID != "" || packetResp.Data.Refs.RunID != "" || packetResp.Data.Refs.SessionID != "" {
+		t.Fatalf("embedded preflight refs = %+v, want no task/run/session side effects", packetResp.Data.Refs)
+	}
+	item := findRenderedContextItemByKind(packetResp.Data, "cairnline_launch_packet")
+	if item == nil || item.Section != contextSectionRuntime || item.Included || item.Origin != "cairnline.assignment_launch_packet" {
+		t.Fatalf("embedded launch packet evidence = %+v, want inspect-only Cairnline runtime evidence", item)
+	}
+	for _, want := range []string{
+		"Ready: true",
+		"Project: " + projectID,
+		"Work item: work_embedded_launch_preflight",
+		"Assignment: asgn_embedded_launch_preflight",
+		"Execution mode: mcp_pull",
+		"Root: root_embedded_launch_preflight",
+	} {
+		if !strings.Contains(item.Body, want) {
+			t.Fatalf("embedded launch packet body = %q, want %q", item.Body, want)
+		}
+	}
+	for key, want := range map[string]string{
+		"read_backend":   "cairnline",
+		"ready":          "true",
+		"project_id":     projectID,
+		"work_item_id":   "work_embedded_launch_preflight",
+		"assignment_id":  "asgn_embedded_launch_preflight",
+		"role_id":        "role_embedded_launch_preflight",
+		"root_id":        "root_embedded_launch_preflight",
+		"execution_mode": "mcp_pull",
+	} {
+		if item.Metadata[key] != want {
+			t.Fatalf("embedded launch packet metadata[%q] = %q, want %q in %+v", key, item.Metadata[key], want, item.Metadata)
+		}
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want no task created by embedded preflight", tasks)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_other/assignments/asgn_embedded_launch_preflight/preflight", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("route-mismatched embedded preflight status = %d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProjectWorkAPI_PreflightAssignmentCairnlineSidecarRequiresStructuredLaunchPacket(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "assignments.launch_packet-text-only")


### PR DESCRIPTION
## Summary
- resolve strict embedded assignment launch inputs directly from the embedded Cairnline database
- make launch-readiness and preflight work without matching Hecate-native project/work/assignment/role rows
- keep Hecate-owned runtime validation and inspect-only launch-packet evidence
- update Projects and runtime docs for the direct strict embedded route family

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(PreflightAssignment(UsesCairnlineSidecarLaunchPacketWhenConfigured|StrictEmbeddedReadModelReadsWithoutHecateProject|CairnlineSidecarRequiresStructuredLaunchPacket|CairnlineSidecarRejectsRouteMismatch|CairnlineSidecarRejectsProjectMismatch)|PreflightAndStartIncludeCairnlineLaunchPacketEvidenceWhenConfigured)'
- just docs-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...