### PR TITLE
fix(projects): align cairnline cutover switchpoint status

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -681,7 +681,9 @@ after these gates are met:
   portable write-authority switchpoints alone does not replace the backend.
   Replacement mode plus all portable write authority can make new project
   identity creates Cairnline-only, but `replacement_ready` remains false until
-  strict embedded read smoke and migration/rollback gates are clean.
+  strict embedded read smoke and migration/rollback gates are clean. Once those
+  gates are clean, the `migration-cutover` switchpoint reports
+  `embedded_cutover_armed` instead of a blocking Hecate-owned cutover gap.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -654,7 +654,8 @@ authoritative storage cutover switch still does not exist. When
 `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed after strict
 embedded reads are verified and all portable write-authority gaps are closed,
 backend status treats that mode as the explicit embedded cutover switch, clears
-the migration blocker, and reports Cairnline as authoritative for portable
+the migration blocker, marks the `migration-cutover` write switchpoint as
+`embedded_cutover_armed`, and reports Cairnline as authoritative for portable
 Projects coordination state. In that armed mode with all portable
 write-authority gaps closed, new Cairnline-authoritative project identity
 creates no longer manufacture native Hecate project identity rows;

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2583,9 +2583,12 @@ the cutover is armed and all replacement gates are ready, the next action become
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
 `snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled
 alpha write-authority switchpoints, or `partial_authoritative_opt_in` when only
-some routes in a family have moved), the related mirror seams, and whether that
-family still blocks portable write authority or remains Hecate-owned runtime
-behavior.
+some routes in a family have moved). When strict embedded mirror parity and
+read smoke are verified, all portable write-authority gaps are closed, and
+`replacement_mode=embedded`, the `migration-cutover` switchpoint reports
+`embedded_cutover_armed` and no longer blocks authority. Each switchpoint also
+reports the related mirror seams and whether that family still blocks portable
+write authority or remains Hecate-owned runtime behavior.
 Non-authoritative bridge seams currently cover project/root/source/defaults,
 agent profiles, skills, roles, work items, assignment metadata upsert/delete plus
 lifecycle-status sync, create-if-missing generic artifacts/evidence/reviews,

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -383,8 +383,8 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 		response.PortableWriteGaps = projectCairnlinePortableWriteGapsSnapshot(effectiveWriteAuthority, response.WriteAdapterGaps)
 		response.OrchestratorCapabilities = projectCairnlineOrchestratorCapabilitiesSnapshot(response.WriteAdapterGaps)
 		response.WriteAdapterReady = len(response.PortableWriteGaps) == 0
-		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority)
 		migrationCutoverArmed := replacementMode == "embedded" && strictEmbeddedReadGate.Ready && len(response.PortableWriteGaps) == 0
+		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority, migrationCutoverArmed)
 		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps, migrationCutoverArmed)
 		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
 		if !connectorReady {
@@ -921,7 +921,7 @@ func projectCairnlineMigrationBlockersSnapshot(writeGaps []string, migrationCuto
 	return out
 }
 
-func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []ProjectCoordinationBackendWriteSwitchpoint {
+func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, migrationCutoverArmed bool) []ProjectCoordinationBackendWriteSwitchpoint {
 	out := make([]ProjectCoordinationBackendWriteSwitchpoint, 0, len(projectCairnlineWriteSwitchpoints))
 	projectMemoryAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory")
 	memoryCandidatesAuthoritative := projectMemoryAuthoritative && projectCairnlineWriteAuthorityEnabled(writeAuthority, "memory-candidates")
@@ -1060,6 +1060,13 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string) []Projec
 			item.BlocksAuthority = false
 			item.Gap = ""
 			item.Detail = "Project memory-candidate create, promote, and reject mutations commit to the embedded Cairnline database first, validating project identity from Cairnline when no Hecate-native project row exists, then best-effort shadow review state and promoted-memory references back into Hecate-native stores for compatibility."
+		}
+		if migrationCutoverArmed && item.Name == "migration-cutover" {
+			item.CurrentAuthority = "cairnline"
+			item.CairnlineState = "embedded_cutover_armed"
+			item.BlocksAuthority = false
+			item.Gap = ""
+			item.Detail = "Strict embedded mirror parity and read smoke are verified, all portable write-authority gaps are closed, and embedded replacement mode is armed as the explicit Cairnline cutover switch."
 		}
 		item.Seams = append([]string(nil), item.Seams...)
 		out = append(out, item)

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -466,6 +466,9 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 	if gate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); gate == nil || !gate.Ready || gate.Status != "ready" {
 		t.Fatalf("migration gate = %+v, want ready migration gate after embedded replacement cutover is armed", gate)
 	}
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "embedded_cutover_armed" || point.BlocksAuthority || point.Gap != "" {
+		t.Fatalf("migration cutover switchpoint = %+v, want armed Cairnline cutover switchpoint after replacement is ready", point)
+	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "monitor-cairnline-backend" {
 		t.Fatalf("next action = %+v, want monitor action after replacement is ready", status.NextReplacementAction)
 	}


### PR DESCRIPTION
## Summary
- feed the embedded cutover-armed state into the Cairnline write switchpoint snapshot
- report the migration-cutover switchpoint as embedded_cutover_armed when replacement readiness is actually achieved
- document the switchpoint state and add a regression assertion

## Tests
- go test ./internal/api -run 'TestProjectCoordinationBackendStatus_(EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover|StrictEmbeddedReadSmokeGateVerifiedAfterSync|CairnlineEmbeddedReplacementModeArmed)'
- go test ./internal/api
- go vet ./...
- just docs-check
- just go-format-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
