### PR TITLE
fix(projects): reconcile Cairnline external-agent chats

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -74,6 +74,10 @@ do not make runtime preservation depend on a native compatibility assignment row
 In strict embedded mode, Hecate-task and external-agent assignment start may
 claim/progress the assignment directly in Cairnline and persist only the runtime
 overlay; do not reintroduce native project-work guards for those start paths.
+Linked external-agent chat reconciliation must follow the same boundary: when
+native project-work stores are absent, reconcile status/ref changes back to the
+embedded Cairnline assignment plus Hecate's runtime overlay rather than
+requiring a compatibility assignment row.
 Do not describe
 `internal/cairnlinebridge` as only a future proof; it maps Hecate Projects to
 Cairnline snapshots and backs the current embedded/sidecar replacement probes.

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -482,7 +482,9 @@ require the task runtime. Successful start results and start-side
 conflict/cleanup states are best-effort mirrored after Hecate commits them.
 Linked external-agent chat reconciliation also mirrors the
 committed assignment status/ref when Hecate updates the linked assignment from a
-chat session. Collaboration artifact creation, including generic artifacts,
+chat session. In strict embedded mode, that reconciliation can update the
+embedded Cairnline assignment and Hecate runtime overlay without a native
+project-work row. Collaboration artifact creation, including generic artifacts,
 evidence links, and reviews, and handoff create/update/delete routes also mirror
 portable collaboration metadata after Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-collaboration` makes those
@@ -669,7 +671,9 @@ after these gates are met:
   context packets, and timestamps in Hecate's runtime overlay when the native
   project-work store is absent; it does not create a native project identity row
   or compatibility assignment row.
-  Committed start and linked-chat reconciliation results may be mirrored only as
+  Linked external-agent chat reconciliation can update embedded Cairnline and
+  the runtime overlay in the same no-native-project-work posture. Committed
+  start and linked-chat reconciliation results may be mirrored only as
   replacement evidence.
   Backend-status `write_adapter_seams`
   lists non-authoritative proof

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -591,6 +591,9 @@ it does not create a native Hecate project identity row or compatibility
 assignment row. Runtime dispatch, task execution, and external-agent supervision
 remain Hecate-owned. Pre-dispatch cleanup and conflict states are mirrored back
 into Cairnline so replacement probes do not leave stale claimed assignment rows.
+Linked external-agent chat reconciliation can also update the embedded
+Cairnline assignment and Hecate runtime overlay when no native project-work row
+exists.
 Project
 memory entries mirror after Hecate commits unless the
 `project-memory` Cairnline write-authority switchpoint is enabled; memory

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2686,7 +2686,10 @@ compatibility assignment row; runtime dispatch, task execution, and
 external-agent supervision remain Hecate-owned.
 `project-assignment-chat-reconcile-live-mirror`
 best-effort mirrors assignment status/ref updates committed by linked
-external-agent chat reconciliation. `project-collaboration-live-mirror` mirrors
+external-agent chat reconciliation, and strict embedded reconciliation can
+commit those linked-chat status/ref updates to embedded Cairnline plus Hecate's
+runtime overlay even when no native project-work row exists.
+`project-collaboration-live-mirror` mirrors
 collaboration artifact creation, including generic artifacts, evidence links,
 and reviews, and `project-handoffs-live-mirror` mirrors handoff
 create/update/delete mutations and status-transition timestamps after Hecate

--- a/internal/api/handler_chat_project_work.go
+++ b/internal/api/handler_chat_project_work.go
@@ -2,14 +2,25 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
+	"time"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
 )
 
 func (h *Handler) reconcileProjectAssignmentsForChat(ctx context.Context, session chat.Session) {
-	if h == nil || h.projectWork == nil || strings.TrimSpace(session.ProjectID) == "" || strings.TrimSpace(session.ID) == "" {
+	if h == nil || strings.TrimSpace(session.ProjectID) == "" || strings.TrimSpace(session.ID) == "" {
+		return
+	}
+	if h.projectWork == nil {
+		if h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads() {
+			h.reconcileStrictEmbeddedCairnlineProjectAssignmentsForChat(ctx, session)
+		}
 		return
 	}
 	result, err := h.projectWorkApplication().ReconcileChatSessionAssignments(ctx, session)
@@ -25,8 +36,68 @@ func (h *Handler) reconcileProjectAssignmentsForChat(ctx context.Context, sessio
 	}
 }
 
+func (h *Handler) reconcileStrictEmbeddedCairnlineProjectAssignmentsForChat(ctx context.Context, session chat.Session) {
+	projectID := strings.TrimSpace(session.ProjectID)
+	sessionID := strings.TrimSpace(session.ID)
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		items, err := service.ListAssignments(ctx, projectID)
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, item := range items {
+			assignment := projectWorkAssignmentFromCairnline(item)
+			assignment, err = h.projectWorkApplication().ApplyAssignmentRuntime(ctx, assignment)
+			if err != nil {
+				return err
+			}
+			ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
+			if strings.TrimSpace(ref.ChatSessionID) != sessionID {
+				continue
+			}
+			projection := projectworkapp.ProjectAssignmentChatExecution(assignment, session)
+			if projection == nil || projection.Missing || strings.TrimSpace(projection.Status) == "" {
+				continue
+			}
+			updated := projectAssignmentWithChatProjection(assignment, projection, time.Now().UTC())
+			recorded, err := h.writeStrictEmbeddedCairnlineAssignmentRuntime(ctx, service, updated)
+			if err != nil {
+				return err
+			}
+			h.shadowProjectAssignmentRuntimeToHecate(ctx, "project_assignment_chat_reconcile_cairnline_runtime", recorded)
+		}
+		return nil
+	})
+	if err != nil && h.logger != nil {
+		h.logger.WarnContext(ctx, "project.assignment_chat_reconcile_cairnline_failed",
+			slog.String("project_id", projectID),
+			slog.String("chat_session_id", sessionID),
+			slog.Any("error", err),
+		)
+	}
+}
+
+func projectAssignmentWithChatProjection(assignment projectwork.Assignment, projection *projectworkapp.AssignmentChatProjection, now time.Time) projectwork.Assignment {
+	if projection == nil {
+		return assignment
+	}
+	assignment.Status = projection.Status
+	if ref := projectworkapp.AssignmentExecutionRefForChat(assignment, projection, projection.Status); ref != nil {
+		assignment.ExecutionRef = projectwork.NormalizeAssignmentExecutionRef(*ref)
+	}
+	if assignment.StartedAt.IsZero() && !projection.StartedAt.IsZero() {
+		assignment.StartedAt = projection.StartedAt
+	}
+	if projectworkapp.AssignmentIsTerminal(projection.Status) {
+		assignment.CompletedAt = projectworkapp.FirstNonZeroTime(assignment.CompletedAt, projection.CompletedAt, projection.ProjectedAt, now)
+	}
+	return assignment
+}
+
 func (h *Handler) reconcileProjectAssignmentsForAllChats(ctx context.Context) {
-	if h == nil || h.agentChat == nil || h.projectWork == nil {
+	if h == nil || h.agentChat == nil {
 		return
 	}
 	sessions, err := h.agentChat.List(ctx)

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -1071,25 +1071,11 @@ func (h *Handler) releaseStrictEmbeddedCairnlineAssignmentClaim(ctx context.Cont
 func (h *Handler) persistStrictEmbeddedCairnlineAssignmentRuntime(ctx context.Context, assignment projectwork.Assignment) (projectwork.Assignment, error) {
 	var recorded projectwork.Assignment
 	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
-		existing, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
+		var err error
+		recorded, err = h.writeStrictEmbeddedCairnlineAssignmentRuntime(ctx, service, assignment)
 		if err != nil {
 			return err
 		}
-		existing.Status = cairnlinebridge.AssignmentStatus(assignment.Status)
-		existing.ExecutionRef = firstNonEmptyString(
-			strings.TrimSpace(assignment.ExecutionRef.RunID),
-			strings.TrimSpace(assignment.ExecutionRef.TaskID),
-			strings.TrimSpace(assignment.ExecutionRef.ChatSessionID),
-			strings.TrimSpace(assignment.ExecutionRef.ContextSnapshotID),
-		)
-		existing.ContextSnapshotID = strings.TrimSpace(assignment.ExecutionRef.ContextSnapshotID)
-		existing.StartedAt = assignment.StartedAt
-		existing.CompletedAt = assignment.CompletedAt
-		written, err := service.UpdateAssignment(ctx, existing)
-		if err != nil {
-			return err
-		}
-		recorded = projectWorkAssignmentFromCairnlineAuthority(written, assignment)
 		return nil
 	})
 	if err != nil {
@@ -1097,6 +1083,28 @@ func (h *Handler) persistStrictEmbeddedCairnlineAssignmentRuntime(ctx context.Co
 	}
 	h.shadowProjectAssignmentRuntimeToHecate(ctx, "project_assignment_start_cairnline_runtime", recorded)
 	return h.projectWorkApplication().ApplyAssignmentRuntime(ctx, recorded)
+}
+
+func (h *Handler) writeStrictEmbeddedCairnlineAssignmentRuntime(ctx context.Context, service *cairnline.Service, assignment projectwork.Assignment) (projectwork.Assignment, error) {
+	existing, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
+	if err != nil {
+		return assignment, err
+	}
+	existing.Status = cairnlinebridge.AssignmentStatus(assignment.Status)
+	existing.ExecutionRef = firstNonEmptyString(
+		strings.TrimSpace(assignment.ExecutionRef.RunID),
+		strings.TrimSpace(assignment.ExecutionRef.TaskID),
+		strings.TrimSpace(assignment.ExecutionRef.ChatSessionID),
+		strings.TrimSpace(assignment.ExecutionRef.ContextSnapshotID),
+	)
+	existing.ContextSnapshotID = strings.TrimSpace(assignment.ExecutionRef.ContextSnapshotID)
+	existing.StartedAt = assignment.StartedAt
+	existing.CompletedAt = assignment.CompletedAt
+	written, err := service.UpdateAssignment(ctx, existing)
+	if err != nil {
+		return assignment, err
+	}
+	return projectWorkAssignmentFromCairnlineAuthority(written, assignment), nil
 }
 
 func (h *Handler) projectAssignmentStartInputs(ctx context.Context, projectID, workItemID, assignmentID string, strictEmbeddedRead bool) (projectAssignmentLaunchInputs, error) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -4118,6 +4118,32 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelLaunc
 	if mirrored.Status != cairnlinebridge.AssignmentStatus(runtime.ExecutionRef.Status) || mirrored.ExecutionRef != ref.ChatSessionID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
 		t.Fatalf("mirrored Cairnline assignment = status %q ref %q context %q, want %q/%q/%q", mirrored.Status, mirrored.ExecutionRef, mirrored.ContextSnapshotID, cairnlinebridge.AssignmentStatus(runtime.ExecutionRef.Status), ref.ChatSessionID, ref.ContextSnapshotID)
 	}
+
+	completedAt := time.Now().UTC().Add(time.Second)
+	session, err = handler.agentChat.AppendMessage(t.Context(), ref.ChatSessionID, chat.Message{
+		ID:          "msg_embedded_external_done",
+		Role:        "assistant",
+		Status:      "completed",
+		TraceID:     "trace_embedded_external_done",
+		CreatedAt:   completedAt.Add(-time.Second),
+		StartedAt:   completedAt.Add(-time.Second),
+		CompletedAt: completedAt,
+	})
+	if err != nil {
+		t.Fatalf("Append completed chat message: %v", err)
+	}
+	handler.reconcileProjectAssignmentsForChat(t.Context(), session)
+	runtime, ok, err = handler.projectRuntime.Get(t.Context(), projectID, "asgn_embedded_external_start")
+	if err != nil || !ok {
+		t.Fatalf("Hecate assignment runtime after reconcile ok=%v err=%v, want runtime overlay", ok, err)
+	}
+	if runtime.ExecutionRef.Status != projectwork.AssignmentStatusCompleted || runtime.ExecutionRef.MessageID != "msg_embedded_external_done" || runtime.ExecutionRef.TraceID != "trace_embedded_external_done" || runtime.CompletedAt.IsZero() {
+		t.Fatalf("Hecate assignment runtime after reconcile = %+v completed_at=%v, want completed chat projection", runtime.ExecutionRef, runtime.CompletedAt)
+	}
+	mirrored = getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_embedded_external_start")
+	if mirrored.Status != cairnline.AssignmentCompleted || mirrored.ExecutionRef != ref.ChatSessionID || mirrored.ContextSnapshotID != ref.ContextSnapshotID || mirrored.CompletedAt.IsZero() {
+		t.Fatalf("mirrored Cairnline assignment after reconcile = %+v, want completed chat assignment", mirrored)
+	}
 }
 
 func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelCleansPreparedSessionWhenClaimLost(t *testing.T) {


### PR DESCRIPTION
## Summary
- reconcile linked External Agent chat completion/status back into embedded Cairnline when native project-work stores are absent
- share the strict embedded Cairnline assignment runtime write path between launch and reconciliation
- update Projects/Cairnline cutover docs and agent guidance for the no-native-project-work reconciliation boundary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModel(LaunchesCairnlineOnlyProject|CleansPreparedSessionWhenClaimLost)' -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
