### PR TITLE
feat(projects): report strict embedded smoke gate

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -127,6 +127,11 @@ is actually authoritative. It also reports `replacement_ready`,
 `replacement_gates`, and `write_switchpoints` so operator tools can distinguish
 ready read routes from strict embedded probe work, non-authoritative live
 mirrors, still-Hecate-owned dispatch, and missing migration/rollback authority.
+When configured for the embedded connector, strict embedded read source, and a
+runtime data directory, the strict embedded read-smoke gate is backed by the
+read-only mirror-parity probe: missing mirrors, drift, probe errors, and verified
+route smoke are reflected directly in backend status instead of relying only on
+manual checklist prose.
 It keeps `write_adapter_gaps` as the broad diagnostic list and also groups
 that list into `portable_write_gaps`, `orchestrator_capabilities`, and
 `migration_blockers`, so operator tooling can tell durable coordination-state

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -627,8 +627,14 @@ root, role/work-item/assignment/handoff, and memory-candidate switchpoints. It
 also reports `replacement_ready`, `next_replacement_action`,
 `replacement_gates`, and `write_switchpoints` so operators can see the
 suggested next step, relevant env-var hints, and the exact read-route,
-strict-embedded-probe, write-authority, and migration blockers without parsing
-warning prose. It also groups the broad `write_adapter_gaps` diagnostic list into
+strict-embedded-read-smoke, write-authority, and migration blockers without
+parsing warning prose. When the embedded connector, strict embedded read source,
+and a configured data directory are active, the strict read-smoke gate is driven
+by the same read-only mirror-parity evidence returned by
+`GET /hecate/v1/projects/cairnline/mirror-parity`: a missing mirror reports
+`not_run`, mirror drift reports `drift_detected`, and an exact mirror with passing
+strict embedded route smoke reports `verified`. It also groups the broad
+`write_adapter_gaps` diagnostic list into
 `portable_write_gaps`,
 `orchestrator_capabilities`, and `migration_blockers`, so durable
 coordination-state switchpoint work is separated from Hecate-owned

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2526,7 +2526,14 @@ operator guidance, not as mutations to apply automatically. `replacement_gates`
 reports those high-level gates as structured checklist items so clients do not
 need to parse warning prose. Each gate may include `probe_urls`, a list of route
 templates that produce supporting evidence for that gate; these URLs identify
-checks to run and are not proof that the gate has already passed. The
+checks to run and are not proof that the gate has already passed unless the
+gate status itself is ready/verified. The `strict-embedded-read-smoke` gate is
+evidence-backed when Hecate is configured with the embedded connector,
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and a data directory: backend
+status runs the read-only mirror-parity check and reports `not_run` for a
+missing mirror, `drift_detected` for parity drift, `probe_error` when the
+inspection cannot run, and `verified` only when the existing mirror matches
+Hecate stores and strict embedded route smoke passes. The
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
 it is driven by `portable_write_gaps` and ignores Hecate-owned orchestrator
 capabilities and the separate `migration-cutover` gap because those are reported
@@ -2827,8 +2834,8 @@ Example response, with `write_switchpoints` shortened for readability:
       {
         "id": "strict-embedded-read-smoke",
         "ready": false,
-        "status": "operator_probe_required",
-        "detail": "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
+        "status": "not_run",
+        "detail": "No embedded Cairnline mirror database exists yet; run /hecate/v1/projects/cairnline/sync and then /hecate/v1/projects/cairnline/mirror-parity.",
         "probe_urls": [
           "/hecate/v1/projects/cairnline/sync",
           "/hecate/v1/projects/cairnline/mirror-parity"

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -62,32 +62,7 @@ func (h *Handler) HandleSyncProjectsToCairnline(w http.ResponseWriter, r *http.R
 }
 
 func (h *Handler) HandleProjectCairnlineMirrorParity(w http.ResponseWriter, r *http.Request) {
-	dbPath := h.cairnlineEmbeddedDatabasePath()
-	snapshots, err := cairnlinebridge.LoadSnapshots(r.Context(), h.cairnlineSnapshotSources())
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if _, err := os.Stat(dbPath); err != nil {
-		if !os.IsNotExist(err) {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-		item := projectCairnlineMissingMirrorParity(dbPath, snapshots)
-		WriteJSON(w, http.StatusOK, ProjectCairnlineSyncResponse{
-			Object: "project_cairnline_mirror_parity",
-			Data:   item,
-		})
-		return
-	}
-	service, store, err := cairnline.NewSQLiteService(r.Context(), dbPath)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	defer store.Close()
-	smoke := h.projectCairnlineStrictEmbeddedSmoke(r.Context(), snapshots)
-	item, err := projectCairnlineServiceParity(r.Context(), dbPath, true, "mirror_parity", snapshots, service, smoke)
+	item, err := h.projectCairnlineMirrorParity(r.Context())
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
@@ -96,6 +71,31 @@ func (h *Handler) HandleProjectCairnlineMirrorParity(w http.ResponseWriter, r *h
 		Object: "project_cairnline_mirror_parity",
 		Data:   item,
 	})
+}
+
+func (h *Handler) projectCairnlineMirrorParity(ctx context.Context) (ProjectCairnlineSyncResponseItem, error) {
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	snapshots, err := cairnlinebridge.LoadSnapshots(ctx, h.cairnlineSnapshotSources())
+	if err != nil {
+		return ProjectCairnlineSyncResponseItem{}, err
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		if !os.IsNotExist(err) {
+			return ProjectCairnlineSyncResponseItem{}, err
+		}
+		return projectCairnlineMissingMirrorParity(dbPath, snapshots), nil
+	}
+	service, store, err := cairnline.NewSQLiteService(ctx, dbPath)
+	if err != nil {
+		return ProjectCairnlineSyncResponseItem{}, err
+	}
+	defer store.Close()
+	smoke := h.projectCairnlineStrictEmbeddedSmoke(ctx, snapshots)
+	item, err := projectCairnlineServiceParity(ctx, dbPath, true, "mirror_parity", snapshots, service, smoke)
+	if err != nil {
+		return ProjectCairnlineSyncResponseItem{}, err
+	}
+	return item, nil
 }
 
 func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"strings"
 )
@@ -307,11 +309,15 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 func (h *Handler) HandleProjectCoordinationBackendStatus(w http.ResponseWriter, r *http.Request) {
 	WriteJSON(w, http.StatusOK, ProjectCoordinationBackendStatusEnvelope{
 		Object: "project_coordination_backend_status",
-		Data:   h.projectCoordinationBackendStatus(),
+		Data:   h.projectCoordinationBackendStatusWithContext(r.Context()),
 	})
 }
 
 func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendStatusResponse {
+	return h.projectCoordinationBackendStatusWithContext(context.Background())
+}
+
+func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Context) ProjectCoordinationBackendStatusResponse {
 	configured := "hecate"
 	storageBackend := ""
 	readSource := "auto"
@@ -364,6 +370,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 	switch configured {
 	case "cairnline":
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
+		strictEmbeddedReadGate := h.projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx, connectorReady, readSource, readReady)
 		writeAuthority := h.config.ProjectsCairnlineWriteAuthority()
 		effectiveWriteAuthority := writeAuthority
 		if !connectorReady {
@@ -376,13 +383,13 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps)
 		response.WriteAdapterReady = len(response.PortableWriteGaps) == 0
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
-		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode)
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate)
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
 				response.Detail = "Cairnline sidecar is configured as the project read source, so " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " routes read through the persistent standalone Cairnline MCP client. Project writes and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
-				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode)
+				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate)
 				response.Warnings = []string{
 					"Only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
@@ -392,7 +399,7 @@ func (h *Handler) projectCoordinationBackendStatus() ProjectCoordinationBackendS
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
-			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode)
+			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
 				"Project reads and writes still use Hecate-native stores.",
@@ -614,7 +621,10 @@ func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
 	}
 }
 
-func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string) []ProjectCoordinationBackendReplacementGate {
+func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate) []ProjectCoordinationBackendReplacementGate {
+	if strings.TrimSpace(strictEmbeddedReadGate.ID) == "" {
+		strictEmbeddedReadGate = projectCairnlineStrictEmbeddedReadSmokeDefaultGate()
+	}
 	writeGate := projectCairnlineWriteAuthorityReplacementGate(portableWriteGaps)
 	return []ProjectCoordinationBackendReplacementGate{
 		{
@@ -624,13 +634,7 @@ func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []
 			Detail:    "Configured live project read families can be served from Cairnline's projected read model.",
 			ProbeURLs: []string{projectCoordinationBackendReadinessURL, projectCoordinationBackendEmbeddedReadModelURL, projectCoordinationBackendEmbeddedParityReportURL},
 		},
-		{
-			ID:        "strict-embedded-read-smoke",
-			Ready:     false,
-			Status:    "operator_probe_required",
-			Detail:    "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
-			ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL},
-		},
+		strictEmbeddedReadGate,
 		writeGate,
 		{
 			ID:        "migration-and-rollback",
@@ -641,6 +645,72 @@ func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []
 		},
 		projectCairnlineReplacementModeGate(replacementMode),
 	}
+}
+
+func projectCairnlineStrictEmbeddedReadSmokeDefaultGate() ProjectCoordinationBackendReplacementGate {
+	return ProjectCoordinationBackendReplacementGate{
+		ID:        "strict-embedded-read-smoke",
+		Ready:     false,
+		Status:    "operator_probe_required",
+		Detail:    "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
+		ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL},
+	}
+}
+
+func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx context.Context, connectorReady bool, readSource string, readRoutesReady bool) ProjectCoordinationBackendReplacementGate {
+	gate := projectCairnlineStrictEmbeddedReadSmokeDefaultGate()
+	if !connectorReady {
+		gate.Status = "blocked"
+		gate.Detail = "Strict embedded read smoke requires the embedded Cairnline connector; configure HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded before using the embedded mirror as a replacement candidate."
+		return gate
+	}
+	if readSource != "embedded" {
+		gate.Detail = "Set HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded and run the embedded sync/parity/smoke probes before treating the mirror database as a cutover candidate."
+		return gate
+	}
+	if !readRoutesReady {
+		gate.Status = "blocked"
+		gate.Detail = "Strict embedded read smoke cannot run until the Cairnline read adapter can load the full Hecate project graph."
+		return gate
+	}
+	if strings.TrimSpace(h.config.Server.DataDir) == "" {
+		gate.Detail = "Run backend status with a configured Hecate data directory, then run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate."
+		return gate
+	}
+	item, err := h.projectCairnlineMirrorParity(ctx)
+	if err != nil {
+		gate.Status = "probe_error"
+		gate.Detail = "Strict embedded read smoke could not inspect the embedded Cairnline mirror: " + err.Error()
+		return gate
+	}
+	if !item.DatabaseExists {
+		gate.Status = "not_run"
+		gate.Detail = "No embedded Cairnline mirror database exists yet; run " + projectCoordinationBackendSyncReadinessURL + " and then " + projectCoordinationBackendMirrorParityURL + "."
+		return gate
+	}
+	if !item.Match {
+		gate.Status = "drift_detected"
+		gate.Detail = "The embedded Cairnline mirror exists but no longer matches Hecate's authoritative stores; rerun the sync and mirror-parity probes before cutover."
+		return gate
+	}
+	smoke := item.MigrationRehearsal.EmbeddedSmoke
+	if smoke == nil {
+		gate.Status = "operator_probe_required"
+		gate.Detail = "The embedded Cairnline mirror matches Hecate stores, but strict embedded read smoke evidence is missing; rerun the mirror-parity probe."
+		return gate
+	}
+	if smoke.Status != "passed" {
+		gate.Status = smoke.Status
+		if gate.Status == "" {
+			gate.Status = "failed"
+		}
+		gate.Detail = fmt.Sprintf("The embedded Cairnline mirror matches Hecate stores, but strict embedded read smoke reported %s with %d error(s).", gate.Status, len(smoke.Errors))
+		return gate
+	}
+	gate.Ready = true
+	gate.Status = "verified"
+	gate.Detail = fmt.Sprintf("Existing embedded Cairnline mirror matches Hecate stores and strict embedded read smoke passed across %d project(s) and %d route check(s).", smoke.ProjectCount, smoke.ReadRouteChecks)
+	return gate
 }
 
 func projectCairnlineReplacementModeGate(replacementMode string) ProjectCoordinationBackendReplacementGate {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -10,7 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.T) {
@@ -341,6 +346,71 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	}
 	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY"); hint == nil || hint.Value != "project-identity,project-metadata-defaults" {
 		t.Fatalf("next action config hints = %+v, want project identity + metadata defaults write authority", status.NextReplacementAction.ConfigHints)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_StrictEmbeddedReadSmokeGateMissingMirror(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+
+	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
+	gate := findReplacementGate(status.ReplacementGates, "strict-embedded-read-smoke")
+	if gate == nil || gate.Ready || gate.Status != "not_run" {
+		t.Fatalf("strict embedded gate = %+v, want missing-mirror not_run gate", gate)
+	}
+	if !containsString(gate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !strings.Contains(gate.Detail, projectCoordinationBackendSyncReadinessURL) {
+		t.Fatalf("strict embedded gate = %+v, want sync probe guidance", gate)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false while strict embedded smoke is not run")
+	}
+}
+
+func TestProjectCoordinationBackendStatus_StrictEmbeddedReadSmokeGateVerifiedAfterSync(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			Backend:                 "sqlite",
+			CoordinationBackend:     "cairnline",
+			CairnlineConnector:      "embedded",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: "all-portable",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Backend Status Strict Embedded",
+	}))
+	mustRequestJSONStatus[ProjectCairnlineSyncResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/cairnline/sync", "")
+
+	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
+	gate := findReplacementGate(status.ReplacementGates, "strict-embedded-read-smoke")
+	if gate == nil || !gate.Ready || gate.Status != "verified" || !strings.Contains(gate.Detail, "strict embedded read smoke passed") {
+		t.Fatalf("strict embedded gate = %+v, want verified strict embedded smoke gate", gate)
+	}
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false while migration/cutover gate remains blocked")
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "rehearse-migration-cutover" {
+		t.Fatalf("next action = %+v, want migration rehearsal after read/write gates are ready", status.NextReplacementAction)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reuse the Cairnline mirror-parity helper from backend status.
- Make the strict embedded read-smoke replacement gate evidence-backed (`not_run`, `drift_detected`, `probe_error`, `verified`) instead of static checklist prose.
- Update operator/runtime/design docs for the new gate behavior.

## Tests
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus|TestProjectCairnlineMirrorParityAPI'`\n- `GOCACHE="$(pwd)/.gocache" go test ./internal/api`\n- `GOCACHE="$(pwd)/.gocache" go test ./...`\n- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`\n- `just agent-docs-check`\n