### PR TITLE
fix(projects): map sidecar chat project read failures

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -6768,10 +6768,12 @@ that existence check uses the active Cairnline read backend, so strict embedded
 replacement mode and sidecar read mode can create chats for Cairnline-only
 project identities. Project-linked Hecate Chat prelude/context assembly uses
 the same configured Cairnline read source for project identity, role, skill,
-work, and accepted-memory metadata. The chat transcript itself remains Hecate
-chat state. Project-scoped sessions are still normal chat sessions, but
-deleting the project later deletes those project-scoped transcripts as part of
-the project cleanup.
+work, and accepted-memory metadata. In sidecar read mode, malformed or
+text-only Cairnline responses during the existence check fail with
+`502 gateway_error`. The chat transcript itself remains Hecate chat state.
+Project-scoped sessions are still normal chat sessions, but deleting the
+project later deletes those project-scoped transcripts as part of the project
+cleanup.
 
 `title` is optional session metadata. The Projects UI uses it when launching a
 chat from a project-work assignment so the empty chat shell is named after the

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -64,6 +64,10 @@ func (h *Handler) HandleCreateChatSession(w http.ResponseWriter, r *http.Request
 	projectID := strings.TrimSpace(req.ProjectID)
 	if projectID != "" {
 		if ok, err := h.chatSessionProjectExists(r.Context(), projectID); err != nil {
+			if errors.Is(err, errProjectCairnlineSidecarReadFailed) {
+				WriteError(w, http.StatusBadGateway, errCodeGatewayError, err.Error())
+				return
+			}
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		} else if !ok {

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -957,6 +957,18 @@ func TestChatSessionsProjectIDUsesStrictEmbeddedCairnlineProject(t *testing.T) {
 	}
 }
 
+func TestChatSessionsProjectIDMapsSidecarReadFailure(t *testing.T) {
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "projects.get-text-only")
+	client := newAPITestClient(t, server)
+
+	recorder := client.mustRequestStatus(http.StatusBadGateway, http.MethodPost, "/hecate/v1/chat/sessions",
+		`{"agent_id":"hecate","project_id":"proj_fixture","provider":"openai","model":"gpt-4o-mini"}`)
+	body := recorder.Body.String()
+	if !strings.Contains(body, errCodeGatewayError) || !strings.Contains(body, "cairnline sidecar project read failed") {
+		t.Fatalf("sidecar read failure response = %s, want gateway error with Cairnline sidecar detail", body)
+	}
+}
+
 func TestProjectChatWorkflowSystemPromptUsesSidecarCairnlineProject(t *testing.T) {
 	handler, _ := newProjectsCairnlineSidecarReadTestServer(t, "memory-fixture")
 	const projectID = "proj_fixture"


### PR DESCRIPTION
## Summary
- return `502 gateway_error` when chat session `project_id` validation hits a Cairnline sidecar read failure
- add a regression test for text-only `projects.get` sidecar output during chat creation
- document the chat session API behavior for malformed/text-only sidecar responses

## Tests
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -count=1 -run 'TestChatSessionsProjectID(MapsSidecarReadFailure|UsesStrictEmbeddedCairnlineProject|UsesProject)|TestProjectChatWorkflowSystemPromptUsesSidecarCairnlineProject'`\n- `./ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md`\n- `git diff --check`\n- `GOCACHE="$(pwd)/.gocache" go test ./internal/api`\n- `just agent-docs-check`\n- `GOCACHE="$(pwd)/.gocache" go vet ./...`\n- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`\n\n## Self-review\n- The chat creation path now matches other Cairnline sidecar read routes: malformed/text-only sidecar data is a dependency/read-model failure, not an internal server error.\n- Missing projects still return `404 not_found`; non-sidecar store errors continue to return `500 gateway_error`.\n- No UI changes were needed; this is API behavior plus docs.