### PR TITLE
fix(projects): align sidecar read status docs

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -511,9 +511,10 @@ sequenceDiagram
   sidecar mode. Live project list/detail reads use Hecate-native stores unless
   `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` is also set; setup-readiness,
   health, skills, memory, memory candidates, roles, work items, assignment
-  lists, launch-readiness, assignment preflight, artifact lists, handoff lists,
-  activity, closeout readiness, and operations brief use the same sidecar source
-  when it is configured.
+  lists, assignment context, launch-readiness, assignment preflight, artifact
+  lists, handoff lists, Project Assistant context/proposal, project-chat
+  prelude/context, activity, closeout readiness, and operations brief use the
+  same sidecar source when it is configured.
 - `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto|snapshot|embedded|sidecar` controls which
   Cairnline service backing configured read routes use while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`. With
@@ -3269,9 +3270,11 @@ Local-only standalone Cairnline MCP client connect/status surface. It uses the
 same command, database, timeout, and required-tool contract as
 `sidecar-probe`, but acquires the sidecar through Hecate's Cairnline-specific
 MCP client cache. A successful call leaves the sidecar process idle in that
-cache until the cache evicts it or Hecate shuts down. This is still not live
-Projects routing: read/write routes and write-authority switchpoints remain
-disabled in `sidecar` connector mode.
+cache until the cache evicts it or Hecate shuts down. This connection alone
+does not change live Projects routing. Add
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` to route the explicit sidecar
+read families through the standalone MCP client; write-authority switchpoints
+still require the embedded Cairnline connector.
 
 The response uses the same fields as `sidecar-probe` plus cache metadata:
 
@@ -3584,7 +3587,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_assignment_context_ready",
-    "detail": "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. Hecate still keeps live assignment/context reads and writes on Hecate-native stores or embedded dogfood paths in sidecar mode.",
+    "detail": "Hecate called the read-only Cairnline sidecar assignments.context tool through the persistent sidecar client. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3655,7 +3658,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_launch_packet_ready",
-    "detail": "Hecate called the read-only Cairnline sidecar assignments.launch_packet tool through the persistent sidecar client. Hecate still keeps live assignment launch reads and writes on Hecate-native stores or embedded dogfood paths in sidecar mode.",
+    "detail": "Hecate called the read-only Cairnline sidecar assignments.launch_packet tool through the persistent sidecar client. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -1209,7 +1209,7 @@ func projectCairnlineReadSourceWarning(source string) string {
 	case "embedded":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded requires a populated embedded Cairnline mirror database and fails configured read routes when the database, project row, or proposal record is missing."
 	case "sidecar":
-		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " through the standalone Cairnline MCP client; writes remain Hecate-owned unless a separate write-authority switchpoint is enabled."
+		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " through the standalone Cairnline MCP client; writes remain Hecate-owned because current write-authority switchpoints require HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded."
 	case "snapshot":
 		return "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=snapshot keeps configured read routes on the snapshot-seeded in-memory Cairnline bridge projection even when an embedded mirror database exists."
 	default:

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -1057,6 +1057,16 @@ func TestProjectCoordinationBackendStatus_NextActionWriteAuthorityHints(t *testi
 	}
 }
 
+func TestProjectCoordinationBackendStatus_SidecarReadSourceWarningKeepsWritesEmbedded(t *testing.T) {
+	warning := projectCairnlineReadSourceWarning("sidecar")
+	if !strings.Contains(warning, "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar") ||
+		!strings.Contains(warning, "project-chat-prelude, project-chat-context") ||
+		!strings.Contains(warning, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded") ||
+		strings.Contains(warning, "unless a separate write-authority switchpoint is enabled") {
+		t.Fatalf("warning = %q, want sidecar read guidance with embedded write-authority boundary", warning)
+	}
+}
+
 func TestProjectCoordinationBackendStatus_NextActionReplacementModeHints(t *testing.T) {
 	status := ProjectCoordinationBackendStatusResponse{
 		ConfiguredBackend:       "cairnline",


### PR DESCRIPTION
## Summary

- align sidecar connect/read-smoke docs with the now-live sidecar read-source mode
- update assignment-context and launch-packet sidecar examples to use the shared read-route/write-boundary wording
- tighten the sidecar read-source warning so it says write authority still requires the embedded connector

## Validation

- `go test ./internal/api -run 'TestProjectCoordinationBackendStatus_(SidecarReadSourceWarningKeepsWritesEmbedded|CairnlineSidecarReadRoutesReady|CairnlineSidecarConnectorBlocksEmbeddedRoutes)'`
- `just go-format-check`
- `just docs-format-check`
- `git diff --check`
- `go test ./internal/api`
- `just docs-check`
- `go vet ./...`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
