### PR TITLE
fix(projects): prefer Cairnline metadata for strict authority

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -254,7 +254,11 @@ project-linked Hecate Chat prelude/context reads load directly from the embedded
 Cairnline project, skill, role, work-item,
 assignment, launch-packet, artifact, evidence, review, handoff, memory, and
 assistant proposal records instead of loading a Hecate-native project snapshot
-first.
+first. Cairnline-authoritative portable write helpers follow the same strict
+embedded boundary for project identity/root metadata: when strict embedded reads
+are configured, they load the embedded Cairnline project graph before consulting
+any Hecate-native compatibility shadow, so stale shadows cannot win over the
+configured source of truth.
 Activity, assignment-list, assignment-context, launch-readiness, assignment
 preflight, Project Assistant context/proposal, and operations brief reads render
 work items, assignments, roles, artifacts, and handoffs from the Cairnline

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -437,7 +437,9 @@ context/proposal, and project-linked Hecate Chat prelude/context directly from
 the embedded Cairnline graph so dogfood routes do not require shadow
 Hecate-native project rows. Route selection in this mode is configuration-driven:
 direct-read routes attempt the embedded Cairnline graph without first requiring
-a Hecate-native snapshot projection. Set
+a Hecate-native snapshot projection, and Cairnline-authoritative portable write
+helpers use the embedded graph for project identity/root metadata before any
+Hecate-native compatibility shadow. Set
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot` to force the snapshot-seeded
 bridge, or `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` to make configured
 read routes require a populated

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2425,6 +2425,10 @@ create default and closeout-readiness gate. In these opt-in authority modes,
 portable project-work write routes can validate project identity and roots from
 the embedded Cairnline project graph, so they no longer require a matching
 Hecate-native compatibility project row before reaching Cairnline authority.
+When `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` is set, those authority
+helpers prefer the embedded Cairnline project graph over any Hecate-native
+compatibility shadow so stale shadows cannot override authoritative project/root
+metadata.
 Adding `agent-profiles` makes global agent-profile create/update/delete
 Cairnline-first, writing Cairnline's separate portable profile and
 execution-posture records before shadowing Hecate's combined profile row.

--- a/internal/api/handler_project_work_item_authority.go
+++ b/internal/api/handler_project_work_item_authority.go
@@ -120,6 +120,9 @@ func (h *Handler) projectForCairnlineWriteAuthority(ctx context.Context, project
 		return projects.Project{}, errors.New("handler is not configured")
 	}
 	projectID = strings.TrimSpace(projectID)
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		return h.projectFromEmbeddedCairnlineWriteAuthority(ctx, projectID)
+	}
 	if h.projects != nil {
 		project, ok, err := h.projects.Get(ctx, projectID)
 		if err != nil {
@@ -129,6 +132,10 @@ func (h *Handler) projectForCairnlineWriteAuthority(ctx context.Context, project
 			return project, nil
 		}
 	}
+	return h.projectFromEmbeddedCairnlineWriteAuthority(ctx, projectID)
+}
+
+func (h *Handler) projectFromEmbeddedCairnlineWriteAuthority(ctx context.Context, projectID string) (projects.Project, error) {
 	var project projects.Project
 	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
 		item, err := service.GetProject(ctx, projectID)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1381,6 +1381,65 @@ func TestProjectWorkAPI_CairnlineWorkItemAuthorityWritesCairnlineOnlyProject(t *
 	}
 }
 
+func TestProjectWorkAPI_CairnlineWorkItemAuthorityStrictEmbeddedUsesCairnlineProjectOverStaleNative(t *testing.T) {
+	t.Parallel()
+	const projectID = "proj_work_authority_stale_native"
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectWorkItems,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   projectID,
+		Name: "Stale native project",
+	}); err != nil {
+		t.Fatalf("create stale native project: %v", err)
+	}
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		_, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:            projectID,
+			Name:          "Authoritative Cairnline project",
+			DefaultRootID: "root_authoritative",
+			Roots: []cairnline.Root{{
+				ID:     "root_authoritative",
+				Path:   "/workspace/authoritative",
+				Kind:   "git",
+				Active: true,
+			}},
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed authoritative Cairnline project: %v", err)
+	}
+
+	client := newAPITestClient(t, NewServer(quietLogger(), handler))
+	created := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":      "work_authoritative_root",
+		"title":   "Use authoritative root metadata",
+		"root_id": "root_authoritative",
+	}))
+	if created.Data.RootID != "root_authoritative" {
+		t.Fatalf("created work item = %+v, want item using authoritative Cairnline root", created.Data)
+	}
+	mirroredWork := getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_authoritative_root")
+	if mirroredWork.RootID != "root_authoritative" {
+		t.Fatalf("mirrored work item = %+v, want authoritative Cairnline root", mirroredWork)
+	}
+	native, ok, err := handler.projects.Get(t.Context(), projectID)
+	if err != nil || !ok {
+		t.Fatalf("native project ok=%v error=%v, want stale compatibility row still present", ok, err)
+	}
+	if len(native.Roots) != 0 {
+		t.Fatalf("native project roots = %+v, want stale compatibility row not used for root validation", native.Roots)
+	}
+}
+
 func TestProjectWorkAPI_CairnlineAssignmentAuthorityWritesCairnlineOnlyProject(t *testing.T) {
 	t.Parallel()
 	const projectID = "proj_assignment_authority_cairnline_only"


### PR DESCRIPTION
## Summary
- Make Cairnline-authoritative write helpers load project identity/root metadata from embedded Cairnline first when strict embedded reads are configured
- Add a regression for stale Hecate-native compatibility project rows losing to the authoritative Cairnline graph
- Update the Projects design, runtime API, and operator deployment docs for the strict embedded authority boundary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_CairnlineWorkItemAuthorityStrictEmbeddedUsesCairnlineProjectOverStaleNative|TestProjectWorkAPI_CairnlineWorkItemAuthorityWritesCairnlineOnlyProject'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- just agent-docs-check