### PR TITLE
fix(projects): derive sidecar health from activity

### DIFF
--- a/internal/api/handler_project_cairnline_sidecar_health.go
+++ b/internal/api/handler_project_cairnline_sidecar_health.go
@@ -17,6 +17,10 @@ func (h *Handler) renderCairnlineSidecarProjectHealth(ctx context.Context, proje
 		return ProjectHealthResponse{}, projects.ErrNotFound
 	}
 	project := projectFromCairnlineSidecar(projectItem)
+	activity, err := h.renderCairnlineSidecarProjectActivity(ctx, project.ID)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
 	roles, err := h.cairnlineSidecarProjectRoles(ctx, project.ID)
 	if err != nil {
 		return ProjectHealthResponse{}, err
@@ -63,10 +67,6 @@ func (h *Handler) renderCairnlineSidecarProjectHealth(ctx context.Context, proje
 	}
 
 	now := time.Now().UTC()
-	activity := ProjectActivityDataResponse{
-		ProjectID:   project.ID,
-		ReadBackend: "cairnline",
-	}
 	convertedWorkItems := projectWorkItemsFromCairnlineSidecar(workItems)
 	convertedAssignments := projectAssignmentsFromCairnlineSidecar(assignments)
 	convertedHandoffs := projectHandoffsFromCairnlineSidecar(handoffs)

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -517,6 +517,28 @@ func TestProjectHealth_CairnlineSidecarRequiresStructuredContent(t *testing.T) {
 	}
 }
 
+func TestProjectHealth_CairnlineSidecarRequiresTypedActivity(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineSidecarReadTestServer(t, "projects.activity-text-only")
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/health", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("health status = %d body=%s, want 502 for text-only sidecar activity", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(response.Error.Message, "projects.activity did not return typed structuredContent") {
+		t.Fatalf("error = %+v, want activity structuredContent failure", response.Error)
+	}
+}
+
 func TestProjectHealth_CairnlineMatchesHecateProjectionGraph(t *testing.T) {
 	t.Parallel()
 	hecateHandler, hecateServer := newProjectWorkProjectionTestServer(t, "memory")


### PR DESCRIPTION
## Summary
- make Cairnline sidecar project health reuse the typed sidecar activity projection instead of deriving attention from an empty activity shell
- fail loudly when the sidecar projects.activity tool does not return typed structured content, matching the sidecar read contract used by the activity route
- add a regression test for the activity-typed-content requirement

## Verification
- go test ./internal/api -run 'TestProjectHealth_(ReadsUseCairnlineSidecarWhenConfigured|CairnlineSidecarRequiresStructuredContent|CairnlineSidecarRequiresTypedActivity)'\n- go test ./internal/api\n- go vet ./...\n- just docs-check\n- just go-format-check\n- git diff --check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n\nDocs unchanged: this aligns an existing sidecar read route with its typed activity dependency.