### PR TITLE
fix(settings): show project backend probe routes

### DIFF
--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -182,9 +182,77 @@ describe("SettingsView", () => {
       screen.getByText("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles"),
     ).toBeTruthy();
     expect(screen.getAllByText("1 probe").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("/hecate/v1/projects/{id}/cairnline/read-model").length).toBe(2);
+    expect(screen.getByText("/hecate/v1/projects/cairnline/sync")).toBeTruthy();
+    expect(screen.getByText("/hecate/v1/projects/cairnline/mirror-parity")).toBeTruthy();
     expect(screen.getByText("memory-candidates")).toBeTruthy();
     expect(screen.getByText("assignment-start")).toBeTruthy();
     expect(screen.getByText("migration-cutover")).toBeTruthy();
+  });
+
+  it("shows strict embedded smoke probe routes in the next project backend action", async () => {
+    vi.mocked(getProjectCoordinationBackendStatus).mockResolvedValue({
+      object: "project_coordination_backend_status",
+      data: {
+        configured_backend: "cairnline",
+        authoritative_backend: "hecate",
+        storage_backend: "sqlite",
+        cairnline_connector: "embedded",
+        cairnline_connector_ready: true,
+        cairnline_read_source: "embedded",
+        cairnline_bridge_ready: true,
+        cairnline_authoritative: false,
+        read_model_switch_ready: true,
+        write_adapter_ready: true,
+        replacement_ready: false,
+        replacement_mode: "disabled",
+        replacement_mode_armed: false,
+        portable_write_gaps: [],
+        orchestrator_capabilities: ["assignment-start"],
+        migration_blockers: ["migration-cutover"],
+        next_replacement_action: {
+          id: "run-strict-embedded-read-smoke",
+          label: "Run strict embedded read smoke",
+          detail:
+            "Portable write authority is clear; verify the embedded Cairnline mirror and strict read-smoke evidence before treating migration cutover as the next blocker.",
+          target: "strict-embedded-read-smoke",
+          config_hints: [
+            {
+              env: "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE",
+              value: "embedded",
+            },
+          ],
+          probe_urls: [
+            "/hecate/v1/projects/cairnline/sync",
+            "/hecate/v1/projects/cairnline/mirror-parity",
+          ],
+        },
+        replacement_gates: [
+          {
+            id: "strict-embedded-read-smoke",
+            ready: false,
+            status: "operator_probe_required",
+            detail:
+              "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
+            probe_urls: [
+              "/hecate/v1/projects/cairnline/sync",
+              "/hecate/v1/projects/cairnline/mirror-parity",
+            ],
+          },
+        ],
+        status: "cairnline_read_routes_ready",
+        detail: "Cairnline read routes are served from the read model.",
+      },
+    });
+    const { state, actions } = setup();
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
+
+    expect(await screen.findByText("Run strict embedded read smoke")).toBeTruthy();
+    expect(screen.getByText("strict-embedded-read-smoke")).toBeTruthy();
+    expect(screen.getAllByText("Probe routes").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("/hecate/v1/projects/cairnline/sync").length).toBe(2);
+    expect(screen.getAllByText("/hecate/v1/projects/cairnline/mirror-parity").length).toBe(2);
+    expect(screen.getByText("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded")).toBeTruthy();
   });
 
   it("renders authoritative Cairnline status with runtime boundary warnings", async () => {

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -459,6 +459,7 @@ function ProjectBackendGateList({
               <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.45 }}>
                 {gate.detail}
               </div>
+              {probes.length > 0 && <ProjectBackendProbeList probes={probes} />}
             </div>
           );
         })}
@@ -523,6 +524,7 @@ function ProjectBackendNextAction({
       </div>
       <div style={{ color: "var(--t0)", fontSize: 13, fontWeight: 650 }}>{action.label}</div>
       <div style={{ color: "var(--t2)", fontSize: 12, lineHeight: 1.45 }}>{action.detail}</div>
+      {probes.length > 0 && <ProjectBackendProbeList probes={probes} />}
       {configHints.length > 0 && (
         <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
           {configHints.map((hint) => (
@@ -543,6 +545,43 @@ function ProjectBackendNextAction({
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function ProjectBackendProbeList({ probes }: { probes: string[] }) {
+  return (
+    <div style={{ display: "grid", gap: 4 }}>
+      <div
+        style={{
+          color: "var(--t3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        Probe routes
+      </div>
+      <div style={{ display: "grid", gap: 4 }}>
+        {probes.map((probe, index) => (
+          <code
+            key={`${probe}:${index}`}
+            style={{
+              background: "var(--bg3)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-sm)",
+              color: "var(--t1)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              overflowWrap: "anywhere",
+              padding: "5px 7px",
+              whiteSpace: "normal",
+            }}
+          >
+            {probe}
+          </code>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show project backend probe route templates under next action and replacement gates
- add Settings coverage for strict embedded smoke probe URLs

## Tests
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test