### PR TITLE
fix(projects): apply assistant graphs from committed results

### DIFF
--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -129,6 +129,15 @@ func (s failingCreateRoleProjectWorkStore) CreateRole(context.Context, projectwo
 	return projectwork.AgentRoleProfile{}, s.err
 }
 
+type failingCreateWorkItemProjectWorkStore struct {
+	projectwork.Store
+	err error
+}
+
+func (s failingCreateWorkItemProjectWorkStore) CreateWorkItem(context.Context, projectwork.WorkItem) (projectwork.WorkItem, error) {
+	return projectwork.WorkItem{}, s.err
+}
+
 type failingUpdateProjectStore struct {
 	projects.Store
 	err error
@@ -1386,6 +1395,90 @@ func TestProjectAssistantAPI_CairnlineApplyWorkAuthorityDoesNotBlockOnRoleShadow
 		if role.ID == "role_apply_authority" {
 			t.Fatalf("shadow role store unexpectedly contains %+v, want Cairnline authority to survive failed Hecate shadow", role)
 		}
+	}
+}
+
+func TestProjectAssistantAPI_CairnlineApplyAssignmentGraphDoesNotDependOnWorkItemShadow(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	handler.SetProjectWorkStore(failingCreateWorkItemProjectWorkStore{
+		Store: projectwork.NewMemoryStore(),
+		err:   errors.New("shadow work item store unavailable"),
+	})
+	client := newAPITestClient(t, server)
+	root := t.TempDir()
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Assistant Cairnline Shadowless Graph",
+		"roots": []map[string]any{{
+			"id":     "root_shadowless_graph",
+			"path":   root,
+			"kind":   "git",
+			"active": true,
+		}},
+	}))
+	projectID := project.Data.ID
+	if projectID == "" || project.Data.ReadBackend != "cairnline" {
+		t.Fatalf("project = %+v, want Cairnline-backed project", project.Data)
+	}
+
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_shadowless_assignment_graph",
+		Title:                "Create graph without work item shadow",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{
+			{
+				Kind: projectassistant.ActionCreateRole,
+				Patch: json.RawMessage(`{
+					"id":"role_shadowless_graph",
+					"project_id":"` + projectID + `",
+					"name":"Shadowless owner",
+					"instructions":"Own the shadowless Cairnline graph.",
+					"default_driver_kind":"hecate_task"
+				}`),
+			},
+			{
+				Kind: projectassistant.ActionCreateWorkItem,
+				Patch: json.RawMessage(`{
+					"id":"work_shadowless_graph",
+					"project_id":"` + projectID + `",
+					"title":"Shadowless graph",
+					"brief":"Create the assignment graph even when Hecate work-item shadowing fails.",
+					"status":"ready",
+					"owner_role_id":"role_shadowless_graph"
+				}`),
+			},
+			{
+				Kind: projectassistant.ActionCreateAssignment,
+				Patch: json.RawMessage(`{
+					"id":"asgn_shadowless_graph",
+					"project_id":"` + projectID + `",
+					"work_item_id":"work_shadowless_graph",
+					"role_id":"role_shadowless_graph",
+					"root_id":"root_shadowless_graph",
+					"driver_kind":"hecate_task",
+					"status":"queued"
+				}`),
+			},
+		},
+	}
+	applied := mustRequestJSONStatus[projectAssistantApplyResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposal,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 3 || len(applied.Data.Actions) != 3 {
+		t.Fatalf("apply response = %+v, want applied role/work/assignment graph despite work-item shadow failure", applied.Data)
+	}
+	if _, ok, err := handler.projectWork.GetWorkItem(t.Context(), projectID, "work_shadowless_graph"); err != nil || ok {
+		t.Fatalf("Hecate shadow work item ok=%v err=%v, want absent shadow after injected failure", ok, err)
+	}
+	work := getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_shadowless_graph")
+	if work.Title != "Shadowless graph" || work.OwnerRoleID != "role_shadowless_graph" {
+		t.Fatalf("Cairnline work item = %+v, want authoritative assistant-created work item", work)
+	}
+	assignment := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_shadowless_graph")
+	if assignment.WorkItemID != "work_shadowless_graph" || assignment.RoleID != "role_shadowless_graph" || assignment.RootID != "root_shadowless_graph" {
+		t.Fatalf("Cairnline assignment = %+v, want assignment linked to authoritative work item", assignment)
 	}
 }
 

--- a/internal/projectassistant/action_handlers.go
+++ b/internal/projectassistant/action_handlers.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
-func (s *Service) applyCreateProject(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyCreateProject(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.projectAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -57,7 +57,7 @@ func (s *Service) applyCreateProject(ctx context.Context, action Action) (Action
 	return ActionResult{Kind: ActionCreateProject, ID: created.ID, Data: map[string]string{"project_id": created.ID}}, nil
 }
 
-func (s *Service) applyUpdateProject(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyUpdateProject(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.projectAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -82,7 +82,7 @@ func (s *Service) applyUpdateProject(ctx context.Context, action Action) (Action
 	return ActionResult{Kind: ActionUpdateProject, ID: updated.ID, Data: map[string]string{"project_id": updated.ID}}, nil
 }
 
-func (s *Service) applyAttachProjectRoot(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyAttachProjectRoot(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.projectAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -105,7 +105,7 @@ func (s *Service) applyAttachProjectRoot(ctx context.Context, action Action) (Ac
 	return ActionResult{Kind: ActionAttachProjectRoot, ID: root.ID, Data: map[string]string{"project_id": updated.ID, "root_id": root.ID}}, nil
 }
 
-func (s *Service) applyRemoveProjectRoot(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyRemoveProjectRoot(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.projectAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -128,7 +128,7 @@ func (s *Service) applyRemoveProjectRoot(ctx context.Context, action Action) (Ac
 	return ActionResult{Kind: ActionRemoveProjectRoot, ID: rootID, Data: map[string]string{"project_id": updated.ID, "root_id": rootID}}, nil
 }
 
-func (s *Service) applySetProjectDefaults(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applySetProjectDefaults(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.projectAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -163,7 +163,7 @@ func (s *Service) applySetProjectDefaults(ctx context.Context, action Action) (A
 	return ActionResult{Kind: ActionSetProjectDefaults, ID: updated.ID, Data: map[string]string{"project_id": updated.ID}}, nil
 }
 
-func (s *Service) applyMoveChatSession(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyMoveChatSession(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.chats == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -195,7 +195,7 @@ func (s *Service) applyMoveChatSession(ctx context.Context, action Action) (Acti
 	return ActionResult{Kind: ActionMoveChatSession, ID: updated.ID, Data: map[string]string{"chat_session_id": updated.ID, "project_id": updated.ProjectID}}, nil
 }
 
-func (s *Service) applyCreateRole(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyCreateRole(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -231,7 +231,7 @@ func (s *Service) applyCreateRole(ctx context.Context, action Action) (ActionRes
 	return ActionResult{Kind: ActionCreateRole, ID: role.ID, Data: map[string]string{"project_id": role.ProjectID, "role_id": role.ID}}, nil
 }
 
-func (s *Service) applyCreateWorkItem(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyCreateWorkItem(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -265,7 +265,7 @@ func (s *Service) applyCreateWorkItem(ctx context.Context, action Action) (Actio
 	return ActionResult{Kind: ActionCreateWorkItem, ID: item.ID, Data: map[string]string{"project_id": item.ProjectID, "work_item_id": item.ID}}, nil
 }
 
-func (s *Service) applyUpdateWorkItem(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyUpdateWorkItem(ctx context.Context, action Action, previous []ActionResult) (ActionResult, error) {
 	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -274,7 +274,7 @@ func (s *Service) applyUpdateWorkItem(ctx context.Context, action Action) (Actio
 	if projectID == "" || workItemID == "" {
 		return ActionResult{}, fmt.Errorf("%w: target.project_id and target.work_item_id are required", ErrInvalid)
 	}
-	if _, err := s.requireWorkItem(ctx, projectID, workItemID); err != nil {
+	if _, err := s.requireWorkItemForApply(ctx, projectID, workItemID, previous); err != nil {
 		return ActionResult{}, err
 	}
 	var patch updateWorkItemPatch
@@ -299,7 +299,7 @@ func (s *Service) applyUpdateWorkItem(ctx context.Context, action Action) (Actio
 	return ActionResult{Kind: ActionUpdateWorkItem, ID: item.ID, Data: map[string]string{"project_id": item.ProjectID, "work_item_id": item.ID}}, nil
 }
 
-func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyCreateAssignment(ctx context.Context, action Action, previous []ActionResult) (ActionResult, error) {
 	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -311,7 +311,7 @@ func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (Act
 	if projectID == "" {
 		projectID = targetValue(action, "project_id")
 	}
-	item, err := s.requireWorkItem(ctx, projectID, patch.WorkItemID)
+	item, err := s.requireWorkItemForApply(ctx, projectID, patch.WorkItemID, previous)
 	if err != nil {
 		return ActionResult{}, err
 	}
@@ -340,10 +340,10 @@ func (s *Service) applyCreateAssignment(ctx context.Context, action Action) (Act
 	if err != nil {
 		return ActionResult{}, mapProjectWorkErr(err)
 	}
-	return ActionResult{Kind: ActionCreateAssignment, ID: assignment.ID, Data: map[string]string{"project_id": assignment.ProjectID, "assignment_id": assignment.ID}}, nil
+	return ActionResult{Kind: ActionCreateAssignment, ID: assignment.ID, Data: map[string]string{"project_id": assignment.ProjectID, "work_item_id": assignment.WorkItemID, "assignment_id": assignment.ID}}, nil
 }
 
-func (s *Service) applyCreateHandoff(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyCreateHandoff(ctx context.Context, action Action, previous []ActionResult) (ActionResult, error) {
 	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -355,14 +355,16 @@ func (s *Service) applyCreateHandoff(ctx context.Context, action Action) (Action
 	if projectID == "" {
 		projectID = targetValue(action, "project_id")
 	}
-	if _, err := s.requireWorkItem(ctx, projectID, patch.WorkItemID); err != nil {
+	item, err := s.requireWorkItemForApply(ctx, projectID, patch.WorkItemID, previous)
+	if err != nil {
 		return ActionResult{}, err
 	}
+	projectID = item.ProjectID
 	id := strings.TrimSpace(patch.ID)
 	if id == "" {
 		id = s.idgen("handoff")
 	}
-	handoff, err := s.workAuthority.CreateHandoff(ctx, projectID, patch.WorkItemID, WorkHandoffCommand{
+	handoff, err := s.workAuthority.CreateHandoff(ctx, projectID, item.ID, WorkHandoffCommand{
 		ID:                    id,
 		SourceAssignmentID:    patch.SourceAssignmentID,
 		SourceRunID:           patch.SourceRunID,
@@ -385,10 +387,10 @@ func (s *Service) applyCreateHandoff(ctx context.Context, action Action) (Action
 	if err != nil {
 		return ActionResult{}, mapProjectWorkErr(err)
 	}
-	return ActionResult{Kind: ActionCreateHandoff, ID: handoff.ID, Data: map[string]string{"project_id": handoff.ProjectID, "handoff_id": handoff.ID}}, nil
+	return ActionResult{Kind: ActionCreateHandoff, ID: handoff.ID, Data: map[string]string{"project_id": handoff.ProjectID, "work_item_id": handoff.WorkItemID, "handoff_id": handoff.ID}}, nil
 }
 
-func (s *Service) applyUpdateHandoff(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyUpdateHandoff(ctx context.Context, action Action, previous []ActionResult) (ActionResult, error) {
 	if s.workAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -398,7 +400,7 @@ func (s *Service) applyUpdateHandoff(ctx context.Context, action Action) (Action
 	if projectID == "" || workItemID == "" || handoffID == "" {
 		return ActionResult{}, fmt.Errorf("%w: target.project_id, target.work_item_id, and target.handoff_id are required", ErrInvalid)
 	}
-	if _, err := s.requireWorkItem(ctx, projectID, workItemID); err != nil {
+	if _, err := s.requireWorkItemForApply(ctx, projectID, workItemID, previous); err != nil {
 		return ActionResult{}, err
 	}
 	var patch updateHandoffPatch
@@ -428,7 +430,7 @@ func (s *Service) applyUpdateHandoff(ctx context.Context, action Action) (Action
 	}, nil
 }
 
-func (s *Service) applyCreateMemoryCandidate(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyCreateMemoryCandidate(ctx context.Context, action Action, _ []ActionResult) (ActionResult, error) {
 	if s.memoryCandidateAuthority == nil {
 		return ActionResult{}, ErrStoreNotConfigured
 	}
@@ -479,6 +481,53 @@ func (s *Service) requireProject(ctx context.Context, projectID string) (project
 		return projects.Project{}, fmt.Errorf("%w: project %q", ErrNotFound, projectID)
 	}
 	return project, nil
+}
+
+func (s *Service) requireWorkItemForApply(ctx context.Context, projectID, workItemID string, previous []ActionResult) (projectwork.WorkItem, error) {
+	item, err := s.requireWorkItem(ctx, projectID, workItemID)
+	if err == nil {
+		return item, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return projectwork.WorkItem{}, err
+	}
+	if item, ok := workItemFromApplyResults(projectID, workItemID, previous); ok {
+		if _, projectErr := s.requireProject(ctx, item.ProjectID); projectErr != nil {
+			return projectwork.WorkItem{}, projectErr
+		}
+		return item, nil
+	}
+	return projectwork.WorkItem{}, err
+}
+
+func workItemFromApplyResults(projectID, workItemID string, previous []ActionResult) (projectwork.WorkItem, bool) {
+	projectID = strings.TrimSpace(projectID)
+	workItemID = strings.TrimSpace(workItemID)
+	if workItemID == "" {
+		return projectwork.WorkItem{}, false
+	}
+	for idx := len(previous) - 1; idx >= 0; idx-- {
+		result := previous[idx]
+		if result.Kind != ActionCreateWorkItem && result.Kind != ActionUpdateWorkItem {
+			continue
+		}
+		resultWorkItemID := strings.TrimSpace(result.Data["work_item_id"])
+		if resultWorkItemID == "" {
+			resultWorkItemID = strings.TrimSpace(result.ID)
+		}
+		resultProjectID := strings.TrimSpace(result.Data["project_id"])
+		if resultWorkItemID != workItemID || (projectID != "" && resultProjectID != projectID) {
+			continue
+		}
+		if resultProjectID == "" {
+			resultProjectID = projectID
+		}
+		if resultProjectID == "" {
+			return projectwork.WorkItem{}, false
+		}
+		return projectwork.WorkItem{ID: resultWorkItemID, ProjectID: resultProjectID}, true
+	}
+	return projectwork.WorkItem{}, false
 }
 
 func (s *Service) requireWorkItem(ctx context.Context, projectID, workItemID string) (projectwork.WorkItem, error) {

--- a/internal/projectassistant/proposal_apply.go
+++ b/internal/projectassistant/proposal_apply.go
@@ -45,7 +45,7 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 		return ApplyResult{}, fmt.Errorf("%w: proposal %q was already applied", ErrConflict, proposal.ID)
 	}
 	results := applyRecordResults(record)
-	if failedActionIndex, err := s.preflightApply(ctx, proposal.Actions, len(results)); err != nil {
+	if failedActionIndex, err := s.preflightApply(ctx, proposal.Actions, results); err != nil {
 		partial := applyResult(proposal.ID, ApplyStatusBlockedBeforeApply, false, len(proposal.Actions), &failedActionIndex, results)
 		if _, ledgerErr := s.proposals.RecordApplyAttempt(ctx, applyAttemptForResult(s.idgen("paatt"), confirmed, partial, err)); ledgerErr != nil {
 			err = fmt.Errorf("%v; record apply attempt: %w", err, ledgerErr)
@@ -60,7 +60,7 @@ func (s *Service) Apply(ctx context.Context, proposal Proposal, confirmed bool) 
 
 	for idx := len(results); idx < len(proposal.Actions); idx++ {
 		action := proposal.Actions[idx]
-		result, err := s.applyAction(ctx, action)
+		result, err := s.applyAction(ctx, action, results)
 		if err != nil {
 			partial := applyResult(proposal.ID, ApplyStatusPartialDueToRuntimeFailure, false, len(proposal.Actions), &idx, results)
 			if _, ledgerErr := s.proposals.RecordApplyAttempt(ctx, applyAttemptForResult(s.idgen("paatt"), confirmed, partial, err)); ledgerErr != nil {
@@ -120,7 +120,7 @@ func applyRecordResults(record ProposalRecord) []ActionResult {
 type applyActionSpec struct {
 	kind      string
 	preflight func(*applyPreflight, context.Context, Action) error
-	apply     func(*Service, context.Context, Action) (ActionResult, error)
+	apply     func(*Service, context.Context, Action, []ActionResult) (ActionResult, error)
 }
 
 // applyActionSpecs is the maintenance contract between preflight and durable
@@ -152,12 +152,12 @@ func lookupApplyActionSpec(kind string) (applyActionSpec, bool) {
 	return applyActionSpec{}, false
 }
 
-func (s *Service) applyAction(ctx context.Context, action Action) (ActionResult, error) {
+func (s *Service) applyAction(ctx context.Context, action Action, previous []ActionResult) (ActionResult, error) {
 	spec, ok := lookupApplyActionSpec(action.Kind)
 	if !ok {
 		return ActionResult{}, fmt.Errorf("%w: %s", ErrUnknownActionKind, action.Kind)
 	}
-	return spec.apply(s, ctx, action)
+	return spec.apply(s, ctx, action, previous)
 }
 
 func cloneActionResults(results []ActionResult) []ActionResult {

--- a/internal/projectassistant/proposal_apply_preflight.go
+++ b/internal/projectassistant/proposal_apply_preflight.go
@@ -21,7 +21,7 @@ type applyPreflight struct {
 	memoryCandidates map[string]memory.Candidate
 }
 
-func (s *Service) preflightApply(ctx context.Context, actions []Action, startIndex int) (int, error) {
+func (s *Service) preflightApply(ctx context.Context, actions []Action, committedResults []ActionResult) (int, error) {
 	preflight := &applyPreflight{
 		service:          s,
 		projects:         make(map[string]projects.Project),
@@ -31,6 +31,8 @@ func (s *Service) preflightApply(ctx context.Context, actions []Action, startInd
 		handoffs:         make(map[string]projectwork.Handoff),
 		memoryCandidates: make(map[string]memory.Candidate),
 	}
+	preflight.seedActionResults(committedResults)
+	startIndex := len(committedResults)
 	for idx := startIndex; idx < len(actions); idx++ {
 		if err := preflight.action(ctx, actions[idx]); err != nil {
 			return idx, err
@@ -45,6 +47,54 @@ func (p *applyPreflight) action(ctx context.Context, action Action) error {
 		return fmt.Errorf("%w: %s", ErrUnknownActionKind, action.Kind)
 	}
 	return spec.preflight(p, ctx, action)
+}
+
+func (p *applyPreflight) seedActionResults(results []ActionResult) {
+	for _, result := range results {
+		projectID := strings.TrimSpace(result.Data["project_id"])
+		switch result.Kind {
+		case ActionCreateWorkItem, ActionUpdateWorkItem:
+			workItemID := strings.TrimSpace(result.Data["work_item_id"])
+			if workItemID == "" {
+				workItemID = strings.TrimSpace(result.ID)
+			}
+			if projectID != "" && workItemID != "" {
+				p.workItems[scopedKey(projectID, workItemID)] = projectwork.WorkItem{ID: workItemID, ProjectID: projectID}
+			}
+		case ActionCreateAssignment:
+			assignmentID := strings.TrimSpace(result.Data["assignment_id"])
+			if assignmentID == "" {
+				assignmentID = strings.TrimSpace(result.ID)
+			}
+			if projectID != "" && assignmentID != "" {
+				p.assignments[scopedKey(projectID, assignmentID)] = projectwork.Assignment{
+					ID:         assignmentID,
+					ProjectID:  projectID,
+					WorkItemID: strings.TrimSpace(result.Data["work_item_id"]),
+				}
+			}
+		case ActionCreateHandoff, ActionUpdateHandoff:
+			handoffID := strings.TrimSpace(result.Data["handoff_id"])
+			if handoffID == "" {
+				handoffID = strings.TrimSpace(result.ID)
+			}
+			if projectID != "" && handoffID != "" {
+				p.handoffs[scopedKey(projectID, handoffID)] = projectwork.Handoff{
+					ID:         handoffID,
+					ProjectID:  projectID,
+					WorkItemID: strings.TrimSpace(result.Data["work_item_id"]),
+				}
+			}
+		case ActionCreateMemoryCandidate:
+			candidateID := strings.TrimSpace(result.Data["candidate_id"])
+			if candidateID == "" {
+				candidateID = strings.TrimSpace(result.ID)
+			}
+			if projectID != "" && candidateID != "" {
+				p.memoryCandidates[scopedKey(projectID, candidateID)] = memory.Candidate{ID: candidateID, ProjectID: projectID}
+			}
+		}
+	}
 }
 
 func (p *applyPreflight) createProject(ctx context.Context, action Action) error {

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -1955,6 +1955,55 @@ func TestService_ApplyLoopFailureReportsCommittedProgressAcrossStores(t *testing
 	}
 }
 
+func TestService_PreflightApplyUsesCommittedActionResults(t *testing.T) {
+	t.Parallel()
+	for _, builder := range assistantFixtureBuilders() {
+		t.Run(builder.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := builder.build(t)
+			project := createTestProject(t, ctx, fixture.projects)
+
+			actions := []Action{
+				{
+					Kind: ActionCreateWorkItem,
+					Patch: rawPatch(t, map[string]any{
+						"id":         "work_committed_only",
+						"project_id": project.ID,
+						"title":      "Committed outside compatibility store",
+					}),
+				},
+				{
+					Kind: ActionCreateAssignment,
+					Patch: rawPatch(t, map[string]any{
+						"id":           "asgn_committed_only",
+						"project_id":   project.ID,
+						"work_item_id": "work_committed_only",
+						"role_id":      "software_developer",
+						"root_id":      project.Roots[0].ID,
+						"driver_kind":  projectwork.AssignmentDriverHecateTask,
+					}),
+				},
+			}
+			committed := []ActionResult{{
+				Kind: ActionCreateWorkItem,
+				ID:   "work_committed_only",
+				Data: map[string]string{
+					"project_id":   project.ID,
+					"work_item_id": "work_committed_only",
+				},
+			}}
+
+			if idx, err := fixture.service.preflightApply(ctx, actions, committed); err != nil {
+				t.Fatalf("preflightApply failed at %d: %v", idx, err)
+			}
+			if _, ok, err := fixture.work.GetWorkItem(ctx, project.ID, "work_committed_only"); err != nil || ok {
+				t.Fatalf("compatibility work item ok=%v err=%v, want absent committed-result-only item", ok, err)
+			}
+		})
+	}
+}
+
 func TestService_ApplyRejectsNonQueuedAssignmentProposal(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- pass committed action results through Project Assistant durable apply
- seed apply preflight from committed results so retries do not depend on Hecate compatibility shadows
- cover Cairnline-authoritative assignment graph apply when the work-item shadow write fails

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/projectassistant ./internal/api -run 'TestService_PreflightApplyUsesCommittedActionResults|TestService_ApplyCreatesProjectWorkRecords|TestService_ApplyLoopFailureReportsCommittedProgressAcrossStores|TestProjectAssistantAPI_CairnlineApplyAssignmentGraphDoesNotDependOnWorkItemShadow|TestProjectAssistantAPI_ApplyCreatesAssignmentGraphWithCairnlineAuthority'\n- GOCACHE="$(pwd)/.gocache" go test ./internal/projectassistant ./internal/api\n- just go-format-check\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...