### PR TITLE
fix(projects): start Cairnline task assignments without native work store

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -71,6 +71,11 @@ compatibility project row; keep any Hecate shadow writes best-effort and do not
 add native `requireProject*` guards ahead of those authority paths. Assignment
 runtime refs/context/timestamps belong in Hecate's separate runtime overlay, so
 do not make runtime preservation depend on a native compatibility assignment row.
+In strict embedded mode, Hecate-task assignment start may claim/progress the
+assignment directly in Cairnline and persist only the runtime overlay; do not
+reintroduce native project-work guards for that task-start path. External-agent
+assignment start still uses the compatibility project-work path until that
+runtime path is replaced separately.
 Do not describe
 `internal/cairnlinebridge` as only a future proof; it maps Hecate Projects to
 Cairnline snapshots and backs the current embedded/sidecar replacement probes.

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -662,11 +662,16 @@ after these gates are met:
   packets may carry non-authoritative
   Cairnline launch-packet evidence, and strict embedded reads may use a
   Cairnline-only project graph as the source of launch inputs. Launch-readiness
-  and preflight can use those inputs without native Hecate project/work stores,
-  but assignment-start remains a Hecate-owned orchestrator capability. Hecate
-  creates only the narrow project-work/runtime shadow needed for claim and
-  dispatch, not a native project identity row; committed start and linked-chat
-  reconciliation results may be mirrored only as replacement evidence.
+  and preflight can use those inputs without native Hecate project/work stores.
+  Hecate-task assignment start remains a Hecate-owned orchestrator capability,
+  but strict embedded mode can claim/progress the assignment in Cairnline and
+  persist only task/run refs, context packets, and timestamps in Hecate's
+  runtime overlay when the native project-work store is absent; it does not
+  create a native project identity row or compatibility assignment row.
+  External-agent assignment start still uses the native project-work
+  compatibility path until that runtime path has its own replacement slice.
+  Committed start and linked-chat reconciliation results may be mirrored only as
+  replacement evidence.
   Backend-status `write_adapter_seams`
   lists non-authoritative proof
   coverage; `write_adapter_gaps` remains a broad diagnostic list, while

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -581,15 +581,17 @@ commit. Committed
 assignment-start results, linked-chat reconciliation, collaboration artifact
 creation, and handoff create/update/delete mutations also best-effort mirror
 portable metadata after Hecate commits, but assignment start/dispatch remains
-Hecate-owned. In strict embedded read mode, assignment start can resolve the
-project, work item, assignment, role, root, and execution defaults from a
-Cairnline-only project graph; Hecate creates a narrow project-work/runtime
-shadow for the atomic claim and dispatch path without creating a native Hecate
-project identity row. Task/chat execution refs, context packets, and launch
-timestamps are stored in Hecate's project assignment runtime overlay before
-compatibility shadows or replacement-evidence mirrors are written.
-Pre-dispatch cleanup and conflict states are mirrored back into Cairnline so
-replacement probes do not leave stale claimed assignment rows.
+Hecate-owned. In strict embedded read mode, Hecate-task assignment start can
+resolve the project, work item, assignment, role, root, and execution defaults
+from a Cairnline-only project graph. When the native project-work store is
+absent, Hecate claims and progresses the assignment in embedded Cairnline and
+stores only task/run refs, context packets, and launch timestamps in Hecate's
+project assignment runtime overlay; it does not create a native Hecate project
+identity row or compatibility assignment row. External-agent assignment start
+still uses the native project-work compatibility path until that runtime path
+has its own replacement slice. Pre-dispatch cleanup and conflict states are
+mirrored back into Cairnline so replacement probes do not leave stale claimed
+assignment rows.
 Project
 memory entries mirror after Hecate commits unless the
 `project-memory` Cairnline write-authority switchpoint is enabled; memory

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2677,10 +2677,13 @@ committed assignment-start results after Hecate-owned dispatch completes or
 returns a committed cleanup/conflict state; it is replacement evidence, not
 runtime write authority. With strict embedded Cairnline reads, assignment
 start may load the launch project/work/assignment/role/root/defaults from a
-Cairnline-only graph, create only the narrow Hecate project-work/runtime
-shadow needed for the existing atomic claim and task/chat dispatch path, and
-mirror the committed result back to Cairnline without requiring a native
-Hecate project identity row. `project-assignment-chat-reconcile-live-mirror`
+Cairnline-only graph. Hecate-task assignment start can claim/progress the
+assignment in embedded Cairnline and persist only Hecate-owned task/run refs,
+context packets, and launch timestamps in the assignment runtime overlay when
+the native project-work store is absent. It does not require a native Hecate
+project identity row or compatibility assignment row. External-agent assignment
+start still uses the native project-work compatibility path until that runtime
+path has its own replacement slice. `project-assignment-chat-reconcile-live-mirror`
 best-effort mirrors assignment status/ref updates committed by linked
 external-agent chat reconciliation. `project-collaboration-live-mirror` mirrors
 collaboration artifact creation, including generic artifacts, evidence links,

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -801,7 +801,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	workItemID := r.PathValue("work_item_id")
 	assignmentID := r.PathValue("assignment_id")
 	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
-	if (!strictEmbeddedRead && h.projects == nil) || h.projectWork == nil {
+	if !strictEmbeddedRead && (h.projects == nil || h.projectWork == nil) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project stores are not configured")
 		return
 	}
@@ -830,6 +830,10 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	if assignment.DriverKind == projectwork.AssignmentDriverExternalAgent {
+		if strictEmbeddedRead && h.projectWork == nil {
+			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project work store is not configured for external-agent assignment start")
+			return
+		}
 		if strictEmbeddedRead {
 			inputs.Assignment = assignment
 			shadowedAssignment, err := h.shadowCairnlineAssignmentStartInputsToHecate(ctx, inputs)
@@ -883,6 +887,11 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		contextPacket.ID = newChatID("ctx")
 	}
 
+	if strictEmbeddedRead && h.projectWork == nil {
+		result, err := h.startStrictEmbeddedCairnlineTaskAssignment(ctx, project, workItem, assignment, role, plan, contextPacket)
+		h.writeProjectTaskAssignmentStartResult(w, ctx, assignment, result, err)
+		return
+	}
 	if strictEmbeddedRead {
 		inputs.Assignment = assignment
 		shadowedAssignment, err := h.shadowCairnlineAssignmentStartInputsToHecate(ctx, inputs)
@@ -912,11 +921,22 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 			)))
 		},
 	})
+	h.writeProjectTaskAssignmentStartResult(w, ctx, assignment, result, err)
+}
+
+func (h *Handler) writeProjectTaskAssignmentStartResult(w http.ResponseWriter, ctx context.Context, assignment projectwork.Assignment, result *projectworkapp.StartTaskAssignmentResult, err error) {
 	if err != nil {
 		resultAssignment := assignment
 		if result != nil && result.Assignment.ID != "" {
 			resultAssignment = result.Assignment
-			h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
+			if h.projectWork != nil {
+				h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
+			}
+		}
+		var launchErr projectAssignmentPreflightError
+		if errors.As(err, &launchErr) {
+			WriteError(w, projectAssignmentPreflightHTTPStatus(err), projectAssignmentPreflightErrorCode(err), err.Error())
+			return
 		}
 		if errors.Is(err, projectworkapp.ErrAssignmentStartConflict) {
 			projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, resultAssignment)
@@ -944,13 +964,143 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 	if result.SpanID != "" {
 		w.Header().Set("X-Span-Id", result.SpanID)
 	}
-	h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
+	if h.projectWork != nil {
+		h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
+	}
 	projected, err := h.renderProjectedProjectWorkAssignment(ctx, result.Assignment)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+}
+
+func (h *Handler) startStrictEmbeddedCairnlineTaskAssignment(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, plan projectworkapp.TaskAssignmentLaunchPlan, contextPacket chat.ContextPacket) (*projectworkapp.StartTaskAssignmentResult, error) {
+	claimed, err := h.claimStrictEmbeddedCairnlineTaskAssignment(ctx, assignment)
+	if err != nil {
+		return &projectworkapp.StartTaskAssignmentResult{Assignment: assignment}, err
+	}
+	assignment = claimed
+	taskID := newOpaqueTaskResourceID("task")
+	task := projectworkapp.NewAssignmentTask(taskID, project, workItem, assignment, role, plan, time.Now().UTC())
+	task, err = h.taskStore.CreateTask(ctx, task)
+	if err != nil {
+		return &projectworkapp.StartTaskAssignmentResult{Assignment: assignment}, errors.Join(err, h.releaseStrictEmbeddedCairnlineAssignmentClaim(context.Background(), assignment.ProjectID, assignment.ID))
+	}
+	contextPacket.Refs.TaskID = task.ID
+	result, err := h.taskRunner.StartTaskWithRunInitializer(ctx, task, newOpaqueTaskResourceID, func(run *types.TaskRun) {
+		contextPacket.Refs.RunID = run.ID
+		run.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(contextPacket, chatcontext.MergeRefs(
+			chatcontext.TaskRunRefs(task.ID, run.ID, project.ID),
+			chatcontext.ProjectAssignmentRefs(project.ID, workItem.ID, assignment.ID, role.ID),
+		)))
+	})
+	if err != nil {
+		failed := assignment
+		failed.ExecutionRef = projectwork.AssignmentExecutionRef{
+			Kind:   projectwork.AssignmentExecutionKindTaskRun,
+			TaskID: task.ID,
+			Status: projectwork.AssignmentStatusFailed,
+		}
+		failed.Status = projectwork.AssignmentStatusFailed
+		failed.CompletedAt = time.Now().UTC()
+		failed, updateErr := h.persistStrictEmbeddedCairnlineTaskAssignment(ctx, failed)
+		if updateErr != nil {
+			err = errors.Join(err, updateErr)
+		}
+		return &projectworkapp.StartTaskAssignmentResult{Assignment: failed, Task: task}, err
+	}
+	status := projectworkapp.AssignmentStatusFromRun(result.Run.Status)
+	running := assignment
+	running.ExecutionRef = projectwork.NormalizeAssignmentExecutionRef(projectwork.AssignmentExecutionRef{
+		Kind:              projectwork.AssignmentExecutionKindTaskRun,
+		TaskID:            result.Task.ID,
+		RunID:             result.Run.ID,
+		ContextSnapshotID: contextPacket.ID,
+		Status:            status,
+		TraceID:           result.Run.TraceID,
+	})
+	running.ContextPacket = append([]byte(nil), result.Run.ContextPacket...)
+	running.Status = status
+	if running.StartedAt.IsZero() {
+		running.StartedAt = time.Now().UTC()
+	}
+	running, err = h.persistStrictEmbeddedCairnlineTaskAssignment(ctx, running)
+	if err != nil {
+		return &projectworkapp.StartTaskAssignmentResult{Task: result.Task, Run: result.Run, TraceID: result.TraceID, SpanID: result.SpanID}, err
+	}
+	return &projectworkapp.StartTaskAssignmentResult{
+		Assignment: running,
+		Task:       result.Task,
+		Run:        result.Run,
+		TraceID:    result.TraceID,
+		SpanID:     result.SpanID,
+	}, nil
+}
+
+func (h *Handler) claimStrictEmbeddedCairnlineTaskAssignment(ctx context.Context, assignment projectwork.Assignment) (projectwork.Assignment, error) {
+	var claimed cairnline.Assignment
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		item, err := service.ClaimAssignment(ctx, assignment.ProjectID, assignment.ID, "hecate")
+		if err != nil {
+			return err
+		}
+		claimed = item
+		return nil
+	})
+	if errors.Is(err, cairnline.ErrConflict) {
+		return assignment, projectworkapp.ErrAssignmentStartConflict
+	}
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return assignment, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
+	}
+	if err != nil {
+		return assignment, err
+	}
+	out := projectWorkAssignmentFromCairnline(claimed)
+	out.Status = projectwork.AssignmentStatusQueued
+	return out, nil
+}
+
+func (h *Handler) releaseStrictEmbeddedCairnlineAssignmentClaim(ctx context.Context, projectID, assignmentID string) error {
+	return h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		_, err := service.ReleaseAssignment(ctx, projectID, assignmentID, "hecate")
+		if errors.Is(err, cairnline.ErrConflict) || errors.Is(err, cairnline.ErrNotFound) {
+			return nil
+		}
+		return err
+	})
+}
+
+func (h *Handler) persistStrictEmbeddedCairnlineTaskAssignment(ctx context.Context, assignment projectwork.Assignment) (projectwork.Assignment, error) {
+	var recorded projectwork.Assignment
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
+		if err != nil {
+			return err
+		}
+		existing.Status = cairnlinebridge.AssignmentStatus(assignment.Status)
+		existing.ExecutionRef = firstNonEmptyString(
+			strings.TrimSpace(assignment.ExecutionRef.RunID),
+			strings.TrimSpace(assignment.ExecutionRef.TaskID),
+			strings.TrimSpace(assignment.ExecutionRef.ChatSessionID),
+			strings.TrimSpace(assignment.ExecutionRef.ContextSnapshotID),
+		)
+		existing.ContextSnapshotID = strings.TrimSpace(assignment.ExecutionRef.ContextSnapshotID)
+		existing.StartedAt = assignment.StartedAt
+		existing.CompletedAt = assignment.CompletedAt
+		written, err := service.UpdateAssignment(ctx, existing)
+		if err != nil {
+			return err
+		}
+		recorded = projectWorkAssignmentFromCairnlineAuthority(written, assignment)
+		return nil
+	})
+	if err != nil {
+		return assignment, err
+	}
+	h.shadowProjectAssignmentRuntimeToHecate(ctx, "project_assignment_start_cairnline_task_runtime", recorded)
+	return h.projectWorkApplication().ApplyAssignmentRuntime(ctx, recorded)
 }
 
 func (h *Handler) projectAssignmentStartInputs(ctx context.Context, projectID, workItemID, assignmentID string, strictEmbeddedRead bool) (projectAssignmentLaunchInputs, error) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3858,6 +3858,7 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineO
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row before launch", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_launch_start/assignments/asgn_embedded_launch_start/start", bytes.NewReader([]byte(`{}`))))
@@ -3890,16 +3891,104 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineO
 		t.Fatalf("task prompt/system = %q / %q, want Cairnline work and role context", task.Prompt, task.SystemPrompt)
 	}
 
-	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
-		t.Fatalf("Hecate project store ok=%v err=%v after launch, want no native project row", ok, err)
+	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_embedded_launch_start")
+	if err != nil || !ok {
+		t.Fatalf("Hecate assignment runtime ok=%v err=%v, want runtime overlay", ok, err)
 	}
-	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_embedded_launch_start", "asgn_embedded_launch_start")
-	if shadow.ExecutionRef.RunID != ref.RunID || shadow.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
-		t.Fatalf("Hecate assignment shadow ref = %+v, want run/context %q/%q", shadow.ExecutionRef, ref.RunID, ref.ContextSnapshotID)
+	if runtime.ExecutionRef.RunID != ref.RunID || runtime.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("Hecate assignment runtime ref = %+v, want run/context %q/%q", runtime.ExecutionRef, ref.RunID, ref.ContextSnapshotID)
 	}
 	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_embedded_launch_start")
-	if mirrored.Status != cairnlinebridge.AssignmentStatus(shadow.Status) || mirrored.ExecutionRef != ref.RunID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
-		t.Fatalf("mirrored Cairnline assignment = status %q ref %q context %q, want %q/%q/%q", mirrored.Status, mirrored.ExecutionRef, mirrored.ContextSnapshotID, cairnlinebridge.AssignmentStatus(shadow.Status), ref.RunID, ref.ContextSnapshotID)
+	if mirrored.Status != cairnlinebridge.AssignmentStatus(runtime.ExecutionRef.Status) || mirrored.ExecutionRef != ref.RunID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("mirrored Cairnline assignment = status %q ref %q context %q, want %q/%q/%q", mirrored.Status, mirrored.ExecutionRef, mirrored.ContextSnapshotID, cairnlinebridge.AssignmentStatus(runtime.ExecutionRef.Status), ref.RunID, ref.ContextSnapshotID)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelReleasesCairnlineClaimWhenTaskCreateFails(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.taskStore = failingCreateTaskStore{Store: handler.taskStore}
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_launch_task_create_fail"
+	workspace := t.TempDir()
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateExecutionProfile(t.Context(), cairnline.ExecutionProfile{
+			ID:           "exec_embedded_launch_task_create_fail",
+			Name:         "Embedded launch task create fail",
+			ProviderHint: "anthropic",
+			ModelHint:    "claude-sonnet-4",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:                        projectID,
+			Name:                      "Embedded Launch Task Create Fail",
+			Description:               "Coordinate failed assignment launch from embedded Cairnline.",
+			DefaultRootID:             "root_embedded_launch_task_create_fail",
+			DefaultExecutionProfileID: "exec_embedded_launch_task_create_fail",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_launch_task_create_fail",
+				Path:   workspace,
+				Kind:   "git",
+				Active: true,
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:                        "role_embedded_launch_task_create_fail",
+			ProjectID:                 projectID,
+			Name:                      "Launch Implementer",
+			Instructions:              "Use the embedded Cairnline graph.",
+			DefaultExecutionProfileID: "exec_embedded_launch_task_create_fail",
+			DefaultExecutionMode:      cairnline.ExecutionOrchestrated,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded_launch_task_create_fail",
+			ProjectID:   projectID,
+			Title:       "Start embedded assignment with task create failure",
+			Brief:       "Launch a Hecate task from a Cairnline-only project graph.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_embedded_launch_task_create_fail",
+			RootID:      "root_embedded_launch_task_create_fail",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_launch_task_create_fail",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_launch_task_create_fail",
+			RoleID:        "role_embedded_launch_task_create_fail",
+			RootID:        "root_embedded_launch_task_create_fail",
+			ExecutionMode: cairnline.ExecutionOrchestrated,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline launch task create failure: %v", err)
+	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_launch_task_create_fail/assignments/asgn_embedded_launch_task_create_fail/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("task create failure status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_embedded_launch_task_create_fail")
+	if mirrored.Status != cairnline.AssignmentQueued || mirrored.ClaimedBy != "" || mirrored.ExecutionRef != "" || mirrored.ContextSnapshotID != "" || !mirrored.StartedAt.IsZero() || !mirrored.CompletedAt.IsZero() {
+		t.Fatalf("mirrored assignment = %+v, want released queued claim for retry", mirrored)
+	}
+	if _, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_embedded_launch_task_create_fail"); err != nil || ok {
+		t.Fatalf("Hecate assignment runtime ok=%v err=%v, want no runtime overlay on task create failure", ok, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- let strict embedded Cairnline Hecate-task assignment starts claim and progress assignments without the native project-work store
- persist task/run/context runtime refs in Hecate runtime overlay and avoid the legacy native-store mirror when that store is absent
- document the new Hecate-task vs external-agent launch boundary and add cleanup coverage for failed task creation

## Tests

- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|StartExternalAgentAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHecateProject|StrictEmbeddedLaunchInputsUseRuntimeOverlayWithoutNativeProjectStores|StartAssignment|StartExternalAgentAssignment)' -count=1\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModel(ReleasesCairnlineClaimWhenTaskCreateFails|LaunchesCairnlineOnlyProject)' -count=1\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- GOCACHE="$(pwd)/.gocache" go vet ./internal/api\n- just go-format-check\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n