### PR TITLE
Report Cairnline orchestrator capabilities

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -123,10 +123,12 @@ is actually authoritative. It also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operator tools can distinguish
 ready read routes from strict embedded probe work, non-authoritative live
 mirrors, still-Hecate-owned dispatch, and missing migration/rollback authority.
-It keeps `write_adapter_gaps` as the compatibility stop list and also groups
-that list into `portable_write_gaps`, `side_effect_blockers`, and
-`migration_blockers`, so operator tooling can tell switchpoint work apart from
-runtime/workspace side effects and final cutover work.
+It keeps `write_adapter_gaps` as the broad diagnostic list and also groups
+that list into `portable_write_gaps`, `orchestrator_capabilities`, and
+`migration_blockers`, so operator tooling can tell durable coordination-state
+switchpoint work apart from Hecate-owned runtime/workspace capabilities and
+final cutover work. `portable_write_gaps` drives the write-authority replacement
+gate; `orchestrator_capabilities` are intentionally outside Cairnline core.
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded` is the current live-route
 dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes
 local-only standalone Cairnline MCP contract probe/connect surfaces at
@@ -256,8 +258,8 @@ assembly stay aligned, while the proposal ledger remains Hecate-owned unless
 Confirmed Project Assistant apply routes project create, project
 metadata/default, root, role, work-item, assignment, handoff, and
 memory-candidate actions through the same opt-in Cairnline authority
-switchpoints when those switchpoints are enabled; chat/runtime side effects
-still keep apply as a mixed-authority replacement blocker.
+switchpoints when those switchpoints are enabled; chat/runtime effects remain
+Hecate-owned orchestrator capabilities outside Cairnline core.
 Project list/detail reconstruct default profile and execution posture from
 Cairnline project/execution-profile records where available. Launch-readiness
 and assignment preflight read
@@ -298,8 +300,7 @@ context-source list replacement, and context-source discovery-result
 replacement can commit to embedded Cairnline first, then best-effort shadow
 Hecate's compatibility project row. Worktree-created root records also move
 with `project-roots`, but Hecate still performs root discovery scans and Git
-worktree creation side effects, so the worktree side-effect gap still blocks
-full cutover.
+worktree creation as orchestrator capabilities outside Cairnline core.
 `project-collaboration` is another opt-in authority slice: collaboration
 artifact creation and handoff create/update/status/delete commit to embedded
 Cairnline first, then best-effort shadow the portable records into Hecate-native
@@ -331,8 +332,8 @@ Assistant draft/propose/apply-attempt ledger records commit to embedded
 Cairnline first, then best-effort shadow Hecate's proposal store for
 compatibility. Confirmed apply uses the enabled Cairnline authority seams for
 project create, project metadata/default, root, role, work-item, assignment,
-handoff, and memory-candidate actions, but chat/runtime side effects still keep
-Assistant apply as a mixed-authority replacement blocker.
+handoff, and memory-candidate actions, but chat/runtime effects remain
+Hecate-owned orchestrator capabilities outside Cairnline core.
 Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results and cleanup/conflict states are best-effort mirrored
 for replacement evidence, and other live Projects reads/writes still use the
@@ -447,7 +448,8 @@ commits proposal records and apply attempts unless `project-assistant-proposals`
 is enabled, in which case the proposal ledger commits to Cairnline first while
 confirmed apply uses enabled project create, project metadata/default, root,
 role/work-item/assignment/handoff, and memory-candidate authority seams and
-still blocks replacement on the remaining chat/runtime side effects.
+leaves remaining chat/runtime effects as Hecate-owned orchestrator capabilities
+outside Cairnline core.
 `POST /hecate/v1/projects/{id}/cairnline/export` writes a refreshable Cairnline
 SQLite export under Hecate's data directory and returns the same
 `migration_rehearsal` evidence for the single-project database. Both sync and

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -572,7 +572,7 @@ case the proposal ledger commits to Cairnline first and shadows Hecate's
 proposal store for compatibility. Confirmed apply uses the enabled Cairnline
 authority seams for project create, project metadata/default, root, role,
 work-item, assignment, handoff, and memory-candidate actions, but chat/runtime
-side effects still keep apply as a mixed-authority replacement blocker.
+effects remain Hecate-owned orchestrator capabilities outside Cairnline core.
 Other live Projects reads/writes still use Hecate-native
 stores until the remaining read routes, write adapter, and migration path are
 ready. Current bridge write experiments cover non-authoritative
@@ -602,11 +602,12 @@ also reports `replacement_ready`, `next_replacement_action`,
 `replacement_gates`, and `write_switchpoints` so operators can see the
 suggested next step, relevant env-var hints, and the exact read-route,
 strict-embedded-probe, write-authority, and migration blockers without parsing
-warning prose. It also groups the `write_adapter_gaps` stop list into
+warning prose. It also groups the broad `write_adapter_gaps` diagnostic list into
 `portable_write_gaps`,
-`side_effect_blockers`, and `migration_blockers`, so switchpoint work is
-separated from Hecate-owned runtime/workspace side effects and final cutover
-work. Settings shows the same backend-status summary and next action under
+`orchestrator_capabilities`, and `migration_blockers`, so durable
+coordination-state switchpoint work is separated from Hecate-owned
+runtime/workspace capabilities and final cutover work. Settings shows the same
+backend-status summary and next action under
 Project coordination for local operator inspection. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -588,7 +588,8 @@ sequenceDiagram
   store for compatibility. Confirmed Project Assistant apply uses enabled
   project create, project metadata/default, root,
   role/work-item/assignment/handoff, and memory-candidate authority seams and
-  still blocks replacement on the remaining chat/runtime side effects.
+  leaves remaining chat/runtime effects as Hecate-owned orchestrator
+  capabilities outside Cairnline core.
   `project-roots` makes project root create/update/delete plus root list
   replacement plus discovery-result replacement and worktree-created root
   record mutations Cairnline-first, then shadows Hecate's compatibility project
@@ -2453,17 +2454,20 @@ read model. `write_adapter_ready=false` means writes and migration are still
 Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
 can write Cairnline-shaped records during tests or local sync rehearsals;
 `write_adapter_gaps` lists mutation families whose live Hecate routes are not
-Cairnline-backed yet and therefore still block authority switch.
+Cairnline-backed yet. That broad diagnostic list includes both portable
+coordination-state gaps and Hecate-owned runtime/workspace capabilities.
 `portable_write_gaps` groups the durable project-state gaps that can be closed
-by existing Cairnline write-authority switchpoints. `side_effect_blockers`
-groups still-Hecate-owned runtime/workspace effects such as root discovery or
-worktree creation, assignment dispatch, and Project Assistant chat/runtime side
-effects. `migration_blockers` lists remaining cutover/rollback work. These
-grouped fields are explanatory; the full machine-readable stop list remains
-`write_adapter_gaps`. The groups are not guaranteed to be exclusive: for
-example, `roots` can appear in `portable_write_gaps` until root metadata writes
-are Cairnline-authoritative and can remain in `side_effect_blockers` while
-Hecate still owns discovery scans and Git worktree creation.
+by existing Cairnline write-authority switchpoints. It is the write-authority
+replacement blocker list. `orchestrator_capabilities` groups still-Hecate-owned
+runtime/workspace behavior such as root discovery or worktree creation,
+assignment dispatch, and Project Assistant chat/runtime effects. Those
+capabilities are intentionally outside Cairnline core and do not block
+Cairnline owning portable project coordination state. `migration_blockers`
+lists remaining cutover/rollback work. The groups are explanatory and not
+guaranteed to be exclusive: for example, `roots` can appear in
+`portable_write_gaps` until root metadata writes are Cairnline-authoritative and
+can remain in `orchestrator_capabilities` while Hecate still owns discovery
+scans and Git worktree creation.
 `replacement_ready` stays `false` until read parity, strict embedded mirror
 probes, write-authority switchpoints, and migration/rollback gates are all
 ready. `next_replacement_action` is an advisory next operator step derived from
@@ -2477,14 +2481,16 @@ need to parse warning prose. Each gate may include `probe_urls`, a list of route
 templates that produce supporting evidence for that gate; these URLs identify
 checks to run and are not proof that the gate has already passed. The
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
-it ignores the separate `migration-cutover` gap because migration and rollback
-are reported by the `migration-and-rollback` gate.
+it is driven by `portable_write_gaps` and ignores Hecate-owned orchestrator
+capabilities and the separate `migration-cutover` gap because those are reported
+by their own status fields/gates.
 `write_switchpoints` maps each live mutation family to the current authority,
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
 `snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled
 alpha write-authority switchpoints, or `partial_authoritative_opt_in` when only
 some routes in a family have moved), the related mirror seams, and whether that
-family still blocks replacement.
+family still blocks portable write authority or remains Hecate-owned runtime
+behavior.
 Non-authoritative bridge seams currently cover project/root/source/defaults,
 agent profiles, skills, roles, work items, assignment metadata upsert/delete plus
 lifecycle-status sync, create-if-missing generic artifacts/evidence/reviews,
@@ -2712,7 +2718,11 @@ Example response, with `write_switchpoints` shortened for readability:
       "handoffs",
       "project-assistant-proposals"
     ],
-    "side_effect_blockers": ["roots", "assignment-start", "project-assistant-apply-side-effects"],
+    "orchestrator_capabilities": [
+      "roots",
+      "assignment-start",
+      "project-assistant-apply-side-effects"
+    ],
     "migration_blockers": ["migration-cutover"],
     "next_replacement_action": {
       "id": "move-portable-write-authority",
@@ -6416,8 +6426,8 @@ while proposal ledger writes remain Hecate-owned unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
 enabled. Confirmed apply uses enabled project create, project metadata/default,
 root, role/work-item/assignment/handoff, and memory-candidate
-Cairnline-authority seams and still blocks replacement on the remaining
-chat/runtime side effects.
+Cairnline-authority seams and leaves remaining chat/runtime effects as
+Hecate-owned orchestrator capabilities outside Cairnline core.
 `GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
 Cairnline read source as the other read routes; strict embedded mode reads the
 proposal record from the embedded mirror instead of falling back to the native

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -365,16 +365,16 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.WriteAdapterSeams = append([]string(nil), projectCairnlineWriteAdapterSeamNames...)
 		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsSnapshot(effectiveWriteAuthority)
 		response.PortableWriteGaps = projectCairnlinePortableWriteGapsSnapshot(effectiveWriteAuthority, response.WriteAdapterGaps)
-		response.SideEffectBlockers = projectCairnlineSideEffectBlockersSnapshot(response.WriteAdapterGaps)
+		response.OrchestratorCapabilities = projectCairnlineOrchestratorCapabilitiesSnapshot(response.WriteAdapterGaps)
 		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps)
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
-		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.WriteAdapterGaps)
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps)
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
 				response.Detail = "Cairnline sidecar is configured as the project read source, so " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " routes read through the persistent standalone Cairnline MCP client. Project writes and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
-				response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
+				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps)
 				response.Warnings = []string{
 					"Only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
@@ -384,7 +384,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
-			response.ReplacementGates = projectCairnlineReplacementGates(false, response.WriteAdapterGaps)
+			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
 				"Project reads and writes still use Hecate-native stores.",
@@ -497,25 +497,6 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			ConfigHints: projectCairnlineWriteAuthorityHintsForGap(target),
 		}
 	}
-	if len(status.SideEffectBlockers) > 0 {
-		target := status.SideEffectBlockers[0]
-		label := "Separate the next Hecate-owned side effect"
-		detail := "Define the portable record boundary and keep runtime side effects in Hecate or another orchestrator before Cairnline can become authoritative."
-		if target == "roots" {
-			label = "Separate roots and worktree side effects"
-			detail = "Move portable root records toward Cairnline authority while keeping filesystem and Git worktree creation under Hecate's confined runtime boundary."
-		}
-		if target == "assignment-start" {
-			label = "Separate assignment coordination from launch"
-			detail = "Keep assignment records portable while treating task/external-agent launch as an orchestrator capability outside Cairnline core."
-		}
-		return &ProjectCoordinationBackendNextAction{
-			ID:     "separate-side-effect-boundary",
-			Label:  label,
-			Detail: detail,
-			Target: target,
-		}
-	}
 	if len(status.MigrationBlockers) > 0 {
 		return &ProjectCoordinationBackendNextAction{
 			ID:     "rehearse-migration-cutover",
@@ -596,8 +577,8 @@ func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
 	}
 }
 
-func projectCairnlineReplacementGates(readRoutesReady bool, writeGaps []string) []ProjectCoordinationBackendReplacementGate {
-	writeGate := projectCairnlineWriteAuthorityReplacementGate(writeGaps)
+func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string) []ProjectCoordinationBackendReplacementGate {
+	writeGate := projectCairnlineWriteAuthorityReplacementGate(portableWriteGaps)
 	return []ProjectCoordinationBackendReplacementGate{
 		{
 			ID:        "read-routes",
@@ -624,39 +605,36 @@ func projectCairnlineReplacementGates(readRoutesReady bool, writeGaps []string) 
 	}
 }
 
-func projectCairnlineWriteAuthorityReplacementGate(writeGaps []string) ProjectCoordinationBackendReplacementGate {
-	remaining := projectCairnlineWriteSwitchpointGaps(writeGaps)
+func projectCairnlineWriteAuthorityReplacementGate(portableWriteGaps []string) ProjectCoordinationBackendReplacementGate {
+	remaining := append([]string(nil), portableWriteGaps...)
 	gate := ProjectCoordinationBackendReplacementGate{
 		ID:     "write-authority-switchpoints",
 		Ready:  false,
 		Status: "blocked",
-		Detail: "Live mutation routes still commit to Hecate-native stores first; Cairnline mirrors are replacement evidence, not write authority.",
+		Detail: "Portable project-state mutation routes still commit to Hecate-native stores first; Cairnline mirrors are replacement evidence, not write authority.",
 	}
 	switch {
 	case len(remaining) == 0:
 		gate.Ready = true
 		gate.Status = "ready"
-		gate.Detail = "All live mutation switchpoints that have landed are Cairnline-authoritative; migration, rollback, and final cutover still have separate gates."
-	case len(remaining) < projectCairnlineWriteSwitchpointGapCount():
+		gate.Detail = "All portable project-state mutation switchpoints that have landed are Cairnline-authoritative; Hecate-owned orchestrator capabilities, migration, rollback, and final cutover stay outside this gate."
+	case len(remaining) < projectCairnlinePortableWriteGapCount():
 		gate.Status = "partial"
-		gate.Detail = "Some live mutation switchpoints are Cairnline-authoritative; remaining write gaps: " + strings.Join(remaining, ", ") + "."
+		gate.Detail = "Some portable project-state mutation switchpoints are Cairnline-authoritative; remaining portable write gaps: " + strings.Join(remaining, ", ") + "."
 	}
 	return gate
 }
 
-func projectCairnlineWriteSwitchpointGaps(writeGaps []string) []string {
-	out := make([]string, 0, len(writeGaps))
-	for _, gap := range writeGaps {
-		if gap == "migration-cutover" {
+func projectCairnlinePortableWriteGapCount() int {
+	count := 0
+	for _, gap := range projectCairnlineWriteAdapterGapNames {
+		switch gap {
+		case "migration-cutover", "assignment-start", "project-assistant-apply-side-effects":
 			continue
 		}
-		out = append(out, gap)
+		count++
 	}
-	return out
-}
-
-func projectCairnlineWriteSwitchpointGapCount() int {
-	return len(projectCairnlineWriteAdapterGapNames) - 1
+	return count
 }
 
 func projectReplacementGateStatus(ready bool) string {
@@ -736,7 +714,7 @@ func projectCairnlinePortableWriteGapsSnapshot(writeAuthority, writeGaps []strin
 	return out
 }
 
-func projectCairnlineSideEffectBlockersSnapshot(writeGaps []string) []string {
+func projectCairnlineOrchestratorCapabilitiesSnapshot(writeGaps []string) []string {
 	out := make([]string, 0, 3)
 	for _, item := range writeGaps {
 		switch item {
@@ -863,7 +841,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.LiveMirror = true
 			item.BlocksAuthority = true
 			item.Gap = "project-assistant-apply-side-effects"
-			item.Detail = "Project Assistant confirmed apply routes covered portable actions through their enabled Cairnline authority switchpoints: project create, project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime side effects still keep apply as a blocking mixed-authority gap."
+			item.Detail = "Project Assistant confirmed apply routes covered portable actions through their enabled Cairnline authority switchpoints: project create, project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime effects remain Hecate-owned orchestrator capabilities outside Cairnline core."
 		}
 		if projectCollaborationAuthoritative && item.Name == "collaboration-artifacts" {
 			item.CurrentAuthority = "cairnline"
@@ -1006,7 +984,7 @@ func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []strin
 
 func projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority []string) string {
 	if projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority) {
-		return "Project Assistant confirmed apply uses enabled Cairnline authority seams for the portable actions they cover: project create, project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime side effects still keep apply as a mixed-authority replacement blocker."
+		return "Project Assistant confirmed apply uses enabled Cairnline authority seams for the portable actions they cover: project create, project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime effects remain Hecate-owned orchestrator capabilities outside Cairnline core."
 	}
 	return "Project Assistant confirmed apply side effects still execute through Hecate-owned mutation services, then best-effort mirror committed results into Cairnline."
 }

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -73,7 +73,7 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
-	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 || len(status.PortableWriteGaps) != 0 || len(status.SideEffectBlockers) != 0 || len(status.MigrationBlockers) != 0 || len(status.ReplacementGates) != 0 || len(status.WriteSwitchpoints) != 0 {
+	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 || len(status.PortableWriteGaps) != 0 || len(status.OrchestratorCapabilities) != 0 || len(status.SideEffectBlockers) != 0 || len(status.MigrationBlockers) != 0 || len(status.ReplacementGates) != 0 || len(status.WriteSwitchpoints) != 0 {
 		t.Fatalf("status = %+v, want no Cairnline route/seam/gap lists until Cairnline is configured", status)
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "enable-cairnline-dogfood" || status.NextReplacementAction.Target != "configuration" {
@@ -290,8 +290,8 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if !containsString(status.PortableWriteGaps, "projects") || !containsString(status.PortableWriteGaps, "roots") || !containsString(status.PortableWriteGaps, "agent-profiles") || containsString(status.PortableWriteGaps, "assignment-start") || containsString(status.PortableWriteGaps, "project-assistant-apply-side-effects") || containsString(status.PortableWriteGaps, "migration-cutover") {
 		t.Fatalf("portable write gaps = %+v, want portable gaps separated from side-effect and migration blockers", status.PortableWriteGaps)
 	}
-	if !reflect.DeepEqual(status.SideEffectBlockers, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
-		t.Fatalf("side-effect blockers = %+v, want root/worktree, dispatch, and assistant side-effect blockers", status.SideEffectBlockers)
+	if !reflect.DeepEqual(status.OrchestratorCapabilities, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
+		t.Fatalf("orchestrator capabilities = %+v, want root/worktree, dispatch, and assistant apply capabilities", status.OrchestratorCapabilities)
 	}
 	if !reflect.DeepEqual(status.MigrationBlockers, []string{"migration-cutover"}) {
 		t.Fatalf("migration blockers = %+v, want migration cutover blocker", status.MigrationBlockers)
@@ -528,8 +528,8 @@ func TestProjectCoordinationBackendStatus_CairnlineDirectRootSourceAuthorityConf
 	if containsString(status.PortableWriteGaps, "roots") || containsString(status.PortableWriteGaps, "context-sources") {
 		t.Fatalf("portable write gaps = %+v, want root/source portable switchpoint gaps removed", status.PortableWriteGaps)
 	}
-	if !containsString(status.SideEffectBlockers, "roots") {
-		t.Fatalf("side-effect blockers = %+v, want root scan/worktree blocker to remain", status.SideEffectBlockers)
+	if !containsString(status.OrchestratorCapabilities, "roots") {
+		t.Fatalf("orchestrator capabilities = %+v, want root scan/worktree capability to remain", status.OrchestratorCapabilities)
 	}
 	rootPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "roots-and-worktrees")
 	if rootPoint == nil || rootPoint.CurrentAuthority != "mixed" || rootPoint.CairnlineState != "partial_authoritative_opt_in" || !rootPoint.LiveMirror || !rootPoint.BlocksAuthority || rootPoint.Gap != "roots" {
@@ -749,7 +749,7 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 
 	status := handler.projectCoordinationBackendStatus()
 	if !containsString(status.WriteAdapterGaps, "project-assistant-apply-side-effects") {
-		t.Fatalf("write gaps = %+v, want assistant apply side effects to remain a blocking mixed-authority gap", status.WriteAdapterGaps)
+		t.Fatalf("write gaps = %+v, want assistant apply side effects to remain visible as a Hecate-owned capability", status.WriteAdapterGaps)
 	}
 	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
 	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
@@ -761,14 +761,14 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 		}
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "confirmed apply is mixed-authority") || !strings.Contains(warnings, "Project Assistant confirmed apply uses enabled Cairnline authority seams") || !strings.Contains(warnings, "chat/runtime") {
+	if !strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "confirmed apply is mixed-authority") || !strings.Contains(warnings, "Project Assistant confirmed apply uses enabled Cairnline authority seams") || !strings.Contains(warnings, "orchestrator capabilities") {
 		t.Fatalf("warnings = %+v, want assistant proposal authority and mixed apply authority caveats", status.Warnings)
 	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
 	}
-	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "project-assistant-apply-side-effects") {
-		t.Fatalf("write-authority gate = %+v, want partial write authority with mixed assistant apply gap", gate)
+	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "partial" || strings.Contains(gate.Detail, "project-assistant-apply-side-effects") || !strings.Contains(gate.Detail, "agent-profiles") {
+		t.Fatalf("write-authority gate = %+v, want partial portable write authority without assistant side-effect capability", gate)
 	}
 }
 
@@ -809,24 +809,28 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	if len(status.PortableWriteGaps) != 0 {
 		t.Fatalf("portable write gaps = %+v, want all portable gaps removed with all-portable authority alias", status.PortableWriteGaps)
 	}
-	if !reflect.DeepEqual(status.SideEffectBlockers, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
-		t.Fatalf("side-effect blockers = %+v, want remaining non-portable side-effect blockers", status.SideEffectBlockers)
+	if !reflect.DeepEqual(status.OrchestratorCapabilities, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
+		t.Fatalf("orchestrator capabilities = %+v, want remaining Hecate-owned orchestrator capabilities", status.OrchestratorCapabilities)
 	}
 	if !reflect.DeepEqual(status.MigrationBlockers, []string{"migration-cutover"}) {
 		t.Fatalf("migration blockers = %+v, want migration cutover blocker", status.MigrationBlockers)
 	}
-	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "roots") || !strings.Contains(gate.Detail, "assignment-start") || !strings.Contains(gate.Detail, "project-assistant-apply-side-effects") {
-		t.Fatalf("write-authority gate = %+v, want partial write authority with remaining side-effect gaps", gate)
+	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || !gate.Ready || gate.Status != "ready" || !strings.Contains(gate.Detail, "orchestrator capabilities") {
+		t.Fatalf("write-authority gate = %+v, want ready portable write authority with orchestrator capability caveat", gate)
 	}
-	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "separate-side-effect-boundary" || status.NextReplacementAction.Target != "roots" {
-		t.Fatalf("next action = %+v, want roots side-effect action after portable authority gaps close", status.NextReplacementAction)
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "rehearse-migration-cutover" || status.NextReplacementAction.Target != "migration-cutover" {
+		t.Fatalf("next action = %+v, want migration rehearsal after portable authority gaps close", status.NextReplacementAction)
 	}
 }
 
-func TestProjectCoordinationBackendStatus_WriteAuthorityGateIgnoresMigrationGap(t *testing.T) {
-	gate := projectCairnlineWriteAuthorityReplacementGate([]string{"migration-cutover"})
-	if !gate.Ready || gate.Status != "ready" || !strings.Contains(gate.Detail, "migration, rollback, and final cutover still have separate gates") {
-		t.Fatalf("write-authority gate = %+v, want ready when only migration gate remains", gate)
+func TestProjectCoordinationBackendStatus_WriteAuthorityGateUsesPortableGaps(t *testing.T) {
+	gate := projectCairnlineWriteAuthorityReplacementGate(nil)
+	if !gate.Ready || gate.Status != "ready" || !strings.Contains(gate.Detail, "orchestrator capabilities") {
+		t.Fatalf("write-authority gate = %+v, want ready when portable write gaps are closed", gate)
+	}
+	gate = projectCairnlineWriteAuthorityReplacementGate([]string{"memory-candidates"})
+	if gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "memory-candidates") {
+		t.Fatalf("write-authority gate = %+v, want partial when portable write gaps remain", gate)
 	}
 }
 
@@ -880,8 +884,8 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if !response.Data.ReadModelSwitchReady || response.Data.Status != "cairnline_read_routes_ready" {
 		t.Fatalf("response = %+v, want Cairnline read routes ready for fully wired test handler", response)
 	}
-	if !containsString(response.Data.ReadRoutes, "project-detail") || !containsString(response.Data.ReadRoutes, "launch-readiness") || !containsString(response.Data.ReadRoutes, "assignment-preflight") || !containsString(response.Data.ReadRoutes, "project-assistant-context") || !containsString(response.Data.ReadRoutes, "project-assistant-proposal") || !containsString(response.Data.ReadRoutes, "project-chat-prelude") || !containsString(response.Data.ReadRoutes, "project-chat-context") || !containsString(response.Data.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "handoffs") || !containsString(response.Data.WriteAdapterGaps, "memory-candidates") || !containsString(response.Data.PortableWriteGaps, "memory-candidates") || !containsString(response.Data.SideEffectBlockers, "assignment-start") || !containsString(response.Data.MigrationBlockers, "migration-cutover") {
-		t.Fatalf("response routes/seams/gaps = %+v / %+v / %+v portable=%+v side_effect=%+v migration=%+v, want structured readiness details", response.Data.ReadRoutes, response.Data.WriteAdapterSeams, response.Data.WriteAdapterGaps, response.Data.PortableWriteGaps, response.Data.SideEffectBlockers, response.Data.MigrationBlockers)
+	if !containsString(response.Data.ReadRoutes, "project-detail") || !containsString(response.Data.ReadRoutes, "launch-readiness") || !containsString(response.Data.ReadRoutes, "assignment-preflight") || !containsString(response.Data.ReadRoutes, "project-assistant-context") || !containsString(response.Data.ReadRoutes, "project-assistant-proposal") || !containsString(response.Data.ReadRoutes, "project-chat-prelude") || !containsString(response.Data.ReadRoutes, "project-chat-context") || !containsString(response.Data.WriteAdapterSeams, "project-identity-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roots-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-context-sources-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-defaults-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-skills-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-roles-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-work-items-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignments-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-start-result-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assignment-chat-reconcile-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-collaboration-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-handoffs-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-memory-candidates-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-proposal-ledger-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "project-assistant-apply-side-effects-live-mirror") || !containsString(response.Data.WriteAdapterSeams, "handoffs") || !containsString(response.Data.WriteAdapterGaps, "memory-candidates") || !containsString(response.Data.PortableWriteGaps, "memory-candidates") || !containsString(response.Data.OrchestratorCapabilities, "assignment-start") || !containsString(response.Data.MigrationBlockers, "migration-cutover") {
+		t.Fatalf("response routes/seams/gaps = %+v / %+v / %+v portable=%+v orchestrator=%+v migration=%+v, want structured readiness details", response.Data.ReadRoutes, response.Data.WriteAdapterSeams, response.Data.WriteAdapterGaps, response.Data.PortableWriteGaps, response.Data.OrchestratorCapabilities, response.Data.MigrationBlockers)
 	}
 	if response.Data.ReplacementReady {
 		t.Fatalf("response replacement_ready = true, want false until write authority and migration gates are ready")

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -571,6 +571,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	WriteAdapterSeams                    []string                                     `json:"write_adapter_seams,omitempty"`
 	WriteAdapterGaps                     []string                                     `json:"write_adapter_gaps,omitempty"`
 	PortableWriteGaps                    []string                                     `json:"portable_write_gaps,omitempty"`
+	OrchestratorCapabilities             []string                                     `json:"orchestrator_capabilities,omitempty"`
 	SideEffectBlockers                   []string                                     `json:"side_effect_blockers,omitempty"`
 	MigrationBlockers                    []string                                     `json:"migration_blockers,omitempty"`
 	NextReplacementAction                *ProjectCoordinationBackendNextAction        `json:"next_replacement_action,omitempty"`

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -91,7 +91,7 @@ describe("SettingsView", () => {
         replacement_ready: false,
         read_routes: ["project-list", "project-detail"],
         portable_write_gaps: ["agent-profiles", "memory-candidates"],
-        side_effect_blockers: ["assignment-start"],
+        orchestrator_capabilities: ["assignment-start"],
         migration_blockers: ["migration-cutover"],
         next_replacement_action: {
           id: "move-portable-write-authority",
@@ -120,6 +120,7 @@ describe("SettingsView", () => {
     expect(screen.getByText("cairnline read routes ready")).toBeTruthy();
     expect(screen.getByText(/2 read routes use Cairnline/i)).toBeTruthy();
     expect(screen.getByText("Portable write gaps")).toBeTruthy();
+    expect(screen.getByText("Hecate orchestrator capabilities")).toBeTruthy();
     expect(screen.getByText("Next action")).toBeTruthy();
     expect(screen.getByText("Move the next portable write authority")).toBeTruthy();
     expect(screen.getAllByText("agent-profiles").length).toBeGreaterThanOrEqual(1);

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -297,7 +297,8 @@ function ProjectCoordinationBackendSettings({
 }) {
   const readRoutes = status?.read_routes ?? [];
   const portableGaps = status?.portable_write_gaps ?? [];
-  const sideEffectBlockers = status?.side_effect_blockers ?? [];
+  const orchestratorCapabilities =
+    status?.orchestrator_capabilities ?? status?.side_effect_blockers ?? [];
   const migrationBlockers = status?.migration_blockers ?? [];
   const nextAction = status?.next_replacement_action;
   const statusBadge = status
@@ -362,14 +363,14 @@ function ProjectCoordinationBackendSettings({
           >
             <ProjectBackendMetric label="Read routes" value={readRoutes.length} />
             <ProjectBackendMetric label="Portable gaps" value={portableGaps.length} />
-            <ProjectBackendMetric label="Side effects" value={sideEffectBlockers.length} />
+            <ProjectBackendMetric label="Orchestrator" value={orchestratorCapabilities.length} />
             <ProjectBackendMetric label="Migration" value={migrationBlockers.length} />
           </div>
           <div style={{ display: "grid", gap: 10, marginTop: 14 }}>
             <ProjectBackendList title="Portable write gaps" items={portableGaps} empty="none" />
             <ProjectBackendList
-              title="Side-effect blockers"
-              items={sideEffectBlockers}
+              title="Hecate orchestrator capabilities"
+              items={orchestratorCapabilities}
               empty="none"
             />
             <ProjectBackendList title="Migration blockers" items={migrationBlockers} empty="none" />
@@ -456,7 +457,8 @@ function projectBackendTitle(status: ProjectCoordinationBackendStatusRecord): st
 function projectBackendSummary(status: ProjectCoordinationBackendStatusRecord): string {
   const readRoutes = status.read_routes?.length ?? 0;
   const portableGaps = status.portable_write_gaps?.length ?? 0;
-  const sideEffectBlockers = status.side_effect_blockers?.length ?? 0;
+  const orchestratorCapabilities =
+    status.orchestrator_capabilities?.length ?? status.side_effect_blockers?.length ?? 0;
   const migrationBlockers = status.migration_blockers?.length ?? 0;
   if (status.replacement_ready) {
     return "Cairnline replacement gates are ready.";
@@ -465,7 +467,7 @@ function projectBackendSummary(status: ProjectCoordinationBackendStatusRecord): 
     return "Hecate-native project stores are authoritative. Cairnline bridge diagnostics are available for replacement-readiness checks.";
   }
   if (status.read_model_switch_ready || readRoutes > 0) {
-    return `${readRoutes} read route${readRoutes === 1 ? "" : "s"} use Cairnline. ${portableGaps} portable write gap${portableGaps === 1 ? "" : "s"}, ${sideEffectBlockers} side-effect blocker${sideEffectBlockers === 1 ? "" : "s"}, and ${migrationBlockers} migration blocker${migrationBlockers === 1 ? "" : "s"} remain.`;
+    return `${readRoutes} read route${readRoutes === 1 ? "" : "s"} use Cairnline. ${portableGaps} portable write gap${portableGaps === 1 ? "" : "s"} and ${migrationBlockers} migration blocker${migrationBlockers === 1 ? "" : "s"} remain; ${orchestratorCapabilities} Hecate orchestrator capabilit${orchestratorCapabilities === 1 ? "y" : "ies"} stay outside Cairnline core.`;
   }
   return "Cairnline is configured, but live read routes and replacement gates are not ready yet.";
 }

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -120,6 +120,8 @@ export type ProjectCoordinationBackendStatusRecord = {
   write_adapter_seams?: string[];
   write_adapter_gaps?: string[];
   portable_write_gaps?: string[];
+  orchestrator_capabilities?: string[];
+  /** @deprecated use orchestrator_capabilities */
   side_effect_blockers?: string[];
   migration_blockers?: string[];
   next_replacement_action?: ProjectCoordinationBackendNextActionRecord;


### PR DESCRIPTION
## Summary
- add orchestrator_capabilities to the project coordination backend status
- drive the write-authority replacement gate and next action from portable_write_gaps instead of Hecate-owned runtime/workspace behavior
- update Settings UI and docs to describe Hecate-owned launch/workspace behavior as orchestrator capabilities outside Cairnline core

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run TestProjectCoordinationBackendStatus
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just agent-docs-check