### PR TITLE
Hint embedded cutover mode in Projects backend status

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -709,9 +709,10 @@ reports strict embedded rehearsal hints for
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`; after strict embedded
 read smoke is verified, the next action becomes implementing the missing
 migration cutover switch by arming
-`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded`. That status cutover does
-not move Hecate-owned runtime/workspace capabilities such as assignment dispatch
-or Project Assistant apply side effects into Cairnline core. `GET
+`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded`; backend status includes
+that env var as a copyable next-action config hint. That status cutover does not
+move Hecate-owned runtime/workspace capabilities such as assignment dispatch or
+Project Assistant apply side effects into Cairnline core. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded
 mirror database with Hecate's current stores without creating or repairing it;
 `GET /hecate/v1/projects/{id}/cairnline/embedded-read-model` reads operations,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2604,9 +2604,11 @@ dogfood posture expected for the rehearsal:
 operator-applied settings and do not flip Hecate into a replaced backend by
 themselves. Once strict embedded mirror parity and route smoke are verified, the
 next action becomes `implement-migration-cutover`, which is intentionally an
-operator-controlled configuration step rather than an automatic mutation. Once
-the cutover is armed and all replacement gates are ready, the next action becomes
-`monitor-cairnline-backend`.
+operator-controlled configuration step rather than an automatic mutation. That
+action includes the `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded`
+configuration hint so clients can render the cutover arm as a copyable operator
+step. Once the cutover is armed and all replacement gates are ready, the next
+action becomes `monitor-cairnline-backend`.
 The initial embedded dogfood and sidecar-to-embedded connector actions point at
 backend-status plus embedded read-model diagnostics. If the current runtime is
 still using `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, those actions also

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -610,10 +610,11 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 	if len(status.MigrationBlockers) > 0 {
 		if gate := projectCoordinationBackendReplacementGateByID(status.ReplacementGates, "migration-and-rollback"); gate != nil && gate.Status == "cutover_switch_missing" {
 			return &ProjectCoordinationBackendNextAction{
-				ID:     "implement-migration-cutover",
-				Label:  "Implement migration cutover",
-				Detail: "Strict embedded mirror parity and read smoke are verified; the remaining migration blocker is an explicit authoritative cutover and rollback switch.",
-				Target: status.MigrationBlockers[0],
+				ID:          "implement-migration-cutover",
+				Label:       "Implement migration cutover",
+				Detail:      "Strict embedded mirror parity and read smoke are verified; the remaining migration blocker is an explicit authoritative cutover and rollback switch.",
+				Target:      status.MigrationBlockers[0],
+				ConfigHints: projectCairnlineReplacementModeHints(),
 				ProbeURLs: []string{
 					projectCoordinationBackendSyncReadinessURL,
 					projectCoordinationBackendMirrorParityURL,

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -485,6 +485,9 @@ func TestProjectCoordinationBackendStatus_StrictEmbeddedReadSmokeGateVerifiedAft
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "implement-migration-cutover" {
 		t.Fatalf("next action = %+v, want cutover implementation after read/write gates are ready", status.NextReplacementAction)
 	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE"); hint == nil || hint.Value != "embedded" {
+		t.Fatalf("next action config hints = %+v, want embedded replacement mode hint", status.NextReplacementAction.ConfigHints)
+	}
 }
 
 func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover(t *testing.T) {


### PR DESCRIPTION
## Summary
- add the embedded replacement-mode env hint to the implement-migration-cutover next action
- cover the verified strict-smoke path with an assertion for the cutover hint
- update runtime/operator docs so clients can render the cutover arm as a copyable step

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus_StrictEmbeddedReadSmokeGateVerifiedAfterSync|TestProjectCoordinationBackendStatus_NextActionArmReplacementMode'
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...