### PR TITLE
fix(projects): launch strict Cairnline assignments

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -641,9 +641,13 @@ after these gates are met:
   assignment runtime overlay and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative
-  Cairnline launch-packet evidence, but assignment-start remains a Hecate-owned
-  orchestrator capability; committed start and linked-chat reconciliation
-  results may be mirrored only as replacement evidence. Backend-status `write_adapter_seams`
+  Cairnline launch-packet evidence, and strict embedded reads may use a
+  Cairnline-only project graph as the source of launch inputs, but
+  assignment-start remains a Hecate-owned orchestrator capability. Hecate
+  creates only the narrow project-work/runtime shadow needed for claim and
+  dispatch, not a native project identity row; committed start and linked-chat
+  reconciliation results may be mirrored only as replacement evidence.
+  Backend-status `write_adapter_seams`
   lists non-authoritative proof
   coverage; `write_adapter_gaps` remains a broad diagnostic list, while
   `portable_write_gaps` is the machine-readable blocker list for mutation

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -575,11 +575,15 @@ commit. Committed
 assignment-start results, linked-chat reconciliation, collaboration artifact
 creation, and handoff create/update/delete mutations also best-effort mirror
 portable metadata after Hecate commits, but assignment start/dispatch remains
-Hecate-owned. Task/chat execution refs, context packets, and launch timestamps
-are stored in Hecate's project assignment runtime overlay before compatibility
-shadows or replacement-evidence mirrors are written. Pre-dispatch cleanup and
-conflict states are mirrored back into Cairnline so replacement probes do not
-leave stale claimed assignment rows.
+Hecate-owned. In strict embedded read mode, assignment start can resolve the
+project, work item, assignment, role, root, and execution defaults from a
+Cairnline-only project graph; Hecate creates a narrow project-work/runtime
+shadow for the atomic claim and dispatch path without creating a native Hecate
+project identity row. Task/chat execution refs, context packets, and launch
+timestamps are stored in Hecate's project assignment runtime overlay before
+compatibility shadows or replacement-evidence mirrors are written.
+Pre-dispatch cleanup and conflict states are mirrored back into Cairnline so
+replacement probes do not leave stale claimed assignment rows.
 Project
 memory entries mirror after Hecate commits unless the
 `project-memory` Cairnline write-authority switchpoint is enabled; memory

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2648,7 +2648,12 @@ Mirror failures are logged.
 `project-assignment-start-result-live-mirror` best-effort mirrors
 committed assignment-start results after Hecate-owned dispatch completes or
 returns a committed cleanup/conflict state; it is replacement evidence, not
-runtime write authority. `project-assignment-chat-reconcile-live-mirror`
+runtime write authority. With strict embedded Cairnline reads, assignment
+start may load the launch project/work/assignment/role/root/defaults from a
+Cairnline-only graph, create only the narrow Hecate project-work/runtime
+shadow needed for the existing atomic claim and task/chat dispatch path, and
+mirror the committed result back to Cairnline without requiring a native
+Hecate project identity row. `project-assignment-chat-reconcile-live-mirror`
 best-effort mirrors assignment status/ref updates committed by linked
 external-agent chat reconciliation. `project-collaboration-live-mirror` mirrors
 collaboration artifact creation, including generic artifacts, evidence links,

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -802,7 +802,8 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task runner is not configured")
 		return
 	}
-	if h.projects == nil || h.projectWork == nil {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if (!strictEmbeddedRead && h.projects == nil) || h.projectWork == nil {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
 		return
 	}
@@ -811,42 +812,12 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 
-	project, ok, err := h.projects.Get(ctx, projectID)
+	inputs, err := h.projectAssignmentStartInputs(ctx, projectID, workItemID, assignmentID, strictEmbeddedRead)
 	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
 		return
 	}
-	if !ok {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
-		return
-	}
-	workItem, ok, err := h.projectWork.GetWorkItem(ctx, projectID, workItemID)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if !ok {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "work item not found")
-		return
-	}
-	assignment, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if !ok {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment not found")
-		return
-	}
-	role, ok, err := h.loadProjectWorkRole(ctx, projectID, assignment.RoleID)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-		return
-	}
-	if !ok {
-		WriteError(w, http.StatusNotFound, errCodeNotFound, "assignment role not found")
-		return
-	}
+	project, workItem, assignment, role := inputs.Project, inputs.WorkItem, inputs.Assignment, inputs.Role
 	if driver := strings.TrimSpace(req.DriverKind); driver != "" && driver != assignment.DriverKind {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, fmt.Sprintf("assignment driver_kind is %q, not %q", assignment.DriverKind, driver))
 		return
@@ -895,6 +866,16 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	h.appendCairnlineAssignmentLaunchPacketEvidence(ctx, &contextPacket, assignment)
 	if contextPacket.ID == "" {
 		contextPacket.ID = newChatID("ctx")
+	}
+
+	if strictEmbeddedRead {
+		inputs.Assignment = assignment
+		shadowedAssignment, err := h.shadowCairnlineAssignmentStartInputsToHecate(ctx, inputs)
+		if err != nil {
+			WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+			return
+		}
+		assignment = shadowedAssignment
 	}
 
 	result, err := h.projectWorkApplication().StartTaskAssignment(ctx, projectworkapp.StartTaskAssignmentCommand{
@@ -955,6 +936,80 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+}
+
+func (h *Handler) projectAssignmentStartInputs(ctx context.Context, projectID, workItemID, assignmentID string, strictEmbeddedRead bool) (projectAssignmentLaunchInputs, error) {
+	if strictEmbeddedRead {
+		inputs, err := h.cairnlineProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
+		if err != nil {
+			return projectAssignmentLaunchInputs{}, err
+		}
+		if !inputs.RoleOK {
+			return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment role not found")
+		}
+		return inputs, nil
+	}
+	project, ok, err := h.projects.Get(ctx, projectID)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if !ok {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "project not found")
+	}
+	workItem, ok, err := h.projectWork.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if !ok {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "work item not found")
+	}
+	assignment, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if !ok {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
+	}
+	role, ok, err := h.loadProjectWorkRole(ctx, projectID, assignment.RoleID)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
+	if !ok {
+		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment role not found")
+	}
+	return projectAssignmentLaunchInputs{
+		Project:    project,
+		WorkItem:   workItem,
+		Assignment: assignment,
+		Role:       role,
+		RoleOK:     true,
+	}, nil
+}
+
+func (h *Handler) shadowCairnlineAssignmentStartInputsToHecate(ctx context.Context, inputs projectAssignmentLaunchInputs) (projectwork.Assignment, error) {
+	if h == nil || h.projectWork == nil {
+		return projectwork.Assignment{}, projectworkapp.ErrStoreNotConfigured
+	}
+	if inputs.RoleOK {
+		if _, ok := h.shadowProjectRoleToHecate(ctx, "project_assignment_start_cairnline_shadow", inputs.Role); !ok {
+			return projectwork.Assignment{}, errors.New("assignment role could not be shadowed for Hecate launch")
+		}
+	}
+	h.shadowProjectWorkItemToHecate(ctx, "project_assignment_start_cairnline_shadow", inputs.WorkItem)
+	if _, ok, err := h.projectWork.GetWorkItem(ctx, inputs.WorkItem.ProjectID, inputs.WorkItem.ID); err != nil {
+		return projectwork.Assignment{}, err
+	} else if !ok {
+		return projectwork.Assignment{}, errors.New("work item could not be shadowed for Hecate launch")
+	}
+	h.shadowProjectAssignmentToHecate(ctx, "project_assignment_start_cairnline_shadow", inputs.Assignment)
+	assignment, ok, err := h.loadProjectWorkAssignment(ctx, inputs.Assignment.ProjectID, inputs.Assignment.WorkItemID, inputs.Assignment.ID)
+	if err != nil {
+		return projectwork.Assignment{}, err
+	}
+	if !ok {
+		return projectwork.Assignment{}, errors.New("assignment could not be shadowed for Hecate launch")
+	}
+	return assignment, nil
 }
 
 func (h *Handler) projectExternalAgentAssignmentContextPacket(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, plan projectworkapp.ExternalAgentAssignmentLaunchPlan, sessionID string) chat.ContextPacket {

--- a/internal/api/handler_project_cairnline_mirror.go
+++ b/internal/api/handler_project_cairnline_mirror.go
@@ -229,6 +229,20 @@ func (h *Handler) projectForCairnlineMirror(ctx context.Context, operation, proj
 	if !h.projectCairnlineEmbeddedConnectorEnabled() {
 		return projects.Project{}, false
 	}
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		project, err := h.projectFromEmbeddedCairnlineWriteAuthority(ctx, projectID)
+		if err == nil {
+			return project, true
+		}
+		if !errors.Is(err, cairnline.ErrNotFound) {
+			h.logCairnlineMirrorError(ctx, operation, projectID, err)
+			return projects.Project{}, false
+		}
+	}
+	if h.projects == nil {
+		h.logCairnlineMirrorError(ctx, operation, projectID, errors.New("project store is not configured for Cairnline mirror"))
+		return projects.Project{}, false
+	}
 	project, ok, err := h.projects.Get(ctx, projectID)
 	if err != nil {
 		h.logCairnlineMirrorError(ctx, operation, projectID, err)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3591,6 +3591,125 @@ func TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHe
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_launch_start"
+	workspace := t.TempDir()
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateExecutionProfile(t.Context(), cairnline.ExecutionProfile{
+			ID:           "exec_embedded_launch_start",
+			Name:         "Embedded launch start",
+			ProviderHint: "anthropic",
+			ModelHint:    "claude-sonnet-4",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:                        projectID,
+			Name:                      "Embedded Launch Start",
+			Description:               "Coordinate assignment launch from embedded Cairnline.",
+			DefaultRootID:             "root_embedded_launch_start",
+			DefaultExecutionProfileID: "exec_embedded_launch_start",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_launch_start",
+				Path:   workspace,
+				Kind:   "git",
+				Active: true,
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:                        "role_embedded_launch_start",
+			ProjectID:                 projectID,
+			Name:                      "Launch Implementer",
+			Instructions:              "Use the embedded Cairnline graph.",
+			DefaultExecutionProfileID: "exec_embedded_launch_start",
+			DefaultExecutionMode:      cairnline.ExecutionOrchestrated,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded_launch_start",
+			ProjectID:   projectID,
+			Title:       "Start embedded assignment",
+			Brief:       "Launch a Hecate task from a Cairnline-only project graph.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_embedded_launch_start",
+			RootID:      "root_embedded_launch_start",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_launch_start",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_launch_start",
+			RoleID:        "role_embedded_launch_start",
+			RootID:        "root_embedded_launch_start",
+			ExecutionMode: cairnline.ExecutionOrchestrated,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline launch start: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row before launch", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_launch_start/assignments/asgn_embedded_launch_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("start embedded assignment status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var assignment ProjectWorkAssignmentEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &assignment); err != nil {
+		t.Fatalf("decode assignment: %v", err)
+	}
+	ref := assignmentExecutionRefForTest(t, assignment.Data)
+	if ref.TaskID == "" || ref.RunID == "" || ref.ContextSnapshotID == "" {
+		t.Fatalf("assignment execution_ref = %+v, want task, run, and context links", ref)
+	}
+	if assignment.Data.ProjectID != projectID || assignment.Data.WorkItemID != "work_embedded_launch_start" || assignment.Data.RoleID != "role_embedded_launch_start" {
+		t.Fatalf("assignment linkage = %+v, want embedded Cairnline project/work/role linkage", assignment.Data)
+	}
+
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
+	}
+	if task.ProjectID != projectID || task.WorkItemID != "work_embedded_launch_start" || task.AssignmentID != "asgn_embedded_launch_start" {
+		t.Fatalf("task linkage = project %q work %q assignment %q, want embedded Cairnline refs", task.ProjectID, task.WorkItemID, task.AssignmentID)
+	}
+	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.WorkingDirectory != workspace {
+		t.Fatalf("task provider/model/workspace = %q/%q/%q, want anthropic/claude-sonnet-4/%q", task.RequestedProvider, task.RequestedModel, task.WorkingDirectory, workspace)
+	}
+	if !strings.Contains(task.Prompt, "Start embedded assignment") || !strings.Contains(task.SystemPrompt, "Use the embedded Cairnline graph.") {
+		t.Fatalf("task prompt/system = %q / %q, want Cairnline work and role context", task.Prompt, task.SystemPrompt)
+	}
+
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after launch, want no native project row", ok, err)
+	}
+	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_embedded_launch_start", "asgn_embedded_launch_start")
+	if shadow.ExecutionRef.RunID != ref.RunID || shadow.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("Hecate assignment shadow ref = %+v, want run/context %q/%q", shadow.ExecutionRef, ref.RunID, ref.ContextSnapshotID)
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_embedded_launch_start")
+	if mirrored.Status != cairnlinebridge.AssignmentStatus(shadow.Status) || mirrored.ExecutionRef != ref.RunID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("mirrored Cairnline assignment = status %q ref %q context %q, want %q/%q/%q", mirrored.Status, mirrored.ExecutionRef, mirrored.ContextSnapshotID, cairnlinebridge.AssignmentStatus(shadow.Status), ref.RunID, ref.ContextSnapshotID)
+	}
+}
+
 func TestProjectWorkAPI_PreflightAssignmentCairnlineSidecarRequiresStructuredLaunchPacket(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "assignments.launch_packet-text-only")


### PR DESCRIPTION
## Summary
- allow strict embedded Cairnline read mode to start assignments from a Cairnline-only project graph
- create only the narrow Hecate project-work/runtime shadow needed for atomic Hecate-owned dispatch, without creating a native project identity row
- prefer embedded Cairnline project metadata when mirroring committed start results back to Cairnline
- document the Cairnline-input/Hecate-dispatch boundary

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHecateProject|StartAssignmentCreatesNativeTaskRun|StartAssignmentMirrorsResultToCairnline)'\n- just agent-docs-check\n- git diff --check\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- GOCACHE="$(pwd)/.gocache" go test ./...\n- GOCACHE="$(pwd)/.gocache" go vet ./internal/api\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n