### PR TITLE
test(projects): pin cairnline replacement shadow gate

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -142,7 +142,10 @@ Projects coordination state. In that armed mode with all portable
 write-authority gaps closed, Cairnline-authoritative project identity create no
 longer creates a native Hecate project identity row; strict embedded reads serve
 the project from Cairnline, while Hecate keeps only the runtime/workspace
-compatibility shadows it still owns.
+compatibility shadows it still owns. The identity-create shadow switch is
+config-gated by replacement mode plus portable write authority; backend status
+remains the operator-facing readiness signal and still reports not-ready when
+strict embedded mirror/read-smoke evidence is missing or stale.
 It keeps `write_adapter_gaps` as the broad diagnostic list and also groups
 that list into `portable_write_gaps`, `orchestrator_capabilities`, and
 `migration_blockers`, so operator tooling can tell durable coordination-state
@@ -674,6 +677,9 @@ after these gates are met:
   `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` after the read,
   write-authority, migration, and rollback gates are ready; enabling all
   portable write-authority switchpoints alone does not replace the backend.
+  Replacement mode plus all portable write authority can make new project
+  identity creates Cairnline-only, but `replacement_ready` remains false until
+  strict embedded read smoke and migration/rollback gates are clean.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2562,6 +2562,10 @@ replacement mode with all portable write-authority gaps closed,
 Cairnline-authoritative project identity create returns the Cairnline record
 with `read_backend: "cairnline"` and without creating a native Hecate project
 identity row; strict embedded read routes serve the new project from Cairnline.
+That identity-shadow behavior is a write-path switch, not the full readiness
+verdict: clients should use `replacement_ready` and `replacement_gates` to tell
+whether mirror parity, strict read smoke, migration, and rollback are actually
+clean.
 When the next action is `rehearse-migration-cutover`, `config_hints` identify
 the strict embedded dogfood posture expected for the rehearsal:
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,

--- a/internal/api/handler_project_identity_authority.go
+++ b/internal/api/handler_project_identity_authority.go
@@ -24,6 +24,9 @@ func (h *Handler) projectCairnlineEmbeddedReplacementModeArmed() bool {
 	if h == nil {
 		return false
 	}
+	// This is the write-path shadow switch for newly-created project identity.
+	// Backend status still owns the broader replacement-readiness verdict,
+	// including strict embedded mirror parity and read-smoke evidence.
 	if h.config.ProjectsCoordinationBackend() != "cairnline" ||
 		!h.projectCairnlineEmbeddedConnectorEnabled() ||
 		h.config.ProjectsCairnlineReadSource() != "embedded" ||

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -707,6 +707,47 @@ func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *tes
 	}
 }
 
+func TestProjectsAPI_CairnlineReplacementModeWithoutPortableAuthorityKeepsNativeIdentityShadow(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineWriteAuthority:  projectCairnlineWriteAuthorityProjectIdentity,
+			CairnlineReplacementMode: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
+		"name":"Replacement Identity With Shadow",
+		"description":"replacement mode is armed, but portable write authority is incomplete",
+		"default_provider":"openai",
+		"default_model":"gpt-5"
+	}`))))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
+	}
+	var created ProjectResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || !ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after replacement-mode create, want compatibility identity shadow while portable authority is incomplete", ok, err)
+	}
+	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
+	if status.ReplacementReady {
+		t.Fatalf("replacement_ready = true, want false while only project identity authority is enabled")
+	}
+	if !containsString(status.PortableWriteGaps, "memory") || !containsString(status.PortableWriteGaps, "work-items") {
+		t.Fatalf("portable write gaps = %+v, want remaining portable blockers", status.PortableWriteGaps)
+	}
+}
+
 func TestProjectsAPI_CairnlineIdentityAuthorityCommitsDeleteFirst(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineIdentityAuthorityTestServer(t)


### PR DESCRIPTION
## Summary
- document that the embedded replacement identity-shadow switch is separate from the broader backend-status readiness verdict
- add a regression test proving replacement mode alone does not skip the native identity shadow when portable write authority is incomplete
- clarify runtime/design docs so clients use replacement_ready and replacement_gates as the cutover readiness signal

## Tests
- go test ./internal/api -run 'TestProjectsAPI_CairnlineReplacementMode|TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed|TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover'
- go test ./internal/api
- go vet ./...
- just go-format-check
- just docs-format-check
- just docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...