### PR TITLE
fix(projects): read Cairnline launch collaboration context

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -78,6 +78,9 @@ When embedded replacement mode is armed, prefer that Cairnline runtime path even
 if a compatibility project-work store is configured, and keep task/run or
 chat-session refs in the runtime overlay instead of advancing the native
 assignment shadow.
+Assignment launch/preflight context must read inspect-only collaboration
+artifact and handoff metadata from the active Cairnline read model before
+falling back to Hecate-native project-work rows.
 Linked external-agent chat reconciliation must follow the same boundary: when
 native project-work stores are absent, reconcile status/ref changes back to the
 embedded Cairnline assignment plus Hecate's runtime overlay rather than

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -665,6 +665,9 @@ after these gates are met:
   Cairnline launch-packet evidence, and strict embedded reads may use a
   Cairnline-only project graph as the source of launch inputs. Launch-readiness
   and preflight can use those inputs without native Hecate project/work stores.
+  Launch/preflight context also reads inspect-only collaboration artifact and
+  handoff metadata from the active Cairnline read model, preserving
+  evidence/review/handoff hints for Cairnline-only graphs.
   Hecate-task and external-agent assignment start remain Hecate-owned
   orchestrator capabilities, but strict embedded mode can claim/progress the
   assignment in Cairnline and persist only task/run or chat-session refs,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2684,7 +2684,10 @@ timestamps in the assignment runtime overlay when the native project-work store
 is absent or embedded replacement mode is armed. They do not require or advance
 a native Hecate project identity row, and they do not advance compatibility
 assignment rows with runtime refs; runtime dispatch, task execution, and
-external-agent supervision remain Hecate-owned.
+external-agent supervision remain Hecate-owned. Assignment launch/preflight
+context uses the active Cairnline read model for inspect-only collaboration
+artifact and handoff metadata, so Cairnline-only project graphs preserve the
+same evidence/review/handoff hints as native project-work rows.
 `project-assignment-chat-reconcile-live-mirror`
 best-effort mirrors assignment status/ref updates committed by linked
 external-agent chat reconciliation, and strict embedded reconciliation can

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -700,6 +700,9 @@ func (h *Handler) enabledProjectMemoryEntries(ctx context.Context, projectID str
 }
 
 func (h *Handler) assignmentRelevantArtifacts(ctx context.Context, assignment projectwork.Assignment) []projectwork.CollaborationArtifact {
+	if items, ok := h.cairnlineAssignmentRelevantArtifacts(ctx, assignment); ok {
+		return items
+	}
 	if h == nil || h.projectWork == nil {
 		return nil
 	}
@@ -720,6 +723,9 @@ func (h *Handler) assignmentRelevantArtifacts(ctx context.Context, assignment pr
 }
 
 func (h *Handler) assignmentRelevantHandoffs(ctx context.Context, assignment projectwork.Assignment, roleID string) []projectwork.Handoff {
+	if items, ok := h.cairnlineAssignmentRelevantHandoffs(ctx, assignment, roleID); ok {
+		return items
+	}
 	if h == nil || h.projectWork == nil {
 		return nil
 	}
@@ -737,6 +743,78 @@ func (h *Handler) assignmentRelevantHandoffs(ctx context.Context, assignment pro
 		}
 	}
 	return filtered
+}
+
+func (h *Handler) cairnlineAssignmentRelevantArtifacts(ctx context.Context, assignment projectwork.Assignment) ([]projectwork.CollaborationArtifact, bool) {
+	if h == nil || strings.TrimSpace(assignment.ProjectID) == "" || strings.TrimSpace(assignment.WorkItemID) == "" {
+		return nil, false
+	}
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		project, ok, err := h.cairnlineSidecarProject(ctx, assignment.ProjectID)
+		if err != nil || !ok {
+			return nil, true
+		}
+		artifacts, err := h.cairnlineSidecarProjectArtifactList(ctx, project.ID, assignment.WorkItemID)
+		if err != nil {
+			return nil, true
+		}
+		evidence, err := h.cairnlineSidecarProjectEvidenceList(ctx, project.ID, assignment.WorkItemID)
+		if err != nil {
+			return nil, true
+		}
+		reviews, err := h.cairnlineSidecarProjectReviewList(ctx, project.ID, assignment.WorkItemID)
+		if err != nil {
+			return nil, true
+		}
+		items := filterAssignmentArtifacts(projectArtifactsFromCairnlineSidecar(artifacts, evidence, reviews), assignment.ID)
+		sortProjectWorkArtifactsForProjection(items)
+		return items, true
+	}
+	if !h.projectReadRoutesUseCairnlineReadModel() {
+		return nil, false
+	}
+	view, err := h.cairnlineProjectWorkView(ctx, assignment.ProjectID)
+	if err != nil {
+		return nil, true
+	}
+	defer view.Close()
+	items, err := cairnlineProjectWorkArtifacts(ctx, view.service, view.snapshot.Project.ID, assignment.WorkItemID)
+	if err != nil {
+		return nil, true
+	}
+	return filterAssignmentArtifacts(items, assignment.ID), true
+}
+
+func (h *Handler) cairnlineAssignmentRelevantHandoffs(ctx context.Context, assignment projectwork.Assignment, roleID string) ([]projectwork.Handoff, bool) {
+	if h == nil || strings.TrimSpace(assignment.ProjectID) == "" || strings.TrimSpace(assignment.WorkItemID) == "" {
+		return nil, false
+	}
+	if h.projectCairnlineSidecarReadRoutesEnabled() {
+		project, ok, err := h.cairnlineSidecarProject(ctx, assignment.ProjectID)
+		if err != nil || !ok {
+			return nil, true
+		}
+		handoffs, err := h.cairnlineSidecarProjectHandoffList(ctx, project.ID, assignment.WorkItemID)
+		if err != nil {
+			return nil, true
+		}
+		items := filterAssignmentHandoffs(projectHandoffsFromCairnlineSidecar(handoffs), assignment.ID, roleID)
+		sortProjectHandoffsForProjection(items)
+		return items, true
+	}
+	if !h.projectReadRoutesUseCairnlineReadModel() {
+		return nil, false
+	}
+	view, err := h.cairnlineProjectWorkView(ctx, assignment.ProjectID)
+	if err != nil {
+		return nil, true
+	}
+	defer view.Close()
+	items, err := cairnlineProjectHandoffs(ctx, view.service, view.snapshot.Project.ID, assignment.WorkItemID, "")
+	if err != nil {
+		return nil, true
+	}
+	return filterAssignmentHandoffs(items, assignment.ID, roleID), true
 }
 
 func appendProjectMemory(packet *chat.ContextPacket, entries []memory.Entry, includedMemoryIDs map[string]bool) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3843,13 +3843,42 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineO
 		}); err != nil {
 			return err
 		}
-		_, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+		if _, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
 			ID:            "asgn_embedded_launch_start",
 			ProjectID:     projectID,
 			WorkItemID:    "work_embedded_launch_start",
 			RoleID:        "role_embedded_launch_start",
 			RootID:        "root_embedded_launch_start",
 			ExecutionMode: cairnline.ExecutionOrchestrated,
+		}); err != nil {
+			return err
+		}
+		if _, err := service.CreateArtifact(t.Context(), cairnline.Artifact{
+			ID:           "artifact_embedded_launch_start",
+			ProjectID:    projectID,
+			WorkItemID:   "work_embedded_launch_start",
+			AssignmentID: "asgn_embedded_launch_start",
+			Kind:         projectwork.ArtifactKindBrief,
+			Title:        "Launch context artifact",
+			Body:         "Keep this Cairnline-only artifact visible in the start context.",
+			AuthorRoleID: "role_embedded_launch_start",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateHandoff(t.Context(), cairnline.Handoff{
+			ID:                    "handoff_embedded_launch_start",
+			ProjectID:             projectID,
+			WorkItemID:            "work_embedded_launch_start",
+			SourceAssignmentID:    "asgn_embedded_launch_start",
+			FromRoleID:            "role_embedded_launch_start",
+			ToRoleID:              "role_embedded_launch_start",
+			Title:                 "Launch context handoff",
+			Body:                  "Keep this Cairnline-only handoff visible in the start context.",
+			RecommendedNextAction: "Inspect the persisted context packet.",
+			LinkedArtifactIDs:     []string{"artifact_embedded_launch_start"},
+			ContextRefs:           []string{"ctx_embedded_launch_start"},
+			Status:                cairnline.HandoffStatusOpen,
+			TrustLabel:            "operator_reviewed",
 		})
 		return err
 	}); err != nil {
@@ -3889,6 +3918,13 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineO
 	}
 	if !strings.Contains(task.Prompt, "Start embedded assignment") || !strings.Contains(task.SystemPrompt, "Use the embedded Cairnline graph.") {
 		t.Fatalf("task prompt/system = %q / %q, want Cairnline work and role context", task.Prompt, task.SystemPrompt)
+	}
+	packetResp := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/tasks/"+ref.TaskID+"/runs/"+ref.RunID+"/context", "")
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "artifact_embedded_launch_start"); item == nil || item.Included || item.Section != contextSectionProjectWork {
+		t.Fatalf("Cairnline artifact context item = %+v, want inspect-only project_work artifact metadata", item)
+	}
+	if item := findRenderedContextItemByOrigin(packetResp.Data, "handoff_embedded_launch_start"); item == nil || item.Included || item.Section != contextSectionProjectWork {
+		t.Fatalf("Cairnline handoff context item = %+v, want inspect-only project_work handoff metadata", item)
 	}
 
 	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_embedded_launch_start")


### PR DESCRIPTION
## Summary
- read assignment launch/preflight artifact metadata from the active Cairnline read model before falling back to Hecate-native project-work rows
- read assignment launch/preflight handoff metadata from the active Cairnline read model before falling back to Hecate-native project-work rows
- cover the Cairnline-only strict embedded start path so persisted context packets include inspect-only artifact and handoff items
- update runtime/design/AI docs for the launch-context boundary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject' -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- just go-format-check
- just docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...