### PR TITLE
feat(settings): show Cairnline probe checklist

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -648,10 +648,11 @@ also reports `replacement_ready`, `next_replacement_action`,
 suggested next step, relevant env-var hints, and the exact read-route,
 strict-embedded-read-smoke, write-authority, and migration blockers without
 parsing warning prose. Gates and next actions include method-aware `probes`
-alongside compatibility `probe_urls`, so Settings can distinguish POST smoke
-probes from GET read checks. When the embedded connector, strict embedded read
-source, and a configured data directory are active, the strict read-smoke gate
-is driven by the same read-only mirror-parity evidence returned by
+alongside compatibility `probe_urls`, so Settings can turn the next action into
+an ordered, copyable probe checklist and distinguish POST smoke/rehearsal routes
+from GET read checks. When the embedded connector, strict embedded read source,
+and a configured data directory are active, the strict read-smoke gate is driven
+by the same read-only mirror-parity evidence returned by
 `GET /hecate/v1/projects/cairnline/mirror-parity`: a missing mirror reports
 `not_run`, mirror drift reports `drift_detected`, and an exact mirror with passing
 strict embedded route smoke reports `verified`. The migration/rollback gate then
@@ -677,10 +678,11 @@ diagnostic list into
 `orchestrator_capabilities`, and `migration_blockers`, so durable
 coordination-state switchpoint work is separated from Hecate-owned
 runtime/workspace capabilities and final cutover work. Settings shows the same
-backend-status summary, next action, and replacement-gate checklist under
-Project coordination for local operator inspection. The reported replacement
-target is embedded Cairnline first: Hecate should make the embedded Cairnline
-database the Projects source of truth before treating an external sidecar as the
+backend-status summary, turns the next action's probes into a run-in-order
+checklist, and keeps replacement gates as supporting evidence under Project
+coordination for local operator inspection. The reported replacement target is
+embedded Cairnline first: Hecate should make the embedded Cairnline database the
+Projects source of truth before treating an external sidecar as the
 standalone/interoperability boundary. `replacement_mode=disabled|embedded`
 reports the explicit operator cutover arm; `embedded` is only valid with the
 embedded connector and strict embedded read source, and it does not bypass the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2550,7 +2550,10 @@ need to parse warning prose. Each gate and next action may include `probes`, a
 method-aware list of route templates that produce supporting evidence, plus the
 legacy `probe_urls` string list for compatibility. These probes identify checks
 to run and are not proof that the gate has already passed unless the gate
-status itself is ready/verified. The `strict-embedded-read-smoke` gate is
+status itself is ready/verified. Clients can use the method-aware list to render
+operator-safe probe checklists, with POST routes presented as smoke/rehearsal
+actions and GET routes presented as read checks. The
+`strict-embedded-read-smoke` gate is
 evidence-backed when Hecate is configured with the embedded connector,
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and a data directory: backend
 status runs the read-only mirror-parity check and reports `not_run` for a

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -171,6 +171,8 @@ describe("SettingsView", () => {
     expect(screen.getByText("Hecate orchestrator capabilities")).toBeTruthy();
     expect(screen.getByText("Next action")).toBeTruthy();
     expect(screen.getByText("Move the next portable write authority")).toBeTruthy();
+    expect(screen.getByText("Probe checklist")).toBeTruthy();
+    expect(screen.getByText("Inspect read model")).toBeTruthy();
     expect(screen.getByText("Replacement gates")).toBeTruthy();
     expect(screen.getByText("read routes")).toBeTruthy();
     expect(screen.getByText("write authority switchpoints")).toBeTruthy();
@@ -270,11 +272,20 @@ describe("SettingsView", () => {
 
     expect(await screen.findByText("Run strict embedded read smoke")).toBeTruthy();
     expect(screen.getByText("strict-embedded-read-smoke")).toBeTruthy();
+    expect(screen.getByText("Probe checklist")).toBeTruthy();
+    expect(screen.getByText(/Run these routes in order/i)).toBeTruthy();
+    expect(screen.getByText("Step 1")).toBeTruthy();
+    expect(screen.getByText("Rebuild embedded mirror")).toBeTruthy();
+    expect(screen.getByText(/Refresh the Cairnline mirror/i)).toBeTruthy();
+    expect(screen.getByText("Step 2")).toBeTruthy();
+    expect(screen.getByText("Verify mirror parity")).toBeTruthy();
+    expect(screen.getByText(/Compare the existing embedded mirror/i)).toBeTruthy();
     expect(screen.getAllByText("Probe routes").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("POST").length).toBe(2);
     expect(screen.getAllByText("GET").length).toBe(2);
     expect(screen.getAllByText("/hecate/v1/projects/cairnline/sync").length).toBe(2);
     expect(screen.getAllByText("/hecate/v1/projects/cairnline/mirror-parity").length).toBe(2);
+    expect(screen.getAllByRole("button", { name: "copy" }).length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded")).toBeTruthy();
   });
 

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -9,7 +9,7 @@ import type {
   ProjectCoordinationBackendProbeRecord,
   ProjectCoordinationBackendStatusRecord,
 } from "../../types/project";
-import { Badge, ConfirmModal, Icon, Icons, InlineError } from "../shared/ui";
+import { Badge, ConfirmModal, CopyBtn, Icon, Icons, InlineError } from "../shared/ui";
 
 export function SettingsView() {
   const retention = useRetention();
@@ -527,7 +527,7 @@ function ProjectBackendNextAction({
       </div>
       <div style={{ color: "var(--t0)", fontSize: 13, fontWeight: 650 }}>{action.label}</div>
       <div style={{ color: "var(--t2)", fontSize: 12, lineHeight: 1.45 }}>{action.detail}</div>
-      {probes.length > 0 && <ProjectBackendProbeList probes={probes} />}
+      {probes.length > 0 && <ProjectBackendProbeList probes={probes} checklist />}
       {configHints.length > 0 && (
         <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
           {configHints.map((hint) => (
@@ -552,7 +552,13 @@ function ProjectBackendNextAction({
   );
 }
 
-function ProjectBackendProbeList({ probes }: { probes: ProjectCoordinationBackendProbeRecord[] }) {
+function ProjectBackendProbeList({
+  checklist = false,
+  probes,
+}: {
+  checklist?: boolean;
+  probes: ProjectCoordinationBackendProbeRecord[];
+}) {
   return (
     <div style={{ display: "grid", gap: 4 }}>
       <div
@@ -563,34 +569,89 @@ function ProjectBackendProbeList({ probes }: { probes: ProjectCoordinationBacken
           textTransform: "uppercase",
         }}
       >
-        Probe routes
+        {checklist ? "Probe checklist" : "Probe routes"}
       </div>
+      {checklist && (
+        <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.45 }}>
+          Run these routes in order from a local operator session. POST rows perform smoke or
+          rehearsal actions; GET rows inspect the resulting read model.
+        </div>
+      )}
       <div style={{ display: "grid", gap: 4 }}>
         {probes.map((probe, index) => (
-          <div
+          <ProjectBackendProbeRow
             key={`${probe.method}:${probe.url}:${index}`}
-            style={{
-              alignItems: "center",
-              background: "var(--bg3)",
-              border: "1px solid var(--border)",
-              borderRadius: "var(--radius-sm)",
-              color: "var(--t1)",
-              display: "flex",
-              gap: 7,
-              fontFamily: "var(--font-mono)",
-              fontSize: 11,
-              overflowWrap: "anywhere",
-              padding: "5px 7px",
-              whiteSpace: "normal",
-            }}
-          >
-            <span className="badge badge-muted" style={{ flexShrink: 0, textTransform: "none" }}>
-              {probe.method || "GET"}
-            </span>
-            <code style={{ overflowWrap: "anywhere", whiteSpace: "normal" }}>{probe.url}</code>
-          </div>
+            checklist={checklist}
+            index={index}
+            probe={probe}
+          />
         ))}
       </div>
+    </div>
+  );
+}
+
+function ProjectBackendProbeRow({
+  checklist,
+  index,
+  probe,
+}: {
+  checklist: boolean;
+  index: number;
+  probe: ProjectCoordinationBackendProbeRecord;
+}) {
+  const method = normalizedProjectBackendProbeMethod(probe.method);
+  const plan = projectBackendProbePlan(probe.url, method);
+  const copyText = `${method} ${probe.url}`;
+  return (
+    <div
+      style={{
+        alignItems: checklist ? "flex-start" : "center",
+        background: "var(--bg3)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        color: "var(--t1)",
+        display: "grid",
+        gap: 7,
+        gridTemplateColumns: checklist ? "auto minmax(0, 1fr) auto" : "auto minmax(0, 1fr) auto",
+        overflowWrap: "anywhere",
+        padding: checklist ? "8px 9px" : "5px 7px",
+        whiteSpace: "normal",
+      }}
+    >
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        {checklist && (
+          <span className="badge badge-muted" style={{ textTransform: "none" }}>
+            Step {index + 1}
+          </span>
+        )}
+        <span
+          className={method === "POST" ? "badge badge-amber" : "badge badge-muted"}
+          style={{ flexShrink: 0, textTransform: "none" }}
+        >
+          {method}
+        </span>
+      </div>
+      <div style={{ display: "grid", gap: checklist ? 3 : 0, minWidth: 0 }}>
+        {checklist && (
+          <div style={{ color: "var(--t0)", fontSize: 12, fontWeight: 650 }}>{plan.label}</div>
+        )}
+        {checklist && (
+          <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.4 }}>{plan.detail}</div>
+        )}
+        <code
+          style={{
+            color: "var(--t1)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            overflowWrap: "anywhere",
+            whiteSpace: "normal",
+          }}
+        >
+          {probe.url}
+        </code>
+      </div>
+      <CopyBtn text={copyText} />
     </div>
   );
 }
@@ -605,6 +666,11 @@ function projectBackendProbes(
   return (probeURLs ?? []).map((url) => ({ method: projectBackendProbeMethod(url), url }));
 }
 
+function normalizedProjectBackendProbeMethod(method: string | undefined): string {
+  const normalized = (method || "GET").trim().toUpperCase();
+  return normalized || "GET";
+}
+
 function projectBackendProbeMethod(url: string): string {
   if (
     url === "/hecate/v1/projects/cairnline/sync" ||
@@ -614,6 +680,80 @@ function projectBackendProbeMethod(url: string): string {
     return "POST";
   }
   return "GET";
+}
+
+function projectBackendProbePlan(url: string, method: string): { label: string; detail: string } {
+  if (url === "/hecate/v1/projects/cairnline/sync") {
+    return {
+      label: "Rebuild embedded mirror",
+      detail:
+        "Refresh the Cairnline mirror from current Hecate project stores before checking reads.",
+    };
+  }
+  if (url === "/hecate/v1/projects/cairnline/mirror-parity") {
+    return {
+      label: "Verify mirror parity",
+      detail: "Compare the existing embedded mirror with Hecate's current project stores.",
+    };
+  }
+  if (url.includes("/embedded-read-model")) {
+    return {
+      label: "Inspect embedded read model",
+      detail: "Read the project projection directly from the embedded Cairnline graph.",
+    };
+  }
+  if (url.includes("/embedded-parity-report")) {
+    return {
+      label: "Compare embedded route shape",
+      detail: "Check that Cairnline-backed cockpit projections still match Hecate route shape.",
+    };
+  }
+  if (url.includes("/read-model")) {
+    return {
+      label: "Inspect read model",
+      detail: "Check the active Cairnline-backed read model for the selected project route.",
+    };
+  }
+  if (url.includes("/parity-report")) {
+    return {
+      label: "Compare project parity",
+      detail: "Compare Cairnline projection output with Hecate's native project view.",
+    };
+  }
+  if (url.includes("/sidecar-connect")) {
+    return {
+      label: "Connect sidecar client",
+      detail: "Start or reuse the local Cairnline MCP sidecar client before sidecar read checks.",
+    };
+  }
+  if (url.includes("/sidecar-probe")) {
+    return {
+      label: "Probe sidecar tools",
+      detail: "Confirm the standalone Cairnline MCP server exposes the expected tools.",
+    };
+  }
+  if (url.includes("/sidecar-")) {
+    return {
+      label: "Run sidecar smoke",
+      detail: "Exercise the named standalone Cairnline MCP smoke route and inspect its evidence.",
+    };
+  }
+  if (url.endsWith("/cairnline/export")) {
+    return {
+      label: "Export project",
+      detail: "Generate a project-level Cairnline export rehearsal for migration review.",
+    };
+  }
+  if (method === "POST") {
+    return {
+      label: "Run smoke route",
+      detail: "Execute the operator probe route and review the returned evidence.",
+    };
+  }
+  return {
+    label: "Inspect read route",
+    detail: "Read the diagnostic route and confirm the returned state matches the gate detail.",
+  };
 }
 
 function projectBackendTitle(status: ProjectCoordinationBackendStatusRecord): string {


### PR DESCRIPTION
## Summary

- render Project coordination next-action probes as an ordered checklist in Settings
- label common Cairnline probe routes with operator-friendly intent and copyable method/URL rows
- update Settings tests and docs for method-aware probe checklist behavior

## Verification

- go build ./...
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run test
- just docs-format-check
- just agent-docs-check
- git diff --check

## Notes

No backend route behavior changes. The checklist remains inspect/copy guidance; Settings does not auto-run probe routes because some probe URLs are templates or require operator-provided payloads.