### PR TITLE
fix(projects): preserve identity uniqueness in Cairnline mode

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -32,6 +32,9 @@ and role/memory suggestions.
 When setup context exists and the project has no work items yet, first-work
 creation opens with a draft title, brief, and owner role for operator review.
 
+Project names and concrete root paths are unique in Hecate's operator cockpit,
+including Cairnline replacement-mode project identity.
+
 ## Work Flow
 
 For each work item:

--- a/internal/api/handler_project_metadata_authority.go
+++ b/internal/api/handler_project_metadata_authority.go
@@ -101,25 +101,60 @@ func applyProjectMetadataDefaultsUpdate(project *projects.Project, req updatePro
 }
 
 func (h *Handler) validateProjectMetadataDefaultsHecateCompatibility(ctx context.Context, project projects.Project) error {
-	if h == nil || h.projects == nil {
-		return nil
-	}
 	if strings.TrimSpace(project.Name) == "" {
 		return fmt.Errorf("%w: project name is required", projects.ErrInvalid)
 	}
-	items, err := h.projects.List(ctx)
+	if h != nil && h.projects != nil {
+		items, err := h.projects.List(ctx)
+		if err != nil {
+			return err
+		}
+		projectID := strings.TrimSpace(project.ID)
+		nameKey := strings.ToLower(strings.TrimSpace(project.Name))
+		for _, existing := range items {
+			if strings.TrimSpace(existing.ID) == projectID {
+				continue
+			}
+			if strings.ToLower(strings.TrimSpace(existing.Name)) == nameKey {
+				return fmt.Errorf("%w: project name %q already exists", projects.ErrAlreadyExists, project.Name)
+			}
+		}
+	}
+	return h.validateProjectNameCairnlineAuthorityCompatibility(ctx, project)
+}
+
+func (h *Handler) validateProjectNameCairnlineAuthorityCompatibility(ctx context.Context, project projects.Project) error {
+	name := strings.TrimSpace(project.Name)
+	if name == "" {
+		return fmt.Errorf("%w: project name is required", projects.ErrInvalid)
+	}
+	if h == nil || !h.projectCairnlineEmbeddedConnectorEnabled() {
+		return nil
+	}
+	projectID := strings.TrimSpace(project.ID)
+	nameKey := strings.ToLower(name)
+	var conflict string
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		items, err := service.ListProjects(ctx)
+		if err != nil {
+			return err
+		}
+		for _, existing := range items {
+			if strings.TrimSpace(existing.ID) == projectID {
+				continue
+			}
+			if strings.ToLower(strings.TrimSpace(existing.Name)) == nameKey {
+				conflict = existing.Name
+				return nil
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}
-	projectID := strings.TrimSpace(project.ID)
-	nameKey := strings.ToLower(strings.TrimSpace(project.Name))
-	for _, existing := range items {
-		if strings.TrimSpace(existing.ID) == projectID {
-			continue
-		}
-		if strings.ToLower(strings.TrimSpace(existing.Name)) == nameKey {
-			return fmt.Errorf("%w: project name %q already exists", projects.ErrAlreadyExists, project.Name)
-		}
+	if conflict != "" {
+		return fmt.Errorf("%w: project name %q already exists", projects.ErrAlreadyExists, name)
 	}
 	return nil
 }

--- a/internal/api/handler_project_root_source_authority.go
+++ b/internal/api/handler_project_root_source_authority.go
@@ -450,23 +450,56 @@ func (h *Handler) validateProjectRootsHecateCompatibility(ctx context.Context, p
 			return fmt.Errorf("%w: default_root_id %q does not match a project root", projects.ErrInvalid, project.DefaultRootID)
 		}
 	}
-	if h == nil || h.projects == nil || len(rootPathKeys) == 0 {
+	if h != nil && h.projects != nil && len(rootPathKeys) > 0 {
+		items, err := h.projects.List(ctx)
+		if err != nil {
+			return err
+		}
+		projectID := strings.TrimSpace(project.ID)
+		for _, existing := range items {
+			if strings.TrimSpace(existing.ID) == projectID {
+				continue
+			}
+			for _, root := range existing.Roots {
+				if path, ok := rootPathKeys[projectRootPathKeyForCairnlineAuthority(root.Path)]; ok {
+					return fmt.Errorf("%w: project root path %q already belongs to project %q", projects.ErrAlreadyExists, path, existing.ID)
+				}
+			}
+		}
+	}
+	return h.validateProjectRootPathsCairnlineAuthorityCompatibility(ctx, project, rootPathKeys)
+}
+
+func (h *Handler) validateProjectRootPathsCairnlineAuthorityCompatibility(ctx context.Context, project projects.Project, rootPathKeys map[string]string) error {
+	if len(rootPathKeys) == 0 || h == nil || !h.projectCairnlineEmbeddedConnectorEnabled() {
 		return nil
 	}
-	items, err := h.projects.List(ctx)
+	projectID := strings.TrimSpace(project.ID)
+	var conflictPath, conflictProjectID string
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		items, err := service.ListProjects(ctx)
+		if err != nil {
+			return err
+		}
+		for _, existing := range items {
+			if strings.TrimSpace(existing.ID) == projectID {
+				continue
+			}
+			for _, root := range existing.Roots {
+				if path, ok := rootPathKeys[projectRootPathKeyForCairnlineAuthority(root.Path)]; ok {
+					conflictPath = path
+					conflictProjectID = existing.ID
+					return nil
+				}
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}
-	projectID := strings.TrimSpace(project.ID)
-	for _, existing := range items {
-		if strings.TrimSpace(existing.ID) == projectID {
-			continue
-		}
-		for _, root := range existing.Roots {
-			if path, ok := rootPathKeys[projectRootPathKeyForCairnlineAuthority(root.Path)]; ok {
-				return fmt.Errorf("%w: project root path %q already belongs to project %q", projects.ErrAlreadyExists, path, existing.ID)
-			}
-		}
+	if conflictPath != "" {
+		return fmt.Errorf("%w: project root path %q already belongs to project %q", projects.ErrAlreadyExists, conflictPath, conflictProjectID)
 	}
 	return nil
 }

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -704,6 +705,50 @@ func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *tes
 	detail := getProjectForTest(t, server, created.Data.ID)
 	if detail.ID != created.Data.ID || detail.ReadBackend != "cairnline" || detail.Name != "Replacement Identity" {
 		t.Fatalf("project detail = %+v, want strict embedded Cairnline replacement identity", detail)
+	}
+}
+
+func TestProjectsAPI_CairnlineReplacementModeRejectsDuplicateNameAndRootPath(t *testing.T) {
+	t.Parallel()
+	_, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+
+	created := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", `{
+		"name":"Replacement Duplicate",
+		"roots":[{"id":"root_main","path":"/workspace/replacement-duplicate","kind":"git"}]
+	}`)
+
+	nameConflict := client.mustRequestStatus(http.StatusConflict, http.MethodPost, "/hecate/v1/projects", `{
+		"name":"Replacement Duplicate",
+		"roots":[{"id":"root_other","path":"/workspace/replacement-duplicate-other","kind":"git"}]
+	}`)
+	if !strings.Contains(nameConflict.Body.String(), "project name") {
+		t.Fatalf("duplicate name response = %s, want project name conflict", nameConflict.Body.String())
+	}
+
+	rootConflict := client.mustRequestStatus(http.StatusConflict, http.MethodPost, "/hecate/v1/projects", fmt.Sprintf(`{
+		"name":"Replacement Duplicate Root",
+		"roots":[{"id":"root_conflict","path":%q,"kind":"git"}]
+	}`, created.Data.Roots[0].Path))
+	if !strings.Contains(rootConflict.Body.String(), "project root path") {
+		t.Fatalf("duplicate root response = %s, want project root path conflict", rootConflict.Body.String())
+	}
+
+	other := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", `{
+		"name":"Replacement Unique",
+		"roots":[{"id":"root_unique","path":"/workspace/replacement-unique","kind":"git"}]
+	}`)
+	renameConflict := client.mustRequestStatus(http.StatusConflict, http.MethodPatch, "/hecate/v1/projects/"+other.Data.ID, `{
+		"name":"Replacement Duplicate"
+	}`)
+	if !strings.Contains(renameConflict.Body.String(), "project name") {
+		t.Fatalf("rename conflict response = %s, want project name conflict", renameConflict.Body.String())
+	}
+	updateRootConflict := client.mustRequestStatus(http.StatusConflict, http.MethodPatch, "/hecate/v1/projects/"+other.Data.ID, fmt.Sprintf(`{
+		"roots":[{"id":"root_unique","path":%q,"kind":"git"}]
+	}`, created.Data.Roots[0].Path))
+	if !strings.Contains(updateRootConflict.Body.String(), "project root path") {
+		t.Fatalf("update root conflict response = %s, want project root path conflict", updateRootConflict.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- check embedded Cairnline project identities for duplicate project names during Cairnline-authoritative create/update
- check embedded Cairnline roots for duplicate concrete root paths during Cairnline-authoritative create/update
- cover replacement-mode create and update conflicts for duplicate names and root paths
- document that Hecate keeps project names and root paths unique in the operator cockpit

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...

Note: one initial full race run hit a transient worktree setup failure in TestProjectRoots_CreateWorktreeRoot_CairnlineAuthorityCommitsRootRecordFirst; the test passed alone under -race, and the full race suite passed on rerun.
