### PR TITLE
fix(projects): align sidecar diagnostic details

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -540,10 +540,11 @@ sequenceDiagram
   list/detail, setup-readiness, health, project skill list, project memory list,
   memory-candidate list, project role list, work-item list/detail,
   assignment-list, assignment-context, launch-readiness, assignment preflight, artifact-list,
-  handoff-list, Project Assistant context/proposal reads, activity,
-  closeout-readiness, and operations-brief reads through the standalone
-  Cairnline MCP client. Draft/propose/apply mutations remain Hecate-owned
-  unless their explicit write-authority switchpoints are enabled.
+  handoff-list, Project Assistant context/proposal reads, project-chat
+  prelude/context reads, activity, closeout-readiness, and operations-brief
+  reads through the standalone Cairnline MCP client. Draft/propose/apply
+  mutations remain Hecate-owned unless their explicit write-authority
+  switchpoints are enabled.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|all-portable|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and
@@ -2463,10 +2464,11 @@ graph, including the Project Assistant proposal ledger. In that state, project
 list/detail reads, project setup readiness, project health, skills, memory
 entries, memory candidates, roles, work items, assignment lists, assignment
 context previews, assignment launch-readiness, assignment preflight, artifact
-lists, handoff lists, Project Assistant context/proposal reads, closeout
-readiness, activity inbox, and operations brief can be served from the Cairnline
-read model, while other live Projects reads still use Hecate. Most of those
-configured embedded read routes still load Hecate snapshots as bridge
+lists, handoff lists, Project Assistant context/proposal reads, project-chat
+prelude/context reads, closeout readiness, activity inbox, and operations brief
+can be served from the Cairnline read model, while other live Projects reads
+still use Hecate. Most of those configured embedded read routes still load
+Hecate snapshots as bridge
 scaffolding, but strict embedded project list/detail, setup-readiness, health,
 project skill list, project role list, work-item list/detail, assignment-list,
 assignment-context, launch-readiness, assignment preflight, activity,
@@ -3072,7 +3074,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, Project Assistant context/proposal, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3285,7 +3287,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects writes on Hecate-native stores in sidecar mode; project list/detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, Project Assistant context/proposal, activity, closeout-readiness, and operations-brief read routing requires HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3502,7 +3504,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_coordination_ready",
-    "detail": "Hecate called read-only Cairnline sidecar coordination list tools through the persistent sidecar client. Hecate still keeps live Projects writes and non-project-identity reads on Hecate-native stores or embedded dogfood paths in sidecar mode.",
+    "detail": "Hecate called read-only Cairnline sidecar coordination list tools through the persistent sidecar client. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -153,6 +153,10 @@ func projectCairnlineConnectorWarning(mode string) string {
 	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " through the sidecar."
 }
 
+func projectCairnlineSidecarLiveReadDetail() string {
+	return "Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " through the standalone Cairnline MCP client."
+}
+
 func (h *Handler) HandleProjectCairnlineSidecarProbe(w http.ResponseWriter, r *http.Request) {
 	if !requireLoopbackClient(w, r, "Cairnline sidecar probe") {
 		return
@@ -382,7 +386,7 @@ func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairn
 	}
 	response.Ready = true
 	response.Status = "sidecar_probe_ready"
-	response.Detail = "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	response.Detail = "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 
@@ -436,7 +440,7 @@ func (h *Handler) projectCairnlineSidecarConnect(ctx context.Context) ProjectCai
 	}
 	response.Ready = true
 	response.Status = "sidecar_client_ready"
-	response.Detail = "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	response.Detail = "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 
@@ -488,7 +492,7 @@ func (h *Handler) projectCairnlineSidecarReadSmoke(ctx context.Context) ProjectC
 	response.setSidecarCacheStats(cache.Stats())
 	if result.IsError {
 		response.Status = "sidecar_read_tool_failed"
-		response.Detail = "Cairnline sidecar projects.list returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+		response.Detail = "Cairnline sidecar projects.list returned a tool-level error. " + projectCairnlineSidecarLiveReadDetail()
 		return response
 	}
 	structuredProjects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(result.Result.StructuredContent)
@@ -503,7 +507,7 @@ func (h *Handler) projectCairnlineSidecarReadSmoke(ctx context.Context) ProjectC
 	}
 	response.Ready = true
 	response.Status = "sidecar_read_ready"
-	response.Detail = "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	response.Detail = "Hecate called the read-only Cairnline sidecar projects.list tool through the persistent sidecar client. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 
@@ -562,7 +566,7 @@ func (h *Handler) projectCairnlineSidecarDetailSmoke(ctx context.Context, req Pr
 		response.ListMeta = listResult.Result.Meta
 		if listResult.IsError {
 			response.Status = "sidecar_detail_list_tool_failed"
-			response.Detail = "Cairnline sidecar projects.list returned a tool-level error before Hecate could select a project for projects.get. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+			response.Detail = "Cairnline sidecar projects.list returned a tool-level error before Hecate could select a project for projects.get. " + projectCairnlineSidecarLiveReadDetail()
 			response.setSidecarCacheStats(cache.Stats())
 			return response
 		}
@@ -610,7 +614,7 @@ func (h *Handler) projectCairnlineSidecarDetailSmoke(ctx context.Context, req Pr
 	response.setSidecarCacheStats(cache.Stats())
 	if result.IsError {
 		response.Status = "sidecar_detail_tool_failed"
-		response.Detail = "Cairnline sidecar projects.get returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+		response.Detail = "Cairnline sidecar projects.get returned a tool-level error. " + projectCairnlineSidecarLiveReadDetail()
 		return response
 	}
 	structuredProject, structuredReady, structuredErr := projectCairnlineSidecarStructuredProject(result.Result.StructuredContent)
@@ -626,7 +630,7 @@ func (h *Handler) projectCairnlineSidecarDetailSmoke(ctx context.Context, req Pr
 	}
 	response.Ready = true
 	response.Status = "sidecar_detail_ready"
-	response.Detail = "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	response.Detail = "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 
@@ -684,7 +688,7 @@ func (h *Handler) projectCairnlineSidecarCoordinationSmoke(ctx context.Context, 
 		response.Lists = append(response.Lists, result)
 		if result.ToolIsError {
 			response.Status = "sidecar_coordination_tool_failed"
-			response.Detail = "Cairnline sidecar " + result.Tool + " returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+			response.Detail = "Cairnline sidecar " + result.Tool + " returned a tool-level error. " + projectCairnlineSidecarLiveReadDetail()
 			response.setSidecarCacheStats(cache.Stats())
 			return response
 		}
@@ -711,7 +715,7 @@ func (h *Handler) projectCairnlineSidecarCoordinationSmoke(ctx context.Context, 
 	response.StructuredReady = projectCairnlineSidecarCoordinationStructuredReady(response.Lists)
 	response.Ready = true
 	response.Status = "sidecar_coordination_ready"
-	response.Detail = "Hecate called read-only Cairnline sidecar coordination list tools through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	response.Detail = "Hecate called read-only Cairnline sidecar coordination list tools through the persistent sidecar client. " + projectCairnlineSidecarLiveReadDetail()
 	response.setSidecarCacheStats(cache.Stats())
 	return response
 }
@@ -793,7 +797,7 @@ func (h *Handler) projectCairnlineSidecarAssignmentContextSmoke(ctx context.Cont
 	response.setSidecarCacheStats(cache.Stats())
 	if result.IsError {
 		response.Status = "sidecar_assignment_context_tool_failed"
-		response.Detail = "Cairnline sidecar assignments.context returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+		response.Detail = "Cairnline sidecar assignments.context returned a tool-level error. " + projectCairnlineSidecarLiveReadDetail()
 		return response
 	}
 	contextIDs, structuredReady, structuredErr := projectCairnlineSidecarStructuredAssignmentContextIDs(result.Result.StructuredContent)
@@ -811,7 +815,7 @@ func (h *Handler) projectCairnlineSidecarAssignmentContextSmoke(ctx context.Cont
 	}
 	response.Ready = true
 	response.Status = "sidecar_assignment_context_ready"
-	response.Detail = "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	response.Detail = "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 
@@ -890,7 +894,7 @@ func (h *Handler) projectCairnlineSidecarLaunchPacketSmoke(ctx context.Context, 
 	response.setSidecarCacheStats(cache.Stats())
 	if result.IsError {
 		response.Status = "sidecar_launch_packet_tool_failed"
-		response.Detail = "Cairnline sidecar assignments.launch_packet returned a tool-level error. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+		response.Detail = "Cairnline sidecar assignments.launch_packet returned a tool-level error. " + projectCairnlineSidecarLiveReadDetail()
 		return response
 	}
 	ids, counts, packetWarnings, structuredReady, structuredErr := projectCairnlineSidecarStructuredLaunchPacket(result.Result.StructuredContent)
@@ -910,7 +914,7 @@ func (h *Handler) projectCairnlineSidecarLaunchPacketSmoke(ctx context.Context, 
 	}
 	response.Ready = true
 	response.Status = "sidecar_launch_packet_ready"
-	response.Detail = "Hecate called the read-only Cairnline sidecar assignments.launch_packet tool through the persistent sidecar client. Hecate still keeps live Projects reads and writes on Hecate-native stores in sidecar mode."
+	response.Detail = "Hecate called the read-only Cairnline sidecar assignments.launch_packet tool through the persistent sidecar client. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/hecatehq/hecate/internal/config"
 )
 
+func assertSidecarLiveReadDetail(t *testing.T, detail string) {
+	t.Helper()
+	if strings.Contains(detail, "live Projects reads and writes") {
+		t.Fatalf("detail = %q, want no stale native-read claim", detail)
+	}
+	if !strings.Contains(detail, "Project writes stay on Hecate-native stores") ||
+		!strings.Contains(detail, "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar") ||
+		!strings.Contains(detail, "project-chat-prelude, project-chat-context") {
+		t.Fatalf("detail = %q, want sidecar read-route guidance with project chat routes", detail)
+	}
+}
+
 func TestProjectCairnlineSidecarMCPConfig_DefaultsToInMemoryProbe(t *testing.T) {
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
 
@@ -98,6 +110,7 @@ func TestProjectCairnlineSidecarProbe_Ready(t *testing.T) {
 	if len(got.MissingTools) != 0 {
 		t.Fatalf("missing tools = %+v, want none", got.MissingTools)
 	}
+	assertSidecarLiveReadDetail(t, got.Detail)
 	for _, name := range []string{"projects.update", "roots.create", "context_sources.update", "profiles.create", "assignments.create", "memory_entries.create", "assistant.apply", "memory_candidates.delete"} {
 		if !containsString(got.RequiredTools, name) {
 			t.Fatalf("required tools = %+v, want %q", got.RequiredTools, name)
@@ -154,6 +167,7 @@ func TestProjectCairnlineSidecarConnect_ReadyUsesPersistentClientCache(t *testin
 	if got.ToolCount != len(projectCairnlineSidecarRequiredTools) || len(got.MissingTools) != 0 {
 		t.Fatalf("tool count=%d missing=%+v, want full contract", got.ToolCount, got.MissingTools)
 	}
+	assertSidecarLiveReadDetail(t, got.Detail)
 	for _, name := range []string{"projects.activity", "skills.discover", "work_items.closeout_readiness", "artifacts.create", "handoffs.update_status", "memory_candidates.promote"} {
 		if !containsString(got.RequiredTools, name) {
 			t.Fatalf("required tools = %+v, want %q", got.RequiredTools, name)


### PR DESCRIPTION
## Summary

- replace stale Cairnline sidecar diagnostic wording with a shared live-read detail helper
- document that sidecar mode keeps writes Hecate-native while opt-in read routes, including project-chat prelude/context, can route through Cairnline
- add regression coverage so probe/connect details include project-chat read routes and do not claim reads remain native

## Validation

- `go test ./internal/api -run 'TestProjectCairnlineSidecar(Probe_Ready|Connect_ReadyUsesPersistentClientCache|ReadSmoke|DetailSmoke|CoordinationSmoke|AssignmentContextSmoke|LaunchPacketSmoke)'`
- `just agent-docs-check`
- `just go-format-check`
- `just docs-format-check`
- `git diff --check`
- `go test ./internal/api`
- `just docs-check`
- `go vet ./...`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
