### PR TITLE
fix(projects): prefer Cairnline runtime starts in replacement mode

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -74,6 +74,10 @@ do not make runtime preservation depend on a native compatibility assignment row
 In strict embedded mode, Hecate-task and external-agent assignment start may
 claim/progress the assignment directly in Cairnline and persist only the runtime
 overlay; do not reintroduce native project-work guards for those start paths.
+When embedded replacement mode is armed, prefer that Cairnline runtime path even
+if a compatibility project-work store is configured, and keep task/run or
+chat-session refs in the runtime overlay instead of advancing the native
+assignment shadow.
 Linked external-agent chat reconciliation must follow the same boundary: when
 native project-work stores are absent, reconcile status/ref changes back to the
 embedded Cairnline assignment plus Hecate's runtime overlay rather than

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -669,8 +669,9 @@ after these gates are met:
   orchestrator capabilities, but strict embedded mode can claim/progress the
   assignment in Cairnline and persist only task/run or chat-session refs,
   context packets, and timestamps in Hecate's runtime overlay when the native
-  project-work store is absent; it does not create a native project identity row
-  or compatibility assignment row.
+  project-work store is absent or embedded replacement mode is armed; it does
+  not create a native project identity row, and it does not advance
+  compatibility assignment rows with runtime refs.
   Linked external-agent chat reconciliation can update embedded Cairnline and
   the runtime overlay in the same no-native-project-work posture. Committed
   start and linked-chat reconciliation results may be mirrored only as

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -584,11 +584,12 @@ portable metadata after Hecate commits, but assignment start/dispatch remains
 Hecate-owned. In strict embedded read mode, Hecate-task and external-agent
 assignment start can resolve the project, work item, assignment, role, root, and
 execution defaults from a Cairnline-only project graph. When the native
-project-work store is absent, Hecate claims and progresses the assignment in
-embedded Cairnline and stores only task/run or chat-session refs, context
-packets, and launch timestamps in Hecate's project assignment runtime overlay;
-it does not create a native Hecate project identity row or compatibility
-assignment row. Runtime dispatch, task execution, and external-agent supervision
+project-work store is absent, or when embedded replacement mode is armed,
+Hecate claims and progresses the assignment in embedded Cairnline and stores
+only task/run or chat-session refs, context packets, and launch timestamps in
+Hecate's project assignment runtime overlay; it does not create a native Hecate
+project identity row, and it does not advance compatibility assignment rows
+with runtime refs. Runtime dispatch, task execution, and external-agent supervision
 remain Hecate-owned. Pre-dispatch cleanup and conflict states are mirrored back
 into Cairnline so replacement probes do not leave stale claimed assignment rows.
 Linked external-agent chat reconciliation can also update the embedded

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2681,8 +2681,9 @@ Cairnline-only graph. Hecate-task and external-agent assignment start can
 claim/progress the assignment in embedded Cairnline and persist only
 Hecate-owned task/run or chat-session refs, context packets, and launch
 timestamps in the assignment runtime overlay when the native project-work store
-is absent. They do not require a native Hecate project identity row or
-compatibility assignment row; runtime dispatch, task execution, and
+is absent or embedded replacement mode is armed. They do not require or advance
+a native Hecate project identity row, and they do not advance compatibility
+assignment rows with runtime refs; runtime dispatch, task execution, and
 external-agent supervision remain Hecate-owned.
 `project-assignment-chat-reconcile-live-mirror`
 best-effort mirrors assignment status/ref updates committed by linked

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -816,6 +816,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	project, workItem, assignment, role := inputs.Project, inputs.WorkItem, inputs.Assignment, inputs.Role
+	strictEmbeddedRuntime := h.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(strictEmbeddedRead)
 	if driver := strings.TrimSpace(req.DriverKind); driver != "" && driver != assignment.DriverKind {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, fmt.Sprintf("assignment driver_kind is %q, not %q", assignment.DriverKind, driver))
 		return
@@ -830,7 +831,7 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		return
 	}
 	if assignment.DriverKind == projectwork.AssignmentDriverExternalAgent {
-		if strictEmbeddedRead && h.projectWork != nil {
+		if strictEmbeddedRead && !strictEmbeddedRuntime && h.projectWork != nil {
 			inputs.Assignment = assignment
 			shadowedAssignment, err := h.shadowCairnlineAssignmentStartInputsToHecate(ctx, inputs)
 			if err != nil {
@@ -883,9 +884,9 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		contextPacket.ID = newChatID("ctx")
 	}
 
-	if strictEmbeddedRead && h.projectWork == nil {
+	if strictEmbeddedRuntime {
 		result, err := h.startStrictEmbeddedCairnlineTaskAssignment(ctx, project, workItem, assignment, role, plan, contextPacket)
-		h.writeProjectTaskAssignmentStartResult(w, ctx, assignment, result, err)
+		h.writeProjectTaskAssignmentStartResult(w, ctx, assignment, result, err, false)
 		return
 	}
 	if strictEmbeddedRead {
@@ -917,15 +918,22 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 			)))
 		},
 	})
-	h.writeProjectTaskAssignmentStartResult(w, ctx, assignment, result, err)
+	h.writeProjectTaskAssignmentStartResult(w, ctx, assignment, result, err, true)
 }
 
-func (h *Handler) writeProjectTaskAssignmentStartResult(w http.ResponseWriter, ctx context.Context, assignment projectwork.Assignment, result *projectworkapp.StartTaskAssignmentResult, err error) {
+func (h *Handler) projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(strictEmbeddedRead bool) bool {
+	if !strictEmbeddedRead {
+		return false
+	}
+	return h.projectWork == nil || h.config.ProjectsCairnlineReplacementMode() == "embedded"
+}
+
+func (h *Handler) writeProjectTaskAssignmentStartResult(w http.ResponseWriter, ctx context.Context, assignment projectwork.Assignment, result *projectworkapp.StartTaskAssignmentResult, err error, mirrorStartResult bool) {
 	if err != nil {
 		resultAssignment := assignment
 		if result != nil && result.Assignment.ID != "" {
 			resultAssignment = result.Assignment
-			if h.projectWork != nil {
+			if mirrorStartResult && h.projectWork != nil {
 				h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
 			}
 		}
@@ -939,6 +947,9 @@ func (h *Handler) writeProjectTaskAssignmentStartResult(w http.ResponseWriter, c
 			if projectErr != nil {
 				WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
 				return
+			}
+			if !mirrorStartResult {
+				projected.ReadBackend = "cairnline"
 			}
 			WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 			return
@@ -960,13 +971,16 @@ func (h *Handler) writeProjectTaskAssignmentStartResult(w http.ResponseWriter, c
 	if result.SpanID != "" {
 		w.Header().Set("X-Span-Id", result.SpanID)
 	}
-	if h.projectWork != nil {
+	if mirrorStartResult && h.projectWork != nil {
 		h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
 	}
 	projected, err := h.renderProjectedProjectWorkAssignment(ctx, result.Assignment)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
+	}
+	if !mirrorStartResult {
+		projected.ReadBackend = "cairnline"
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 }
@@ -1243,9 +1257,10 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		chatcontext.ProjectAssignmentRefs(project.ID, workItem.ID, assignment.ID, role.ID),
 	))
 	packetBytes := chatcontext.Marshal(contextPacket)
-	if h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads() && h.projectWork == nil {
+	strictEmbeddedRead := h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads()
+	if h.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(strictEmbeddedRead) {
 		result, err := h.startStrictEmbeddedCairnlineExternalAgentAssignment(ctx, assignment, session, contextPacket.ID, packetBytes)
-		h.writeProjectExternalAgentAssignmentStartResult(w, ctx, assignment, plan.Adapter.Name, result, err)
+		h.writeProjectExternalAgentAssignmentStartResult(w, ctx, assignment, plan.Adapter.Name, result, err, false)
 		return
 	}
 	result, err := h.projectWorkApplication().StartExternalAgentAssignment(ctx, projectworkapp.StartExternalAgentAssignmentCommand{
@@ -1255,7 +1270,7 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		ContextSnapshotID: contextPacket.ID,
 		ContextPacket:     packetBytes,
 	})
-	h.writeProjectExternalAgentAssignmentStartResult(w, ctx, assignment, plan.Adapter.Name, result, err)
+	h.writeProjectExternalAgentAssignmentStartResult(w, ctx, assignment, plan.Adapter.Name, result, err, true)
 }
 
 func (h *Handler) startStrictEmbeddedCairnlineExternalAgentAssignment(ctx context.Context, assignment projectwork.Assignment, session chat.Session, contextSnapshotID string, packetBytes []byte) (*projectworkapp.StartExternalAgentAssignmentResult, error) {
@@ -1342,7 +1357,7 @@ func (h *Handler) cleanupStrictEmbeddedExternalAgentSession(sessionID string) {
 	}
 }
 
-func (h *Handler) writeProjectExternalAgentAssignmentStartResult(w http.ResponseWriter, ctx context.Context, assignment projectwork.Assignment, adapterName string, result *projectworkapp.StartExternalAgentAssignmentResult, err error) {
+func (h *Handler) writeProjectExternalAgentAssignmentStartResult(w http.ResponseWriter, ctx context.Context, assignment projectwork.Assignment, adapterName string, result *projectworkapp.StartExternalAgentAssignmentResult, err error, mirrorStartResult bool) {
 	if err != nil {
 		var prepareErr projectworkapp.ExternalAgentPrepareError
 		if errors.As(err, &prepareErr) {
@@ -1352,7 +1367,7 @@ func (h *Handler) writeProjectExternalAgentAssignmentStartResult(w http.Response
 		resultAssignment := assignment
 		if result != nil && result.Assignment.ID != "" {
 			resultAssignment = result.Assignment
-			if h.projectWork != nil {
+			if mirrorStartResult && h.projectWork != nil {
 				h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
 			}
 		}
@@ -1362,19 +1377,25 @@ func (h *Handler) writeProjectExternalAgentAssignmentStartResult(w http.Response
 				WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
 				return
 			}
+			if !mirrorStartResult {
+				projected.ReadBackend = "cairnline"
+			}
 			WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 			return
 		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	if h.projectWork != nil {
+	if mirrorStartResult && h.projectWork != nil {
 		h.mirrorProjectAssignmentStartResultToCairnline(ctx, result.Assignment)
 	}
 	projected, err := h.renderProjectedProjectWorkAssignment(ctx, result.Assignment)
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
+	}
+	if !mirrorStartResult {
+		projected.ReadBackend = "cairnline"
 	}
 	WriteJSON(w, http.StatusOK, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
 }

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -265,9 +267,16 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if mirrored.ExecutionRef != ref.RunID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
 		t.Fatalf("mirrored Cairnline assignment = ref %q context %q, want %q/%q", mirrored.ExecutionRef, mirrored.ContextSnapshotID, ref.RunID, ref.ContextSnapshotID)
 	}
+	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_replacement")
+	if err != nil || !ok {
+		t.Fatalf("Hecate runtime overlay ok=%v err=%v after replacement start, want runtime refs", ok, err)
+	}
+	if runtime.ExecutionRef.RunID != ref.RunID || runtime.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("Hecate runtime overlay = %+v, want run/context %q/%q", runtime.ExecutionRef, ref.RunID, ref.ContextSnapshotID)
+	}
 	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_replacement", "asgn_replacement")
-	if shadow.ExecutionRef.RunID != ref.RunID || shadow.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
-		t.Fatalf("Hecate runtime shadow assignment = %+v, want run/context %q/%q", shadow.ExecutionRef, ref.RunID, ref.ContextSnapshotID)
+	if shadow.ExecutionRef.RunID != "" || shadow.ExecutionRef.ContextSnapshotID != "" {
+		t.Fatalf("Hecate compatibility shadow assignment = %+v, want replacement-mode start refs to live only in runtime overlay", shadow.ExecutionRef)
 	}
 
 	completed := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments/asgn_replacement", projectJourneyJSON(t, map[string]any{
@@ -361,6 +370,107 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	}
 	if mirroredWork := getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_replacement"); mirroredWork.Status != projectwork.WorkItemStatusDone {
 		t.Fatalf("mirrored Cairnline work = %+v, want done", mirroredWork)
+	}
+}
+
+func TestProjectJourneyAPI_CairnlineReplacementModeStartsExternalAgentWithoutAdvancingNativeShadow(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	runner := &fakeAgentChatRunner{nativeSessionID: "native_replacement_external"}
+	handler.SetAgentChatRunner(runner)
+	client := newAPITestClient(t, server)
+	root := t.TempDir()
+
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                "prof_replacement_external",
+		Name:              "Replacement external agent",
+		Surface:           agentprofiles.SurfaceExternalAgent,
+		ExecutionProfile:  "external_implementation",
+		ExternalAgentKind: "codex",
+	}); err != nil {
+		t.Fatalf("Create external profile: %v", err)
+	}
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Cairnline Replacement External Journey",
+		"roots": []map[string]any{{
+			"id":     "root_replacement_external",
+			"path":   root,
+			"kind":   "git",
+			"active": true,
+		}},
+	}))
+	projectID := project.Data.ID
+	if projectID == "" || project.Data.ReadBackend != "cairnline" {
+		t.Fatalf("project = %+v, want Cairnline replacement identity", project.Data)
+	}
+
+	role := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                    "role_replacement_external",
+		"name":                  "Replacement external implementer",
+		"instructions":          "Prepare the external adapter session from Cairnline state.",
+		"default_driver_kind":   projectwork.AssignmentDriverExternalAgent,
+		"default_agent_profile": "prof_replacement_external",
+	}))
+	if role.Data.ID != "role_replacement_external" || role.Data.ReadBackend != "cairnline" {
+		t.Fatalf("role = %+v, want Cairnline-backed external role", role.Data)
+	}
+
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_replacement_external",
+		"title":         "Prepare replacement external assignment",
+		"brief":         "Exercise replacement-mode External Agent launch with the compatibility store present.",
+		"status":        projectwork.WorkItemStatusReady,
+		"owner_role_id": "role_replacement_external",
+		"root_id":       "root_replacement_external",
+	}))
+	if work.Data.ID != "work_replacement_external" || work.Data.ReadBackend != "cairnline" {
+		t.Fatalf("work = %+v, want Cairnline-backed external work item", work.Data)
+	}
+
+	assignment := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement_external/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_replacement_external",
+		"role_id":     "role_replacement_external",
+		"root_id":     "root_replacement_external",
+		"driver_kind": projectwork.AssignmentDriverExternalAgent,
+	}))
+	if assignment.Data.ID != "asgn_replacement_external" || assignment.Data.ReadBackend != "cairnline" || assignment.Data.Status != projectwork.AssignmentStatusQueued {
+		t.Fatalf("assignment = %+v, want queued Cairnline-backed external assignment", assignment.Data)
+	}
+
+	started := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement_external/assignments/asgn_replacement_external/start", `{"driver_kind":"external_agent"}`)
+	ref := assignmentExecutionRefForTest(t, started.Data)
+	if ref.ChatSessionID == "" || ref.ContextSnapshotID == "" || ref.TaskID != "" || ref.RunID != "" {
+		t.Fatalf("started assignment execution_ref = %+v, want chat/context links only", ref)
+	}
+	if started.Data.Status != projectwork.AssignmentStatusRunning || started.Data.ReadBackend != "cairnline" {
+		t.Fatalf("started assignment = %+v, want running Cairnline-backed external assignment", started.Data)
+	}
+	resolvedWorkspace, err := agentadapters.ValidateWorkspace(root)
+	if err != nil {
+		t.Fatalf("ValidateWorkspace: %v", err)
+	}
+	if len(runner.prepareRequests) != 1 || runner.prepareRequests[0].AdapterID != "codex" || runner.prepareRequests[0].SessionID != ref.ChatSessionID || runner.prepareRequests[0].Workspace != resolvedWorkspace {
+		t.Fatalf("prepare requests = %+v, want one codex session in workspace %q", runner.prepareRequests, resolvedWorkspace)
+	}
+	if len(runner.runRequests) != 0 {
+		t.Fatalf("run requests = %+v, want no automatic external-agent turn", runner.runRequests)
+	}
+
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_replacement_external")
+	if mirrored.ExecutionRef != ref.ChatSessionID || mirrored.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("mirrored Cairnline assignment = ref %q context %q, want %q/%q", mirrored.ExecutionRef, mirrored.ContextSnapshotID, ref.ChatSessionID, ref.ContextSnapshotID)
+	}
+	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_replacement_external")
+	if err != nil || !ok {
+		t.Fatalf("Hecate runtime overlay ok=%v err=%v after replacement external start, want runtime refs", ok, err)
+	}
+	if runtime.ExecutionRef.ChatSessionID != ref.ChatSessionID || runtime.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
+		t.Fatalf("Hecate runtime overlay = %+v, want chat/context %q/%q", runtime.ExecutionRef, ref.ChatSessionID, ref.ContextSnapshotID)
+	}
+	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_replacement_external", "asgn_replacement_external")
+	if shadow.ExecutionRef.ChatSessionID != "" || shadow.ExecutionRef.ContextSnapshotID != "" {
+		t.Fatalf("Hecate compatibility shadow assignment = %+v, want replacement-mode external start refs to live only in runtime overlay", shadow.ExecutionRef)
 	}
 }
 


### PR DESCRIPTION
## Summary
- route replacement-mode assignment starts through the strict embedded Cairnline runtime path even when the native compatibility store is present
- keep task/run and external-agent chat refs in the runtime overlay instead of advancing native assignment shadows during start
- add replacement-mode journey coverage for both Hecate task and External Agent starts
- update operator/runtime/design guidance for the replacement-mode start boundary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectJourneyAPI_CairnlineReplacementMode' -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|StartAssignmentStrictEmbeddedReadModelReleasesCairnlineClaimWhenTaskCreateFails|StartExternalAgentAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|StartExternalAgentAssignmentStrictEmbeddedReadModelCleansPreparedSessionWhenClaimLost)' -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus_(EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover|CairnlineEmbeddedReplacementModeArmed)|TestProjectsAPI_CairnlineReplacementMode' -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...