### PR TITLE
docs(projects): clarify memory candidate authority surface

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -317,10 +317,12 @@ accepted project memory entry create/update/delete commits to embedded
 Cairnline first, then best-effort shadows the entry into Hecate-native memory
 stores for compatibility. Adding `memory-candidates` to that setting makes
 memory-candidate create/promote/reject Cairnline-first too; it requires
-`project-memory` because promotion creates accepted project memory. These
-memory authority routes can validate project identity from the embedded
-Cairnline graph and do not require a matching Hecate-native compatibility
-project row before the Cairnline commit.
+`project-memory` because promotion creates accepted project memory. Hecate's
+live memory-candidate authority surface is create/promote/reject; standalone
+Cairnline sidecar delete smoke tests remain diagnostic and do not represent a
+Hecate route cutover. These memory authority routes can validate project
+identity from the embedded Cairnline graph and do not require a matching
+Hecate-native compatibility project row before the Cairnline commit.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable` expands to every
 current portable write-authority switchpoint for embedded dogfooding; Hecate
 runtime side effects and migration cutover remain separate gates.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -515,9 +515,11 @@ best-effort shadows the row into Hecate-native memory stores. The default is
 `none`. `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory,memory-candidates`
 also makes memory-candidate create/promote/reject Cairnline-first; the
 `memory-candidates` switch requires `project-memory` because candidate promotion
-creates accepted project memory. All other Projects mutations remain
-Hecate-owned unless one of the other alpha write-authority switchpoints is
-explicitly listed.
+creates accepted project memory. Hecate's live memory-candidate authority
+surface is create/promote/reject; sidecar delete smoke tests are standalone
+Cairnline diagnostics, not Hecate route migration evidence. All other Projects
+mutations remain Hecate-owned unless one of the other alpha write-authority
+switchpoints is explicitly listed.
 Project metadata/default-only PATCHes also best-effort mirror after the Hecate
 store commit unless `project-metadata-defaults` is enabled, in which case those
 scoped updates commit portable metadata and launch defaults to Cairnline first

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2406,7 +2406,9 @@ compatibility project row. Adding `memory-candidates` to that comma-separated
 setting makes candidate create/promote/reject Cairnline-first as well; it
 requires `project-memory` because candidate promotion creates accepted project
 memory, and candidate routes use the same Cairnline project-identity
-validation.
+validation. Hecate's live memory-candidate authority surface is
+create/promote/reject; standalone Cairnline sidecar delete smoke tests remain
+diagnostic and do not represent a Hecate route cutover.
 Adding `project-collaboration` makes generic collaboration artifact, evidence,
 review, and handoff mutations Cairnline-first, then shadows the portable records
 back into Hecate-native project-work stores for compatibility. In that alpha

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -275,7 +275,7 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 		BlocksAuthority:  true,
 		Seams:            []string{"project-memory-candidates-live-mirror"},
 		Gap:              "memory-candidates",
-		Detail:           "Memory-candidate create/promote/reject/delete still commits to Hecate first, then mirrors review state and promoted-memory references into Cairnline.",
+		Detail:           "Memory-candidate create/promote/reject still commits to Hecate first, then mirrors review state and promoted-memory references into Cairnline.",
 	},
 	{
 		Name:             "project-assistant-proposal-ledger",

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -337,6 +337,9 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "project-memory"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "live_mirror_non_authoritative" || !point.LiveMirror || !point.BlocksAuthority || point.Gap != "memory" {
 		t.Fatalf("project-memory switchpoint = %+v, want Hecate-owned live mirror blocker", point)
 	}
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "memory-candidates"); point == nil || !strings.Contains(point.Detail, "create/promote/reject still commits") || strings.Contains(point.Detail, "delete") {
+		t.Fatalf("memory-candidates switchpoint = %+v, want live Hecate API surface limited to create/promote/reject", point)
+	}
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "snapshot_import_rehearsal_available" || point.LiveMirror || !point.BlocksAuthority || point.Gap != "migration-cutover" || !containsString(point.Seams, "sync-rehearsal") {
 		t.Fatalf("migration switchpoint = %+v, want snapshot-import rehearsal blocker", point)
 	}


### PR DESCRIPTION
## Summary
- align backend status wording with Hecate's live memory-candidate API surface
- document that sidecar delete smoke is diagnostic, not Hecate route cutover evidence
- add a backend status regression assertion for the switchpoint detail

## Tests
- go test ./internal/api -run TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady
- go test ./internal/api
- go vet ./...
- just docs-check
- just go-format-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
