### PR TITLE
test(projects): cover cairnline preflight route smoke

### DIFF
--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -816,6 +816,7 @@ func TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments", "", "assignment list")
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments/"+assignment.Data.ID+"/context", "", "assignment context")
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments/"+assignment.Data.ID+"/launch-readiness", "", "launch readiness")
+	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments/"+assignment.Data.ID+"/preflight", "", "assignment preflight")
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/artifacts", "", "artifact list")
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/handoffs", "", "handoff list")
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/activity", "", "activity")


### PR DESCRIPTION
## Summary
- add assignment preflight to the representative strict embedded Cairnline route smoke
- lock the documented preflight read route to an actual HTTP path that emits Cairnline launch-packet evidence

## Tests
- go test ./internal/api -run TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
- go test ./internal/api
- just go-format-check
- git diff --check
- just docs-check