### PR TITLE
chore(projects): update cairnline dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260630034324-bb4d449008d8
+	github.com/hecatehq/cairnline v0.0.0-20260703124839-4d010b5c7cdf
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.0.0-20260630034324-bb4d449008d8 h1:H64pvdRd31kiF1W9Phg6gjy0EjK0e69tSzzT5UOvtao=
-github.com/hecatehq/cairnline v0.0.0-20260630034324-bb4d449008d8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260703124839-4d010b5c7cdf h1:z5WQAHTKTdoZhYncpJam2AtTQ6fJPaMFjI4iaki8Ijo=
+github.com/hecatehq/cairnline v0.0.0-20260703124839-4d010b5c7cdf/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -1254,6 +1254,13 @@ func TestUpsertWorkItemMirrorsWorkItemMutations(t *testing.T) {
 	if created.ID != item.ID || created.Status != projectwork.WorkItemStatusBacklog || created.Priority != "high" || created.RootID != "root_main" || len(created.ReviewerRoleIDs) != 1 || created.ReviewerRoleIDs[0] != "reviewer" {
 		t.Fatalf("created work item = %+v, want mapped Hecate work item metadata", created)
 	}
+	mirroredRoles, err := service.ListRoles(ctx, item.ProjectID)
+	if err != nil {
+		t.Fatalf("ListRoles() error = %v", err)
+	}
+	if !hasCairnlineRole(mirroredRoles, "writer") || !hasCairnlineRole(mirroredRoles, "reviewer") {
+		t.Fatalf("mirrored roles = %+v, want work item role placeholders", mirroredRoles)
+	}
 
 	item.Title = "Document adapter updated"
 	item.Status = projectwork.WorkItemStatusReady
@@ -2531,6 +2538,15 @@ func hasAgentProfile(profiles []agentprofiles.Profile, id string) bool {
 }
 
 func hasRole(roles []projectwork.AgentRoleProfile, id string) bool {
+	for _, role := range roles {
+		if role.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCairnlineRole(roles []cairnline.Role, id string) bool {
 	for _, role := range roles {
 		if role.ID == id {
 			return true

--- a/internal/cairnlinebridge/work_write.go
+++ b/internal/cairnlinebridge/work_write.go
@@ -75,6 +75,9 @@ func UpsertWorkItem(ctx context.Context, service *cairnline.Service, item projec
 	if strings.TrimSpace(mapped.ID) == "" {
 		return cairnline.WorkItem{}, errors.Join(cairnline.ErrInvalid, errors.New("work item id is required"))
 	}
+	if err := ensureWorkItemRoles(ctx, service, mapped); err != nil {
+		return cairnline.WorkItem{}, err
+	}
 	if _, err := service.GetWorkItem(ctx, mapped.ProjectID, mapped.ID); err != nil {
 		if !errors.Is(err, cairnline.ErrNotFound) {
 			return cairnline.WorkItem{}, err
@@ -82,6 +85,33 @@ func UpsertWorkItem(ctx context.Context, service *cairnline.Service, item projec
 		return service.CreateWorkItem(ctx, mapped)
 	}
 	return service.UpdateWorkItem(ctx, mapped)
+}
+
+func ensureWorkItemRoles(ctx context.Context, service *cairnline.Service, item cairnline.WorkItem) error {
+	existing, err := service.ListRoles(ctx, item.ProjectID)
+	if err != nil {
+		return err
+	}
+	rolesByID := make(map[string]struct{}, len(existing))
+	for _, role := range existing {
+		rolesByID[strings.TrimSpace(role.ID)] = struct{}{}
+	}
+	for _, roleID := range compactStrings(append([]string{item.OwnerRoleID}, item.ReviewerRoleIDs...)) {
+		if _, ok := rolesByID[roleID]; ok {
+			continue
+		}
+		// Work-item mirrors can arrive before the corresponding role mirror;
+		// seed a minimal record so Cairnline can preserve the role reference.
+		if _, err := service.CreateRole(ctx, cairnline.Role{
+			ID:        roleID,
+			ProjectID: item.ProjectID,
+			Name:      roleID,
+		}); err != nil && !errors.Is(err, cairnline.ErrDuplicate) {
+			return err
+		}
+		rolesByID[roleID] = struct{}{}
+	}
+	return nil
 }
 
 func DeleteWorkItem(ctx context.Context, service *cairnline.Service, projectID, id string) error {


### PR DESCRIPTION
## Summary
- update Hecate to the current Cairnline module revision
- seed minimal Cairnline role placeholders before mirroring work items with owner/reviewer refs
- cover placeholder seeding in the Cairnline bridge test

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/cairnlinebridge
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_PartialApplyMirrorsCommittedActionsToCairnlineWhenConfigured'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProject.*Cairnline|TestProjectCoordinationBackend|Test.*Cairnline'
- go vet ./internal/cairnlinebridge ./internal/api
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- git diff --check