### PR TITLE
fix(projects): apply assistant project authority without native store

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -384,7 +384,11 @@ Cairnline first, then best-effort shadow Hecate's proposal store for
 compatibility. Confirmed apply uses the enabled Cairnline authority seams for
 project create, project metadata/default, root, role, work-item, assignment,
 handoff, and memory-candidate actions, but chat/runtime effects remain
-Hecate-owned orchestrator capabilities outside Cairnline core.
+Hecate-owned orchestrator capabilities outside Cairnline core. In strict
+embedded mode, the Project Assistant project authority can create project
+identity and mutate portable project metadata, defaults, and roots from the
+embedded Cairnline graph without requiring a Hecate-native compatibility
+project store.
 Assignment-start is still a Hecate-native dispatch mutation, committed
 assignment-start results and cleanup/conflict states are best-effort mirrored
 for replacement evidence, and other live Projects reads/writes still use the
@@ -648,8 +652,10 @@ after these gates are met:
   Cairnline-authoritative with the `project-assistant-proposals` switchpoint.
   Confirmed apply may use enabled project create, project metadata/default, root,
   role/work-item/assignment/handoff, and memory-candidate Cairnline-authority
-  seams, but chat/runtime effects remain Hecate-owned orchestrator capabilities
-  outside Cairnline core. Assignment runtime effects live in Hecate's project
+  seams, including project identity/metadata/default/root actions against a
+  Cairnline-only project graph in strict embedded mode, but chat/runtime
+  effects remain Hecate-owned orchestrator capabilities outside Cairnline core.
+  Assignment runtime effects live in Hecate's project
   assignment runtime overlay and are mirrored as
   non-authoritative Cairnline replacement evidence. Assignment preflight/start
   packets may carry non-authoritative

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -596,8 +596,10 @@ sequenceDiagram
   store for compatibility. Confirmed Project Assistant apply uses enabled
   project create, project metadata/default, root,
   role/work-item/assignment/handoff, and memory-candidate authority seams and
-  leaves remaining chat/runtime effects as Hecate-owned orchestrator
-  capabilities outside Cairnline core.
+  can use a Cairnline-only project graph for project
+  identity/metadata/default/root actions in strict embedded mode. Remaining
+  chat/runtime effects stay Hecate-owned orchestrator capabilities outside
+  Cairnline core.
   `project-roots` makes project root create/update/delete plus root list
   replacement plus discovery-result replacement and worktree-created root
   record mutations Cairnline-first, then shadows Hecate's compatibility project
@@ -6573,7 +6575,10 @@ while proposal ledger writes remain Hecate-owned unless
 enabled. Confirmed apply uses enabled project create, project metadata/default,
 root, role/work-item/assignment/handoff, and memory-candidate
 Cairnline-authority seams and leaves remaining chat/runtime effects as
-Hecate-owned orchestrator capabilities outside Cairnline core.
+Hecate-owned orchestrator capabilities outside Cairnline core. In strict
+embedded mode, confirmed apply can create project identity and update portable
+project metadata, defaults, and roots from the embedded Cairnline graph without
+requiring a Hecate-native compatibility project store.
 `GET /hecate/v1/project-assistant/proposals/{id}` uses the same configured
 Cairnline read source as the other read routes; strict embedded mode reads the
 proposal record from the embedded mirror instead of falling back to the native

--- a/internal/api/handler_project_assistant_apply_authority.go
+++ b/internal/api/handler_project_assistant_apply_authority.go
@@ -73,12 +73,15 @@ func (authority projectAssistantProjectAuthority) GetProject(ctx context.Context
 
 func (authority projectAssistantProjectAuthority) CreateProject(ctx context.Context, project projects.Project) (projects.Project, error) {
 	h := authority.handler
-	if h == nil || h.projects == nil {
+	if h == nil {
 		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	if h.projectIdentityWritesUseCairnlineAuthority() {
 		created, err := h.createProjectWithCairnlineAuthority(ctx, project)
 		return created, projectAssistantApplyProjectError(err)
+	}
+	if h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	created, err := h.projects.Create(ctx, project)
 	return created, projectAssistantApplyProjectError(err)
@@ -86,13 +89,16 @@ func (authority projectAssistantProjectAuthority) CreateProject(ctx context.Cont
 
 func (authority projectAssistantProjectAuthority) UpdateProject(ctx context.Context, projectID string, cmd projectassistant.ProjectUpdateCommand) (projects.Project, error) {
 	h := authority.handler
-	if h == nil || h.projects == nil {
+	if h == nil {
 		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	req := updateProjectRequest{Name: cmd.Name, Description: cmd.Description}
 	if h.projectMetadataDefaultsWritesUseCairnlineAuthority() && projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req) {
 		updated, err := h.updateProjectMetadataDefaultsWithCairnlineAuthority(ctx, projectID, req)
 		return updated, projectAssistantApplyProjectError(err)
+	}
+	if h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
 		if cmd.Name != nil {
@@ -107,12 +113,15 @@ func (authority projectAssistantProjectAuthority) UpdateProject(ctx context.Cont
 
 func (authority projectAssistantProjectAuthority) AttachProjectRoot(ctx context.Context, projectID string, root projects.Root) (projects.Project, error) {
 	h := authority.handler
-	if h == nil || h.projects == nil {
+	if h == nil {
 		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	if h.projectRootWritesUseCairnlineAuthority() {
 		updated, _, err := h.createProjectRootWithCairnlineAuthority(ctx, projectID, root)
 		return updated, projectAssistantApplyProjectError(err)
+	}
+	if h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
 		project.Roots = append(project.Roots, root)
@@ -122,12 +131,15 @@ func (authority projectAssistantProjectAuthority) AttachProjectRoot(ctx context.
 
 func (authority projectAssistantProjectAuthority) RemoveProjectRoot(ctx context.Context, projectID, rootID string) (projects.Project, error) {
 	h := authority.handler
-	if h == nil || h.projects == nil {
+	if h == nil {
 		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	if h.projectRootWritesUseCairnlineAuthority() {
 		updated, _, err := h.deleteProjectRootWithCairnlineAuthority(ctx, projectID, rootID)
 		return updated, projectAssistantApplyProjectError(err)
+	}
+	if h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
 		roots := project.Roots[:0]
@@ -146,7 +158,7 @@ func (authority projectAssistantProjectAuthority) RemoveProjectRoot(ctx context.
 
 func (authority projectAssistantProjectAuthority) SetProjectDefaults(ctx context.Context, projectID string, cmd projectassistant.ProjectDefaultsCommand) (projects.Project, error) {
 	h := authority.handler
-	if h == nil || h.projects == nil {
+	if h == nil {
 		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	req := updateProjectRequest{
@@ -162,6 +174,9 @@ func (authority projectAssistantProjectAuthority) SetProjectDefaults(ctx context
 	if h.projectMetadataDefaultsWritesUseCairnlineAuthority() && projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req) {
 		updated, err := h.updateProjectMetadataDefaultsWithCairnlineAuthority(ctx, projectID, req)
 		return updated, projectAssistantApplyProjectError(err)
+	}
+	if h.projects == nil {
+		return projects.Project{}, projectassistant.ErrStoreNotConfigured
 	}
 	updated, err := h.projects.Update(ctx, projectID, func(project *projects.Project) {
 		if cmd.DefaultRootID != nil {

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -1773,6 +1773,133 @@ func TestProjectAssistantAPI_CairnlineApplyProjectRootAuthorityDoesNotBlockOnSha
 	}
 }
 
+func TestProjectAssistantAPI_CairnlineApplyProjectIdentityAuthorityDoesNotRequireHecateProjectStore(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineReadSource = "embedded"
+	handler.config.Projects.CairnlineWriteAuthority = projectCairnlineWriteAuthorityProjectIdentity
+	handler.projects = nil
+	client := newAPITestClient(t, server)
+
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_apply_project_identity_cairnline_only",
+		Title:                "Create Cairnline-only project",
+		Summary:              "Project Assistant apply should use Cairnline identity authority without a native project store.",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{{
+			Kind: projectassistant.ActionCreateProject,
+			Patch: json.RawMessage(`{
+				"id":"proj_pa_apply_project_identity_cairnline_only",
+				"name":"Assistant Cairnline-only Identity",
+				"description":"Cairnline owns this project identity.",
+				"roots":[{"id":"root_main","path":"/workspace/cairnline-only","kind":"git","active":true}],
+				"default_provider":"anthropic",
+				"default_model":"claude-sonnet-4-5"
+			}`),
+		}},
+	}
+	applied := mustRequestJSONStatus[projectAssistantApplyResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposal,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 1 {
+		t.Fatalf("apply response = %+v, want applied project create without native project store", applied.Data)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, "proj_pa_apply_project_identity_cairnline_only")
+	if mirrored.Name != "Assistant Cairnline-only Identity" || mirrored.Description != "Cairnline owns this project identity." || mirrored.DefaultRootID != "root_main" {
+		t.Fatalf("Cairnline project = %+v, want authoritative project identity", mirrored)
+	}
+	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" || mirrored.Roots[0].Path != "/workspace/cairnline-only" {
+		t.Fatalf("Cairnline roots = %+v, want root_main", mirrored.Roots)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "anthropic", "claude-sonnet-4-5")
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/proj_pa_apply_project_identity_cairnline_only", "")
+	if project.Data.ReadBackend != "cairnline" || project.Data.ID != mirrored.ID {
+		t.Fatalf("project response = %+v, want strict embedded Cairnline project", project.Data)
+	}
+}
+
+func TestProjectAssistantAPI_CairnlineApplyProjectMetadataRootAuthorityDoesNotRequireHecateProjectStore(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineReadSource = "embedded"
+	handler.config.Projects.CairnlineWriteAuthority = strings.Join([]string{
+		projectCairnlineWriteAuthorityProjectMetadataDefaults,
+		projectCairnlineWriteAuthorityProjectRoots,
+	}, ",")
+	const projectID = "proj_pa_apply_project_cairnline_only"
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		_, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:            projectID,
+			Name:          "Assistant Cairnline-only Project",
+			Description:   "Project Assistant mutates this through Cairnline only.",
+			DefaultRootID: "root_main",
+			Roots: []cairnline.Root{{
+				ID:     "root_main",
+				Path:   "/workspace/main",
+				Kind:   "git",
+				Active: true,
+			}},
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed Cairnline-only project: %v", err)
+	}
+	handler.projects = nil
+	client := newAPITestClient(t, server)
+
+	proposal := projectassistant.Proposal{
+		ID:                   "pa_apply_project_cairnline_only",
+		Title:                "Update Cairnline-only project",
+		Summary:              "Project Assistant apply should mutate project metadata, roots, and defaults without a native project store.",
+		RequiresConfirmation: true,
+		Actions: []projectassistant.Action{
+			{
+				Kind:   projectassistant.ActionUpdateProject,
+				Target: map[string]string{"project_id": projectID},
+				Patch:  json.RawMessage(`{"name":"Assistant Cairnline-only Project Updated","description":"Updated through Cairnline authority."}`),
+			},
+			{
+				Kind:   projectassistant.ActionAttachProjectRoot,
+				Target: map[string]string{"project_id": projectID},
+				Patch:  json.RawMessage(`{"id":"root_attached","path":"/workspace/attached","kind":"git_worktree","active":true}`),
+			},
+			{
+				Kind:   projectassistant.ActionSetProjectDefaults,
+				Target: map[string]string{"project_id": projectID},
+				Patch:  json.RawMessage(`{"default_root_id":"root_attached","default_provider":"anthropic","default_model":"claude-sonnet-4-5"}`),
+			},
+			{
+				Kind:   projectassistant.ActionRemoveProjectRoot,
+				Target: map[string]string{"project_id": projectID, "root_id": "root_main"},
+			},
+		},
+	}
+	applied := mustRequestJSONStatus[projectAssistantApplyResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposal,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 4 {
+		t.Fatalf("apply response = %+v, want applied project mutations without native project store", applied.Data)
+	}
+
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, projectID)
+	if mirrored.Name != "Assistant Cairnline-only Project Updated" || mirrored.Description != "Updated through Cairnline authority." || mirrored.DefaultRootID != "root_attached" {
+		t.Fatalf("Cairnline project = %+v, want updated metadata/default root", mirrored)
+	}
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_attached") == nil || findMirroredCairnlineRootForTest(mirrored.Roots, "root_main") != nil {
+		t.Fatalf("Cairnline roots = %+v, want attached root only", mirrored.Roots)
+	}
+	assertMirroredExecutionProfileForTest(t, handler, mirrored.DefaultExecutionProfileID, "anthropic", "claude-sonnet-4-5")
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID, "")
+	if project.Data.ReadBackend != "cairnline" || project.Data.DefaultRootID != "root_attached" || len(project.Data.Roots) != 1 || project.Data.Roots[0].ID != "root_attached" {
+		t.Fatalf("project response = %+v, want strict embedded Cairnline project with attached root", project.Data)
+	}
+}
+
 func TestProjectAssistantAPI_ProposalRouteUsesStrictEmbeddedReadSource(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)


### PR DESCRIPTION
## Summary
- route Project Assistant project identity, metadata/default, and root apply actions through Cairnline authority before requiring the native project store
- add strict embedded regression coverage for assistant apply against Cairnline-only project graphs
- document the Cairnline-only Project Assistant apply behavior in design and runtime docs

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_CairnlineApplyProject(IdentityAuthorityDoesNotRequireHecateProjectStore|MetadataRootAuthorityDoesNotRequireHecateProjectStore|IdentityAuthorityDoesNotBlockOnShadowFailure|MetadataAuthorityDoesNotBlockOnShadowFailure|RootAuthorityDoesNotBlockOnShadowFailure)'\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- just go-format-check\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n- GOCACHE="$(pwd)/.gocache" go vet ./internal/api