### PR TITLE
fix(projects): clarify sidecar write boundary

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2384,10 +2384,12 @@ being built.
 
 `configured_backend` reflects `HECATE_PROJECTS_COORDINATION_BACKEND`.
 `cairnline_connector` reflects `HECATE_PROJECTS_CAIRNLINE_CONNECTOR`.
-`embedded` is the only connector that can make live Hecate routes use Cairnline
-today. `sidecar` exposes standalone MCP contract probe/connect surfaces and
-reports `cairnline_connector_ready=false`, so read/write routing and
-write-authority switchpoints stay disabled.
+`embedded` is the only connector that can make live Hecate write routes use
+Cairnline today. `sidecar` exposes standalone MCP contract probe/connect
+surfaces and can serve the explicit sidecar read-route families when
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`; it still reports
+`cairnline_connector_ready=false` for replacement-readiness because
+write-authority switchpoints are ignored in sidecar connector mode.
 `cairnline_read_source` reflects `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable` expands to every
 current portable write-authority switchpoint for dogfooding the embedded
@@ -6331,7 +6333,8 @@ When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` are both configured, project
 handoff lists are read through typed `handoffs.list` on the standalone
 Cairnline MCP client. Handoff create/update/status/delete routes remain
-Hecate-owned unless a separate write-authority switchpoint is enabled.
+Hecate-owned unless an embedded Cairnline write-authority switchpoint is
+enabled.
 
 #### `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/handoffs`
 
@@ -6437,7 +6440,7 @@ When `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 endpoint validates the work item through typed `work_items.list`, then combines
 typed `artifacts.list`, `evidence.list`, and `reviews.list` from the standalone
 Cairnline MCP client. Collaboration artifact creation remains Hecate-owned
-unless a separate write-authority switchpoint is enabled.
+unless an embedded Cairnline write-authority switchpoint is enabled.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/artifacts`
 

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -395,7 +395,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
 				response.Warnings = []string{
 					"Only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " use the Cairnline sidecar MCP client in this mode.",
-					"Project writes still use Hecate-native stores unless a separate embedded Cairnline authority switchpoint is explicitly enabled.",
+					projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
 					"Full Cairnline replacement remains blocked on authoritative write migration.",
 				}
 				return projectCairnlineStatusWithNextAction(response)
@@ -405,7 +405,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
-				"Project reads and writes still use Hecate-native stores.",
+				projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
 			}
 			return projectCairnlineStatusWithNextAction(response)
 		}
@@ -1215,6 +1215,13 @@ func projectCairnlineReadSourceWarning(source string) string {
 	default:
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project or proposal record, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection."
 	}
+}
+
+func projectCairnlineSidecarWriteAuthorityWarning(writeAuthority []string) string {
+	if len(writeAuthority) > 0 {
+		return "Configured HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY values (" + strings.Join(writeAuthority, ", ") + ") are ignored in sidecar connector mode; project writes still use Hecate-native stores unless HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded is used for embedded Cairnline write-authority dogfooding."
+	}
+	return "Project writes still use Hecate-native stores; current write-authority switchpoints require HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded."
 }
 
 func (h *Handler) cairnlineReadModelReadiness() (bool, []string) {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -221,7 +221,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 		t.Fatalf("next action = %+v, want embedded connector action for sidecar mode", status.NextReplacementAction)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration/memory/assistant diagnostics") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "Hecate-native stores") {
+	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration/memory/assistant diagnostics") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "ignored in sidecar connector mode") || !strings.Contains(warnings, projectCairnlineWriteAuthorityProjectAssignments) {
 		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
 	}
 }
@@ -233,6 +233,11 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 			CoordinationBackend: "cairnline",
 			CairnlineConnector:  "sidecar",
 			CairnlineReadSource: "sidecar",
+			CairnlineWriteAuthority: strings.Join([]string{
+				projectCairnlineWriteAuthorityProjectIdentity,
+				projectCairnlineWriteAuthorityProjectMetadataDefaults,
+				projectCairnlineWriteAuthorityProjectAssignments,
+			}, ","),
 		},
 	}, quietLogger(), nil, nil, nil, nil)
 
@@ -245,6 +250,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 	}
 	if status.CairnlineAuthoritative || status.ReadModelSwitchReady || status.WriteAdapterReady || status.ReplacementReady {
 		t.Fatalf("status = %+v, want sidecar project reads without full replacement readiness", status)
+	}
+	if len(status.PortableWriteGaps) == 0 || !containsString(status.PortableWriteGaps, "projects") || !containsString(status.PortableWriteGaps, "assignments") {
+		t.Fatalf("portable write gaps = %+v, want sidecar mode to ignore configured write authority", status.PortableWriteGaps)
 	}
 	if handler.projectReadRoutesUseCairnlineReadModel() {
 		t.Fatal("sidecar project reads enabled embedded Cairnline read-model routes")
@@ -262,7 +270,7 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 		t.Fatalf("read-routes gate = %+v, want blocked while sidecar reads remain an interoperability mode", gate)
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "project-assistant-context, project-assistant-proposal") || !strings.Contains(warnings, "project-chat-prelude, project-chat-context") || !strings.Contains(warnings, "authoritative write migration") {
+	if !strings.Contains(warnings, "project-assistant-context, project-assistant-proposal") || !strings.Contains(warnings, "project-chat-prelude, project-chat-context") || !strings.Contains(warnings, "ignored in sidecar connector mode") || !strings.Contains(warnings, projectCairnlineWriteAuthorityProjectIdentity) || !strings.Contains(warnings, "authoritative write migration") {
 		t.Fatalf("warnings = %+v, want sidecar read routes with write-migration warning", status.Warnings)
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "use-embedded-cairnline-connector" || status.NextReplacementAction.Target != "connector" {


### PR DESCRIPTION
## Summary

- make backend status explicitly warn when Cairnline write-authority settings are ignored in sidecar connector mode
- test that sidecar read-source mode keeps portable write gaps open even when write authority is configured
- update runtime API docs to distinguish sidecar live reads from embedded Cairnline write-authority switchpoints

## Validation

- `go test ./internal/api -run 'TestProjectCoordinationBackendStatus_CairnlineSidecar(ConnectorBlocksEmbeddedRoutes|ReadRoutesReady)'`
- `just go-format-check`
- `just docs-format-check`
- `git diff --check`
- `go test ./internal/api`
- `just docs-check`
- `go vet ./...`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
