### PR TITLE
Show next Cairnline replacement action

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -598,14 +598,15 @@ switchpoint is enabled; currently only the proposal-ledger switchpoint can be
 made Cairnline-authoritative, while apply side effects become mixed-authority
 through the enabled project create, project metadata/default, root,
 role/work-item/assignment/handoff, and memory-candidate switchpoints. It
-also reports `replacement_ready`,
-`replacement_gates`, and `write_switchpoints` so operators can see the exact
-read-route, strict-embedded-probe, write-authority, and migration blockers
-without parsing warning prose. It also groups the `write_adapter_gaps` stop list
-into `portable_write_gaps`, `side_effect_blockers`, and `migration_blockers`,
-so switchpoint work is separated from Hecate-owned runtime/workspace side
-effects and final cutover work. Settings shows the same backend-status summary
-under Project coordination for local operator inspection. `GET
+also reports `replacement_ready`, `next_replacement_action`,
+`replacement_gates`, and `write_switchpoints` so operators can see the
+suggested next step plus the exact read-route, strict-embedded-probe,
+write-authority, and migration blockers without parsing warning prose. It also
+groups the `write_adapter_gaps` stop list into `portable_write_gaps`,
+`side_effect_blockers`, and `migration_blockers`, so switchpoint work is
+separated from Hecate-owned runtime/workspace side effects and final cutover
+work. Settings shows the same backend-status summary and next action under
+Project coordination for local operator inspection. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2466,11 +2466,13 @@ are Cairnline-authoritative and can remain in `side_effect_blockers` while
 Hecate still owns discovery scans and Git worktree creation.
 `replacement_ready` stays `false` until read parity, strict embedded mirror
 probes, write-authority switchpoints, and migration/rollback gates are all
-ready. `replacement_gates` reports those high-level gates as structured
-checklist items so clients do not need to parse warning prose. Each gate may
-include `probe_urls`, a list of route templates that produce supporting
-evidence for that gate; these URLs identify checks to run and are not proof
-that the gate has already passed. The
+ready. `next_replacement_action` is an advisory next operator step derived from
+the same status snapshot; it is not a command, permission, gate result, or proof
+that replacement is safe. `replacement_gates` reports those high-level gates as
+structured checklist items so clients do not need to parse warning prose. Each
+gate may include `probe_urls`, a list of route templates that produce
+supporting evidence for that gate; these URLs identify checks to run and are
+not proof that the gate has already passed. The
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
 it ignores the separate `migration-cutover` gap because migration and rollback
 are reported by the `migration-and-rollback` gate.
@@ -2709,6 +2711,12 @@ Example response, with `write_switchpoints` shortened for readability:
     ],
     "side_effect_blockers": ["roots", "assignment-start", "project-assistant-apply-side-effects"],
     "migration_blockers": ["migration-cutover"],
+    "next_replacement_action": {
+      "id": "move-portable-write-authority",
+      "label": "Move the next portable write authority",
+      "detail": "Close the next portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
+      "target": "projects"
+    },
     "replacement_gates": [
       {
         "id": "read-routes",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -380,7 +380,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
 					"Full Cairnline replacement remains blocked on authoritative write migration.",
 				}
-				return response
+				return projectCairnlineStatusWithNextAction(response)
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
@@ -389,7 +389,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 				projectCairnlineConnectorWarning(connector),
 				"Project reads and writes still use Hecate-native stores.",
 			}
-			return response
+			return projectCairnlineStatusWithNextAction(response)
 		}
 		response.ReadModelSwitchReady = readReady
 		if readReady {
@@ -414,7 +414,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 				"Other project mutation routes still write only Hecate-native stores.",
 				"Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready.",
 			}
-			return response
+			return projectCairnlineStatusWithNextAction(response)
 		}
 		response.Status = "cairnline_configured_read_adapter_missing_sources"
 		response.Detail = "Cairnline is configured as the future Projects coordination backend, but the read adapter cannot project the full Hecate project graph from the currently wired stores."
@@ -426,7 +426,113 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.Status = "hecate_authoritative"
 		response.Detail = "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks."
 	}
+	return projectCairnlineStatusWithNextAction(response)
+}
+
+func projectCairnlineStatusWithNextAction(response ProjectCoordinationBackendStatusResponse) ProjectCoordinationBackendStatusResponse {
+	response.NextReplacementAction = projectCairnlineNextReplacementAction(response)
 	return response
+}
+
+func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStatusResponse) *ProjectCoordinationBackendNextAction {
+	if status.ReplacementReady {
+		return &ProjectCoordinationBackendNextAction{
+			ID:     "replace-projects-backend",
+			Label:  "Replace the Projects backend",
+			Detail: "All Cairnline replacement gates are ready; the remaining action is an explicit operator cutover.",
+			Target: "cutover",
+		}
+	}
+	if status.ConfiguredBackend != "cairnline" {
+		return &ProjectCoordinationBackendNextAction{
+			ID:     "enable-cairnline-dogfood",
+			Label:  "Enable Cairnline dogfood",
+			Detail: "Configure Cairnline as the project coordination backend in a local dogfood runtime before moving any authority.",
+			Target: "configuration",
+			ProbeURLs: []string{
+				projectCoordinationBackendSidecarProbeURL,
+				projectCoordinationBackendSidecarConnectURL,
+			},
+		}
+	}
+	if !status.CairnlineConnectorReady {
+		return &ProjectCoordinationBackendNextAction{
+			ID:     "use-embedded-cairnline-connector",
+			Label:  "Use the embedded Cairnline connector",
+			Detail: "Sidecar mode is useful for MCP diagnostics and read smoke tests, but write-authority dogfood currently requires the embedded Cairnline connector.",
+			Target: "connector",
+			ProbeURLs: []string{
+				projectCoordinationBackendSidecarProbeURL,
+				projectCoordinationBackendSidecarConnectURL,
+			},
+		}
+	}
+	if !status.ReadModelSwitchReady && len(status.ReadRoutes) == 0 {
+		return &ProjectCoordinationBackendNextAction{
+			ID:     "complete-read-model-sources",
+			Label:  "Complete Cairnline read-model sources",
+			Detail: "Wire the remaining Hecate project stores into the Cairnline projection so live read routes can switch safely.",
+			Target: "read-routes",
+			ProbeURLs: []string{
+				projectCoordinationBackendReadinessURL,
+				projectCoordinationBackendEmbeddedReadModelURL,
+				projectCoordinationBackendEmbeddedParityReportURL,
+			},
+		}
+	}
+	if len(status.PortableWriteGaps) > 0 {
+		target := status.PortableWriteGaps[0]
+		return &ProjectCoordinationBackendNextAction{
+			ID:     "move-portable-write-authority",
+			Label:  "Move the next portable write authority",
+			Detail: "Close the next portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
+			Target: target,
+		}
+	}
+	if len(status.SideEffectBlockers) > 0 {
+		target := status.SideEffectBlockers[0]
+		label := "Separate the next Hecate-owned side effect"
+		detail := "Define the portable record boundary and keep runtime side effects in Hecate or another orchestrator before Cairnline can become authoritative."
+		if target == "roots" {
+			label = "Separate roots and worktree side effects"
+			detail = "Move portable root records toward Cairnline authority while keeping filesystem and Git worktree creation under Hecate's confined runtime boundary."
+		}
+		if target == "assignment-start" {
+			label = "Separate assignment coordination from launch"
+			detail = "Keep assignment records portable while treating task/external-agent launch as an orchestrator capability outside Cairnline core."
+		}
+		return &ProjectCoordinationBackendNextAction{
+			ID:     "separate-side-effect-boundary",
+			Label:  label,
+			Detail: detail,
+			Target: target,
+		}
+	}
+	if len(status.MigrationBlockers) > 0 {
+		return &ProjectCoordinationBackendNextAction{
+			ID:     "rehearse-migration-cutover",
+			Label:  "Rehearse migration and rollback",
+			Detail: "Run sync/parity/export rehearsal paths and document the explicit cutover and rollback procedure before replacement.",
+			Target: status.MigrationBlockers[0],
+			ProbeURLs: []string{
+				projectCoordinationBackendSyncReadinessURL,
+				projectCoordinationBackendMirrorParityURL,
+				projectCoordinationBackendExportURL,
+			},
+		}
+	}
+	return &ProjectCoordinationBackendNextAction{
+		ID:     "run-final-replacement-probes",
+		Label:  "Run final replacement probes",
+		Detail: "No blocker groups remain in the status snapshot; rerun read, parity, sync, and migration probes before marking the backend replaceable.",
+		Target: "replacement-gates",
+		ProbeURLs: []string{
+			projectCoordinationBackendReadinessURL,
+			projectCoordinationBackendEmbeddedParityReportURL,
+			projectCoordinationBackendSyncReadinessURL,
+			projectCoordinationBackendMirrorParityURL,
+		},
+	}
 }
 
 func projectCairnlineReplacementGates(readRoutesReady bool, writeGaps []string) []ProjectCoordinationBackendReplacementGate {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -76,6 +76,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 || len(status.PortableWriteGaps) != 0 || len(status.SideEffectBlockers) != 0 || len(status.MigrationBlockers) != 0 || len(status.ReplacementGates) != 0 || len(status.WriteSwitchpoints) != 0 {
 		t.Fatalf("status = %+v, want no Cairnline route/seam/gap lists until Cairnline is configured", status)
 	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "enable-cairnline-dogfood" || status.NextReplacementAction.Target != "configuration" {
+		t.Fatalf("next action = %+v, want enable-cairnline-dogfood configuration action", status.NextReplacementAction)
+	}
 }
 
 func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *testing.T) {
@@ -116,6 +119,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	}
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "result_mirror_only" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "assignment-start" {
 		t.Fatalf("assignment-start switchpoint = %+v, want Hecate-owned result mirror blocker", point)
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "complete-read-model-sources" || status.NextReplacementAction.Target != "read-routes" || !containsString(status.NextReplacementAction.ProbeURLs, projectCoordinationBackendEmbeddedParityReportURL) {
+		t.Fatalf("next action = %+v, want read-model source action with embedded parity probe", status.NextReplacementAction)
 	}
 }
 
@@ -197,6 +203,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-identity"); point == nil || point.CurrentAuthority != "hecate" || !point.BlocksAuthority || point.Gap != "projects" {
 		t.Fatalf("project-identity switchpoint = %+v, want Hecate authority while sidecar routing is not live", point)
 	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "use-embedded-cairnline-connector" || status.NextReplacementAction.Target != "connector" {
+		t.Fatalf("next action = %+v, want embedded connector action for sidecar mode", status.NextReplacementAction)
+	}
 	warnings := strings.Join(status.Warnings, "\n")
 	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration/memory/assistant diagnostics") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
 		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
@@ -238,6 +247,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 	warnings := strings.Join(status.Warnings, "\n")
 	if !strings.Contains(warnings, "project-assistant-context, project-assistant-proposal") || !strings.Contains(warnings, "authoritative write migration") {
 		t.Fatalf("warnings = %+v, want sidecar read routes with write-migration warning", status.Warnings)
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "use-embedded-cairnline-connector" || status.NextReplacementAction.Target != "connector" {
+		t.Fatalf("next action = %+v, want embedded connector action even when sidecar read routes are active", status.NextReplacementAction)
 	}
 }
 
@@ -311,6 +323,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	}
 	if status.MirrorParityURL != projectCoordinationBackendMirrorParityURL {
 		t.Fatalf("mirror parity URL = %q, want %q", status.MirrorParityURL, projectCoordinationBackendMirrorParityURL)
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "move-portable-write-authority" || status.NextReplacementAction.Target != "projects" {
+		t.Fatalf("next action = %+v, want first portable write authority gap", status.NextReplacementAction)
 	}
 }
 
@@ -797,6 +812,9 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "roots") || !strings.Contains(gate.Detail, "assignment-start") || !strings.Contains(gate.Detail, "project-assistant-apply-side-effects") {
 		t.Fatalf("write-authority gate = %+v, want partial write authority with remaining side-effect gaps", gate)
 	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "separate-side-effect-boundary" || status.NextReplacementAction.Target != "roots" {
+		t.Fatalf("next action = %+v, want roots side-effect action after portable authority gaps close", status.NextReplacementAction)
+	}
 }
 
 func TestProjectCoordinationBackendStatus_WriteAuthorityGateIgnoresMigrationGap(t *testing.T) {
@@ -844,6 +862,9 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	}
 	if !containsString(migrationGate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !containsString(migrationGate.ProbeURLs, projectCoordinationBackendMirrorParityURL) || !containsString(migrationGate.ProbeURLs, projectCoordinationBackendExportURL) {
 		t.Fatalf("response migration gate probe URLs = %+v, want sync, mirror parity, and export probes", migrationGate.ProbeURLs)
+	}
+	if response.Data.NextReplacementAction == nil || response.Data.NextReplacementAction.ID != "move-portable-write-authority" || response.Data.NextReplacementAction.Target == "" {
+		t.Fatalf("response next action = %+v, want portable write-authority action", response.Data.NextReplacementAction)
 	}
 	migrationSwitchpoint := findWriteSwitchpoint(response.Data.WriteSwitchpoints, "migration-cutover")
 	if migrationSwitchpoint == nil || migrationSwitchpoint.CairnlineState != "snapshot_import_rehearsal_available" || !containsString(migrationSwitchpoint.Seams, "sync-rehearsal") {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -573,6 +573,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	PortableWriteGaps                    []string                                     `json:"portable_write_gaps,omitempty"`
 	SideEffectBlockers                   []string                                     `json:"side_effect_blockers,omitempty"`
 	MigrationBlockers                    []string                                     `json:"migration_blockers,omitempty"`
+	NextReplacementAction                *ProjectCoordinationBackendNextAction        `json:"next_replacement_action,omitempty"`
 	ReplacementGates                     []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
 	WriteSwitchpoints                    []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`
 	Status                               string                                       `json:"status"`
@@ -597,6 +598,14 @@ type ProjectCoordinationBackendStatusResponse struct {
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
 	MirrorParityURL                      string                                       `json:"mirror_parity_url,omitempty"`
+}
+
+type ProjectCoordinationBackendNextAction struct {
+	ID        string   `json:"id"`
+	Label     string   `json:"label"`
+	Detail    string   `json:"detail"`
+	Target    string   `json:"target,omitempty"`
+	ProbeURLs []string `json:"probe_urls,omitempty"`
 }
 
 type ProjectCoordinationBackendReplacementGate struct {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -54,6 +54,13 @@ beforeEach(() => {
       status: "hecate_authoritative",
       detail:
         "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks.",
+      next_replacement_action: {
+        id: "enable-cairnline-dogfood",
+        label: "Enable Cairnline dogfood",
+        detail:
+          "Configure Cairnline as the project coordination backend in a local dogfood runtime before moving any authority.",
+        target: "configuration",
+      },
     },
   });
   vi.mocked(resetSystemData).mockReset();
@@ -86,6 +93,14 @@ describe("SettingsView", () => {
         portable_write_gaps: ["agent-profiles", "memory-candidates"],
         side_effect_blockers: ["assignment-start"],
         migration_blockers: ["migration-cutover"],
+        next_replacement_action: {
+          id: "move-portable-write-authority",
+          label: "Move the next portable write authority",
+          detail:
+            "Close the next portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
+          target: "agent-profiles",
+          probe_urls: ["/hecate/v1/projects/{id}/cairnline/read-model"],
+        },
         status: "cairnline_read_routes_ready",
         detail: "Cairnline read routes are served from the read model.",
       },
@@ -99,7 +114,10 @@ describe("SettingsView", () => {
     expect(screen.getByText("cairnline read routes ready")).toBeTruthy();
     expect(screen.getByText(/2 read routes use Cairnline/i)).toBeTruthy();
     expect(screen.getByText("Portable write gaps")).toBeTruthy();
-    expect(screen.getByText("agent-profiles")).toBeTruthy();
+    expect(screen.getByText("Next action")).toBeTruthy();
+    expect(screen.getByText("Move the next portable write authority")).toBeTruthy();
+    expect(screen.getAllByText("agent-profiles").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("1 probe")).toBeTruthy();
     expect(screen.getByText("memory-candidates")).toBeTruthy();
     expect(screen.getByText("assignment-start")).toBeTruthy();
     expect(screen.getByText("migration-cutover")).toBeTruthy();

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -299,6 +299,7 @@ function ProjectCoordinationBackendSettings({
   const portableGaps = status?.portable_write_gaps ?? [];
   const sideEffectBlockers = status?.side_effect_blockers ?? [];
   const migrationBlockers = status?.migration_blockers ?? [];
+  const nextAction = status?.next_replacement_action;
   const statusBadge = status
     ? status.replacement_ready
       ? "ok"
@@ -350,6 +351,7 @@ function ProjectCoordinationBackendSettings({
               </div>
             </div>
           </div>
+          {nextAction && <ProjectBackendNextAction action={nextAction} />}
           <div
             style={{
               display: "grid",
@@ -375,6 +377,52 @@ function ProjectCoordinationBackendSettings({
         </article>
       )}
     </section>
+  );
+}
+
+function ProjectBackendNextAction({
+  action,
+}: {
+  action: NonNullable<ProjectCoordinationBackendStatusRecord["next_replacement_action"]>;
+}) {
+  const probes = action.probe_urls ?? [];
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        background: "var(--bg2)",
+        display: "grid",
+        gap: 7,
+        marginTop: 14,
+        padding: "10px 12px",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <span
+          style={{
+            color: "var(--t3)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            textTransform: "uppercase",
+          }}
+        >
+          Next action
+        </span>
+        {action.target && (
+          <span className="badge badge-muted" style={{ textTransform: "none" }}>
+            {action.target}
+          </span>
+        )}
+        {probes.length > 0 && (
+          <span className="badge badge-muted" style={{ textTransform: "none" }}>
+            {probes.length} probe{probes.length === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+      <div style={{ color: "var(--t0)", fontSize: 13, fontWeight: 650 }}>{action.label}</div>
+      <div style={{ color: "var(--t2)", fontSize: 12, lineHeight: 1.45 }}>{action.detail}</div>
+    </div>
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -90,6 +90,14 @@ export type ProjectCoordinationBackendWriteSwitchpointRecord = {
   detail: string;
 };
 
+export type ProjectCoordinationBackendNextActionRecord = {
+  id: string;
+  label: string;
+  detail: string;
+  target?: string;
+  probe_urls?: string[];
+};
+
 export type ProjectCoordinationBackendStatusRecord = {
   configured_backend: string;
   authoritative_backend: string;
@@ -109,6 +117,7 @@ export type ProjectCoordinationBackendStatusRecord = {
   portable_write_gaps?: string[];
   side_effect_blockers?: string[];
   migration_blockers?: string[];
+  next_replacement_action?: ProjectCoordinationBackendNextActionRecord;
   replacement_gates?: ProjectCoordinationBackendReplacementGateRecord[];
   write_switchpoints?: ProjectCoordinationBackendWriteSwitchpointRecord[];
   status: string;


### PR DESCRIPTION
## Summary
- add a typed next_replacement_action to the project coordination backend status response
- render the next Cairnline replacement action in Settings under Project coordination
- document the advisory action field in runtime and operator docs

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run test
- cd ui && bun run format:check
- just agent-docs-check
- ./ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md docs/operator/deployment.md
- git diff --check