### PR TITLE
fix(projects): preflight Cairnline assignments without native stores

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -654,8 +654,9 @@ after these gates are met:
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative
   Cairnline launch-packet evidence, and strict embedded reads may use a
-  Cairnline-only project graph as the source of launch inputs, but
-  assignment-start remains a Hecate-owned orchestrator capability. Hecate
+  Cairnline-only project graph as the source of launch inputs. Launch-readiness
+  and preflight can use those inputs without native Hecate project/work stores,
+  but assignment-start remains a Hecate-owned orchestrator capability. Hecate
   creates only the narrow project-work/runtime shadow needed for claim and
   dispatch, not a native project identity row; committed start and linked-chat
   reconciliation results may be mirrored only as replacement evidence.

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -78,10 +78,6 @@ func (h *Handler) HandleProjectWorkAssignmentLaunchReadiness(w http.ResponseWrit
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
 	assignmentID := r.PathValue("assignment_id")
-	if h.projects == nil || h.projectWork == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
-		return
-	}
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		readiness, err := h.renderCairnlineSidecarProjectAssignmentLaunchReadiness(ctx, projectID, workItemID, assignmentID)
 		if err != nil {
@@ -98,6 +94,10 @@ func (h *Handler) HandleProjectWorkAssignmentLaunchReadiness(w http.ResponseWrit
 			return
 		}
 		WriteJSON(w, http.StatusOK, ProjectAssignmentLaunchReadinessEnvelope{Object: "project_assignment_launch_readiness", Data: readiness})
+		return
+	}
+	if h.projects == nil || h.projectWork == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
 		return
 	}
 	project, ok, err := h.projects.Get(ctx, projectID)
@@ -146,10 +146,6 @@ func (h *Handler) HandleProjectWorkAssignmentPreflight(w http.ResponseWriter, r 
 	projectID := r.PathValue("id")
 	workItemID := r.PathValue("work_item_id")
 	assignmentID := r.PathValue("assignment_id")
-	if h.projects == nil || h.projectWork == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
-		return
-	}
 	if h.projectCairnlineSidecarReadRoutesEnabled() {
 		inputs, err := h.cairnlineSidecarProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
 		if err != nil {
@@ -194,6 +190,10 @@ func (h *Handler) HandleProjectWorkAssignmentPreflight(w http.ResponseWriter, r 
 			return
 		}
 		writeChatContextPacket(w, contextPacket)
+		return
+	}
+	if h.projects == nil || h.projectWork == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
 		return
 	}
 	project, ok, err := h.projects.Get(ctx, projectID)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3579,6 +3579,10 @@ func TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHe
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	// Strict embedded launch-readiness and preflight are read-only Cairnline
+	// projections; they should not require native Hecate project/work stores.
+	handler.projects = nil
+	handler.projectWork = nil
 
 	client := newAPITestClient(t, server)
 	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_launch_preflight/assignments/asgn_embedded_launch_preflight/launch-readiness", "")


### PR DESCRIPTION
## Summary
- let launch-readiness and assignment preflight enter Cairnline read branches before requiring native project/work stores
- strengthen the strict embedded launch-readiness/preflight regression by disabling native project/work stores
- update the Projects design record to state this replacement boundary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHecateProject
- just go-format-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...