### PR TITLE
docs(projects): align sidecar route boundary

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -218,16 +218,17 @@ routes only project list/detail, setup-readiness, health, project skill list,
 project memory list, memory-candidate list, project role list, work-item
 list/detail, assignment-list, assignment-context, launch-readiness, assignment preflight,
 artifact-list, handoff-list, Project Assistant context/proposal record reads,
-activity, closeout-readiness, and operations brief reads through the cached
-standalone Cairnline MCP client. Assignment-context reads consume typed
-`assignments.context` sidecar data. Launch-readiness and assignment preflight
-consume typed `assignments.launch_packet` sidecar data before applying Hecate
-runtime validation. Project Assistant context/proposal reads consume typed
-project, work, skill, memory, and `assistant.proposals.get` sidecar data.
+project-linked Hecate Chat prelude/context reads, activity, closeout-readiness,
+and operations brief reads through the cached standalone Cairnline MCP client.
+Assignment-context reads consume typed `assignments.context` sidecar data.
+Launch-readiness and assignment preflight consume typed
+`assignments.launch_packet` sidecar data before applying Hecate runtime
+validation. Project Assistant context/proposal reads consume typed project,
+work, skill, memory, and `assistant.proposals.get` sidecar data.
 Proposal-record reads fall back to the Hecate-native proposal ledger only when
 the sidecar reports the proposal is missing, because draft/propose/apply
-mutations remain Hecate-owned unless their explicit write-authority switchpoints
-are enabled.
+mutations remain Hecate-owned and write-authority switchpoints require
+`HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`.
 Other Projects reads, writes, mirrors, dispatch, approvals, and write-authority
 switchpoints remain Hecate-native or on the embedded dogfood path until
 sidecar-specific adapters exist for those route families.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -378,12 +378,15 @@ launch agents. Those remain explicit operator or orchestrator actions.
   list/detail, setup-readiness, health, project skill list, project memory
   list, memory-candidate list, project role list, work-item list/detail,
   assignment-list, assignment-context, launch-readiness, assignment preflight, artifact-list,
-  handoff-list, activity, closeout-readiness, and operations brief reads through
-  the cached standalone MCP client. Assignment-context reads consume typed
-  sidecar `assignments.context` data. Launch-readiness and assignment preflight
-  consume typed sidecar `assignments.launch_packet` data before applying Hecate
-  runtime validation. Other live Projects reads, writes, mirrors, and
-  write-authority switchpoints do not route through the sidecar yet.
+  handoff-list, Project Assistant context/proposal record reads,
+  project-linked Hecate Chat prelude/context reads, activity,
+  closeout-readiness, and operations brief reads through the cached standalone
+  MCP client. Assignment-context reads consume typed sidecar
+  `assignments.context` data. Launch-readiness and assignment preflight consume
+  typed sidecar `assignments.launch_packet` data before applying Hecate runtime
+  validation. Other live Projects reads, writes, mirrors, and write-authority
+  switchpoints do not route through the sidecar yet; write-authority
+  switchpoints require `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -457,11 +457,12 @@ setup-readiness, health, project skill list, project memory list,
 memory-candidate list, project role list, work-item list/detail,
 assignment-list, assignment-context, launch-readiness, assignment preflight, artifact-list,
 handoff-list, Project Assistant context/proposal record reads, activity,
-closeout-readiness, and operations brief reads through the standalone Cairnline
-MCP client. Proposal-record reads fall back to the Hecate-native proposal
-ledger only when the sidecar reports the proposal is missing; draft/propose/apply
-mutations remain Hecate-owned unless their explicit write-authority switchpoints
-are enabled.
+project-linked Hecate Chat prelude/context reads, closeout-readiness, and
+operations brief reads through the standalone Cairnline MCP client.
+Proposal-record reads fall back to the Hecate-native proposal ledger only when
+the sidecar reports the proposal is missing; draft/propose/apply mutations
+remain Hecate-owned because write-authority switchpoints require
+`HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`.
 Assignment-context reads use typed sidecar `assignments.context` data.
 Launch-readiness and assignment preflight use the typed sidecar
 `assignments.launch_packet` response as their coordination input, then apply

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -544,8 +544,8 @@ sequenceDiagram
   handoff-list, Project Assistant context/proposal reads, project-chat
   prelude/context reads, activity, closeout-readiness, and operations-brief
   reads through the standalone Cairnline MCP client. Draft/propose/apply
-  mutations remain Hecate-owned unless their explicit write-authority
-  switchpoints are enabled.
+  mutations remain Hecate-owned because write-authority switchpoints require
+  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=none|all-portable|project-memory|project-memory,memory-candidates|project-collaboration|project-skills|project-roles|project-work-items|project-assignments|agent-profiles|project-metadata-defaults|project-roots|project-context-sources|project-identity|project-assistant-proposals`
   controls alpha Cairnline write-authority switchpoints while
   `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and


### PR DESCRIPTION
## Summary
- align sidecar read-source docs with the canonical route set
- clarify that sidecar read mode keeps writes Hecate-owned because write-authority switchpoints require the embedded connector
- update the Cairnline proposal and accepted Projects docs with project-chat sidecar read coverage

## Tests
- just docs-format-check
- just docs-check
- git diff --check