### PR TITLE
Show Cairnline replacement config hints

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -600,9 +600,10 @@ through the enabled project create, project metadata/default, root,
 role/work-item/assignment/handoff, and memory-candidate switchpoints. It
 also reports `replacement_ready`, `next_replacement_action`,
 `replacement_gates`, and `write_switchpoints` so operators can see the
-suggested next step plus the exact read-route, strict-embedded-probe,
-write-authority, and migration blockers without parsing warning prose. It also
-groups the `write_adapter_gaps` stop list into `portable_write_gaps`,
+suggested next step, relevant env-var hints, and the exact read-route,
+strict-embedded-probe, write-authority, and migration blockers without parsing
+warning prose. It also groups the `write_adapter_gaps` stop list into
+`portable_write_gaps`,
 `side_effect_blockers`, and `migration_blockers`, so switchpoint work is
 separated from Hecate-owned runtime/workspace side effects and final cutover
 work. Settings shows the same backend-status summary and next action under

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2468,11 +2468,14 @@ Hecate still owns discovery scans and Git worktree creation.
 probes, write-authority switchpoints, and migration/rollback gates are all
 ready. `next_replacement_action` is an advisory next operator step derived from
 the same status snapshot; it is not a command, permission, gate result, or proof
-that replacement is safe. `replacement_gates` reports those high-level gates as
-structured checklist items so clients do not need to parse warning prose. Each
-gate may include `probe_urls`, a list of route templates that produce
-supporting evidence for that gate; these URLs identify checks to run and are
-not proof that the gate has already passed. The
+that replacement is safe. It can include `config_hints`, which are environment
+setting suggestions such as a specific
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY` value; clients must treat them as
+operator guidance, not as mutations to apply automatically. `replacement_gates`
+reports those high-level gates as structured checklist items so clients do not
+need to parse warning prose. Each gate may include `probe_urls`, a list of route
+templates that produce supporting evidence for that gate; these URLs identify
+checks to run and are not proof that the gate has already passed. The
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
 it ignores the separate `migration-cutover` gap because migration and rollback
 are reported by the `migration-and-rollback` gate.
@@ -2715,7 +2718,14 @@ Example response, with `write_switchpoints` shortened for readability:
       "id": "move-portable-write-authority",
       "label": "Move the next portable write authority",
       "detail": "Close the next portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
-      "target": "projects"
+      "target": "projects",
+      "config_hints": [
+        {
+          "env": "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY",
+          "value": "project-identity,project-metadata-defaults",
+          "detail": "Add these comma-separated values to HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY; this gap requires the switchpoints together."
+        }
+      ]
     },
     "replacement_gates": [
       {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -449,6 +449,10 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			Label:  "Enable Cairnline dogfood",
 			Detail: "Configure Cairnline as the project coordination backend in a local dogfood runtime before moving any authority.",
 			Target: "configuration",
+			ConfigHints: []ProjectCoordinationBackendActionConfigHint{
+				projectCairnlineConfigHint("HECATE_PROJECTS_COORDINATION_BACKEND", "cairnline", "Enable Cairnline as the Projects coordination backend for local dogfooding."),
+				projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector for the current write-authority dogfood path."),
+			},
 			ProbeURLs: []string{
 				projectCoordinationBackendSidecarProbeURL,
 				projectCoordinationBackendSidecarConnectURL,
@@ -461,6 +465,9 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			Label:  "Use the embedded Cairnline connector",
 			Detail: "Sidecar mode is useful for MCP diagnostics and read smoke tests, but write-authority dogfood currently requires the embedded Cairnline connector.",
 			Target: "connector",
+			ConfigHints: []ProjectCoordinationBackendActionConfigHint{
+				projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector before enabling Cairnline write-authority switchpoints."),
+			},
 			ProbeURLs: []string{
 				projectCoordinationBackendSidecarProbeURL,
 				projectCoordinationBackendSidecarConnectURL,
@@ -483,10 +490,11 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 	if len(status.PortableWriteGaps) > 0 {
 		target := status.PortableWriteGaps[0]
 		return &ProjectCoordinationBackendNextAction{
-			ID:     "move-portable-write-authority",
-			Label:  "Move the next portable write authority",
-			Detail: "Close the next portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
-			Target: target,
+			ID:          "move-portable-write-authority",
+			Label:       "Move the next portable write authority",
+			Detail:      "Close the next portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
+			Target:      target,
+			ConfigHints: projectCairnlineWriteAuthorityHintsForGap(target),
 		}
 	}
 	if len(status.SideEffectBlockers) > 0 {
@@ -532,6 +540,59 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			projectCoordinationBackendSyncReadinessURL,
 			projectCoordinationBackendMirrorParityURL,
 		},
+	}
+}
+
+func projectCairnlineConfigHint(env, value, detail string) ProjectCoordinationBackendActionConfigHint {
+	return ProjectCoordinationBackendActionConfigHint{
+		Env:    env,
+		Value:  value,
+		Detail: detail,
+	}
+}
+
+func projectCairnlineWriteAuthorityHintsForGap(gap string) []ProjectCoordinationBackendActionConfigHint {
+	values := projectCairnlineWriteAuthorityValuesForGap(gap)
+	if len(values) == 0 {
+		return nil
+	}
+	detail := "Add this value to HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY for embedded Cairnline write-authority dogfooding."
+	if len(values) > 1 {
+		detail = "Add these comma-separated values to HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY; this gap requires the switchpoints together."
+	}
+	return []ProjectCoordinationBackendActionConfigHint{
+		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", strings.Join(values, ","), detail),
+	}
+}
+
+func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
+	switch gap {
+	case "projects":
+		return []string{projectCairnlineWriteAuthorityProjectIdentity, projectCairnlineWriteAuthorityProjectMetadataDefaults}
+	case "roots":
+		return []string{projectCairnlineWriteAuthorityProjectRoots}
+	case "context-sources":
+		return []string{projectCairnlineWriteAuthorityProjectContextSources}
+	case "agent-profiles":
+		return []string{projectCairnlineWriteAuthorityAgentProfiles}
+	case "skills":
+		return []string{projectCairnlineWriteAuthorityProjectSkills}
+	case "memory":
+		return []string{"project-memory"}
+	case "memory-candidates":
+		return []string{"project-memory", "memory-candidates"}
+	case "roles":
+		return []string{projectCairnlineWriteAuthorityProjectRoles}
+	case "work-items":
+		return []string{projectCairnlineWriteAuthorityProjectWorkItems}
+	case "assignments":
+		return []string{projectCairnlineWriteAuthorityProjectAssignments}
+	case "artifacts", "handoffs":
+		return []string{projectCairnlineWriteAuthorityProjectCollaboration}
+	case "project-assistant-proposals":
+		return []string{projectCairnlineWriteAuthorityProjectAssistantProposals}
+	default:
+		return nil
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -79,6 +79,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "enable-cairnline-dogfood" || status.NextReplacementAction.Target != "configuration" {
 		t.Fatalf("next action = %+v, want enable-cairnline-dogfood configuration action", status.NextReplacementAction)
 	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_COORDINATION_BACKEND"); hint == nil || hint.Value != "cairnline" {
+		t.Fatalf("next action config hints = %+v, want coordination backend=cairnline", status.NextReplacementAction.ConfigHints)
+	}
 }
 
 func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *testing.T) {
@@ -326,6 +329,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "move-portable-write-authority" || status.NextReplacementAction.Target != "projects" {
 		t.Fatalf("next action = %+v, want first portable write authority gap", status.NextReplacementAction)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY"); hint == nil || hint.Value != "project-identity,project-metadata-defaults" {
+		t.Fatalf("next action config hints = %+v, want project identity + metadata defaults write authority", status.NextReplacementAction.ConfigHints)
 	}
 }
 
@@ -824,6 +830,30 @@ func TestProjectCoordinationBackendStatus_WriteAuthorityGateIgnoresMigrationGap(
 	}
 }
 
+func TestProjectCoordinationBackendStatus_NextActionWriteAuthorityHints(t *testing.T) {
+	tests := []struct {
+		gap  string
+		want string
+	}{
+		{gap: "projects", want: "project-identity,project-metadata-defaults"},
+		{gap: "memory-candidates", want: "project-memory,memory-candidates"},
+		{gap: "artifacts", want: "project-collaboration"},
+		{gap: "project-assistant-proposals", want: "project-assistant-proposals"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.gap, func(t *testing.T) {
+			hints := projectCairnlineWriteAuthorityHintsForGap(tt.gap)
+			hint := findConfigHint(hints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY")
+			if hint == nil || hint.Value != tt.want || hint.Detail == "" {
+				t.Fatalf("hints = %+v, want write authority value %q with detail", hints, tt.want)
+			}
+		})
+	}
+	if hints := projectCairnlineWriteAuthorityHintsForGap("assignment-start"); len(hints) != 0 {
+		t.Fatalf("assignment-start hints = %+v, want none because dispatch is not a portable write-authority switchpoint", hints)
+	}
+}
+
 func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	cfg := config.Config{
@@ -866,6 +896,9 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if response.Data.NextReplacementAction == nil || response.Data.NextReplacementAction.ID != "move-portable-write-authority" || response.Data.NextReplacementAction.Target == "" {
 		t.Fatalf("response next action = %+v, want portable write-authority action", response.Data.NextReplacementAction)
 	}
+	if findConfigHint(response.Data.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY") == nil {
+		t.Fatalf("response next action config hints = %+v, want write authority hint", response.Data.NextReplacementAction.ConfigHints)
+	}
 	migrationSwitchpoint := findWriteSwitchpoint(response.Data.WriteSwitchpoints, "migration-cutover")
 	if migrationSwitchpoint == nil || migrationSwitchpoint.CairnlineState != "snapshot_import_rehearsal_available" || !containsString(migrationSwitchpoint.Seams, "sync-rehearsal") {
 		t.Fatalf("response migration switchpoint = %+v, want snapshot-import rehearsal blocker", migrationSwitchpoint)
@@ -896,6 +929,15 @@ func findReplacementGate(items []ProjectCoordinationBackendReplacementGate, id s
 func findWriteSwitchpoint(items []ProjectCoordinationBackendWriteSwitchpoint, name string) *ProjectCoordinationBackendWriteSwitchpoint {
 	for idx := range items {
 		if items[idx].Name == name {
+			return &items[idx]
+		}
+	}
+	return nil
+}
+
+func findConfigHint(items []ProjectCoordinationBackendActionConfigHint, env string) *ProjectCoordinationBackendActionConfigHint {
+	for idx := range items {
+		if items[idx].Env == env {
 			return &items[idx]
 		}
 	}

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -601,11 +601,18 @@ type ProjectCoordinationBackendStatusResponse struct {
 }
 
 type ProjectCoordinationBackendNextAction struct {
-	ID        string   `json:"id"`
-	Label     string   `json:"label"`
-	Detail    string   `json:"detail"`
-	Target    string   `json:"target,omitempty"`
-	ProbeURLs []string `json:"probe_urls,omitempty"`
+	ID          string                                       `json:"id"`
+	Label       string                                       `json:"label"`
+	Detail      string                                       `json:"detail"`
+	Target      string                                       `json:"target,omitempty"`
+	ConfigHints []ProjectCoordinationBackendActionConfigHint `json:"config_hints,omitempty"`
+	ProbeURLs   []string                                     `json:"probe_urls,omitempty"`
+}
+
+type ProjectCoordinationBackendActionConfigHint struct {
+	Env    string `json:"env"`
+	Value  string `json:"value"`
+	Detail string `json:"detail,omitempty"`
 }
 
 type ProjectCoordinationBackendReplacementGate struct {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -99,6 +99,12 @@ describe("SettingsView", () => {
           detail:
             "Close the next portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
           target: "agent-profiles",
+          config_hints: [
+            {
+              env: "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY",
+              value: "agent-profiles",
+            },
+          ],
           probe_urls: ["/hecate/v1/projects/{id}/cairnline/read-model"],
         },
         status: "cairnline_read_routes_ready",
@@ -117,6 +123,9 @@ describe("SettingsView", () => {
     expect(screen.getByText("Next action")).toBeTruthy();
     expect(screen.getByText("Move the next portable write authority")).toBeTruthy();
     expect(screen.getAllByText("agent-profiles").length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByText("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles"),
+    ).toBeTruthy();
     expect(screen.getByText("1 probe")).toBeTruthy();
     expect(screen.getByText("memory-candidates")).toBeTruthy();
     expect(screen.getByText("assignment-start")).toBeTruthy();

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -386,6 +386,7 @@ function ProjectBackendNextAction({
   action: NonNullable<ProjectCoordinationBackendStatusRecord["next_replacement_action"]>;
 }) {
   const probes = action.probe_urls ?? [];
+  const configHints = action.config_hints ?? [];
   return (
     <div
       style={{
@@ -422,6 +423,26 @@ function ProjectBackendNextAction({
       </div>
       <div style={{ color: "var(--t0)", fontSize: 13, fontWeight: 650 }}>{action.label}</div>
       <div style={{ color: "var(--t2)", fontSize: 12, lineHeight: 1.45 }}>{action.detail}</div>
+      {configHints.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {configHints.map((hint) => (
+            <span
+              key={`${hint.env}:${hint.value}`}
+              className="badge badge-muted"
+              style={{
+                fontFamily: "var(--font-mono)",
+                maxWidth: "100%",
+                overflowWrap: "anywhere",
+                textTransform: "none",
+                whiteSpace: "normal",
+              }}
+              title={hint.detail || `${hint.env}=${hint.value}`}
+            >
+              {hint.env}={hint.value}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -95,6 +95,11 @@ export type ProjectCoordinationBackendNextActionRecord = {
   label: string;
   detail: string;
   target?: string;
+  config_hints?: Array<{
+    env: string;
+    value: string;
+    detail?: string;
+  }>;
   probe_urls?: string[];
 };
 


### PR DESCRIPTION
## Summary
- add advisory config_hints to the project coordination next replacement action
- map portable write gaps to the Cairnline write-authority values that close them
- render next-action env hints in Settings and document the advisory contract

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run test
- cd ui && bun run format:check
- just agent-docs-check
- ./ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md docs/operator/deployment.md
- git diff --check