### PR TITLE
Expose Cairnline gate probe URLs

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2457,7 +2457,10 @@ Cairnline-backed yet and therefore still block authority switch.
 `replacement_ready` stays `false` until read parity, strict embedded mirror
 probes, write-authority switchpoints, and migration/rollback gates are all
 ready. `replacement_gates` reports those high-level gates as structured
-checklist items so clients do not need to parse warning prose. The
+checklist items so clients do not need to parse warning prose. Each gate may
+include `probe_urls`, a list of route templates that produce supporting
+evidence for that gate; these URLs identify checks to run and are not proof
+that the gate has already passed. The
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
 it ignores the separate `migration-cutover` gap because migration and rollback
 are reported by the `migration-and-rollback` gate.
@@ -2617,6 +2620,8 @@ Example response, with `write_switchpoints` shortened for readability:
       "handoff-list",
       "project-assistant-context",
       "project-assistant-proposal",
+      "project-chat-prelude",
+      "project-chat-context",
       "activity",
       "closeout-readiness",
       "operations-brief"
@@ -2682,13 +2687,22 @@ Example response, with `write_switchpoints` shortened for readability:
         "id": "read-routes",
         "ready": true,
         "status": "ready",
-        "detail": "Configured live project read families can be served from Cairnline's projected read model."
+        "detail": "Configured live project read families can be served from Cairnline's projected read model.",
+        "probe_urls": [
+          "/hecate/v1/projects/{id}/cairnline/read-model",
+          "/hecate/v1/projects/{id}/cairnline/embedded-read-model",
+          "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
+        ]
       },
       {
         "id": "strict-embedded-read-smoke",
         "ready": false,
         "status": "operator_probe_required",
-        "detail": "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate."
+        "detail": "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
+        "probe_urls": [
+          "/hecate/v1/projects/cairnline/sync",
+          "/hecate/v1/projects/cairnline/mirror-parity"
+        ]
       },
       {
         "id": "write-authority-switchpoints",
@@ -2700,7 +2714,12 @@ Example response, with `write_switchpoints` shortened for readability:
         "id": "migration-and-rollback",
         "ready": false,
         "status": "rehearsal_available",
-        "detail": "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet."
+        "detail": "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet.",
+        "probe_urls": [
+          "/hecate/v1/projects/cairnline/sync",
+          "/hecate/v1/projects/cairnline/mirror-parity",
+          "/hecate/v1/projects/{id}/cairnline/export"
+        ]
       }
     ],
     "write_switchpoints": [

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -6,6 +6,7 @@ import (
 )
 
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
+const projectCoordinationBackendExportURL = "/hecate/v1/projects/{id}/cairnline/export"
 const projectCoordinationBackendSidecarProbeURL = "/hecate/v1/projects/cairnline/sidecar-probe"
 const projectCoordinationBackendSidecarConnectURL = "/hecate/v1/projects/cairnline/sidecar-connect"
 const projectCoordinationBackendSidecarReadURL = "/hecate/v1/projects/cairnline/sidecar-read-smoke"
@@ -429,23 +430,26 @@ func projectCairnlineReplacementGates(readRoutesReady bool, writeGaps []string) 
 	writeGate := projectCairnlineWriteAuthorityReplacementGate(writeGaps)
 	return []ProjectCoordinationBackendReplacementGate{
 		{
-			ID:     "read-routes",
-			Ready:  readRoutesReady,
-			Status: projectReplacementGateStatus(readRoutesReady),
-			Detail: "Configured live project read families can be served from Cairnline's projected read model.",
+			ID:        "read-routes",
+			Ready:     readRoutesReady,
+			Status:    projectReplacementGateStatus(readRoutesReady),
+			Detail:    "Configured live project read families can be served from Cairnline's projected read model.",
+			ProbeURLs: []string{projectCoordinationBackendReadinessURL, projectCoordinationBackendEmbeddedReadModelURL, projectCoordinationBackendEmbeddedParityReportURL},
 		},
 		{
-			ID:     "strict-embedded-read-smoke",
-			Ready:  false,
-			Status: "operator_probe_required",
-			Detail: "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
+			ID:        "strict-embedded-read-smoke",
+			Ready:     false,
+			Status:    "operator_probe_required",
+			Detail:    "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
+			ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL},
 		},
 		writeGate,
 		{
-			ID:     "migration-and-rollback",
-			Ready:  false,
-			Status: "rehearsal_available",
-			Detail: "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet.",
+			ID:        "migration-and-rollback",
+			Ready:     false,
+			Status:    "rehearsal_available",
+			Detail:    "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet.",
+			ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL, projectCoordinationBackendExportURL},
 		},
 	}
 }

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -277,9 +277,13 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	}
 	if gate := findReplacementGate(status.ReplacementGates, "read-routes"); gate == nil || !gate.Ready || gate.Status != "ready" {
 		t.Fatalf("read-routes gate = %+v, want ready gate", gate)
+	} else if !containsString(gate.ProbeURLs, projectCoordinationBackendReadinessURL) || !containsString(gate.ProbeURLs, projectCoordinationBackendEmbeddedReadModelURL) || !containsString(gate.ProbeURLs, projectCoordinationBackendEmbeddedParityReportURL) {
+		t.Fatalf("read-routes gate probe URLs = %+v, want read-model and embedded parity probes", gate.ProbeURLs)
 	}
 	if gate := findReplacementGate(status.ReplacementGates, "strict-embedded-read-smoke"); gate == nil || gate.Ready || gate.Status != "operator_probe_required" {
 		t.Fatalf("strict embedded gate = %+v, want operator probe gate", gate)
+	} else if !containsString(gate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !containsString(gate.ProbeURLs, projectCoordinationBackendMirrorParityURL) {
+		t.Fatalf("strict embedded gate probe URLs = %+v, want sync and mirror parity probes", gate.ProbeURLs)
 	}
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-memory"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "live_mirror_non_authoritative" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "memory" {
 		t.Fatalf("project-memory switchpoint = %+v, want Hecate-owned live mirror blocker", point)
@@ -813,6 +817,9 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	migrationGate := findReplacementGate(response.Data.ReplacementGates, "migration-and-rollback")
 	if migrationGate == nil || migrationGate.Status != "rehearsal_available" {
 		t.Fatalf("response migration gate = %+v, want rehearsal-available blocker", migrationGate)
+	}
+	if !containsString(migrationGate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !containsString(migrationGate.ProbeURLs, projectCoordinationBackendMirrorParityURL) || !containsString(migrationGate.ProbeURLs, projectCoordinationBackendExportURL) {
+		t.Fatalf("response migration gate probe URLs = %+v, want sync, mirror parity, and export probes", migrationGate.ProbeURLs)
 	}
 	migrationSwitchpoint := findWriteSwitchpoint(response.Data.WriteSwitchpoints, "migration-cutover")
 	if migrationSwitchpoint == nil || migrationSwitchpoint.CairnlineState != "snapshot_import_rehearsal_available" || !containsString(migrationSwitchpoint.Seams, "sync-rehearsal") {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -597,10 +597,11 @@ type ProjectCoordinationBackendStatusResponse struct {
 }
 
 type ProjectCoordinationBackendReplacementGate struct {
-	ID     string `json:"id"`
-	Ready  bool   `json:"ready"`
-	Status string `json:"status"`
-	Detail string `json:"detail"`
+	ID        string   `json:"id"`
+	Ready     bool     `json:"ready"`
+	Status    string   `json:"status"`
+	Detail    string   `json:"detail"`
+	ProbeURLs []string `json:"probe_urls,omitempty"`
 }
 
 type ProjectCoordinationBackendWriteSwitchpoint struct {


### PR DESCRIPTION
## Summary
- add probe URL templates to Cairnline replacement gates in backend status
- document probe_urls as evidence routes, not proof that a gate has passed
- align the backend-status read_routes example with the current Hecate Chat routes

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api (rerun with escalation after sandbox httptest bind failure)
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...

## Notes
- UI unchanged; this is a runtime API/status contract improvement for the Cairnline migration surface.