### PR TITLE
fix(projects): honor Cairnline replacement identities

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -138,7 +138,11 @@ embedded reads are verified, all portable write-authority gaps are closed, and
 `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed, backend status
 treats that replacement mode as the explicit embedded cutover switch, clears the
 migration blocker, and reports embedded Cairnline as authoritative for portable
-Projects coordination state.
+Projects coordination state. In that armed mode with all portable
+write-authority gaps closed, Cairnline-authoritative project identity create no
+longer creates a native Hecate project identity row; strict embedded reads serve
+the project from Cairnline, while Hecate keeps only the runtime/workspace
+compatibility shadows it still owns.
 It keeps `write_adapter_gaps` as the broad diagnostic list and also groups
 that list into `portable_write_gaps`, `orchestrator_capabilities`, and
 `migration_blockers`, so operator tooling can tell durable coordination-state

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -530,7 +530,10 @@ context sources, and launch defaults after the Hecate store commit unless
 first and then shadows Hecate's compatibility project row. Delete restores the
 Cairnline snapshot if Hecate compatibility cleanup fails. Identity delete can
 also target a Cairnline-only project graph and clean Hecate compatibility shadow
-rows without requiring a matching native project row.
+rows without requiring a matching native project row. When embedded replacement
+mode is armed with all portable write-authority gaps closed, project-identity
+create returns the Cairnline record without creating a native Hecate project
+identity row; strict embedded reads then serve the new project from Cairnline.
 Project root create/update/delete and root list replacement mutations also
 best-effort mirror after the Hecate store commit unless `project-roots` is
 enabled, in which case those root mutations plus discovery-result replacement
@@ -649,7 +652,11 @@ authoritative storage cutover switch still does not exist. When
 embedded reads are verified and all portable write-authority gaps are closed,
 backend status treats that mode as the explicit embedded cutover switch, clears
 the migration blocker, and reports Cairnline as authoritative for portable
-Projects coordination state. It also groups the broad `write_adapter_gaps`
+Projects coordination state. In that armed mode with all portable
+write-authority gaps closed, new Cairnline-authoritative project identity
+creates no longer manufacture native Hecate project identity rows;
+compatibility shadows remain limited to Hecate-owned runtime/workspace needs.
+It also groups the broad `write_adapter_gaps`
 diagnostic list into
 `portable_write_gaps`,
 `orchestrator_capabilities`, and `migration_blockers`, so durable

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2551,7 +2551,11 @@ embedded reads are verified, all portable write-authority gaps are closed, and
 `replacement_mode=embedded`, backend status treats replacement mode as that
 explicit embedded cutover switch: `migration_blockers` is empty, the
 `migration-and-rollback` gate is `ready`, and `authoritative_backend` reports
-`cairnline` for portable Projects coordination state.
+`cairnline` for portable Projects coordination state. In armed embedded
+replacement mode with all portable write-authority gaps closed,
+Cairnline-authoritative project identity create returns the Cairnline record
+without creating a native Hecate project identity row; strict embedded read
+routes serve the new project from Cairnline.
 When the next action is `rehearse-migration-cutover`, `config_hints` identify
 the strict embedded dogfood posture expected for the rehearsal:
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,

--- a/internal/api/handler_project_identity_authority.go
+++ b/internal/api/handler_project_identity_authority.go
@@ -20,6 +20,21 @@ func (h *Handler) projectIdentityWritesUseCairnlineAuthority() bool {
 		h.config.ProjectsCairnlineWriteAuthorityEnabled(projectCairnlineWriteAuthorityProjectIdentity)
 }
 
+func (h *Handler) projectCairnlineEmbeddedReplacementModeArmed() bool {
+	if h == nil {
+		return false
+	}
+	if h.config.ProjectsCoordinationBackend() != "cairnline" ||
+		!h.projectCairnlineEmbeddedConnectorEnabled() ||
+		h.config.ProjectsCairnlineReadSource() != "embedded" ||
+		h.config.ProjectsCairnlineReplacementMode() != "embedded" {
+		return false
+	}
+	writeAuthority := h.config.ProjectsCairnlineWriteAuthority()
+	writeGaps := projectCairnlineWriteAdapterGapsSnapshot(writeAuthority)
+	return len(projectCairnlinePortableWriteGapsSnapshot(writeAuthority, writeGaps)) == 0
+}
+
 func (h *Handler) createProjectWithCairnlineAuthority(ctx context.Context, project projects.Project) (projects.Project, error) {
 	if err := h.validateProjectMetadataDefaultsHecateCompatibility(ctx, project); err != nil {
 		return projects.Project{}, err
@@ -52,6 +67,9 @@ func (h *Handler) createProjectWithCairnlineAuthority(ctx context.Context, proje
 		return projects.Project{}, err
 	}
 	shadow := projectFromCairnlineProjectCreate(project, written)
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		return shadow, nil
+	}
 	if shadowed, ok := h.shadowProjectCreateToHecate(ctx, "project_identity_cairnline_authority_create", shadow); ok {
 		return shadowed, nil
 	}

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -203,7 +203,8 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if req.DefaultRootID != nil {
+	usesCairnlineMetadataDefaultsAuthority := h.projectMetadataDefaultsWritesUseCairnlineAuthority() && projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req)
+	if req.DefaultRootID != nil && !usesCairnlineMetadataDefaultsAuthority {
 		defaultRootID := strings.TrimSpace(*req.DefaultRootID)
 		rootsToCheck := roots
 		if req.Roots == nil {
@@ -223,7 +224,7 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if h.projectMetadataDefaultsWritesUseCairnlineAuthority() && projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req) {
+	if usesCairnlineMetadataDefaultsAuthority {
 		project, err := h.updateProjectMetadataDefaultsWithCairnlineAuthority(r.Context(), r.PathValue("id"), req)
 		if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
 			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -90,6 +90,22 @@ func newProjectsCairnlineIdentityAuthorityTestServer(t *testing.T) (*Handler, ht
 	return handler, NewServer(quietLogger(), handler)
 }
 
+func newProjectsCairnlineReplacementIdentityAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineWriteAuthority:  "all-portable",
+			CairnlineReplacementMode: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	return handler, NewServer(quietLogger(), handler)
+}
+
 func newProjectsCairnlineRootSourceAuthorityTestServer(t *testing.T) (*Handler, http.Handler) {
 	t.Helper()
 	handler := NewHandler(config.Config{
@@ -642,6 +658,47 @@ func TestProjectsAPI_CairnlineIdentityAuthorityCommitsCreateFirst(t *testing.T) 
 		t.Fatalf("mirrored project = %+v, want identity create committed to Cairnline", mirrored)
 	}
 	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "openai", "gpt-5")
+}
+
+func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Replacement Identity",
+		"description":"created only in Cairnline",
+		"roots":[{"id":"root_main","path":"/workspace/replacement","kind":"git","git_branch":"main"}],
+		"default_provider":"openai",
+		"default_model":"gpt-5"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Data.Name != "Replacement Identity" || created.Data.DefaultRootID != "root_main" || created.Data.DefaultProvider != "openai" || created.Data.DefaultModel != "gpt-5" {
+		t.Fatalf("created project = %+v, want Cairnline-authored replacement identity", created.Data)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after replacement create, want no native identity row", ok, err)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.Name != "Replacement Identity" || mirrored.Description != "created only in Cairnline" || mirrored.DefaultRootID != "root_main" || len(mirrored.Roots) != 1 {
+		t.Fatalf("mirrored project = %+v, want Cairnline-only replacement identity", mirrored)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "openai", "gpt-5")
+
+	listed := listProjectsForTest(t, server)
+	if len(listed) != 1 || listed[0].ID != created.Data.ID || listed[0].ReadBackend != "cairnline" {
+		t.Fatalf("listed projects = %+v, want strict embedded Cairnline read of replacement identity", listed)
+	}
+	detail := getProjectForTest(t, server, created.Data.ID)
+	if detail.ID != created.Data.ID || detail.ReadBackend != "cairnline" || detail.Name != "Replacement Identity" {
+		t.Fatalf("project detail = %+v, want strict embedded Cairnline replacement identity", detail)
+	}
 }
 
 func TestProjectsAPI_CairnlineIdentityAuthorityCommitsDeleteFirst(t *testing.T) {
@@ -1271,6 +1328,64 @@ func TestProjectsAPI_DefaultOnlyPatchMirrorsDefaultsWithoutReplacingCairnlineSta
 		t.Fatalf("mirrored context sources = %+v, want Cairnline-only source preserved", mirrored.ContextSources)
 	}
 	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "anthropic", "claude-sonnet-4-5")
+}
+
+func TestProjectsAPI_DefaultRootPatchCairnlineAuthorityUsesCairnlineOnlyRoots(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineReadSource:     "embedded",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectMetadataDefaults,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_defaults_cairnline_only_root"
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		_, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:            projectID,
+			Name:          "Defaults Cairnline Only Root",
+			DefaultRootID: "root_main",
+			Roots: []cairnline.Root{
+				{ID: "root_main", Path: "/workspace/main", Kind: "git", Active: true},
+				{ID: "root_next", Path: "/workspace/next", Kind: "git_worktree", Active: true},
+			},
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed Cairnline-only project: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v before patch, want no native project row", ok, err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+projectID, bytes.NewReader([]byte(`{
+		"default_root_id":"root_next",
+		"default_provider":"anthropic",
+		"default_model":"claude-sonnet-4-5"
+	}`))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("defaults update status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var updated ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode update response: %v", err)
+	}
+	if updated.Data.DefaultRootID != "root_next" || updated.Data.DefaultProvider != "anthropic" || updated.Data.DefaultModel != "claude-sonnet-4-5" {
+		t.Fatalf("updated defaults = root %q provider/model %q/%q, want root_next anthropic/claude-sonnet-4-5", updated.Data.DefaultRootID, updated.Data.DefaultProvider, updated.Data.DefaultModel)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, projectID)
+	if mirrored.DefaultRootID != "root_next" {
+		t.Fatalf("mirrored default root = %q, want root_next", mirrored.DefaultRootID)
+	}
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_next") == nil {
+		t.Fatalf("mirrored roots = %+v, want root_next preserved", mirrored.Roots)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after patch, want no native project row", ok, err)
+	}
 }
 
 func TestProjectsAPI_MetadataPatchMirrorsMetadataWithoutReplacingCairnlineState(t *testing.T) {


### PR DESCRIPTION
## Summary
- let armed embedded replacement mode with closed portable write gaps create project identities only in Cairnline
- keep normal project-identity authority compatibility shadow behavior unchanged outside replacement mode
- validate default_root_id updates against Cairnline roots for Cairnline-authoritative metadata/default PATCHes
- update runtime/operator/design docs for the replacement identity boundary

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -count=1 -run 'TestProjectsAPI_(CairnlineReplacementModeCreatesCairnlineOnlyIdentity|DefaultRootPatchCairnlineAuthorityUsesCairnlineOnlyRoots|CairnlineIdentityAuthorityCommitsCreateFirst)'\n- just agent-docs-check\n- git diff --check\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- GOCACHE="$(pwd)/.gocache" go vet ./internal/api\n- GOCACHE="$(pwd)/.gocache" go test ./...\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n