### PR TITLE
fix(projects): preserve Cairnline assignment runtime without native stores

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -68,7 +68,10 @@ context-source discovery, project skills, roles, work items, assignments,
 collaboration artifacts, handoffs, accepted memory, and memory candidates can
 operate from embedded Cairnline project graphs without a matching Hecate-native
 compatibility project row; keep any Hecate shadow writes best-effort and do not
-add native `requireProject*` guards ahead of those authority paths. Do not describe
+add native `requireProject*` guards ahead of those authority paths. Assignment
+runtime refs/context/timestamps belong in Hecate's separate runtime overlay, so
+do not make runtime preservation depend on a native compatibility assignment row.
+Do not describe
 `internal/cairnlinebridge` as only a future proof; it maps Hecate Projects to
 Cairnline snapshots and backs the current embedded/sidecar replacement probes.
 Project-linked Hecate Chat prelude/context helpers also use the configured

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -610,8 +610,9 @@ project identity, roots, work items, roles, and assignment dependencies from
 the embedded Cairnline graph when present, so dogfood writes no longer require
 a matching Hecate-native compatibility project row before the Cairnline commit.
 Hecate stores task/chat execution refs, context packets, and launch timestamps
-in a separate project assignment runtime overlay before shadowing compatibility
-fields or mirroring replacement evidence. The `project-collaboration` switch
+in a separate project assignment runtime overlay even when there is no native
+compatibility assignment row, before shadowing compatibility fields or mirroring
+replacement evidence. The `project-collaboration` switch
 can make the collaboration and handoff route family Cairnline-authoritative as
 opt-in dogfood switchpoints; dependency checks accept existing Cairnline records
 before falling back to Hecate shadows. `project-memory` and

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -579,11 +579,13 @@ sequenceDiagram
   `backlog` default and closeout-readiness gate before shadowing the resulting
   work item back into Hecate-native project-work stores. `project-assignments`
   makes assignment create/update/delete record mutations Cairnline-first, then
-  shadows portable assignment state back into Hecate-native project-work stores
-  for compatibility. Assignment start/dispatch remains Hecate-owned and writes
-  task/chat execution refs, context packets, and launch timestamps to Hecate's
-  project assignment runtime overlay before any compatibility shadow or
-  replacement-evidence mirror. `agent-profiles`
+  best-effort shadows portable assignment state back into Hecate-native
+  project-work stores for compatibility when that store is configured.
+  Assignment execution refs, context packets, and launch timestamps are
+  preserved in Hecate's separate project assignment runtime overlay even when no
+  native compatibility assignment row exists. Assignment start/dispatch remains
+  Hecate-owned and writes that runtime overlay before any compatibility shadow
+  or replacement-evidence mirror. `agent-profiles`
   makes global agent-profile
   create/update/delete Cairnline-first, writing Cairnline's separate portable
   profile and execution-posture records before shadowing Hecate's combined
@@ -2433,6 +2435,10 @@ create default and closeout-readiness gate. In these opt-in authority modes,
 portable project-work write routes can validate project identity and roots from
 the embedded Cairnline project graph, so they no longer require a matching
 Hecate-native compatibility project row before reaching Cairnline authority.
+Adding `project-assignments` makes assignment create/update/delete mutations
+Cairnline-first; Hecate keeps task/chat execution refs, context packets, and
+launch timestamps in the separate project assignment runtime overlay even when
+there is no native compatibility assignment row to shadow.
 When `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` is set, those authority
 helpers prefer the embedded Cairnline project graph over any Hecate-native
 compatibility shadow so stale shadows cannot override authoritative project/root

--- a/internal/api/handler_project_assignment_authority.go
+++ b/internal/api/handler_project_assignment_authority.go
@@ -79,10 +79,17 @@ func (h *Handler) updateProjectWorkAssignmentWithCairnlineAuthority(ctx context.
 			return cairnline.ErrNotFound
 		}
 		assignment := projectWorkAssignmentFromCairnline(existing)
-		if shadow, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID); err != nil {
+		if h != nil && h.projectWork != nil {
+			if shadow, ok, err := h.loadProjectWorkAssignment(ctx, projectID, workItemID, assignmentID); err != nil {
+				return err
+			} else if ok {
+				overlayProjectAssignmentRuntimeShadow(&assignment, shadow)
+			}
+		}
+		if overlaid, err := h.projectWorkApplication().ApplyAssignmentRuntime(ctx, assignment); err != nil {
 			return err
-		} else if ok {
-			overlayProjectAssignmentRuntimeShadow(&assignment, shadow)
+		} else {
+			assignment = overlaid
 		}
 		applyProjectAssignmentUpdate(&assignment, cmd)
 		if err := validateProjectAssignmentForCairnlineAuthority(assignment); err != nil {
@@ -163,17 +170,19 @@ func (h *Handler) projectWorkItemForCairnlineAssignmentAuthority(ctx context.Con
 }
 
 func (h *Handler) projectRoleForCairnlineAssignmentAuthority(ctx context.Context, service *cairnline.Service, projectID, roleID string) (projectwork.AgentRoleProfile, agentprofiles.Profile, error) {
-	if role, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, projectID, roleID); err != nil {
-		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
-	} else if ok {
-		profile, err := h.writeRoleAgentProfileToCairnline(ctx, service, role)
-		if err != nil {
+	if h != nil && h.projectWork != nil {
+		if role, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, projectID, roleID); err != nil {
 			return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+		} else if ok {
+			profile, err := h.writeRoleAgentProfileToCairnline(ctx, service, role)
+			if err != nil {
+				return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+			}
+			if _, err := cairnlinebridge.UpsertRole(ctx, service, role); err != nil {
+				return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+			}
+			return role, profile, nil
 		}
-		if _, err := cairnlinebridge.UpsertRole(ctx, service, role); err != nil {
-			return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
-		}
-		return role, profile, nil
 	}
 	role, err := getCairnlineProjectRoleForAuthority(ctx, service, projectID, roleID)
 	if err != nil {
@@ -273,7 +282,11 @@ func projectAssignmentExecutionRefEmpty(ref projectwork.AssignmentExecutionRef) 
 }
 
 func (h *Handler) shadowProjectAssignmentToHecate(ctx context.Context, operation string, assignment projectwork.Assignment) {
-	if h == nil || h.projectWork == nil {
+	if h == nil {
+		return
+	}
+	if h.projectWork == nil {
+		h.shadowProjectAssignmentRuntimeToHecate(ctx, operation, assignment)
 		return
 	}
 	if _, err := h.projectWork.CreateAssignment(ctx, assignment); err == nil {
@@ -302,17 +315,20 @@ func (h *Handler) shadowProjectAssignmentToHecate(ctx context.Context, operation
 }
 
 func (h *Handler) shadowProjectAssignmentDeleteToHecate(ctx context.Context, operation, projectID, workItemID, assignmentID string) {
-	if h == nil || h.projectWork == nil {
+	if h == nil {
 		return
-	}
-	if err := h.projectWork.DeleteAssignment(ctx, projectID, workItemID, assignmentID); err != nil && !errors.Is(err, projectwork.ErrNotFound) {
-		h.logCairnlineMirrorError(ctx, operation, projectID, err)
 	}
 	if h.projectRuntime != nil {
 		err := h.projectRuntime.Delete(ctx, projectID, assignmentID)
 		if err != nil && !errors.Is(err, projectruntime.ErrNotFound) {
 			h.logCairnlineMirrorError(ctx, operation, projectID, err)
 		}
+	}
+	if h.projectWork == nil {
+		return
+	}
+	if err := h.projectWork.DeleteAssignment(ctx, projectID, workItemID, assignmentID); err != nil && !errors.Is(err, projectwork.ErrNotFound) {
+		h.logCairnlineMirrorError(ctx, operation, projectID, err)
 	}
 }
 

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -164,8 +164,10 @@ func seedCairnlineOnlyProjectWorkGraphForTest(t *testing.T, handler *Handler, pr
 	}); err != nil {
 		t.Fatalf("seed Cairnline-only project graph: %v", err)
 	}
-	if _, ok, err := handler.projects.Get(t.Context(), project.ID); err != nil || ok {
-		t.Fatalf("native project exists = %t err=%v, want missing native project", ok, err)
+	if handler.projects != nil {
+		if _, ok, err := handler.projects.Get(t.Context(), project.ID); err != nil || ok {
+			t.Fatalf("native project exists = %t err=%v, want missing native project", ok, err)
+		}
 	}
 }
 
@@ -1329,6 +1331,8 @@ func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineOnlyProject(t *test
 		ID:   projectID,
 		Name: "Role authority Cairnline only",
 	}, nil, nil, nil)
+	handler.projects = nil
+	handler.projectWork = nil
 
 	created := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
 		"id":                  "role_cairnline_only",
@@ -1343,8 +1347,8 @@ func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineOnlyProject(t *test
 	if mirroredRole.Name != "Cairnline-only reviewer" || mirroredRole.DefaultExecutionMode != cairnline.ExecutionExternalAdapter {
 		t.Fatalf("mirrored role = %+v, want Cairnline-authoritative role", mirroredRole)
 	}
-	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
-		t.Fatalf("native project exists after role create = %t err=%v, want missing native project", ok, err)
+	if handler.projects != nil || handler.projectWork != nil {
+		t.Fatal("native project/work stores were unexpectedly configured")
 	}
 
 	updated := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/roles/role_cairnline_only", projectJourneyJSON(t, map[string]any{
@@ -1380,6 +1384,8 @@ func TestProjectWorkAPI_CairnlineWorkItemAuthorityWritesCairnlineOnlyProject(t *
 		ProjectID: projectID,
 		Name:      "Cairnline-only owner",
 	}}, nil, nil)
+	handler.projects = nil
+	handler.projectWork = nil
 
 	created := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
 		"id":            "work_cairnline_only",
@@ -1394,8 +1400,8 @@ func TestProjectWorkAPI_CairnlineWorkItemAuthorityWritesCairnlineOnlyProject(t *
 	if mirroredWork.Title != "Create work from Cairnline-only project" || mirroredWork.RootID != "root_cairnline_only" {
 		t.Fatalf("mirrored work item = %+v, want Cairnline-authoritative work item", mirroredWork)
 	}
-	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
-		t.Fatalf("native project exists after work item create = %t err=%v, want missing native project", ok, err)
+	if handler.projects != nil || handler.projectWork != nil {
+		t.Fatal("native project/work stores were unexpectedly configured")
 	}
 
 	updated := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_cairnline_only", projectJourneyJSON(t, map[string]any{
@@ -1406,9 +1412,6 @@ func TestProjectWorkAPI_CairnlineWorkItemAuthorityWritesCairnlineOnlyProject(t *
 		t.Fatalf("updated work response = %+v, want edited Cairnline-only work item", updated.Data)
 	}
 	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_cairnline_only", "")
-	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
-		t.Fatalf("native project exists after work delete = %t err=%v, want missing native project", ok, err)
-	}
 }
 
 func TestProjectWorkAPI_CairnlineWorkItemAuthorityStrictEmbeddedUsesCairnlineProjectOverStaleNative(t *testing.T) {
@@ -1498,6 +1501,8 @@ func TestProjectWorkAPI_CairnlineAssignmentAuthorityWritesCairnlineOnlyProject(t
 		Priority:  cairnline.PriorityNormal,
 		RootID:    "root_cairnline_only",
 	}}, nil)
+	handler.projects = nil
+	handler.projectWork = nil
 
 	invalidRoot := mustRequestJSONStatus[projectWorkErrorResponse](client, http.StatusNotFound, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_cairnline_only/assignments", projectJourneyJSON(t, map[string]any{
 		"id":      "asgn_bad_root",
@@ -1512,25 +1517,46 @@ func TestProjectWorkAPI_CairnlineAssignmentAuthorityWritesCairnlineOnlyProject(t
 		"id":      "asgn_cairnline_only",
 		"role_id": "role_cairnline_only",
 		"root_id": "root_cairnline_only",
+		"execution_ref": map[string]any{
+			"kind":                "external_agent",
+			"context_snapshot_id": "ctx_cairnline_only",
+			"trace_id":            "trace_cairnline_only",
+		},
 	}))
 	if created.Data.ReadBackend != "cairnline" || created.Data.DriverKind != projectwork.AssignmentDriverExternalAgent || created.Data.Status != projectwork.AssignmentStatusQueued {
 		t.Fatalf("created assignment response = %+v, want Cairnline-only assignment with role default driver", created.Data)
+	}
+	if created.Data.ExecutionRef == nil || created.Data.ExecutionRef.ContextSnapshotID != "ctx_cairnline_only" {
+		t.Fatalf("created assignment execution_ref = %+v, want runtime overlay persisted without native work store", created.Data.ExecutionRef)
 	}
 	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_cairnline_only")
 	if mirrored.WorkItemID != "work_cairnline_only" || mirrored.ExecutionMode != cairnline.ExecutionExternalAdapter || mirrored.RootID != "root_cairnline_only" {
 		t.Fatalf("mirrored assignment = %+v, want Cairnline-authoritative assignment", mirrored)
 	}
-	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
-		t.Fatalf("native project exists after assignment create = %t err=%v, want missing native project", ok, err)
+	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_cairnline_only")
+	if err != nil || !ok || runtime.ExecutionRef.ContextSnapshotID != "ctx_cairnline_only" {
+		t.Fatalf("runtime overlay after assignment create = %+v ok=%v err=%v, want persisted execution ref", runtime, ok, err)
 	}
 
 	updated := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_cairnline_only/assignments/asgn_cairnline_only", projectJourneyJSON(t, map[string]any{
 		"status": projectwork.AssignmentStatusCompleted,
+		"execution_ref": map[string]any{
+			"kind":            "external_agent",
+			"chat_session_id": "chat_cairnline_only",
+			"message_id":      "msg_cairnline_only",
+			"status":          "completed",
+		},
 	}))
 	if updated.Data.Status != projectwork.AssignmentStatusCompleted {
 		t.Fatalf("updated assignment response = %+v, want completed Cairnline-only assignment", updated.Data)
 	}
+	if updated.Data.ExecutionRef == nil || updated.Data.ExecutionRef.ChatSessionID != "chat_cairnline_only" {
+		t.Fatalf("updated assignment execution_ref = %+v, want runtime overlay updated without native work store", updated.Data.ExecutionRef)
+	}
 	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_cairnline_only/assignments/asgn_cairnline_only", "")
+	if _, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_cairnline_only"); err != nil || ok {
+		t.Fatalf("runtime overlay after assignment delete ok=%v err=%v, want deleted", ok, err)
+	}
 }
 
 func TestProjectWorkAPI_CairnlineCollaborationAuthorityWritesCairnlineOnlyProject(t *testing.T) {
@@ -1559,6 +1585,8 @@ func TestProjectWorkAPI_CairnlineCollaborationAuthorityWritesCairnlineOnlyProjec
 		ExecutionMode: cairnline.ExecutionManual,
 		Status:        cairnline.AssignmentCompleted,
 	}})
+	handler.projects = nil
+	handler.projectWork = nil
 
 	missingWork := mustRequestJSONStatus[projectWorkErrorResponse](client, http.StatusNotFound, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_missing/artifacts", projectJourneyJSON(t, map[string]any{
 		"id":                     "review_missing_work",
@@ -1603,9 +1631,15 @@ func TestProjectWorkAPI_CairnlineCollaborationAuthorityWritesCairnlineOnlyProjec
 	if handoff.Data.ID != "handoff_cairnline_only" || handoff.Data.Status != projectwork.HandoffStatusPending {
 		t.Fatalf("handoff response = %+v, want Cairnline-only pending handoff", handoff.Data)
 	}
+	updated := mustRequestJSONStatus[ProjectHandoffEnvelope](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_cairnline_only/handoffs/handoff_cairnline_only/status", projectJourneyJSON(t, map[string]any{
+		"status": projectwork.HandoffStatusAccepted,
+	}))
+	if updated.Data.Status != projectwork.HandoffStatusAccepted {
+		t.Fatalf("updated handoff response = %+v, want Cairnline-only accepted handoff", updated.Data)
+	}
 	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_cairnline_only/handoffs/handoff_cairnline_only", "")
-	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
-		t.Fatalf("native project exists after collaboration writes = %t err=%v, want missing native project", ok, err)
+	if handler.projects != nil || handler.projectWork != nil {
+		t.Fatal("native project/work stores were unexpectedly configured")
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep Cairnline assignment authority using the separate Hecate runtime overlay even when the native project-work store is absent
- fall back from native role shadows to Cairnline roles for assignment authority dependency resolution
- tighten Cairnline-only role, work-item, assignment, and collaboration authority tests to run without native project/work stores
- update runtime/design/AI docs for Cairnline-only assignment runtime overlay behavior

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_Cairnline(Role|WorkItem|Assignment|Collaboration)AuthorityWritesCairnlineOnlyProject' -count=1\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- GOCACHE="$(pwd)/.gocache" go vet ./internal/api\n- just go-format-check\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...