### PR TITLE
fix(projects): report sidecar chat read routes

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2487,11 +2487,12 @@ first requiring a Hecate-native snapshot or compatibility project row. With
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` routes only project list/detail,
 setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
-assignment-list, assignment-context, launch-readiness, assignment preflight, artifact-list,
-handoff-list, activity, closeout-readiness, and operations-brief reads through
-the standalone Cairnline MCP client; backend status reports those routes in
-`read_routes` while `read_model_switch_ready` remains false because the broader
-read model is not sidecar-backed yet.
+assignment-list, assignment-context, launch-readiness, assignment preflight,
+artifact-list, handoff-list, project-assistant context/proposal, project-chat
+prelude/context, activity, closeout-readiness, and operations-brief reads
+through the standalone Cairnline MCP client; backend status reports those
+routes in `read_routes` while `read_model_switch_ready` remains false because
+the broader read model is not sidecar-backed yet.
 `read_routes` lists the live read families currently backed by the Cairnline
 read model. `replacement_target=embedded_cairnline_first` documents the
 current source-of-truth strategy: replace Hecate-native Projects with embedded

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -71,6 +71,8 @@ var projectCairnlineSidecarReadRouteNames = []string{
 	"handoff-list",
 	"project-assistant-context",
 	"project-assistant-proposal",
+	"project-chat-prelude",
+	"project-chat-context",
 	"activity",
 	"closeout-readiness",
 	"operations-brief",

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -255,11 +255,14 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 	if !reflect.DeepEqual(status.ReadRoutes, projectCairnlineSidecarReadRouteNames) {
 		t.Fatalf("read routes = %+v, want sidecar read routes", status.ReadRoutes)
 	}
+	if !containsString(status.ReadRoutes, "project-chat-prelude") || !containsString(status.ReadRoutes, "project-chat-context") {
+		t.Fatalf("sidecar read routes = %+v, want project chat prelude/context included", status.ReadRoutes)
+	}
 	if gate := findReplacementGate(status.ReplacementGates, "read-routes"); gate == nil || gate.Ready || gate.Status != "blocked" {
-		t.Fatalf("read-routes gate = %+v, want blocked because only partial read routes are sidecar-backed", gate)
+		t.Fatalf("read-routes gate = %+v, want blocked while sidecar reads remain an interoperability mode", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "project-assistant-context, project-assistant-proposal") || !strings.Contains(warnings, "authoritative write migration") {
+	if !strings.Contains(warnings, "project-assistant-context, project-assistant-proposal") || !strings.Contains(warnings, "project-chat-prelude, project-chat-context") || !strings.Contains(warnings, "authoritative write migration") {
 		t.Fatalf("warnings = %+v, want sidecar read routes with write-migration warning", status.Warnings)
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "use-embedded-cairnline-connector" || status.NextReplacementAction.Target != "connector" {


### PR DESCRIPTION
## Summary
- include project-chat prelude/context in the Cairnline sidecar read-route status list
- tighten the coordination backend status test so sidecar read status reflects the chat route contract
- update runtime API docs for the sidecar read-source route list

## Tests
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -count=1 -run 'TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady|TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady'`\n- `./ui/node_modules/.bin/oxfmt --check docs/runtime/runtime-api.md`\n- `git diff --check`\n- `GOCACHE="$(pwd)/.gocache" go test ./internal/api`\n- `just agent-docs-check`\n- `GOCACHE="$(pwd)/.gocache" go vet ./...`\n- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`\n\n## Self-review\n- This is status/reporting alignment for the sidecar read-source contract after project chat started reading sidecar project metadata.\n- It does not change runtime routing or write authority; sidecar mode still remains interoperability/read-mode only and replacement readiness stays blocked on write migration.\n- The docs now match the backend status route list.