### PR TITLE
fix(projects): route assistant apply through project authority

### DIFF
--- a/internal/api/handler_project_assistant_apply_authority.go
+++ b/internal/api/handler_project_assistant_apply_authority.go
@@ -44,6 +44,33 @@ func (h *Handler) projectAssistantMemoryCandidateAuthorityForApplication() proje
 	return projectAssistantMemoryCandidateAuthority{handler: h}
 }
 
+func (authority projectAssistantProjectAuthority) GetProject(ctx context.Context, projectID string) (projects.Project, bool, error) {
+	h := authority.handler
+	if h == nil {
+		return projects.Project{}, false, projectassistant.ErrStoreNotConfigured
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return projects.Project{}, false, nil
+	}
+	if h.requiresEmbeddedCairnlineProjectReads() {
+		view, err := h.cairnlineEmbeddedProjectWorkView(ctx, projectID)
+		if err != nil {
+			if errors.Is(err, projects.ErrNotFound) || errors.Is(err, cairnline.ErrNotFound) {
+				return projects.Project{}, false, nil
+			}
+			return projects.Project{}, false, projectAssistantApplyProjectError(err)
+		}
+		defer view.Close()
+		return view.snapshot.Project, true, nil
+	}
+	if h.projects == nil {
+		return projects.Project{}, false, projectassistant.ErrStoreNotConfigured
+	}
+	project, ok, err := h.projects.Get(ctx, projectID)
+	return project, ok, projectAssistantApplyProjectError(err)
+}
+
 func (authority projectAssistantProjectAuthority) CreateProject(ctx context.Context, project projects.Project) (projects.Project, error) {
 	h := authority.handler
 	if h == nil || h.projects == nil {

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -2998,6 +2998,91 @@ func TestProjectAssistantAPI_ApplyDoneReturnsCloseoutReadiness(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantAPI_ApplyDoneUsesCairnlineProjectAuthority(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Assistant Cairnline Closeout",
+	}))
+	projectID := project.Data.ID
+	if projectID == "" || project.Data.ReadBackend != "cairnline" {
+		t.Fatalf("project = %+v, want Cairnline project identity", project.Data)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after create, want no native project identity row", ok, err)
+	}
+
+	mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                  "role_assistant_closeout",
+		"name":                "Assistant closer",
+		"default_driver_kind": projectwork.AssignmentDriverHecateTask,
+	}))
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_assistant_cairnline_closeout",
+		"title":         "Assistant Cairnline closeout",
+		"brief":         "Mark a Cairnline-only work item done through Project Assistant apply.",
+		"status":        projectwork.WorkItemStatusReview,
+		"owner_role_id": "role_assistant_closeout",
+	}))
+	if work.Data.ReadBackend != "cairnline" {
+		t.Fatalf("work = %+v, want Cairnline-backed work item", work.Data)
+	}
+	mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_assistant_cairnline_closeout/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_assistant_cairnline_closeout",
+		"role_id":     "role_assistant_closeout",
+		"driver_kind": projectwork.AssignmentDriverHecateTask,
+		"status":      projectwork.AssignmentStatusCompleted,
+	}))
+	mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_assistant_cairnline_closeout/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                   "artifact_assistant_cairnline_evidence",
+		"assignment_id":        "asgn_assistant_cairnline_closeout",
+		"kind":                 projectwork.ArtifactKindEvidenceLink,
+		"title":                "Assistant Cairnline evidence",
+		"body":                 "The completed assignment has reviewable evidence.",
+		"author_role_id":       "role_assistant_closeout",
+		"evidence_url":         "https://example.invalid/hecate/assistant-cairnline-closeout",
+		"evidence_provider":    "operator",
+		"evidence_trust_label": projectwork.EvidenceTrustOperatorProvided,
+	}))
+	readiness := mustRequestJSONStatus[ProjectWorkItemReadinessEnvelope](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_assistant_cairnline_closeout/readiness", "")
+	if !readiness.Data.Ready || readiness.Data.ReadBackend != "cairnline" || readiness.Data.CompletedAssignments != 1 {
+		t.Fatalf("readiness = %+v, want Cairnline-backed ready closeout", readiness.Data)
+	}
+
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_assistant_cairnline_closeout",
+		Title:                "Mark Cairnline work done",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{{
+			Kind: projectassistant.ActionUpdateWorkItem,
+			Target: map[string]string{
+				"project_id":   projectID,
+				"work_item_id": "work_assistant_cairnline_closeout",
+			},
+			Patch: json.RawMessage(`{"status":"done"}`),
+		}},
+	}
+	applied := mustRequestJSONStatus[projectAssistantApplyResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposal,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 1 {
+		t.Fatalf("apply response = %+v, want applied closeout update", applied.Data)
+	}
+	closed := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_assistant_cairnline_closeout", "")
+	if closed.Data.Status != projectwork.WorkItemStatusDone || closed.Data.ReadBackend != "cairnline" {
+		t.Fatalf("closed work item = %+v, want Cairnline-backed done status", closed.Data)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after assistant closeout, want no native project identity row", ok, err)
+	}
+	if mirroredWork := getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_assistant_cairnline_closeout"); mirroredWork.Status != projectwork.WorkItemStatusDone {
+		t.Fatalf("mirrored Cairnline work = %+v, want done", mirroredWork)
+	}
+}
+
 func getMirroredCairnlineAssistantProposalForTest(t *testing.T, handler *Handler, proposalID string) cairnline.AssistantProposalRecord {
 	t.Helper()
 	service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())

--- a/internal/projectassistant/action_handlers.go
+++ b/internal/projectassistant/action_handlers.go
@@ -24,8 +24,8 @@ func (s *Service) applyCreateProject(ctx context.Context, action Action) (Action
 	id := strings.TrimSpace(patch.ID)
 	if id == "" {
 		id = s.idgen("proj")
-	} else if s.projects != nil {
-		_, ok, err := s.projects.Get(ctx, id)
+	} else {
+		_, ok, err := s.projectAuthority.GetProject(ctx, id)
 		if err != nil {
 			return ActionResult{}, err
 		}
@@ -464,14 +464,14 @@ func (s *Service) applyCreateMemoryCandidate(ctx context.Context, action Action)
 }
 
 func (s *Service) requireProject(ctx context.Context, projectID string) (projects.Project, error) {
-	if s.projects == nil {
+	if s.projectAuthority == nil {
 		return projects.Project{}, ErrStoreNotConfigured
 	}
 	projectID = strings.TrimSpace(projectID)
 	if projectID == "" {
 		return projects.Project{}, fmt.Errorf("%w: project_id is required", ErrInvalid)
 	}
-	project, ok, err := s.projects.Get(ctx, projectID)
+	project, ok, err := s.projectAuthority.GetProject(ctx, projectID)
 	if err != nil {
 		return projects.Project{}, err
 	}

--- a/internal/projectassistant/project_authority.go
+++ b/internal/projectassistant/project_authority.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ProjectAuthority interface {
+	GetProject(ctx context.Context, projectID string) (projects.Project, bool, error)
 	CreateProject(ctx context.Context, project projects.Project) (projects.Project, error)
 	UpdateProject(ctx context.Context, projectID string, cmd ProjectUpdateCommand) (projects.Project, error)
 	AttachProjectRoot(ctx context.Context, projectID string, root projects.Root) (projects.Project, error)
@@ -42,6 +43,10 @@ func projectAuthorityForStores(stores Stores) ProjectAuthority {
 
 type storeProjectAuthority struct {
 	store projects.Store
+}
+
+func (authority storeProjectAuthority) GetProject(ctx context.Context, projectID string) (projects.Project, bool, error) {
+	return authority.store.Get(ctx, projectID)
 }
 
 func (authority storeProjectAuthority) CreateProject(ctx context.Context, project projects.Project) (projects.Project, error) {

--- a/internal/projectassistant/proposal_apply_preflight.go
+++ b/internal/projectassistant/proposal_apply_preflight.go
@@ -48,7 +48,7 @@ func (p *applyPreflight) action(ctx context.Context, action Action) error {
 }
 
 func (p *applyPreflight) createProject(ctx context.Context, action Action) error {
-	if p.service.projects == nil {
+	if p.service.projectAuthority == nil {
 		return ErrStoreNotConfigured
 	}
 	var patch projectPatch
@@ -467,7 +467,7 @@ func (p *applyPreflight) createMemoryCandidate(ctx context.Context, action Actio
 }
 
 func (p *applyPreflight) requireProject(ctx context.Context, projectID string) (projects.Project, error) {
-	if p.service.projects == nil {
+	if p.service.projectAuthority == nil {
 		return projects.Project{}, ErrStoreNotConfigured
 	}
 	projectID = strings.TrimSpace(projectID)
@@ -477,7 +477,7 @@ func (p *applyPreflight) requireProject(ctx context.Context, projectID string) (
 	if project, ok := p.projects[projectID]; ok {
 		return project, nil
 	}
-	project, ok, err := p.service.projects.Get(ctx, projectID)
+	project, ok, err := p.service.projectAuthority.GetProject(ctx, projectID)
 	if err != nil {
 		return projects.Project{}, err
 	}
@@ -496,7 +496,10 @@ func (p *applyPreflight) projectExists(ctx context.Context, projectID string) (b
 	if _, ok := p.projects[projectID]; ok {
 		return true, nil
 	}
-	_, ok, err := p.service.projects.Get(ctx, projectID)
+	if p.service.projectAuthority == nil {
+		return false, ErrStoreNotConfigured
+	}
+	_, ok, err := p.service.projectAuthority.GetProject(ctx, projectID)
 	return ok, err
 }
 


### PR DESCRIPTION
## Summary
- route Project Assistant apply/preflight project reads through ProjectAuthority
- teach the Hecate Project Assistant authority to read embedded Cairnline project identity in strict embedded mode
- add a Cairnline replacement-mode regression for assistant proposal closeout without native project identity shadow

## Tests
- go test ./internal/projectassistant ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...