### PR TITLE
fix(projects): prefer runtime assignment context packets

### DIFF
--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -81,6 +81,10 @@ assignment shadow.
 Assignment launch/preflight context must read inspect-only collaboration
 artifact and handoff metadata from the active Cairnline read model before
 falling back to Hecate-native project-work rows.
+Strict embedded assignment context reads must prefer a matching Hecate runtime
+overlay context packet after Hecate has launched the assignment, and use
+Cairnline's inspect-only assignment context only when no persisted runtime
+snapshot exists yet.
 Linked external-agent chat reconciliation must follow the same boundary: when
 native project-work stores are absent, reconcile status/ref changes back to the
 embedded Cairnline assignment plus Hecate's runtime overlay rather than

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -272,6 +272,10 @@ preflight, Project Assistant context/proposal, and operations brief reads render
 work items, assignments, roles, artifacts, and handoffs from the Cairnline
 service records, then overlay Hecate-only runtime refs/timestamps and runtime
 launch validation where Hecate still owns execution.
+For strict embedded assignment context, Hecate prefers a matching persisted
+runtime-overlay context packet after a Hecate-owned task/chat launch; queued
+assignments without that runtime snapshot continue to return Cairnline's
+inspect-only assignment context.
 For remaining embedded read-route families, some project compatibility
 scaffolding still comes from Hecate until Cairnline becomes authoritative. The
 direct strict embedded exceptions are project list/detail, project skill list,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -6082,7 +6082,11 @@ entry, artifact, or assignment update. It shows portable project/work/role,
 profile, skill, source, memory, evidence, review, and handoff metadata so the
 operator can inspect what Cairnline would hand to a compatible orchestrator.
 
-In strict embedded mode, the endpoint reads the assignment context directly
+In strict embedded mode, the endpoint first checks Hecate's assignment runtime
+overlay for a persisted task/chat execution context packet whose refs match the
+requested project, work item, and assignment. When that snapshot exists, the
+endpoint returns it so assignment context matches the launched execution. Before
+an assignment is started, it reads the inspect-only assignment context directly
 from the embedded Cairnline database and does not require a matching
 Hecate-native project or assignment row.
 

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/chatcontext"
@@ -135,7 +136,16 @@ func (h *Handler) HandleProjectWorkAssignmentContext(w http.ResponseWriter, r *h
 		return
 	}
 	if h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads() {
-		packet, ok, err := h.contextPacketForStrictEmbeddedCairnlineProjectAssignment(ctx, projectID, workItemID, assignmentID)
+		packet, ok, err := h.contextPacketForStrictEmbeddedCairnlineRuntimeAssignment(ctx, projectID, workItemID, assignmentID)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		if ok {
+			writeChatContextPacket(w, packet)
+			return
+		}
+		packet, ok, err = h.contextPacketForStrictEmbeddedCairnlineProjectAssignment(ctx, projectID, workItemID, assignmentID)
 		if err != nil {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
@@ -255,6 +265,56 @@ func (h *Handler) contextPacketForProjectAssignment(ctx context.Context, assignm
 		return packet, found, nil
 	}
 	return h.contextPacketForCairnlineProjectAssignment(ctx, assignment)
+}
+
+func (h *Handler) contextPacketForStrictEmbeddedCairnlineRuntimeAssignment(ctx context.Context, projectID, workItemID, assignmentID string) (chat.ContextPacket, bool, error) {
+	if h == nil || h.projectRuntime == nil {
+		return chat.ContextPacket{}, false, nil
+	}
+	projectID = strings.TrimSpace(projectID)
+	workItemID = strings.TrimSpace(workItemID)
+	assignmentID = strings.TrimSpace(assignmentID)
+	runtime, ok, err := h.projectRuntime.Get(ctx, projectID, assignmentID)
+	if err != nil || !ok || len(runtime.ContextPacket) == 0 {
+		return chat.ContextPacket{}, false, err
+	}
+	view, err := h.cairnlineProjectWorkView(ctx, projectID)
+	if errors.Is(err, projects.ErrNotFound) {
+		return chat.ContextPacket{}, false, nil
+	}
+	if err != nil {
+		return chat.ContextPacket{}, false, err
+	}
+	defer view.Close()
+	assignment, err := view.service.GetAssignment(ctx, view.snapshot.Project.ID, assignmentID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return chat.ContextPacket{}, false, nil
+	}
+	if err != nil {
+		return chat.ContextPacket{}, false, err
+	}
+	if strings.TrimSpace(assignment.ProjectID) != projectID ||
+		strings.TrimSpace(assignment.WorkItemID) != workItemID ||
+		strings.TrimSpace(assignment.ID) != assignmentID {
+		return chat.ContextPacket{}, false, nil
+	}
+	packet, ok, err := chatcontext.FromProjectAssignmentPayload(runtime.ContextPacket)
+	if err != nil || !ok {
+		return chat.ContextPacket{}, ok, err
+	}
+	if packet.Refs == nil ||
+		strings.TrimSpace(packet.Refs.ProjectID) != projectID ||
+		strings.TrimSpace(packet.Refs.WorkItemID) != workItemID ||
+		strings.TrimSpace(packet.Refs.AssignmentID) != assignmentID {
+		return chat.ContextPacket{}, false, nil
+	}
+	roleID := strings.TrimSpace(packet.Refs.RoleID)
+	ref := projectwork.NormalizeAssignmentExecutionRef(runtime.ExecutionRef)
+	return chatcontext.Normalize(packet, chatcontext.MergeRefs(
+		chatcontext.ProjectAssignmentRefs(projectID, workItemID, assignmentID, roleID),
+		chatcontext.TaskRunRefs(ref.TaskID, ref.RunID, projectID),
+		chatcontext.ChatMessageRefs(ref.ChatSessionID, ref.MessageID, projectID),
+	)), true, nil
 }
 
 func (h *Handler) directModelContextPacket(ctx context.Context, session chat.Session, provider, model, systemPrompt string) chat.ContextPacket {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3927,6 +3927,28 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineO
 		t.Fatalf("Cairnline handoff context item = %+v, want inspect-only project_work handoff metadata", item)
 	}
 
+	assignmentPacket := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_embedded_launch_start/assignments/asgn_embedded_launch_start/context", "")
+	if assignmentPacket.Data.ID != ref.ContextSnapshotID {
+		t.Fatalf("assignment context id = %q, want persisted runtime context %q", assignmentPacket.Data.ID, ref.ContextSnapshotID)
+	}
+	if assignmentPacket.Data.Refs == nil || assignmentPacket.Data.Refs.TaskID != ref.TaskID || assignmentPacket.Data.Refs.RunID != ref.RunID || assignmentPacket.Data.Refs.ProjectID != projectID || assignmentPacket.Data.Refs.WorkItemID != "work_embedded_launch_start" || assignmentPacket.Data.Refs.AssignmentID != "asgn_embedded_launch_start" {
+		t.Fatalf("assignment context refs = %+v, want persisted task/run assignment refs", assignmentPacket.Data.Refs)
+	}
+	if item := findRenderedContextItemByOrigin(assignmentPacket.Data, "artifact_embedded_launch_start"); item == nil || item.Included || item.Section != contextSectionProjectWork {
+		t.Fatalf("assignment context artifact item = %+v, want persisted runtime artifact metadata", item)
+	}
+	if item := findRenderedContextItemByOrigin(assignmentPacket.Data, "handoff_embedded_launch_start"); item == nil || item.Included || item.Section != contextSectionProjectWork {
+		t.Fatalf("assignment context handoff item = %+v, want persisted runtime handoff metadata", item)
+	}
+	if item := findRenderedContextItemByOrigin(assignmentPacket.Data, "cairnline.assignments.context"); item != nil {
+		t.Fatalf("assignment context runtime item = %+v, want persisted runtime packet rather than inspect-only Cairnline preview", item)
+	}
+	mismatchRec := httptest.NewRecorder()
+	server.ServeHTTP(mismatchRec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_other/assignments/asgn_embedded_launch_start/context", nil))
+	if mismatchRec.Code != http.StatusNotFound {
+		t.Fatalf("route-mismatched runtime assignment context status = %d body=%s, want 404", mismatchRec.Code, mismatchRec.Body.String())
+	}
+
 	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_embedded_launch_start")
 	if err != nil || !ok {
 		t.Fatalf("Hecate assignment runtime ok=%v err=%v, want runtime overlay", ok, err)


### PR DESCRIPTION
## Summary
- prefer persisted Hecate assignment runtime context packets for strict embedded Cairnline assignment context reads
- keep queued assignments on inspect-only Cairnline assignment context previews
- document the runtime-overlay preference in runtime/API and project context docs

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineOnlyProject|AssignmentContextStrictEmbeddedReadModelReadsWithoutHecateProject)'\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- GOCACHE="$(pwd)/.gocache" go vet ./internal/api\n- just go-format-check\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n