### PR TITLE
fix(projects): start external assignments without task runtime

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -472,7 +472,9 @@ graph without a Hecate-native compatibility project row.
 Assignment create/update/delete
 routes mirror coordination metadata and lifecycle status after Hecate commits;
 assignment-start remains a Hecate-owned orchestrator capability because dispatch
-still carries runtime coupling, but successful start results and start-side
+still carries runtime coupling. Hecate Task starts require the task runtime,
+while External Agent starts prepare agent-chat adapter sessions and do not
+require the task runtime. Successful start results and start-side
 conflict/cleanup states are best-effort mirrored after Hecate commits them.
 Linked external-agent chat reconciliation also mirrors the
 committed assignment status/ref when Hecate updates the linked assignment from a

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -48,6 +48,9 @@ For each work item:
 
 Assignments keep their own execution records. Projects coordinate the work, but
 Tasks, Chats, and External Agents remain the execution surfaces.
+Starting a Hecate Task assignment requires the task runtime. Preparing an
+External Agent assignment uses the agent-chat adapter runtime and does not
+require the Hecate task runtime to be configured.
 
 The project header's **Needs Attention** menu is server-derived from
 `GET /hecate/v1/projects/{id}/health`. It surfaces compact setup and operations

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -794,14 +794,6 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
 	assignmentID := r.PathValue("assignment_id")
-	if h.taskStore == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
-		return
-	}
-	if h.taskRunner == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task runner is not configured")
-		return
-	}
 	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
 	if (!strictEmbeddedRead && h.projects == nil) || h.projectWork == nil {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
@@ -846,6 +838,14 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	}
 	if assignment.DriverKind != projectwork.AssignmentDriverHecateTask {
 		WriteError(w, http.StatusConflict, errCodeConflict, fmt.Sprintf("assignment driver_kind %q is not supported; V1 supports %q and %q", assignment.DriverKind, projectwork.AssignmentDriverHecateTask, projectwork.AssignmentDriverExternalAgent))
+		return
+	}
+	if h.taskStore == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task store is not configured")
+		return
+	}
+	if h.taskRunner == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "task runner is not configured")
 		return
 	}
 	active, err := projectWorkAssignmentHasActiveExecution(ctx, h.taskStore, assignment)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3774,6 +3774,10 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelLaunc
 	}, quietLogger(), nil, nil, nil, nil)
 	runner := &fakeAgentChatRunner{nativeSessionID: "native_embedded_external"}
 	handler.SetAgentChatRunner(runner)
+	// External Agent starts prepare chat sessions, so they should not require
+	// the native Hecate task runtime to be configured.
+	handler.taskStore = nil
+	handler.taskRunner = nil
 	server := NewServer(quietLogger(), handler)
 	const projectID = "proj_embedded_external_start"
 	workspace := t.TempDir()


### PR DESCRIPTION
## Summary
- move task runtime checks into the Hecate-task assignment start branch
- keep External Agent assignment start dependent on agent-chat adapter runtime only
- strengthen the strict embedded Cairnline external-agent launch regression with task runtime disabled
- document the task-vs-external-agent runtime boundary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_Start(ExternalAgentAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|AssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...