### PR TITLE
fix(projects): gate embedded launch runtime by authority

### DIFF
--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -925,7 +925,7 @@ func (h *Handler) projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(stric
 	if !strictEmbeddedRead {
 		return false
 	}
-	return h.projectWork == nil || h.config.ProjectsCairnlineReplacementMode() == "embedded"
+	return h.projectWork == nil || h.projectCairnlineEmbeddedReplacementModeArmed()
 }
 
 func (h *Handler) writeProjectTaskAssignmentStartResult(w http.ResponseWriter, ctx context.Context, assignment projectwork.Assignment, result *projectworkapp.StartTaskAssignmentResult, err error, mirrorStartResult bool) {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -292,6 +292,31 @@ func TestProjectWorkAPI_CairnlineReadSourceEmbeddedRequiresMirror(t *testing.T) 
 	}
 }
 
+func TestProjectWorkAPI_StrictEmbeddedRuntimeRequiresReplacementAuthority(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineReplacementMode: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	if handler.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(true) {
+		t.Fatal("strict embedded runtime = true, want false until portable write authority gaps are closed")
+	}
+
+	handler.config.Projects.CairnlineWriteAuthority = "all-portable"
+	if !handler.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(true) {
+		t.Fatal("strict embedded runtime = false, want true when replacement mode is armed and portable write gaps are closed")
+	}
+	if handler.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(false) {
+		t.Fatal("strict embedded runtime = true without strict embedded reads")
+	}
+}
+
 func TestProjectWorkAPI_CairnlineReadSourceEmbeddedUsesCairnlineOnlyProject(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{


### PR DESCRIPTION
## Summary
- make strict embedded assignment start use the shared embedded replacement authority predicate
- prevent replacement_mode=embedded alone from moving launch runtime mutation ahead of portable write-authority gates
- add a regression test for the negative and all-portable positive cases

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(StrictEmbeddedRuntimeRequiresReplacementAuthority|StartAssignmentStrictEmbeddedReadModel)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...