### PR TITLE
fix(settings): show project read source

### DIFF
--- a/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
+++ b/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
@@ -70,6 +70,11 @@ export function ProjectCoordinationBackendSettings({
                     {status.cairnline_connector}
                   </span>
                 )}
+                {status.cairnline_read_source && (
+                  <span className="badge badge-muted" style={{ textTransform: "none" }}>
+                    reads: {projectBackendDisplayLabel(status.cairnline_read_source)}
+                  </span>
+                )}
               </div>
               <div style={{ fontSize: 12, color: "var(--t2)", lineHeight: 1.45, marginTop: 8 }}>
                 {projectBackendSummary(status)}

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -185,6 +185,7 @@ describe("SettingsView", () => {
 
     expect(await screen.findByText("Project coordination")).toBeTruthy();
     expect(screen.getByText("Cairnline dogfood active")).toBeTruthy();
+    expect(screen.getByText("reads: embedded")).toBeTruthy();
     expect(screen.getByText("cairnline configured · hecate authoritative")).toBeTruthy();
     expect(screen.getByText("cairnline read routes ready")).toBeTruthy();
     expect(screen.getByText(/2 read routes use Cairnline/i)).toBeTruthy();


### PR DESCRIPTION
## Summary
- show the configured Cairnline project read source in the Project coordination settings header
- cover the read-source badge in the existing Settings status test

## Tests
- cd ui && bun run typecheck
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test
- just agent-docs-check
- git diff --check

Docs unchanged: UI-only visibility improvement for an existing API field.