### PR TITLE
fix(projects): delete Cairnline-only project identities

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -326,7 +326,9 @@ remain Hecate-owned unless their separate switchpoints are enabled.
 portable identity, initial roots, context sources, launch defaults, and project
 identity removal to embedded Cairnline first, then best-effort shadows Hecate's
 compatibility project row. Delete restores the Cairnline snapshot if Hecate
-compatibility cleanup fails.
+compatibility cleanup fails. Identity delete can also target a Cairnline-only
+project graph and clean any Hecate compatibility shadow rows for that project
+without requiring a matching native project row.
 `project-roots` and `project-context-sources` are scoped partial authority
 slices: project root create/update/delete, root list replacement, root
 discovery-result replacement, context-source create/update/delete,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -528,7 +528,9 @@ Project create also best-effort mirrors portable identity, initial roots,
 context sources, and launch defaults after the Hecate store commit unless
 `project-identity` is enabled, in which case create/delete commits to Cairnline
 first and then shadows Hecate's compatibility project row. Delete restores the
-Cairnline snapshot if Hecate compatibility cleanup fails.
+Cairnline snapshot if Hecate compatibility cleanup fails. Identity delete can
+also target a Cairnline-only project graph and clean Hecate compatibility shadow
+rows without requiring a matching native project row.
 Project root create/update/delete and root list replacement mutations also
 best-effort mirror after the Hecate store commit unless `project-roots` is
 enabled, in which case those root mutations plus discovery-result replacement

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2450,7 +2450,9 @@ context-source discovery can run against a Cairnline-only project graph.
 Adding `project-identity` makes project create/delete Cairnline-first for
 portable identity, initial roots, context sources, launch defaults, and project
 identity removal, then shadows the compatibility project row. Delete restores
-the Cairnline snapshot if Hecate compatibility cleanup fails.
+the Cairnline snapshot if Hecate compatibility cleanup fails. Identity delete can
+also target a Cairnline-only project graph and clean any Hecate compatibility
+shadow rows for that project without requiring a matching native project row.
 `authoritative_backend` remains `hecate` until Hecate can run project read/write
 flows against Cairnline without UI-local fallback state. When
 `configured_backend=cairnline` and `cairnline_connector=embedded`, Hecate still

--- a/internal/api/handler_project_identity_authority.go
+++ b/internal/api/handler_project_identity_authority.go
@@ -61,7 +61,7 @@ func (h *Handler) createProjectWithCairnlineAuthority(ctx context.Context, proje
 func (h *Handler) deleteProjectWithCairnlineAuthority(ctx context.Context, projectID string) (projectapp.DeleteProjectResult, error) {
 	snapshot, err := cairnlinebridge.LoadSnapshot(ctx, h.cairnlineSnapshotSources(), projectID)
 	if errors.Is(err, projects.ErrNotFound) {
-		return projectapp.DeleteProjectResult{}, projectapp.ErrProjectNotFound
+		return h.deleteCairnlineOnlyProjectWithAuthority(ctx, projectID)
 	}
 	if err != nil {
 		return projectapp.DeleteProjectResult{}, err
@@ -78,6 +78,49 @@ func (h *Handler) deleteProjectWithCairnlineAuthority(ctx context.Context, proje
 		return result, errors.Join(err, fmt.Errorf("restore Cairnline project snapshot after failed delete: %w", restoreErr))
 	}
 	return result, err
+}
+
+func (h *Handler) deleteCairnlineOnlyProjectWithAuthority(ctx context.Context, projectID string) (projectapp.DeleteProjectResult, error) {
+	var project projects.Project
+	var rollback cairnline.Snapshot
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		item, err := service.GetProject(ctx, strings.TrimSpace(projectID))
+		if err != nil {
+			return err
+		}
+		executionProfile, err := cairnlineExecutionProfileByID(ctx, service, item.DefaultExecutionProfileID)
+		if err != nil {
+			return err
+		}
+		project = projectFromCairnline(item, executionProfile, projects.Project{})
+		rollback, err = service.ExportSnapshot(ctx)
+		if err != nil {
+			return err
+		}
+		return cairnlinebridge.DeleteProject(ctx, service, project)
+	})
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return projectapp.DeleteProjectResult{}, projectapp.ErrProjectNotFound
+	}
+	if err != nil {
+		return projectapp.DeleteProjectResult{}, projectAppErrorFromCairnlineAuthority(err, "project")
+	}
+	result, err := h.projectApplication().DeleteProjectScopedRows(ctx, project)
+	if err == nil {
+		return result, nil
+	}
+	if restoreErr := h.restoreCairnlineSnapshot(ctx, rollback); restoreErr != nil {
+		h.logCairnlineMirrorError(ctx, "project_identity_cairnline_authority_delete_cairnline_only_rollback", project.ID, restoreErr)
+		return result, errors.Join(err, fmt.Errorf("restore Cairnline snapshot after failed delete: %w", restoreErr))
+	}
+	return result, err
+}
+
+func (h *Handler) restoreCairnlineSnapshot(ctx context.Context, snapshot cairnline.Snapshot) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		_, err := service.ImportSnapshot(ctx, snapshot)
+		return err
+	})
 }
 
 func (h *Handler) restoreProjectSnapshotToCairnline(ctx context.Context, snapshot cairnlinebridge.Snapshot) error {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -684,6 +684,84 @@ func TestProjectsAPI_CairnlineIdentityAuthorityCommitsDeleteFirst(t *testing.T) 
 	}
 }
 
+func TestProjectsAPI_CairnlineIdentityAuthorityDeletesCairnlineOnlyProject(t *testing.T) {
+	t.Parallel()
+	const projectID = "proj_identity_delete_cairnline_only"
+	handler, server := newProjectsCairnlineIdentityAuthorityTestServer(t)
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		_, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Cairnline-only delete",
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed Cairnline-only project: %v", err)
+	}
+	if _, err := handler.projectWork.CreateWorkItem(t.Context(), projectwork.WorkItem{
+		ID:        "work_shadow",
+		ProjectID: projectID,
+		Title:     "Shadow cleanup",
+	}); err != nil {
+		t.Fatalf("seed Hecate shadow work item: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("native project exists = %t err=%v, want missing before delete", ok, err)
+	}
+
+	deleted := mustRequestJSONStatus[ProjectDeleteResponse](newAPITestClient(t, server), http.StatusOK, http.MethodDelete, "/hecate/v1/projects/"+projectID, "")
+	if deleted.Data.ProjectID != projectID || deleted.Data.ProjectName != "Cairnline-only delete" || deleted.Data.ProjectWorkRowsDeleted != 1 {
+		t.Fatalf("delete response = %+v, want Cairnline project identity and shadow work cleanup", deleted.Data)
+	}
+	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+	if err != nil {
+		t.Fatalf("open Cairnline mirror after delete: %v", err)
+	}
+	defer store.Close()
+	if _, err := service.GetProject(t.Context(), projectID); !errors.Is(err, cairnline.ErrNotFound) {
+		t.Fatalf("Cairnline project after delete error = %v, want ErrNotFound", err)
+	}
+	workItems, err := handler.projectWork.ListWorkItems(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("ListWorkItems after delete: %v", err)
+	}
+	if len(workItems) != 0 {
+		t.Fatalf("shadow work items after delete = %+v, want none", workItems)
+	}
+}
+
+func TestProjectsAPI_CairnlineIdentityAuthorityRollsBackCairnlineOnlyDeleteWhenShadowCleanupFails(t *testing.T) {
+	t.Parallel()
+	const projectID = "proj_identity_delete_cairnline_only_rollback"
+	handler, server := newProjectsCairnlineIdentityAuthorityTestServer(t)
+	handler.SetProjectSkillStore(failingProjectSkillDeleteStore{
+		Store: projectskills.NewMemoryStore(),
+		err:   errors.New("skill cleanup failed"),
+	})
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		_, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   projectID,
+			Name: "Cairnline-only rollback",
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed Cairnline-only project: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("native project exists = %t err=%v, want missing before delete", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/hecate/v1/projects/"+projectID, nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("delete status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, projectID)
+	if mirrored.Name != "Cairnline-only rollback" {
+		t.Fatalf("rolled-back Cairnline project = %+v, want restored project", mirrored)
+	}
+}
+
 func TestProjectsAPI_CairnlineIdentityAuthorityRollsBackDeleteWhenCompatibilityCleanupFails(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineIdentityAuthorityTestServer(t)

--- a/internal/projectapp/application.go
+++ b/internal/projectapp/application.go
@@ -335,50 +335,8 @@ func (app *Application) DeleteProject(ctx context.Context, id string) (DeletePro
 	}
 
 	result := DeleteProjectResult{Project: project}
-	if err := app.deleteProjectChats(ctx, projectID, &result); err != nil {
+	if err := app.deleteProjectScopedRows(ctx, projectID, &result); err != nil {
 		return result, err
-	}
-	if app.projectWork != nil {
-		deleted, err := app.projectWork.DeleteProject(ctx, projectID)
-		if err != nil {
-			return result, err
-		}
-		result.ProjectWorkRowsDeleted = deleted
-	}
-	if app.projectRuntime != nil {
-		deleted, err := app.projectRuntime.DeleteProject(ctx, projectID)
-		if err != nil {
-			return result, err
-		}
-		result.ProjectRuntimeRowsDeleted = deleted
-	}
-	if app.projectSkills != nil {
-		deleted, err := app.projectSkills.DeleteProject(ctx, projectID)
-		if err != nil {
-			return result, err
-		}
-		result.ProjectSkillsDeleted = deleted
-	}
-	if app.projectAssistantProposals != nil {
-		deleted, err := app.projectAssistantProposals.DeleteProject(ctx, projectID)
-		if err != nil {
-			return result, err
-		}
-		result.ProjectAssistantProposalsDeleted = deleted
-	}
-	if app.memory != nil {
-		deleted, err := app.memory.DeleteByProjectID(ctx, projectID)
-		if err != nil {
-			return result, err
-		}
-		result.MemoryEntriesDeleted = deleted
-	}
-	if app.memoryCandidates != nil {
-		deleted, err := app.memoryCandidates.DeleteCandidatesByProjectID(ctx, projectID)
-		if err != nil {
-			return result, err
-		}
-		result.MemoryCandidatesDeleted = deleted
 	}
 	// Cross-store cleanup is retry-friendly rather than transactional: the
 	// project identity stays durable until every scoped cleanup step succeeds.
@@ -389,6 +347,70 @@ func (app *Application) DeleteProject(ctx context.Context, id string) (DeletePro
 		return result, err
 	}
 	return result, nil
+}
+
+func (app *Application) DeleteProjectScopedRows(ctx context.Context, project projects.Project) (DeleteProjectResult, error) {
+	if app == nil {
+		return DeleteProjectResult{}, ErrProjectStoreNotConfigured
+	}
+	projectID := strings.TrimSpace(project.ID)
+	if projectID == "" {
+		return DeleteProjectResult{}, ErrProjectNotFound
+	}
+	result := DeleteProjectResult{Project: project}
+	if err := app.deleteProjectScopedRows(ctx, projectID, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (app *Application) deleteProjectScopedRows(ctx context.Context, projectID string, result *DeleteProjectResult) error {
+	if err := app.deleteProjectChats(ctx, projectID, result); err != nil {
+		return err
+	}
+	if app.projectWork != nil {
+		deleted, err := app.projectWork.DeleteProject(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		result.ProjectWorkRowsDeleted = deleted
+	}
+	if app.projectRuntime != nil {
+		deleted, err := app.projectRuntime.DeleteProject(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		result.ProjectRuntimeRowsDeleted = deleted
+	}
+	if app.projectSkills != nil {
+		deleted, err := app.projectSkills.DeleteProject(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		result.ProjectSkillsDeleted = deleted
+	}
+	if app.projectAssistantProposals != nil {
+		deleted, err := app.projectAssistantProposals.DeleteProject(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		result.ProjectAssistantProposalsDeleted = deleted
+	}
+	if app.memory != nil {
+		deleted, err := app.memory.DeleteByProjectID(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		result.MemoryEntriesDeleted = deleted
+	}
+	if app.memoryCandidates != nil {
+		deleted, err := app.memoryCandidates.DeleteCandidatesByProjectID(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		result.MemoryCandidatesDeleted = deleted
+	}
+	return nil
 }
 
 func findProjectRoot(roots []projects.Root, id string) (projects.Root, bool) {

--- a/internal/projectapp/application_test.go
+++ b/internal/projectapp/application_test.go
@@ -189,6 +189,43 @@ func TestApplication_DeleteProjectCleansProjectScopedStores(t *testing.T) {
 	}, 2)
 }
 
+func TestApplication_DeleteProjectScopedRowsDoesNotRequireProjectRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	projectStore := projects.NewMemoryStore()
+	workStore := projectwork.NewMemoryStore()
+	memoryStore := memory.NewMemoryStore()
+	projectID := "proj_scoped_only"
+
+	if _, err := workStore.CreateWorkItem(ctx, projectwork.WorkItem{ID: "work_scoped", ProjectID: projectID, Title: "Scoped"}); err != nil {
+		t.Fatalf("CreateWorkItem(project): %v", err)
+	}
+	if _, err := memoryStore.Create(ctx, memory.Entry{ID: "mem_scoped", Scope: memory.ScopeProject, ProjectID: projectID, Title: "Scoped", Body: "Scoped"}); err != nil {
+		t.Fatalf("Create(memory): %v", err)
+	}
+	app := New(Options{
+		Projects:         projectStore,
+		ProjectWork:      workStore,
+		Memory:           memoryStore,
+		MemoryCandidates: memoryStore,
+	})
+	result, err := app.DeleteProjectScopedRows(ctx, projects.Project{ID: projectID, Name: "Scoped only"})
+	if err != nil {
+		t.Fatalf("DeleteProjectScopedRows() error = %v", err)
+	}
+	if result.Project.ID != projectID || result.ProjectWorkRowsDeleted != 1 || result.MemoryEntriesDeleted != 1 {
+		t.Fatalf("DeleteProjectScopedRows() result = %+v, want scoped cleanup counts", result)
+	}
+	if _, ok, err := projectStore.Get(ctx, projectID); err != nil || ok {
+		t.Fatalf("Get(project) ok=%v err=%v, want still missing", ok, err)
+	}
+	assertProjectAppListCount(t, "project work", func() (int, error) {
+		items, err := workStore.ListWorkItems(ctx, projectID)
+		return len(items), err
+	}, 0)
+}
+
 func TestApplication_DeleteProjectStopsBeforeCleanupWhenProjectChatIsStopping(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- allow project identity delete to fall back to the embedded Cairnline graph when the native Hecate project row is already absent
- add projectapp scoped cleanup so Cairnline-only deletes can remove Hecate compatibility shadow rows without deleting a native identity
- restore the Cairnline snapshot when compatibility cleanup fails
- document the Cairnline-only identity delete behavior

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/projectapp ./internal/api -run 'Test(Application_DeleteProjectScopedRowsDoesNotRequireProjectRow|ProjectsAPI_CairnlineIdentityAuthority(CommitsDeleteFirst|DeletesCairnlineOnlyProject|RollsBackCairnlineOnlyDeleteWhenShadowCleanupFails|RollsBackDeleteWhenCompatibilityCleanupFails))'
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api ./internal/projectapp