### PR TITLE
Mark orchestrator switchpoints nonblocking

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -418,10 +418,10 @@ Project skill discovery/update can be switched to Cairnline-first authority with
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills`.
 Assignment create/update/delete
 routes mirror coordination metadata and lifecycle status after Hecate commits;
-assignment-start remains a Hecate-owned write gap because dispatch still carries
-runtime coupling that needs a narrower switch point, but successful start
-results and start-side conflict/cleanup states are best-effort mirrored after
-Hecate commits them. Linked external-agent chat reconciliation also mirrors the
+assignment-start remains a Hecate-owned orchestrator capability because dispatch
+still carries runtime coupling, but successful start results and start-side
+conflict/cleanup states are best-effort mirrored after Hecate commits them.
+Linked external-agent chat reconciliation also mirrors the
 committed assignment status/ref when Hecate updates the linked assignment from a
 chat session. Collaboration artifact creation, including generic artifacts,
 evidence links, and reviews, and handoff create/update/delete routes also mirror
@@ -576,17 +576,18 @@ after these gates are met:
   Cairnline-authoritative with the `project-assistant-proposals` switchpoint.
   Confirmed apply may use enabled project create, project metadata/default, root,
   role/work-item/assignment/handoff, and memory-candidate Cairnline-authority
-  seams, but chat/runtime side effects remain a mixed-authority replacement
-  blocker and are mirrored as
+  seams, but chat/runtime effects remain Hecate-owned orchestrator capabilities
+  outside Cairnline core and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative
   Cairnline launch-packet evidence, but assignment-start remains a Hecate-owned
-  write gap; committed start and linked-chat reconciliation results may be
-  mirrored only as replacement evidence. Backend-status `write_adapter_seams`
+  orchestrator capability; committed start and linked-chat reconciliation
+  results may be mirrored only as replacement evidence. Backend-status `write_adapter_seams`
   lists non-authoritative proof
-  coverage; `write_adapter_gaps` remains the machine-readable stop list for
-  mutation families that still need live switch points before authority can
-  move.
+  coverage; `write_adapter_gaps` remains a broad diagnostic list, while
+  `portable_write_gaps` is the machine-readable blocker list for mutation
+  families that still need live switch points before portable write authority
+  can move.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha; the embedded Cairnline sync database proves a
   durable all-project seed through Cairnline's native snapshot import with

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2793,7 +2793,7 @@ Example response, with `write_switchpoints` shortened for readability:
         "current_authority": "hecate",
         "cairnline_state": "result_mirror_only",
         "live_mirror": true,
-        "blocks_authority": true,
+        "blocks_authority": false,
         "seams": ["project-assignment-start-result-live-mirror"],
         "gap": "assignment-start",
         "detail": "Assignment start still dispatches through Hecate runtime/task/external-agent authority; Cairnline receives only committed start results and cleanup/conflict states."

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -228,7 +228,7 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 		CurrentAuthority: "hecate",
 		CairnlineState:   "result_mirror_only",
 		LiveMirror:       true,
-		BlocksAuthority:  true,
+		BlocksAuthority:  false,
 		Seams:            []string{"project-assignment-start-result-live-mirror"},
 		Gap:              "assignment-start",
 		Detail:           "Assignment start still dispatches through Hecate runtime/task/external-agent authority; Cairnline receives only committed start results and cleanup/conflict states.",
@@ -288,7 +288,7 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 		CurrentAuthority: "hecate",
 		CairnlineState:   "side_effect_mirror_only",
 		LiveMirror:       true,
-		BlocksAuthority:  true,
+		BlocksAuthority:  false,
 		Seams:            []string{"project-assistant-apply-side-effects-live-mirror"},
 		Gap:              "project-assistant-apply-side-effects",
 		Detail:           "Project Assistant confirmed apply still executes Hecate-owned project mutations, then mirrors committed side effects into Cairnline as replacement evidence.",
@@ -772,7 +772,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.CurrentAuthority = "mixed"
 			item.CairnlineState = "partial_authoritative_opt_in"
 			item.LiveMirror = true
-			item.BlocksAuthority = true
+			item.BlocksAuthority = false
 			item.Gap = "roots"
 			item.Detail = "Project root create/update/delete, root list replacement, discovery-result replacement, and worktree-created root record mutations commit to the embedded Cairnline database first, then best-effort shadow Hecate's compatibility row; Hecate still performs root discovery scans and Git worktree creation side effects."
 		}
@@ -839,7 +839,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.CurrentAuthority = "mixed"
 			item.CairnlineState = "partial_authoritative_via_portable_switchpoints"
 			item.LiveMirror = true
-			item.BlocksAuthority = true
+			item.BlocksAuthority = false
 			item.Gap = "project-assistant-apply-side-effects"
 			item.Detail = "Project Assistant confirmed apply routes covered portable actions through their enabled Cairnline authority switchpoints: project create, project metadata/default, root, role, work-item, assignment, handoff, and memory-candidate; chat/runtime effects remain Hecate-owned orchestrator capabilities outside Cairnline core."
 		}

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -120,8 +120,8 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	if gate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); gate == nil || gate.Ready || gate.Status != "rehearsal_available" {
 		t.Fatalf("migration gate = %+v, want rehearsal-available blocker", gate)
 	}
-	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "result_mirror_only" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "assignment-start" {
-		t.Fatalf("assignment-start switchpoint = %+v, want Hecate-owned result mirror blocker", point)
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "result_mirror_only" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "assignment-start" {
+		t.Fatalf("assignment-start switchpoint = %+v, want Hecate-owned result mirror capability outside portable write authority", point)
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "complete-read-model-sources" || status.NextReplacementAction.Target != "read-routes" || !containsString(status.NextReplacementAction.ProbeURLs, projectCoordinationBackendEmbeddedParityReportURL) {
 		t.Fatalf("next action = %+v, want read-model source action with embedded parity probe", status.NextReplacementAction)
@@ -446,8 +446,8 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectMetadataDefaultsAuthor
 		t.Fatalf("project-identity switchpoint = %+v, want create/delete to remain Hecate-owned and blocking", identityPoint)
 	}
 	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
-	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
-		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed authority through metadata/default switchpoint", applyPoint)
+	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed orchestrator capability through metadata/default switchpoint", applyPoint)
 	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
@@ -477,8 +477,8 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectIdentityAuthorityConfi
 		t.Fatalf("project-identity switchpoint = %+v, want opt-in Cairnline authority", point)
 	}
 	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
-	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
-		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed authority through project identity switchpoint", applyPoint)
+	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed orchestrator capability through project identity switchpoint", applyPoint)
 	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
@@ -532,8 +532,8 @@ func TestProjectCoordinationBackendStatus_CairnlineDirectRootSourceAuthorityConf
 		t.Fatalf("orchestrator capabilities = %+v, want root scan/worktree capability to remain", status.OrchestratorCapabilities)
 	}
 	rootPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "roots-and-worktrees")
-	if rootPoint == nil || rootPoint.CurrentAuthority != "mixed" || rootPoint.CairnlineState != "partial_authoritative_opt_in" || !rootPoint.LiveMirror || !rootPoint.BlocksAuthority || rootPoint.Gap != "roots" {
-		t.Fatalf("roots-and-worktrees switchpoint = %+v, want partial opt-in authority with roots gap still blocking", rootPoint)
+	if rootPoint == nil || rootPoint.CurrentAuthority != "mixed" || rootPoint.CairnlineState != "partial_authoritative_opt_in" || !rootPoint.LiveMirror || rootPoint.BlocksAuthority || rootPoint.Gap != "roots" {
+		t.Fatalf("roots-and-worktrees switchpoint = %+v, want partial opt-in authority with root orchestration outside portable write authority", rootPoint)
 	}
 	sourcePoint := findWriteSwitchpoint(status.WriteSwitchpoints, "context-sources")
 	if sourcePoint == nil || sourcePoint.CurrentAuthority != "cairnline" || sourcePoint.CairnlineState != "authoritative_opt_in" || !sourcePoint.LiveMirror || sourcePoint.BlocksAuthority || sourcePoint.Gap != "" {
@@ -673,15 +673,15 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssignmentsAuthorityCo
 		t.Fatalf("write gaps = %+v, want assignments removed for opt-in Cairnline authority", status.WriteAdapterGaps)
 	}
 	if !containsString(status.WriteAdapterGaps, "assignment-start") {
-		t.Fatalf("write gaps = %+v, want assignment-start to remain Hecate-owned and blocking", status.WriteAdapterGaps)
+		t.Fatalf("write gaps = %+v, want assignment-start to remain visible as a Hecate-owned orchestrator capability", status.WriteAdapterGaps)
 	}
 	point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignments")
 	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
 		t.Fatalf("assignments switchpoint = %+v, want opt-in Cairnline authority", point)
 	}
 	startPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch")
-	if startPoint == nil || startPoint.CurrentAuthority != "hecate" || startPoint.CairnlineState != "result_mirror_only" || !startPoint.BlocksAuthority || startPoint.Gap != "assignment-start" {
-		t.Fatalf("assignment-start switchpoint = %+v, want Hecate start authority to remain blocking", startPoint)
+	if startPoint == nil || startPoint.CurrentAuthority != "hecate" || startPoint.CairnlineState != "result_mirror_only" || startPoint.BlocksAuthority || startPoint.Gap != "assignment-start" {
+		t.Fatalf("assignment-start switchpoint = %+v, want Hecate start authority outside portable write authority", startPoint)
 	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
@@ -707,15 +707,15 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantProposalAutho
 		t.Fatalf("write gaps = %+v, want assistant proposal ledger removed for opt-in Cairnline authority", status.WriteAdapterGaps)
 	}
 	if !containsString(status.WriteAdapterGaps, "project-assistant-apply-side-effects") {
-		t.Fatalf("write gaps = %+v, want assistant apply side effects to remain Hecate-owned and blocking", status.WriteAdapterGaps)
+		t.Fatalf("write gaps = %+v, want assistant apply side effects to remain visible as a Hecate-owned orchestrator capability", status.WriteAdapterGaps)
 	}
 	point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-proposal-ledger")
 	if point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "authoritative_opt_in" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "" {
 		t.Fatalf("project-assistant-proposal-ledger switchpoint = %+v, want opt-in Cairnline authority", point)
 	}
 	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
-	if applyPoint == nil || applyPoint.CurrentAuthority != "hecate" || applyPoint.CairnlineState != "side_effect_mirror_only" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
-		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want Hecate-owned side-effect mirror blocker", applyPoint)
+	if applyPoint == nil || applyPoint.CurrentAuthority != "hecate" || applyPoint.CairnlineState != "side_effect_mirror_only" || applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want Hecate-owned side-effect mirror capability outside portable write authority", applyPoint)
 	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
@@ -752,8 +752,8 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssistantApplyPortable
 		t.Fatalf("write gaps = %+v, want assistant apply side effects to remain visible as a Hecate-owned capability", status.WriteAdapterGaps)
 	}
 	applyPoint := findWriteSwitchpoint(status.WriteSwitchpoints, "project-assistant-apply-side-effects")
-	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || !applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
-		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed authority through enabled portable switchpoints", applyPoint)
+	if applyPoint == nil || applyPoint.CurrentAuthority != "mixed" || applyPoint.CairnlineState != "partial_authoritative_via_portable_switchpoints" || applyPoint.BlocksAuthority || applyPoint.Gap != "project-assistant-apply-side-effects" {
+		t.Fatalf("project-assistant-apply-side-effects switchpoint = %+v, want mixed orchestrator capability through enabled portable switchpoints", applyPoint)
 	}
 	for _, name := range []string{"roles", "work-items", "assignments", "artifacts", "handoffs", "memory", "memory-candidates", "project-assistant-proposals"} {
 		if containsString(status.WriteAdapterGaps, name) {

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -312,7 +312,7 @@ function ProjectCoordinationBackendSettings({
     <section style={{ marginBottom: 20 }}>
       <SectionHeader
         title="Project coordination"
-        description="Current Projects backend authority and Cairnline replacement-readiness blockers."
+        description="Current Projects backend authority, Cairnline replacement readiness, and Hecate-owned orchestrator capabilities."
         meta={
           status
             ? `${status.configured_backend} configured · ${status.authoritative_backend} authoritative`


### PR DESCRIPTION
## Summary
- mark assignment-start, assistant apply, and root orchestration-only switchpoints as nonblocking for portable write authority
- keep their diagnostic gap names visible while blocks_authority now means portable write-authority blocking
- update Settings copy and Cairnline docs to avoid calling orchestrator capabilities blockers

## Tests
- GOCACHE="$PWD/.gocache" go test ./internal/api -run TestProjectCoordinationBackendStatus
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just agent-docs-check