### PR TITLE
Expose Cairnline migration evidence in backend status

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -131,9 +131,13 @@ When configured for the embedded connector, strict embedded read source, and a
 runtime data directory, the strict embedded read-smoke gate is backed by the
 read-only mirror-parity probe: missing mirrors, drift, probe errors, and verified
 route smoke are reflected directly in backend status instead of relying only on
-manual checklist prose. The migration/rollback gate depends on that read-smoke
-evidence: it waits for verified strict embedded reads first, then reports the
-remaining missing authoritative cutover/rollback switch separately. Once strict
+manual checklist prose. Backend status also carries the mirror-parity
+`migration_rehearsal` object when available, so the replacement gate can inspect
+snapshot-import/parity/smoke checks and rollback notes as structured evidence.
+The migration/rollback gate depends on that read-smoke and rehearsal evidence:
+it waits for verified strict embedded reads first, reports incomplete rehearsal
+evidence separately, then reports the remaining missing authoritative
+cutover/rollback switch. Once strict
 embedded reads are verified, all portable write-authority gaps are closed, and
 `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed, backend status
 treats that replacement mode as the explicit embedded cutover switch, clears the

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -660,10 +660,14 @@ and a configured data directory are active, the strict read-smoke gate is driven
 by the same read-only mirror-parity evidence returned by
 `GET /hecate/v1/projects/cairnline/mirror-parity`: a missing mirror reports
 `not_run`, mirror drift reports `drift_detected`, and an exact mirror with passing
-strict embedded route smoke reports `verified`. The migration/rollback gate then
-reports `waiting_for_read_smoke` until that evidence is verified, and
-`cutover_switch_missing` once the read evidence is clean but the explicit
-authoritative storage cutover switch still does not exist. When
+strict embedded route smoke reports `verified`. Backend status also exposes the
+same mirror-parity `migration_rehearsal` object so operators can inspect the
+snapshot-import checklist, rollback notes, and strict embedded smoke details
+without calling the probe endpoint separately. The migration/rollback gate then
+reports `waiting_for_read_smoke` until read evidence is verified,
+`rehearsal_incomplete` when the attached rehearsal evidence is missing or
+incomplete, and `cutover_switch_missing` once the rehearsal evidence is clean
+but the explicit authoritative storage cutover switch still does not exist. When
 `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed after strict
 embedded reads are verified and all portable write-authority gaps are closed,
 backend status treats that mode as the explicit embedded cutover switch, clears

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2560,13 +2560,22 @@ status runs the read-only mirror-parity check and reports `not_run` for a
 missing mirror, `drift_detected` for parity drift, `probe_error` when the
 inspection cannot run, and `verified` only when the existing mirror matches
 Hecate stores and strict embedded route smoke passes. The
+same backend-status response includes `migration_rehearsal` when that
+mirror-parity probe can run. That object is the same structured rehearsal
+evidence returned by `/hecate/v1/projects/cairnline/mirror-parity`: snapshot
+import mode, snapshot version, checklist, rollback notes, and strict embedded
+smoke details. The `migration-and-rollback` gate uses this object directly
+rather than only relying on prose. It treats missing evidence, non-verified
+mirror parity, incomplete import/parity/smoke checks, missing rollback steps, or
+non-passing embedded smoke as `rehearsal_incomplete`.
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
 it is driven by `portable_write_gaps` and ignores Hecate-owned orchestrator
 capabilities and the separate `migration-cutover` gap because those are reported
 by their own status fields/gates. The `migration-and-rollback` gate reports
 `waiting_for_read_smoke` until strict embedded read-smoke evidence is verified;
-after that it reports `cutover_switch_missing` until Hecate has an explicit
-authoritative Cairnline storage cutover and rollback switch. When strict
+after that, with complete migration rehearsal evidence attached, it reports
+`cutover_switch_missing` until Hecate has an explicit authoritative Cairnline
+storage cutover and rollback switch. When strict
 embedded reads are verified, all portable write-authority gaps are closed, and
 `replacement_mode=embedded`, backend status treats replacement mode as that
 explicit embedded cutover switch: `migration_blockers` is empty, the

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -373,7 +373,8 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 	switch configured {
 	case "cairnline":
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
-		strictEmbeddedReadGate := h.projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx, connectorReady, readSource, readReady)
+		strictEmbeddedReadGate, migrationRehearsal := h.projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx, connectorReady, readSource, readReady)
+		response.MigrationRehearsal = migrationRehearsal
 		writeAuthority := h.config.ProjectsCairnlineWriteAuthority()
 		effectiveWriteAuthority := writeAuthority
 		if !connectorReady {
@@ -384,16 +385,16 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 		response.PortableWriteGaps = projectCairnlinePortableWriteGapsSnapshot(effectiveWriteAuthority, response.WriteAdapterGaps)
 		response.OrchestratorCapabilities = projectCairnlineOrchestratorCapabilitiesSnapshot(response.WriteAdapterGaps)
 		response.WriteAdapterReady = len(response.PortableWriteGaps) == 0
-		migrationCutoverArmed := replacementMode == "embedded" && strictEmbeddedReadGate.Ready && len(response.PortableWriteGaps) == 0
+		migrationCutoverArmed := replacementMode == "embedded" && strictEmbeddedReadGate.Ready && projectCairnlineMigrationRollbackEvidenceReady(migrationRehearsal) && len(response.PortableWriteGaps) == 0
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority, migrationCutoverArmed)
 		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps, migrationCutoverArmed)
-		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed)
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
 				response.Detail = "Cairnline sidecar is configured as the project read source, so " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " routes read through the persistent standalone Cairnline MCP client. Project writes and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
-				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
+				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed)
 				response.Warnings = []string{
 					"Only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " use the Cairnline sidecar MCP client in this mode.",
 					projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
@@ -403,7 +404,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
-			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationCutoverArmed)
+			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
 				projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
@@ -742,7 +743,7 @@ func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
 	}
 }
 
-func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationCutoverArmed bool) []ProjectCoordinationBackendReplacementGate {
+func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool) []ProjectCoordinationBackendReplacementGate {
 	if strings.TrimSpace(strictEmbeddedReadGate.ID) == "" {
 		strictEmbeddedReadGate = projectCairnlineStrictEmbeddedReadSmokeDefaultGate()
 	}
@@ -757,7 +758,7 @@ func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []
 		},
 		strictEmbeddedReadGate,
 		writeGate,
-		projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate, migrationCutoverArmed),
+		projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed),
 		projectCairnlineReplacementModeGate(replacementMode),
 	}
 }
@@ -772,47 +773,48 @@ func projectCairnlineStrictEmbeddedReadSmokeDefaultGate() ProjectCoordinationBac
 	}
 }
 
-func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx context.Context, connectorReady bool, readSource string, readRoutesReady bool) ProjectCoordinationBackendReplacementGate {
+func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx context.Context, connectorReady bool, readSource string, readRoutesReady bool) (ProjectCoordinationBackendReplacementGate, *ProjectCairnlineMigrationRehearsal) {
 	gate := projectCairnlineStrictEmbeddedReadSmokeDefaultGate()
 	if !connectorReady {
 		gate.Status = "blocked"
 		gate.Detail = "Strict embedded read smoke requires the embedded Cairnline connector; configure HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded before using the embedded mirror as a replacement candidate."
-		return gate
+		return gate, nil
 	}
 	if readSource != "embedded" {
 		gate.Detail = "Set HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded and run the embedded sync/parity/smoke probes before treating the mirror database as a cutover candidate."
-		return gate
+		return gate, nil
 	}
 	if !readRoutesReady {
 		gate.Status = "blocked"
 		gate.Detail = "Strict embedded read smoke cannot run until the Cairnline read adapter can load the full Hecate project graph."
-		return gate
+		return gate, nil
 	}
 	if strings.TrimSpace(h.config.Server.DataDir) == "" {
 		gate.Detail = "Run backend status with a configured Hecate data directory, then run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate."
-		return gate
+		return gate, nil
 	}
 	item, err := h.projectCairnlineMirrorParity(ctx)
 	if err != nil {
 		gate.Status = "probe_error"
 		gate.Detail = "Strict embedded read smoke could not inspect the embedded Cairnline mirror: " + err.Error()
-		return gate
+		return gate, nil
 	}
+	migrationRehearsal := item.MigrationRehearsal
 	if !item.DatabaseExists {
 		gate.Status = "not_run"
 		gate.Detail = "No embedded Cairnline mirror database exists yet; run " + projectCoordinationBackendSyncReadinessURL + " and then " + projectCoordinationBackendMirrorParityURL + "."
-		return gate
+		return gate, &migrationRehearsal
 	}
 	if !item.Match {
 		gate.Status = "drift_detected"
 		gate.Detail = "The embedded Cairnline mirror exists but no longer matches Hecate's authoritative stores; rerun the sync and mirror-parity probes before cutover."
-		return gate
+		return gate, &migrationRehearsal
 	}
 	smoke := item.MigrationRehearsal.EmbeddedSmoke
 	if smoke == nil {
 		gate.Status = "operator_probe_required"
 		gate.Detail = "The embedded Cairnline mirror matches Hecate stores, but strict embedded read smoke evidence is missing; rerun the mirror-parity probe."
-		return gate
+		return gate, &migrationRehearsal
 	}
 	if smoke.Status != "passed" {
 		gate.Status = smoke.Status
@@ -820,15 +822,15 @@ func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx con
 			gate.Status = "failed"
 		}
 		gate.Detail = fmt.Sprintf("The embedded Cairnline mirror matches Hecate stores, but strict embedded read smoke reported %s with %d error(s).", gate.Status, len(smoke.Errors))
-		return gate
+		return gate, &migrationRehearsal
 	}
 	gate.Ready = true
 	gate.Status = "verified"
 	gate.Detail = fmt.Sprintf("Existing embedded Cairnline mirror matches Hecate stores and strict embedded read smoke passed across %d project(s) and %d route check(s).", smoke.ProjectCount, smoke.ReadRouteChecks)
-	return gate
+	return gate, &migrationRehearsal
 }
 
-func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationCutoverArmed bool) ProjectCoordinationBackendReplacementGate {
+func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool) ProjectCoordinationBackendReplacementGate {
 	gate := ProjectCoordinationBackendReplacementGate{
 		ID:        "migration-and-rollback",
 		Ready:     false,
@@ -836,16 +838,70 @@ func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate Pro
 		Detail:    "Strict embedded mirror parity and read smoke must be verified before migration and rollback can be treated as rehearsed.",
 		ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL, projectCoordinationBackendExportURL},
 	}
-	if strictEmbeddedReadGate.Ready {
-		gate.Status = "cutover_switch_missing"
-		gate.Detail = "Strict embedded mirror parity and read smoke are verified, and rehearsal endpoints expose rollback notes, but no authoritative Cairnline storage cutover switch exists yet."
-	}
-	if migrationCutoverArmed {
+	if migrationCutoverArmed && projectCairnlineMigrationRollbackEvidenceReady(migrationRehearsal) {
 		gate.Ready = true
 		gate.Status = "ready"
-		gate.Detail = "Strict embedded mirror parity and read smoke are verified, all portable write-authority gaps are closed, and embedded replacement mode is the explicit cutover switch."
+		gate.Detail = "Strict embedded mirror parity, route smoke, snapshot-import evidence, and rollback notes are verified; all portable write-authority gaps are closed; embedded replacement mode is the explicit cutover switch."
+		return gate
 	}
+	if !strictEmbeddedReadGate.Ready {
+		return gate
+	}
+	if blocker := projectCairnlineMigrationRollbackEvidenceBlocker(migrationRehearsal); blocker != "" {
+		gate.Status = "rehearsal_incomplete"
+		gate.Detail = "Strict embedded read smoke is verified, but migration and rollback evidence is incomplete: " + blocker + "."
+		return gate
+	}
+	gate.Status = "cutover_switch_missing"
+	gate.Detail = "Strict embedded mirror parity, route smoke, snapshot-import evidence, and rollback notes are verified, but no explicit authoritative Cairnline storage cutover switch is armed yet."
 	return gate
+}
+
+func projectCairnlineMigrationRollbackEvidenceReady(migrationRehearsal *ProjectCairnlineMigrationRehearsal) bool {
+	return projectCairnlineMigrationRollbackEvidenceBlocker(migrationRehearsal) == ""
+}
+
+func projectCairnlineMigrationRollbackEvidenceBlocker(migrationRehearsal *ProjectCairnlineMigrationRehearsal) string {
+	if migrationRehearsal == nil {
+		return "backend status does not include mirror-parity rehearsal evidence"
+	}
+	if migrationRehearsal.Operation != "mirror_parity" {
+		return "expected mirror_parity rehearsal evidence, got " + migrationRehearsal.Operation
+	}
+	if migrationRehearsal.Status != "verified" {
+		return "mirror-parity rehearsal status is " + migrationRehearsal.Status
+	}
+	requiredChecks := []ProjectCairnlineMigrationRehearsalCheck{
+		{ID: "load-hecate-stores", Status: "complete"},
+		{ID: "native-snapshot-import", Status: "complete"},
+		{ID: "parity-check", Status: "complete"},
+		{ID: "strict-embedded-read-smoke", Status: "complete"},
+		{ID: "rollback-plan", Status: "documented"},
+	}
+	for _, check := range requiredChecks {
+		if !projectCairnlineMigrationChecklistHas(migrationRehearsal.Checklist, check.ID, check.Status) {
+			return fmt.Sprintf("check %q is not %q", check.ID, check.Status)
+		}
+	}
+	if len(migrationRehearsal.Rollback) == 0 {
+		return "rollback steps are missing"
+	}
+	if migrationRehearsal.EmbeddedSmoke == nil {
+		return "strict embedded smoke details are missing"
+	}
+	if migrationRehearsal.EmbeddedSmoke.Status != "passed" {
+		return "strict embedded smoke status is " + migrationRehearsal.EmbeddedSmoke.Status
+	}
+	return ""
+}
+
+func projectCairnlineMigrationChecklistHas(items []ProjectCairnlineMigrationRehearsalCheck, id, status string) bool {
+	for _, item := range items {
+		if item.ID == id && item.Status == status {
+			return true
+		}
+	}
+	return false
 }
 
 func projectCairnlineReplacementModeGate(replacementMode string) ProjectCoordinationBackendReplacementGate {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -431,6 +431,9 @@ func TestProjectCoordinationBackendStatus_StrictEmbeddedReadSmokeGateMissingMirr
 	if gate == nil || gate.Ready || gate.Status != "not_run" {
 		t.Fatalf("strict embedded gate = %+v, want missing-mirror not_run gate", gate)
 	}
+	if status.MigrationRehearsal == nil || status.MigrationRehearsal.Operation != "mirror_parity" || status.MigrationRehearsal.Status != "not_run" || status.MigrationRehearsal.CutoverReady {
+		t.Fatalf("migration rehearsal = %+v, want not-run mirror parity evidence while mirror is missing", status.MigrationRehearsal)
+	}
 	if !containsString(gate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || !strings.Contains(gate.Detail, projectCoordinationBackendSyncReadinessURL) {
 		t.Fatalf("strict embedded gate = %+v, want sync probe guidance", gate)
 	}
@@ -468,11 +471,16 @@ func TestProjectCoordinationBackendStatus_StrictEmbeddedReadSmokeGateVerifiedAft
 	if gate == nil || !gate.Ready || gate.Status != "verified" || !strings.Contains(gate.Detail, "strict embedded read smoke passed") {
 		t.Fatalf("strict embedded gate = %+v, want verified strict embedded smoke gate", gate)
 	}
+	if status.MigrationRehearsal == nil || status.MigrationRehearsal.Operation != "mirror_parity" || status.MigrationRehearsal.Status != "verified" || !projectCairnlineMigrationRollbackEvidenceReady(status.MigrationRehearsal) {
+		t.Fatalf("migration rehearsal = %+v, want backend status to expose verified mirror-parity rollback evidence", status.MigrationRehearsal)
+	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false while migration/cutover gate remains blocked")
 	}
 	if migrationGate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); migrationGate == nil || migrationGate.Ready || migrationGate.Status != "cutover_switch_missing" {
 		t.Fatalf("migration gate = %+v, want cutover-switch blocker after strict embedded verification", migrationGate)
+	} else if !strings.Contains(migrationGate.Detail, "rollback notes") {
+		t.Fatalf("migration gate = %+v, want rollback evidence detail", migrationGate)
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "implement-migration-cutover" {
 		t.Fatalf("next action = %+v, want cutover implementation after read/write gates are ready", status.NextReplacementAction)
@@ -521,6 +529,9 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 	}
 	if len(status.MigrationBlockers) != 0 {
 		t.Fatalf("migration blockers = %+v, want none after embedded replacement cutover is armed", status.MigrationBlockers)
+	}
+	if status.MigrationRehearsal == nil || !projectCairnlineMigrationRollbackEvidenceReady(status.MigrationRehearsal) || len(status.MigrationRehearsal.Rollback) == 0 {
+		t.Fatalf("migration rehearsal = %+v, want replacement-ready status to expose verified rollback evidence", status.MigrationRehearsal)
 	}
 	if gate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); gate == nil || !gate.Ready || gate.Status != "ready" {
 		t.Fatalf("migration gate = %+v, want ready migration gate after embedded replacement cutover is armed", gate)
@@ -1095,6 +1106,20 @@ func TestProjectCoordinationBackendStatus_WriteAuthorityGateUsesPortableGaps(t *
 	gate = projectCairnlineWriteAuthorityReplacementGate([]string{"memory-candidates"})
 	if gate.Ready || gate.Status != "partial" || !strings.Contains(gate.Detail, "memory-candidates") {
 		t.Fatalf("write-authority gate = %+v, want partial when portable write gaps remain", gate)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_MigrationRollbackGateRequiresRehearsalEvidence(t *testing.T) {
+	strictGate := ProjectCoordinationBackendReplacementGate{ID: "strict-embedded-read-smoke", Ready: true, Status: "verified"}
+	gate := projectCairnlineMigrationRollbackReplacementGate(strictGate, nil, false)
+	if gate.Ready || gate.Status != "rehearsal_incomplete" || !strings.Contains(gate.Detail, "does not include mirror-parity") {
+		t.Fatalf("migration gate = %+v, want missing rehearsal evidence blocker", gate)
+	}
+
+	rehearsal := projectCairnlineMigrationRehearsal("mirror_parity", true, true, nil)
+	gate = projectCairnlineMigrationRollbackReplacementGate(strictGate, &rehearsal, true)
+	if gate.Ready || gate.Status != "rehearsal_incomplete" || !strings.Contains(gate.Detail, "strict-embedded-read-smoke") {
+		t.Fatalf("migration gate = %+v, want incomplete smoke evidence to block even when replacement mode is armed", gate)
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -580,6 +580,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	OrchestratorCapabilities             []string                                     `json:"orchestrator_capabilities,omitempty"`
 	SideEffectBlockers                   []string                                     `json:"side_effect_blockers,omitempty"`
 	MigrationBlockers                    []string                                     `json:"migration_blockers,omitempty"`
+	MigrationRehearsal                   *ProjectCairnlineMigrationRehearsal          `json:"migration_rehearsal,omitempty"`
 	NextReplacementAction                *ProjectCoordinationBackendNextAction        `json:"next_replacement_action,omitempty"`
 	ReplacementGates                     []ProjectCoordinationBackendReplacementGate  `json:"replacement_gates,omitempty"`
 	WriteSwitchpoints                    []ProjectCoordinationBackendWriteSwitchpoint `json:"write_switchpoints,omitempty"`

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -110,6 +110,40 @@ export type ProjectCoordinationBackendNextActionRecord = {
   probe_urls?: string[];
 };
 
+export type ProjectCairnlineMigrationRehearsalRecord = {
+  operation: string;
+  import_mode: string;
+  snapshot_version: number;
+  source_authority: string;
+  target: string;
+  refreshes_target: boolean;
+  authoritative: boolean;
+  cutover_ready: boolean;
+  status: string;
+  checklist: Array<{
+    id: string;
+    status: string;
+    detail: string;
+  }>;
+  rollback: string[];
+  embedded_smoke?: {
+    status: string;
+    project_count: number;
+    checked_project_ids?: string[];
+    read_route_checks: number;
+    read_routes?: string[];
+    read_model_count: number;
+    launch_packet_count: number;
+    launch_packet_warning_count: number;
+    launch_packet_error_count: number;
+    errors?: Array<{
+      project_id?: string;
+      check: string;
+      error: string;
+    }>;
+  };
+};
+
 export type ProjectCoordinationBackendStatusRecord = {
   configured_backend: string;
   authoritative_backend: string;
@@ -136,6 +170,7 @@ export type ProjectCoordinationBackendStatusRecord = {
   /** @deprecated use orchestrator_capabilities */
   side_effect_blockers?: string[];
   migration_blockers?: string[];
+  migration_rehearsal?: ProjectCairnlineMigrationRehearsalRecord;
   next_replacement_action?: ProjectCoordinationBackendNextActionRecord;
   replacement_gates?: ProjectCoordinationBackendReplacementGateRecord[];
   write_switchpoints?: ProjectCoordinationBackendWriteSwitchpointRecord[];


### PR DESCRIPTION
## Summary
- expose mirror-parity migration rehearsal evidence on the Projects backend-status response
- make the migration/rollback replacement gate validate structured rehearsal evidence before it can be ready
- update API/docs/frontend contract types for the new optional field

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus'
- just agent-docs-check
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...