### PR TITLE
Resolve project provider defaults by id

### DIFF
--- a/internal/api/handler_project_assignment_launch_readiness_test.go
+++ b/internal/api/handler_project_assignment_launch_readiness_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/providers"
 )
 
 func TestProjectWorkAPI_AssignmentLaunchReadinessReturnsNativePlanWithoutSideEffects(t *testing.T) {
@@ -83,6 +84,38 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessReturnsNativePlanWithoutSideEff
 	}
 	if len(tasks) != 0 {
 		t.Fatalf("tasks = %+v, want no task created by launch readiness", tasks)
+	}
+}
+
+func TestProjectWorkAPI_AssignmentLaunchReadinessAcceptsProviderIDForNamedProvider(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkTestServerWithProviders(&fakeProvider{
+		name: "Fake Dogfood",
+		capabilities: providers.Capabilities{
+			Name:         "Fake Dogfood",
+			Kind:         providers.KindCloud,
+			DefaultModel: "dogfood-model",
+			Models:       []string{"dogfood-model"},
+		},
+	})
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           t.TempDir(),
+		Driver:              projectwork.AssignmentDriverHecateTask,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.projects.Update(t.Context(), "proj_start", func(project *projects.Project) {
+		project.DefaultProvider = "fake-dogfood"
+		project.DefaultModel = "dogfood-model"
+	}); err != nil {
+		t.Fatalf("Update project defaults: %v", err)
+	}
+
+	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/launch-readiness", "")
+	if !readiness.Data.Ready || readiness.Data.Provider != "fake-dogfood" || readiness.Data.Model != "dogfood-model" {
+		t.Fatalf("readiness = %+v, want ready launch using saved provider id", readiness.Data)
+	}
+	if readiness.Data.ModelReadiness == nil || !readiness.Data.ModelReadiness.Ready || readiness.Data.ModelReadiness.MatchedProvider != "Fake Dogfood" {
+		t.Fatalf("model_readiness = %+v, want provider id to resolve to named runtime provider", readiness.Data.ModelReadiness)
 	}
 }
 

--- a/internal/catalog/provider_match.go
+++ b/internal/catalog/provider_match.go
@@ -1,0 +1,57 @@
+package catalog
+
+import (
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/providers"
+)
+
+func EntryMatchesProvider(entry Entry, provider string) bool {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return false
+	}
+	if providerNameMatches(entry.Name, provider) {
+		return true
+	}
+	if reporter, ok := entry.Provider.(providers.AliasReporter); ok {
+		for _, alias := range reporter.Aliases() {
+			if providerNameMatches(alias, provider) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func providerNameMatches(candidate, provider string) bool {
+	candidate = strings.TrimSpace(candidate)
+	provider = strings.TrimSpace(provider)
+	if candidate == "" || provider == "" {
+		return false
+	}
+	if strings.EqualFold(candidate, provider) {
+		return true
+	}
+	candidateKey := providerLookupKey(candidate)
+	providerKey := providerLookupKey(provider)
+	return candidateKey != "" && candidateKey == providerKey
+}
+
+func providerLookupKey(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	out := make([]rune, 0, len(value))
+	lastDash := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			out = append(out, r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			out = append(out, '-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(string(out), "-")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -418,6 +418,7 @@ type ProvidersConfig struct {
 
 type OpenAICompatibleProviderConfig struct {
 	Name         string        `json:"name"`
+	Aliases      []string      `json:"aliases,omitempty"`
 	Kind         string        `json:"kind"`
 	Protocol     string        `json:"protocol"`
 	BaseURL      string        `json:"base_url"`

--- a/internal/gateway/executor_test.go
+++ b/internal/gateway/executor_test.go
@@ -16,6 +16,7 @@ import (
 
 type sequenceProvider struct {
 	name      string
+	aliases   []string
 	kind      providers.Kind
 	responses []providerResponse
 	callCount int
@@ -27,6 +28,8 @@ type providerResponse struct {
 }
 
 func (p *sequenceProvider) Name() string { return p.name }
+
+func (p *sequenceProvider) Aliases() []string { return append([]string(nil), p.aliases...) }
 
 func (p *sequenceProvider) Kind() providers.Kind { return p.kind }
 

--- a/internal/gateway/provider_model_readiness.go
+++ b/internal/gateway/provider_model_readiness.go
@@ -69,7 +69,7 @@ func providerModelReadiness(entries []catalog.Entry, provider, model string) Pro
 	}
 	if provider != "" {
 		for _, entry := range entries {
-			if strings.EqualFold(entry.Name, provider) {
+			if catalog.EntryMatchesProvider(entry, provider) {
 				return providerModelReadinessForEntry(entry, entry.Name, model)
 			}
 		}
@@ -160,7 +160,7 @@ func providerModelAvailable(entry catalog.Entry, model string) bool {
 func suggestedModels(entries []catalog.Entry, provider string) []string {
 	out := make([]string, 0, 8)
 	for _, entry := range entries {
-		if provider != "" && !strings.EqualFold(entry.Name, provider) {
+		if provider != "" && !catalog.EntryMatchesProvider(entry, provider) {
 			continue
 		}
 		out = appendUniqueStrings(out, entry.Models...)

--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -291,6 +291,23 @@ func TestProviderModelReadiness(t *testing.T) {
 			CredentialState: "missing",
 			Models:          []string{"claude-sonnet-4-5"},
 		},
+		{
+			Name:            "Fake Dogfood",
+			Kind:            providers.KindCloud,
+			Status:          "healthy",
+			Healthy:         true,
+			CredentialState: "configured",
+			Models:          []string{"dogfood-model"},
+		},
+		{
+			Provider:        &sequenceProvider{name: "Runtime Custom", aliases: []string{"custom-provider-id"}, kind: providers.KindCloud},
+			Name:            "Runtime Custom",
+			Kind:            providers.KindCloud,
+			Status:          "healthy",
+			Healthy:         true,
+			CredentialState: "configured",
+			Models:          []string{"custom-model"},
+		},
 	}
 
 	tests := []struct {
@@ -325,6 +342,26 @@ func TestProviderModelReadiness(t *testing.T) {
 			wantProvider:        "ollama",
 			wantReason:          "model_available",
 			wantMatchedProvider: "ollama",
+			wantStatus:          "ok",
+		},
+		{
+			name:                "explicit provider id matches display name slug",
+			provider:            "fake-dogfood",
+			model:               "dogfood-model",
+			wantReady:           true,
+			wantProvider:        "Fake Dogfood",
+			wantReason:          "model_available",
+			wantMatchedProvider: "Fake Dogfood",
+			wantStatus:          "ok",
+		},
+		{
+			name:                "explicit provider id matches reported alias",
+			provider:            "custom-provider-id",
+			model:               "custom-model",
+			wantReady:           true,
+			wantProvider:        "Runtime Custom",
+			wantReason:          "model_available",
+			wantMatchedProvider: "Runtime Custom",
 			wantStatus:          "ok",
 		},
 		{

--- a/internal/providers/anthropic.go
+++ b/internal/providers/anthropic.go
@@ -157,6 +157,10 @@ func (p *AnthropicProvider) Name() string {
 	return p.config.Name
 }
 
+func (p *AnthropicProvider) Aliases() []string {
+	return append([]string(nil), p.config.Aliases...)
+}
+
 func (p *AnthropicProvider) Enabled() bool {
 	return p.config.Enabled
 }

--- a/internal/providers/openai.go
+++ b/internal/providers/openai.go
@@ -302,6 +302,10 @@ func (p *OpenAICompatibleProvider) Name() string {
 	return p.config.Name
 }
 
+func (p *OpenAICompatibleProvider) Aliases() []string {
+	return append([]string(nil), p.config.Aliases...)
+}
+
 func (p *OpenAICompatibleProvider) Enabled() bool {
 	return p.config.Enabled
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -27,6 +27,13 @@ type Provider interface {
 	Supports(model string) bool
 }
 
+// AliasReporter lets provider-management surfaces expose stable identifiers
+// that differ from the runtime routing name, such as a control-plane provider
+// ID for an operator-named custom provider.
+type AliasReporter interface {
+	Aliases() []string
+}
+
 // CapabilityRefresher is implemented by providers that can bypass their
 // discovery cache for explicit operator refreshes.
 type CapabilityRefresher interface {

--- a/internal/providers/runtime_manager.go
+++ b/internal/providers/runtime_manager.go
@@ -229,6 +229,7 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 		}
 		cfg := config.OpenAICompatibleProviderConfig{
 			Name:         item.Name,
+			Aliases:      providerRuntimeAliases(item),
 			Kind:         item.Kind,
 			Protocol:     item.Protocol,
 			BaseURL:      item.BaseURL,
@@ -276,6 +277,27 @@ func (m *ControlPlaneRuntimeManager) resolvedConfigs(ctx context.Context) ([]con
 		out = append(out, cfg)
 	}
 	return out, nil
+}
+
+func providerRuntimeAliases(provider controlplane.Provider) []string {
+	out := make([]string, 0, 2)
+	for _, value := range []string{provider.ID, provider.PresetID} {
+		value = strings.TrimSpace(value)
+		if value == "" || strings.EqualFold(value, provider.Name) {
+			continue
+		}
+		seen := false
+		for _, existing := range out {
+			if strings.EqualFold(existing, value) {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 func hydrateControlPlaneProviderDefaults(provider controlplane.Provider) controlplane.Provider {

--- a/internal/providers/runtime_manager_test.go
+++ b/internal/providers/runtime_manager_test.go
@@ -277,6 +277,50 @@ func TestControlPlaneRuntimeManagerHydratesPresetEndpointPaths(t *testing.T) {
 	}
 }
 
+func TestControlPlaneRuntimeManagerStampsProviderIDAlias(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	store := controlplane.NewMemoryStore()
+	key := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	cipher, err := secrets.NewAESGCMCipher(key)
+	if err != nil {
+		t.Fatalf("NewAESGCMCipher() error = %v", err)
+	}
+
+	manager := NewControlPlaneRuntimeManager(logger, nil, store, cipher)
+	if _, err := manager.Upsert(context.Background(), controlplane.Provider{
+		ID:       "fake-dogfood",
+		Name:     "Fake Dogfood",
+		Kind:     "cloud",
+		Protocol: "openai",
+		BaseURL:  "https://fake-dogfood.example/v1",
+		Enabled:  true,
+	}, "fake-secret"); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	provider, ok := manager.Registry().Get("Fake Dogfood")
+	if !ok {
+		t.Fatal("expected Fake Dogfood provider in registry")
+	}
+	reporter, ok := provider.(AliasReporter)
+	if !ok {
+		t.Fatalf("provider type = %T, want AliasReporter", provider)
+	}
+	aliases := reporter.Aliases()
+	found := false
+	for _, alias := range aliases {
+		if alias == "fake-dogfood" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("aliases = %#v, want fake-dogfood", aliases)
+	}
+}
+
 func TestControlPlaneRuntimeManagerAppliesFireworksAccountID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -135,7 +135,7 @@ func (r *RuleRouter) Fallbacks(ctx context.Context, req types.ChatRequest, curre
 }
 
 func (r *RuleRouter) routeExplicitProvider(ctx context.Context, req types.ChatRequest, explicitProvider, model string) (types.RouteDecision, error) {
-	entry, ok := r.catalog.Get(ctx, explicitProvider)
+	entry, ok := r.lookupProvider(ctx, explicitProvider)
 	if !ok {
 		return types.RouteDecision{}, fmt.Errorf("provider %q not found", explicitProvider)
 	}
@@ -160,6 +160,19 @@ func (r *RuleRouter) routeExplicitProvider(ctx context.Context, req types.ChatRe
 		Model:        routedModel,
 		Reason:       routeReasonForHealth(reason, entry.Status),
 	}, nil
+}
+
+func (r *RuleRouter) lookupProvider(ctx context.Context, provider string) (catalog.Entry, bool) {
+	entry, ok := r.catalog.Get(ctx, provider)
+	if ok {
+		return entry, true
+	}
+	for _, entry := range r.catalog.Snapshot(ctx) {
+		if catalog.EntryMatchesProvider(entry, provider) {
+			return entry, true
+		}
+	}
+	return catalog.Entry{}, false
 }
 
 func (r *RuleRouter) explicitModelCandidates(ctx context.Context, model string) []routeCandidate {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -120,6 +120,7 @@ func TestRuleRouterOrdersProvidersAlphabetically(t *testing.T) {
 
 type fakeProvider struct {
 	name            string
+	aliases         []string
 	kind            providers.Kind
 	defaultModel    string
 	supportedModels []string
@@ -142,6 +143,7 @@ func (t staticHealthTracker) State(provider string) providers.HealthState {
 }
 
 func (p *fakeProvider) Name() string         { return p.name }
+func (p *fakeProvider) Aliases() []string    { return append([]string(nil), p.aliases...) }
 func (p *fakeProvider) Kind() providers.Kind { return p.kind }
 func (p *fakeProvider) DefaultModel() string { return p.defaultModel }
 func (p *fakeProvider) Chat(_ context.Context, _ types.ChatRequest) (*types.ChatResponse, error) {
@@ -235,6 +237,27 @@ func TestRuleRouterHonorsExplicitProvider(t *testing.T) {
 	}
 	if got.Reason != "pinned_provider" {
 		t.Fatalf("Route() reason = %q, want pinned_provider", got.Reason)
+	}
+}
+
+func TestRuleRouterHonorsExplicitProviderAlias(t *testing.T) {
+	t.Parallel()
+
+	registry := providers.NewRegistry(
+		&fakeProvider{name: "Fake Dogfood", aliases: []string{"fake-dogfood"}, kind: providers.KindCloud, defaultModel: "dogfood-model"},
+	)
+	router := NewRuleRouter("gpt-4o-mini", catalog.NewRegistryCatalog(registry, nil))
+
+	got, err := router.Route(context.Background(), types.ChatRequest{
+		Scope: types.RequestScope{
+			ProviderHint: "fake-dogfood",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Route() error = %v", err)
+	}
+	if got.Provider != "Fake Dogfood" || got.Model != "dogfood-model" || got.Reason != "pinned_provider" {
+		t.Fatalf("Route() = %+v, want Fake Dogfood default model via alias", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve control-plane provider IDs as runtime provider aliases
- use shared provider alias/slug matching for model readiness and explicit routing
- cover the dogfood case where a project stores provider id `fake-dogfood` while runtime provider name is `Fake Dogfood`

## Tests
- `GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/catalog ./internal/providers ./internal/gateway ./internal/router ./internal/api -count=1`
- `GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...`
- `GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/catalog ./internal/providers ./internal/gateway ./internal/router ./internal/api`
- `GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...`
- `just agent-docs-check`

## Docs
- No docs changed; this is an internal provider identity resolution fix with regression coverage.