### PR TITLE
fix(projects): use runtime overlay for Cairnline launch inputs

### DIFF
--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -516,8 +516,14 @@ func (h *Handler) cairnlineSidecarProjectAssignmentLaunchInputs(ctx context.Cont
 
 func (h *Handler) cairnlineAssignmentWithRuntimeRef(ctx context.Context, projectID string, assignment projectwork.Assignment, nativeAssignments []projectwork.Assignment) (projectwork.Assignment, error) {
 	if native, ok := projectWorkAssignmentsByID(nativeAssignments)[assignment.ID]; ok {
-		assignment.ExecutionRef = native.ExecutionRef
-		return assignment, nil
+		overlayProjectAssignmentRuntimeShadow(&assignment, native)
+	}
+	if h != nil {
+		overlaid, err := h.projectWorkApplication().ApplyAssignmentRuntime(ctx, assignment)
+		if err != nil {
+			return assignment, err
+		}
+		assignment = overlaid
 	}
 	if h == nil || h.projectWork == nil {
 		return assignment, nil
@@ -529,8 +535,8 @@ func (h *Handler) cairnlineAssignmentWithRuntimeRef(ctx context.Context, project
 	if !ok {
 		return assignment, nil
 	}
-	assignment.ExecutionRef = native.ExecutionRef
-	return assignment, nil
+	overlayProjectAssignmentRuntimeShadow(&assignment, native)
+	return h.projectWorkApplication().ApplyAssignmentRuntime(ctx, assignment)
 }
 
 func cairnlineSidecarLaunchPacketRouteMismatch(launch cairnline.AssignmentLaunchPacket, projectID, workItemID, assignmentID string) bool {

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -549,6 +549,7 @@ func TestProjectAssistantAPI_ContextAndDraftStrictEmbeddedReadModelReadWithoutHe
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	client := newAPITestClient(t, server)
 	contextResp := mustRequestJSON[projectAssistantContextResponse](client, http.MethodPost, "/hecate/v1/project-assistant/context", `{

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -802,6 +802,7 @@ func TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
 	}
 
 	handler.config.Projects.CairnlineReadSource = "embedded"
+	disableNativeProjectStoresForTest(t, handler)
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects", "", "project list")
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID, "", "project detail")
 	assertStrictEmbeddedCairnlineReadBackend(t, client, http.MethodGet, "/hecate/v1/projects/"+projectID+"/setup-readiness", "", "setup readiness")

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -424,6 +424,7 @@ func TestProjectHealth_StrictEmbeddedReadModelReadsWithoutHecateProject(t *testi
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/health", nil))

--- a/internal/api/handler_project_setup_readiness_test.go
+++ b/internal/api/handler_project_setup_readiness_test.go
@@ -355,6 +355,7 @@ func TestProjectSetupReadiness_StrictEmbeddedReadModelReadsWithoutHecateProject(
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/setup-readiness", nil))

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -171,6 +171,32 @@ func seedCairnlineOnlyProjectWorkGraphForTest(t *testing.T, handler *Handler, pr
 	}
 }
 
+func requireCairnlineOnlyProjectReadsForTest(t *testing.T, handler *Handler, projectID string) {
+	t.Helper()
+	if handler == nil {
+		t.Fatal("handler is nil")
+	}
+	projectID = strings.TrimSpace(projectID)
+	if handler.projects != nil && projectID != "" {
+		if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+			t.Fatalf("native project exists = %t err=%v, want missing native project", ok, err)
+		}
+	}
+	disableNativeProjectStoresForTest(t, handler)
+}
+
+func disableNativeProjectStoresForTest(t *testing.T, handler *Handler) {
+	t.Helper()
+	if handler == nil {
+		t.Fatal("handler is nil")
+	}
+	handler.projects = nil
+	handler.projectWork = nil
+	handler.projectSkills = nil
+	handler.memory = nil
+	handler.memoryCandidates = nil
+}
+
 type projectWorkErrorResponse struct {
 	Error struct {
 		Type    string `json:"type"`
@@ -1978,6 +2004,7 @@ func TestProjectWorkAPI_StrictEmbeddedReadModelReadsRolesWithoutHecateProject(t 
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/roles", nil))
@@ -2128,6 +2155,7 @@ func TestProjectWorkAPI_StrictEmbeddedReadModelReadsWorkItemsWithoutHecateProjec
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items", nil))
@@ -2294,6 +2322,7 @@ func TestProjectWorkAPI_StrictEmbeddedReadModelReadsAssignmentsWithoutHecateProj
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded/assignments", nil))
@@ -2470,6 +2499,7 @@ func TestProjectWorkAPI_StrictEmbeddedReadModelReadsArtifactsWithoutHecateProjec
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded/artifacts", nil))
@@ -2661,6 +2691,7 @@ func TestProjectWorkAPI_StrictEmbeddedReadModelReadsHandoffsWithoutHecateProject
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/handoffs?work_item_id=work_embedded&status=pending", nil))
@@ -2785,6 +2816,7 @@ func TestProjectWorkAPI_StrictEmbeddedReadModelReadsCloseoutReadinessWithoutHeca
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded/readiness", nil))
@@ -3682,6 +3714,76 @@ func TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHe
 	}
 }
 
+func TestProjectWorkAPI_StrictEmbeddedLaunchInputsUseRuntimeOverlayWithoutNativeProjectStores(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	const projectID = "proj_embedded_launch_runtime"
+
+	seedCairnlineOnlyProjectWorkGraphForTest(t, handler, cairnline.Project{
+		ID:            projectID,
+		Name:          "Embedded Launch Runtime",
+		DefaultRootID: "root_embedded_launch_runtime",
+		Roots: []cairnline.Root{{
+			ID:     "root_embedded_launch_runtime",
+			Path:   "/workspace/embedded-launch-runtime",
+			Kind:   "git",
+			Active: true,
+		}},
+	}, []cairnline.Role{{
+		ID:        "role_embedded_launch_runtime",
+		ProjectID: projectID,
+		Name:      "Runtime Reviewer",
+	}}, []cairnline.WorkItem{{
+		ID:          "work_embedded_launch_runtime",
+		ProjectID:   projectID,
+		Title:       "Preserve launch runtime overlay",
+		Status:      cairnline.WorkStatusReady,
+		Priority:    cairnline.PriorityNormal,
+		OwnerRoleID: "role_embedded_launch_runtime",
+		RootID:      "root_embedded_launch_runtime",
+	}}, []cairnline.Assignment{{
+		ID:            "asgn_embedded_launch_runtime",
+		ProjectID:     projectID,
+		WorkItemID:    "work_embedded_launch_runtime",
+		RoleID:        "role_embedded_launch_runtime",
+		RootID:        "root_embedded_launch_runtime",
+		ExecutionMode: cairnline.ExecutionOrchestrated,
+	}})
+	if _, err := handler.projectRuntime.Upsert(t.Context(), projectruntime.AssignmentRuntime{
+		ProjectID:    projectID,
+		AssignmentID: "asgn_embedded_launch_runtime",
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:              projectwork.AssignmentExecutionKindTaskRun,
+			TaskID:            "task_runtime_overlay",
+			RunID:             "run_runtime_overlay",
+			ContextSnapshotID: "ctx_runtime_overlay",
+			Status:            projectwork.AssignmentStatusRunning,
+		},
+		ContextPacket: []byte(`{"id":"ctx_runtime_overlay"}`),
+	}); err != nil {
+		t.Fatalf("seed assignment runtime overlay: %v", err)
+	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
+
+	inputs, err := handler.projectAssignmentStartInputs(t.Context(), projectID, "work_embedded_launch_runtime", "asgn_embedded_launch_runtime", true)
+	if err != nil {
+		t.Fatalf("projectAssignmentStartInputs() error = %v, want nil", err)
+	}
+	ref := inputs.Assignment.ExecutionRef
+	if ref.TaskID != "task_runtime_overlay" || ref.RunID != "run_runtime_overlay" || ref.ContextSnapshotID != "ctx_runtime_overlay" || ref.Status != projectwork.AssignmentStatusRunning {
+		t.Fatalf("assignment runtime ref = %+v, want runtime overlay without native project stores", ref)
+	}
+	if string(inputs.Assignment.ContextPacket) != `{"id":"ctx_runtime_overlay"}` {
+		t.Fatalf("assignment context packet = %s, want runtime overlay packet", string(inputs.Assignment.ContextPacket))
+	}
+}
+
 func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{
@@ -4073,6 +4175,7 @@ func TestProjectWorkAPI_AssignmentContextStrictEmbeddedReadModelReadsWithoutHeca
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_assignment_context/assignments/asgn_embedded_assignment_context/context", "")
 	if packetResp.Data.ExecutionMode != cairnline.ExecutionMCPPull {
@@ -6464,6 +6567,7 @@ func TestProjectWorkAPI_ProjectActivityStrictEmbeddedReadModelReadsWithoutHecate
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/activity", nil))


### PR DESCRIPTION
## Summary

- Apply Hecate project runtime overlays while resolving strict embedded Cairnline assignment launch inputs, even when native Projects stores are absent.
- Tighten strict embedded read-route tests so the main project read surfaces run after native project/work/skill/memory stores are removed.
- Add a regression for launch input runtime refs/context packets coming from projectruntime without native project stores.

## Validation

- Focused strict embedded internal/api tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api
- GOCACHE="$(pwd)/.gocache" go vet ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...

Docs are unchanged because the existing Cairnline replacement docs already state that assignment runtime refs, context, and timestamps live in Hecate runtime overlays and must not depend on native compatibility assignment rows.