### PR TITLE
Render Cairnline migration rehearsal in Settings

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -689,8 +689,9 @@ coordination-state switchpoint work is separated from Hecate-owned
 runtime/workspace capabilities and final cutover work. Settings shows the same
 backend-status summary, shows copyable next-action configuration hints, turns
 the next action's probes into a run-in-order checklist, keeps replacement gates
-as supporting evidence, and lists write-switchpoint authority/state rows under
-Project coordination for local operator inspection. The reported replacement
+and migration rehearsal evidence as supporting proof, and lists
+write-switchpoint authority/state rows under Project coordination for local
+operator inspection. The reported replacement
 target is embedded Cairnline first: Hecate should make the embedded Cairnline
 database the Projects source of truth before treating an external sidecar as the
 standalone/interoperability boundary. `replacement_mode=disabled|embedded`

--- a/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
+++ b/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
@@ -23,6 +23,7 @@ export function ProjectCoordinationBackendSettings({
   const migrationBlockers = status?.migration_blockers ?? [];
   const replacementGates = status?.replacement_gates ?? [];
   const statusWarnings = status?.warnings ?? [];
+  const migrationRehearsal = status?.migration_rehearsal;
   const nextAction = status?.next_replacement_action;
   const writeSwitchpoints = status?.write_switchpoints ?? [];
   const statusBadge = status
@@ -110,6 +111,9 @@ export function ProjectCoordinationBackendSettings({
           </div>
           {nextAction && <ProjectBackendNextAction action={nextAction} />}
           {replacementGates.length > 0 && <ProjectBackendGateList gates={replacementGates} />}
+          {migrationRehearsal && (
+            <ProjectBackendMigrationRehearsal rehearsal={migrationRehearsal} />
+          )}
           {writeSwitchpoints.length > 0 && (
             <ProjectBackendSwitchpointList switchpoints={writeSwitchpoints} />
           )}
@@ -141,6 +145,135 @@ export function ProjectCoordinationBackendSettings({
         </article>
       )}
     </section>
+  );
+}
+
+function ProjectBackendMigrationRehearsal({
+  rehearsal,
+}: {
+  rehearsal: NonNullable<ProjectCoordinationBackendStatusRecord["migration_rehearsal"]>;
+}) {
+  const smoke = rehearsal.embedded_smoke;
+  return (
+    <div style={{ display: "grid", gap: 8, marginTop: 14 }}>
+      <div
+        style={{
+          color: "var(--t3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        Migration rehearsal
+      </div>
+      <div
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius-sm)",
+          display: "grid",
+          gap: 9,
+          padding: "9px 10px",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 7, flexWrap: "wrap" }}>
+          <span className={projectBackendEvidenceBadge(rehearsal.status)}>
+            {projectBackendDisplayLabel(rehearsal.status)}
+          </span>
+          <span style={{ color: "var(--t0)", fontSize: 12, fontWeight: 650 }}>
+            {projectBackendDisplayLabel(rehearsal.operation)}
+          </span>
+          <span className="badge badge-muted" style={{ textTransform: "none" }}>
+            snapshot v{rehearsal.snapshot_version}
+          </span>
+          <span className="badge badge-muted" style={{ textTransform: "none" }}>
+            {projectBackendDisplayLabel(rehearsal.target)}
+          </span>
+          {rehearsal.refreshes_target && (
+            <span className="badge badge-amber" style={{ textTransform: "none" }}>
+              refreshes target
+            </span>
+          )}
+        </div>
+        <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.45 }}>
+          {projectBackendDisplayLabel(rehearsal.import_mode)} from{" "}
+          {projectBackendDisplayLabel(rehearsal.source_authority)}
+        </div>
+        {rehearsal.checklist.length > 0 && (
+          <div style={{ display: "grid", gap: 5 }}>
+            <div
+              style={{
+                color: "var(--t3)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                textTransform: "uppercase",
+              }}
+            >
+              Checklist
+            </div>
+            {rehearsal.checklist.map((check) => (
+              <div
+                key={check.id}
+                style={{
+                  display: "grid",
+                  gap: 6,
+                  gridTemplateColumns: "auto minmax(0, 1fr)",
+                }}
+              >
+                <span className={projectBackendEvidenceBadge(check.status)}>
+                  {projectBackendDisplayLabel(check.status)}
+                </span>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ color: "var(--t0)", fontSize: 11, fontWeight: 650 }}>
+                    {projectBackendDisplayLabel(check.id)}
+                  </div>
+                  <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.35 }}>
+                    {check.detail}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {smoke && (
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            <span className={projectBackendEvidenceBadge(smoke.status)}>
+              embedded smoke {projectBackendDisplayLabel(smoke.status)}
+            </span>
+            <span className="badge badge-muted" style={{ textTransform: "none" }}>
+              {smoke.project_count} project{smoke.project_count === 1 ? "" : "s"}
+            </span>
+            <span className="badge badge-muted" style={{ textTransform: "none" }}>
+              {smoke.read_route_checks} route check{smoke.read_route_checks === 1 ? "" : "s"}
+            </span>
+            <span className="badge badge-muted" style={{ textTransform: "none" }}>
+              {smoke.launch_packet_error_count} launch error
+              {smoke.launch_packet_error_count === 1 ? "" : "s"}
+            </span>
+          </div>
+        )}
+        {rehearsal.rollback.length > 0 && (
+          <div style={{ display: "grid", gap: 4 }}>
+            <div
+              style={{
+                color: "var(--t3)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                textTransform: "uppercase",
+              }}
+            >
+              Rollback
+            </div>
+            <ul style={{ margin: 0, paddingLeft: 18, color: "var(--t2)", fontSize: 11 }}>
+              {rehearsal.rollback.map((step) => (
+                <li key={step} style={{ lineHeight: 1.45 }}>
+                  {step}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -300,6 +433,31 @@ function ProjectBackendGateBadge({ ready, status }: { ready: boolean; status: st
       {status.replaceAll("_", " ")}
     </span>
   );
+}
+
+function projectBackendEvidenceBadge(status: string): string {
+  switch (status) {
+    case "complete":
+    case "documented":
+    case "exported":
+    case "passed":
+    case "ready":
+    case "rehearsed":
+    case "verified":
+      return "badge badge-green";
+    case "blocked":
+    case "drift_detected":
+    case "failed":
+    case "probe_error":
+      return "badge badge-red";
+    case "not_run":
+    case "operator_probe_required":
+    case "partial":
+    case "rehearsal_incomplete":
+      return "badge badge-amber";
+    default:
+      return "badge badge-muted";
+  }
 }
 
 function ProjectBackendNextAction({

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -102,6 +102,47 @@ describe("SettingsView", () => {
         portable_write_gaps: ["agent-profiles", "memory-candidates"],
         orchestrator_capabilities: ["assignment-start"],
         migration_blockers: ["migration-cutover"],
+        migration_rehearsal: {
+          operation: "mirror_parity",
+          import_mode: "cairnline_snapshot_import",
+          snapshot_version: 3,
+          source_authority: "hecate_authoritative_stores",
+          target: "embedded_cairnline_sqlite",
+          refreshes_target: false,
+          authoritative: false,
+          cutover_ready: false,
+          status: "verified",
+          checklist: [
+            {
+              id: "native-snapshot-import",
+              status: "complete",
+              detail: "Imported through Cairnline's versioned snapshot contract.",
+            },
+            {
+              id: "strict-embedded-read-smoke",
+              status: "complete",
+              detail: "Exercised Projects routes before cutover.",
+            },
+            {
+              id: "rollback-plan",
+              status: "documented",
+              detail: "Rollback is switching reads back to Hecate.",
+            },
+          ],
+          rollback: [
+            "Unset HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE.",
+            "Switch HECATE_PROJECTS_CAIRNLINE_READ_SOURCE back to auto.",
+          ],
+          embedded_smoke: {
+            status: "passed",
+            project_count: 2,
+            read_route_checks: 38,
+            read_model_count: 2,
+            launch_packet_count: 1,
+            launch_packet_warning_count: 0,
+            launch_packet_error_count: 0,
+          },
+        },
         write_switchpoints: [
           {
             name: "agent-profiles",
@@ -200,6 +241,16 @@ describe("SettingsView", () => {
     expect(screen.getByText("Probe checklist")).toBeTruthy();
     expect(screen.getByText("Inspect read model")).toBeTruthy();
     expect(screen.getByText("Replacement gates")).toBeTruthy();
+    expect(screen.getByText("Migration rehearsal")).toBeTruthy();
+    expect(screen.getByText("mirror parity")).toBeTruthy();
+    expect(screen.getByText("snapshot v3")).toBeTruthy();
+    expect(screen.getByText(/cairnline snapshot import/i)).toBeTruthy();
+    expect(screen.getByText("native snapshot import")).toBeTruthy();
+    expect(screen.getByText("strict embedded read smoke")).toBeTruthy();
+    expect(screen.getByText("Rollback")).toBeTruthy();
+    expect(screen.getByText(/Unset HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE/i)).toBeTruthy();
+    expect(screen.getByText("embedded smoke passed")).toBeTruthy();
+    expect(screen.getByText("38 route checks")).toBeTruthy();
     expect(screen.getByText("Write switchpoints")).toBeTruthy();
     expect(screen.getByText("agent profiles")).toBeTruthy();
     expect(screen.getByText("live mirror non authoritative")).toHaveClass("badge-amber");


### PR DESCRIPTION
## Summary
- show backend-status migration rehearsal evidence in Project coordination Settings
- render rehearsal status, checklist, embedded smoke summary, and rollback steps
- update operator docs to mention Settings now shows migration rehearsal proof

## Tests
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run format:check
- just agent-docs-check