### PR TITLE
feat(settings): show Cairnline write switchpoints

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -679,11 +679,12 @@ diagnostic list into
 coordination-state switchpoint work is separated from Hecate-owned
 runtime/workspace capabilities and final cutover work. Settings shows the same
 backend-status summary, turns the next action's probes into a run-in-order
-checklist, and keeps replacement gates as supporting evidence under Project
-coordination for local operator inspection. The reported replacement target is
-embedded Cairnline first: Hecate should make the embedded Cairnline database the
-Projects source of truth before treating an external sidecar as the
-standalone/interoperability boundary. `replacement_mode=disabled|embedded`
+checklist, keeps replacement gates as supporting evidence, and lists
+write-switchpoint authority/state rows under Project coordination for local
+operator inspection. The reported replacement target is embedded Cairnline
+first: Hecate should make the embedded Cairnline database the Projects source of
+truth before treating an external sidecar as the standalone/interoperability
+boundary. `replacement_mode=disabled|embedded`
 reports the explicit operator cutover arm; `embedded` is only valid with the
 embedded connector and strict embedded read source, and it does not bypass the
 read, write-authority, migration, rollback, or Hecate-owned runtime side-effect

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -102,6 +102,30 @@ describe("SettingsView", () => {
         portable_write_gaps: ["agent-profiles", "memory-candidates"],
         orchestrator_capabilities: ["assignment-start"],
         migration_blockers: ["migration-cutover"],
+        write_switchpoints: [
+          {
+            name: "agent-profiles",
+            current_authority: "hecate",
+            cairnline_state: "live_mirror_non_authoritative",
+            live_mirror: true,
+            blocks_authority: true,
+            seams: ["agent-profiles-live-mirror"],
+            gap: "agent-profiles",
+            detail:
+              "Agent profile mutations still commit to Hecate first, then mirror portable profile metadata and execution posture into Cairnline.",
+          },
+          {
+            name: "assignment-start-dispatch",
+            current_authority: "hecate",
+            cairnline_state: "result_mirror_only",
+            live_mirror: true,
+            blocks_authority: false,
+            seams: ["project-assignment-start-result-live-mirror"],
+            gap: "assignment-start",
+            detail:
+              "Assignment start stays Hecate-owned and mirrors committed runtime refs into Cairnline.",
+          },
+        ],
         next_replacement_action: {
           id: "move-portable-write-authority",
           label: "Move the next portable write authority",
@@ -174,6 +198,16 @@ describe("SettingsView", () => {
     expect(screen.getByText("Probe checklist")).toBeTruthy();
     expect(screen.getByText("Inspect read model")).toBeTruthy();
     expect(screen.getByText("Replacement gates")).toBeTruthy();
+    expect(screen.getByText("Write switchpoints")).toBeTruthy();
+    expect(screen.getByText("agent profiles")).toBeTruthy();
+    expect(screen.getByText("live mirror non authoritative")).toHaveClass("badge-amber");
+    expect(screen.getByText("blocks authority")).toBeTruthy();
+    expect(screen.getByText("gap agent-profiles")).toBeTruthy();
+    expect(screen.getByText("agent-profiles-live-mirror")).toBeTruthy();
+    expect(screen.getByText("assignment start dispatch")).toBeTruthy();
+    expect(screen.getByText("result mirror only")).toBeTruthy();
+    expect(screen.getByText("non-blocking")).toBeTruthy();
+    expect(screen.getByText("project-assignment-start-result-live-mirror")).toBeTruthy();
     expect(screen.getByText("read routes")).toBeTruthy();
     expect(screen.getByText("write authority switchpoints")).toBeTruthy();
     expect(screen.getByText("migration and rollback")).toBeTruthy();

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -306,6 +306,7 @@ function ProjectCoordinationBackendSettings({
   const replacementGates = status?.replacement_gates ?? [];
   const statusWarnings = status?.warnings ?? [];
   const nextAction = status?.next_replacement_action;
+  const writeSwitchpoints = status?.write_switchpoints ?? [];
   const statusBadge = status
     ? status.replacement_ready
       ? "ok"
@@ -386,6 +387,9 @@ function ProjectCoordinationBackendSettings({
           </div>
           {nextAction && <ProjectBackendNextAction action={nextAction} />}
           {replacementGates.length > 0 && <ProjectBackendGateList gates={replacementGates} />}
+          {writeSwitchpoints.length > 0 && (
+            <ProjectBackendSwitchpointList switchpoints={writeSwitchpoints} />
+          )}
           <div
             style={{
               display: "grid",
@@ -414,6 +418,97 @@ function ProjectCoordinationBackendSettings({
         </article>
       )}
     </section>
+  );
+}
+
+function ProjectBackendSwitchpointList({
+  switchpoints,
+}: {
+  switchpoints: NonNullable<ProjectCoordinationBackendStatusRecord["write_switchpoints"]>;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 8, marginTop: 14 }}>
+      <div
+        style={{
+          color: "var(--t3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        Write switchpoints
+      </div>
+      <div style={{ display: "grid", gap: 7 }}>
+        {switchpoints.map((switchpoint) => {
+          const seams = switchpoint.seams ?? [];
+          return (
+            <div
+              key={switchpoint.name}
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius-sm)",
+                display: "grid",
+                gap: 6,
+                padding: "8px 10px",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 7, flexWrap: "wrap" }}>
+                <span style={{ color: "var(--t0)", fontSize: 12, fontWeight: 650 }}>
+                  {switchpoint.name.replaceAll("-", " ")}
+                </span>
+                <span className="badge badge-muted" style={{ textTransform: "none" }}>
+                  {projectBackendDisplayLabel(switchpoint.current_authority)}
+                </span>
+                <span
+                  className={projectBackendSwitchpointStateBadge(
+                    switchpoint.cairnline_state,
+                    switchpoint.live_mirror,
+                  )}
+                  style={{ textTransform: "none" }}
+                >
+                  {projectBackendDisplayLabel(switchpoint.cairnline_state)}
+                </span>
+                {switchpoint.blocks_authority ? (
+                  <span className="badge badge-amber" style={{ textTransform: "none" }}>
+                    blocks authority
+                  </span>
+                ) : (
+                  <span className="badge badge-green" style={{ textTransform: "none" }}>
+                    non-blocking
+                  </span>
+                )}
+                {switchpoint.live_mirror && (
+                  <span className="badge badge-muted" style={{ textTransform: "none" }}>
+                    live mirror
+                  </span>
+                )}
+                {switchpoint.gap && (
+                  <span className="badge badge-muted" style={{ textTransform: "none" }}>
+                    gap {switchpoint.gap}
+                  </span>
+                )}
+              </div>
+              <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.45 }}>
+                {switchpoint.detail}
+              </div>
+              {seams.length > 0 && (
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 5 }}>
+                  {seams.map((seam) => (
+                    <span
+                      key={seam}
+                      className="badge badge-muted"
+                      style={{ fontSize: 9, textTransform: "none" }}
+                    >
+                      {seam}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
@@ -754,6 +849,22 @@ function projectBackendProbePlan(url: string, method: string): { label: string; 
     label: "Inspect read route",
     detail: "Read the diagnostic route and confirm the returned state matches the gate detail.",
   };
+}
+
+function projectBackendDisplayLabel(value: string): string {
+  return value.replaceAll("_", " ").replaceAll("-", " ");
+}
+
+function projectBackendSwitchpointStateBadge(state: string, liveMirror: boolean): string {
+  if (
+    state === "authoritative_opt_in" ||
+    state === "partial_authoritative_opt_in" ||
+    state === "embedded_cutover_armed"
+  ) {
+    return "badge badge-green";
+  }
+  if (liveMirror) return "badge badge-amber";
+  return "badge badge-muted";
 }
 
 function projectBackendTitle(status: ProjectCoordinationBackendStatusRecord): string {


### PR DESCRIPTION
## Summary

- render Cairnline write-switchpoint authority/state rows in Settings
- show blocking, live-mirror, gap, and seam metadata for each mutation family
- cover blocking and non-blocking switchpoints in Settings tests and update operator docs

## Verification

- go build ./...
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run test
- just docs-format-check
- just agent-docs-check
- git diff --check

## Review notes

Self-review caught and fixed a badge classification edge: `live_mirror_non_authoritative` is now amber rather than matching the green authoritative state path by substring.