### PR TITLE
docs(projects): clarify embedded dogfood hints

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2598,6 +2598,11 @@ next action becomes `implement-migration-cutover`, which is intentionally an
 operator-controlled configuration step rather than an automatic mutation. Once
 the cutover is armed and all replacement gates are ready, the next action becomes
 `monitor-cairnline-backend`.
+The initial embedded dogfood and sidecar-to-embedded connector actions point at
+backend-status plus embedded read-model diagnostics. If the current runtime is
+still using `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, those actions also
+include `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` so the suggested
+configuration matches the embedded probe set.
 `write_switchpoints` maps each live mutation family to the current authority,
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
 `snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled


### PR DESCRIPTION
## Summary
- clarify backend-status next-action config hints for embedded dogfood and sidecar-to-embedded transitions
- note that a sidecar read-source runtime gets an embedded read-source hint when the next action points at embedded diagnostics

## Tests
- just docs-format-check
- just agent-docs-check
- git diff --check

Docs-only change.