### PR TITLE
fix(projects): clear armed migration cutover gap

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -716,7 +716,11 @@ after these gates are met:
   `embedded_cutover_armed` instead of a blocking Hecate-owned cutover gap.
   At that point backend status reports `status=cairnline_authoritative`; any
   warnings should describe the remaining Hecate-owned runtime/workspace
-  side-effect boundary, not stale Hecate-store authority.
+  side-effect boundary, not stale Hecate-store authority. The broad
+  `write_adapter_gaps` diagnostic also stops listing `migration-cutover` after
+  the embedded cutover switch is armed, while non-portable runtime/workspace
+  capabilities such as `assignment-start` can remain visible as Hecate-owned
+  boundaries.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -680,7 +680,10 @@ compatibility shadows remain limited to Hecate-owned runtime/workspace needs.
 Once all replacement gates are ready, backend status reports
 `status=cairnline_authoritative` and keeps warnings focused on Hecate-owned
 runtime/workspace side effects instead of saying Hecate stores remain
-authoritative.
+authoritative. The same status snapshot clears `migration-cutover` from the
+broad `write_adapter_gaps` diagnostic once the embedded cutover switch is
+armed, while Hecate-owned runtime/workspace capabilities such as
+`assignment-start` may still appear there and under `orchestrator_capabilities`.
 It also groups the broad `write_adapter_gaps`
 diagnostic list into
 `portable_write_gaps`,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2593,7 +2593,10 @@ When every replacement gate is ready, `status` becomes
 `cairnline_authoritative`, `detail` describes Cairnline as authoritative for
 portable Projects coordination state, and warnings are limited to the remaining
 Hecate-owned runtime/workspace side-effect boundary rather than stale
-Hecate-store authority warnings.
+Hecate-store authority warnings. At that point `migration-cutover` is also
+removed from `write_adapter_gaps`; Hecate-owned runtime/workspace capabilities
+such as `assignment-start` can still remain in `write_adapter_gaps` and
+`orchestrator_capabilities` because they are not portable Cairnline core.
 When all portable write-authority gaps are closed but strict embedded mirror
 evidence is not yet verified, the next action is
 `run-strict-embedded-read-smoke`; `config_hints` identify the strict embedded

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -381,11 +381,12 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 			effectiveWriteAuthority = nil
 		}
 		response.WriteAdapterSeams = append([]string(nil), projectCairnlineWriteAdapterSeamNames...)
-		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsSnapshot(effectiveWriteAuthority)
-		response.PortableWriteGaps = projectCairnlinePortableWriteGapsSnapshot(effectiveWriteAuthority, response.WriteAdapterGaps)
-		response.OrchestratorCapabilities = projectCairnlineOrchestratorCapabilitiesSnapshot(response.WriteAdapterGaps)
+		writeAdapterGaps := projectCairnlineWriteAdapterGapsSnapshot(effectiveWriteAuthority)
+		response.PortableWriteGaps = projectCairnlinePortableWriteGapsSnapshot(effectiveWriteAuthority, writeAdapterGaps)
+		response.OrchestratorCapabilities = projectCairnlineOrchestratorCapabilitiesSnapshot(writeAdapterGaps)
 		response.WriteAdapterReady = len(response.PortableWriteGaps) == 0
 		migrationCutoverArmed := replacementMode == "embedded" && strictEmbeddedReadGate.Ready && projectCairnlineMigrationRollbackEvidenceReady(migrationRehearsal) && len(response.PortableWriteGaps) == 0
+		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsAfterMigrationCutover(writeAdapterGaps, migrationCutoverArmed)
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority, migrationCutoverArmed)
 		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps, migrationCutoverArmed)
 		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed)
@@ -1070,6 +1071,20 @@ func projectCairnlineMigrationBlockersSnapshot(writeGaps []string, migrationCuto
 		if item == "migration-cutover" {
 			out = append(out, item)
 		}
+	}
+	return out
+}
+
+func projectCairnlineWriteAdapterGapsAfterMigrationCutover(writeGaps []string, migrationCutoverArmed bool) []string {
+	if !migrationCutoverArmed {
+		return append([]string(nil), writeGaps...)
+	}
+	out := make([]string, 0, len(writeGaps))
+	for _, item := range writeGaps {
+		if item == "migration-cutover" {
+			continue
+		}
+		out = append(out, item)
 	}
 	return out
 }

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -533,6 +533,12 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 	if len(status.MigrationBlockers) != 0 {
 		t.Fatalf("migration blockers = %+v, want none after embedded replacement cutover is armed", status.MigrationBlockers)
 	}
+	if containsString(status.WriteAdapterGaps, "migration-cutover") {
+		t.Fatalf("write adapter gaps = %+v, want migration-cutover cleared after embedded replacement cutover is armed", status.WriteAdapterGaps)
+	}
+	if !containsString(status.WriteAdapterGaps, "assignment-start") || !containsString(status.OrchestratorCapabilities, "assignment-start") {
+		t.Fatalf("write adapter gaps = %+v orchestrator = %+v, want Hecate-owned runtime capability still reported after cutover", status.WriteAdapterGaps, status.OrchestratorCapabilities)
+	}
 	if status.MigrationRehearsal == nil || !projectCairnlineMigrationRollbackEvidenceReady(status.MigrationRehearsal) || len(status.MigrationRehearsal.Rollback) == 0 {
 		t.Fatalf("migration rehearsal = %+v, want replacement-ready status to expose verified rollback evidence", status.MigrationRehearsal)
 	}


### PR DESCRIPTION
## Summary
- clear `migration-cutover` from backend-status `write_adapter_gaps` once embedded replacement cutover is actually armed
- keep Hecate-owned runtime capabilities, such as `assignment-start`, visible in write gaps and orchestrator capabilities
- update Projects/runtime/deployment docs for the armed-cutover status contract

## Tests
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover|TestProjectCoordinationBackendStatusRoute'`\n- `just agent-docs-check`\n- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`