### PR TITLE
fix(projects): align Cairnline embedded probes

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -688,8 +688,10 @@ standalone/interoperability boundary. `replacement_mode=disabled|embedded`
 reports the explicit operator cutover arm; `embedded` is only valid with the
 embedded connector and strict embedded read source, and it does not bypass the
 read, write-authority, migration, rollback, or Hecate-owned runtime side-effect
-gates. Once portable write gaps are
-closed, the next action becomes `run-strict-embedded-read-smoke` until strict
+gates. The initial embedded dogfood and sidecar-to-embedded connector next
+actions point at backend-status and embedded read-model diagnostics; sidecar
+probe/connect routes remain separate standalone MCP diagnostics. Once portable
+write gaps are closed, the next action becomes `run-strict-embedded-read-smoke` until strict
 embedded mirror parity and route-smoke evidence are verified; that action
 reports strict embedded rehearsal hints for
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+const projectCoordinationBackendStatusURL = "/hecate/v1/projects/backend-status"
 const projectCoordinationBackendReadinessURL = "/hecate/v1/projects/{id}/cairnline/read-model"
 const projectCoordinationBackendExportURL = "/hecate/v1/projects/{id}/cairnline/export"
 const projectCoordinationBackendSidecarProbeURL = "/hecate/v1/projects/cairnline/sidecar-probe"
@@ -551,8 +552,10 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 				projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector for the current write-authority dogfood path."),
 			},
 			ProbeURLs: []string{
-				projectCoordinationBackendSidecarProbeURL,
-				projectCoordinationBackendSidecarConnectURL,
+				projectCoordinationBackendStatusURL,
+				projectCoordinationBackendReadinessURL,
+				projectCoordinationBackendEmbeddedReadModelURL,
+				projectCoordinationBackendEmbeddedParityReportURL,
 			},
 		}
 	}
@@ -566,8 +569,10 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 				projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector before enabling Cairnline write-authority switchpoints."),
 			},
 			ProbeURLs: []string{
-				projectCoordinationBackendSidecarProbeURL,
-				projectCoordinationBackendSidecarConnectURL,
+				projectCoordinationBackendStatusURL,
+				projectCoordinationBackendReadinessURL,
+				projectCoordinationBackendEmbeddedReadModelURL,
+				projectCoordinationBackendEmbeddedParityReportURL,
 			},
 		}
 	}

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -93,6 +93,9 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_COORDINATION_BACKEND"); hint == nil || hint.Value != "cairnline" {
 		t.Fatalf("next action config hints = %+v, want coordination backend=cairnline", status.NextReplacementAction.ConfigHints)
 	}
+	if !hasEmbeddedDogfoodProbes(status.NextReplacementAction.Probes) {
+		t.Fatalf("next action probes = %+v, want embedded dogfood status/read-model probes", status.NextReplacementAction.Probes)
+	}
 }
 
 func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *testing.T) {
@@ -220,6 +223,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "use-embedded-cairnline-connector" || status.NextReplacementAction.Target != "connector" {
 		t.Fatalf("next action = %+v, want embedded connector action for sidecar mode", status.NextReplacementAction)
 	}
+	if !hasEmbeddedDogfoodProbes(status.NextReplacementAction.Probes) {
+		t.Fatalf("next action probes = %+v, want embedded connector status/read-model probes", status.NextReplacementAction.Probes)
+	}
 	warnings := strings.Join(status.Warnings, "\n")
 	if !strings.Contains(warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar") || !strings.Contains(warnings, "lifecycle/write/setup/work/collaboration/memory/assistant diagnostics") || strings.Contains(warnings, "read-smoke surfaces only") || !strings.Contains(warnings, "ignored in sidecar connector mode") || !strings.Contains(warnings, projectCairnlineWriteAuthorityProjectAssignments) {
 		t.Fatalf("warnings = %+v, want full sidecar diagnostic warning", status.Warnings)
@@ -275,6 +281,9 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "use-embedded-cairnline-connector" || status.NextReplacementAction.Target != "connector" {
 		t.Fatalf("next action = %+v, want embedded connector action even when sidecar read routes are active", status.NextReplacementAction)
+	}
+	if !hasEmbeddedDogfoodProbes(status.NextReplacementAction.Probes) {
+		t.Fatalf("next action probes = %+v, want embedded connector status/read-model probes", status.NextReplacementAction.Probes)
 	}
 }
 
@@ -1252,4 +1261,13 @@ func hasProbe(items []ProjectCoordinationBackendProbe, method, url string) bool 
 		}
 	}
 	return false
+}
+
+func hasEmbeddedDogfoodProbes(items []ProjectCoordinationBackendProbe) bool {
+	return hasProbe(items, http.MethodGet, projectCoordinationBackendStatusURL) &&
+		hasProbe(items, http.MethodGet, projectCoordinationBackendReadinessURL) &&
+		hasProbe(items, http.MethodGet, projectCoordinationBackendEmbeddedReadModelURL) &&
+		hasProbe(items, http.MethodGet, projectCoordinationBackendEmbeddedParityReportURL) &&
+		!hasProbe(items, http.MethodPost, projectCoordinationBackendSidecarProbeURL) &&
+		!hasProbe(items, http.MethodPost, projectCoordinationBackendSidecarConnectURL)
 }


### PR DESCRIPTION
## Summary
- Point the initial embedded Cairnline dogfood next action at backend-status and embedded read-model diagnostics instead of sidecar-only probe routes.
- Do the same for the sidecar-to-embedded connector action.
- Document the distinction between embedded dogfood probes and standalone sidecar diagnostics.

## Tests
- go build ./...
- go test ./internal/api -run TestProjectCoordinationBackendStatus
- go vet ./internal/api
- just docs-format-check
- just agent-docs-check
- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...
- git diff --check