### PR TITLE
fix(projects): align embedded dogfood hints

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -503,6 +503,11 @@ project identity, project setup metadata, project work coordination records,
 collaboration metadata records, memory/candidate records, and Project Assistant
 proposal/apply records. None of these routes operator project reads or writes
 through the sidecar backend.
+The backend-status next action treats embedded dogfood as the replacement path:
+when it points at embedded status/read-model probes from a sidecar read-source
+runtime, it also includes
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` alongside the embedded
+connector hint so the suggested configuration matches the probe set.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable` expands to every
 current portable write-authority dogfood switchpoint. It does not make Hecate
 runtime side effects or migration cutover Cairnline-owned: root

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -547,10 +547,9 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 			Label:  "Enable Cairnline dogfood",
 			Detail: "Configure Cairnline as the project coordination backend in a local dogfood runtime before moving any authority.",
 			Target: "configuration",
-			ConfigHints: []ProjectCoordinationBackendActionConfigHint{
+			ConfigHints: append([]ProjectCoordinationBackendActionConfigHint{
 				projectCairnlineConfigHint("HECATE_PROJECTS_COORDINATION_BACKEND", "cairnline", "Enable Cairnline as the Projects coordination backend for local dogfooding."),
-				projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector for the current write-authority dogfood path."),
-			},
+			}, projectCairnlineEmbeddedDogfoodHints(status.CairnlineReadSource)...),
 			ProbeURLs: []string{
 				projectCoordinationBackendStatusURL,
 				projectCoordinationBackendReadinessURL,
@@ -561,13 +560,11 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 	}
 	if !status.CairnlineConnectorReady {
 		return &ProjectCoordinationBackendNextAction{
-			ID:     "use-embedded-cairnline-connector",
-			Label:  "Use the embedded Cairnline connector",
-			Detail: "Sidecar mode is useful for MCP diagnostics and read smoke tests, but write-authority dogfood currently requires the embedded Cairnline connector.",
-			Target: "connector",
-			ConfigHints: []ProjectCoordinationBackendActionConfigHint{
-				projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector before enabling Cairnline write-authority switchpoints."),
-			},
+			ID:          "use-embedded-cairnline-connector",
+			Label:       "Use the embedded Cairnline connector",
+			Detail:      "Sidecar mode is useful for MCP diagnostics and read smoke tests, but write-authority dogfood currently requires the embedded Cairnline connector.",
+			Target:      "connector",
+			ConfigHints: projectCairnlineEmbeddedDogfoodHints(status.CairnlineReadSource),
 			ProbeURLs: []string{
 				projectCoordinationBackendStatusURL,
 				projectCoordinationBackendReadinessURL,
@@ -680,6 +677,16 @@ func projectCairnlineMigrationCutoverHints() []ProjectCoordinationBackendActionC
 		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "embedded", "Force configured project reads to fail loudly when the embedded mirror is missing or stale during cutover rehearsal."),
 		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", "all-portable", "Keep all portable write-authority switchpoints enabled while rehearsing migration and rollback."),
 	}
+}
+
+func projectCairnlineEmbeddedDogfoodHints(readSource string) []ProjectCoordinationBackendActionConfigHint {
+	hints := []ProjectCoordinationBackendActionConfigHint{
+		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector for current write-authority and embedded read-model dogfood paths."),
+	}
+	if readSource == "sidecar" {
+		hints = append(hints, projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "embedded", "Switch project reads back to the embedded read source before running embedded dogfood status/read-model probes."))
+	}
+	return hints
 }
 
 func projectCairnlineConfigHint(env, value, detail string) ProjectCoordinationBackendActionConfigHint {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -223,6 +223,12 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarConnectorBlocksEmbedde
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "use-embedded-cairnline-connector" || status.NextReplacementAction.Target != "connector" {
 		t.Fatalf("next action = %+v, want embedded connector action for sidecar mode", status.NextReplacementAction)
 	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("next action config hints = %+v, want embedded connector hint", status.NextReplacementAction.ConfigHints)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE"); hint != nil {
+		t.Fatalf("next action config hints = %+v, did not expect read-source hint when source is already embedded", status.NextReplacementAction.ConfigHints)
+	}
 	if !hasEmbeddedDogfoodProbes(status.NextReplacementAction.Probes) {
 		t.Fatalf("next action probes = %+v, want embedded connector status/read-model probes", status.NextReplacementAction.Probes)
 	}
@@ -281,6 +287,12 @@ func TestProjectCoordinationBackendStatus_CairnlineSidecarReadRoutesReady(t *tes
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "use-embedded-cairnline-connector" || status.NextReplacementAction.Target != "connector" {
 		t.Fatalf("next action = %+v, want embedded connector action even when sidecar read routes are active", status.NextReplacementAction)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("next action config hints = %+v, want embedded connector hint", status.NextReplacementAction.ConfigHints)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("next action config hints = %+v, want embedded read-source hint before embedded dogfood probes", status.NextReplacementAction.ConfigHints)
 	}
 	if !hasEmbeddedDogfoodProbes(status.NextReplacementAction.Probes) {
 		t.Fatalf("next action probes = %+v, want embedded connector status/read-model probes", status.NextReplacementAction.Probes)


### PR DESCRIPTION
## Summary
- reuse embedded dogfood config hints for backend-status replacement actions
- add the embedded read-source hint when a sidecar read-source runtime is asked to run embedded status/read-model probes
- document the backend-status hint behavior for sidecar-to-embedded dogfood transitions

## Tests
- go test ./internal/api -run 'TestProjectCoordinationBackendStatus_(DefaultHecateAuthoritative|CairnlineSidecarConnectorBlocksEmbeddedRoutes|CairnlineSidecarReadRoutesReady)'
- go vet ./internal/api
- just docs-format-check
- just agent-docs-check
- go build ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- git diff --check