### PR TITLE
fix(projects): validate chats against Cairnline projects

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -6763,9 +6763,12 @@ When `provider` is omitted on a model-backed turn, Hecate routes across
 configured providers that expose the selected model.
 
 `project_id` is optional. When supplied, it must reference an existing project
-or Hecate returns `404 not_found`. Project-scoped sessions are still normal
-chat sessions, but deleting the project later deletes those project-scoped
-transcripts as part of the project cleanup.
+or Hecate returns `404 not_found`. When Cairnline project reads are configured,
+that existence check uses the active Cairnline read backend, so strict embedded
+replacement mode can create chats for Cairnline-only project identities. The
+chat transcript itself remains Hecate chat state. Project-scoped sessions are
+still normal chat sessions, but deleting the project later deletes those
+project-scoped transcripts as part of the project cleanup.
 
 `title` is optional session metadata. The Projects UI uses it when launching a
 chat from a project-work assignment so the empty chat shell is named after the

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hecatehq/hecate/internal/chatcontext"
 	"github.com/hecatehq/hecate/internal/gitrunner"
 	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/requestscope"
 	"github.com/hecatehq/hecate/internal/taskapp"
 	"github.com/hecatehq/hecate/internal/telemetry"
@@ -62,7 +63,7 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 	}
 	projectID := strings.TrimSpace(req.ProjectID)
 	if projectID != "" {
-		if _, ok, err := h.projects.Get(r.Context(), projectID); err != nil {
+		if ok, err := h.chatSessionProjectExists(r.Context(), projectID); err != nil {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		} else if !ok {
@@ -168,6 +169,35 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 	WriteJSON(w, http.StatusOK, ChatSessionResponse{Object: "chat_session", Data: renderChatSession(result.Session, h.agentChatSnapshotConfig())})
+}
+
+func (h *Handler) chatSessionProjectExists(ctx context.Context, projectID string) (bool, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return true, nil
+	}
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		_, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+		return ok, err
+	}
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		view, err := h.cairnlineEmbeddedProjectWorkView(ctx, projectID)
+		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) {
+				return false, nil
+			}
+			return false, err
+		}
+		if view != nil {
+			_ = view.Close()
+		}
+		return true, nil
+	}
+	if h == nil || h.projects == nil {
+		return false, errors.New("project store is not configured")
+	}
+	_, ok, err := h.projects.Get(ctx, projectID)
+	return ok, err
 }
 
 func normalizeChatAgentID(agentID string) string {

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -908,6 +908,55 @@ func TestChatSessionsProjectID(t *testing.T) {
 	}
 }
 
+func TestChatSessionsProjectIDUsesStrictEmbeddedCairnlineProject(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	provider := &fakeProvider{name: "openai"}
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{provider}, config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, controlplane.NewMemoryStore())
+	handler := NewServer(logger, apiHandler)
+	client := newAPITestClient(t, handler)
+	const projectID = "proj_chat_cairnline_only"
+
+	if err := apiHandler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		_, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:          projectID,
+			Name:        "Cairnline-only chat project",
+			Description: "Chat sessions should validate against embedded Cairnline.",
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline project: %v", err)
+	}
+	if _, ok, err := apiHandler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("native project exists = %t err=%v, want missing native project", ok, err)
+	}
+
+	created := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","project_id":%q,"provider":"openai","model":"gpt-4o-mini"}`, projectID))
+	if created.Data.ProjectID != projectID {
+		t.Fatalf("created project_id = %q, want %q", created.Data.ProjectID, projectID)
+	}
+	if _, ok, err := apiHandler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("native project exists after chat create = %t err=%v, want missing native project", ok, err)
+	}
+
+	list := mustRequestJSON[ChatSessionsResponse](client, http.MethodGet, "/hecate/v1/chat/sessions", "")
+	if len(list.Data) != 1 || list.Data[0].ProjectID != projectID {
+		t.Fatalf("listed chat sessions = %+v, want one session for Cairnline-only project %q", list.Data, projectID)
+	}
+
+	recorder := client.mustRequestStatus(http.StatusNotFound, http.MethodPost, "/hecate/v1/chat/sessions",
+		`{"agent_id":"hecate","project_id":"proj_missing","provider":"openai","model":"gpt-4o-mini"}`)
+	if !strings.Contains(recorder.Body.String(), "project not found") {
+		t.Fatalf("missing project response = %s, want project not found", recorder.Body.String())
+	}
+}
+
 func TestHecateAgentChatCreateDefaultsTitle(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	provider := &fakeProvider{


### PR DESCRIPTION
## Summary
- validate chat-session `project_id` through the active project read backend
- allow strict embedded Cairnline replacement mode to create chats for Cairnline-only project identities
- document that chat transcripts remain Hecate-owned even when project identity is Cairnline-backed

## Why
After the Projects cutover work, new replacement-mode project identities can exist only in embedded Cairnline. Chat session creation still checked the native Hecate project store directly, so project-linked chats could reject valid Cairnline-only projects.

## Validation
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -count=1 -run 'TestChatSessionsProjectID|TestProjectChatWorkflowSystemPromptUsesStrictEmbeddedCairnlineProject|TestProjectChatWorkflowSystemPromptStrictEmbeddedSkipsNativeFallback'`
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -count=1 -run 'TestChatSessionsProjectID'`
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api`
- `just agent-docs-check`
- `./ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md`
- `git diff --check`
- `GOCACHE="$(pwd)/.gocache" go test ./...`
- `GOCACHE="$(pwd)/.gocache" go vet ./...`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
