### PR TITLE
fix(projects): disambiguate setup checklist actions

### DIFF
--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -48,6 +48,9 @@ test("Projects journey: setup, first work, assignment, evidence, closeout", asyn
   await expect(page.getByText("Applied 3 actions")).toBeVisible();
   await page.getByRole("button", { name: "Dismiss" }).click();
   await expect(page.getByText("Setup ready")).toBeVisible();
+  await expect(page.getByRole("region", { name: "Project onboarding" })).toHaveCount(0);
+  await expect(page.getByRole("region", { name: "Project Assistant" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Set up project" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Create first work" })).toBeVisible();
   await page.getByRole("button", { name: "Create first work" }).click();
   await page.getByLabel("Title").fill("Verify launch checklist");
@@ -113,7 +116,7 @@ test("Projects rootless journey: plan work without setup or workspace", async ({
     page.getByText("Optional; attach files when this project needs them."),
   ).toBeVisible();
   const onboarding = page.getByRole("region", { name: "Project onboarding" });
-  await onboarding.getByRole("button", { name: "Create work" }).click();
+  await onboarding.getByRole("button", { name: "Create work: First work item" }).click();
 
   await page.getByLabel("Title").fill("Summarize interview themes");
   await page

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -374,13 +374,20 @@ describe("ProjectWorkspaceView", () => {
     expect(screen.getByText("Optional; attach files when this project needs them.")).toBeTruthy();
     expect(screen.getByText("optional")).toBeTruthy();
 
-    await userEvent.click(screen.getByRole("button", { name: "Add purpose" }));
-    await userEvent.click(screen.getByRole("button", { name: "Set defaults" }));
+    const onboarding = screen.getByRole("region", { name: "Project onboarding" });
+    await userEvent.click(
+      within(onboarding).getByRole("button", { name: "Add purpose: Project purpose" }),
+    );
+    await userEvent.click(
+      within(onboarding).getByRole("button", { name: "Set defaults: Provider and model" }),
+    );
     expect(screen.queryByRole("button", { name: "Review setup" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Set up" })).toBeNull();
     const firstWorkCheck = screen.getByRole("group", { name: "First work item" });
-    await userEvent.click(within(firstWorkCheck).getByRole("button", { name: "Create work" }));
-    await userEvent.click(screen.getAllByRole("button", { name: "Set up project" })[0]);
+    await userEvent.click(
+      within(firstWorkCheck).getByRole("button", { name: "Create work: First work item" }),
+    );
+    await userEvent.click(within(onboarding).getByRole("button", { name: "Set up project" }));
     await userEvent.click(screen.getByRole("button", { name: "Project settings" }));
 
     expect(handlers.onSetupReadinessAction).toHaveBeenCalledTimes(4);

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -634,6 +634,7 @@ function ProjectOnboardingPanel({
             </div>
             {check.status !== "ready" && !check.optional && check.action && (
               <button
+                aria-label={`${check.action.label}: ${check.label}`}
                 className="btn btn-ghost btn-sm"
                 disabled={bootstrapPending && check.action.type === "bootstrap_project"}
                 onClick={() => onAction(check.action!)}


### PR DESCRIPTION
## Summary

- Give Project onboarding checklist action buttons unique accessible names while keeping the visible labels unchanged.
- Pin the browser-level Projects journey so setup/onboarding disappears after an applied setup proposal.
- Tighten the component test to scope setup actions through the onboarding region instead of positional button selection.

## Tests

- `cd ui && bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx`
- `cd ui && bun run test:e2e -- projects.spec.ts`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`

## Docs

No docs changed; this is an accessibility/test hardening fix for existing Projects onboarding behavior.
