### PR TITLE
Classify Cairnline replacement blockers

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -123,6 +123,10 @@ is actually authoritative. It also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operator tools can distinguish
 ready read routes from strict embedded probe work, non-authoritative live
 mirrors, still-Hecate-owned dispatch, and missing migration/rollback authority.
+It keeps `write_adapter_gaps` as the compatibility stop list and also groups
+that list into `portable_write_gaps`, `side_effect_blockers`, and
+`migration_blockers`, so operator tooling can tell switchpoint work apart from
+runtime/workspace side effects and final cutover work.
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded` is the current live-route
 dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes
 local-only standalone Cairnline MCP contract probe/connect surfaces at
@@ -541,7 +545,9 @@ reports these proofs as
 `write_adapter_seams`, while `write_adapter_gaps`
 remains the machine-readable live-route stop list until route switch points,
 atomic promotion semantics, and authoritative cutover semantics are
-implemented. The snapshot import/export rehearsal and rollback notes exist, but
+implemented. The grouped status fields are derived from that stop list and make
+the remaining replacement work easier to operate without changing authority
+semantics. The snapshot import/export rehearsal and rollback notes exist, but
 they are evidence for a future cutover rather than a storage authority switch.
 
 Current read-model parity includes queued-assignment attention semantics:

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -601,7 +601,10 @@ role/work-item/assignment/handoff, and memory-candidate switchpoints. It
 also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operators can see the exact
 read-route, strict-embedded-probe, write-authority, and migration blockers
-without parsing warning prose. `GET
+without parsing warning prose. It also groups the `write_adapter_gaps` stop list
+into `portable_write_gaps`, `side_effect_blockers`, and `migration_blockers`,
+so switchpoint work is separated from Hecate-owned runtime/workspace side
+effects and final cutover work. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2454,6 +2454,16 @@ Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
 can write Cairnline-shaped records during tests or local sync rehearsals;
 `write_adapter_gaps` lists mutation families whose live Hecate routes are not
 Cairnline-backed yet and therefore still block authority switch.
+`portable_write_gaps` groups the durable project-state gaps that can be closed
+by existing Cairnline write-authority switchpoints. `side_effect_blockers`
+groups still-Hecate-owned runtime/workspace effects such as root discovery or
+worktree creation, assignment dispatch, and Project Assistant chat/runtime side
+effects. `migration_blockers` lists remaining cutover/rollback work. These
+grouped fields are explanatory; the full machine-readable stop list remains
+`write_adapter_gaps`. The groups are not guaranteed to be exclusive: for
+example, `roots` can appear in `portable_write_gaps` until root metadata writes
+are Cairnline-authoritative and can remain in `side_effect_blockers` while
+Hecate still owns discovery scans and Git worktree creation.
 `replacement_ready` stays `false` until read parity, strict embedded mirror
 probes, write-authority switchpoints, and migration/rollback gates are all
 ready. `replacement_gates` reports those high-level gates as structured
@@ -2682,6 +2692,23 @@ Example response, with `write_switchpoints` shortened for readability:
       "project-assistant-apply-side-effects",
       "migration-cutover"
     ],
+    "portable_write_gaps": [
+      "projects",
+      "roots",
+      "context-sources",
+      "agent-profiles",
+      "skills",
+      "memory",
+      "memory-candidates",
+      "roles",
+      "work-items",
+      "assignments",
+      "artifacts",
+      "handoffs",
+      "project-assistant-proposals"
+    ],
+    "side_effect_blockers": ["roots", "assignment-start", "project-assistant-apply-side-effects"],
+    "migration_blockers": ["migration-cutover"],
     "replacement_gates": [
       {
         "id": "read-routes",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -364,6 +364,9 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		}
 		response.WriteAdapterSeams = append([]string(nil), projectCairnlineWriteAdapterSeamNames...)
 		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsSnapshot(effectiveWriteAuthority)
+		response.PortableWriteGaps = projectCairnlinePortableWriteGapsSnapshot(effectiveWriteAuthority, response.WriteAdapterGaps)
+		response.SideEffectBlockers = projectCairnlineSideEffectBlockersSnapshot(response.WriteAdapterGaps)
+		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps)
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
 		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.WriteAdapterGaps)
 		if !connectorReady {
@@ -545,6 +548,44 @@ func projectCairnlineWriteAdapterGapsSnapshot(writeAuthority []string) []string 
 			continue
 		}
 		out = append(out, item)
+	}
+	return out
+}
+
+func projectCairnlinePortableWriteGapsSnapshot(writeAuthority, writeGaps []string) []string {
+	out := make([]string, 0, len(writeGaps))
+	projectRootsAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoots)
+	for _, item := range writeGaps {
+		switch item {
+		case "migration-cutover", "assignment-start", "project-assistant-apply-side-effects":
+			continue
+		case "roots":
+			if projectRootsAuthoritative {
+				continue
+			}
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func projectCairnlineSideEffectBlockersSnapshot(writeGaps []string) []string {
+	out := make([]string, 0, 3)
+	for _, item := range writeGaps {
+		switch item {
+		case "roots", "assignment-start", "project-assistant-apply-side-effects":
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func projectCairnlineMigrationBlockersSnapshot(writeGaps []string) []string {
+	out := make([]string, 0, 1)
+	for _, item := range writeGaps {
+		if item == "migration-cutover" {
+			out = append(out, item)
+		}
 	}
 	return out
 }

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -73,7 +73,7 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
-	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 || len(status.ReplacementGates) != 0 || len(status.WriteSwitchpoints) != 0 {
+	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 || len(status.PortableWriteGaps) != 0 || len(status.SideEffectBlockers) != 0 || len(status.MigrationBlockers) != 0 || len(status.ReplacementGates) != 0 || len(status.WriteSwitchpoints) != 0 {
 		t.Fatalf("status = %+v, want no Cairnline route/seam/gap lists until Cairnline is configured", status)
 	}
 }
@@ -271,6 +271,15 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	}
 	if !containsString(status.WriteAdapterGaps, "agent-profiles") || !containsString(status.WriteAdapterGaps, "assignments") || !containsString(status.WriteAdapterGaps, "project-assistant-proposals") || !containsString(status.WriteAdapterGaps, "project-assistant-apply-side-effects") || !containsString(status.WriteAdapterGaps, "migration-cutover") {
 		t.Fatalf("write gaps = %+v, want structured remaining write-adapter gaps", status.WriteAdapterGaps)
+	}
+	if !containsString(status.PortableWriteGaps, "projects") || !containsString(status.PortableWriteGaps, "roots") || !containsString(status.PortableWriteGaps, "agent-profiles") || containsString(status.PortableWriteGaps, "assignment-start") || containsString(status.PortableWriteGaps, "project-assistant-apply-side-effects") || containsString(status.PortableWriteGaps, "migration-cutover") {
+		t.Fatalf("portable write gaps = %+v, want portable gaps separated from side-effect and migration blockers", status.PortableWriteGaps)
+	}
+	if !reflect.DeepEqual(status.SideEffectBlockers, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
+		t.Fatalf("side-effect blockers = %+v, want root/worktree, dispatch, and assistant side-effect blockers", status.SideEffectBlockers)
+	}
+	if !reflect.DeepEqual(status.MigrationBlockers, []string{"migration-cutover"}) {
+		t.Fatalf("migration blockers = %+v, want migration cutover blocker", status.MigrationBlockers)
 	}
 	if !containsString(status.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(status.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(status.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(status.WriteAdapterSeams, "agent-profiles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(status.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(status.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(status.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(status.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(status.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(status.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(status.WriteAdapterSeams, "assignment-status") || !containsString(status.WriteAdapterSeams, "project-assistant-proposal-ledger-import") || !containsString(status.WriteAdapterSeams, "memory-candidates") {
 		t.Fatalf("write seams = %+v, want structured non-authoritative write-adapter seam coverage", status.WriteAdapterSeams)
@@ -494,6 +503,12 @@ func TestProjectCoordinationBackendStatus_CairnlineDirectRootSourceAuthorityConf
 	status := handler.projectCoordinationBackendStatus()
 	if !containsString(status.WriteAdapterGaps, "roots") || containsString(status.WriteAdapterGaps, "context-sources") {
 		t.Fatalf("write gaps = %+v, want roots to remain blocking and context-sources removed for discovery-result authority", status.WriteAdapterGaps)
+	}
+	if containsString(status.PortableWriteGaps, "roots") || containsString(status.PortableWriteGaps, "context-sources") {
+		t.Fatalf("portable write gaps = %+v, want root/source portable switchpoint gaps removed", status.PortableWriteGaps)
+	}
+	if !containsString(status.SideEffectBlockers, "roots") {
+		t.Fatalf("side-effect blockers = %+v, want root scan/worktree blocker to remain", status.SideEffectBlockers)
 	}
 	rootPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "roots-and-worktrees")
 	if rootPoint == nil || rootPoint.CurrentAuthority != "mixed" || rootPoint.CairnlineState != "partial_authoritative_opt_in" || !rootPoint.LiveMirror || !rootPoint.BlocksAuthority || rootPoint.Gap != "roots" {
@@ -770,6 +785,15 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 			t.Fatalf("write gaps = %+v, want remaining non-portable/migration gap %q with all-portable authority alias", status.WriteAdapterGaps, name)
 		}
 	}
+	if len(status.PortableWriteGaps) != 0 {
+		t.Fatalf("portable write gaps = %+v, want all portable gaps removed with all-portable authority alias", status.PortableWriteGaps)
+	}
+	if !reflect.DeepEqual(status.SideEffectBlockers, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
+		t.Fatalf("side-effect blockers = %+v, want remaining non-portable side-effect blockers", status.SideEffectBlockers)
+	}
+	if !reflect.DeepEqual(status.MigrationBlockers, []string{"migration-cutover"}) {
+		t.Fatalf("migration blockers = %+v, want migration cutover blocker", status.MigrationBlockers)
+	}
 	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "roots") || !strings.Contains(gate.Detail, "assignment-start") || !strings.Contains(gate.Detail, "project-assistant-apply-side-effects") {
 		t.Fatalf("write-authority gate = %+v, want partial write authority with remaining side-effect gaps", gate)
 	}
@@ -808,8 +832,8 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if !response.Data.ReadModelSwitchReady || response.Data.Status != "cairnline_read_routes_ready" {
 		t.Fatalf("response = %+v, want Cairnline read routes ready for fully wired test handler", response)
 	}
-	if !containsString(response.Data.ReadRoutes, "project-detail") || !containsString(response.Data.ReadRoutes, "launch-readiness") || !containsString(response.Data.ReadRoutes, "assignment-preflight") || !containsString(response.Data.ReadRoutes, "project-assistant-context") || !containsString(response.Data.ReadRoutes, "project-assistant-proposal") || !containsString(response.Data.ReadRoutes, "project-chat-prelude") || !containsString(response.Data.ReadRoutes, "project-chat-context") || !containsString(response.Data.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "handoffs") || !containsString(response.Data.WriteAdapterGaps, "memory-candidates") {
-		t.Fatalf("response routes/seams/gaps = %+v / %+v / %+v, want structured readiness details", response.Data.ReadRoutes, response.Data.WriteAdapterSeams, response.Data.WriteAdapterGaps)
+	if !containsString(response.Data.ReadRoutes, "project-detail") || !containsString(response.Data.ReadRoutes, "launch-readiness") || !containsString(response.Data.ReadRoutes, "assignment-preflight") || !containsString(response.Data.ReadRoutes, "project-assistant-context") || !containsString(response.Data.ReadRoutes, "project-assistant-proposal") || !containsString(response.Data.ReadRoutes, "project-chat-prelude") || !containsString(response.Data.ReadRoutes, "project-chat-context") || !containsString(response.Data.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "handoffs") || !containsString(response.Data.WriteAdapterGaps, "memory-candidates") || !containsString(response.Data.PortableWriteGaps, "memory-candidates") || !containsString(response.Data.SideEffectBlockers, "assignment-start") || !containsString(response.Data.MigrationBlockers, "migration-cutover") {
+		t.Fatalf("response routes/seams/gaps = %+v / %+v / %+v portable=%+v side_effect=%+v migration=%+v, want structured readiness details", response.Data.ReadRoutes, response.Data.WriteAdapterSeams, response.Data.WriteAdapterGaps, response.Data.PortableWriteGaps, response.Data.SideEffectBlockers, response.Data.MigrationBlockers)
 	}
 	if response.Data.ReplacementReady {
 		t.Fatalf("response replacement_ready = true, want false until write authority and migration gates are ready")

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -570,6 +570,9 @@ type ProjectCoordinationBackendStatusResponse struct {
 	ReadRoutes                           []string                                     `json:"read_routes,omitempty"`
 	WriteAdapterSeams                    []string                                     `json:"write_adapter_seams,omitempty"`
 	WriteAdapterGaps                     []string                                     `json:"write_adapter_gaps,omitempty"`
+	PortableWriteGaps                    []string                                     `json:"portable_write_gaps,omitempty"`
+	SideEffectBlockers                   []string                                     `json:"side_effect_blockers,omitempty"`
+	MigrationBlockers                    []string                                     `json:"migration_blockers,omitempty"`
 	ReplacementGates                     []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
 	WriteSwitchpoints                    []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
 	Status                               string                                       `json:"status"`


### PR DESCRIPTION
## Summary
- add grouped Cairnline backend status fields for portable write gaps, Hecate-owned side-effect blockers, and migration blockers
- keep write_adapter_gaps as the compatibility stop list while making the remaining replacement work easier to operate
- document the new fields in runtime, operator, and Projects design docs

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'\n- just agent-docs-check\n- GOCACHE="$PWD/.gocache" go vet ./internal/api\n- GOCACHE="$PWD/.gocache" go test ./internal/api\n- git diff --check\n- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...