### PR TITLE
Read embedded Cairnline assistant context directly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -218,32 +218,34 @@ project list/detail plus setup-readiness, health, project skill list, project
 role list, work-item list/detail, assignment-list, assignment-context,
 launch-readiness, assignment preflight, activity, artifact-list, handoff-list,
 closeout-readiness, operations brief, project memory list, and
-memory-candidate list reads load directly from the embedded Cairnline project,
-skill, role, work-item, assignment, launch-packet, artifact, evidence, review,
-handoff, and memory records instead of loading a Hecate-native project snapshot
+memory-candidate list reads plus Project Assistant context/proposal reads load
+directly from the embedded Cairnline project, skill, role, work-item,
+assignment, launch-packet, artifact, evidence, review, handoff, memory, and
+assistant proposal records instead of loading a Hecate-native project snapshot
 first.
 Activity, assignment-list, assignment-context, launch-readiness, assignment
-preflight, and operations brief reads render work items, assignments, roles,
-artifacts, and handoffs from the Cairnline service records, then overlay
-Hecate-only runtime refs/timestamps and runtime launch validation where Hecate
-still owns execution.
+preflight, Project Assistant context/proposal, and operations brief reads render
+work items, assignments, roles, artifacts, and handoffs from the Cairnline
+service records, then overlay Hecate-only runtime refs/timestamps and runtime
+launch validation where Hecate still owns execution.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,
 setup-readiness, health, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,
 activity, artifact-list, handoff-list, closeout-readiness, operations brief,
-project memory list, and memory-candidate list reads. The explicit sidecar
-read-source routes remain the broader
+project memory list, memory-candidate list, and Project Assistant
+context/proposal reads. The explicit sidecar read-source routes remain the broader
 standalone-process exception for project list/detail, setup-readiness, health,
 project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,
 artifact-list, handoff-list, activity, closeout-readiness, and operations brief
 reads.
-Project Assistant draft generation also uses the Cairnline-projected context so
-preview and proposal assembly stay aligned, while the proposal ledger remains
-Hecate-owned unless `project-assistant-proposals` is enabled.
+Project Assistant draft generation also uses the same Cairnline-projected
+context, including strict embedded direct context, so preview and proposal
+assembly stay aligned, while the proposal ledger remains Hecate-owned unless
+`project-assistant-proposals` is enabled.
 Confirmed Project Assistant apply routes project create, project
 metadata/default, root, role, work-item, assignment, handoff, and
 memory-candidate actions through the same opt-in Cairnline authority

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -398,27 +398,29 @@ launch agents. Those remain explicit operator or orchestrator actions.
   work-item list/detail, assignment-list, assignment-context, launch-readiness,
   assignment preflight, activity, artifact-list, handoff-list,
   closeout-readiness, operations brief, project memory list, and
-  memory-candidate list reads can load directly from embedded Cairnline rows
-  without first building a Hecate snapshot.
+  memory-candidate list reads plus Project Assistant context/proposal reads can
+  load directly from embedded Cairnline rows without first building a Hecate
+  snapshot.
 - In configured Hecate embed mode, activity, work-item list/detail,
   assignment-list, assignment-context, launch-readiness, assignment preflight,
-  and operations brief reads now render work items, assignments, roles,
-  artifacts, and handoffs from Cairnline service records, then overlay
-  Hecate-only runtime refs/timestamps and runtime launch validation while Hecate
-  still owns execution. Outside the strict embedded direct-read exceptions for project
-  list/detail plus setup-readiness, health, skill, role, work-item,
-  assignment-list, assignment-context, launch-readiness, assignment preflight,
-  activity, artifact-list, handoff-list, closeout-readiness, operations brief,
-  and memory lists,
-  and outside the explicit sidecar read-source routes for project list/detail,
-  setup-readiness, health, skills, memory, memory candidates, roles, work items,
-  assignment lists, assignment context, launch-readiness, assignment preflight,
-  artifact lists, handoff lists, activity, closeout readiness, and operations
-  brief, some project compatibility
+  Project Assistant context/proposal, and operations brief reads now render work
+  items, assignments, roles, artifacts, and handoffs from Cairnline service
+  records, then overlay Hecate-only runtime refs/timestamps and runtime launch
+  validation while Hecate still owns execution. Outside the strict embedded
+  direct-read exceptions for project list/detail plus setup-readiness, health,
+  skill, role, work-item, assignment-list, assignment-context,
+  launch-readiness, assignment preflight, activity, artifact-list,
+  handoff-list, closeout-readiness, operations brief, memory lists, and Project
+  Assistant context/proposal, and outside the explicit sidecar read-source
+  routes for project list/detail, setup-readiness, health, skills, memory,
+  memory candidates, roles, work items, assignment lists, assignment context,
+  launch-readiness, assignment preflight, artifact lists, handoff lists,
+  activity, closeout readiness, and operations brief, some project compatibility
   scaffolding remains Hecate-owned until Cairnline becomes authoritative.
 - Project Assistant draft generation can use the same Cairnline-projected
-  context as the inspect endpoint, so proposal assembly is exercised against the
-  portable read model while proposal persistence and apply remain Hecate-owned.
+  context as the inspect endpoint, including strict embedded direct context, so
+  proposal assembly is exercised against the portable read model while proposal
+  persistence and apply remain Hecate-owned.
 - Hecate launch-readiness and assignment preflight can read Cairnline
   project/work/assignment/role coordination records before applying Hecate-owned
   runtime validation. Native assignment preflight/start context packets can

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -530,11 +530,12 @@ sequenceDiagram
   skill list, project role list, work-item list/detail, assignment-list,
   assignment-context, launch-readiness, assignment preflight, activity,
   artifact-list, handoff-list, closeout-readiness, operations brief, project
-  memory list, and memory-candidate list reads use the embedded Cairnline
-  project, skill, role, work-item, assignment, launch-packet, artifact,
-  evidence, review, handoff, and memory records directly instead of loading a
-  Hecate snapshot first; other embedded read routes may still use Hecate
-  snapshot scaffolding until their route families are cut over. With
+  memory list, and memory-candidate list reads plus Project Assistant
+  context/proposal reads use the embedded Cairnline project, skill, role,
+  work-item, assignment, launch-packet, artifact, evidence, review, handoff,
+  memory, and assistant proposal records directly instead of loading a Hecate
+  snapshot first; other embedded read routes may still use Hecate snapshot
+  scaffolding until their route families are cut over. With
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar`, `sidecar` routes project
   list/detail, setup-readiness, health, project skill list, project memory list,
   memory-candidate list, project role list, work-item list/detail,
@@ -2428,9 +2429,10 @@ scaffolding, but strict embedded project list/detail, setup-readiness, health,
 project skill list, project role list, work-item list/detail, assignment-list,
 assignment-context, launch-readiness, assignment preflight, activity,
 artifact-list, handoff-list, closeout-readiness, operations brief, project
-memory list, and memory-candidate list reads now load directly from the embedded
-Cairnline project, skill, role, work-item, assignment, launch-packet, artifact,
-evidence, review, handoff, and memory records. Their
+memory list, and memory-candidate list reads plus Project Assistant
+context/proposal reads now load directly from the embedded Cairnline project,
+skill, role, work-item, assignment, launch-packet, artifact, evidence, review,
+handoff, memory, and assistant proposal records. Their
 Cairnline service read source is controlled by
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`: `auto` prefers the embedded mirror and
 falls back to the snapshot-seeded bridge, `snapshot` always uses the
@@ -6314,9 +6316,11 @@ from the configured Cairnline read source. With
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, the context packet is composed
 from typed sidecar project/work/skill/memory read tools and rejects malformed or
-text-only sidecar output. Draft generation uses the same Cairnline-projected
-context so preview and proposal assembly do not drift, while proposal ledger
-writes remain Hecate-owned unless
+text-only sidecar output. In strict embedded mode, the context packet is seeded
+directly from the embedded Cairnline database and does not require a matching
+Hecate-native project row. Draft generation uses the same
+Cairnline-projected context so preview and proposal assembly do not drift,
+while proposal ledger writes remain Hecate-owned unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
 enabled. Confirmed apply uses enabled project create, project metadata/default,
 root, role/work-item/assignment/handoff, and memory-candidate

--- a/internal/api/handler_project_assistant_cairnline.go
+++ b/internal/api/handler_project_assistant_cairnline.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/hecatehq/cairnline"
@@ -15,6 +16,24 @@ import (
 )
 
 func (h *Handler) cairnlineProjectAssistantContext(ctx context.Context, input projectassistant.ContextInput) (projectassistant.DraftContext, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		seed, err := h.strictEmbeddedCairnlineProjectAssistantContextSeed(ctx, input.ProjectID)
+		if err != nil {
+			return projectassistant.DraftContext{}, err
+		}
+		draftContext, err := projectassistant.NewService(projectassistant.Stores{
+			Projects:         seed.projects,
+			Work:             seed.work,
+			ProjectSkills:    seed.skills,
+			Memory:           seed.memory,
+			MemoryCandidates: seed.memory,
+		}, nil).Context(ctx, input)
+		if err != nil {
+			return projectassistant.DraftContext{}, err
+		}
+		draftContext.ReadBackend = "cairnline"
+		return draftContext, nil
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, input.ProjectID)
 	if err != nil {
 		return projectassistant.DraftContext{}, err
@@ -58,6 +77,34 @@ func (h *Handler) cairnlineSidecarProjectAssistantContext(ctx context.Context, i
 }
 
 func (h *Handler) cairnlineProjectAssistantDraft(ctx context.Context, command projectassistantapp.DraftCommand) (projectassistant.Proposal, error) {
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		seed, err := h.strictEmbeddedCairnlineProjectAssistantContextSeed(ctx, command.ProjectID)
+		if err != nil {
+			return projectassistant.Proposal{}, err
+		}
+		return projectassistant.NewService(projectassistant.Stores{
+			Projects:         seed.projects,
+			Chats:            h.agentChat,
+			Work:             seed.work,
+			ProjectSkills:    seed.skills,
+			Memory:           seed.memory,
+			MemoryCandidates: seed.memory,
+			Proposals:        h.projectAssistantProposalStoreForApplication(),
+			LLM:              gatewayAgentLLMClient{service: h.service},
+		}, newOpaqueTaskResourceID).Draft(ctx, projectassistant.DraftInput{
+			ProjectID:        command.ProjectID,
+			WorkItemID:       command.WorkItemID,
+			Request:          command.Request,
+			RoleID:           command.RoleID,
+			DriverKind:       command.DriverKind,
+			DraftMode:        command.DraftMode,
+			ReviewArtifactID: command.ReviewArtifactID,
+			Provider:         command.Provider,
+			Model:            command.Model,
+			RequestID:        command.RequestID,
+			TraceID:          command.TraceID,
+		})
+	}
 	view, err := h.cairnlineProjectWorkView(ctx, command.ProjectID)
 	if err != nil {
 		return projectassistant.Proposal{}, err
@@ -165,9 +212,27 @@ func (h *Handler) cairnlineSidecarProjectAssistantContextSeed(ctx context.Contex
 }
 
 func (h *Handler) cairnlineProjectAssistantContextSeed(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) (cairnlineProjectAssistantContextSeed, error) {
+	return h.cairnlineProjectAssistantContextSeedFromService(ctx, service, snapshot.Project.ID, snapshot)
+}
+
+func (h *Handler) strictEmbeddedCairnlineProjectAssistantContextSeed(ctx context.Context, projectID string) (cairnlineProjectAssistantContextSeed, error) {
 	var seed cairnlineProjectAssistantContextSeed
-	projectID := snapshot.Project.ID
+	projectID = strings.TrimSpace(projectID)
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return seed, err
+	}
+	defer store.Close()
+	return h.cairnlineProjectAssistantContextSeedFromService(ctx, service, projectID, cairnlinebridge.Snapshot{})
+}
+
+func (h *Handler) cairnlineProjectAssistantContextSeedFromService(ctx context.Context, service *cairnline.Service, projectID string, snapshot cairnlinebridge.Snapshot) (cairnlineProjectAssistantContextSeed, error) {
+	var seed cairnlineProjectAssistantContextSeed
+	projectID = strings.TrimSpace(firstNonEmpty(snapshot.Project.ID, projectID))
 	project, err := service.GetProject(ctx, projectID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return seed, projectassistant.ErrNotFound
+	}
 	if err != nil {
 		return seed, err
 	}
@@ -181,12 +246,12 @@ func (h *Handler) cairnlineProjectAssistantContextSeed(ctx context.Context, serv
 	}
 
 	seed.work = projectwork.NewMemoryStore()
-	if err := seedCairnlineProjectAssistantWork(ctx, seed.work, service, snapshot); err != nil {
+	if err := seedCairnlineProjectAssistantWork(ctx, seed.work, service, projectID, snapshot); err != nil {
 		return seed, err
 	}
 
 	seed.skills = projectskills.NewMemoryStore()
-	if err := seedCairnlineProjectAssistantSkills(ctx, seed.skills, service, snapshot); err != nil {
+	if err := seedCairnlineProjectAssistantSkills(ctx, seed.skills, service, projectID, snapshot); err != nil {
 		return seed, err
 	}
 
@@ -282,8 +347,8 @@ func projectAssistantWorkItemStatusFromCairnline(status string) string {
 	}
 }
 
-func seedCairnlineProjectAssistantWork(ctx context.Context, store *projectwork.MemoryStore, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) error {
-	projectID := snapshot.Project.ID
+func seedCairnlineProjectAssistantWork(ctx context.Context, store *projectwork.MemoryStore, service *cairnline.Service, projectID string, snapshot cairnlinebridge.Snapshot) error {
+	projectID = strings.TrimSpace(firstNonEmpty(snapshot.Project.ID, projectID))
 	roles, err := service.ListRoles(ctx, projectID)
 	if err != nil {
 		return err
@@ -366,8 +431,8 @@ func (h *Handler) seedCairnlineSidecarProjectAssistantSkills(ctx context.Context
 	return nil
 }
 
-func seedCairnlineProjectAssistantSkills(ctx context.Context, store *projectskills.MemoryStore, service *cairnline.Service, snapshot cairnlinebridge.Snapshot) error {
-	projectID := snapshot.Project.ID
+func seedCairnlineProjectAssistantSkills(ctx context.Context, store *projectskills.MemoryStore, service *cairnline.Service, projectID string, snapshot cairnlinebridge.Snapshot) error {
+	projectID = strings.TrimSpace(firstNonEmpty(snapshot.Project.ID, projectID))
 	items, err := service.ListProjectSkills(ctx, projectID)
 	if err != nil {
 		return err

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -430,6 +430,166 @@ func TestProjectAssistantAPI_ContextUsesCairnlineReadModelWhenConfigured(t *test
 	}
 }
 
+func TestProjectAssistantAPI_ContextAndDraftStrictEmbeddedReadModelReadWithoutHecateProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_assistant"
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:            projectID,
+			Name:          "Embedded Assistant",
+			Description:   "Project Assistant reads strict embedded Cairnline state.",
+			DefaultRootID: "root_embedded_assistant",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_assistant",
+				Path:   t.TempDir(),
+				Kind:   "git",
+				Active: true,
+			}},
+			ContextSources: []cairnline.Source{{
+				ID:         "ctx_embedded_assistant",
+				Kind:       "workspace_instruction",
+				Title:      "AGENTS.md",
+				Locator:    "AGENTS.md",
+				Enabled:    true,
+				Format:     "agents_md",
+				TrustLabel: "workspace_guidance",
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:                   "role_embedded_assistant",
+			ProjectID:            projectID,
+			Name:                 "Embedded Planner",
+			DefaultSkillIDs:      []string{"planning"},
+			DefaultExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProjectSkill(t.Context(), cairnline.ProjectSkill{
+			ID:          "planning",
+			ProjectID:   projectID,
+			Title:       "Planning",
+			Description: "Plan reviewable project work.",
+			Path:        ".agents/skills/planning/SKILL.md",
+			RootID:      "root_embedded_assistant",
+			Format:      cairnline.SkillFormatMarkdown,
+			Enabled:     true,
+			Status:      cairnline.SkillStatusAvailable,
+			TrustLabel:  cairnline.SkillTrustWorkspace,
+			SourceRefs:  []string{"ctx_embedded_assistant"},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded_assistant",
+			ProjectID:   projectID,
+			Title:       "Shape embedded assistant work",
+			Brief:       "Use strict embedded Project Assistant context.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_embedded_assistant",
+			RootID:      "root_embedded_assistant",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_assistant",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_assistant",
+			RoleID:        "role_embedded_assistant",
+			RootID:        "root_embedded_assistant",
+			ExecutionMode: cairnline.ExecutionMCPPull,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateMemoryEntry(t.Context(), cairnline.MemoryEntry{
+			ID:         "mem_embedded_assistant",
+			ProjectID:  projectID,
+			Title:      "Embedded assistant memory",
+			Body:       "Use embedded Cairnline rows for assistant context.",
+			Enabled:    true,
+			TrustLabel: memory.TrustLabelOperatorMemory,
+			SourceKind: memory.SourceKindOperator,
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateMemoryCandidate(t.Context(), cairnline.MemoryCandidate{
+			ID:                  "memcand_embedded_assistant",
+			ProjectID:           projectID,
+			Title:               "Embedded assistant candidate",
+			Body:                "Pending assistant memory candidate.",
+			Status:              cairnline.MemoryCandidatePending,
+			SuggestedKind:       "note",
+			SuggestedTrustLabel: memory.TrustLabelGenerated,
+			SuggestedSourceKind: memory.SourceKindGenerated,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline assistant context: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
+	}
+
+	client := newAPITestClient(t, server)
+	contextResp := mustRequestJSON[projectAssistantContextResponse](client, http.MethodPost, "/hecate/v1/project-assistant/context", `{
+		"project_id":"proj_embedded_assistant",
+		"work_item_id":"work_embedded_assistant",
+		"request":"Queue embedded assistant work"
+	}`)
+	if contextResp.Data.ReadBackend != "cairnline" || contextResp.Data.Project.ID != projectID {
+		t.Fatalf("embedded assistant context backend/project = %q/%+v, want Cairnline embedded project", contextResp.Data.ReadBackend, contextResp.Data.Project)
+	}
+	if contextResp.Data.SelectedWork == nil || contextResp.Data.SelectedWork.ID != "work_embedded_assistant" || contextResp.Data.Selection.RoleID != "role_embedded_assistant" || contextResp.Data.Selection.DriverKind != projectwork.AssignmentDriverHecateTask {
+		t.Fatalf("embedded assistant selected work/selection = %+v/%+v, want selected work owner and Hecate task driver", contextResp.Data.SelectedWork, contextResp.Data.Selection)
+	}
+	if !projectAssistantContextHasRole(contextResp.Data.Roles, "role_embedded_assistant") {
+		t.Fatalf("embedded assistant roles = %+v, want role from Cairnline", contextResp.Data.Roles)
+	}
+	if len(contextResp.Data.Skills) != 1 || contextResp.Data.Skills[0].ID != "planning" || len(contextResp.Data.Skills[0].SourceContextSourceIDs) != 1 {
+		t.Fatalf("embedded assistant skills = %+v, want skill metadata and provenance", contextResp.Data.Skills)
+	}
+	if len(contextResp.Data.Assignments) != 1 || contextResp.Data.Assignments[0].ID != "asgn_embedded_assistant" {
+		t.Fatalf("embedded assistant assignments = %+v, want assignment from Cairnline", contextResp.Data.Assignments)
+	}
+	if len(contextResp.Data.Memory) != 1 || contextResp.Data.Memory[0].ID != "mem_embedded_assistant" || len(contextResp.Data.MemoryCandidates) != 1 || contextResp.Data.MemoryCandidates[0].ID != "memcand_embedded_assistant" {
+		t.Fatalf("embedded assistant memory/candidates = %+v/%+v, want Cairnline memory context", contextResp.Data.Memory, contextResp.Data.MemoryCandidates)
+	}
+
+	draftResp := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/draft", `{
+		"project_id":"proj_embedded_assistant",
+		"work_item_id":"work_embedded_assistant",
+		"request":"Queue embedded assistant implementation",
+		"draft_mode":"deterministic"
+	}`)
+	if draftResp.Object != "project_assistant.proposal" || !draftResp.Data.RequiresConfirmation {
+		t.Fatalf("embedded assistant draft response = %+v, want reviewable proposal for embedded project", draftResp)
+	}
+	if len(draftResp.Data.Actions) != 1 || draftResp.Data.Actions[0].Kind != projectassistant.ActionCreateAssignment {
+		t.Fatalf("embedded assistant draft actions = %+v, want create_assignment", draftResp.Data.Actions)
+	}
+	if draftResp.Data.Actions[0].Target["project_id"] != projectID {
+		t.Fatalf("embedded assistant draft target = %+v, want embedded project", draftResp.Data.Actions[0].Target)
+	}
+	var patch map[string]any
+	if err := json.Unmarshal(draftResp.Data.Actions[0].Patch, &patch); err != nil {
+		t.Fatalf("decode embedded assistant draft patch: %v", err)
+	}
+	if patch["project_id"] != projectID || patch["work_item_id"] != "work_embedded_assistant" || patch["role_id"] != "role_embedded_assistant" || patch["root_id"] != "root_embedded_assistant" {
+		t.Fatalf("embedded assistant draft patch = %+v, want selected embedded work assignment", patch)
+	}
+}
+
 func TestProjectAssistantAPI_ContextUsesCairnlineSidecarWhenConfigured(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "memory-fixture")


### PR DESCRIPTION
## Summary
- seed Project Assistant context/draft stores directly from embedded Cairnline in strict embedded read mode
- make Project Assistant context and deterministic draft work without matching Hecate-native project/work rows
- keep proposal persistence/apply authority Hecate-owned unless the existing proposal-ledger authority switchpoint is enabled
- update Projects/runtime docs for the direct strict embedded Assistant read path

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_(ContextAndDraftStrictEmbeddedReadModelReadWithoutHecateProject|ContextUsesCairnlineReadModelWhenConfigured|DraftCairnlineMatchesHecate|ProposalReadUsesCairnlineReadModel)'\n- just docs-format-check\n- just docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./...\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...