### PR TITLE
feat(projects): arm embedded Cairnline cutover status

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -133,7 +133,12 @@ read-only mirror-parity probe: missing mirrors, drift, probe errors, and verifie
 route smoke are reflected directly in backend status instead of relying only on
 manual checklist prose. The migration/rollback gate depends on that read-smoke
 evidence: it waits for verified strict embedded reads first, then reports the
-remaining missing authoritative cutover/rollback switch separately.
+remaining missing authoritative cutover/rollback switch separately. Once strict
+embedded reads are verified, all portable write-authority gaps are closed, and
+`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed, backend status
+treats that replacement mode as the explicit embedded cutover switch, clears the
+migration blocker, and reports embedded Cairnline as authoritative for portable
+Projects coordination state.
 It keeps `write_adapter_gaps` as the broad diagnostic list and also groups
 that list into `portable_write_gaps`, `orchestrator_capabilities`, and
 `migration_blockers`, so operator tooling can tell durable coordination-state

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -636,8 +636,13 @@ by the same read-only mirror-parity evidence returned by
 strict embedded route smoke reports `verified`. The migration/rollback gate then
 reports `waiting_for_read_smoke` until that evidence is verified, and
 `cutover_switch_missing` once the read evidence is clean but the explicit
-authoritative storage cutover switch still does not exist. It also groups the
-broad `write_adapter_gaps` diagnostic list into
+authoritative storage cutover switch still does not exist. When
+`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed after strict
+embedded reads are verified and all portable write-authority gaps are closed,
+backend status treats that mode as the explicit embedded cutover switch, clears
+the migration blocker, and reports Cairnline as authoritative for portable
+Projects coordination state. It also groups the broad `write_adapter_gaps`
+diagnostic list into
 `portable_write_gaps`,
 `orchestrator_capabilities`, and `migration_blockers`, so durable
 coordination-state switchpoint work is separated from Hecate-owned
@@ -656,9 +661,10 @@ closed, the migration next action reports strict embedded rehearsal hints for
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`; after strict embedded
 read smoke is verified, the next action becomes implementing the missing
-migration cutover switch. After those gates are ready,
-`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is the explicit operator
-arm, not an automatic backend replacement. `GET
+migration cutover switch by arming
+`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded`. That status cutover does
+not move Hecate-owned runtime/workspace capabilities such as assignment dispatch
+or Project Assistant apply side effects into Cairnline core. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2540,7 +2540,12 @@ capabilities and the separate `migration-cutover` gap because those are reported
 by their own status fields/gates. The `migration-and-rollback` gate reports
 `waiting_for_read_smoke` until strict embedded read-smoke evidence is verified;
 after that it reports `cutover_switch_missing` until Hecate has an explicit
-authoritative Cairnline storage cutover and rollback switch.
+authoritative Cairnline storage cutover and rollback switch. When strict
+embedded reads are verified, all portable write-authority gaps are closed, and
+`replacement_mode=embedded`, backend status treats replacement mode as that
+explicit embedded cutover switch: `migration_blockers` is empty, the
+`migration-and-rollback` gate is `ready`, and `authoritative_backend` reports
+`cairnline` for portable Projects coordination state.
 When the next action is `rehearse-migration-cutover`, `config_hints` identify
 the strict embedded dogfood posture expected for the rehearsal:
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
@@ -2549,7 +2554,9 @@ the strict embedded dogfood posture expected for the rehearsal:
 operator-applied settings and do not flip Hecate into a replaced backend by
 themselves. Once strict embedded mirror parity and route smoke are verified, the
 next action becomes `implement-migration-cutover`, which is intentionally an
-implementation blocker rather than an automatic operator action.
+operator-controlled configuration step rather than an automatic mutation. Once
+the cutover is armed and all replacement gates are ready, the next action becomes
+`monitor-cairnline-backend`.
 `write_switchpoints` maps each live mutation family to the current authority,
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
 `snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -380,16 +380,17 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsSnapshot(effectiveWriteAuthority)
 		response.PortableWriteGaps = projectCairnlinePortableWriteGapsSnapshot(effectiveWriteAuthority, response.WriteAdapterGaps)
 		response.OrchestratorCapabilities = projectCairnlineOrchestratorCapabilitiesSnapshot(response.WriteAdapterGaps)
-		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps)
 		response.WriteAdapterReady = len(response.PortableWriteGaps) == 0
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
-		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate)
+		migrationCutoverArmed := replacementMode == "embedded" && strictEmbeddedReadGate.Ready && len(response.PortableWriteGaps) == 0
+		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps, migrationCutoverArmed)
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
 				response.Detail = "Cairnline sidecar is configured as the project read source, so " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " routes read through the persistent standalone Cairnline MCP client. Project writes and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
-				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate)
+				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
 				response.Warnings = []string{
 					"Only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " use the Cairnline sidecar MCP client in this mode.",
 					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
@@ -399,7 +400,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
-			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate)
+			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
 				"Project reads and writes still use Hecate-native stores.",
@@ -457,10 +458,10 @@ func projectCairnlineStatusWithNextAction(response ProjectCoordinationBackendSta
 func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStatusResponse) *ProjectCoordinationBackendNextAction {
 	if status.ReplacementReady {
 		return &ProjectCoordinationBackendNextAction{
-			ID:     "replace-projects-backend",
-			Label:  "Replace the Projects backend",
-			Detail: "All Cairnline replacement gates are ready; the remaining action is an explicit operator cutover.",
-			Target: "cutover",
+			ID:     "monitor-cairnline-backend",
+			Label:  "Monitor Cairnline backend",
+			Detail: "All Cairnline replacement gates are ready and embedded replacement mode is armed; Projects are reporting Cairnline as authoritative.",
+			Target: "cairnline",
 		}
 	}
 	if status.ConfiguredBackend != "cairnline" {
@@ -643,7 +644,7 @@ func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
 	}
 }
 
-func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate) []ProjectCoordinationBackendReplacementGate {
+func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationCutoverArmed bool) []ProjectCoordinationBackendReplacementGate {
 	if strings.TrimSpace(strictEmbeddedReadGate.ID) == "" {
 		strictEmbeddedReadGate = projectCairnlineStrictEmbeddedReadSmokeDefaultGate()
 	}
@@ -658,7 +659,7 @@ func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []
 		},
 		strictEmbeddedReadGate,
 		writeGate,
-		projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate),
+		projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate, migrationCutoverArmed),
 		projectCairnlineReplacementModeGate(replacementMode),
 	}
 }
@@ -729,7 +730,7 @@ func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx con
 	return gate
 }
 
-func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate) ProjectCoordinationBackendReplacementGate {
+func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationCutoverArmed bool) ProjectCoordinationBackendReplacementGate {
 	gate := ProjectCoordinationBackendReplacementGate{
 		ID:        "migration-and-rollback",
 		Ready:     false,
@@ -740,6 +741,11 @@ func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate Pro
 	if strictEmbeddedReadGate.Ready {
 		gate.Status = "cutover_switch_missing"
 		gate.Detail = "Strict embedded mirror parity and read smoke are verified, and rehearsal endpoints expose rollback notes, but no authoritative Cairnline storage cutover switch exists yet."
+	}
+	if migrationCutoverArmed {
+		gate.Ready = true
+		gate.Status = "ready"
+		gate.Detail = "Strict embedded mirror parity and read smoke are verified, all portable write-authority gaps are closed, and embedded replacement mode is the explicit cutover switch."
 	}
 	return gate
 }
@@ -900,7 +906,10 @@ func projectCairnlineOrchestratorCapabilitiesSnapshot(writeGaps []string) []stri
 	return out
 }
 
-func projectCairnlineMigrationBlockersSnapshot(writeGaps []string) []string {
+func projectCairnlineMigrationBlockersSnapshot(writeGaps []string, migrationCutoverArmed bool) []string {
+	if migrationCutoverArmed {
+		return nil
+	}
 	out := make([]string, 0, 1)
 	for _, item := range writeGaps {
 		if item == "migration-cutover" {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -417,6 +417,46 @@ func TestProjectCoordinationBackendStatus_StrictEmbeddedReadSmokeGateVerifiedAft
 	}
 }
 
+func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			Backend:                  "sqlite",
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineWriteAuthority:  "all-portable",
+			CairnlineReplacementMode: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Backend Status Embedded Replacement",
+	}))
+	mustRequestJSONStatus[ProjectCairnlineSyncResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/cairnline/sync", "")
+
+	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
+	if !status.ReplacementReady || status.AuthoritativeBackend != "cairnline" || !status.CairnlineAuthoritative {
+		t.Fatalf("status = %+v, want verified embedded replacement to report Cairnline authoritative", status)
+	}
+	if len(status.MigrationBlockers) != 0 {
+		t.Fatalf("migration blockers = %+v, want none after embedded replacement cutover is armed", status.MigrationBlockers)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); gate == nil || !gate.Ready || gate.Status != "ready" {
+		t.Fatalf("migration gate = %+v, want ready migration gate after embedded replacement cutover is armed", gate)
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "monitor-cairnline-backend" {
+		t.Fatalf("next action = %+v, want monitor action after replacement is ready", status.NextReplacementAction)
+	}
+}
+
 func TestProjectCoordinationBackendStatus_CairnlineProjectMemoryAuthorityConfigured(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{


### PR DESCRIPTION
## Summary
- Treat embedded replacement mode as the explicit backend-status cutover switch once strict embedded read smoke is verified and portable write gaps are closed
- Clear migration blockers and report Cairnline authoritative only under that fully armed gate
- Update Projects design, runtime API, and operator deployment docs for the cutover-status contract

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...