### PR TITLE
fix(projects): report authoritative Cairnline status clearly

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -710,6 +710,9 @@ after these gates are met:
   strict embedded read smoke and migration/rollback gates are clean. Once those
   gates are clean, the `migration-cutover` switchpoint reports
   `embedded_cutover_armed` instead of a blocking Hecate-owned cutover gap.
+  At that point backend status reports `status=cairnline_authoritative`; any
+  warnings should describe the remaining Hecate-owned runtime/workspace
+  side-effect boundary, not stale Hecate-store authority.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -665,6 +665,10 @@ Projects coordination state. In that armed mode with all portable
 write-authority gaps closed, new Cairnline-authoritative project identity
 creates no longer manufacture native Hecate project identity rows;
 compatibility shadows remain limited to Hecate-owned runtime/workspace needs.
+Once all replacement gates are ready, backend status reports
+`status=cairnline_authoritative` and keeps warnings focused on Hecate-owned
+runtime/workspace side effects instead of saying Hecate stores remain
+authoritative.
 It also groups the broad `write_adapter_gaps`
 diagnostic list into
 `portable_write_gaps`,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2576,6 +2576,11 @@ That identity-shadow behavior is a write-path switch, not the full readiness
 verdict: clients should use `replacement_ready` and `replacement_gates` to tell
 whether mirror parity, strict read smoke, migration, and rollback are actually
 clean.
+When every replacement gate is ready, `status` becomes
+`cairnline_authoritative`, `detail` describes Cairnline as authoritative for
+portable Projects coordination state, and warnings are limited to the remaining
+Hecate-owned runtime/workspace side-effect boundary rather than stale
+Hecate-store authority warnings.
 When the next action is `rehearse-migration-cutover`, `config_hints` identify
 the strict embedded dogfood posture expected for the rehearsal:
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -452,9 +452,26 @@ func projectCairnlineStatusWithNextAction(response ProjectCoordinationBackendSta
 	if response.ReplacementReady {
 		response.AuthoritativeBackend = "cairnline"
 		response.CairnlineAuthoritative = true
+		response.Status = "cairnline_authoritative"
+		response.Detail = projectCairnlineReplacementReadyDetail()
+		response.Warnings = projectCairnlineReplacementReadyWarnings(response.OrchestratorCapabilities)
 	}
 	response.NextReplacementAction = projectCairnlineNextReplacementAction(response)
 	return response
+}
+
+func projectCairnlineReplacementReadyDetail() string {
+	return "All Cairnline replacement gates are ready and embedded replacement mode is armed; Hecate is reporting Cairnline as authoritative for portable Projects coordination state."
+}
+
+func projectCairnlineReplacementReadyWarnings(orchestratorCapabilities []string) []string {
+	warnings := []string{
+		"Hecate still owns runtime/workspace side effects such as task/chat execution, External Agent supervision, approvals, traces, root discovery, and Git worktree creation.",
+	}
+	if len(orchestratorCapabilities) > 0 {
+		warnings = append(warnings, "Remaining Hecate-owned orchestrator capabilities: "+strings.Join(orchestratorCapabilities, ", ")+".")
+	}
+	return warnings
 }
 
 func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStatusResponse) *ProjectCoordinationBackendNextAction {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -460,6 +460,17 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 	if !status.ReplacementReady || status.AuthoritativeBackend != "cairnline" || !status.CairnlineAuthoritative {
 		t.Fatalf("status = %+v, want verified embedded replacement to report Cairnline authoritative", status)
 	}
+	if status.Status != "cairnline_authoritative" || !strings.Contains(status.Detail, "Cairnline as authoritative") {
+		t.Fatalf("status/detail = %q/%q, want authoritative Cairnline replacement wording", status.Status, status.Detail)
+	}
+	for _, warning := range status.Warnings {
+		if strings.Contains(warning, "Hecate stores remain authoritative") || strings.Contains(warning, "Other project mutation routes still write only Hecate-native stores") {
+			t.Fatalf("warning = %q, want replacement-ready runtime-boundary warning without stale Hecate-authoritative wording", warning)
+		}
+	}
+	if len(status.Warnings) == 0 || !strings.Contains(strings.Join(status.Warnings, "\n"), "Hecate still owns runtime/workspace side effects") {
+		t.Fatalf("warnings = %+v, want runtime/workspace side-effect boundary after replacement is ready", status.Warnings)
+	}
 	if len(status.MigrationBlockers) != 0 {
 		t.Fatalf("migration blockers = %+v, want none after embedded replacement cutover is armed", status.MigrationBlockers)
 	}


### PR DESCRIPTION
## Summary
- report `status=cairnline_authoritative` when every Cairnline replacement gate is ready
- replace stale Hecate-authoritative warning prose with runtime/workspace side-effect boundary warnings
- document the ready-status contract in runtime, operator, and design docs

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover|TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed|TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAliasConfigured'\n- GOCACHE="$(pwd)/.gocache" go test ./internal/api\n- GOCACHE="$(pwd)/.gocache" go vet ./internal/api\n- just go-format-check\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n