### PR TITLE
refactor(projects): drop assistant native project store field

### DIFF
--- a/internal/projectassistant/service.go
+++ b/internal/projectassistant/service.go
@@ -51,7 +51,6 @@ type IDGenerator func(prefix string) string
 
 type Service struct {
 	mu                       sync.Mutex
-	projects                 projects.Store
 	projectAuthority         ProjectAuthority
 	chats                    chat.Store
 	work                     projectwork.Store
@@ -191,7 +190,6 @@ func NewService(stores Stores, idgen IDGenerator) *Service {
 		proposals = NewMemoryProposalStore()
 	}
 	return &Service{
-		projects:                 stores.Projects,
 		projectAuthority:         projectAuthorityForStores(stores),
 		chats:                    stores.Chats,
 		work:                     stores.Work,


### PR DESCRIPTION
## Summary
- remove the retained native project store field from Project Assistant service state
- keep Projects as a constructor fallback for the project-authority seam only

## Tests
- go test ./internal/projectassistant ./internal/projectassistantapp ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...