### PR TITLE
Align Cairnline replacement readbacks

### DIFF
--- a/internal/api/handler_project_context_discovery_test.go
+++ b/internal/api/handler_project_context_discovery_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -375,6 +376,9 @@ func TestProjectContextDiscovery_CairnlineAuthorityAcceptsCairnlineOnlyProject(t
 	if got := projectContextSourceResponseByPath(resp.Data.ContextSources, "AGENTS.md"); got == nil || got.Kind != "workspace_instruction" || got.Metadata["root_id"] != "root_main" {
 		t.Fatalf("response AGENTS source = %+v, want discovered Cairnline-owned root guidance", got)
 	}
+	if resp.Data.ReadBackend != "cairnline" {
+		t.Fatalf("discovery read_backend = %q, want cairnline for Cairnline-authoritative discovery response", resp.Data.ReadBackend)
+	}
 	if _, ok, err := projectStore.Get(t.Context(), "proj_guidance_cairnline_only"); err != nil || ok {
 		t.Fatalf("native project lookup ok=%v err=%v, want no native project row", ok, err)
 	}
@@ -382,6 +386,53 @@ func TestProjectContextDiscovery_CairnlineAuthorityAcceptsCairnlineOnlyProject(t
 	project := getMirroredCairnlineProjectForTest(t, handler, "proj_guidance_cairnline_only")
 	if got := findCairnlineSourceByLocatorForAPITest(project.ContextSources, "AGENTS.md"); got == nil || got.Kind != "workspace_instruction" {
 		t.Fatalf("Cairnline sources = %+v, want discovered AGENTS.md source", project.ContextSources)
+	}
+}
+
+func TestProjectContextDiscovery_CairnlineReplacementModeSkipsMissingCompatibilityShadowWarning(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeDiscoveryFile(t, root, "AGENTS.md")
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineWriteAuthority:  "all-portable",
+			CairnlineReplacementMode: "embedded",
+		},
+	}, logger, nil, nil, nil, nil)
+	projectStore := projects.NewMemoryStore()
+	handler.SetProjectStore(projectStore)
+	server := NewServer(logger, handler)
+	client := newAPITestClient(t, server)
+
+	created := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Replacement guidance discovery",
+		"roots": []map[string]any{{
+			"id":     "root_main",
+			"path":   root,
+			"kind":   "local",
+			"active": true,
+		}},
+	}))
+	if _, ok, err := projectStore.Get(t.Context(), created.Data.ID); err != nil || ok {
+		t.Fatalf("native project lookup ok=%v err=%v, want no native project row", ok, err)
+	}
+
+	resp := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+created.Data.ID+"/context-sources/discover", `{}`)
+	if resp.Data.ReadBackend != "cairnline" {
+		t.Fatalf("discovery read_backend = %q, want cairnline for replacement-mode authoritative response", resp.Data.ReadBackend)
+	}
+	if got := projectContextSourceResponseByPath(resp.Data.ContextSources, "AGENTS.md"); got == nil || got.Kind != "workspace_instruction" {
+		t.Fatalf("response AGENTS source = %+v, want discovered workspace guidance", got)
+	}
+	if bytes.Contains(logs.Bytes(), []byte("cairnline project mirror write failed")) {
+		t.Fatalf("logs contain compatibility-shadow warning for intentional Cairnline-only project:\n%s", logs.String())
 	}
 }
 

--- a/internal/api/handler_project_metadata_authority.go
+++ b/internal/api/handler_project_metadata_authority.go
@@ -203,6 +203,9 @@ func (h *Handler) shadowProjectMetadataDefaultsToHecate(ctx context.Context, ope
 		item.DefaultCompactToolOutput = cloneBool(project.DefaultCompactToolOutput)
 	})
 	if err != nil {
+		if h.shouldSkipMissingProjectCompatibilityShadow(err) {
+			return project, false
+		}
 		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
 		return project, false
 	}

--- a/internal/api/handler_project_root_source_authority.go
+++ b/internal/api/handler_project_root_source_authority.go
@@ -595,6 +595,10 @@ func (h *Handler) shadowProjectRootsToHecate(ctx context.Context, operation stri
 		item.DefaultRootID = project.DefaultRootID
 	})
 	if err != nil {
+		if h.shouldSkipMissingProjectCompatibilityShadow(err) {
+			root, _ := findProjectRootByID(project.Roots, rootID)
+			return project, root
+		}
 		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
 		root, _ := findProjectRootByID(project.Roots, rootID)
 		return project, root
@@ -613,6 +617,10 @@ func (h *Handler) shadowProjectContextSourcesToHecate(ctx context.Context, opera
 		item.ContextSources = append([]projects.ContextSource(nil), project.ContextSources...)
 	})
 	if err != nil {
+		if h.shouldSkipMissingProjectCompatibilityShadow(err) {
+			source, _ := findProjectContextSourceByID(project.ContextSources, sourceID)
+			return project, source
+		}
 		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
 		source, _ := findProjectContextSourceByID(project.ContextSources, sourceID)
 		return project, source
@@ -648,10 +656,17 @@ func (h *Handler) shadowProjectRootSourceListsToHecate(ctx context.Context, oper
 		}
 	})
 	if err != nil {
+		if h.shouldSkipMissingProjectCompatibilityShadow(err) {
+			return project, false
+		}
 		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
 		return project, false
 	}
 	return shadowed, true
+}
+
+func (h *Handler) shouldSkipMissingProjectCompatibilityShadow(err error) bool {
+	return errors.Is(err, projects.ErrNotFound)
 }
 
 func projectAppErrorFromCairnlineAuthority(err error, missing string) error {
@@ -710,7 +725,7 @@ func writeProjectRootCairnlineAuthorityResponse(w http.ResponseWriter, status in
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, status, ProjectResponse{Object: "project", Data: renderProject(project)})
+	WriteJSON(w, status, ProjectResponse{Object: "project", Data: renderCairnlineAuthorityProject(project)})
 }
 
 func writeProjectListReplaceCairnlineAuthorityResponse(w http.ResponseWriter, project projects.Project, err error) {
@@ -730,7 +745,7 @@ func writeProjectListReplaceCairnlineAuthorityResponse(w http.ResponseWriter, pr
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
+	WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderCairnlineAuthorityProject(project)})
 }
 
 func writeProjectContextSourceCairnlineAuthorityResponse(w http.ResponseWriter, status int, project projects.Project, err error) {
@@ -754,5 +769,11 @@ func writeProjectContextSourceCairnlineAuthorityResponse(w http.ResponseWriter, 
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, status, ProjectResponse{Object: "project", Data: renderProject(project)})
+	WriteJSON(w, status, ProjectResponse{Object: "project", Data: renderCairnlineAuthorityProject(project)})
+}
+
+func renderCairnlineAuthorityProject(project projects.Project) ProjectResponseItem {
+	rendered := renderProject(project)
+	rendered.ReadBackend = "cairnline"
+	return rendered
 }

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -658,14 +658,69 @@ func (h *Handler) renderCairnlineProjectWorkItemReadiness(ctx context.Context, p
 		return ProjectWorkItemReadinessResponse{}, err
 	}
 	defer view.Close()
-	readiness, err := view.service.WorkItemCloseoutReadiness(ctx, view.snapshot.Project.ID, workItemID)
-	if errors.Is(err, cairnline.ErrNotFound) {
-		return ProjectWorkItemReadinessResponse{}, projectwork.ErrNotFound
-	}
+	readiness, err := h.cairnlineProjectWorkItemReadiness(ctx, view.service, view.snapshot, workItemID)
 	if err != nil {
 		return ProjectWorkItemReadinessResponse{}, err
 	}
-	return renderCairnlineProjectWorkItemReadiness(readiness), nil
+	rendered := renderProjectWorkItemReadiness(readiness)
+	rendered.ReadBackend = "cairnline"
+	return rendered, nil
+}
+
+func (h *Handler) cairnlineProjectWorkItemReadiness(ctx context.Context, service *cairnline.Service, snapshot cairnlinebridge.Snapshot, workItemID string) (projectwork.WorkItemReadiness, error) {
+	workItem, err := service.GetWorkItem(ctx, snapshot.Project.ID, workItemID)
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return projectwork.WorkItemReadiness{}, projectwork.ErrNotFound
+	}
+	if err != nil {
+		return projectwork.WorkItemReadiness{}, err
+	}
+	cairnlineAssignments, err := service.ListAssignments(ctx, snapshot.Project.ID)
+	if err != nil {
+		return projectwork.WorkItemReadiness{}, err
+	}
+	assignments := filterProjectWorkAssignments(projectWorkAssignmentsFromCairnline(cairnlineAssignments, snapshot.Assignments), workItemID)
+	assignments, err = h.applyRuntimeForCairnlineReadiness(ctx, assignments)
+	if err != nil {
+		return projectwork.WorkItemReadiness{}, err
+	}
+	artifacts, err := cairnlineProjectWorkArtifacts(ctx, service, snapshot.Project.ID, workItemID)
+	if err != nil {
+		return projectwork.WorkItemReadiness{}, err
+	}
+	handoffs, err := cairnlineProjectHandoffs(ctx, service, snapshot.Project.ID, workItemID, "")
+	if err != nil {
+		return projectwork.WorkItemReadiness{}, err
+	}
+	return projectwork.EvaluateWorkItemReadiness(projectWorkItemFromCairnline(workItem), assignments, artifacts, handoffs), nil
+}
+
+func (h *Handler) applyRuntimeForCairnlineReadiness(ctx context.Context, assignments []projectwork.Assignment) ([]projectwork.Assignment, error) {
+	projected, err := h.projectWorkApplication().ApplyAssignmentsRuntimeProjection(ctx, assignments)
+	if err != nil {
+		return nil, err
+	}
+	for index := range projected {
+		if index >= len(assignments) {
+			break
+		}
+		status := strings.TrimSpace(assignments[index].Status)
+		if !terminalProjectWorkAssignmentStatus(status) {
+			continue
+		}
+		projected[index].Status = status
+		projected[index].ExecutionRef.Status = status
+	}
+	return projected, nil
+}
+
+func terminalProjectWorkAssignmentStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case projectwork.AssignmentStatusCompleted, projectwork.AssignmentStatusFailed, projectwork.AssignmentStatusCancelled:
+		return true
+	default:
+		return false
+	}
 }
 
 type cairnlineProjectWorkView struct {

--- a/internal/api/handler_project_work_item_authority.go
+++ b/internal/api/handler_project_work_item_authority.go
@@ -112,54 +112,13 @@ func (h *Handler) projectWorkItemCloseoutReadinessForCairnlineAuthority(ctx cont
 			return projectwork.WorkItemReadiness{}, err
 		}
 		defer view.Close()
-		readiness, err := view.service.WorkItemCloseoutReadiness(ctx, view.snapshot.Project.ID, workItemID)
-		if errors.Is(err, cairnline.ErrNotFound) {
-			return projectwork.WorkItemReadiness{}, projectwork.ErrNotFound
-		}
+		readiness, err := h.cairnlineProjectWorkItemReadiness(ctx, view.service, view.snapshot, workItemID)
 		if err != nil {
 			return projectwork.WorkItemReadiness{}, err
 		}
-		return projectWorkItemReadinessFromCairnline(readiness), nil
+		return readiness, nil
 	}
 	return h.projectWorkApplication().WorkItemReadiness(ctx, projectID, workItemID)
-}
-
-func projectWorkItemReadinessFromCairnline(readiness cairnline.WorkItemCloseoutReadiness) projectwork.WorkItemReadiness {
-	return projectwork.WorkItemReadiness{
-		ProjectID:                    readiness.ProjectID,
-		WorkItemID:                   readiness.WorkItemID,
-		Ready:                        readiness.Ready,
-		Status:                       readiness.Status,
-		Title:                        readiness.Title,
-		Detail:                       readiness.Detail,
-		Blockers:                     renderCairnlineProjectWorkItemReadinessBlockers(readiness.Blockers),
-		Warnings:                     append([]string(nil), readiness.Warnings...),
-		AssignmentCount:              readiness.AssignmentCount,
-		CompletedAssignments:         readiness.CompletedAssignments,
-		ReviewFollowUpCount:          readiness.ReviewFollowUpCount,
-		ReviewFollowUpArtifactIDs:    append([]string(nil), readiness.ReviewFollowUpArtifactIDs...),
-		ReviewFollowUps:              projectWorkItemReviewFollowUpsFromCairnline(readiness.ReviewFollowUps),
-		MissingEvidenceAssignmentIDs: append([]string(nil), readiness.MissingEvidenceAssignmentIDs...),
-	}
-}
-
-func projectWorkItemReviewFollowUpsFromCairnline(items []cairnline.ReviewFollowUpReadiness) []projectwork.ReviewFollowUpReadiness {
-	if len(items) == 0 {
-		return nil
-	}
-	out := make([]projectwork.ReviewFollowUpReadiness, 0, len(items))
-	for _, item := range items {
-		out = append(out, projectwork.ReviewFollowUpReadiness{
-			ArtifactID:           item.ArtifactID,
-			Title:                item.Title,
-			Status:               item.Status,
-			Blocker:              renderCairnlineProjectWorkItemReadinessBlocker(item.Blocker),
-			ReviewedAssignmentID: item.ReviewedAssignmentID,
-			ReviewVerdict:        item.ReviewVerdict,
-			ReviewRisk:           item.ReviewRisk,
-		})
-	}
-	return out
 }
 
 func (h *Handler) deleteProjectWorkItemWithCairnlineAuthority(ctx context.Context, projectID, workItemID string) error {

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -242,7 +242,7 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
-		WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderProject(project)})
+		WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: renderCairnlineAuthorityProject(project)})
 		return
 	}
 	if h.projectRootSourceListUpdateWritesUseCairnlineAuthority(req) {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -1157,6 +1157,9 @@ func TestProjectsAPI_CairnlineRootAuthorityCommitsDirectMutationsFirst(t *testin
 	if len(withRoot.Data.Roots) != 2 || withRoot.Data.DefaultRootID != "root_main" {
 		t.Fatalf("root create response = %+v, want Hecate compatibility row shadowed with two roots and stable default", withRoot.Data)
 	}
+	if withRoot.Data.ReadBackend != "cairnline" {
+		t.Fatalf("root create read_backend = %q, want cairnline for Cairnline-authoritative response", withRoot.Data.ReadBackend)
+	}
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
 	if feature := findMirroredCairnlineRootForTest(mirrored.Roots, "root_feature"); feature == nil || feature.Path != "/workspace/root-feature" || feature.Active {
 		t.Fatalf("mirrored root_feature = %+v in %+v, want inactive created root", feature, mirrored.Roots)
@@ -1276,6 +1279,9 @@ func TestProjectsAPI_CairnlineRootAuthorityCommitsListReplacementFirst(t *testin
 	if len(updated.Data.Roots) != 2 || updated.Data.Roots[0].ID != "root_next" || updated.Data.Roots[1].ID != "root_docs" || updated.Data.DefaultRootID != "root_next" {
 		t.Fatalf("root replacement response = %+v, want replacement roots with first root promoted to default", updated.Data)
 	}
+	if updated.Data.ReadBackend != "cairnline" {
+		t.Fatalf("root replacement read_backend = %q, want cairnline for Cairnline-authoritative response", updated.Data.ReadBackend)
+	}
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
 	if len(mirrored.Roots) != 2 || mirrored.Roots[0].ID != "root_next" || mirrored.Roots[1].ID != "root_docs" || mirrored.DefaultRootID != "root_next" {
 		t.Fatalf("mirrored roots after list replacement = %+v default=%q, want replacement committed to Cairnline first", mirrored.Roots, mirrored.DefaultRootID)
@@ -1315,6 +1321,9 @@ func TestProjectsAPI_CairnlineContextSourceAuthorityCommitsDirectMutationsFirst(
 	}
 	if len(withSource.Data.ContextSources) != 1 || withSource.Data.ContextSources[0].ID != "ctx_agents" {
 		t.Fatalf("source create response = %+v, want ctx_agents", withSource.Data.ContextSources)
+	}
+	if withSource.Data.ReadBackend != "cairnline" {
+		t.Fatalf("source create read_backend = %q, want cairnline for Cairnline-authoritative response", withSource.Data.ReadBackend)
 	}
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
 	if source := findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_agents"); source == nil || source.Locator != "AGENTS.md" || source.Format != "agents_md" {
@@ -1406,6 +1415,9 @@ func TestProjectsAPI_CairnlineContextSourceAuthorityCommitsListReplacementFirst(
 	}
 	if len(updated.Data.ContextSources) != 2 || updated.Data.ContextSources[0].ID != "ctx_agents" || updated.Data.ContextSources[1].ID != "ctx_claude" || updated.Data.ContextSources[1].Enabled {
 		t.Fatalf("source replacement response = %+v, want replacement sources with disabled ctx_claude", updated.Data.ContextSources)
+	}
+	if updated.Data.ReadBackend != "cairnline" {
+		t.Fatalf("source replacement read_backend = %q, want cairnline for Cairnline-authoritative response", updated.Data.ReadBackend)
 	}
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
 	if len(mirrored.ContextSources) != 2 || mirrored.ContextSources[0].ID != "ctx_agents" || mirrored.ContextSources[1].ID != "ctx_claude" || mirrored.ContextSources[1].Enabled {
@@ -1504,6 +1516,9 @@ func TestProjectsAPI_DefaultRootPatchCairnlineAuthorityUsesCairnlineOnlyRoots(t 
 	}
 	if updated.Data.DefaultRootID != "root_next" || updated.Data.DefaultProvider != "anthropic" || updated.Data.DefaultModel != "claude-sonnet-4-5" {
 		t.Fatalf("updated defaults = root %q provider/model %q/%q, want root_next anthropic/claude-sonnet-4-5", updated.Data.DefaultRootID, updated.Data.DefaultProvider, updated.Data.DefaultModel)
+	}
+	if updated.Data.ReadBackend != "cairnline" {
+		t.Fatalf("defaults update read_backend = %q, want cairnline for Cairnline-authoritative response", updated.Data.ReadBackend)
 	}
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, projectID)
 	if mirrored.DefaultRootID != "root_next" {

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectruntime"
 	"github.com/hecatehq/hecate/internal/projectwork"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -471,6 +472,80 @@ func TestProjectJourneyAPI_CairnlineReplacementModeStartsExternalAgentWithoutAdv
 	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_replacement_external", "asgn_replacement_external")
 	if shadow.ExecutionRef.ChatSessionID != "" || shadow.ExecutionRef.ContextSnapshotID != "" {
 		t.Fatalf("Hecate compatibility shadow assignment = %+v, want replacement-mode external start refs to live only in runtime overlay", shadow.ExecutionRef)
+	}
+}
+
+func TestProjectJourneyAPI_CairnlineReplacementCloseoutReadinessUsesRuntimeOverlay(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	root := t.TempDir()
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Cairnline Runtime Overlay Closeout",
+		"roots": []map[string]any{{
+			"id":     "root_overlay",
+			"path":   root,
+			"kind":   "git",
+			"active": true,
+		}},
+	}))
+	projectID := project.Data.ID
+	mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                  "role_overlay",
+		"name":                "Runtime overlay implementer",
+		"default_driver_kind": projectwork.AssignmentDriverHecateTask,
+	}))
+	mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_overlay",
+		"title":         "Close with runtime overlay",
+		"status":        projectwork.WorkItemStatusReady,
+		"owner_role_id": "role_overlay",
+		"root_id":       "root_overlay",
+	}))
+	assignment := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_overlay/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_overlay",
+		"role_id":     "role_overlay",
+		"root_id":     "root_overlay",
+		"driver_kind": projectwork.AssignmentDriverHecateTask,
+	}))
+	if assignment.Data.Status != projectwork.AssignmentStatusQueued || assignment.Data.ReadBackend != "cairnline" {
+		t.Fatalf("assignment = %+v, want queued Cairnline-backed assignment", assignment.Data)
+	}
+	if _, err := handler.projectRuntime.Upsert(t.Context(), projectruntime.AssignmentRuntime{
+		ProjectID:    projectID,
+		AssignmentID: "asgn_overlay",
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:              "task_run",
+			TaskID:            "task_overlay",
+			RunID:             "run_overlay",
+			ContextSnapshotID: "ctx_overlay",
+			Status:            projectwork.AssignmentStatusCompleted,
+		},
+	}); err != nil {
+		t.Fatalf("Upsert runtime overlay: %v", err)
+	}
+	mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_overlay/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":                   "artifact_overlay_evidence",
+		"assignment_id":        "asgn_overlay",
+		"kind":                 projectwork.ArtifactKindEvidenceLink,
+		"title":                "Runtime overlay evidence",
+		"body":                 "The Hecate runtime overlay completed while Cairnline still held the portable queued assignment.",
+		"author_role_id":       "role_overlay",
+		"evidence_url":         "hecate://tasks/task_overlay/runs/run_overlay",
+		"evidence_provider":    "hecate",
+		"evidence_trust_label": projectwork.EvidenceTrustOperatorProvided,
+	}))
+
+	readiness := mustRequestJSONStatus[ProjectWorkItemReadinessEnvelope](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_overlay/readiness", "")
+	if !readiness.Data.Ready || readiness.Data.Status != "ready" || readiness.Data.ReadBackend != "cairnline" || readiness.Data.CompletedAssignments != 1 {
+		t.Fatalf("readiness = %+v, want runtime-overlay completed Cairnline closeout", readiness.Data)
+	}
+	closed := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_overlay", projectJourneyJSON(t, map[string]any{
+		"status": projectwork.WorkItemStatusDone,
+	}))
+	if closed.Data.Status != projectwork.WorkItemStatusDone || closed.Data.ReadBackend != "cairnline" {
+		t.Fatalf("closed work item = %+v, want Cairnline-backed closeout", closed.Data)
 	}
 }
 

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -26,6 +26,8 @@ var (
 type TaskStore interface {
 	TaskRunLookupStore
 	CreateTask(ctx context.Context, task types.Task) (types.Task, error)
+	GetTask(ctx context.Context, taskID string) (types.Task, bool, error)
+	ListApprovals(ctx context.Context, taskID string) ([]types.TaskApproval, error)
 }
 
 type TaskRunLookupStore interface {
@@ -44,6 +46,7 @@ type AgentRunner interface {
 
 type ChatSessionStore interface {
 	Create(ctx context.Context, session chat.Session) (chat.Session, error)
+	Get(ctx context.Context, id string) (chat.Session, bool, error)
 	UpdateSession(ctx context.Context, id string, update func(*chat.Session)) (chat.Session, error)
 	Delete(ctx context.Context, id string) error
 }

--- a/internal/projectworkapp/application_test.go
+++ b/internal/projectworkapp/application_test.go
@@ -185,6 +185,60 @@ func TestApplication_WorkItemReadinessUsesRuntimeOverlay(t *testing.T) {
 	}
 }
 
+func TestApplication_WorkItemReadinessPreservesRuntimeChatStatusWhenChatMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := projectwork.NewMemoryStore()
+	runtimeStore := projectruntime.NewMemoryStore()
+	app := New(Options{
+		Store:        store,
+		RuntimeStore: runtimeStore,
+		IDGenerator:  func(prefix string) string { return prefix + "_fixed" },
+	})
+	if _, err := app.CreateWorkItem(ctx, "proj_1", CreateWorkItemCommand{ID: "work_1", Title: "Build", Status: projectwork.WorkItemStatusReview}); err != nil {
+		t.Fatalf("CreateWorkItem() error = %v", err)
+	}
+	if _, err := app.CreateAssignment(ctx, "proj_1", "work_1", CreateAssignmentCommand{
+		ID:     "asgn_1",
+		RoleID: "software_developer",
+		Status: projectwork.AssignmentStatusQueued,
+	}); err != nil {
+		t.Fatalf("CreateAssignment() error = %v", err)
+	}
+	if _, err := runtimeStore.Upsert(ctx, projectruntime.AssignmentRuntime{
+		ProjectID:    "proj_1",
+		AssignmentID: "asgn_1",
+		ExecutionRef: projectwork.AssignmentExecutionRef{
+			Kind:          projectwork.AssignmentExecutionKindChatSession,
+			ChatSessionID: "chat_missing",
+			Status:        projectwork.AssignmentStatusCompleted,
+		},
+	}); err != nil {
+		t.Fatalf("Upsert(runtime) error = %v", err)
+	}
+	if _, err := store.CreateArtifact(ctx, projectwork.CollaborationArtifact{
+		ID:           "artifact_evidence",
+		ProjectID:    "proj_1",
+		WorkItemID:   "work_1",
+		AssignmentID: "asgn_1",
+		Kind:         projectwork.ArtifactKindEvidenceLink,
+		Title:        "Evidence",
+		Body:         "Evidence recorded.",
+		EvidenceURL:  "hecate://external-agents/chat_missing",
+	}); err != nil {
+		t.Fatalf("CreateArtifact(evidence) error = %v", err)
+	}
+
+	readiness, err := app.WorkItemReadiness(ctx, "proj_1", "work_1")
+	if err != nil {
+		t.Fatalf("WorkItemReadiness() error = %v", err)
+	}
+	if !readiness.Ready || readiness.CompletedAssignments != 1 || len(readiness.Blockers) != 0 {
+		t.Fatalf("readiness = %+v, want missing chat to preserve completed runtime status", readiness)
+	}
+}
+
 func TestApplication_UpdateWorkItemDoneAllowsManualEmptyCloseoutAndAlreadyDone(t *testing.T) {
 	t.Parallel()
 

--- a/internal/projectworkapp/closeout_readiness.go
+++ b/internal/projectworkapp/closeout_readiness.go
@@ -100,6 +100,9 @@ func (app *Application) ApplyAssignmentExecutionProjection(ctx context.Context, 
 	if chatProjection == nil {
 		return assignment, nil
 	}
+	if chatProjection.Missing && strings.TrimSpace(assignment.ExecutionRef.Status) != "" {
+		return assignment, nil
+	}
 	if strings.TrimSpace(chatProjection.Status) != "" {
 		assignment.Status = chatProjection.Status
 	}

--- a/internal/projectworkapp/closeout_readiness.go
+++ b/internal/projectworkapp/closeout_readiness.go
@@ -2,6 +2,7 @@ package projectworkapp
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
@@ -31,6 +32,10 @@ func (app *Application) WorkItemReadiness(ctx context.Context, projectID, workIt
 	if err != nil {
 		return WorkItemReadiness{}, err
 	}
+	assignments, err = app.ApplyAssignmentsExecutionProjection(ctx, assignments)
+	if err != nil {
+		return WorkItemReadiness{}, err
+	}
 	artifacts, err := app.store.ListArtifacts(ctx, projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: workItemID})
 	if err != nil {
 		return WorkItemReadiness{}, err
@@ -40,6 +45,95 @@ func (app *Application) WorkItemReadiness(ctx context.Context, projectID, workIt
 		return WorkItemReadiness{}, err
 	}
 	return projectwork.EvaluateWorkItemReadiness(workItem, assignments, artifacts, handoffs), nil
+}
+
+func (app *Application) ApplyAssignmentsRuntimeProjection(ctx context.Context, assignments []projectwork.Assignment) ([]projectwork.Assignment, error) {
+	assignments, err := app.ApplyAssignmentsRuntime(ctx, assignments)
+	if err != nil {
+		return nil, err
+	}
+	return app.ApplyAssignmentsExecutionProjection(ctx, assignments)
+}
+
+func (app *Application) ApplyAssignmentsExecutionProjection(ctx context.Context, assignments []projectwork.Assignment) ([]projectwork.Assignment, error) {
+	if len(assignments) == 0 {
+		return assignments, nil
+	}
+	out := make([]projectwork.Assignment, 0, len(assignments))
+	for _, assignment := range assignments {
+		projected, err := app.ApplyAssignmentExecutionProjection(ctx, assignment)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, projected)
+	}
+	return out, nil
+}
+
+func (app *Application) ApplyAssignmentExecutionProjection(ctx context.Context, assignment projectwork.Assignment) (projectwork.Assignment, error) {
+	projection, err := ProjectAssignmentExecution(ctx, app.taskStore, assignment)
+	if err != nil {
+		return projectwork.Assignment{}, err
+	}
+	if projection != nil {
+		if projection.Execution.Missing && strings.TrimSpace(assignment.ExecutionRef.Status) != "" {
+			return assignment, nil
+		}
+		if strings.TrimSpace(projection.Status) != "" {
+			assignment.Status = projection.Status
+		}
+		if assignment.StartedAt.IsZero() && !projection.StartedAt.IsZero() {
+			assignment.StartedAt = projection.StartedAt
+		}
+		if assignment.CompletedAt.IsZero() && !projection.CompletedAt.IsZero() {
+			assignment.CompletedAt = projection.CompletedAt
+		}
+		if ref := AssignmentExecutionRefFor(assignment, &projection.Execution, assignment.Status); ref != nil {
+			normalized := projectwork.NormalizeAssignmentExecutionRef(*ref)
+			normalized.Status = assignment.Status
+			assignment.ExecutionRef = normalized
+		}
+		return assignment, nil
+	}
+
+	chatProjection := app.assignmentChatProjection(ctx, assignment)
+	if chatProjection == nil {
+		return assignment, nil
+	}
+	if strings.TrimSpace(chatProjection.Status) != "" {
+		assignment.Status = chatProjection.Status
+	}
+	if assignment.StartedAt.IsZero() && !chatProjection.StartedAt.IsZero() {
+		assignment.StartedAt = chatProjection.StartedAt
+	}
+	if assignment.CompletedAt.IsZero() && !chatProjection.CompletedAt.IsZero() {
+		assignment.CompletedAt = chatProjection.CompletedAt
+	}
+	if ref := AssignmentExecutionRefForChat(assignment, chatProjection, assignment.Status); ref != nil {
+		assignment.ExecutionRef = projectwork.NormalizeAssignmentExecutionRef(*ref)
+	}
+	return assignment, nil
+}
+
+func (app *Application) assignmentChatProjection(ctx context.Context, assignment projectwork.Assignment) *AssignmentChatProjection {
+	ref := projectwork.NormalizeAssignmentExecutionRef(assignment.ExecutionRef)
+	chatSessionID := strings.TrimSpace(ref.ChatSessionID)
+	if chatSessionID == "" {
+		return nil
+	}
+	missing := &AssignmentChatProjection{
+		ChatSessionID: chatSessionID,
+		Status:        assignment.Status,
+		Missing:       true,
+	}
+	if app == nil || app.chatStore == nil {
+		return missing
+	}
+	session, ok, err := app.chatStore.Get(ctx, chatSessionID)
+	if err != nil || !ok || strings.TrimSpace(session.ProjectID) != strings.TrimSpace(assignment.ProjectID) {
+		return missing
+	}
+	return ProjectAssignmentChatExecution(assignment, session)
 }
 
 func EvaluateWorkItemReadiness(workItem projectwork.WorkItem, assignments []projectwork.Assignment, artifacts []projectwork.CollaborationArtifact, handoffs []projectwork.Handoff) WorkItemReadiness {


### PR DESCRIPTION
## Summary
- return Cairnline read_backend metadata from Cairnline-authoritative project root/source/default responses
- skip compatibility-shadow warnings for intentional Cairnline-only replacement projects
- make closeout readiness use the same runtime/task/chat execution projection as assignment/activity views

## Dogfood
- Created a Cairnline-authoritative Hecate project, discovered guidance and skills, bootstrapped roles/memory candidates, created work and assignment, launched a Hecate task against a local fake provider, recorded evidence/review/handoff, accepted the handoff, and closed the work item.
- Found and fixed stale closeout readiness: the activity/detail projections saw completed runtime work while closeout readiness still saw the portable assignment as active.

## Validation
- GOCACHE="$PWD/.gocache" go test ./internal/api
- GOCACHE="$PWD/.gocache" go test ./...
- GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...
- just agent-docs-check

## Docs
- No operator docs changed; this is runtime/readback consistency plus regression coverage.