### PR TITLE
Report Cairnline embedded smoke routes

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -4384,9 +4384,13 @@ generated SQLite database is evidence for future migration rather than a source
 of truth. Sync and mirror-parity responses also include
 `migration_rehearsal.embedded_smoke` when an embedded Cairnline database was
 available. That smoke forces Hecate's read adapter to `cairnline + embedded`
-for representative project read routes (project detail, setup readiness,
-health, work items, activity, operations brief, and read model) without
-mutating live configuration.
+for project list/detail, setup, health, skills, memory, roles, work/activity,
+operations, assignment context/readiness, collaboration artifact/handoff,
+Project Assistant, project-linked Hecate Chat, and read-model routes without
+mutating live configuration. Nested work-item, assignment, and proposal reads
+are checked when matching records exist in the snapshot. `read_route_checks`
+counts every per-project check; `read_routes` lists the unique route/check
+families that were exercised.
 
 Example response:
 
@@ -4482,7 +4486,31 @@ Example response:
         "status": "passed",
         "project_count": 2,
         "checked_project_ids": ["proj_a", "proj_b"],
-        "read_route_checks": 14,
+        "read_route_checks": 37,
+        "read_routes": [
+          "project-list",
+          "project-detail",
+          "setup-readiness",
+          "health",
+          "skills",
+          "memory",
+          "memory-candidate",
+          "roles",
+          "work-item",
+          "assignment-list",
+          "artifact-list",
+          "closeout-readiness",
+          "assignment-context",
+          "launch-readiness",
+          "handoff-list",
+          "activity",
+          "operations-brief",
+          "project-chat-prelude",
+          "project-chat-context",
+          "project-assistant-context",
+          "project-assistant-proposal",
+          "embedded-read-model"
+        ],
         "read_model_count": 2,
         "launch_packet_count": 5,
         "launch_packet_warning_count": 0,

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -809,6 +809,7 @@ func (h *Handler) projectCairnlineStrictEmbeddedProbeHandler() *Handler {
 
 func checkProjectCairnlineEmbeddedSmoke(smoke *ProjectCairnlineMigrationEmbeddedSmoke, projectID, check string, fn func() error) {
 	smoke.ReadRouteChecks++
+	smoke.ReadRoutes = appendUniqueProjectCairnlineSmokeRoute(smoke.ReadRoutes, check)
 	if err := fn(); err != nil {
 		smoke.Errors = append(smoke.Errors, ProjectCairnlineMigrationEmbeddedSmokeError{
 			ProjectID: projectID,
@@ -816,6 +817,19 @@ func checkProjectCairnlineEmbeddedSmoke(smoke *ProjectCairnlineMigrationEmbedded
 			Error:     err.Error(),
 		})
 	}
+}
+
+func appendUniqueProjectCairnlineSmokeRoute(items []string, route string) []string {
+	route = strings.TrimSpace(route)
+	if route == "" {
+		return items
+	}
+	for _, item := range items {
+		if item == route {
+			return items
+		}
+	}
+	return append(items, route)
 }
 
 func projectCairnlineMigrationSmokeStatus(smoke *ProjectCairnlineMigrationEmbeddedSmoke) string {

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -394,6 +394,11 @@ func TestProjectCairnlineSyncAPI_WritesDurableAllProjectsSQLiteDB(t *testing.T) 
 	if second.Data.MigrationRehearsal.EmbeddedSmoke == nil || second.Data.MigrationRehearsal.EmbeddedSmoke.Status != "passed" || second.Data.MigrationRehearsal.EmbeddedSmoke.ProjectCount != 2 || second.Data.MigrationRehearsal.EmbeddedSmoke.ReadRouteChecks != 36 || second.Data.MigrationRehearsal.EmbeddedSmoke.ReadModelCount != 2 || second.Data.MigrationRehearsal.EmbeddedSmoke.LaunchPacketCount != 1 || second.Data.MigrationRehearsal.EmbeddedSmoke.LaunchPacketErrorCount != 0 || len(second.Data.MigrationRehearsal.EmbeddedSmoke.Errors) != 0 {
 		t.Fatalf("sync embedded smoke = %+v, want strict embedded route smoke across both synced projects", second.Data.MigrationRehearsal.EmbeddedSmoke)
 	}
+	for _, route := range []string{"project-list", "skills", "memory-candidate", "assignment-context", "launch-readiness", "project-assistant-context", "project-chat-context"} {
+		if !hasProjectCairnlineSmokeRoute(second.Data.MigrationRehearsal.EmbeddedSmoke, route) {
+			t.Fatalf("sync embedded smoke routes = %+v, want %q", second.Data.MigrationRehearsal.EmbeddedSmoke.ReadRoutes, route)
+		}
+	}
 	if !second.Data.Match || len(second.Data.Differences) != 0 || len(second.Data.IDDifferences) != 0 || len(second.Data.ContentDifferences) != 0 {
 		t.Fatalf("sync parity = match %v differences %+v id_differences %+v content_differences %+v, want exact count, id, and content match", second.Data.Match, second.Data.Differences, second.Data.IDDifferences, second.Data.ContentDifferences)
 	}
@@ -559,6 +564,11 @@ func TestProjectCairnlineMirrorParityAPI_ReportsLiveMirrorMatch(t *testing.T) {
 	}
 	if !hasProjectCairnlineMigrationCheck(response.Data.MigrationRehearsal.Checklist, "strict-embedded-read-smoke", "complete") || response.Data.MigrationRehearsal.EmbeddedSmoke == nil || response.Data.MigrationRehearsal.EmbeddedSmoke.Status != "passed" || response.Data.MigrationRehearsal.EmbeddedSmoke.ProjectCount != 1 || response.Data.MigrationRehearsal.EmbeddedSmoke.ReadRouteChecks != 16 || len(response.Data.MigrationRehearsal.EmbeddedSmoke.Errors) != 0 {
 		t.Fatalf("mirror embedded smoke = %+v checklist %+v, want read-only strict embedded route smoke", response.Data.MigrationRehearsal.EmbeddedSmoke, response.Data.MigrationRehearsal.Checklist)
+	}
+	for _, route := range []string{"project-list", "roles", "handoff-list", "project-chat-prelude", "embedded-read-model"} {
+		if !hasProjectCairnlineSmokeRoute(response.Data.MigrationRehearsal.EmbeddedSmoke, route) {
+			t.Fatalf("mirror embedded smoke routes = %+v, want %q", response.Data.MigrationRehearsal.EmbeddedSmoke.ReadRoutes, route)
+		}
 	}
 	if len(response.Data.Differences) != 0 || len(response.Data.IDDifferences) != 0 || len(response.Data.ContentDifferences) != 0 {
 		t.Fatalf("mirror parity differences = %+v id %+v content %+v, want none", response.Data.Differences, response.Data.IDDifferences, response.Data.ContentDifferences)
@@ -1120,6 +1130,18 @@ func hasProjectCairnlineContentDifference(items []ProjectCairnlineContentDiffere
 func hasProjectCairnlineMigrationCheck(items []ProjectCairnlineMigrationRehearsalCheck, id, status string) bool {
 	for _, item := range items {
 		if item.ID == id && item.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+func hasProjectCairnlineSmokeRoute(smoke *ProjectCairnlineMigrationEmbeddedSmoke, route string) bool {
+	if smoke == nil {
+		return false
+	}
+	for _, item := range smoke.ReadRoutes {
+		if item == route {
 			return true
 		}
 	}

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -359,6 +359,7 @@ type ProjectCairnlineMigrationEmbeddedSmoke struct {
 	ProjectCount             int                                           `json:"project_count"`
 	CheckedProjectIDs        []string                                      `json:"checked_project_ids,omitempty"`
 	ReadRouteChecks          int                                           `json:"read_route_checks"`
+	ReadRoutes               []string                                      `json:"read_routes,omitempty"`
 	ReadModelCount           int                                           `json:"read_model_count"`
 	LaunchPacketCount        int                                           `json:"launch_packet_count"`
 	LaunchPacketWarningCount int                                           `json:"launch_packet_warning_count"`


### PR DESCRIPTION
## Summary
- include unique read route/check names in embedded Cairnline migration smoke evidence
- assert representative project, memory, assignment, assistant, and chat smoke routes in sync/mirror tests
- update runtime API docs for the new read_routes field and broader smoke description

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline(Sync|MirrorParity)'
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...