### PR TITLE
feat(projects): expose method-aware backend probes

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -647,9 +647,11 @@ also reports `replacement_ready`, `next_replacement_action`,
 `replacement_gates`, and `write_switchpoints` so operators can see the
 suggested next step, relevant env-var hints, and the exact read-route,
 strict-embedded-read-smoke, write-authority, and migration blockers without
-parsing warning prose. When the embedded connector, strict embedded read source,
-and a configured data directory are active, the strict read-smoke gate is driven
-by the same read-only mirror-parity evidence returned by
+parsing warning prose. Gates and next actions include method-aware `probes`
+alongside compatibility `probe_urls`, so Settings can distinguish POST smoke
+probes from GET read checks. When the embedded connector, strict embedded read
+source, and a configured data directory are active, the strict read-smoke gate
+is driven by the same read-only mirror-parity evidence returned by
 `GET /hecate/v1/projects/cairnline/mirror-parity`: a missing mirror reports
 `not_run`, mirror drift reports `drift_detected`, and an exact mirror with passing
 strict embedded route smoke reports `verified`. The migration/rollback gate then

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2546,10 +2546,11 @@ include `config_hints`, which are environment setting suggestions such as a spec
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY` value; clients must treat them as
 operator guidance, not as mutations to apply automatically. `replacement_gates`
 reports those high-level gates as structured checklist items so clients do not
-need to parse warning prose. Each gate may include `probe_urls`, a list of route
-templates that produce supporting evidence for that gate; these URLs identify
-checks to run and are not proof that the gate has already passed unless the
-gate status itself is ready/verified. The `strict-embedded-read-smoke` gate is
+need to parse warning prose. Each gate and next action may include `probes`, a
+method-aware list of route templates that produce supporting evidence, plus the
+legacy `probe_urls` string list for compatibility. These probes identify checks
+to run and are not proof that the gate has already passed unless the gate
+status itself is ready/verified. The `strict-embedded-read-smoke` gate is
 evidence-backed when Hecate is configured with the embedded connector,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and a data directory: backend
 status runs the read-only mirror-parity check and reports `not_run` for a
@@ -2893,6 +2894,20 @@ Example response, with `write_switchpoints` shortened for readability:
         "ready": true,
         "status": "ready",
         "detail": "Configured live project read families can be served from Cairnline's projected read model.",
+        "probes": [
+          {
+            "method": "GET",
+            "url": "/hecate/v1/projects/{id}/cairnline/read-model"
+          },
+          {
+            "method": "GET",
+            "url": "/hecate/v1/projects/{id}/cairnline/embedded-read-model"
+          },
+          {
+            "method": "GET",
+            "url": "/hecate/v1/projects/{id}/cairnline/embedded-parity-report"
+          }
+        ],
         "probe_urls": [
           "/hecate/v1/projects/{id}/cairnline/read-model",
           "/hecate/v1/projects/{id}/cairnline/embedded-read-model",
@@ -2904,6 +2919,16 @@ Example response, with `write_switchpoints` shortened for readability:
         "ready": false,
         "status": "not_run",
         "detail": "No embedded Cairnline mirror database exists yet; run /hecate/v1/projects/cairnline/sync and then /hecate/v1/projects/cairnline/mirror-parity.",
+        "probes": [
+          {
+            "method": "POST",
+            "url": "/hecate/v1/projects/cairnline/sync"
+          },
+          {
+            "method": "GET",
+            "url": "/hecate/v1/projects/cairnline/mirror-parity"
+          }
+        ],
         "probe_urls": [
           "/hecate/v1/projects/cairnline/sync",
           "/hecate/v1/projects/cairnline/mirror-parity"
@@ -2920,6 +2945,20 @@ Example response, with `write_switchpoints` shortened for readability:
         "ready": false,
         "status": "waiting_for_read_smoke",
         "detail": "Strict embedded mirror parity and read smoke must be verified before migration and rollback can be treated as rehearsed.",
+        "probes": [
+          {
+            "method": "POST",
+            "url": "/hecate/v1/projects/cairnline/sync"
+          },
+          {
+            "method": "GET",
+            "url": "/hecate/v1/projects/cairnline/mirror-parity"
+          },
+          {
+            "method": "POST",
+            "url": "/hecate/v1/projects/{id}/cairnline/export"
+          }
+        ],
         "probe_urls": [
           "/hecate/v1/projects/cairnline/sync",
           "/hecate/v1/projects/cairnline/mirror-parity",

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -457,7 +457,64 @@ func projectCairnlineStatusWithNextAction(response ProjectCoordinationBackendSta
 		response.Warnings = projectCairnlineReplacementReadyWarnings(response.OrchestratorCapabilities)
 	}
 	response.NextReplacementAction = projectCairnlineNextReplacementAction(response)
+	projectCairnlineHydrateProbeMetadata(&response)
 	return response
+}
+
+func projectCairnlineHydrateProbeMetadata(response *ProjectCoordinationBackendStatusResponse) {
+	if response == nil {
+		return
+	}
+	for i := range response.ReplacementGates {
+		if len(response.ReplacementGates[i].Probes) == 0 {
+			response.ReplacementGates[i].Probes = projectCairnlineProbesForURLs(response.ReplacementGates[i].ProbeURLs)
+		}
+	}
+	if response.NextReplacementAction != nil && len(response.NextReplacementAction.Probes) == 0 {
+		response.NextReplacementAction.Probes = projectCairnlineProbesForURLs(response.NextReplacementAction.ProbeURLs)
+	}
+}
+
+func projectCairnlineProbesForURLs(urls []string) []ProjectCoordinationBackendProbe {
+	if len(urls) == 0 {
+		return nil
+	}
+	probes := make([]ProjectCoordinationBackendProbe, 0, len(urls))
+	for _, url := range urls {
+		url = strings.TrimSpace(url)
+		if url == "" {
+			continue
+		}
+		probes = append(probes, ProjectCoordinationBackendProbe{
+			Method: projectCairnlineProbeMethod(url),
+			URL:    url,
+		})
+	}
+	return probes
+}
+
+func projectCairnlineProbeMethod(url string) string {
+	switch strings.TrimSpace(url) {
+	case projectCoordinationBackendSyncReadinessURL,
+		projectCoordinationBackendExportURL,
+		projectCoordinationBackendSidecarProbeURL,
+		projectCoordinationBackendSidecarConnectURL,
+		projectCoordinationBackendSidecarReadURL,
+		projectCoordinationBackendSidecarDetailURL,
+		projectCoordinationBackendSidecarCoordinationURL,
+		projectCoordinationBackendSidecarAssignmentContextURL,
+		projectCoordinationBackendSidecarLaunchPacketURL,
+		projectCoordinationBackendSidecarLifecycleURL,
+		projectCoordinationBackendSidecarSetupURL,
+		projectCoordinationBackendSidecarWriteURL,
+		projectCoordinationBackendSidecarWorkURL,
+		projectCoordinationBackendSidecarCollaborationURL,
+		projectCoordinationBackendSidecarMemoryURL,
+		projectCoordinationBackendSidecarAssistantURL:
+		return http.MethodPost
+	default:
+		return http.MethodGet
+	}
 }
 
 func projectCairnlineReplacementReadyDetail() string {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -992,6 +992,9 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	if !containsString(status.NextReplacementAction.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !containsString(status.NextReplacementAction.ProbeURLs, projectCoordinationBackendMirrorParityURL) {
 		t.Fatalf("next action probe URLs = %+v, want strict embedded sync and mirror-parity probes", status.NextReplacementAction.ProbeURLs)
 	}
+	if !hasProbe(status.NextReplacementAction.Probes, http.MethodPost, projectCoordinationBackendSyncReadinessURL) || !hasProbe(status.NextReplacementAction.Probes, http.MethodGet, projectCoordinationBackendMirrorParityURL) {
+		t.Fatalf("next action probes = %+v, want POST sync and GET mirror-parity probes", status.NextReplacementAction.Probes)
+	}
 	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR"); hint == nil || hint.Value != "embedded" {
 		t.Fatalf("next action config hints = %+v, want embedded connector hint", status.NextReplacementAction.ConfigHints)
 	}
@@ -1030,6 +1033,9 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 	}
 	if !containsString(status.NextReplacementAction.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !containsString(status.NextReplacementAction.ProbeURLs, projectCoordinationBackendMirrorParityURL) {
 		t.Fatalf("next action probe URLs = %+v, want strict embedded sync and mirror-parity probes", status.NextReplacementAction.ProbeURLs)
+	}
+	if !hasProbe(status.NextReplacementAction.Probes, http.MethodPost, projectCoordinationBackendSyncReadinessURL) || !hasProbe(status.NextReplacementAction.Probes, http.MethodGet, projectCoordinationBackendMirrorParityURL) {
+		t.Fatalf("next action probes = %+v, want POST sync and GET mirror-parity probes", status.NextReplacementAction.Probes)
 	}
 }
 
@@ -1185,6 +1191,9 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	if !containsString(migrationGate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !containsString(migrationGate.ProbeURLs, projectCoordinationBackendMirrorParityURL) || !containsString(migrationGate.ProbeURLs, projectCoordinationBackendExportURL) {
 		t.Fatalf("response migration gate probe URLs = %+v, want sync, mirror parity, and export probes", migrationGate.ProbeURLs)
 	}
+	if !hasProbe(migrationGate.Probes, http.MethodPost, projectCoordinationBackendSyncReadinessURL) || !hasProbe(migrationGate.Probes, http.MethodGet, projectCoordinationBackendMirrorParityURL) || !hasProbe(migrationGate.Probes, http.MethodPost, projectCoordinationBackendExportURL) {
+		t.Fatalf("response migration gate probes = %+v, want POST sync, GET mirror parity, and POST export probes", migrationGate.Probes)
+	}
 	if response.Data.NextReplacementAction == nil || response.Data.NextReplacementAction.ID != "move-portable-write-authority" || response.Data.NextReplacementAction.Target == "" {
 		t.Fatalf("response next action = %+v, want portable write-authority action", response.Data.NextReplacementAction)
 	}
@@ -1234,4 +1243,13 @@ func findConfigHint(items []ProjectCoordinationBackendActionConfigHint, env stri
 		}
 	}
 	return nil
+}
+
+func hasProbe(items []ProjectCoordinationBackendProbe, method, url string) bool {
+	for _, item := range items {
+		if item.Method == method && item.URL == url {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -613,7 +613,13 @@ type ProjectCoordinationBackendNextAction struct {
 	Detail      string                                       `json:"detail"`
 	Target      string                                       `json:"target,omitempty"`
 	ConfigHints []ProjectCoordinationBackendActionConfigHint `json:"config_hints,omitempty"`
+	Probes      []ProjectCoordinationBackendProbe            `json:"probes,omitempty"`
 	ProbeURLs   []string                                     `json:"probe_urls,omitempty"`
+}
+
+type ProjectCoordinationBackendProbe struct {
+	Method string `json:"method"`
+	URL    string `json:"url"`
 }
 
 type ProjectCoordinationBackendActionConfigHint struct {
@@ -623,11 +629,12 @@ type ProjectCoordinationBackendActionConfigHint struct {
 }
 
 type ProjectCoordinationBackendReplacementGate struct {
-	ID        string   `json:"id"`
-	Ready     bool     `json:"ready"`
-	Status    string   `json:"status"`
-	Detail    string   `json:"detail"`
-	ProbeURLs []string `json:"probe_urls,omitempty"`
+	ID        string                            `json:"id"`
+	Ready     bool                              `json:"ready"`
+	Status    string                            `json:"status"`
+	Detail    string                            `json:"detail"`
+	Probes    []ProjectCoordinationBackendProbe `json:"probes,omitempty"`
+	ProbeURLs []string                          `json:"probe_urls,omitempty"`
 }
 
 type ProjectCoordinationBackendWriteSwitchpoint struct {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -185,6 +185,7 @@ describe("SettingsView", () => {
     expect(screen.getAllByText("/hecate/v1/projects/{id}/cairnline/read-model").length).toBe(2);
     expect(screen.getByText("/hecate/v1/projects/cairnline/sync")).toBeTruthy();
     expect(screen.getByText("/hecate/v1/projects/cairnline/mirror-parity")).toBeTruthy();
+    expect(screen.getByText("POST")).toBeTruthy();
     expect(screen.getByText("memory-candidates")).toBeTruthy();
     expect(screen.getByText("assignment-start")).toBeTruthy();
     expect(screen.getByText("migration-cutover")).toBeTruthy();
@@ -222,6 +223,16 @@ describe("SettingsView", () => {
               value: "embedded",
             },
           ],
+          probes: [
+            {
+              method: "POST",
+              url: "/hecate/v1/projects/cairnline/sync",
+            },
+            {
+              method: "GET",
+              url: "/hecate/v1/projects/cairnline/mirror-parity",
+            },
+          ],
           probe_urls: [
             "/hecate/v1/projects/cairnline/sync",
             "/hecate/v1/projects/cairnline/mirror-parity",
@@ -234,6 +245,16 @@ describe("SettingsView", () => {
             status: "operator_probe_required",
             detail:
               "Run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate.",
+            probes: [
+              {
+                method: "POST",
+                url: "/hecate/v1/projects/cairnline/sync",
+              },
+              {
+                method: "GET",
+                url: "/hecate/v1/projects/cairnline/mirror-parity",
+              },
+            ],
             probe_urls: [
               "/hecate/v1/projects/cairnline/sync",
               "/hecate/v1/projects/cairnline/mirror-parity",
@@ -250,6 +271,8 @@ describe("SettingsView", () => {
     expect(await screen.findByText("Run strict embedded read smoke")).toBeTruthy();
     expect(screen.getByText("strict-embedded-read-smoke")).toBeTruthy();
     expect(screen.getAllByText("Probe routes").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("POST").length).toBe(2);
+    expect(screen.getAllByText("GET").length).toBe(2);
     expect(screen.getAllByText("/hecate/v1/projects/cairnline/sync").length).toBe(2);
     expect(screen.getAllByText("/hecate/v1/projects/cairnline/mirror-parity").length).toBe(2);
     expect(screen.getByText("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded")).toBeTruthy();

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -5,7 +5,10 @@ import { useWiredDashboardActions } from "../../app/state/coordinators/wired";
 import { useSettings } from "../../app/state/settings";
 import { getPlugins, getProjectCoordinationBackendStatus, resetSystemData } from "../../lib/api";
 import type { PluginRecord } from "../../types/plugin";
-import type { ProjectCoordinationBackendStatusRecord } from "../../types/project";
+import type {
+  ProjectCoordinationBackendProbeRecord,
+  ProjectCoordinationBackendStatusRecord,
+} from "../../types/project";
 import { Badge, ConfirmModal, Icon, Icons, InlineError } from "../shared/ui";
 
 export function SettingsView() {
@@ -433,7 +436,7 @@ function ProjectBackendGateList({
       </div>
       <div style={{ display: "grid", gap: 7 }}>
         {gates.map((gate) => {
-          const probes = gate.probe_urls ?? [];
+          const probes = projectBackendProbes(gate.probes, gate.probe_urls);
           return (
             <div
               key={gate.id}
@@ -486,7 +489,7 @@ function ProjectBackendNextAction({
 }: {
   action: NonNullable<ProjectCoordinationBackendStatusRecord["next_replacement_action"]>;
 }) {
-  const probes = action.probe_urls ?? [];
+  const probes = projectBackendProbes(action.probes, action.probe_urls);
   const configHints = action.config_hints ?? [];
   return (
     <div
@@ -549,7 +552,7 @@ function ProjectBackendNextAction({
   );
 }
 
-function ProjectBackendProbeList({ probes }: { probes: string[] }) {
+function ProjectBackendProbeList({ probes }: { probes: ProjectCoordinationBackendProbeRecord[] }) {
   return (
     <div style={{ display: "grid", gap: 4 }}>
       <div
@@ -564,13 +567,16 @@ function ProjectBackendProbeList({ probes }: { probes: string[] }) {
       </div>
       <div style={{ display: "grid", gap: 4 }}>
         {probes.map((probe, index) => (
-          <code
-            key={`${probe}:${index}`}
+          <div
+            key={`${probe.method}:${probe.url}:${index}`}
             style={{
+              alignItems: "center",
               background: "var(--bg3)",
               border: "1px solid var(--border)",
               borderRadius: "var(--radius-sm)",
               color: "var(--t1)",
+              display: "flex",
+              gap: 7,
               fontFamily: "var(--font-mono)",
               fontSize: 11,
               overflowWrap: "anywhere",
@@ -578,12 +584,36 @@ function ProjectBackendProbeList({ probes }: { probes: string[] }) {
               whiteSpace: "normal",
             }}
           >
-            {probe}
-          </code>
+            <span className="badge badge-muted" style={{ flexShrink: 0, textTransform: "none" }}>
+              {probe.method || "GET"}
+            </span>
+            <code style={{ overflowWrap: "anywhere", whiteSpace: "normal" }}>{probe.url}</code>
+          </div>
         ))}
       </div>
     </div>
   );
+}
+
+function projectBackendProbes(
+  probes: ProjectCoordinationBackendProbeRecord[] | undefined,
+  probeURLs: string[] | undefined,
+): ProjectCoordinationBackendProbeRecord[] {
+  if (probes && probes.length > 0) {
+    return probes;
+  }
+  return (probeURLs ?? []).map((url) => ({ method: projectBackendProbeMethod(url), url }));
+}
+
+function projectBackendProbeMethod(url: string): string {
+  if (
+    url === "/hecate/v1/projects/cairnline/sync" ||
+    url.endsWith("/cairnline/export") ||
+    url.includes("/cairnline/sidecar-")
+  ) {
+    return "POST";
+  }
+  return "GET";
 }
 
 function projectBackendTitle(status: ProjectCoordinationBackendStatusRecord): string {

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -76,7 +76,13 @@ export type ProjectCoordinationBackendReplacementGateRecord = {
   ready: boolean;
   status: string;
   detail: string;
+  probes?: ProjectCoordinationBackendProbeRecord[];
   probe_urls?: string[];
+};
+
+export type ProjectCoordinationBackendProbeRecord = {
+  method: string;
+  url: string;
 };
 
 export type ProjectCoordinationBackendWriteSwitchpointRecord = {
@@ -100,6 +106,7 @@ export type ProjectCoordinationBackendNextActionRecord = {
     value: string;
     detail?: string;
   }>;
+  probes?: ProjectCoordinationBackendProbeRecord[];
   probe_urls?: string[];
 };
 


### PR DESCRIPTION
## Summary
- add structured method-aware project backend probe metadata while keeping legacy probe_urls
- render probe methods in Settings with fallback inference for older probe_urls payloads
- document the probes field and update status tests/docs

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run TestProjectCoordinationBackendStatus -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -count=1
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just agent-docs-check
- just docs-format-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...