### PR TITLE
Report embedded Cairnline replacement target

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -129,6 +129,11 @@ that list into `portable_write_gaps`, `orchestrator_capabilities`, and
 switchpoint work apart from Hecate-owned runtime/workspace capabilities and
 final cutover work. `portable_write_gaps` drives the write-authority replacement
 gate; `orchestrator_capabilities` are intentionally outside Cairnline core.
+The replacement target is embedded Cairnline first: Hecate should make the
+embedded Cairnline database authoritative for Projects before treating the
+standalone sidecar as the external MCP/server boundary. That keeps Hecate's
+operator UI and compatibility shadow stable while the portable contract is
+proven locally.
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded` is the current live-route
 dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes
 local-only standalone Cairnline MCP contract probe/connect surfaces at
@@ -595,6 +600,11 @@ after these gates are met:
   strict embedded configured-route smoke across representative project, setup,
   health, skill, memory, role, work, collaboration, assistant-context,
   activity, and operations route families before it becomes a write path.
+- The cutover sequence is embedded first, sidecar later: embedded Cairnline
+  becomes the Hecate Projects source of truth before Hecate grows a full
+  external-sidecar backend adapter. Sidecar diagnostics remain valuable MCP
+  interoperability evidence, but they are not the first Hecate replacement
+  target.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -93,7 +93,8 @@ side-by-side MCP server
 -> embedded read/write experiment
 -> parity adapter behind a feature flag
 -> state migration/import-export
--> replacement after dogfood
+-> embedded Cairnline replacement after dogfood
+-> optional external sidecar backend after embedded replacement is stable
 ```
 
 ## Product Boundary
@@ -530,8 +531,9 @@ launch agents. Those remain explicit operator or orchestrator actions.
   configured-route smoke tests after sync and live-mirror parity to prove normal
   project, setup, health, skill, memory, role, work, collaboration, assistant
   context, activity, and operations reads can run from the embedded database.
-- After V0 stabilizes, Hecate may embed the portable core as its Projects
-  backend or talk to the MCP server as a separate local coordination process.
+- After V0 stabilizes, Hecate should embed the portable core as its first
+  Projects backend replacement. Talking to the MCP server as a separate local
+  coordination process remains the later standalone/interoperability boundary.
 - Hecate remains the richer cockpit and orchestrator for supervised Hecate
   Tasks and External Agents.
 - Hecate integration tests should start only after Hecate consumes the

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -608,7 +608,10 @@ warning prose. It also groups the broad `write_adapter_gaps` diagnostic list int
 coordination-state switchpoint work is separated from Hecate-owned
 runtime/workspace capabilities and final cutover work. Settings shows the same
 backend-status summary, next action, and replacement-gate checklist under
-Project coordination for local operator inspection. Once portable write gaps are
+Project coordination for local operator inspection. The reported replacement
+target is embedded Cairnline first: Hecate should make the embedded Cairnline
+database the Projects source of truth before treating an external sidecar as the
+standalone/interoperability boundary. Once portable write gaps are
 closed, the migration next action reports strict embedded rehearsal hints for
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2450,10 +2450,14 @@ the standalone Cairnline MCP client; backend status reports those routes in
 `read_routes` while `read_model_switch_ready` remains false because the broader
 read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
-read model. `write_adapter_ready=true` means all portable project-state
-write-authority gaps known to this Hecate build are closed through explicit
-Cairnline switchpoints; it does not mean Hecate runtime side effects,
-migration, rollback, or final replacement are ready. `write_adapter_seams`
+read model. `replacement_target=embedded_cairnline_first` documents the
+current source-of-truth strategy: replace Hecate-native Projects with embedded
+Cairnline first, then keep the standalone Cairnline sidecar as the later
+interoperability and external-server boundary. `write_adapter_ready=true` means
+all portable project-state write-authority gaps known to this Hecate build are
+closed through explicit Cairnline switchpoints; it does not mean Hecate runtime
+side effects, migration, rollback, or final replacement are ready.
+`write_adapter_seams`
 lists non-authoritative bridge proofs that can write Cairnline-shaped records
 during tests or local sync rehearsals;
 `write_adapter_gaps` lists mutation families whose live Hecate routes are not
@@ -2633,6 +2637,8 @@ Example response, with `write_switchpoints` shortened for readability:
     "read_model_switch_ready": true,
     "write_adapter_ready": false,
     "replacement_ready": false,
+    "replacement_target": "embedded_cairnline_first",
+    "replacement_target_detail": "Hecate's Projects replacement path targets embedded Cairnline as the first source of truth; the standalone sidecar remains an interoperability and future external-server boundary.",
     "read_routes": [
       "project-list",
       "project-detail",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -335,6 +335,8 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		CairnlineAuthoritative:               false,
 		WriteAdapterReady:                    false,
 		ReplacementReadinessURL:              projectCoordinationBackendReadinessURL,
+		ReplacementTarget:                    "embedded_cairnline_first",
+		ReplacementTargetDetail:              "Hecate's Projects replacement path targets embedded Cairnline as the first source of truth; the standalone sidecar remains an interoperability and future external-server boundary.",
 		CairnlineSidecarProbeURL:             projectCoordinationBackendSidecarProbeURL,
 		CairnlineSidecarConnectURL:           projectCoordinationBackendSidecarConnectURL,
 		CairnlineSidecarReadURL:              projectCoordinationBackendSidecarReadURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -73,6 +73,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if !status.CairnlineBridgeReady || status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady || len(status.Warnings) != 0 {
 		t.Fatalf("status = %+v, want bridge-ready but inactive Cairnline adapter flags", status)
 	}
+	if status.ReplacementTarget != "embedded_cairnline_first" || !strings.Contains(status.ReplacementTargetDetail, "embedded Cairnline") || !strings.Contains(status.ReplacementTargetDetail, "sidecar") {
+		t.Fatalf("replacement target/detail = %q/%q, want embedded-first target with sidecar boundary detail", status.ReplacementTarget, status.ReplacementTargetDetail)
+	}
 	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 || len(status.PortableWriteGaps) != 0 || len(status.OrchestratorCapabilities) != 0 || len(status.SideEffectBlockers) != 0 || len(status.MigrationBlockers) != 0 || len(status.ReplacementGates) != 0 || len(status.WriteSwitchpoints) != 0 {
 		t.Fatalf("status = %+v, want no Cairnline route/seam/gap lists until Cairnline is configured", status)
 	}
@@ -814,6 +817,9 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until migration and cutover gates are ready")
+	}
+	if status.ReplacementTarget != "embedded_cairnline_first" {
+		t.Fatalf("replacement target = %q, want embedded-first Cairnline target", status.ReplacementTarget)
 	}
 	if !reflect.DeepEqual(status.OrchestratorCapabilities, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
 		t.Fatalf("orchestrator capabilities = %+v, want remaining Hecate-owned orchestrator capabilities", status.OrchestratorCapabilities)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -567,6 +567,8 @@ type ProjectCoordinationBackendStatusResponse struct {
 	ReadModelSwitchReady                 bool                                         `json:"read_model_switch_ready"`
 	WriteAdapterReady                    bool                                         `json:"write_adapter_ready"`
 	ReplacementReady                     bool                                         `json:"replacement_ready"`
+	ReplacementTarget                    string                                       `json:"replacement_target,omitempty"`
+	ReplacementTargetDetail              string                                       `json:"replacement_target_detail,omitempty"`
 	ReadRoutes                           []string                                     `json:"read_routes,omitempty"`
 	WriteAdapterSeams                    []string                                     `json:"write_adapter_seams,omitempty"`
 	WriteAdapterGaps                     []string                                     `json:"write_adapter_gaps,omitempty"`

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -89,6 +89,9 @@ describe("SettingsView", () => {
         read_model_switch_ready: true,
         write_adapter_ready: false,
         replacement_ready: false,
+        replacement_target: "embedded_cairnline_first",
+        replacement_target_detail:
+          "Hecate's Projects replacement path targets embedded Cairnline as the first source of truth; the standalone sidecar remains an interoperability and future external-server boundary.",
         read_routes: ["project-list", "project-detail"],
         portable_write_gaps: ["agent-profiles", "memory-candidates"],
         orchestrator_capabilities: ["assignment-start"],
@@ -147,6 +150,8 @@ describe("SettingsView", () => {
     expect(screen.getByText("cairnline configured · hecate authoritative")).toBeTruthy();
     expect(screen.getByText("cairnline read routes ready")).toBeTruthy();
     expect(screen.getByText(/2 read routes use Cairnline/i)).toBeTruthy();
+    expect(screen.getByText(/Target: embedded cairnline first/i)).toBeTruthy();
+    expect(screen.getByText(/standalone sidecar remains an interoperability/i)).toBeTruthy();
     expect(screen.getByText("Portable write gaps")).toBeTruthy();
     expect(screen.getByText("Hecate orchestrator capabilities")).toBeTruthy();
     expect(screen.getByText("Next action")).toBeTruthy();

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -351,6 +351,19 @@ function ProjectCoordinationBackendSettings({
               <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.45, marginTop: 8 }}>
                 {projectBackendSummary(status)}
               </div>
+              {status.replacement_target && (
+                <div
+                  style={{
+                    color: "var(--t3)",
+                    fontSize: 11,
+                    lineHeight: 1.45,
+                    marginTop: 6,
+                  }}
+                >
+                  Target: {status.replacement_target.replaceAll("_", " ")}
+                  {status.replacement_target_detail ? ` · ${status.replacement_target_detail}` : ""}
+                </div>
+              )}
             </div>
           </div>
           {nextAction && <ProjectBackendNextAction action={nextAction} />}

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -116,6 +116,8 @@ export type ProjectCoordinationBackendStatusRecord = {
   read_model_switch_ready: boolean;
   write_adapter_ready: boolean;
   replacement_ready: boolean;
+  replacement_target?: string;
+  replacement_target_detail?: string;
   read_routes?: string[];
   write_adapter_seams?: string[];
   write_adapter_gaps?: string[];


### PR DESCRIPTION
Summary
- Expose the Projects replacement target in the backend status response as embedded Cairnline first.
- Render that target in Settings so the replacement strategy is visible to operators.
- Update runtime/operator/design docs to state that embedded Cairnline is the first source-of-truth target and the sidecar remains the later interoperability boundary.

Validation
- GOCACHE="$PWD/.gocache" go test ./internal/api -run TestProjectCoordinationBackendStatus
- GOCACHE="$PWD/.gocache" go test ./internal/api
- GOCACHE="$PWD/.gocache" go vet ./internal/api
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run test
- just agent-docs-check
- git diff --check