### PR TITLE
fix(projects): read sidecar context for project chat

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -71,6 +71,10 @@ compatibility project row; keep any Hecate shadow writes best-effort and do not
 add native `requireProject*` guards ahead of those authority paths. Do not describe
 `internal/cairnlinebridge` as only a future proof; it maps Hecate Projects to
 Cairnline snapshots and backs the current embedded/sidecar replacement probes.
+Project-linked Hecate Chat prelude/context helpers also use the configured
+Cairnline read source for project identity, roles, skills, work, and accepted
+memory, so sidecar-only or strict-embedded project identities must not fall back
+to native Hecate stores for those chat metadata paths.
 Model-backed assistant turns should carry a small context-inspector packet:
 execution mode, route/workspace metadata, source provenance, and visible
 transcript counts. Do not store full prompt bodies, raw transcript text, file

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -159,9 +159,12 @@ surfaces without sending a chat message.
 Project-linked Hecate Chat also receives a bounded Hecate-owned prompt prelude
 with project-root metadata, role hints, enabled skill metadata, active work,
 and accepted project memory excerpts. Roots and skills are metadata only: the
-chat path does not read root files or inject `SKILL.md` bodies. External Agent
-sessions may share the same project filter and sidebar scope, but their prompt
-packing remains agent-owned and does not receive this Hecate prelude.
+chat path does not read root files or inject `SKILL.md` bodies. When Cairnline
+is the configured read source, that prelude and its context-packet metadata are
+assembled from the active embedded or sidecar Cairnline project graph rather
+than requiring a native Hecate project row. External Agent sessions may share
+the same project filter and sidebar scope, but their prompt packing remains
+agent-owned and does not receive this Hecate prelude.
 
 | Command               | Available when                          | Behavior                                                                    |
 | --------------------- | --------------------------------------- | --------------------------------------------------------------------------- |

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -6765,10 +6765,13 @@ configured providers that expose the selected model.
 `project_id` is optional. When supplied, it must reference an existing project
 or Hecate returns `404 not_found`. When Cairnline project reads are configured,
 that existence check uses the active Cairnline read backend, so strict embedded
-replacement mode can create chats for Cairnline-only project identities. The
-chat transcript itself remains Hecate chat state. Project-scoped sessions are
-still normal chat sessions, but deleting the project later deletes those
-project-scoped transcripts as part of the project cleanup.
+replacement mode and sidecar read mode can create chats for Cairnline-only
+project identities. Project-linked Hecate Chat prelude/context assembly uses
+the same configured Cairnline read source for project identity, role, skill,
+work, and accepted-memory metadata. The chat transcript itself remains Hecate
+chat state. Project-scoped sessions are still normal chat sessions, but
+deleting the project later deletes those project-scoped transcripts as part of
+the project cleanup.
 
 `title` is optional session metadata. The Projects UI uses it when launching a
 chat from a project-work assignment so the empty chat shell is named after the

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -638,6 +638,9 @@ func (h *Handler) projectContextSources(ctx context.Context, session chat.Sessio
 }
 
 func (h *Handler) projectSummary(ctx context.Context, projectID string) *projects.Project {
+	if project, ok := h.sidecarCairnlineProjectSummary(ctx, projectID); ok {
+		return project
+	}
 	if project, ok := h.strictEmbeddedCairnlineProjectSummary(ctx, projectID); ok {
 		return project
 	}
@@ -680,6 +683,9 @@ func (h *Handler) projectMemoryEntries(ctx context.Context, session chat.Session
 }
 
 func (h *Handler) enabledProjectMemoryEntries(ctx context.Context, projectID string) []memory.Entry {
+	if items, ok := h.sidecarCairnlineEnabledProjectMemoryEntries(ctx, projectID); ok {
+		return items
+	}
 	if items, ok := h.strictEmbeddedCairnlineEnabledProjectMemoryEntries(ctx, projectID); ok {
 		return items
 	}

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -957,6 +957,52 @@ func TestChatSessionsProjectIDUsesStrictEmbeddedCairnlineProject(t *testing.T) {
 	}
 }
 
+func TestProjectChatWorkflowSystemPromptUsesSidecarCairnlineProject(t *testing.T) {
+	handler, _ := newProjectsCairnlineSidecarReadTestServer(t, "memory-fixture")
+	const projectID = "proj_fixture"
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("native project exists = %t err=%v, want missing native project", ok, err)
+	}
+	entries := handler.enabledProjectMemoryEntries(t.Context(), projectID)
+	if len(entries) != 1 || entries[0].ID != "mem_fixture" || !entries[0].Enabled {
+		t.Fatalf("sidecar memory entries = %+v, want only enabled fixture memory", entries)
+	}
+
+	prompt := handler.projectChatWorkflowSystemPrompt(t.Context(), chat.Session{ProjectID: projectID})
+	for _, want := range []string{
+		"Project: Fixture Project (proj_fixture)",
+		"Project roots (metadata only; files are not read):",
+		"- Root /workspace/fixture (root_fixture): active=true, default=true, kind=local",
+		"Role hints:",
+		"Fixture Reviewer (role_fixture)",
+		"Project skills (metadata only; skill bodies are not loaded):",
+		"Fixture Skill (skill_fixture): Path: .agents/skills/fixture/SKILL.md",
+		"Active project work snapshot:",
+		"- Assignment asg_fixture: work_item=work_fixture, role=role_fixture, status=queued, driver=hecate_task",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("sidecar project prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, notWant := range []string{
+		"Disabled fixture memory",
+		"This memory entry is disabled.",
+	} {
+		if strings.Contains(prompt, notWant) {
+			t.Fatalf("sidecar project prompt included disabled memory %q:\n%s", notWant, prompt)
+		}
+	}
+
+	packet := renderChatContextPacket(handler.directModelContextPacket(t.Context(), chat.Session{ProjectID: projectID}, "openai", "gpt-4o-mini", ""))
+	if packet == nil ||
+		!chatContextPacketHasKind(*packet, "project") ||
+		!chatContextPacketHasKind(*packet, "project_skills") ||
+		!chatContextPacketHasKind(*packet, "project_work") ||
+		!chatContextPacketHasKind(*packet, "memory") {
+		t.Fatalf("sidecar context packet missing project metadata: %+v", packet)
+	}
+}
+
 func TestHecateAgentChatCreateDefaultsTitle(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	provider := &fakeProvider{

--- a/internal/api/handler_chat_project_prompt.go
+++ b/internal/api/handler_chat_project_prompt.go
@@ -254,6 +254,9 @@ func projectChatRootHints(project projects.Project) string {
 }
 
 func (h *Handler) projectChatRoleHints(ctx context.Context, projectID string) string {
+	if roles, ok := h.sidecarCairnlineProjectChatRoles(ctx, projectID); ok {
+		return projectChatRoleHintText(roles)
+	}
 	if roles, ok := h.strictEmbeddedCairnlineProjectChatRoles(ctx, projectID); ok {
 		return projectChatRoleHintText(roles)
 	}
@@ -339,6 +342,9 @@ type projectChatWorkSnapshot struct {
 }
 
 func (h *Handler) projectChatEnabledSkills(ctx context.Context, projectID string) []projectskills.Skill {
+	if items, ok := h.sidecarCairnlineProjectChatSkills(ctx, projectID); ok {
+		return items
+	}
 	if items, ok := h.strictEmbeddedCairnlineProjectChatSkills(ctx, projectID); ok {
 		return items
 	}
@@ -376,6 +382,9 @@ func sortProjectChatSkills(out []projectskills.Skill) {
 }
 
 func (h *Handler) projectChatWorkSnapshot(ctx context.Context, projectID string) projectChatWorkSnapshot {
+	if snapshot, ok := h.sidecarCairnlineProjectChatWorkSnapshot(ctx, projectID); ok {
+		return snapshot
+	}
 	if snapshot, ok := h.strictEmbeddedCairnlineProjectChatWorkSnapshot(ctx, projectID); ok {
 		return snapshot
 	}

--- a/internal/api/handler_chat_project_prompt_cairnline.go
+++ b/internal/api/handler_chat_project_prompt_cairnline.go
@@ -14,6 +14,10 @@ func (h *Handler) projectChatStrictEmbeddedCairnlineReads() bool {
 	return h != nil && h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
 }
 
+func (h *Handler) projectChatSidecarCairnlineReads() bool {
+	return h != nil && h.projectCairnlineSidecarReadRoutesEnabled()
+}
+
 func (h *Handler) strictEmbeddedCairnlineProjectChatView(ctx context.Context, projectID string) (*cairnlineProjectWorkView, bool) {
 	projectID = strings.TrimSpace(projectID)
 	if !h.projectChatStrictEmbeddedCairnlineReads() || projectID == "" {
@@ -24,6 +28,19 @@ func (h *Handler) strictEmbeddedCairnlineProjectChatView(ctx context.Context, pr
 		return nil, true
 	}
 	return view, true
+}
+
+func (h *Handler) sidecarCairnlineProjectSummary(ctx context.Context, projectID string) (*projects.Project, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatSidecarCairnlineReads() || projectID == "" {
+		return nil, false
+	}
+	item, ok, err := h.cairnlineSidecarProject(ctx, projectID)
+	if err != nil || !ok {
+		return nil, true
+	}
+	project := projectFromCairnlineSidecar(item)
+	return &project, true
 }
 
 func (h *Handler) strictEmbeddedCairnlineProjectSummary(ctx context.Context, projectID string) (*projects.Project, bool) {
@@ -37,6 +54,18 @@ func (h *Handler) strictEmbeddedCairnlineProjectSummary(ctx context.Context, pro
 	defer view.Close()
 	item := view.snapshot.Project
 	return &item, true
+}
+
+func (h *Handler) sidecarCairnlineProjectChatRoles(ctx context.Context, projectID string) ([]projectwork.AgentRoleProfile, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatSidecarCairnlineReads() || projectID == "" {
+		return nil, false
+	}
+	roles, err := h.cairnlineSidecarProjectRoles(ctx, projectID)
+	if err != nil {
+		return nil, true
+	}
+	return projectRolesFromCairnlineSidecar(roles), true
 }
 
 func (h *Handler) strictEmbeddedCairnlineProjectChatRoles(ctx context.Context, projectID string) ([]projectwork.AgentRoleProfile, bool) {
@@ -61,6 +90,30 @@ func (h *Handler) strictEmbeddedCairnlineProjectChatRoles(ctx context.Context, p
 	for _, role := range roles {
 		out = append(out, projectWorkRoleFromCairnline(role, executionProfilesByID, projectwork.AgentRoleProfile{}))
 	}
+	return out, true
+}
+
+func (h *Handler) sidecarCairnlineProjectChatSkills(ctx context.Context, projectID string) ([]projectskills.Skill, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatSidecarCairnlineReads() || projectID == "" {
+		return nil, false
+	}
+	items, err := h.cairnlineSidecarProjectSkills(ctx, projectID)
+	if err != nil {
+		return nil, true
+	}
+	out := make([]projectskills.Skill, 0, len(items))
+	for _, skill := range projectSkillsFromCairnlineSidecar(items) {
+		if !skill.Enabled {
+			continue
+		}
+		status := strings.TrimSpace(skill.Status)
+		if status != "" && status != projectskills.StatusAvailable {
+			continue
+		}
+		out = append(out, skill)
+	}
+	sortProjectChatSkills(out)
 	return out, true
 }
 
@@ -91,6 +144,48 @@ func (h *Handler) strictEmbeddedCairnlineProjectChatSkills(ctx context.Context, 
 	}
 	sortProjectChatSkills(out)
 	return out, true
+}
+
+func (h *Handler) sidecarCairnlineProjectChatWorkSnapshot(ctx context.Context, projectID string) (projectChatWorkSnapshot, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatSidecarCairnlineReads() || projectID == "" {
+		return projectChatWorkSnapshot{}, false
+	}
+	workItems, err := h.cairnlineSidecarProjectWorkItems(ctx, projectID)
+	if err != nil {
+		return projectChatWorkSnapshot{}, true
+	}
+	filteredWorkItems := make([]projectwork.WorkItem, 0, len(workItems))
+	for _, item := range projectWorkItemsFromCairnlineSidecar(workItems) {
+		if projectChatStatusAllowed(item.Status, projectChatPromptWorkItemStatuses) {
+			filteredWorkItems = append(filteredWorkItems, item)
+		}
+	}
+	workItemsTruncated := len(filteredWorkItems) > projectChatPromptWorkMaxItems
+	if workItemsTruncated {
+		filteredWorkItems = filteredWorkItems[:projectChatPromptWorkMaxItems]
+	}
+
+	assignments, err := h.cairnlineSidecarProjectAssignments(ctx, projectID)
+	if err != nil {
+		assignments = nil
+	}
+	filteredAssignments := make([]projectwork.Assignment, 0, len(assignments))
+	for _, assignment := range projectAssignmentsFromCairnlineSidecar(assignments) {
+		if projectChatStatusAllowed(assignment.Status, projectChatPromptAssignmentStatuses) {
+			filteredAssignments = append(filteredAssignments, assignment)
+		}
+	}
+	assignmentsTruncated := len(filteredAssignments) > projectChatPromptAssignmentMaxItems
+	if assignmentsTruncated {
+		filteredAssignments = filteredAssignments[:projectChatPromptAssignmentMaxItems]
+	}
+	return projectChatWorkSnapshot{
+		WorkItems:            filteredWorkItems,
+		Assignments:          filteredAssignments,
+		WorkItemsTruncated:   workItemsTruncated,
+		AssignmentsTruncated: assignmentsTruncated,
+	}, true
 }
 
 func (h *Handler) strictEmbeddedCairnlineProjectChatWorkSnapshot(ctx context.Context, projectID string) (projectChatWorkSnapshot, bool) {
@@ -140,6 +235,18 @@ func (h *Handler) strictEmbeddedCairnlineProjectChatWorkSnapshot(ctx context.Con
 		WorkItemsTruncated:   workItemsTruncated,
 		AssignmentsTruncated: assignmentsTruncated,
 	}, true
+}
+
+func (h *Handler) sidecarCairnlineEnabledProjectMemoryEntries(ctx context.Context, projectID string) ([]memory.Entry, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if !h.projectChatSidecarCairnlineReads() || projectID == "" {
+		return nil, false
+	}
+	items, err := h.cairnlineSidecarProjectMemoryEntryList(ctx, projectID, false)
+	if err != nil {
+		return nil, true
+	}
+	return projectMemoryEntriesFromCairnlineSidecar(items), true
 }
 
 func (h *Handler) strictEmbeddedCairnlineEnabledProjectMemoryEntries(ctx context.Context, projectID string) ([]memory.Entry, bool) {


### PR DESCRIPTION
## Summary
- route project-linked Hecate Chat summary, roles, skills, work, and memory helpers through the Cairnline sidecar read source
- keep sidecar read mode from falling back to native Hecate project rows for chat metadata
- document that project chat prelude/context uses the configured Cairnline read source

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -count=1 -run 'TestProjectChatWorkflowSystemPromptUsesSidecarCairnlineProject|TestProjectChatWorkflowSystemPromptUsesStrictEmbeddedCairnlineProject|TestChatSessionsProjectIDUsesStrictEmbeddedCairnlineProject|TestChatSessionsProjectID'\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- just agent-docs-check\n- ./ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md docs/runtime/chat-sessions.md docs-ai/core/project-context.md\n- git diff --check\n- GOCACHE="$(pwd)/.gocache" go test ./...\n- GOCACHE="$(pwd)/.gocache" go vet ./...\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n\n## Self-review\n- Sidecar project-chat reads now mirror strict embedded behavior: configured Cairnline read mode answers from Cairnline or omits project metadata; it does not silently mix native project rows.\n- Hecate Chat transcripts remain Hecate-owned; this only changes project prelude/context metadata sourcing.\n- External Agent chat prompt packing remains unchanged and agent-owned.\n