### PR TITLE
Read embedded Cairnline project context for chat

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -205,8 +205,9 @@ plus project list/detail, setup readiness, health, skills, memory entries,
 memory candidates, roles, work-item list/detail, assignment-list,
 assignment-context, launch-readiness, assignment-preflight, artifact-list,
 handoff-list, Project Assistant context and proposal reads, closeout readiness,
-and operations brief can use the Cairnline read model for portable setup/work
-state. Configured read routes prefer the embedded Cairnline mirror database
+project-linked Hecate Chat prelude/context reads, and operations brief can use
+the Cairnline read model for portable setup/work state. Configured read routes
+prefer the embedded Cairnline mirror database
 when it already contains the requested project or proposal record; if the
 mirror database, project row, or proposal record is missing, they fall back to
 the snapshot-seeded in-memory bridge projection.
@@ -218,8 +219,9 @@ project list/detail plus setup-readiness, health, project skill list, project
 role list, work-item list/detail, assignment-list, assignment-context,
 launch-readiness, assignment preflight, activity, artifact-list, handoff-list,
 closeout-readiness, operations brief, project memory list, and
-memory-candidate list reads plus Project Assistant context/proposal reads load
-directly from the embedded Cairnline project, skill, role, work-item,
+memory-candidate list reads plus Project Assistant context/proposal reads and
+project-linked Hecate Chat prelude/context reads load directly from the embedded
+Cairnline project, skill, role, work-item,
 assignment, launch-packet, artifact, evidence, review, handoff, memory, and
 assistant proposal records instead of loading a Hecate-native project snapshot
 first.
@@ -234,8 +236,9 @@ direct strict embedded exceptions are project list/detail, project skill list,
 setup-readiness, health, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight,
 activity, artifact-list, handoff-list, closeout-readiness, operations brief,
-project memory list, memory-candidate list, and Project Assistant
-context/proposal reads. The explicit sidecar read-source routes remain the broader
+project memory list, memory-candidate list, Project Assistant context/proposal
+reads, and project-linked Hecate Chat prelude/context reads. The explicit
+sidecar read-source routes remain the broader
 standalone-process exception for project list/detail, setup-readiness, health,
 project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
@@ -554,13 +557,15 @@ after these gates are met:
   routes are project list/detail, setup readiness, health, skills, memory
   entries, memory candidates, roles, activity, work-item list/detail, assignment
   lists, assignment context, launch-readiness, assignment preflight, artifact
-  lists, handoff lists, Project Assistant context/proposal reads, closeout
-  readiness, and operations brief. Draft generation may use the
+  lists, handoff lists, Project Assistant context/proposal reads,
+  project-linked Hecate Chat prelude/context reads, closeout readiness, and
+  operations brief. Draft generation may use the
   Cairnline-projected context, and proposal ledger writes may become
   Cairnline-authoritative with the `project-assistant-proposals` switchpoint.
   Confirmed apply may use enabled project create, project metadata/default, root,
   role/work-item/assignment/handoff, and memory-candidate Cairnline-authority
-  seams, but chat/runtime side effects remain a mixed-authority replacement blocker and are mirrored as
+  seams, but chat/runtime side effects remain a mixed-authority replacement
+  blocker and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative
   Cairnline launch-packet evidence, but assignment-start remains a Hecate-owned

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -410,11 +410,12 @@ When the embedded Cairnline read adapter is fully wired,
 health, skills, memory entries, memory candidates, roles, work-item
 list/detail, assignment-list, assignment-context, launch-readiness,
 assignment-preflight, artifact-list, handoff-list, Project Assistant
-context/proposal reads, closeout readiness, activity inbox, and operations brief
-can be served from the Cairnline read model. Project Assistant draft generation
-also uses the Cairnline-projected context in this mode, while proposal ledger
-writes remain Hecate-owned unless `project-assistant-proposals` is explicitly
-enabled. Confirmed Project Assistant apply routes project create, project
+context/proposal reads, project-linked Hecate Chat prelude/context reads,
+closeout readiness, activity inbox, and operations brief can be served from the
+Cairnline read model. Project Assistant draft generation also uses the
+Cairnline-projected context in this mode, while proposal ledger writes remain
+Hecate-owned unless `project-assistant-proposals` is explicitly enabled.
+Confirmed Project Assistant apply routes project create, project
 metadata/default, root, role, work-item, assignment, handoff, and
 memory-candidate actions through the same opt-in Cairnline authority
 switchpoints when those switchpoints are enabled; chat and runtime side effects
@@ -428,7 +429,10 @@ task/external agent supervision, approvals, and assignment mutation. Project
 reads backed by the Cairnline read model prefer the embedded Cairnline mirror
 database when that database already contains the requested project or proposal
 record; if the mirror database, project row, or proposal record is missing,
-they fall back to the snapshot-seeded in-memory bridge projection. Set
+they fall back to the snapshot-seeded in-memory bridge projection. Project-linked
+Hecate Chat prelude/context helpers use the embedded Cairnline graph directly in
+strict embedded mode so dogfood chat sessions do not require shadow Hecate
+project rows. Set
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot` to force the snapshot-seeded
 bridge, or `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` to make configured
 read routes require a populated

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -638,6 +638,9 @@ func (h *Handler) projectContextSources(ctx context.Context, session chat.Sessio
 }
 
 func (h *Handler) projectSummary(ctx context.Context, projectID string) *projects.Project {
+	if project, ok := h.strictEmbeddedCairnlineProjectSummary(ctx, projectID); ok {
+		return project
+	}
 	if h == nil || h.projects == nil || strings.TrimSpace(projectID) == "" {
 		return nil
 	}
@@ -677,6 +680,9 @@ func (h *Handler) projectMemoryEntries(ctx context.Context, session chat.Session
 }
 
 func (h *Handler) enabledProjectMemoryEntries(ctx context.Context, projectID string) []memory.Entry {
+	if items, ok := h.strictEmbeddedCairnlineEnabledProjectMemoryEntries(ctx, projectID); ok {
+		return items
+	}
 	if h == nil || h.memory == nil || strings.TrimSpace(projectID) == "" {
 		return nil
 	}

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/controlplane"
@@ -446,6 +447,183 @@ func TestProjectChatWorkflowSystemPromptSkipsExternalAgentSessions(t *testing.T)
 	})
 	if prompt != "" {
 		t.Fatalf("external-agent project prompt = %q, want empty", prompt)
+	}
+}
+
+func TestProjectChatWorkflowSystemPromptUsesStrictEmbeddedCairnlineProject(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	const projectID = "proj_chat_embedded"
+	rootPath := t.TempDir()
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:            projectID,
+			Name:          "Embedded Chat",
+			Description:   "Project prompt comes from embedded Cairnline.",
+			DefaultRootID: "root_chat_embedded",
+			Roots: []cairnline.Root{{
+				ID:        "root_chat_embedded",
+				Path:      rootPath,
+				Kind:      "git",
+				GitBranch: "main",
+				Active:    true,
+			}},
+			ContextSources: []cairnline.Source{{
+				ID:         "ctx_chat_embedded",
+				Kind:       "workspace_instruction",
+				Title:      "AGENTS.md",
+				Locator:    "AGENTS.md",
+				Enabled:    true,
+				Format:     "agents_md",
+				TrustLabel: "workspace_guidance",
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:              "role_chat_planner",
+			ProjectID:       projectID,
+			Name:            "Chat Planner",
+			Description:     "Shapes chat-discovered work.",
+			DefaultSkillIDs: []string{"planning"},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProjectSkill(t.Context(), cairnline.ProjectSkill{
+			ID:          "planning",
+			ProjectID:   projectID,
+			Title:       "Planning",
+			Description: "Plan reviewable chat work.",
+			Path:        ".agents/skills/planning/SKILL.md",
+			RootID:      "root_chat_embedded",
+			Format:      cairnline.SkillFormatMarkdown,
+			Enabled:     true,
+			Status:      cairnline.SkillStatusAvailable,
+			TrustLabel:  cairnline.SkillTrustWorkspace,
+			SourceRefs:  []string{"ctx_chat_embedded"},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_chat_embedded",
+			ProjectID:   projectID,
+			Title:       "Plan embedded chat context",
+			Brief:       "Keep chat project prelude backed by Cairnline.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    "high",
+			OwnerRoleID: "role_chat_planner",
+			RootID:      "root_chat_embedded",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_chat_embedded",
+			ProjectID:     projectID,
+			WorkItemID:    "work_chat_embedded",
+			RoleID:        "role_chat_planner",
+			RootID:        "root_chat_embedded",
+			ExecutionMode: cairnline.ExecutionMCPPull,
+			Status:        cairnline.AssignmentQueued,
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateMemoryEntry(t.Context(), cairnline.MemoryEntry{
+			ID:         "mem_chat_embedded",
+			ProjectID:  projectID,
+			Title:      "Embedded chat memory",
+			Body:       "Hecate Chat should use embedded Cairnline project context.",
+			Enabled:    true,
+			TrustLabel: memory.TrustLabelOperatorMemory,
+			SourceKind: memory.SourceKindOperator,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline chat project: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no native project row", ok, err)
+	}
+
+	prompt := handler.projectChatWorkflowSystemPrompt(t.Context(), chat.Session{ProjectID: projectID})
+	for _, want := range []string{
+		"Project: Embedded Chat (proj_chat_embedded)",
+		"Project roots (metadata only; files are not read):",
+		"- Root " + rootPath + " (root_chat_embedded): active=true, default=true, kind=git, branch=main",
+		"Role hints:",
+		"Chat Planner (role_chat_planner): Shapes chat-discovered work.",
+		"Project skills (metadata only; skill bodies are not loaded):",
+		"Planning (planning): Plan reviewable chat work. Path: .agents/skills/planning/SKILL.md",
+		"Active project work snapshot:",
+		"- Work item Plan embedded chat context (work_chat_embedded): status=ready, priority=high, owner_role=role_chat_planner",
+		"- Assignment asgn_chat_embedded: work_item=work_chat_embedded, role=role_chat_planner, status=queued, driver=hecate_task",
+		"Project memory: Embedded chat memory\nID: mem_chat_embedded\nTrust: operator_memory",
+		"Hecate Chat should use embedded Cairnline project context.",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("strict embedded project prompt missing %q:\n%s", want, prompt)
+		}
+	}
+
+	packet := renderChatContextPacket(handler.directModelContextPacket(t.Context(), chat.Session{ProjectID: projectID}, "openai", "gpt-4o-mini", ""))
+	if packet == nil ||
+		!chatContextPacketHasKind(*packet, "project") ||
+		!chatContextPacketHasKind(*packet, "project_skills") ||
+		!chatContextPacketHasKind(*packet, "project_work") {
+		t.Fatalf("strict embedded context packet missing project metadata: %+v", packet)
+	}
+}
+
+func TestProjectChatWorkflowSystemPromptStrictEmbeddedSkipsNativeFallback(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	const projectID = "proj_chat_native_only"
+
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:          projectID,
+		Name:        "Native Only Chat Project",
+		Description: "This native row should not feed strict embedded chat.",
+	}); err != nil {
+		t.Fatalf("seed native project: %v", err)
+	}
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:         "mem_native_only",
+		Scope:      memory.ScopeProject,
+		ProjectID:  projectID,
+		Title:      "Native-only memory",
+		Body:       "This native memory should not feed strict embedded chat.",
+		Enabled:    true,
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+	}); err != nil {
+		t.Fatalf("seed native memory: %v", err)
+	}
+
+	prompt := handler.projectChatWorkflowSystemPrompt(t.Context(), chat.Session{ProjectID: projectID})
+	for _, notWant := range []string{
+		"Native Only Chat Project",
+		"This native row should not feed strict embedded chat.",
+		"Native-only memory",
+		"This native memory should not feed strict embedded chat.",
+	} {
+		if strings.Contains(prompt, notWant) {
+			t.Fatalf("strict embedded project prompt fell back to native content %q:\n%s", notWant, prompt)
+		}
+	}
+
+	packet := renderChatContextPacket(handler.directModelContextPacket(t.Context(), chat.Session{ProjectID: projectID}, "openai", "gpt-4o-mini", ""))
+	if packet != nil && (chatContextPacketHasKind(*packet, "project") || chatContextPacketHasKind(*packet, "memory")) {
+		t.Fatalf("strict embedded context packet fell back to native project or memory metadata: %+v", packet)
 	}
 }
 

--- a/internal/api/handler_chat_project_prompt.go
+++ b/internal/api/handler_chat_project_prompt.go
@@ -254,11 +254,21 @@ func projectChatRootHints(project projects.Project) string {
 }
 
 func (h *Handler) projectChatRoleHints(ctx context.Context, projectID string) string {
+	if roles, ok := h.strictEmbeddedCairnlineProjectChatRoles(ctx, projectID); ok {
+		return projectChatRoleHintText(roles)
+	}
 	if h == nil || h.projectWork == nil || strings.TrimSpace(projectID) == "" {
 		return ""
 	}
 	roles, err := h.projectWork.ListRoles(ctx, strings.TrimSpace(projectID))
 	if err != nil || len(roles) == 0 {
+		return ""
+	}
+	return projectChatRoleHintText(roles)
+}
+
+func projectChatRoleHintText(roles []projectwork.AgentRoleProfile) string {
+	if len(roles) == 0 {
 		return ""
 	}
 	sort.SliceStable(roles, func(i, j int) bool {
@@ -329,6 +339,9 @@ type projectChatWorkSnapshot struct {
 }
 
 func (h *Handler) projectChatEnabledSkills(ctx context.Context, projectID string) []projectskills.Skill {
+	if items, ok := h.strictEmbeddedCairnlineProjectChatSkills(ctx, projectID); ok {
+		return items
+	}
 	if h == nil || h.projectSkills == nil || strings.TrimSpace(projectID) == "" {
 		return nil
 	}
@@ -347,6 +360,11 @@ func (h *Handler) projectChatEnabledSkills(ctx context.Context, projectID string
 		}
 		out = append(out, item)
 	}
+	sortProjectChatSkills(out)
+	return out
+}
+
+func sortProjectChatSkills(out []projectskills.Skill) {
 	sort.SliceStable(out, func(i, j int) bool {
 		left := firstNonEmptyString(strings.TrimSpace(out[i].Title), strings.TrimSpace(out[i].ID))
 		right := firstNonEmptyString(strings.TrimSpace(out[j].Title), strings.TrimSpace(out[j].ID))
@@ -355,10 +373,12 @@ func (h *Handler) projectChatEnabledSkills(ctx context.Context, projectID string
 		}
 		return strings.TrimSpace(out[i].ID) < strings.TrimSpace(out[j].ID)
 	})
-	return out
 }
 
 func (h *Handler) projectChatWorkSnapshot(ctx context.Context, projectID string) projectChatWorkSnapshot {
+	if snapshot, ok := h.strictEmbeddedCairnlineProjectChatWorkSnapshot(ctx, projectID); ok {
+		return snapshot
+	}
 	if h == nil || h.projectWork == nil || strings.TrimSpace(projectID) == "" {
 		return projectChatWorkSnapshot{}
 	}

--- a/internal/api/handler_chat_project_prompt_cairnline.go
+++ b/internal/api/handler_chat_project_prompt_cairnline.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) projectChatStrictEmbeddedCairnlineReads() bool {
+	return h != nil && h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+}
+
+func (h *Handler) strictEmbeddedCairnlineProjectSummary(ctx context.Context, projectID string) (*projects.Project, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatStrictEmbeddedCairnlineReads() || projectID == "" {
+		return nil, false
+	}
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, true
+	}
+	defer store.Close()
+	project, err := service.GetProject(ctx, projectID)
+	if err != nil {
+		return nil, true
+	}
+	executionProfile, err := cairnlineExecutionProfileByID(ctx, service, project.DefaultExecutionProfileID)
+	if err != nil {
+		return nil, true
+	}
+	item := projectFromCairnline(project, executionProfile, projects.Project{})
+	return &item, true
+}
+
+func (h *Handler) strictEmbeddedCairnlineProjectChatRoles(ctx context.Context, projectID string) ([]projectwork.AgentRoleProfile, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatStrictEmbeddedCairnlineReads() || projectID == "" {
+		return nil, false
+	}
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, true
+	}
+	defer store.Close()
+	roles, err := service.ListRoles(ctx, projectID)
+	if err != nil {
+		return nil, true
+	}
+	executionProfiles, err := service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return nil, true
+	}
+	executionProfilesByID := cairnlineExecutionProfilesByID(executionProfiles)
+	out := make([]projectwork.AgentRoleProfile, 0, len(roles))
+	for _, role := range roles {
+		out = append(out, projectWorkRoleFromCairnline(role, executionProfilesByID, projectwork.AgentRoleProfile{}))
+	}
+	return out, true
+}
+
+func (h *Handler) strictEmbeddedCairnlineProjectChatSkills(ctx context.Context, projectID string) ([]projectskills.Skill, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatStrictEmbeddedCairnlineReads() || projectID == "" {
+		return nil, false
+	}
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, true
+	}
+	defer store.Close()
+	items, err := service.ListProjectSkills(ctx, projectID)
+	if err != nil {
+		return nil, true
+	}
+	out := make([]projectskills.Skill, 0, len(items))
+	for _, item := range items {
+		skill := projectSkillFromCairnline(item, projectskills.Skill{})
+		if !skill.Enabled {
+			continue
+		}
+		status := strings.TrimSpace(skill.Status)
+		if status != "" && status != projectskills.StatusAvailable {
+			continue
+		}
+		out = append(out, skill)
+	}
+	sortProjectChatSkills(out)
+	return out, true
+}
+
+func (h *Handler) strictEmbeddedCairnlineProjectChatWorkSnapshot(ctx context.Context, projectID string) (projectChatWorkSnapshot, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatStrictEmbeddedCairnlineReads() || projectID == "" {
+		return projectChatWorkSnapshot{}, false
+	}
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return projectChatWorkSnapshot{}, true
+	}
+	defer store.Close()
+	workItems, err := service.ListWorkItems(ctx, projectID)
+	if err != nil {
+		workItems = nil
+	}
+	filteredWorkItems := make([]projectwork.WorkItem, 0, len(workItems))
+	for _, item := range workItems {
+		workItem := projectWorkItemFromCairnline(item)
+		if projectChatStatusAllowed(workItem.Status, projectChatPromptWorkItemStatuses) {
+			filteredWorkItems = append(filteredWorkItems, workItem)
+		}
+	}
+	workItemsTruncated := len(filteredWorkItems) > projectChatPromptWorkMaxItems
+	if workItemsTruncated {
+		filteredWorkItems = filteredWorkItems[:projectChatPromptWorkMaxItems]
+	}
+
+	assignments, err := service.ListAssignments(ctx, projectID)
+	if err != nil {
+		assignments = nil
+	}
+	filteredAssignments := make([]projectwork.Assignment, 0, len(assignments))
+	for _, item := range assignments {
+		assignment := projectWorkAssignmentFromCairnline(item)
+		if projectChatStatusAllowed(assignment.Status, projectChatPromptAssignmentStatuses) {
+			filteredAssignments = append(filteredAssignments, assignment)
+		}
+	}
+	assignmentsTruncated := len(filteredAssignments) > projectChatPromptAssignmentMaxItems
+	if assignmentsTruncated {
+		filteredAssignments = filteredAssignments[:projectChatPromptAssignmentMaxItems]
+	}
+	return projectChatWorkSnapshot{
+		WorkItems:            filteredWorkItems,
+		Assignments:          filteredAssignments,
+		WorkItemsTruncated:   workItemsTruncated,
+		AssignmentsTruncated: assignmentsTruncated,
+	}, true
+}
+
+func (h *Handler) strictEmbeddedCairnlineEnabledProjectMemoryEntries(ctx context.Context, projectID string) ([]memory.Entry, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatStrictEmbeddedCairnlineReads() || projectID == "" {
+		return nil, false
+	}
+	_, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return nil, true
+	}
+	defer store.Close()
+	items, err := service.ListMemoryEntries(ctx, projectID, true)
+	if err != nil {
+		return nil, true
+	}
+	out := make([]memory.Entry, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectMemoryFromCairnline(item))
+	}
+	return out, true
+}
+
+func projectChatStatusAllowed(status string, allowed []string) bool {
+	status = strings.TrimSpace(status)
+	for _, item := range allowed {
+		if status == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- route project-linked Hecate Chat prompt and context helpers through strict embedded Cairnline reads
- avoid native project or memory fallback when strict embedded Cairnline chat context is missing
- document the chat prelude/context read-route coverage in the Cairnline migration notes

## Tests
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectChatWorkflowSystemPrompt(UsesStrictEmbeddedCairnlineProject|StrictEmbeddedSkipsNativeFallback|IncludesProjectPrelude|SkipsExternalAgentSessions)|TestDirectHecateChatProjectSessionInjectsProposalGuidance|TestChatContextPacketsIncludeProjectSkillAndWorkMetadata'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...