### PR TITLE
Report portable write readiness

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2450,9 +2450,12 @@ the standalone Cairnline MCP client; backend status reports those routes in
 `read_routes` while `read_model_switch_ready` remains false because the broader
 read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
-read model. `write_adapter_ready=false` means writes and migration are still
-Hecate-owned. `write_adapter_seams` lists non-authoritative bridge proofs that
-can write Cairnline-shaped records during tests or local sync rehearsals;
+read model. `write_adapter_ready=true` means all portable project-state
+write-authority gaps known to this Hecate build are closed through explicit
+Cairnline switchpoints; it does not mean Hecate runtime side effects,
+migration, rollback, or final replacement are ready. `write_adapter_seams`
+lists non-authoritative bridge proofs that can write Cairnline-shaped records
+during tests or local sync rehearsals;
 `write_adapter_gaps` lists mutation families whose live Hecate routes are not
 Cairnline-backed yet. That broad diagnostic list includes both portable
 coordination-state gaps and Hecate-owned runtime/workspace capabilities.

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -367,6 +367,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.PortableWriteGaps = projectCairnlinePortableWriteGapsSnapshot(effectiveWriteAuthority, response.WriteAdapterGaps)
 		response.OrchestratorCapabilities = projectCairnlineOrchestratorCapabilitiesSnapshot(response.WriteAdapterGaps)
 		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps)
+		response.WriteAdapterReady = len(response.PortableWriteGaps) == 0
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
 		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps)
 		if !connectorReady {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -809,6 +809,12 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	if len(status.PortableWriteGaps) != 0 {
 		t.Fatalf("portable write gaps = %+v, want all portable gaps removed with all-portable authority alias", status.PortableWriteGaps)
 	}
+	if !status.WriteAdapterReady {
+		t.Fatalf("write_adapter_ready = false, want true when all portable write gaps are closed")
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false until migration and cutover gates are ready")
+	}
 	if !reflect.DeepEqual(status.OrchestratorCapabilities, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
 		t.Fatalf("orchestrator capabilities = %+v, want remaining Hecate-owned orchestrator capabilities", status.OrchestratorCapabilities)
 	}


### PR DESCRIPTION
Summary
- make write_adapter_ready true once portable write gaps are closed
- keep replacement_ready false until migration and cutover gates are ready
- update runtime API docs for the distinction

Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run TestProjectCoordinationBackendStatus
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- just agent-docs-check