### PR TITLE
Add Cairnline replacement mode contract

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -133,7 +133,10 @@ The replacement target is embedded Cairnline first: Hecate should make the
 embedded Cairnline database authoritative for Projects before treating the
 standalone sidecar as the external MCP/server boundary. That keeps Hecate's
 operator UI and compatibility shadow stable while the portable contract is
-proven locally.
+proven locally. `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is the
+explicit operator arm for that embedded contract; it is valid only with the
+embedded connector and strict embedded read source, and it does not bypass read,
+write-authority, migration, rollback, or Hecate-owned runtime side-effect gates.
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded` is the current live-route
 dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes
 local-only standalone Cairnline MCP contract probe/connect surfaces at
@@ -605,6 +608,10 @@ after these gates are met:
   external-sidecar backend adapter. Sidecar diagnostics remain valuable MCP
   interoperability evidence, but they are not the first Hecate replacement
   target.
+- The embedded cutover contract is explicitly armed with
+  `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` after the read,
+  write-authority, migration, and rollback gates are ready; enabling all
+  portable write-authority switchpoints alone does not replace the backend.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -611,12 +611,17 @@ backend-status summary, next action, and replacement-gate checklist under
 Project coordination for local operator inspection. The reported replacement
 target is embedded Cairnline first: Hecate should make the embedded Cairnline
 database the Projects source of truth before treating an external sidecar as the
-standalone/interoperability boundary. Once portable write gaps are
+standalone/interoperability boundary. `replacement_mode=disabled|embedded`
+reports the explicit operator cutover arm; `embedded` is only valid with the
+embedded connector and strict embedded read source, and it does not bypass the
+read, write-authority, migration, rollback, or Hecate-owned runtime side-effect
+gates. Once portable write gaps are
 closed, the migration next action reports strict embedded rehearsal hints for
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and
-`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`; these remain operator
-settings, not an automatic backend replacement. `GET
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`; after those gates are
+ready, `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is the explicit
+operator arm, not an automatic backend replacement. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -604,6 +604,15 @@ sequenceDiagram
   to Cairnline first, then best-effort shadows Hecate's compatibility project
   row. Delete restores the Cairnline snapshot if Hecate compatibility cleanup
   fails. All other Projects mutations remain Hecate-owned.
+- `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=disabled|embedded` is the
+  explicit cutover-mode arm. The default is `disabled`. `embedded` is accepted
+  only with `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`,
+  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`, and
+  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`. It does not bypass read,
+  write-authority, strict embedded smoke, migration, rollback, or Hecate-owned
+  runtime side-effect gates; backend status reports the mode as an explicit
+  replacement gate so operators can distinguish "all portable writes are
+  Cairnline-first" from "the embedded replacement contract is armed."
 - `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`, `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
   `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
   `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT` configure the standalone
@@ -2453,7 +2462,10 @@ read model is not sidecar-backed yet.
 read model. `replacement_target=embedded_cairnline_first` documents the
 current source-of-truth strategy: replace Hecate-native Projects with embedded
 Cairnline first, then keep the standalone Cairnline sidecar as the later
-interoperability and external-server boundary. `write_adapter_ready=true` means
+interoperability and external-server boundary. `replacement_mode` and
+`replacement_mode_armed` reflect
+`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE`; the mode is a human/operator
+cutover arm, not permission to skip the other gates. `write_adapter_ready=true` means
 all portable project-state write-authority gaps known to this Hecate build are
 closed through explicit Cairnline switchpoints; it does not mean Hecate runtime
 side effects, migration, rollback, or final replacement are ready.
@@ -2476,11 +2488,11 @@ guaranteed to be exclusive: for example, `roots` can appear in
 can remain in `orchestrator_capabilities` while Hecate still owns discovery
 scans and Git worktree creation.
 `replacement_ready` stays `false` until read parity, strict embedded mirror
-probes, write-authority switchpoints, and migration/rollback gates are all
-ready. `next_replacement_action` is an advisory next operator step derived from
-the same status snapshot; it is not a command, permission, gate result, or proof
-that replacement is safe. It can include `config_hints`, which are environment
-setting suggestions such as a specific
+probes, write-authority switchpoints, migration/rollback gates, and explicit
+embedded replacement mode are all ready. `next_replacement_action` is an
+advisory next operator step derived from the same status snapshot; it is not a
+command, permission, gate result, or proof that replacement is safe. It can
+include `config_hints`, which are environment setting suggestions such as a specific
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY` value; clients must treat them as
 operator guidance, not as mutations to apply automatically. `replacement_gates`
 reports those high-level gates as structured checklist items so clients do not
@@ -2639,6 +2651,9 @@ Example response, with `write_switchpoints` shortened for readability:
     "replacement_ready": false,
     "replacement_target": "embedded_cairnline_first",
     "replacement_target_detail": "Hecate's Projects replacement path targets embedded Cairnline as the first source of truth; the standalone sidecar remains an interoperability and future external-server boundary.",
+    "replacement_mode": "disabled",
+    "replacement_mode_armed": false,
+    "replacement_mode_detail": "Embedded Cairnline replacement mode is disabled; Hecate will not report Projects as replaceable without an explicit operator cutover-mode opt-in.",
     "read_routes": [
       "project-list",
       "project-detail",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -316,11 +316,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 	storageBackend := ""
 	readSource := "auto"
 	connector := "embedded"
+	replacementMode := "disabled"
 	if h != nil {
 		configured = h.config.ProjectsCoordinationBackend()
 		storageBackend = h.config.Projects.Backend
 		readSource = h.config.ProjectsCairnlineReadSource()
 		connector = h.config.ProjectsCairnlineConnector()
+		replacementMode = h.config.ProjectsCairnlineReplacementMode()
 	}
 	connectorReady := projectCairnlineConnectorReady(connector)
 	response := ProjectCoordinationBackendStatusResponse{
@@ -337,6 +339,9 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		ReplacementReadinessURL:              projectCoordinationBackendReadinessURL,
 		ReplacementTarget:                    "embedded_cairnline_first",
 		ReplacementTargetDetail:              "Hecate's Projects replacement path targets embedded Cairnline as the first source of truth; the standalone sidecar remains an interoperability and future external-server boundary.",
+		ReplacementMode:                      replacementMode,
+		ReplacementModeArmed:                 replacementMode == "embedded",
+		ReplacementModeDetail:                projectCairnlineReplacementModeDetail(replacementMode),
 		CairnlineSidecarProbeURL:             projectCoordinationBackendSidecarProbeURL,
 		CairnlineSidecarConnectURL:           projectCoordinationBackendSidecarConnectURL,
 		CairnlineSidecarReadURL:              projectCoordinationBackendSidecarReadURL,
@@ -371,13 +376,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps)
 		response.WriteAdapterReady = len(response.PortableWriteGaps) == 0
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
-		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps)
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode)
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
 				response.Detail = "Cairnline sidecar is configured as the project read source, so " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " routes read through the persistent standalone Cairnline MCP client. Project writes and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
-				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps)
+				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode)
 				response.Warnings = []string{
 					"Only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
@@ -387,7 +392,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
-			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps)
+			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
 				"Project reads and writes still use Hecate-native stores.",
@@ -433,6 +438,11 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 }
 
 func projectCairnlineStatusWithNextAction(response ProjectCoordinationBackendStatusResponse) ProjectCoordinationBackendStatusResponse {
+	response.ReplacementReady = projectCairnlineReplacementGatesReady(response.ReplacementGates)
+	if response.ReplacementReady {
+		response.AuthoritativeBackend = "cairnline"
+		response.CairnlineAuthoritative = true
+	}
 	response.NextReplacementAction = projectCairnlineNextReplacementAction(response)
 	return response
 }
@@ -514,6 +524,15 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			},
 		}
 	}
+	if status.ReplacementMode != "embedded" {
+		return &ProjectCoordinationBackendNextAction{
+			ID:          "arm-embedded-replacement-mode",
+			Label:       "Arm embedded Cairnline replacement mode",
+			Detail:      "All status-derived blocker groups are clear; explicitly arm embedded Cairnline replacement mode before final probes or cutover.",
+			Target:      "embedded-replacement-mode",
+			ConfigHints: projectCairnlineReplacementModeHints(),
+		}
+	}
 	return &ProjectCoordinationBackendNextAction{
 		ID:     "run-final-replacement-probes",
 		Label:  "Run final replacement probes",
@@ -525,6 +544,12 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			projectCoordinationBackendSyncReadinessURL,
 			projectCoordinationBackendMirrorParityURL,
 		},
+	}
+}
+
+func projectCairnlineReplacementModeHints() []ProjectCoordinationBackendActionConfigHint {
+	return []ProjectCoordinationBackendActionConfigHint{
+		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE", "embedded", "Arm the explicit embedded Cairnline replacement contract after read, write-authority, migration, and rollback gates are ready."),
 	}
 }
 
@@ -589,7 +614,7 @@ func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
 	}
 }
 
-func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string) []ProjectCoordinationBackendReplacementGate {
+func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string) []ProjectCoordinationBackendReplacementGate {
 	writeGate := projectCairnlineWriteAuthorityReplacementGate(portableWriteGaps)
 	return []ProjectCoordinationBackendReplacementGate{
 		{
@@ -614,7 +639,44 @@ func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []
 			Detail:    "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet.",
 			ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL, projectCoordinationBackendExportURL},
 		},
+		projectCairnlineReplacementModeGate(replacementMode),
 	}
+}
+
+func projectCairnlineReplacementModeGate(replacementMode string) ProjectCoordinationBackendReplacementGate {
+	if replacementMode == "embedded" {
+		return ProjectCoordinationBackendReplacementGate{
+			ID:     "embedded-replacement-mode",
+			Ready:  true,
+			Status: "armed",
+			Detail: "HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded is set, so the operator has explicitly armed the embedded Cairnline cutover contract. This does not bypass read, write, migration, rollback, or Hecate-owned runtime side-effect gates.",
+		}
+	}
+	return ProjectCoordinationBackendReplacementGate{
+		ID:     "embedded-replacement-mode",
+		Ready:  false,
+		Status: "disabled",
+		Detail: "Embedded Cairnline replacement mode is disabled. Keep it disabled until read routes, portable write authority, migration rehearsal, and rollback checks are ready; then set HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded to arm the explicit cutover contract.",
+	}
+}
+
+func projectCairnlineReplacementModeDetail(replacementMode string) string {
+	if replacementMode == "embedded" {
+		return "Embedded Cairnline replacement mode is armed, but status still requires the read, write-authority, migration, rollback, and runtime-boundary gates before any backend can be considered replaceable."
+	}
+	return "Embedded Cairnline replacement mode is disabled; Hecate will not report Projects as replaceable without an explicit operator cutover-mode opt-in."
+}
+
+func projectCairnlineReplacementGatesReady(gates []ProjectCoordinationBackendReplacementGate) bool {
+	if len(gates) == 0 {
+		return false
+	}
+	for _, gate := range gates {
+		if !gate.Ready {
+			return false
+		}
+	}
+	return true
 }
 
 func projectCairnlineWriteAuthorityReplacementGate(portableWriteGaps []string) ProjectCoordinationBackendReplacementGate {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -76,6 +76,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if status.ReplacementTarget != "embedded_cairnline_first" || !strings.Contains(status.ReplacementTargetDetail, "embedded Cairnline") || !strings.Contains(status.ReplacementTargetDetail, "sidecar") {
 		t.Fatalf("replacement target/detail = %q/%q, want embedded-first target with sidecar boundary detail", status.ReplacementTarget, status.ReplacementTargetDetail)
 	}
+	if status.ReplacementMode != "disabled" || status.ReplacementModeArmed || !strings.Contains(status.ReplacementModeDetail, "disabled") {
+		t.Fatalf("replacement mode/detail = %q/%v/%q, want disabled mode", status.ReplacementMode, status.ReplacementModeArmed, status.ReplacementModeDetail)
+	}
 	if len(status.ReadRoutes) != 0 || len(status.WriteAdapterSeams) != 0 || len(status.WriteAdapterGaps) != 0 || len(status.PortableWriteGaps) != 0 || len(status.OrchestratorCapabilities) != 0 || len(status.SideEffectBlockers) != 0 || len(status.MigrationBlockers) != 0 || len(status.ReplacementGates) != 0 || len(status.WriteSwitchpoints) != 0 {
 		t.Fatalf("status = %+v, want no Cairnline route/seam/gap lists until Cairnline is configured", status)
 	}
@@ -311,6 +314,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 		t.Fatalf("strict embedded gate = %+v, want operator probe gate", gate)
 	} else if !containsString(gate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !containsString(gate.ProbeURLs, projectCoordinationBackendMirrorParityURL) {
 		t.Fatalf("strict embedded gate probe URLs = %+v, want sync and mirror parity probes", gate.ProbeURLs)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "embedded-replacement-mode"); gate == nil || gate.Ready || gate.Status != "disabled" || !strings.Contains(gate.Detail, "HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded") {
+		t.Fatalf("embedded replacement mode gate = %+v, want disabled gate with config hint detail", gate)
 	}
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-memory"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "live_mirror_non_authoritative" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "memory" {
 		t.Fatalf("project-memory switchpoint = %+v, want Hecate-owned live mirror blocker", point)
@@ -821,6 +827,9 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	if status.ReplacementTarget != "embedded_cairnline_first" {
 		t.Fatalf("replacement target = %q, want embedded-first Cairnline target", status.ReplacementTarget)
 	}
+	if status.ReplacementMode != "disabled" || status.ReplacementModeArmed {
+		t.Fatalf("replacement mode = %q armed=%v, want disabled by default", status.ReplacementMode, status.ReplacementModeArmed)
+	}
 	if !reflect.DeepEqual(status.OrchestratorCapabilities, []string{"roots", "assignment-start", "project-assistant-apply-side-effects"}) {
 		t.Fatalf("orchestrator capabilities = %+v, want remaining Hecate-owned orchestrator capabilities", status.OrchestratorCapabilities)
 	}
@@ -844,6 +853,33 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	}
 }
 
+func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:                  "sqlite",
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineWriteAuthority:  "all-portable",
+			CairnlineReplacementMode: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatus()
+	if status.ReplacementMode != "embedded" || !status.ReplacementModeArmed || !strings.Contains(status.ReplacementModeDetail, "armed") {
+		t.Fatalf("replacement mode/detail = %q/%v/%q, want armed embedded mode", status.ReplacementMode, status.ReplacementModeArmed, status.ReplacementModeDetail)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false while migration/cutover blockers remain")
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "embedded-replacement-mode"); gate == nil || !gate.Ready || gate.Status != "armed" || !strings.Contains(gate.Detail, "does not bypass") {
+		t.Fatalf("embedded replacement mode gate = %+v, want armed explicit-mode gate", gate)
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "rehearse-migration-cutover" {
+		t.Fatalf("next action = %+v, want migration rehearsal still prioritized while mode is armed", status.NextReplacementAction)
+	}
+}
+
 func TestProjectCoordinationBackendStatus_WriteAuthorityGateUsesPortableGaps(t *testing.T) {
 	gate := projectCairnlineWriteAuthorityReplacementGate(nil)
 	if !gate.Ready || gate.Status != "ready" || !strings.Contains(gate.Detail, "orchestrator capabilities") {
@@ -852,6 +888,18 @@ func TestProjectCoordinationBackendStatus_WriteAuthorityGateUsesPortableGaps(t *
 	gate = projectCairnlineWriteAuthorityReplacementGate([]string{"memory-candidates"})
 	if gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "memory-candidates") {
 		t.Fatalf("write-authority gate = %+v, want partial when portable write gaps remain", gate)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_ReplacementGatesReadyRequiresAllGates(t *testing.T) {
+	if projectCairnlineReplacementGatesReady(nil) {
+		t.Fatal("replacement gates ready = true, want false for empty gate list")
+	}
+	if projectCairnlineReplacementGatesReady([]ProjectCoordinationBackendReplacementGate{{ID: "read", Ready: true}, {ID: "write", Ready: false}}) {
+		t.Fatal("replacement gates ready = true, want false when any gate is blocked")
+	}
+	if !projectCairnlineReplacementGatesReady([]ProjectCoordinationBackendReplacementGate{{ID: "read", Ready: true}, {ID: "write", Ready: true}}) {
+		t.Fatal("replacement gates ready = false, want true when every gate is ready")
 	}
 }
 
@@ -876,6 +924,24 @@ func TestProjectCoordinationBackendStatus_NextActionWriteAuthorityHints(t *testi
 	}
 	if hints := projectCairnlineWriteAuthorityHintsForGap("assignment-start"); len(hints) != 0 {
 		t.Fatalf("assignment-start hints = %+v, want none because dispatch is not a portable write-authority switchpoint", hints)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_NextActionReplacementModeHints(t *testing.T) {
+	status := ProjectCoordinationBackendStatusResponse{
+		ConfiguredBackend:       "cairnline",
+		CairnlineConnectorReady: true,
+		ReadModelSwitchReady:    true,
+		WriteAdapterReady:       true,
+		ReplacementMode:         "disabled",
+	}
+
+	action := projectCairnlineNextReplacementAction(status)
+	if action == nil || action.ID != "arm-embedded-replacement-mode" || action.Target != "embedded-replacement-mode" {
+		t.Fatalf("next action = %+v, want embedded replacement mode arming action", action)
+	}
+	if hint := findConfigHint(action.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("replacement mode hints = %+v, want embedded replacement mode hint", action.ConfigHints)
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -569,6 +569,9 @@ type ProjectCoordinationBackendStatusResponse struct {
 	ReplacementReady                     bool                                         `json:"replacement_ready"`
 	ReplacementTarget                    string                                       `json:"replacement_target,omitempty"`
 	ReplacementTargetDetail              string                                       `json:"replacement_target_detail,omitempty"`
+	ReplacementMode                      string                                       `json:"replacement_mode,omitempty"`
+	ReplacementModeArmed                 bool                                         `json:"replacement_mode_armed"`
+	ReplacementModeDetail                string                                       `json:"replacement_mode_detail,omitempty"`
 	ReadRoutes                           []string                                     `json:"read_routes,omitempty"`
 	WriteAdapterSeams                    []string                                     `json:"write_adapter_seams,omitempty"`
 	WriteAdapterGaps                     []string                                     `json:"write_adapter_gaps,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,6 +246,7 @@ type ProjectsConfig struct {
 	CairnlineSidecarProbeTimeout time.Duration
 	CairnlineReadSource          string
 	CairnlineWriteAuthority      string
+	CairnlineReplacementMode     string
 }
 
 func (c Config) ProjectsCoordinationBackend() string {
@@ -281,6 +282,10 @@ func (c Config) ProjectsCairnlineSidecarProbeTimeout() time.Duration {
 
 func (c Config) ProjectsCairnlineReadSource() string {
 	return normalizeProjectsCairnlineReadSource(c.Projects.CairnlineReadSource)
+}
+
+func (c Config) ProjectsCairnlineReplacementMode() string {
+	return normalizeProjectsCairnlineReplacementMode(c.Projects.CairnlineReplacementMode)
 }
 
 func (c Config) ProjectsCairnlineWriteAuthority() []string {
@@ -557,6 +562,7 @@ func LoadFromEnv() Config {
 			CairnlineSidecarProbeTimeout: getEnvDuration("HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT", 10*time.Second),
 			CairnlineReadSource:          strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "auto"))),
 			CairnlineWriteAuthority:      getEnv("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", "none"),
+			CairnlineReplacementMode:     strings.ToLower(strings.TrimSpace(getEnv("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE", "disabled"))),
 		},
 		OTel: loadOTelFromEnv(),
 		Governor: GovernorConfig{
@@ -643,8 +649,20 @@ func (c Config) Validate() error {
 	validateBackend("HECATE_PROJECTS_COORDINATION_BACKEND", c.ProjectsCoordinationBackend(), "hecate", "cairnline")
 	validateBackend("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", c.ProjectsCairnlineConnector(), "embedded", "sidecar")
 	validateBackend("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", c.ProjectsCairnlineReadSource(), "auto", "snapshot", "embedded", "sidecar")
+	validateBackend("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE", c.ProjectsCairnlineReplacementMode(), "disabled", "embedded")
 	if c.ProjectsCairnlineReadSource() == "sidecar" && c.ProjectsCairnlineConnector() != "sidecar" {
 		errs = append(errs, errors.New("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar requires HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar"))
+	}
+	if c.ProjectsCairnlineReplacementMode() == "embedded" {
+		if c.ProjectsCoordinationBackend() != "cairnline" {
+			errs = append(errs, errors.New("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded requires HECATE_PROJECTS_COORDINATION_BACKEND=cairnline"))
+		}
+		if c.ProjectsCairnlineConnector() != "embedded" {
+			errs = append(errs, errors.New("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded requires HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded"))
+		}
+		if c.ProjectsCairnlineReadSource() != "embedded" {
+			errs = append(errs, errors.New("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded"))
+		}
 	}
 	for _, item := range c.ProjectsCairnlineWriteAuthority() {
 		validateBackend("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", item, "project-memory", "memory-candidates", "project-collaboration", "project-skills", "project-work-items", "project-roles", "project-assignments", "agent-profiles", "project-metadata-defaults", "project-roots", "project-context-sources", "project-identity", "project-assistant-proposals")
@@ -1273,6 +1291,14 @@ func normalizeProjectsCairnlineReadSource(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
 	if value == "" {
 		return "auto"
+	}
+	return value
+}
+
+func normalizeProjectsCairnlineReplacementMode(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "disabled"
 	}
 	return value
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -597,6 +597,25 @@ func TestLoadFromEnvProjectsCairnlineConnector(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvProjectsCairnlineReplacementMode(t *testing.T) {
+	cfg := LoadFromEnv()
+	if got := cfg.ProjectsCairnlineReplacementMode(); got != "disabled" {
+		t.Fatalf("ProjectsCairnlineReplacementMode() = %q, want disabled", got)
+	}
+
+	t.Setenv("HECATE_PROJECTS_COORDINATION_BACKEND", "cairnline")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "embedded")
+	t.Setenv("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE", " Embedded ")
+	cfg = LoadFromEnv()
+	if got := cfg.ProjectsCairnlineReplacementMode(); got != "embedded" {
+		t.Fatalf("ProjectsCairnlineReplacementMode() = %q, want embedded", got)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil for embedded Cairnline replacement mode opt-in", err)
+	}
+}
+
 func TestLoadFromEnvProjectsCairnlineSidecarConfig(t *testing.T) {
 	cfg := LoadFromEnv()
 	if got := cfg.ProjectsCairnlineSidecarCommand(); got != "cairnline" {
@@ -750,6 +769,70 @@ func TestValidateRejectsInvalidProjectsCairnlineConnector(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_CONNECTOR") {
 		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_CONNECTOR", err)
+	}
+}
+
+func TestValidateRejectsInvalidProjectsCairnlineReplacementMode(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Projects.CairnlineReplacementMode = "sidecar"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid projects Cairnline replacement mode error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE") {
+		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE", err)
+	}
+}
+
+func TestValidateRejectsEmbeddedProjectsCairnlineReplacementModeWithoutStrictEmbeddedPrerequisites(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  func(Config) Config
+		want string
+	}{
+		{
+			name: "hecate backend",
+			cfg: func(cfg Config) Config {
+				cfg.Projects.CairnlineReplacementMode = "embedded"
+				cfg.Projects.CairnlineReadSource = "embedded"
+				return cfg
+			},
+			want: "HECATE_PROJECTS_COORDINATION_BACKEND=cairnline",
+		},
+		{
+			name: "sidecar connector",
+			cfg: func(cfg Config) Config {
+				cfg.Projects.CoordinationBackend = "cairnline"
+				cfg.Projects.CairnlineConnector = "sidecar"
+				cfg.Projects.CairnlineReadSource = "embedded"
+				cfg.Projects.CairnlineReplacementMode = "embedded"
+				return cfg
+			},
+			want: "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded",
+		},
+		{
+			name: "non-strict read source",
+			cfg: func(cfg Config) Config {
+				cfg.Projects.CoordinationBackend = "cairnline"
+				cfg.Projects.CairnlineReadSource = "auto"
+				cfg.Projects.CairnlineReplacementMode = "embedded"
+				return cfg
+			},
+			want: "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg(LoadFromEnv())
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatal("Validate() error = nil, want embedded replacement mode prerequisite error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %q, want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -51,6 +51,8 @@ beforeEach(() => {
       read_model_switch_ready: false,
       write_adapter_ready: false,
       replacement_ready: false,
+      replacement_mode: "disabled",
+      replacement_mode_armed: false,
       status: "hecate_authoritative",
       detail:
         "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks.",
@@ -92,6 +94,10 @@ describe("SettingsView", () => {
         replacement_target: "embedded_cairnline_first",
         replacement_target_detail:
           "Hecate's Projects replacement path targets embedded Cairnline as the first source of truth; the standalone sidecar remains an interoperability and future external-server boundary.",
+        replacement_mode: "disabled",
+        replacement_mode_armed: false,
+        replacement_mode_detail:
+          "Embedded Cairnline replacement mode is disabled; Hecate will not report Projects as replaceable without an explicit operator cutover-mode opt-in.",
         read_routes: ["project-list", "project-detail"],
         portable_write_gaps: ["agent-profiles", "memory-candidates"],
         orchestrator_capabilities: ["assignment-start"],
@@ -137,6 +143,13 @@ describe("SettingsView", () => {
               "/hecate/v1/projects/cairnline/mirror-parity",
             ],
           },
+          {
+            id: "embedded-replacement-mode",
+            ready: false,
+            status: "disabled",
+            detail:
+              "Embedded Cairnline replacement mode is disabled until the operator arms the explicit cutover contract.",
+          },
         ],
         status: "cairnline_read_routes_ready",
         detail: "Cairnline read routes are served from the read model.",
@@ -152,6 +165,8 @@ describe("SettingsView", () => {
     expect(screen.getByText(/2 read routes use Cairnline/i)).toBeTruthy();
     expect(screen.getByText(/Target: embedded cairnline first/i)).toBeTruthy();
     expect(screen.getByText(/standalone sidecar remains an interoperability/i)).toBeTruthy();
+    expect(screen.getByText(/Mode: disabled not armed/i)).toBeTruthy();
+    expect(screen.getByText(/explicit operator cutover-mode opt-in/i)).toBeTruthy();
     expect(screen.getByText("Portable write gaps")).toBeTruthy();
     expect(screen.getByText("Hecate orchestrator capabilities")).toBeTruthy();
     expect(screen.getByText("Next action")).toBeTruthy();

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -364,6 +364,20 @@ function ProjectCoordinationBackendSettings({
                   {status.replacement_target_detail ? ` · ${status.replacement_target_detail}` : ""}
                 </div>
               )}
+              {status.replacement_mode && (
+                <div
+                  style={{
+                    color: status.replacement_mode_armed ? "var(--accent)" : "var(--t3)",
+                    fontSize: 11,
+                    lineHeight: 1.45,
+                    marginTop: 4,
+                  }}
+                >
+                  Mode: {status.replacement_mode.replaceAll("_", " ")}
+                  {status.replacement_mode_armed ? " armed" : " not armed"}
+                  {status.replacement_mode_detail ? ` · ${status.replacement_mode_detail}` : ""}
+                </div>
+              )}
             </div>
           </div>
           {nextAction && <ProjectBackendNextAction action={nextAction} />}

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -118,6 +118,9 @@ export type ProjectCoordinationBackendStatusRecord = {
   replacement_ready: boolean;
   replacement_target?: string;
   replacement_target_detail?: string;
+  replacement_mode?: string;
+  replacement_mode_armed: boolean;
+  replacement_mode_detail?: string;
   read_routes?: string[];
   write_adapter_seams?: string[];
   write_adapter_gaps?: string[];


### PR DESCRIPTION
Summary
- Add HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=disabled|embedded as the explicit embedded Cairnline cutover-mode arm.
- Surface replacement mode, armed state, and an embedded replacement-mode gate in backend status and Settings.
- Derive replacement_ready from replacement gates while keeping migration/rollback gates blocking today.
- Update runtime, operator, and design docs for the embedded-first cutover contract.

Validation
- GOCACHE="$PWD/.gocache" go test ./internal/config -run "TestLoadFromEnvProjectsCairnlineReplacementMode|TestValidateRejectsInvalidProjectsCairnlineReplacementMode|TestValidateRejectsEmbeddedProjectsCairnlineReplacementModeWithoutStrictEmbeddedPrerequisites"
- GOCACHE="$PWD/.gocache" go test ./internal/api -run "TestProjectCoordinationBackendStatus"
- GOCACHE="$PWD/.gocache" go test ./internal/config ./internal/api
- GOCACHE="$PWD/.gocache" go vet ./internal/config ./internal/api
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just agent-docs-check
- git diff --check