### PR TITLE
fix(projects): start external Cairnline assignments without native work store

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -71,11 +71,9 @@ compatibility project row; keep any Hecate shadow writes best-effort and do not
 add native `requireProject*` guards ahead of those authority paths. Assignment
 runtime refs/context/timestamps belong in Hecate's separate runtime overlay, so
 do not make runtime preservation depend on a native compatibility assignment row.
-In strict embedded mode, Hecate-task assignment start may claim/progress the
-assignment directly in Cairnline and persist only the runtime overlay; do not
-reintroduce native project-work guards for that task-start path. External-agent
-assignment start still uses the compatibility project-work path until that
-runtime path is replaced separately.
+In strict embedded mode, Hecate-task and external-agent assignment start may
+claim/progress the assignment directly in Cairnline and persist only the runtime
+overlay; do not reintroduce native project-work guards for those start paths.
 Do not describe
 `internal/cairnlinebridge` as only a future proof; it maps Hecate Projects to
 Cairnline snapshots and backs the current embedded/sidecar replacement probes.

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -663,13 +663,12 @@ after these gates are met:
   Cairnline launch-packet evidence, and strict embedded reads may use a
   Cairnline-only project graph as the source of launch inputs. Launch-readiness
   and preflight can use those inputs without native Hecate project/work stores.
-  Hecate-task assignment start remains a Hecate-owned orchestrator capability,
-  but strict embedded mode can claim/progress the assignment in Cairnline and
-  persist only task/run refs, context packets, and timestamps in Hecate's
-  runtime overlay when the native project-work store is absent; it does not
-  create a native project identity row or compatibility assignment row.
-  External-agent assignment start still uses the native project-work
-  compatibility path until that runtime path has its own replacement slice.
+  Hecate-task and external-agent assignment start remain Hecate-owned
+  orchestrator capabilities, but strict embedded mode can claim/progress the
+  assignment in Cairnline and persist only task/run or chat-session refs,
+  context packets, and timestamps in Hecate's runtime overlay when the native
+  project-work store is absent; it does not create a native project identity row
+  or compatibility assignment row.
   Committed start and linked-chat reconciliation results may be mirrored only as
   replacement evidence.
   Backend-status `write_adapter_seams`

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -581,17 +581,16 @@ commit. Committed
 assignment-start results, linked-chat reconciliation, collaboration artifact
 creation, and handoff create/update/delete mutations also best-effort mirror
 portable metadata after Hecate commits, but assignment start/dispatch remains
-Hecate-owned. In strict embedded read mode, Hecate-task assignment start can
-resolve the project, work item, assignment, role, root, and execution defaults
-from a Cairnline-only project graph. When the native project-work store is
-absent, Hecate claims and progresses the assignment in embedded Cairnline and
-stores only task/run refs, context packets, and launch timestamps in Hecate's
-project assignment runtime overlay; it does not create a native Hecate project
-identity row or compatibility assignment row. External-agent assignment start
-still uses the native project-work compatibility path until that runtime path
-has its own replacement slice. Pre-dispatch cleanup and conflict states are
-mirrored back into Cairnline so replacement probes do not leave stale claimed
-assignment rows.
+Hecate-owned. In strict embedded read mode, Hecate-task and external-agent
+assignment start can resolve the project, work item, assignment, role, root, and
+execution defaults from a Cairnline-only project graph. When the native
+project-work store is absent, Hecate claims and progresses the assignment in
+embedded Cairnline and stores only task/run or chat-session refs, context
+packets, and launch timestamps in Hecate's project assignment runtime overlay;
+it does not create a native Hecate project identity row or compatibility
+assignment row. Runtime dispatch, task execution, and external-agent supervision
+remain Hecate-owned. Pre-dispatch cleanup and conflict states are mirrored back
+into Cairnline so replacement probes do not leave stale claimed assignment rows.
 Project
 memory entries mirror after Hecate commits unless the
 `project-memory` Cairnline write-authority switchpoint is enabled; memory

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2677,13 +2677,14 @@ committed assignment-start results after Hecate-owned dispatch completes or
 returns a committed cleanup/conflict state; it is replacement evidence, not
 runtime write authority. With strict embedded Cairnline reads, assignment
 start may load the launch project/work/assignment/role/root/defaults from a
-Cairnline-only graph. Hecate-task assignment start can claim/progress the
-assignment in embedded Cairnline and persist only Hecate-owned task/run refs,
-context packets, and launch timestamps in the assignment runtime overlay when
-the native project-work store is absent. It does not require a native Hecate
-project identity row or compatibility assignment row. External-agent assignment
-start still uses the native project-work compatibility path until that runtime
-path has its own replacement slice. `project-assignment-chat-reconcile-live-mirror`
+Cairnline-only graph. Hecate-task and external-agent assignment start can
+claim/progress the assignment in embedded Cairnline and persist only
+Hecate-owned task/run or chat-session refs, context packets, and launch
+timestamps in the assignment runtime overlay when the native project-work store
+is absent. They do not require a native Hecate project identity row or
+compatibility assignment row; runtime dispatch, task execution, and
+external-agent supervision remain Hecate-owned.
+`project-assignment-chat-reconcile-live-mirror`
 best-effort mirrors assignment status/ref updates committed by linked
 external-agent chat reconciliation. `project-collaboration-live-mirror` mirrors
 collaboration artifact creation, including generic artifacts, evidence links,
@@ -2931,7 +2932,7 @@ Example response, with `write_switchpoints` shortened for readability:
         "blocks_authority": false,
         "seams": ["project-assignment-start-result-live-mirror"],
         "gap": "assignment-start",
-        "detail": "Assignment start still dispatches through Hecate runtime/task/external-agent authority; Cairnline receives only committed start results and cleanup/conflict states."
+        "detail": "Assignment start still dispatches through Hecate runtime/task/external-agent authority; strict embedded starts may claim/progress assignments in Cairnline while Hecate owns runtime refs, cleanup, and conflict handling."
       },
       {
         "name": "migration-cutover",

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -830,11 +830,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	if assignment.DriverKind == projectwork.AssignmentDriverExternalAgent {
-		if strictEmbeddedRead && h.projectWork == nil {
-			WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project work store is not configured for external-agent assignment start")
-			return
-		}
-		if strictEmbeddedRead {
+		if strictEmbeddedRead && h.projectWork != nil {
 			inputs.Assignment = assignment
 			shadowedAssignment, err := h.shadowCairnlineAssignmentStartInputsToHecate(ctx, inputs)
 			if err != nil {
@@ -976,7 +972,7 @@ func (h *Handler) writeProjectTaskAssignmentStartResult(w http.ResponseWriter, c
 }
 
 func (h *Handler) startStrictEmbeddedCairnlineTaskAssignment(ctx context.Context, project projects.Project, workItem projectwork.WorkItem, assignment projectwork.Assignment, role projectwork.AgentRoleProfile, plan projectworkapp.TaskAssignmentLaunchPlan, contextPacket chat.ContextPacket) (*projectworkapp.StartTaskAssignmentResult, error) {
-	claimed, err := h.claimStrictEmbeddedCairnlineTaskAssignment(ctx, assignment)
+	claimed, err := h.claimStrictEmbeddedCairnlineAssignment(ctx, assignment)
 	if err != nil {
 		return &projectworkapp.StartTaskAssignmentResult{Assignment: assignment}, err
 	}
@@ -1004,7 +1000,7 @@ func (h *Handler) startStrictEmbeddedCairnlineTaskAssignment(ctx context.Context
 		}
 		failed.Status = projectwork.AssignmentStatusFailed
 		failed.CompletedAt = time.Now().UTC()
-		failed, updateErr := h.persistStrictEmbeddedCairnlineTaskAssignment(ctx, failed)
+		failed, updateErr := h.persistStrictEmbeddedCairnlineAssignmentRuntime(ctx, failed)
 		if updateErr != nil {
 			err = errors.Join(err, updateErr)
 		}
@@ -1025,7 +1021,7 @@ func (h *Handler) startStrictEmbeddedCairnlineTaskAssignment(ctx context.Context
 	if running.StartedAt.IsZero() {
 		running.StartedAt = time.Now().UTC()
 	}
-	running, err = h.persistStrictEmbeddedCairnlineTaskAssignment(ctx, running)
+	running, err = h.persistStrictEmbeddedCairnlineAssignmentRuntime(ctx, running)
 	if err != nil {
 		return &projectworkapp.StartTaskAssignmentResult{Task: result.Task, Run: result.Run, TraceID: result.TraceID, SpanID: result.SpanID}, err
 	}
@@ -1038,7 +1034,7 @@ func (h *Handler) startStrictEmbeddedCairnlineTaskAssignment(ctx context.Context
 	}, nil
 }
 
-func (h *Handler) claimStrictEmbeddedCairnlineTaskAssignment(ctx context.Context, assignment projectwork.Assignment) (projectwork.Assignment, error) {
+func (h *Handler) claimStrictEmbeddedCairnlineAssignment(ctx context.Context, assignment projectwork.Assignment) (projectwork.Assignment, error) {
 	var claimed cairnline.Assignment
 	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
 		item, err := service.ClaimAssignment(ctx, assignment.ProjectID, assignment.ID, "hecate")
@@ -1072,7 +1068,7 @@ func (h *Handler) releaseStrictEmbeddedCairnlineAssignmentClaim(ctx context.Cont
 	})
 }
 
-func (h *Handler) persistStrictEmbeddedCairnlineTaskAssignment(ctx context.Context, assignment projectwork.Assignment) (projectwork.Assignment, error) {
+func (h *Handler) persistStrictEmbeddedCairnlineAssignmentRuntime(ctx context.Context, assignment projectwork.Assignment) (projectwork.Assignment, error) {
 	var recorded projectwork.Assignment
 	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
 		existing, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
@@ -1099,7 +1095,7 @@ func (h *Handler) persistStrictEmbeddedCairnlineTaskAssignment(ctx context.Conte
 	if err != nil {
 		return assignment, err
 	}
-	h.shadowProjectAssignmentRuntimeToHecate(ctx, "project_assignment_start_cairnline_task_runtime", recorded)
+	h.shadowProjectAssignmentRuntimeToHecate(ctx, "project_assignment_start_cairnline_runtime", recorded)
 	return h.projectWorkApplication().ApplyAssignmentRuntime(ctx, recorded)
 }
 
@@ -1239,6 +1235,11 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		chatcontext.ProjectAssignmentRefs(project.ID, workItem.ID, assignment.ID, role.ID),
 	))
 	packetBytes := chatcontext.Marshal(contextPacket)
+	if h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads() && h.projectWork == nil {
+		result, err := h.startStrictEmbeddedCairnlineExternalAgentAssignment(ctx, assignment, session, contextPacket.ID, packetBytes)
+		h.writeProjectExternalAgentAssignmentStartResult(w, ctx, assignment, plan.Adapter.Name, result, err)
+		return
+	}
 	result, err := h.projectWorkApplication().StartExternalAgentAssignment(ctx, projectworkapp.StartExternalAgentAssignmentCommand{
 		ProjectID:         project.ID,
 		Assignment:        assignment,
@@ -1246,16 +1247,106 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		ContextSnapshotID: contextPacket.ID,
 		ContextPacket:     packetBytes,
 	})
+	h.writeProjectExternalAgentAssignmentStartResult(w, ctx, assignment, plan.Adapter.Name, result, err)
+}
+
+func (h *Handler) startStrictEmbeddedCairnlineExternalAgentAssignment(ctx context.Context, assignment projectwork.Assignment, session chat.Session, contextSnapshotID string, packetBytes []byte) (*projectworkapp.StartExternalAgentAssignmentResult, error) {
+	if strings.TrimSpace(assignment.ExecutionRef.ChatSessionID) != "" ||
+		projectWorkAssignmentIsTerminal(assignment.Status) ||
+		assignment.DriverKind != projectwork.AssignmentDriverExternalAgent {
+		return &projectworkapp.StartExternalAgentAssignmentResult{Assignment: assignment}, projectworkapp.ErrAssignmentStartConflict
+	}
+	session, err := h.agentChat.Create(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	prepareCtx := ctx
+	cancel := func() {}
+	if agentChatPrepareTimeout > 0 {
+		prepareCtx, cancel = context.WithTimeout(ctx, agentChatPrepareTimeout)
+	}
+	prepared, prepareErr := h.agentChatRunner.PrepareSession(prepareCtx, agentadapters.PrepareSessionRequest{
+		SessionID:     session.ID,
+		AdapterID:     session.AgentID,
+		Workspace:     session.Workspace,
+		ConfigOptions: session.ConfigOptions,
+		MCPServers:    session.MCPServers,
+	})
+	cancel()
+	if prepareErr != nil {
+		_ = h.agentChat.Delete(context.Background(), session.ID)
+		return &projectworkapp.StartExternalAgentAssignmentResult{Session: session}, projectworkapp.ExternalAgentPrepareError{Err: prepareErr}
+	}
+
+	session, err = h.agentChat.UpdateSession(ctx, session.ID, func(item *chat.Session) {
+		item.DriverKind = prepared.DriverKind
+		item.NativeSessionID = prepared.NativeSessionID
+		item.ConfigOptions = prepared.ConfigOptions
+	})
+	if err != nil {
+		h.cleanupStrictEmbeddedExternalAgentSession(session.ID)
+		return &projectworkapp.StartExternalAgentAssignmentResult{Session: session}, err
+	}
+
+	claimed, err := h.claimStrictEmbeddedCairnlineAssignment(ctx, assignment)
+	if err != nil {
+		h.cleanupStrictEmbeddedExternalAgentSession(session.ID)
+		return &projectworkapp.StartExternalAgentAssignmentResult{Assignment: claimed, Session: session}, err
+	}
+	assignment = claimed
+	running := assignment
+	running.ExecutionRef = projectwork.NormalizeAssignmentExecutionRef(projectwork.AssignmentExecutionRef{
+		Kind:              projectwork.AssignmentExecutionKindChatSession,
+		ChatSessionID:     session.ID,
+		ContextSnapshotID: strings.TrimSpace(contextSnapshotID),
+		Status:            projectwork.AssignmentStatusRunning,
+	})
+	running.ContextPacket = append([]byte(nil), packetBytes...)
+	running.Status = projectwork.AssignmentStatusRunning
+	if running.StartedAt.IsZero() {
+		running.StartedAt = time.Now().UTC()
+	}
+	running, err = h.persistStrictEmbeddedCairnlineAssignmentRuntime(ctx, running)
+	if err != nil {
+		h.cleanupStrictEmbeddedExternalAgentSession(session.ID)
+		err = errors.Join(err, h.releaseStrictEmbeddedCairnlineAssignmentClaim(context.Background(), assignment.ProjectID, assignment.ID))
+		return &projectworkapp.StartExternalAgentAssignmentResult{Assignment: assignment, Session: session}, err
+	}
+	return &projectworkapp.StartExternalAgentAssignmentResult{Assignment: running, Session: session}, nil
+}
+
+func (h *Handler) cleanupStrictEmbeddedExternalAgentSession(sessionID string) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return
+	}
+	if h.agentChatRunner != nil {
+		cleanupCtx := context.Background()
+		cancel := func() {}
+		if agentChatPrepareTimeout > 0 {
+			cleanupCtx, cancel = context.WithTimeout(cleanupCtx, agentChatPrepareTimeout)
+		}
+		_ = h.agentChatRunner.DeleteSession(cleanupCtx, sessionID)
+		cancel()
+	}
+	if h.agentChat != nil {
+		_ = h.agentChat.Delete(context.Background(), sessionID)
+	}
+}
+
+func (h *Handler) writeProjectExternalAgentAssignmentStartResult(w http.ResponseWriter, ctx context.Context, assignment projectwork.Assignment, adapterName string, result *projectworkapp.StartExternalAgentAssignmentResult, err error) {
 	if err != nil {
 		var prepareErr projectworkapp.ExternalAgentPrepareError
 		if errors.As(err, &prepareErr) {
-			writeAgentChatPrepareError(w, plan.Adapter.Name, prepareErr.Unwrap())
+			writeAgentChatPrepareError(w, adapterName, prepareErr.Unwrap())
 			return
 		}
 		resultAssignment := assignment
 		if result != nil && result.Assignment.ID != "" {
 			resultAssignment = result.Assignment
-			h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
+			if h.projectWork != nil {
+				h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
+			}
 		}
 		if errors.Is(err, projectworkapp.ErrAssignmentStartConflict) {
 			projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, resultAssignment)
@@ -1269,7 +1360,9 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
+	if h.projectWork != nil {
+		h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
+	}
 	projected, err := h.renderProjectedProjectWorkAssignment(ctx, result.Assignment)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -235,7 +235,7 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 		BlocksAuthority:  false,
 		Seams:            []string{"project-assignment-start-result-live-mirror"},
 		Gap:              "assignment-start",
-		Detail:           "Assignment start still dispatches through Hecate runtime/task/external-agent authority; Cairnline receives only committed start results and cleanup/conflict states.",
+		Detail:           "Assignment start still dispatches through Hecate runtime/task/external-agent authority; strict embedded starts may claim/progress assignments in Cairnline while Hecate owns runtime refs, cleanup, and conflict handling.",
 	},
 	{
 		Name:             "collaboration-artifacts",

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -4072,6 +4072,7 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelLaunc
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row before launch", ok, err)
 	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_external_start/assignments/asgn_embedded_external_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
@@ -4106,16 +4107,120 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelLaunc
 	if session.ProjectID != projectID || session.AgentID != "codex" || session.NativeSessionID != "native_embedded_external" {
 		t.Fatalf("session = %+v, want prepared external agent session for Cairnline project", session)
 	}
-	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
-		t.Fatalf("Hecate project store ok=%v err=%v after launch, want no native project row", ok, err)
+	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_embedded_external_start")
+	if err != nil || !ok {
+		t.Fatalf("Hecate assignment runtime ok=%v err=%v, want runtime overlay", ok, err)
 	}
-	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_embedded_external_start", "asgn_embedded_external_start")
-	if shadow.ExecutionRef.ChatSessionID != ref.ChatSessionID || shadow.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
-		t.Fatalf("Hecate assignment shadow ref = %+v, want chat/context %q/%q", shadow.ExecutionRef, ref.ChatSessionID, ref.ContextSnapshotID)
+	if runtime.ExecutionRef.ChatSessionID != ref.ChatSessionID || runtime.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("Hecate assignment runtime ref = %+v, want chat/context %q/%q", runtime.ExecutionRef, ref.ChatSessionID, ref.ContextSnapshotID)
 	}
 	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_embedded_external_start")
-	if mirrored.Status != cairnlinebridge.AssignmentStatus(shadow.Status) || mirrored.ExecutionRef != ref.ChatSessionID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
-		t.Fatalf("mirrored Cairnline assignment = status %q ref %q context %q, want %q/%q/%q", mirrored.Status, mirrored.ExecutionRef, mirrored.ContextSnapshotID, cairnlinebridge.AssignmentStatus(shadow.Status), ref.ChatSessionID, ref.ContextSnapshotID)
+	if mirrored.Status != cairnlinebridge.AssignmentStatus(runtime.ExecutionRef.Status) || mirrored.ExecutionRef != ref.ChatSessionID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("mirrored Cairnline assignment = status %q ref %q context %q, want %q/%q/%q", mirrored.Status, mirrored.ExecutionRef, mirrored.ContextSnapshotID, cairnlinebridge.AssignmentStatus(runtime.ExecutionRef.Status), ref.ChatSessionID, ref.ContextSnapshotID)
+	}
+}
+
+func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelCleansPreparedSessionWhenClaimLost(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend: "cairnline",
+			CairnlineReadSource: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	runner := &fakeAgentChatRunner{nativeSessionID: "native_embedded_external_lost_claim"}
+	handler.SetAgentChatRunner(runner)
+	handler.taskStore = nil
+	handler.taskRunner = nil
+	server := NewServer(quietLogger(), handler)
+	const projectID = "proj_embedded_external_claim_lost"
+	workspace := t.TempDir()
+
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                "prof_embedded_external_claim_lost",
+		Name:              "Embedded External Agent Claim Lost",
+		Surface:           agentprofiles.SurfaceExternalAgent,
+		ExecutionProfile:  "external_implementation",
+		ExternalAgentKind: "codex",
+	}); err != nil {
+		t.Fatalf("Create external profile: %v", err)
+	}
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:            projectID,
+			Name:          "Embedded External Claim Lost",
+			Description:   "Coordinate External Agent assignment launch from embedded Cairnline.",
+			DefaultRootID: "root_embedded_external_claim_lost",
+			Roots: []cairnline.Root{{
+				ID:     "root_embedded_external_claim_lost",
+				Path:   workspace,
+				Kind:   "git",
+				Active: true,
+			}},
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateRole(t.Context(), cairnline.Role{
+			ID:                   "role_embedded_external_claim_lost",
+			ProjectID:            projectID,
+			Name:                 "External Implementer",
+			Instructions:         "Use the embedded Cairnline graph before preparing the adapter session.",
+			DefaultProfileID:     "prof_embedded_external_claim_lost",
+			DefaultExecutionMode: cairnline.ExecutionExternalAdapter,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:          "work_embedded_external_claim_lost",
+			ProjectID:   projectID,
+			Title:       "Prepare embedded external assignment with lost claim",
+			Brief:       "Prepare an External Agent chat from a Cairnline-only project graph.",
+			Status:      cairnline.WorkStatusReady,
+			Priority:    cairnline.PriorityNormal,
+			OwnerRoleID: "role_embedded_external_claim_lost",
+			RootID:      "root_embedded_external_claim_lost",
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+			ID:            "asgn_embedded_external_claim_lost",
+			ProjectID:     projectID,
+			WorkItemID:    "work_embedded_external_claim_lost",
+			RoleID:        "role_embedded_external_claim_lost",
+			RootID:        "root_embedded_external_claim_lost",
+			ExecutionMode: cairnline.ExecutionExternalAdapter,
+		}); err != nil {
+			return err
+		}
+		_, err := service.ClaimAssignment(t.Context(), projectID, "asgn_embedded_external_claim_lost", "other-agent")
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline external lost claim: %v", err)
+	}
+	requireCairnlineOnlyProjectReadsForTest(t, handler, projectID)
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_external_claim_lost/assignments/asgn_embedded_external_claim_lost/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("start embedded external lost claim status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if len(runner.prepareRequests) != 1 {
+		t.Fatalf("prepare requests = %+v, want one prepared session before claim conflict cleanup", runner.prepareRequests)
+	}
+	sessionID := runner.prepareRequests[0].SessionID
+	if len(runner.deletedSessions) != 1 || runner.deletedSessions[0] != sessionID {
+		t.Fatalf("deleted sessions = %+v, want cleanup of prepared session %q", runner.deletedSessions, sessionID)
+	}
+	if _, ok, err := handler.agentChat.Get(t.Context(), sessionID); err != nil || ok {
+		t.Fatalf("Get chat session found=%v err=%v, want cleaned up prepared session", ok, err)
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_embedded_external_claim_lost")
+	if mirrored.Status != cairnline.AssignmentClaimed || mirrored.ClaimedBy != "other-agent" || mirrored.ExecutionRef != "" || mirrored.ContextSnapshotID != "" {
+		t.Fatalf("mirrored assignment = %+v, want existing external claim preserved", mirrored)
+	}
+	if _, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_embedded_external_claim_lost"); err != nil || ok {
+		t.Fatalf("Hecate assignment runtime ok=%v err=%v, want no runtime overlay after claim conflict", ok, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- allow strict embedded external-agent assignment start to claim/progress Cairnline assignments without the native project-work store
- persist external-agent chat-session refs and context packets in the Hecate assignment runtime overlay
- clean up prepared external-agent sessions when the Cairnline claim is lost and update docs/status detail for the new boundary

## Tests

- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModel(LaunchesCairnlineOnlyProject|CleansPreparedSessionWhenClaimLost)' -count=1\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|StartAssignmentStrictEmbeddedReadModelReleasesCairnlineClaimWhenTaskCreateFails|StartExternalAgentAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|StartExternalAgentAssignmentStrictEmbeddedReadModelCleansPreparedSessionWhenClaimLost|StartExternalAgentAssignmentPreparesLinkedSession|StartExternalAgentAssignmentConcurrentRequestsCreateOneChat|StartAssignment|StartExternalAgentAssignment)' -count=1\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackend' -count=1\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- GOCACHE="$(pwd)/.gocache" go vet ./internal/api\n- just go-format-check\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n