### PR TITLE
fix(projects): label Cairnline replacement writes

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2554,8 +2554,8 @@ explicit embedded cutover switch: `migration_blockers` is empty, the
 `cairnline` for portable Projects coordination state. In armed embedded
 replacement mode with all portable write-authority gaps closed,
 Cairnline-authoritative project identity create returns the Cairnline record
-without creating a native Hecate project identity row; strict embedded read
-routes serve the new project from Cairnline.
+with `read_backend: "cairnline"` and without creating a native Hecate project
+identity row; strict embedded read routes serve the new project from Cairnline.
 When the next action is `rehearse-migration-cutover`, `config_hints` identify
 the strict embedded dogfood posture expected for the rehearsal:
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
@@ -5779,6 +5779,9 @@ assignment.
 ```
 
 Returns `{ "object": "project_role", "data": { ... } }`.
+When `project-roles` Cairnline write authority is active, create and update
+responses are labelled with `read_backend: "cairnline"` because the mutation
+record is committed through Cairnline before any Hecate compatibility shadow.
 
 #### `PATCH /hecate/v1/projects/{id}/roles/{role_id}`
 
@@ -5849,6 +5852,11 @@ Returns:
   }
 }
 ```
+
+When `project-work-items` Cairnline write authority is active, create and
+update responses are labelled with `read_backend: "cairnline"` because the
+mutation record is committed through Cairnline before any Hecate compatibility
+shadow.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}`
 

--- a/internal/api/handler_project_work.go
+++ b/internal/api/handler_project_work.go
@@ -396,7 +396,11 @@ func (h *Handler) HandleCreateProjectWorkRole(w http.ResponseWriter, r *http.Req
 	if !usesCairnlineAuthority {
 		h.mirrorProjectRoleByIDToCairnline(r.Context(), "project_role_create", projectID, role)
 	}
-	WriteJSON(w, http.StatusCreated, ProjectWorkRoleEnvelope{Object: "project_role", Data: renderProjectWorkRole(role)})
+	projected := renderProjectWorkRole(role)
+	if usesCairnlineAuthority {
+		projected.ReadBackend = "cairnline"
+	}
+	WriteJSON(w, http.StatusCreated, ProjectWorkRoleEnvelope{Object: "project_role", Data: projected})
 }
 
 func (h *Handler) HandleUpdateProjectWorkRole(w http.ResponseWriter, r *http.Request) {
@@ -432,7 +436,11 @@ func (h *Handler) HandleUpdateProjectWorkRole(w http.ResponseWriter, r *http.Req
 	if !usesCairnlineAuthority {
 		h.mirrorProjectRoleByIDToCairnline(r.Context(), "project_role_update", projectID, role)
 	}
-	WriteJSON(w, http.StatusOK, ProjectWorkRoleEnvelope{Object: "project_role", Data: renderProjectWorkRole(role)})
+	projected := renderProjectWorkRole(role)
+	if usesCairnlineAuthority {
+		projected.ReadBackend = "cairnline"
+	}
+	WriteJSON(w, http.StatusOK, ProjectWorkRoleEnvelope{Object: "project_role", Data: projected})
 }
 
 func (h *Handler) HandleDeleteProjectWorkRole(w http.ResponseWriter, r *http.Request) {
@@ -514,6 +522,10 @@ func (h *Handler) HandleCreateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
+	}
+	if usesCairnlineAuthority {
+		projected.ReadBackend = "cairnline"
+		markProjectWorkAssignmentReadBackend(projected.Assignments, "cairnline")
 	}
 	WriteJSON(w, http.StatusCreated, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
 }
@@ -615,6 +627,10 @@ func (h *Handler) HandleUpdateProjectWorkItem(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
+	}
+	if usesCairnlineAuthority {
+		projected.ReadBackend = "cairnline"
+		markProjectWorkAssignmentReadBackend(projected.Assignments, "cairnline")
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkItemEnvelope{Object: "project_work_item", Data: projected})
 }

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -120,7 +120,7 @@ func (h *Handler) HandleCreateProject(w http.ResponseWriter, r *http.Request) {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
-		WriteJSON(w, http.StatusCreated, ProjectResponse{Object: "project", Data: renderProject(project)})
+		WriteJSON(w, http.StatusCreated, ProjectResponse{Object: "project", Data: renderProjectWithBackend(project, "cairnline")})
 		return
 	}
 	project, err = h.projects.Create(r.Context(), project)

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -652,6 +652,9 @@ func TestProjectsAPI_CairnlineIdentityAuthorityCommitsCreateFirst(t *testing.T) 
 	if created.Data.Name != "Identity Authority" || created.Data.DefaultRootID != "root_main" || created.Data.DefaultProvider != "openai" || created.Data.DefaultModel != "gpt-5" || len(created.Data.Roots) != 1 || len(created.Data.ContextSources) != 1 {
 		t.Fatalf("created project = %+v, want Cairnline-authored project shadowed into Hecate", created.Data)
 	}
+	if created.Data.ReadBackend != "cairnline" {
+		t.Fatalf("created read_backend = %q, want Cairnline-authoritative mutation response", created.Data.ReadBackend)
+	}
 
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
 	if mirrored.Name != "Identity Authority" || mirrored.Description != "created through Cairnline" || mirrored.DefaultRootID != "root_main" || len(mirrored.Roots) != 1 || len(mirrored.ContextSources) != 1 {
@@ -681,6 +684,9 @@ func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *tes
 	}
 	if created.Data.Name != "Replacement Identity" || created.Data.DefaultRootID != "root_main" || created.Data.DefaultProvider != "openai" || created.Data.DefaultModel != "gpt-5" {
 		t.Fatalf("created project = %+v, want Cairnline-authored replacement identity", created.Data)
+	}
+	if created.Data.ReadBackend != "cairnline" {
+		t.Fatalf("created read_backend = %q, want Cairnline-authoritative replacement response", created.Data.ReadBackend)
 	}
 	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || ok {
 		t.Fatalf("Hecate project store ok=%v err=%v after replacement create, want no native identity row", ok, err)

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -168,6 +168,97 @@ func TestProjectJourneyAPI_DiscoverStartInspectAndHandoff(t *testing.T) {
 	}
 }
 
+func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNativeProjectIdentity(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	root := t.TempDir()
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Cairnline Replacement Journey",
+		"roots": []map[string]any{{
+			"id":     "root_replacement",
+			"path":   root,
+			"kind":   "git",
+			"active": true,
+		}},
+		"default_provider": "anthropic",
+		"default_model":    "claude-sonnet-4",
+	}))
+	projectID := project.Data.ID
+	if projectID == "" || project.Data.ReadBackend != "cairnline" || project.Data.DefaultRootID != "root_replacement" {
+		t.Fatalf("project = %+v, want created Cairnline replacement identity with default root", project.Data)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after create, want no native project identity row", ok, err)
+	}
+
+	role := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                  "role_replacement",
+		"name":                "Replacement implementer",
+		"instructions":        "Use the Cairnline replacement graph.",
+		"default_driver_kind": "hecate_task",
+		"default_provider":    "anthropic",
+		"default_model":       "claude-sonnet-4",
+	}))
+	if role.Data.ID != "role_replacement" || role.Data.ProjectID != projectID || role.Data.ReadBackend != "cairnline" {
+		t.Fatalf("role = %+v, want replacement project role", role.Data)
+	}
+
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_replacement",
+		"title":         "Start replacement assignment",
+		"brief":         "Exercise Cairnline-authoritative create, work, assignment, and launch.",
+		"status":        projectwork.WorkItemStatusReady,
+		"owner_role_id": "role_replacement",
+		"root_id":       "root_replacement",
+	}))
+	if work.Data.ID != "work_replacement" || work.Data.ReadBackend != "cairnline" || work.Data.RootID != "root_replacement" {
+		t.Fatalf("work = %+v, want Cairnline replacement work item", work.Data)
+	}
+
+	assignment := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_replacement",
+		"role_id":     "role_replacement",
+		"root_id":     "root_replacement",
+		"driver_kind": projectwork.AssignmentDriverHecateTask,
+	}))
+	if assignment.Data.ID != "asgn_replacement" || assignment.Data.ReadBackend != "cairnline" || assignment.Data.Status != projectwork.AssignmentStatusQueued {
+		t.Fatalf("assignment = %+v, want queued Cairnline replacement assignment", assignment.Data)
+	}
+
+	started := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments/asgn_replacement/start", `{}`)
+	ref := assignmentExecutionRefForTest(t, started.Data)
+	if ref.TaskID == "" || ref.RunID == "" || ref.ContextSnapshotID == "" {
+		t.Fatalf("started assignment execution_ref = %+v, want task/run/context links", ref)
+	}
+	task, found, err := handler.taskStore.GetTask(t.Context(), ref.TaskID)
+	if err != nil || !found {
+		t.Fatalf("GetTask(%q) found=%v err=%v, want task", ref.TaskID, found, err)
+	}
+	if task.ProjectID != projectID || task.WorkItemID != "work_replacement" || task.AssignmentID != "asgn_replacement" {
+		t.Fatalf("task linkage = project %q work %q assignment %q, want replacement refs", task.ProjectID, task.WorkItemID, task.AssignmentID)
+	}
+	if task.RequestedProvider != "anthropic" || task.RequestedModel != "claude-sonnet-4" || task.WorkingDirectory != root {
+		t.Fatalf("task provider/model/workspace = %q/%q/%q, want anthropic/claude-sonnet-4/%q", task.RequestedProvider, task.RequestedModel, task.WorkingDirectory, root)
+	}
+	if !strings.Contains(task.Prompt, "Start replacement assignment") || !strings.Contains(task.SystemPrompt, "Use the Cairnline replacement graph.") {
+		t.Fatalf("task prompt/system = %q / %q, want replacement work and role context", task.Prompt, task.SystemPrompt)
+	}
+
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after start, want no native project identity row", ok, err)
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_replacement")
+	if mirrored.ExecutionRef != ref.RunID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("mirrored Cairnline assignment = ref %q context %q, want %q/%q", mirrored.ExecutionRef, mirrored.ContextSnapshotID, ref.RunID, ref.ContextSnapshotID)
+	}
+	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_replacement", "asgn_replacement")
+	if shadow.ExecutionRef.RunID != ref.RunID || shadow.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("Hecate runtime shadow assignment = %+v, want run/context %q/%q", shadow.ExecutionRef, ref.RunID, ref.ContextSnapshotID)
+	}
+}
+
 func projectJourneyJSON(t *testing.T, payload any) string {
 	t.Helper()
 	raw, err := json.Marshal(payload)


### PR DESCRIPTION
## Summary
- label Cairnline-authoritative project, role, and work-item mutation responses with `read_backend: "cairnline"`
- add a replacement-mode journey test that creates project/role/work/assignment, starts a Hecate task, and verifies no native project identity row is created
- document the response-label behavior for replacement project identity and Cairnline role/work-item write authority

## Validation
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -count=1 -run 'TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNativeProjectIdentity|TestProjectsAPI_CairnlineIdentityAuthorityCommitsCreateFirst|TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity|TestProjectWorkAPI_Cairnline(Role|WorkItem|Assignment)AuthorityWritesCairnlineOnlyProject'\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- just agent-docs-check\n- git diff --check\n- GOCACHE="$(pwd)/.gocache" go test ./...\n- GOCACHE="$(pwd)/.gocache" go vet ./...\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...