### PR TITLE
fix(projects): use cairnline readiness for closeout authority

### DIFF
--- a/internal/api/handler_project_work_item_authority.go
+++ b/internal/api/handler_project_work_item_authority.go
@@ -63,7 +63,7 @@ func (h *Handler) createProjectWorkItemWithCairnlineAuthority(ctx context.Contex
 
 func (h *Handler) updateProjectWorkItemWithCairnlineAuthority(ctx context.Context, projectID, workItemID string, cmd projectworkapp.UpdateWorkItemCommand) (projectwork.WorkItem, error) {
 	if cmd.Status != nil && strings.TrimSpace(*cmd.Status) == projectwork.WorkItemStatusDone {
-		readiness, err := h.projectWorkApplication().WorkItemReadiness(ctx, projectID, workItemID)
+		readiness, err := h.projectWorkItemCloseoutReadinessForCairnlineAuthority(ctx, projectID, workItemID)
 		if err != nil {
 			return projectwork.WorkItem{}, err
 		}
@@ -103,6 +103,63 @@ func (h *Handler) updateProjectWorkItemWithCairnlineAuthority(ctx context.Contex
 	}
 	h.shadowProjectWorkItemToHecate(ctx, "project_work_item_cairnline_authority_update", updated)
 	return updated, nil
+}
+
+func (h *Handler) projectWorkItemCloseoutReadinessForCairnlineAuthority(ctx context.Context, projectID, workItemID string) (projectwork.WorkItemReadiness, error) {
+	if h != nil && h.projectReadRoutesUseCairnlineReadModel() {
+		view, err := h.cairnlineProjectWorkView(ctx, projectID)
+		if err != nil {
+			return projectwork.WorkItemReadiness{}, err
+		}
+		defer view.Close()
+		readiness, err := view.service.WorkItemCloseoutReadiness(ctx, view.snapshot.Project.ID, workItemID)
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return projectwork.WorkItemReadiness{}, projectwork.ErrNotFound
+		}
+		if err != nil {
+			return projectwork.WorkItemReadiness{}, err
+		}
+		return projectWorkItemReadinessFromCairnline(readiness), nil
+	}
+	return h.projectWorkApplication().WorkItemReadiness(ctx, projectID, workItemID)
+}
+
+func projectWorkItemReadinessFromCairnline(readiness cairnline.WorkItemCloseoutReadiness) projectwork.WorkItemReadiness {
+	return projectwork.WorkItemReadiness{
+		ProjectID:                    readiness.ProjectID,
+		WorkItemID:                   readiness.WorkItemID,
+		Ready:                        readiness.Ready,
+		Status:                       readiness.Status,
+		Title:                        readiness.Title,
+		Detail:                       readiness.Detail,
+		Blockers:                     renderCairnlineProjectWorkItemReadinessBlockers(readiness.Blockers),
+		Warnings:                     append([]string(nil), readiness.Warnings...),
+		AssignmentCount:              readiness.AssignmentCount,
+		CompletedAssignments:         readiness.CompletedAssignments,
+		ReviewFollowUpCount:          readiness.ReviewFollowUpCount,
+		ReviewFollowUpArtifactIDs:    append([]string(nil), readiness.ReviewFollowUpArtifactIDs...),
+		ReviewFollowUps:              projectWorkItemReviewFollowUpsFromCairnline(readiness.ReviewFollowUps),
+		MissingEvidenceAssignmentIDs: append([]string(nil), readiness.MissingEvidenceAssignmentIDs...),
+	}
+}
+
+func projectWorkItemReviewFollowUpsFromCairnline(items []cairnline.ReviewFollowUpReadiness) []projectwork.ReviewFollowUpReadiness {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]projectwork.ReviewFollowUpReadiness, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectwork.ReviewFollowUpReadiness{
+			ArtifactID:           item.ArtifactID,
+			Title:                item.Title,
+			Status:               item.Status,
+			Blocker:              renderCairnlineProjectWorkItemReadinessBlocker(item.Blocker),
+			ReviewedAssignmentID: item.ReviewedAssignmentID,
+			ReviewVerdict:        item.ReviewVerdict,
+			ReviewRisk:           item.ReviewRisk,
+		})
+	}
+	return out
 }
 
 func (h *Handler) deleteProjectWorkItemWithCairnlineAuthority(ctx context.Context, projectID, workItemID string) error {

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -204,14 +204,26 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if role.Data.ID != "role_replacement" || role.Data.ProjectID != projectID || role.Data.ReadBackend != "cairnline" {
 		t.Fatalf("role = %+v, want replacement project role", role.Data)
 	}
+	reviewer := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                  "role_reviewer",
+		"name":                "Replacement reviewer",
+		"instructions":        "Review the Cairnline replacement journey.",
+		"default_driver_kind": "hecate_task",
+		"default_provider":    "anthropic",
+		"default_model":       "claude-sonnet-4",
+	}))
+	if reviewer.Data.ID != "role_reviewer" || reviewer.Data.ProjectID != projectID || reviewer.Data.ReadBackend != "cairnline" {
+		t.Fatalf("reviewer role = %+v, want replacement reviewer role", reviewer.Data)
+	}
 
 	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
-		"id":            "work_replacement",
-		"title":         "Start replacement assignment",
-		"brief":         "Exercise Cairnline-authoritative create, work, assignment, and launch.",
-		"status":        projectwork.WorkItemStatusReady,
-		"owner_role_id": "role_replacement",
-		"root_id":       "root_replacement",
+		"id":                "work_replacement",
+		"title":             "Start replacement assignment",
+		"brief":             "Exercise Cairnline-authoritative create, work, assignment, launch, collaboration, and closeout.",
+		"status":            projectwork.WorkItemStatusReady,
+		"owner_role_id":     "role_replacement",
+		"root_id":           "root_replacement",
+		"reviewer_role_ids": []string{"role_reviewer"},
 	}))
 	if work.Data.ID != "work_replacement" || work.Data.ReadBackend != "cairnline" || work.Data.RootID != "root_replacement" {
 		t.Fatalf("work = %+v, want Cairnline replacement work item", work.Data)
@@ -256,6 +268,99 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_replacement", "asgn_replacement")
 	if shadow.ExecutionRef.RunID != ref.RunID || shadow.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
 		t.Fatalf("Hecate runtime shadow assignment = %+v, want run/context %q/%q", shadow.ExecutionRef, ref.RunID, ref.ContextSnapshotID)
+	}
+
+	completed := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments/asgn_replacement", projectJourneyJSON(t, map[string]any{
+		"status": projectwork.AssignmentStatusCompleted,
+	}))
+	if completed.Data.Status != projectwork.AssignmentStatusCompleted || completed.Data.ReadBackend != "cairnline" {
+		t.Fatalf("completed assignment = %+v, want Cairnline-backed completed assignment", completed.Data)
+	}
+
+	evidence := mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                   "artifact_replacement_evidence",
+		"assignment_id":        "asgn_replacement",
+		"kind":                 projectwork.ArtifactKindEvidenceLink,
+		"title":                "Replacement evidence",
+		"body":                 "Task and context links were created from a Cairnline-only project graph.",
+		"author_role_id":       "role_replacement",
+		"evidence_url":         "https://example.invalid/hecate/cairnline-replacement",
+		"evidence_provider":    "operator",
+		"evidence_trust_label": projectwork.EvidenceTrustOperatorProvided,
+	}))
+	if evidence.Data.Kind != projectwork.ArtifactKindEvidenceLink || evidence.Data.AssignmentID != "asgn_replacement" || evidence.Data.EvidenceURL != "https://example.invalid/hecate/cairnline-replacement" {
+		t.Fatalf("evidence = %+v, want assignment evidence response", evidence.Data)
+	}
+	mirroredEvidence := getMirroredCairnlineEvidenceForTest(t, handler, projectID, "work_replacement", "artifact_replacement_evidence")
+	if mirroredEvidence.Locator != "https://example.invalid/hecate/cairnline-replacement" || mirroredEvidence.Provider != "operator" {
+		t.Fatalf("mirrored evidence = %+v, want Cairnline-backed assignment evidence", mirroredEvidence)
+	}
+
+	review := mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                        "artifact_replacement_review",
+		"assignment_id":             "asgn_replacement",
+		"reviewed_assignment_id":    "asgn_replacement",
+		"kind":                      projectwork.ArtifactKindReview,
+		"title":                     "Replacement review",
+		"body":                      "Approved replacement journey evidence.",
+		"author_role_id":            "role_reviewer",
+		"review_verdict":            projectwork.ReviewVerdictApproved,
+		"review_risk":               projectwork.ReviewRiskLow,
+		"review_follow_up_required": false,
+	}))
+	if review.Data.ReviewVerdict != projectwork.ReviewVerdictApproved || review.Data.ReviewFollowUpRequired {
+		t.Fatalf("review = %+v, want approved review response without follow-up", review.Data)
+	}
+	mirroredReview := getMirroredCairnlineReviewForTest(t, handler, projectID, "work_replacement", "artifact_replacement_review")
+	if mirroredReview.Verdict != projectwork.ReviewVerdictApproved || mirroredReview.Risk != projectwork.ReviewRiskLow {
+		t.Fatalf("mirrored review = %+v, want approved Cairnline-backed review without follow-up", mirroredReview)
+	}
+
+	handoff := mustRequestJSONStatus[ProjectHandoffEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/handoffs", projectJourneyJSON(t, map[string]any{
+		"id":                      "handoff_replacement_review",
+		"source_assignment_id":    "asgn_replacement",
+		"source_run_id":           ref.RunID,
+		"target_role_id":          "role_reviewer",
+		"title":                   "Replacement review handoff",
+		"summary":                 "Cairnline replacement journey evidence is ready.",
+		"recommended_next_action": "Review the recorded evidence and close the work item.",
+		"context_refs":            []string{ref.ContextSnapshotID},
+		"linked_artifact_ids":     []string{"artifact_replacement_evidence", "artifact_replacement_review"},
+		"created_by_role_id":      "role_replacement",
+		"provenance_kind":         "agent_draft",
+		"trust_label":             "operator_reviewed",
+	}))
+	if handoff.Data.Status != projectwork.HandoffStatusPending || handoff.Data.TargetRoleID != "role_reviewer" {
+		t.Fatalf("handoff = %+v, want pending review handoff response", handoff.Data)
+	}
+	mirroredHandoff := getMirroredCairnlineHandoffForTest(t, handler, projectID, "work_replacement", "handoff_replacement_review")
+	if mirroredHandoff.ToRoleID != "role_reviewer" || mirroredHandoff.Status != "open" {
+		t.Fatalf("mirrored handoff = %+v, want pending Cairnline-backed review handoff", mirroredHandoff)
+	}
+	accepted := mustRequestJSONStatus[ProjectHandoffEnvelope](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/handoffs/handoff_replacement_review/status", `{"status":"accepted"}`)
+	if accepted.Data.Status != projectwork.HandoffStatusAccepted {
+		t.Fatalf("accepted handoff = %+v, want accepted handoff response", accepted.Data)
+	}
+	mirroredHandoff = getMirroredCairnlineHandoffForTest(t, handler, projectID, "work_replacement", "handoff_replacement_review")
+	if mirroredHandoff.Status != projectwork.HandoffStatusAccepted {
+		t.Fatalf("mirrored accepted handoff = %+v, want accepted Cairnline-backed handoff", mirroredHandoff)
+	}
+
+	readiness := mustRequestJSONStatus[ProjectWorkItemReadinessEnvelope](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/readiness", "")
+	if !readiness.Data.Ready || readiness.Data.Status != "ready" || readiness.Data.ReadBackend != "cairnline" || readiness.Data.CompletedAssignments != 1 {
+		t.Fatalf("readiness = %+v, want Cairnline-backed ready closeout", readiness.Data)
+	}
+	closed := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement", projectJourneyJSON(t, map[string]any{
+		"status": projectwork.WorkItemStatusDone,
+	}))
+	if closed.Data.Status != projectwork.WorkItemStatusDone || closed.Data.ReadBackend != "cairnline" {
+		t.Fatalf("closed work item = %+v, want Cairnline-backed done status", closed.Data)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after closeout, want no native project identity row", ok, err)
+	}
+	if mirroredWork := getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_replacement"); mirroredWork.Status != projectwork.WorkItemStatusDone {
+		t.Fatalf("mirrored Cairnline work = %+v, want done", mirroredWork)
 	}
 }
 


### PR DESCRIPTION
## Summary

- use the Cairnline read model for the Cairnline-authoritative work-item closeout guard
- convert Cairnline closeout readiness back into the existing Hecate readiness error shape
- extend the replacement-mode journey through evidence, review, handoff acceptance, and closeout without creating a native project identity row

## Validation

- go test ./internal/api -run TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNativeProjectIdentity
- go test ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...

Docs unchanged: this aligns the closeout mutation with the existing Cairnline replacement-mode behavior documented for strict embedded reads.