### PR TITLE
Surface Cairnline replacement gates

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -607,8 +607,13 @@ warning prose. It also groups the broad `write_adapter_gaps` diagnostic list int
 `orchestrator_capabilities`, and `migration_blockers`, so durable
 coordination-state switchpoint work is separated from Hecate-owned
 runtime/workspace capabilities and final cutover work. Settings shows the same
-backend-status summary and next action under
-Project coordination for local operator inspection. `GET
+backend-status summary, next action, and replacement-gate checklist under
+Project coordination for local operator inspection. Once portable write gaps are
+closed, the migration next action reports strict embedded rehearsal hints for
+`HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`; these remain operator
+settings, not an automatic backend replacement. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2484,6 +2484,13 @@ checks to run and are not proof that the gate has already passed. The
 it is driven by `portable_write_gaps` and ignores Hecate-owned orchestrator
 capabilities and the separate `migration-cutover` gap because those are reported
 by their own status fields/gates.
+When the next action is `rehearse-migration-cutover`, `config_hints` identify
+the strict embedded dogfood posture expected for the rehearsal:
+`HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`. These are still
+operator-applied settings and do not flip Hecate into a replaced backend by
+themselves.
 `write_switchpoints` maps each live mutation family to the current authority,
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
 `snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -499,10 +499,11 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 	}
 	if len(status.MigrationBlockers) > 0 {
 		return &ProjectCoordinationBackendNextAction{
-			ID:     "rehearse-migration-cutover",
-			Label:  "Rehearse migration and rollback",
-			Detail: "Run sync/parity/export rehearsal paths and document the explicit cutover and rollback procedure before replacement.",
-			Target: status.MigrationBlockers[0],
+			ID:          "rehearse-migration-cutover",
+			Label:       "Rehearse migration and rollback",
+			Detail:      "Run strict embedded sync/parity/export rehearsal paths and document the explicit cutover and rollback procedure before replacement.",
+			Target:      status.MigrationBlockers[0],
+			ConfigHints: projectCairnlineMigrationCutoverHints(),
 			ProbeURLs: []string{
 				projectCoordinationBackendSyncReadinessURL,
 				projectCoordinationBackendMirrorParityURL,
@@ -521,6 +522,14 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			projectCoordinationBackendSyncReadinessURL,
 			projectCoordinationBackendMirrorParityURL,
 		},
+	}
+}
+
+func projectCairnlineMigrationCutoverHints() []ProjectCoordinationBackendActionConfigHint {
+	return []ProjectCoordinationBackendActionConfigHint{
+		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector for current write-authority and migration rehearsal paths."),
+		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "embedded", "Force configured project reads to fail loudly when the embedded mirror is missing or stale during cutover rehearsal."),
+		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", "all-portable", "Keep all portable write-authority switchpoints enabled while rehearsing migration and rollback."),
 	}
 }
 

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -821,6 +821,15 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "rehearse-migration-cutover" || status.NextReplacementAction.Target != "migration-cutover" {
 		t.Fatalf("next action = %+v, want migration rehearsal after portable authority gaps close", status.NextReplacementAction)
 	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("next action config hints = %+v, want embedded connector hint", status.NextReplacementAction.ConfigHints)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("next action config hints = %+v, want strict embedded read-source hint", status.NextReplacementAction.ConfigHints)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY"); hint == nil || hint.Value != "all-portable" {
+		t.Fatalf("next action config hints = %+v, want all-portable authority hint", status.NextReplacementAction.ConfigHints)
+	}
 }
 
 func TestProjectCoordinationBackendStatus_WriteAuthorityGateUsesPortableGaps(t *testing.T) {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -107,6 +107,34 @@ describe("SettingsView", () => {
           ],
           probe_urls: ["/hecate/v1/projects/{id}/cairnline/read-model"],
         },
+        replacement_gates: [
+          {
+            id: "read-routes",
+            ready: true,
+            status: "ready",
+            detail:
+              "Configured live project read families can be served from Cairnline's projected read model.",
+            probe_urls: ["/hecate/v1/projects/{id}/cairnline/read-model"],
+          },
+          {
+            id: "write-authority-switchpoints",
+            ready: false,
+            status: "partial",
+            detail:
+              "Some portable project-state mutation switchpoints are Cairnline-authoritative; remaining portable write gaps: agent-profiles, memory-candidates.",
+          },
+          {
+            id: "migration-and-rollback",
+            ready: false,
+            status: "rehearsal_available",
+            detail:
+              "Embedded sync and project export return structured migration rehearsal evidence with rollback notes.",
+            probe_urls: [
+              "/hecate/v1/projects/cairnline/sync",
+              "/hecate/v1/projects/cairnline/mirror-parity",
+            ],
+          },
+        ],
         status: "cairnline_read_routes_ready",
         detail: "Cairnline read routes are served from the read model.",
       },
@@ -123,11 +151,17 @@ describe("SettingsView", () => {
     expect(screen.getByText("Hecate orchestrator capabilities")).toBeTruthy();
     expect(screen.getByText("Next action")).toBeTruthy();
     expect(screen.getByText("Move the next portable write authority")).toBeTruthy();
+    expect(screen.getByText("Replacement gates")).toBeTruthy();
+    expect(screen.getByText("read routes")).toBeTruthy();
+    expect(screen.getByText("write authority switchpoints")).toBeTruthy();
+    expect(screen.getByText("migration and rollback")).toBeTruthy();
+    expect(screen.getByText("partial")).toBeTruthy();
+    expect(screen.getByText("rehearsal available")).toBeTruthy();
     expect(screen.getAllByText("agent-profiles").length).toBeGreaterThanOrEqual(1);
     expect(
       screen.getByText("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles"),
     ).toBeTruthy();
-    expect(screen.getByText("1 probe")).toBeTruthy();
+    expect(screen.getAllByText("1 probe").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("memory-candidates")).toBeTruthy();
     expect(screen.getByText("assignment-start")).toBeTruthy();
     expect(screen.getByText("migration-cutover")).toBeTruthy();

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -300,6 +300,7 @@ function ProjectCoordinationBackendSettings({
   const orchestratorCapabilities =
     status?.orchestrator_capabilities ?? status?.side_effect_blockers ?? [];
   const migrationBlockers = status?.migration_blockers ?? [];
+  const replacementGates = status?.replacement_gates ?? [];
   const nextAction = status?.next_replacement_action;
   const statusBadge = status
     ? status.replacement_ready
@@ -353,6 +354,7 @@ function ProjectCoordinationBackendSettings({
             </div>
           </div>
           {nextAction && <ProjectBackendNextAction action={nextAction} />}
+          {replacementGates.length > 0 && <ProjectBackendGateList gates={replacementGates} />}
           <div
             style={{
               display: "grid",
@@ -378,6 +380,72 @@ function ProjectCoordinationBackendSettings({
         </article>
       )}
     </section>
+  );
+}
+
+function ProjectBackendGateList({
+  gates,
+}: {
+  gates: NonNullable<ProjectCoordinationBackendStatusRecord["replacement_gates"]>;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 8, marginTop: 14 }}>
+      <div
+        style={{
+          color: "var(--t3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        Replacement gates
+      </div>
+      <div style={{ display: "grid", gap: 7 }}>
+        {gates.map((gate) => {
+          const probes = gate.probe_urls ?? [];
+          return (
+            <div
+              key={gate.id}
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius-sm)",
+                display: "grid",
+                gap: 5,
+                padding: "8px 10px",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 7, flexWrap: "wrap" }}>
+                <ProjectBackendGateBadge ready={gate.ready} status={gate.status} />
+                <span style={{ color: "var(--t0)", fontSize: 12, fontWeight: 600 }}>
+                  {gate.id.replaceAll("-", " ")}
+                </span>
+                {probes.length > 0 && (
+                  <span className="badge badge-muted" style={{ textTransform: "none" }}>
+                    {probes.length} probe{probes.length === 1 ? "" : "s"}
+                  </span>
+                )}
+              </div>
+              <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.45 }}>
+                {gate.detail}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ProjectBackendGateBadge({ ready, status }: { ready: boolean; status: string }) {
+  const className = ready
+    ? "badge badge-green"
+    : status === "partial" || status === "operator_probe_required"
+      ? "badge badge-amber"
+      : "badge badge-muted";
+  return (
+    <span className={className} style={{ textTransform: "none" }}>
+      {status.replaceAll("_", " ")}
+    </span>
   );
 }
 
@@ -467,7 +535,7 @@ function projectBackendSummary(status: ProjectCoordinationBackendStatusRecord): 
     return "Hecate-native project stores are authoritative. Cairnline bridge diagnostics are available for replacement-readiness checks.";
   }
   if (status.read_model_switch_ready || readRoutes > 0) {
-    return `${readRoutes} read route${readRoutes === 1 ? "" : "s"} use Cairnline. ${portableGaps} portable write gap${portableGaps === 1 ? "" : "s"} and ${migrationBlockers} migration blocker${migrationBlockers === 1 ? "" : "s"} remain; ${orchestratorCapabilities} Hecate orchestrator capabilit${orchestratorCapabilities === 1 ? "y" : "ies"} stay outside Cairnline core.`;
+    return `${readRoutes} read route${readRoutes === 1 ? "" : "s"} use Cairnline. ${portableGaps} portable write gap${portableGaps === 1 ? "" : "s"} and ${migrationBlockers} migration blocker${migrationBlockers === 1 ? "" : "s"} remain; ${orchestratorCapabilities} Hecate orchestrator ${orchestratorCapabilities === 1 ? "capability stays" : "capabilities stay"} outside Cairnline core.`;
   }
   return "Cairnline is configured, but live read routes and replacement gates are not ready yet.";
 }


### PR DESCRIPTION
Summary
- show Project coordination replacement gates in Settings instead of hiding them in raw status JSON
- add strict embedded migration rehearsal config hints when portable write gaps are closed
- document the migration hints and Settings replacement-gate checklist

Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run TestProjectCoordinationBackendStatus
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./... (first run hit a root-discovery miss that passed in isolation; rerun passed)
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just agent-docs-check