### PR TITLE
test(projects): cover sidecar dogfood hints

### DIFF
--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -98,6 +98,33 @@ func TestProjectCoordinationBackendStatus_DefaultHecateAuthoritative(t *testing.
 	}
 }
 
+func TestProjectCoordinationBackendStatus_EnableDogfoodHintsEmbeddedReadSourceFromSidecar(t *testing.T) {
+	handler := &Handler{config: config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CairnlineConnector:  "sidecar",
+			CairnlineReadSource: "sidecar",
+		},
+	}}
+
+	status := handler.projectCoordinationBackendStatus()
+	if status.ConfiguredBackend != "hecate" || status.NextReplacementAction == nil || status.NextReplacementAction.ID != "enable-cairnline-dogfood" {
+		t.Fatalf("status = %+v, want Hecate-authoritative enable-dogfood next action", status)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_COORDINATION_BACKEND"); hint == nil || hint.Value != "cairnline" {
+		t.Fatalf("next action config hints = %+v, want coordination backend=cairnline", status.NextReplacementAction.ConfigHints)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("next action config hints = %+v, want embedded connector hint", status.NextReplacementAction.ConfigHints)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("next action config hints = %+v, want embedded read-source hint", status.NextReplacementAction.ConfigHints)
+	}
+	if !hasEmbeddedDogfoodProbes(status.NextReplacementAction.Probes) {
+		t.Fatalf("next action probes = %+v, want embedded dogfood status/read-model probes", status.NextReplacementAction.Probes)
+	}
+}
+
 func TestProjectCoordinationBackendStatus_CairnlineConfiguredMissingSources(t *testing.T) {
 	handler := &Handler{config: config.Config{
 		Projects: config.ProjectsConfig{


### PR DESCRIPTION
## Summary
- cover the initial enable-dogfood next action when the current runtime is in sidecar read-source mode
- assert the action carries coordination backend, embedded connector, embedded read-source hints, and embedded dogfood probes

## Tests
- go test ./internal/api -run 'TestProjectCoordinationBackendStatus_(DefaultHecateAuthoritative|EnableDogfoodHintsEmbeddedReadSourceFromSidecar|CairnlineSidecar)'
- go vet ./internal/api
- go build ./...
- just agent-docs-check
- git diff --check

Docs unchanged: test-only coverage for existing behavior.