### PR TITLE
feat(settings): show Cairnline config hints

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -678,13 +678,13 @@ diagnostic list into
 `orchestrator_capabilities`, and `migration_blockers`, so durable
 coordination-state switchpoint work is separated from Hecate-owned
 runtime/workspace capabilities and final cutover work. Settings shows the same
-backend-status summary, turns the next action's probes into a run-in-order
-checklist, keeps replacement gates as supporting evidence, and lists
-write-switchpoint authority/state rows under Project coordination for local
-operator inspection. The reported replacement target is embedded Cairnline
-first: Hecate should make the embedded Cairnline database the Projects source of
-truth before treating an external sidecar as the standalone/interoperability
-boundary. `replacement_mode=disabled|embedded`
+backend-status summary, shows copyable next-action configuration hints, turns
+the next action's probes into a run-in-order checklist, keeps replacement gates
+as supporting evidence, and lists write-switchpoint authority/state rows under
+Project coordination for local operator inspection. The reported replacement
+target is embedded Cairnline first: Hecate should make the embedded Cairnline
+database the Projects source of truth before treating an external sidecar as the
+standalone/interoperability boundary. `replacement_mode=disabled|embedded`
 reports the explicit operator cutover arm; `embedded` is only valid with the
 embedded connector and strict embedded read source, and it does not bypass the
 read, write-authority, migration, rollback, or Hecate-owned runtime side-effect

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -136,6 +136,7 @@ describe("SettingsView", () => {
             {
               env: "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY",
               value: "agent-profiles",
+              detail: "Enable the profile switchpoint before moving profile writes.",
             },
           ],
           probe_urls: ["/hecate/v1/projects/{id}/cairnline/read-model"],
@@ -216,6 +217,10 @@ describe("SettingsView", () => {
     expect(screen.getAllByText("agent-profiles").length).toBeGreaterThanOrEqual(1);
     expect(
       screen.getByText("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles"),
+    ).toBeTruthy();
+    expect(screen.getByText("Configuration hints")).toBeTruthy();
+    expect(
+      screen.getByText("Enable the profile switchpoint before moving profile writes."),
     ).toBeTruthy();
     expect(screen.getAllByText("1 probe").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("/hecate/v1/projects/{id}/cairnline/read-model").length).toBe(2);

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -623,26 +623,70 @@ function ProjectBackendNextAction({
       <div style={{ color: "var(--t0)", fontSize: 13, fontWeight: 650 }}>{action.label}</div>
       <div style={{ color: "var(--t2)", fontSize: 12, lineHeight: 1.45 }}>{action.detail}</div>
       {probes.length > 0 && <ProjectBackendProbeList probes={probes} checklist />}
-      {configHints.length > 0 && (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-          {configHints.map((hint) => (
-            <span
-              key={`${hint.env}:${hint.value}`}
-              className="badge badge-muted"
+      {configHints.length > 0 && <ProjectBackendConfigHints hints={configHints} />}
+    </div>
+  );
+}
+
+function ProjectBackendConfigHints({
+  hints,
+}: {
+  hints: NonNullable<
+    NonNullable<ProjectCoordinationBackendStatusRecord["next_replacement_action"]>["config_hints"]
+  >;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 4 }}>
+      <div
+        style={{
+          color: "var(--t3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        Configuration hints
+      </div>
+      <div style={{ display: "grid", gap: 4 }}>
+        {hints.map((hint) => {
+          const assignment = `${hint.env}=${hint.value}`;
+          return (
+            <div
+              key={assignment}
               style={{
-                fontFamily: "var(--font-mono)",
-                maxWidth: "100%",
-                overflowWrap: "anywhere",
-                textTransform: "none",
-                whiteSpace: "normal",
+                alignItems: "center",
+                background: "var(--bg3)",
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius-sm)",
+                display: "grid",
+                gap: 7,
+                gridTemplateColumns: "minmax(0, 1fr) auto",
+                padding: "7px 9px",
               }}
-              title={hint.detail || `${hint.env}=${hint.value}`}
             >
-              {hint.env}={hint.value}
-            </span>
-          ))}
-        </div>
-      )}
+              <div style={{ display: "grid", gap: hint.detail ? 3 : 0, minWidth: 0 }}>
+                <code
+                  style={{
+                    color: "var(--t1)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                    overflowWrap: "anywhere",
+                    whiteSpace: "normal",
+                  }}
+                >
+                  {assignment}
+                </code>
+                {hint.detail && (
+                  <span style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.4 }}>
+                    {hint.detail}
+                  </span>
+                )}
+              </div>
+              <CopyBtn text={assignment} />
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- render next-action Cairnline config hints as visible rows instead of compact badges
- show hint detail text directly in Settings and add copy buttons for ENV=value assignments
- update Settings tests and operator deployment docs for copyable config hints

## Verification

- go build ./...
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run test
- just docs-format-check
- just agent-docs-check
- git diff --check

## Notes

No backend route or configuration behavior changes. The Settings panel still presents hints as operator guidance, not as automatic mutations.