### PR TITLE
Show Cairnline replacement blockers in Settings

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -604,7 +604,8 @@ read-route, strict-embedded-probe, write-authority, and migration blockers
 without parsing warning prose. It also groups the `write_adapter_gaps` stop list
 into `portable_write_gaps`, `side_effect_blockers`, and `migration_blockers`,
 so switchpoint work is separated from Hecate-owned runtime/workspace side
-effects and final cutover work. `GET
+effects and final cutover work. Settings shows the same backend-status summary
+under Project coordination for local operator inspection. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getPlugins, resetSystemData } from "../../lib/api";
+import { getPlugins, getProjectCoordinationBackendStatus, resetSystemData } from "../../lib/api";
 import { ConnectionsPanel } from "../connections/ConnectionsPanel";
 import { SettingsView } from "./SettingsView";
 import {
@@ -14,6 +14,7 @@ import { withRuntimeConsole } from "../../test/runtime-console-render";
 vi.mock("../../lib/api", async (importOriginal) => ({
   ...((await importOriginal()) as Record<string, unknown>),
   getPlugins: vi.fn(),
+  getProjectCoordinationBackendStatus: vi.fn(),
   resetSystemData: vi.fn(),
 }));
 
@@ -36,6 +37,25 @@ function capability(id: string, name: string, status = "supported") {
 beforeEach(() => {
   vi.mocked(getPlugins).mockReset();
   vi.mocked(getPlugins).mockResolvedValue({ object: "plugins", data: [] });
+  vi.mocked(getProjectCoordinationBackendStatus).mockReset();
+  vi.mocked(getProjectCoordinationBackendStatus).mockResolvedValue({
+    object: "project_coordination_backend_status",
+    data: {
+      configured_backend: "hecate",
+      authoritative_backend: "hecate",
+      storage_backend: "sqlite",
+      cairnline_connector: "embedded",
+      cairnline_connector_ready: true,
+      cairnline_bridge_ready: true,
+      cairnline_authoritative: false,
+      read_model_switch_ready: false,
+      write_adapter_ready: false,
+      replacement_ready: false,
+      status: "hecate_authoritative",
+      detail:
+        "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks.",
+    },
+  });
   vi.mocked(resetSystemData).mockReset();
   sessionStorage.removeItem("hecate.settingsFocus");
   sessionStorage.removeItem("hecate.connectionsFocus");
@@ -47,6 +67,55 @@ beforeEach(() => {
 // gating and the MCP cache was pure informational stats). Usage lives
 // in the Usage workspace.
 describe("SettingsView", () => {
+  it("renders project coordination backend status", async () => {
+    vi.mocked(getProjectCoordinationBackendStatus).mockResolvedValue({
+      object: "project_coordination_backend_status",
+      data: {
+        configured_backend: "cairnline",
+        authoritative_backend: "hecate",
+        storage_backend: "sqlite",
+        cairnline_connector: "embedded",
+        cairnline_connector_ready: true,
+        cairnline_read_source: "embedded",
+        cairnline_bridge_ready: true,
+        cairnline_authoritative: false,
+        read_model_switch_ready: true,
+        write_adapter_ready: false,
+        replacement_ready: false,
+        read_routes: ["project-list", "project-detail"],
+        portable_write_gaps: ["agent-profiles", "memory-candidates"],
+        side_effect_blockers: ["assignment-start"],
+        migration_blockers: ["migration-cutover"],
+        status: "cairnline_read_routes_ready",
+        detail: "Cairnline read routes are served from the read model.",
+      },
+    });
+    const { state, actions } = setup();
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
+
+    expect(await screen.findByText("Project coordination")).toBeTruthy();
+    expect(screen.getByText("Cairnline dogfood active")).toBeTruthy();
+    expect(screen.getByText("cairnline configured · hecate authoritative")).toBeTruthy();
+    expect(screen.getByText("cairnline read routes ready")).toBeTruthy();
+    expect(screen.getByText(/2 read routes use Cairnline/i)).toBeTruthy();
+    expect(screen.getByText("Portable write gaps")).toBeTruthy();
+    expect(screen.getByText("agent-profiles")).toBeTruthy();
+    expect(screen.getByText("memory-candidates")).toBeTruthy();
+    expect(screen.getByText("assignment-start")).toBeTruthy();
+    expect(screen.getByText("migration-cutover")).toBeTruthy();
+  });
+
+  it("shows project backend load failures without hiding maintenance", async () => {
+    vi.mocked(getProjectCoordinationBackendStatus).mockRejectedValue(
+      new Error("backend status unavailable"),
+    );
+    const { state, actions } = setup();
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
+
+    expect(await screen.findByText("backend status unavailable")).toBeTruthy();
+    expect(screen.getByText("Maintenance")).toBeTruthy();
+  });
+
   it("renders maintenance cleanup without legacy tabs", () => {
     const { state, actions } = setup();
     render(withRuntimeConsole(<SettingsView />, { state, actions }));

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -3,8 +3,9 @@ import { useRetention, type RetentionState } from "../../app/state/retention";
 import { useRetentionActions } from "../../app/state/coordinators/retention";
 import { useWiredDashboardActions } from "../../app/state/coordinators/wired";
 import { useSettings } from "../../app/state/settings";
-import { getPlugins, resetSystemData } from "../../lib/api";
+import { getPlugins, getProjectCoordinationBackendStatus, resetSystemData } from "../../lib/api";
 import type { PluginRecord } from "../../types/plugin";
+import type { ProjectCoordinationBackendStatusRecord } from "../../types/project";
 import { Badge, ConfirmModal, Icon, Icons, InlineError } from "../shared/ui";
 
 export function SettingsView() {
@@ -24,6 +25,10 @@ export function SettingsView() {
   const [plugins, setPlugins] = useState<PluginRecord[]>([]);
   const [pluginsLoading, setPluginsLoading] = useState(false);
   const [pluginsError, setPluginsError] = useState("");
+  const [projectBackendStatus, setProjectBackendStatus] =
+    useState<ProjectCoordinationBackendStatusRecord | null>(null);
+  const [projectBackendLoading, setProjectBackendLoading] = useState(false);
+  const [projectBackendError, setProjectBackendError] = useState("");
   // Retention runs aren't in the boot-time dashboard snapshot —
   // fetch on first SettingsView mount so the user doesn't see a
   // permanently empty list. `loadRuns` is a stable useCallback, so
@@ -38,7 +43,22 @@ export function SettingsView() {
 
   useEffect(() => {
     void loadPlugins();
+    void loadProjectBackendStatus();
   }, []);
+
+  async function loadProjectBackendStatus() {
+    setProjectBackendLoading(true);
+    setProjectBackendError("");
+    try {
+      const response = await getProjectCoordinationBackendStatus();
+      setProjectBackendStatus(response.data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to load project backend status.";
+      setProjectBackendError(message);
+    } finally {
+      setProjectBackendLoading(false);
+    }
+  }
 
   async function loadPlugins() {
     setPluginsLoading(true);
@@ -80,6 +100,12 @@ export function SettingsView() {
   return (
     <div style={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
       <div style={{ flex: 1, overflowY: "auto", padding: 16 }}>
+        <ProjectCoordinationBackendSettings
+          error={projectBackendError}
+          loading={projectBackendLoading}
+          status={projectBackendStatus}
+          onRefresh={() => void loadProjectBackendStatus()}
+        />
         <PluginRegistrySettings
           error={pluginsError}
           loading={pluginsLoading}
@@ -257,6 +283,177 @@ const RETENTION_SUBSYSTEMS = [
     description: "Resolved approval prompts. Durable grants are kept.",
   },
 ] as const;
+
+function ProjectCoordinationBackendSettings({
+  error,
+  loading,
+  onRefresh,
+  status,
+}: {
+  error: string;
+  loading: boolean;
+  onRefresh: () => void;
+  status: ProjectCoordinationBackendStatusRecord | null;
+}) {
+  const readRoutes = status?.read_routes ?? [];
+  const portableGaps = status?.portable_write_gaps ?? [];
+  const sideEffectBlockers = status?.side_effect_blockers ?? [];
+  const migrationBlockers = status?.migration_blockers ?? [];
+  const statusBadge = status
+    ? status.replacement_ready
+      ? "ok"
+      : status.configured_backend === "cairnline"
+        ? "warn"
+        : "disabled"
+    : "disabled";
+  return (
+    <section style={{ marginBottom: 20 }}>
+      <SectionHeader
+        title="Project coordination"
+        description="Current Projects backend authority and Cairnline replacement-readiness blockers."
+        meta={
+          status
+            ? `${status.configured_backend} configured · ${status.authoritative_backend} authoritative`
+            : "not loaded"
+        }
+        actions={
+          <button className="btn btn-ghost btn-sm" disabled={loading} onClick={onRefresh}>
+            <Icon d={Icons.refresh} size={13} /> {loading ? "Loading…" : "Refresh"}
+          </button>
+        }
+      />
+      {error && <InlineError message={error} />}
+      {!status && !error && (
+        <div className="card" style={{ padding: "14px 16px", color: "var(--t3)", fontSize: 12 }}>
+          {loading
+            ? "Loading project coordination status…"
+            : "Project coordination status unavailable."}
+        </div>
+      )}
+      {status && (
+        <article className="card" style={{ padding: "14px 16px" }}>
+          <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <div style={{ fontSize: 14, fontWeight: 600, color: "var(--t0)" }}>
+                  {projectBackendTitle(status)}
+                </div>
+                <Badge status={statusBadge} label={status.status.replaceAll("_", " ")} />
+                {status.cairnline_connector && (
+                  <span className="badge badge-muted" style={{ textTransform: "none" }}>
+                    {status.cairnline_connector}
+                  </span>
+                )}
+              </div>
+              <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.45, marginTop: 8 }}>
+                {projectBackendSummary(status)}
+              </div>
+            </div>
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+              gap: 8,
+              marginTop: 14,
+            }}
+          >
+            <ProjectBackendMetric label="Read routes" value={readRoutes.length} />
+            <ProjectBackendMetric label="Portable gaps" value={portableGaps.length} />
+            <ProjectBackendMetric label="Side effects" value={sideEffectBlockers.length} />
+            <ProjectBackendMetric label="Migration" value={migrationBlockers.length} />
+          </div>
+          <div style={{ display: "grid", gap: 10, marginTop: 14 }}>
+            <ProjectBackendList title="Portable write gaps" items={portableGaps} empty="none" />
+            <ProjectBackendList
+              title="Side-effect blockers"
+              items={sideEffectBlockers}
+              empty="none"
+            />
+            <ProjectBackendList title="Migration blockers" items={migrationBlockers} empty="none" />
+          </div>
+        </article>
+      )}
+    </section>
+  );
+}
+
+function projectBackendTitle(status: ProjectCoordinationBackendStatusRecord): string {
+  if (status.replacement_ready) return "Cairnline replacement ready";
+  if (status.configured_backend === "cairnline") return "Cairnline dogfood active";
+  return "Hecate Projects active";
+}
+
+function projectBackendSummary(status: ProjectCoordinationBackendStatusRecord): string {
+  const readRoutes = status.read_routes?.length ?? 0;
+  const portableGaps = status.portable_write_gaps?.length ?? 0;
+  const sideEffectBlockers = status.side_effect_blockers?.length ?? 0;
+  const migrationBlockers = status.migration_blockers?.length ?? 0;
+  if (status.replacement_ready) {
+    return "Cairnline replacement gates are ready.";
+  }
+  if (status.configured_backend !== "cairnline") {
+    return "Hecate-native project stores are authoritative. Cairnline bridge diagnostics are available for replacement-readiness checks.";
+  }
+  if (status.read_model_switch_ready || readRoutes > 0) {
+    return `${readRoutes} read route${readRoutes === 1 ? "" : "s"} use Cairnline. ${portableGaps} portable write gap${portableGaps === 1 ? "" : "s"}, ${sideEffectBlockers} side-effect blocker${sideEffectBlockers === 1 ? "" : "s"}, and ${migrationBlockers} migration blocker${migrationBlockers === 1 ? "" : "s"} remain.`;
+  }
+  return "Cairnline is configured, but live read routes and replacement gates are not ready yet.";
+}
+
+function ProjectBackendMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        background: "var(--bg3)",
+        padding: "9px 10px",
+      }}
+    >
+      <div style={{ color: "var(--t3)", fontSize: 10, textTransform: "uppercase" }}>{label}</div>
+      <div style={{ color: "var(--t0)", fontSize: 18, fontWeight: 650, marginTop: 3 }}>{value}</div>
+    </div>
+  );
+}
+
+function ProjectBackendList({
+  empty,
+  items,
+  title,
+}: {
+  empty: string;
+  items: string[];
+  title: string;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 6 }}>
+      <div
+        style={{
+          color: "var(--t3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {items.length === 0 ? (
+          <span className="badge badge-green" style={{ textTransform: "none" }}>
+            {empty}
+          </span>
+        ) : (
+          items.map((item) => (
+            <span key={item} className="badge badge-muted" style={{ textTransform: "none" }}>
+              {item}
+            </span>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
 
 function PluginRegistrySettings({
   error,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -92,6 +92,7 @@ import type {
   ProjectActivityResponse,
   ProjectCollaborationArtifactResponse,
   ProjectCollaborationArtifactsResponse,
+  ProjectCoordinationBackendStatusResponse,
   ProjectContextSourcePayload,
   ProjectDeleteResponse,
   ProjectHandoffResponse,
@@ -524,6 +525,12 @@ export async function deleteProject(id: string): Promise<ProjectDeleteResponse> 
   return fetchJSON<ProjectDeleteResponse>(`${HECATE_API}/projects/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });
+}
+
+export async function getProjectCoordinationBackendStatus(): Promise<ProjectCoordinationBackendStatusResponse> {
+  return fetchJSON<ProjectCoordinationBackendStatusResponse>(
+    `${HECATE_API}/projects/backend-status`,
+  );
 }
 
 export async function proposeProjectAssistant(

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -71,6 +71,56 @@ export type ProjectDeleteResponse = {
   data: ProjectDeleteRecord;
 };
 
+export type ProjectCoordinationBackendReplacementGateRecord = {
+  id: string;
+  ready: boolean;
+  status: string;
+  detail: string;
+  probe_urls?: string[];
+};
+
+export type ProjectCoordinationBackendWriteSwitchpointRecord = {
+  name: string;
+  current_authority: string;
+  cairnline_state: string;
+  live_mirror: boolean;
+  blocks_authority: boolean;
+  seams?: string[];
+  gap?: string;
+  detail: string;
+};
+
+export type ProjectCoordinationBackendStatusRecord = {
+  configured_backend: string;
+  authoritative_backend: string;
+  storage_backend: string;
+  cairnline_connector?: string;
+  cairnline_connector_ready: boolean;
+  cairnline_connector_detail?: string;
+  cairnline_read_source?: string;
+  cairnline_bridge_ready: boolean;
+  cairnline_authoritative: boolean;
+  read_model_switch_ready: boolean;
+  write_adapter_ready: boolean;
+  replacement_ready: boolean;
+  read_routes?: string[];
+  write_adapter_seams?: string[];
+  write_adapter_gaps?: string[];
+  portable_write_gaps?: string[];
+  side_effect_blockers?: string[];
+  migration_blockers?: string[];
+  replacement_gates?: ProjectCoordinationBackendReplacementGateRecord[];
+  write_switchpoints?: ProjectCoordinationBackendWriteSwitchpointRecord[];
+  status: string;
+  detail: string;
+  warnings?: string[];
+};
+
+export type ProjectCoordinationBackendStatusResponse = {
+  object: string;
+  data: ProjectCoordinationBackendStatusRecord;
+};
+
 export type ProjectAssistantAction = {
   kind: string;
   target?: Record<string, string>;


### PR DESCRIPTION
## Summary
- add a Settings Project coordination section backed by /hecate/v1/projects/backend-status
- mirror the backend-status response shape in UI project types and API helpers
- show read-route count, portable write gaps, side-effect blockers, and migration blockers without rendering the long backend detail string

## Tests
- cd ui && bun run format:check
- cd ui && bun run typecheck
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run lint
- cd ui && bun run test
- git diff --check
- just agent-docs-check
- ./ui/node_modules/.bin/oxfmt --check docs/operator/deployment.md