### PR TITLE
feat(projects): clarify Cairnline migration gate

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -131,7 +131,9 @@ When configured for the embedded connector, strict embedded read source, and a
 runtime data directory, the strict embedded read-smoke gate is backed by the
 read-only mirror-parity probe: missing mirrors, drift, probe errors, and verified
 route smoke are reflected directly in backend status instead of relying only on
-manual checklist prose.
+manual checklist prose. The migration/rollback gate depends on that read-smoke
+evidence: it waits for verified strict embedded reads first, then reports the
+remaining missing authoritative cutover/rollback switch separately.
 It keeps `write_adapter_gaps` as the broad diagnostic list and also groups
 that list into `portable_write_gaps`, `orchestrator_capabilities`, and
 `migration_blockers`, so operator tooling can tell durable coordination-state

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -633,8 +633,11 @@ and a configured data directory are active, the strict read-smoke gate is driven
 by the same read-only mirror-parity evidence returned by
 `GET /hecate/v1/projects/cairnline/mirror-parity`: a missing mirror reports
 `not_run`, mirror drift reports `drift_detected`, and an exact mirror with passing
-strict embedded route smoke reports `verified`. It also groups the broad
-`write_adapter_gaps` diagnostic list into
+strict embedded route smoke reports `verified`. The migration/rollback gate then
+reports `waiting_for_read_smoke` until that evidence is verified, and
+`cutover_switch_missing` once the read evidence is clean but the explicit
+authoritative storage cutover switch still does not exist. It also groups the
+broad `write_adapter_gaps` diagnostic list into
 `portable_write_gaps`,
 `orchestrator_capabilities`, and `migration_blockers`, so durable
 coordination-state switchpoint work is separated from Hecate-owned
@@ -651,9 +654,11 @@ gates. Once portable write gaps are
 closed, the migration next action reports strict embedded rehearsal hints for
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and
-`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`; after those gates are
-ready, `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is the explicit
-operator arm, not an automatic backend replacement. `GET
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`; after strict embedded
+read smoke is verified, the next action becomes implementing the missing
+migration cutover switch. After those gates are ready,
+`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is the explicit operator
+arm, not an automatic backend replacement. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2537,14 +2537,19 @@ Hecate stores and strict embedded route smoke passes. The
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
 it is driven by `portable_write_gaps` and ignores Hecate-owned orchestrator
 capabilities and the separate `migration-cutover` gap because those are reported
-by their own status fields/gates.
+by their own status fields/gates. The `migration-and-rollback` gate reports
+`waiting_for_read_smoke` until strict embedded read-smoke evidence is verified;
+after that it reports `cutover_switch_missing` until Hecate has an explicit
+authoritative Cairnline storage cutover and rollback switch.
 When the next action is `rehearse-migration-cutover`, `config_hints` identify
 the strict embedded dogfood posture expected for the rehearsal:
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`. These are still
 operator-applied settings and do not flip Hecate into a replaced backend by
-themselves.
+themselves. Once strict embedded mirror parity and route smoke are verified, the
+next action becomes `implement-migration-cutover`, which is intentionally an
+implementation blocker rather than an automatic operator action.
 `write_switchpoints` maps each live mutation family to the current authority,
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
 `snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled
@@ -2850,8 +2855,8 @@ Example response, with `write_switchpoints` shortened for readability:
       {
         "id": "migration-and-rollback",
         "ready": false,
-        "status": "rehearsal_available",
-        "detail": "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet.",
+        "status": "waiting_for_read_smoke",
+        "detail": "Strict embedded mirror parity and read smoke must be verified before migration and rollback can be treated as rehearsed.",
         "probe_urls": [
           "/hecate/v1/projects/cairnline/sync",
           "/hecate/v1/projects/cairnline/mirror-parity",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -518,6 +518,19 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 		}
 	}
 	if len(status.MigrationBlockers) > 0 {
+		if gate := projectCoordinationBackendReplacementGateByID(status.ReplacementGates, "migration-and-rollback"); gate != nil && gate.Status == "cutover_switch_missing" {
+			return &ProjectCoordinationBackendNextAction{
+				ID:     "implement-migration-cutover",
+				Label:  "Implement migration cutover",
+				Detail: "Strict embedded mirror parity and read smoke are verified; the remaining migration blocker is an explicit authoritative cutover and rollback switch.",
+				Target: status.MigrationBlockers[0],
+				ProbeURLs: []string{
+					projectCoordinationBackendSyncReadinessURL,
+					projectCoordinationBackendMirrorParityURL,
+					projectCoordinationBackendExportURL,
+				},
+			}
+		}
 		return &ProjectCoordinationBackendNextAction{
 			ID:          "rehearse-migration-cutover",
 			Label:       "Rehearse migration and rollback",
@@ -552,6 +565,15 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			projectCoordinationBackendMirrorParityURL,
 		},
 	}
+}
+
+func projectCoordinationBackendReplacementGateByID(gates []ProjectCoordinationBackendReplacementGate, id string) *ProjectCoordinationBackendReplacementGate {
+	for i := range gates {
+		if gates[i].ID == id {
+			return &gates[i]
+		}
+	}
+	return nil
 }
 
 func projectCairnlineReplacementModeHints() []ProjectCoordinationBackendActionConfigHint {
@@ -636,13 +658,7 @@ func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []
 		},
 		strictEmbeddedReadGate,
 		writeGate,
-		{
-			ID:        "migration-and-rollback",
-			Ready:     false,
-			Status:    "rehearsal_available",
-			Detail:    "Embedded sync and project export return structured migration rehearsal evidence with rollback notes, but no authoritative Cairnline storage cutover switch exists yet.",
-			ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL, projectCoordinationBackendExportURL},
-		},
+		projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate),
 		projectCairnlineReplacementModeGate(replacementMode),
 	}
 }
@@ -710,6 +726,21 @@ func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx con
 	gate.Ready = true
 	gate.Status = "verified"
 	gate.Detail = fmt.Sprintf("Existing embedded Cairnline mirror matches Hecate stores and strict embedded read smoke passed across %d project(s) and %d route check(s).", smoke.ProjectCount, smoke.ReadRouteChecks)
+	return gate
+}
+
+func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate) ProjectCoordinationBackendReplacementGate {
+	gate := ProjectCoordinationBackendReplacementGate{
+		ID:        "migration-and-rollback",
+		Ready:     false,
+		Status:    "waiting_for_read_smoke",
+		Detail:    "Strict embedded mirror parity and read smoke must be verified before migration and rollback can be treated as rehearsed.",
+		ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL, projectCoordinationBackendExportURL},
+	}
+	if strictEmbeddedReadGate.Ready {
+		gate.Status = "cutover_switch_missing"
+		gate.Detail = "Strict embedded mirror parity and read smoke are verified, and rehearsal endpoints expose rollback notes, but no authoritative Cairnline storage cutover switch exists yet."
+	}
 	return gate
 }
 

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -128,8 +128,8 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *t
 	if gate := findReplacementGate(status.ReplacementGates, "write-authority-switchpoints"); gate == nil || gate.Ready || gate.Status != "blocked" {
 		t.Fatalf("write-authority gate = %+v, want blocking gate", gate)
 	}
-	if gate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); gate == nil || gate.Ready || gate.Status != "rehearsal_available" {
-		t.Fatalf("migration gate = %+v, want rehearsal-available blocker", gate)
+	if gate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); gate == nil || gate.Ready || gate.Status != "waiting_for_read_smoke" {
+		t.Fatalf("migration gate = %+v, want read-smoke waiting blocker", gate)
 	}
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "assignment-start-dispatch"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "result_mirror_only" || !point.LiveMirror || point.BlocksAuthority || point.Gap != "assignment-start" {
 		t.Fatalf("assignment-start switchpoint = %+v, want Hecate-owned result mirror capability outside portable write authority", point)
@@ -409,8 +409,11 @@ func TestProjectCoordinationBackendStatus_StrictEmbeddedReadSmokeGateVerifiedAft
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false while migration/cutover gate remains blocked")
 	}
-	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "rehearse-migration-cutover" {
-		t.Fatalf("next action = %+v, want migration rehearsal after read/write gates are ready", status.NextReplacementAction)
+	if migrationGate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); migrationGate == nil || migrationGate.Ready || migrationGate.Status != "cutover_switch_missing" {
+		t.Fatalf("migration gate = %+v, want cutover-switch blocker after strict embedded verification", migrationGate)
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "implement-migration-cutover" {
+		t.Fatalf("next action = %+v, want cutover implementation after read/write gates are ready", status.NextReplacementAction)
 	}
 }
 
@@ -1054,8 +1057,8 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 		t.Fatalf("response replacement_ready = true, want false until write authority and migration gates are ready")
 	}
 	migrationGate := findReplacementGate(response.Data.ReplacementGates, "migration-and-rollback")
-	if migrationGate == nil || migrationGate.Status != "rehearsal_available" {
-		t.Fatalf("response migration gate = %+v, want rehearsal-available blocker", migrationGate)
+	if migrationGate == nil || migrationGate.Status != "waiting_for_read_smoke" {
+		t.Fatalf("response migration gate = %+v, want read-smoke waiting blocker", migrationGate)
 	}
 	if !containsString(migrationGate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !containsString(migrationGate.ProbeURLs, projectCoordinationBackendMirrorParityURL) || !containsString(migrationGate.ProbeURLs, projectCoordinationBackendExportURL) {
 		t.Fatalf("response migration gate probe URLs = %+v, want sync, mirror parity, and export probes", migrationGate.ProbeURLs)


### PR DESCRIPTION
## Summary
- Make the Cairnline migration/rollback gate depend on strict embedded read-smoke evidence.
- Report `waiting_for_read_smoke` before strict embedded verification and `cutover_switch_missing` once read evidence is clean.
- Move the next replacement action from rehearsal to cutover implementation when read/write gates are ready but the cutover switch is still absent.
- Update operator/runtime/design docs for the refined gate states.

## Tests
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'`\n- `GOCACHE="$(pwd)/.gocache" go test ./...`\n- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`\n- `just agent-docs-check`\n