### PR TITLE
feat(projects): route assignment start claims through cairnline

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -383,9 +383,12 @@ portable work item into Hecate-native project-work stores for compatibility.
 `project-assignments` is a sixth opt-in authority slice: assignment
 create/update/delete record mutations commit to embedded Cairnline first, then
 best-effort shadow portable assignment state into Hecate-native project-work
-stores for compatibility. Assignment start/dispatch remains Hecate-owned; only
-committed start results, pre-dispatch cleanup/conflict states, and linked-chat
-reconciliation updates are mirrored as replacement evidence.
+stores for compatibility. When this authority slice is enabled, assignment
+start first claims the coordination record in embedded Cairnline and releases
+that claim when Hecate-owned launch setup fails before a runtime record is
+committed. Assignment runtime dispatch remains Hecate-owned; committed start
+results, cleanup/conflict states, and linked-chat reconciliation updates are
+mirrored as replacement evidence.
 `project-assistant-proposals` is a seventh opt-in authority slice: Project
 Assistant draft/propose/apply-attempt ledger records commit to embedded
 Cairnline first, then best-effort shadow Hecate's proposal store for
@@ -484,10 +487,13 @@ graph without a Hecate-native compatibility project row.
 Assignment create/update/delete
 routes mirror coordination metadata and lifecycle status after Hecate commits;
 assignment-start remains a Hecate-owned orchestrator capability because dispatch
-still carries runtime coupling. Hecate Task starts require the task runtime,
-while External Agent starts prepare agent-chat adapter sessions and do not
-require the task runtime. Successful start results and start-side
-conflict/cleanup states are best-effort mirrored after Hecate commits them.
+still carries runtime coupling. With `project-assignments` authority enabled,
+Hecate claims the embedded Cairnline assignment before dispatch and releases the
+claim if launch setup fails before a task/run or chat-session reference is
+committed. Hecate Task starts require the task runtime, while External Agent
+starts prepare agent-chat adapter sessions and do not require the task runtime.
+Successful start results and start-side conflict/cleanup states are best-effort
+mirrored after Hecate commits them.
 Linked external-agent chat reconciliation also mirrors the
 committed assignment status/ref when Hecate updates the linked assignment from a
 chat session. In strict embedded mode, that reconciliation can update the

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2705,19 +2705,22 @@ Mirror failures are logged.
 `project-assignment-start-result-live-mirror` best-effort mirrors
 committed assignment-start results after Hecate-owned dispatch completes or
 returns a committed cleanup/conflict state; it is replacement evidence, not
-runtime write authority. With strict embedded Cairnline reads, assignment
-start may load the launch project/work/assignment/role/root/defaults from a
-Cairnline-only graph. Hecate-task and external-agent assignment start can
-claim/progress the assignment in embedded Cairnline and persist only
-Hecate-owned task/run or chat-session refs, context packets, and launch
-timestamps in the assignment runtime overlay when the native project-work store
-is absent or embedded replacement mode is armed. They do not require or advance
-a native Hecate project identity row, and they do not advance compatibility
-assignment rows with runtime refs; runtime dispatch, task execution, and
-external-agent supervision remain Hecate-owned. Assignment launch/preflight
-context uses the active Cairnline read model for inspect-only collaboration
-artifact and handoff metadata, so Cairnline-only project graphs preserve the
-same evidence/review/handoff hints as native project-work rows.
+runtime write authority. With `project-assignments` authority enabled, Hecate
+claims the embedded Cairnline assignment before non-strict dispatch and releases
+that claim if launch setup fails before a runtime record is committed. With
+strict embedded Cairnline reads, assignment start may load the launch
+project/work/assignment/role/root/defaults from a Cairnline-only graph.
+Hecate-task and external-agent assignment start can claim/progress the assignment
+in embedded Cairnline and persist only Hecate-owned task/run or chat-session
+refs, context packets, and launch timestamps in the assignment runtime overlay
+when the native project-work store is absent or embedded replacement mode is
+armed. They do not require or advance a native Hecate project identity row, and
+they do not advance compatibility assignment rows with runtime refs; runtime
+dispatch, task execution, and external-agent supervision remain Hecate-owned.
+Assignment launch/preflight context uses the active Cairnline read model for
+inspect-only collaboration artifact and handoff metadata, so Cairnline-only
+project graphs preserve the same evidence/review/handoff hints as native
+project-work rows.
 `project-assignment-chat-reconcile-live-mirror`
 best-effort mirrors assignment status/ref updates committed by linked
 external-agent chat reconciliation, and strict embedded reconciliation can

--- a/internal/api/handler_project_assignment_authority.go
+++ b/internal/api/handler_project_assignment_authority.go
@@ -144,6 +144,9 @@ func (h *Handler) seedProjectAssignmentDependenciesForCairnlineAuthority(ctx con
 	if err := h.seedProjectWorkItemDependenciesForCairnlineAuthority(ctx, service, project, workItem); err != nil {
 		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
 	}
+	if _, err := cairnlinebridge.UpsertWorkItem(ctx, service, workItem); err != nil {
+		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
+	}
 	if err := h.seedProjectAssignmentRootForCairnlineAuthority(ctx, service, project, assignment.RootID); err != nil {
 		return projectwork.AgentRoleProfile{}, agentprofiles.Profile{}, err
 	}

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -899,6 +899,21 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 		assignment = shadowedAssignment
 	}
 
+	startClaimedBy := projectAssignmentStartClaimedBy(assignment)
+	claimedAssignment, cairnlineStartClaimed, err := h.claimProjectAssignmentStartInCairnlineAuthority(ctx, project, assignment, startClaimedBy)
+	if err != nil {
+		if errors.Is(err, projectworkapp.ErrAssignmentStartConflict) {
+			projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, claimedAssignment)
+			if projectErr != nil {
+				WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
+				return
+			}
+			WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+			return
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	result, err := h.projectWorkApplication().StartTaskAssignment(ctx, projectworkapp.StartTaskAssignmentCommand{
 		ProjectID:         projectID,
 		WorkItemID:        workItemID,
@@ -918,6 +933,11 @@ func (h *Handler) HandleStartProjectWorkAssignment(w http.ResponseWriter, r *htt
 			)))
 		},
 	})
+	if err != nil && cairnlineStartClaimed {
+		if result == nil || result.Assignment.ID == "" {
+			h.releaseProjectAssignmentStartInCairnlineAuthority(ctx, assignment, startClaimedBy)
+		}
+	}
 	h.writeProjectTaskAssignmentStartResult(w, ctx, assignment, result, err, true)
 }
 
@@ -1263,6 +1283,21 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		h.writeProjectExternalAgentAssignmentStartResult(w, ctx, assignment, plan.Adapter.Name, result, err, false)
 		return
 	}
+	startClaimedBy := projectAssignmentStartClaimedBy(assignment)
+	claimedAssignment, cairnlineStartClaimed, err := h.claimProjectAssignmentStartInCairnlineAuthority(ctx, project, assignment, startClaimedBy)
+	if err != nil {
+		if errors.Is(err, projectworkapp.ErrAssignmentStartConflict) {
+			projected, projectErr := h.renderProjectedProjectWorkAssignment(ctx, claimedAssignment)
+			if projectErr != nil {
+				WriteError(w, http.StatusInternalServerError, errCodeGatewayError, projectErr.Error())
+				return
+			}
+			WriteJSON(w, http.StatusConflict, ProjectWorkAssignmentEnvelope{Object: "project_assignment", Data: projected})
+			return
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	result, err := h.projectWorkApplication().StartExternalAgentAssignment(ctx, projectworkapp.StartExternalAgentAssignmentCommand{
 		ProjectID:         project.ID,
 		Assignment:        assignment,
@@ -1270,6 +1305,11 @@ func (h *Handler) startProjectExternalAgentAssignment(w http.ResponseWriter, r *
 		ContextSnapshotID: contextPacket.ID,
 		ContextPacket:     packetBytes,
 	})
+	if err != nil && cairnlineStartClaimed {
+		if result == nil || result.Assignment.ID == "" {
+			h.releaseProjectAssignmentStartInCairnlineAuthority(ctx, assignment, startClaimedBy)
+		}
+	}
 	h.writeProjectExternalAgentAssignmentStartResult(w, ctx, assignment, plan.Adapter.Name, result, err, true)
 }
 

--- a/internal/api/handler_project_assignment_start_authority.go
+++ b/internal/api/handler_project_assignment_start_authority.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+	"github.com/hecatehq/hecate/internal/projectworkapp"
+)
+
+const (
+	projectAssignmentStartClaimedByHecate          = "hecate"
+	projectAssignmentStartClaimedByExternalAdapter = "external_adapter"
+)
+
+func (h *Handler) projectAssignmentStartUsesCairnlineAuthority() bool {
+	return h.projectAssignmentWritesUseCairnlineAuthority()
+}
+
+func (h *Handler) claimProjectAssignmentStartInCairnlineAuthority(ctx context.Context, project projects.Project, assignment projectwork.Assignment, claimedBy string) (projectwork.Assignment, bool, error) {
+	if !h.projectAssignmentStartUsesCairnlineAuthority() {
+		return projectwork.Assignment{}, false, nil
+	}
+	claimedBy = strings.TrimSpace(claimedBy)
+	if claimedBy == "" {
+		claimedBy = projectAssignmentStartClaimedBy(assignment)
+	}
+	var recorded projectwork.Assignment
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		existing, err := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID)
+		if err != nil {
+			if !errors.Is(err, cairnline.ErrNotFound) {
+				return err
+			}
+			role, profile, seedErr := h.seedProjectAssignmentDependenciesForCairnlineAuthority(ctx, service, project, assignment)
+			if seedErr != nil {
+				return seedErr
+			}
+			seeded := assignment
+			seeded.DriverKind = resolvedProjectAssignmentDriverKind(seeded.DriverKind, role.DefaultDriverKind)
+			if _, upsertErr := cairnlinebridge.UpsertAssignment(ctx, service, seeded, role, profile); upsertErr != nil {
+				return upsertErr
+			}
+		} else if existing.ID != "" && existing.WorkItemID != assignment.WorkItemID {
+			return cairnline.ErrNotFound
+		}
+
+		claimed, err := service.ClaimAssignment(ctx, assignment.ProjectID, assignment.ID, claimedBy)
+		if err != nil {
+			if errors.Is(err, cairnline.ErrConflict) {
+				if current, getErr := service.GetAssignment(ctx, assignment.ProjectID, assignment.ID); getErr == nil {
+					recorded = projectWorkAssignmentFromCairnlineAuthority(current, assignment)
+				}
+				return projectworkapp.ErrAssignmentStartConflict
+			}
+			return err
+		}
+		recorded = projectWorkAssignmentFromCairnlineAuthority(claimed, assignment)
+		return nil
+	})
+	if err != nil {
+		if recorded.ID == "" {
+			recorded = assignment
+		}
+		if errors.Is(err, projectworkapp.ErrAssignmentStartConflict) {
+			h.shadowProjectAssignmentToHecate(ctx, "project_assignment_cairnline_authority_start_conflict", recorded)
+		}
+		return recorded, false, err
+	}
+	if recorded.ID != "" {
+		h.shadowProjectAssignmentToHecate(ctx, "project_assignment_cairnline_authority_start_claim", recorded)
+	}
+	return recorded, true, nil
+}
+
+func (h *Handler) releaseProjectAssignmentStartInCairnlineAuthority(ctx context.Context, assignment projectwork.Assignment, claimedBy string) {
+	if !h.projectAssignmentStartUsesCairnlineAuthority() {
+		return
+	}
+	claimedBy = strings.TrimSpace(claimedBy)
+	if claimedBy == "" {
+		claimedBy = projectAssignmentStartClaimedBy(assignment)
+	}
+	var released projectwork.Assignment
+	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+		item, err := service.ReleaseAssignment(ctx, assignment.ProjectID, assignment.ID, claimedBy)
+		if err != nil {
+			if errors.Is(err, cairnline.ErrConflict) || errors.Is(err, cairnline.ErrNotFound) {
+				return nil
+			}
+			return err
+		}
+		released = projectWorkAssignmentFromCairnlineAuthority(item, assignment)
+		return nil
+	})
+	if err != nil {
+		h.logCairnlineMirrorError(ctx, "project_assignment_cairnline_authority_start_release", assignment.ProjectID, err)
+		return
+	}
+	if released.ID != "" {
+		h.shadowProjectAssignmentToHecate(ctx, "project_assignment_cairnline_authority_start_release", released)
+	}
+}
+
+func projectAssignmentStartClaimedBy(assignment projectwork.Assignment) string {
+	if strings.TrimSpace(assignment.DriverKind) == projectwork.AssignmentDriverExternalAgent {
+		return projectAssignmentStartClaimedByExternalAdapter
+	}
+	return projectAssignmentStartClaimedByHecate
+}

--- a/internal/api/handler_project_memory.go
+++ b/internal/api/handler_project_memory.go
@@ -444,12 +444,22 @@ func (h *Handler) HandleDeleteProjectMemoryEntry(w http.ResponseWriter, r *http.
 }
 
 func (h *Handler) requireProjectExists(w http.ResponseWriter, r *http.Request, projectID string) bool {
-	if h.projects == nil {
-		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project store is not configured")
-		return false
-	}
 	if projectID == "" {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project id is required")
+		return false
+	}
+	if h.projectReadRoutesUseCairnlineReadModel() {
+		project, err := h.renderProject(r.Context(), projectID)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return false
+		}
+		if project != nil {
+			return true
+		}
+	}
+	if h.projects == nil {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "project store is not configured")
 		return false
 	}
 	_, ok, err := h.projects.Get(r.Context(), projectID)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1057,6 +1057,59 @@ func TestProjectWorkAPI_CairnlineCollaborationAuthorityWritesCairnlineAndShadows
 	client.mustRequestStatus(http.StatusNotFound, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority/handoffs/handoff_authority", "")
 }
 
+func TestProjectWorkAPI_CairnlineCollaborationAuthorityUsesEmbeddedWorkItemWithoutHecateRow(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectCollaboration,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   "proj_cairnline_collab_only",
+			Name: "Cairnline collaboration only",
+		}); err != nil {
+			return err
+		}
+		_, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+			ID:        "work_cairnline_collab_only",
+			ProjectID: "proj_cairnline_collab_only",
+			Title:     "Cairnline-only collaboration work",
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed Cairnline-only collaboration graph: %v", err)
+	}
+
+	evidence := mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/proj_cairnline_collab_only/work-items/work_cairnline_collab_only/artifacts", projectJourneyJSON(t, map[string]any{
+		"id":           "art_cairnline_collab_only",
+		"kind":         "evidence_link",
+		"body":         "Evidence attached to a Cairnline-only work item.",
+		"evidence_url": "https://example.invalid/cairnline-collab-only",
+	}))
+	if evidence.Data.ID != "art_cairnline_collab_only" || evidence.Data.ProjectID != "proj_cairnline_collab_only" || evidence.Data.WorkItemID != "work_cairnline_collab_only" {
+		t.Fatalf("evidence response = %+v, want Cairnline-authoritative evidence", evidence.Data)
+	}
+	mirroredEvidence := getMirroredCairnlineEvidenceForTest(t, handler, "proj_cairnline_collab_only", "work_cairnline_collab_only", "art_cairnline_collab_only")
+	if mirroredEvidence.Locator != "https://example.invalid/cairnline-collab-only" {
+		t.Fatalf("mirrored evidence = %+v, want Cairnline evidence locator", mirroredEvidence)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), "proj_cairnline_collab_only"); err != nil || ok {
+		t.Fatalf("Hecate project row ok=%v err=%v, want absent compatibility project row", ok, err)
+	}
+}
+
 func TestProjectWorkAPI_CairnlineWorkItemAuthorityWritesCairnlineAndShadowsHecate(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkCairnlineWorkItemAuthorityTestServer(t)
@@ -1146,6 +1199,62 @@ func TestProjectWorkAPI_CairnlineWorkItemAuthorityWritesCairnlineAndShadowsHecat
 		t.Fatalf("deleted Hecate shadow work item ok=%v err=%v, want not found", ok, err)
 	}
 	client.mustRequestStatus(http.StatusNotFound, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/work-items/work_authority", "")
+}
+
+func TestProjectWorkAPI_CairnlineWorkItemAuthorityUsesEmbeddedProjectWithoutHecateRow(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectWorkItems,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:          "proj_cairnline_authority_only",
+			Name:        "Cairnline authority only",
+			Description: "No Hecate-native compatibility project row exists.",
+		}); err != nil {
+			return err
+		}
+		_, _, err := service.CreateRoot(t.Context(), "proj_cairnline_authority_only", cairnline.Root{
+			ID:     "root_cairnline_authority_only",
+			Path:   "/workspace/cairnline-authority-only",
+			Kind:   "folder",
+			Active: true,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed Cairnline-only authority project: %v", err)
+	}
+
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/proj_cairnline_authority_only/work-items", projectJourneyJSON(t, map[string]any{
+		"id":       "work_cairnline_authority_only",
+		"title":    "Create from Cairnline project",
+		"priority": "high",
+		"root_id":  "root_cairnline_authority_only",
+	}))
+	if work.Data.ID != "work_cairnline_authority_only" || work.Data.ProjectID != "proj_cairnline_authority_only" || work.Data.Priority != "high" || work.Data.RootID != "root_cairnline_authority_only" {
+		t.Fatalf("work item response = %+v, want Cairnline-authoritative work item", work.Data)
+	}
+	mirroredWork := getMirroredCairnlineWorkItemForTest(t, handler, "proj_cairnline_authority_only", "work_cairnline_authority_only")
+	if mirroredWork.Title != "Create from Cairnline project" || mirroredWork.ProjectID != "proj_cairnline_authority_only" || mirroredWork.RootID != "root_cairnline_authority_only" {
+		t.Fatalf("mirrored work item = %+v, want authoritative Cairnline record", mirroredWork)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), "proj_cairnline_authority_only"); err != nil || ok {
+		t.Fatalf("Hecate project row ok=%v err=%v, want absent compatibility project row", ok, err)
+	}
+	assertHecateShadowWorkItemForTest(t, handler, "proj_cairnline_authority_only", "work_cairnline_authority_only", projectwork.WorkItemStatusBacklog)
 }
 
 func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineAndShadowsHecate(t *testing.T) {
@@ -5494,6 +5603,58 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentMirrorsResultToCairnline(t *
 	}
 }
 
+func TestProjectWorkAPI_StartExternalAgentAssignmentWithCairnlineAuthorityReleasesClaimWhenPrepareFails(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineAssignmentAuthorityTestServer(t)
+	runner := &fakeAgentChatRunner{prepareErr: errors.New("prepare failed")}
+	handler.SetAgentChatRunner(runner)
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace:           t.TempDir(),
+		Driver:              projectwork.AssignmentDriverExternalAgent,
+		WithoutRoleDefaults: true,
+	})
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                  "prof_external",
+		Name:                "External implementer",
+		Surface:             agentprofiles.SurfaceExternalAgent,
+		ExecutionProfile:    "external_implementation",
+		ExternalAgentKind:   "codex",
+		ProjectMemoryPolicy: agentprofiles.MemoryVisibleOnly,
+		ContextSourcePolicy: agentprofiles.ContextVisibleOnly,
+	}); err != nil {
+		t.Fatalf("Create external profile: %v", err)
+	}
+	if _, err := handler.projectWork.UpdateRole(t.Context(), "proj_start", "role_backend", func(role *projectwork.AgentRoleProfile) {
+		role.DefaultAgentProfile = "prof_external"
+	}); err != nil {
+		t.Fatalf("Update role profile: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{"driver_kind":"external_agent"}`))))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("prepare failure status = %d body=%s, want 502", rec.Code, rec.Body.String())
+	}
+	if len(runner.prepareRequests) != 1 {
+		t.Fatalf("prepare requests = %d, want 1", len(runner.prepareRequests))
+	}
+	sessions, err := handler.agentChat.List(t.Context())
+	if err != nil {
+		t.Fatalf("List chat sessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("chat sessions = %+v, want prepared session cleaned up", sessions)
+	}
+	stored := getStoredProjectWorkAssignmentForTest(t, handler, "proj_start", "work_start", "asgn_start")
+	if stored.Status != projectwork.AssignmentStatusQueued || stored.ExecutionRef.ChatSessionID != "" {
+		t.Fatalf("stored assignment = %+v, want queued retry state after prepare failure", stored)
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_start", "asgn_start")
+	if mirrored.Status != cairnline.AssignmentQueued || mirrored.ClaimedBy != "" || mirrored.ExecutionRef != "" || mirrored.ContextSnapshotID != "" || !mirrored.StartedAt.IsZero() || !mirrored.CompletedAt.IsZero() {
+		t.Fatalf("mirrored assignment = %+v, want released queued claim for retry", mirrored)
+	}
+}
+
 func TestProjectWorkAPI_ExternalAgentChatTurnReconcilesAssignmentStatus(t *testing.T) {
 	t.Parallel()
 
@@ -6530,6 +6691,87 @@ func TestProjectWorkAPI_StartAssignmentReleasesMirroredCairnlineClaimWhenTaskCre
 	}
 }
 
+func TestProjectWorkAPI_StartAssignmentWithCairnlineAuthorityRejectsClaimedAssignment(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineAssignmentAuthorityTestServer(t)
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+	assignment := getStoredProjectWorkAssignmentForTest(t, handler, "proj_start", "work_start", "asgn_start")
+	if err := handler.writeProjectAssignmentToCairnline(t.Context(), assignment); err != nil {
+		t.Fatalf("writeProjectAssignmentToCairnline() error = %v", err)
+	}
+	func() {
+		service, store, err := cairnline.NewSQLiteService(t.Context(), handler.cairnlineEmbeddedDatabasePath())
+		if err != nil {
+			t.Fatalf("open Cairnline mirror: %v", err)
+		}
+		defer store.Close()
+		claimed, err := service.ClaimAssignment(t.Context(), "proj_start", "asgn_start", "other-agent")
+		if err != nil {
+			t.Fatalf("ClaimAssignment(other-agent) error = %v", err)
+		}
+		if claimed.Status != cairnline.AssignmentClaimed || claimed.ClaimedBy != "other-agent" {
+			t.Fatalf("claimed assignment = %+v, want other-agent claim", claimed)
+		}
+	}()
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("preclaimed start status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll())
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want no Hecate task when Cairnline claim blocks start", tasks)
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_start", "asgn_start")
+	if mirrored.Status != cairnline.AssignmentClaimed || mirrored.ClaimedBy != "other-agent" || mirrored.ExecutionRef != "" {
+		t.Fatalf("mirrored assignment = %+v, want preserved other-agent claim", mirrored)
+	}
+}
+
+func TestProjectWorkAPI_StartAssignmentWithCairnlineAuthorityClaimsAndReleasesWhenTaskCreateFails(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectWorkCairnlineAssignmentAuthorityTestServer(t)
+	seedProjectWorkAssignmentStartTest(t, handler, projectWorkAssignmentStartSeed{
+		Workspace: t.TempDir(),
+		Driver:    projectwork.AssignmentDriverHecateTask,
+	})
+	sawClaim := false
+	handler.taskStore = inspectingFailingCreateTaskStore{
+		Store: handler.taskStore,
+		Inspect: func() {
+			mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_start", "asgn_start")
+			if mirrored.Status != cairnline.AssignmentClaimed || mirrored.ClaimedBy != projectAssignmentStartClaimedByHecate {
+				t.Fatalf("mirrored assignment during task create = %+v, want Hecate Cairnline claim", mirrored)
+			}
+			sawClaim = true
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/proj_start/work-items/work_start/assignments/asgn_start/start", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("task create failure status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	if !sawClaim {
+		t.Fatalf("did not observe Cairnline claim during task creation; response body=%s", rec.Body.String())
+	}
+	stored := getStoredProjectWorkAssignmentForTest(t, handler, "proj_start", "work_start", "asgn_start")
+	if stored.Status != projectwork.AssignmentStatusQueued || stored.ExecutionRef.TaskID != "" || stored.ExecutionRef.RunID != "" {
+		t.Fatalf("stored assignment = %+v, want queued retry state after task create failure", stored)
+	}
+	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, "proj_start", "asgn_start")
+	if mirrored.Status != cairnline.AssignmentQueued || mirrored.ClaimedBy != "" || mirrored.ExecutionRef != "" || mirrored.ContextSnapshotID != "" || !mirrored.StartedAt.IsZero() || !mirrored.CompletedAt.IsZero() {
+		t.Fatalf("mirrored assignment = %+v, want released queued claim for retry", mirrored)
+	}
+}
+
 func TestProjectWorkAPI_AssignmentExecutionProjection(t *testing.T) {
 	t.Parallel()
 	for _, backend := range []string{"memory", "sqlite"} {
@@ -7554,6 +7796,18 @@ type failingCreateTaskStore struct {
 }
 
 func (s failingCreateTaskStore) CreateTask(context.Context, types.Task) (types.Task, error) {
+	return types.Task{}, errors.New("create task failed")
+}
+
+type inspectingFailingCreateTaskStore struct {
+	taskstate.Store
+	Inspect func()
+}
+
+func (s inspectingFailingCreateTaskStore) CreateTask(context.Context, types.Task) (types.Task, error) {
+	if s.Inspect != nil {
+		s.Inspect()
+	}
 	return types.Task{}, errors.New("create task failed")
 }
 

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -15,9 +15,11 @@ import (
 	"time"
 
 	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectskills"
 	"github.com/hecatehq/hecate/internal/projectwork"
@@ -62,6 +64,11 @@ func newProjectsCairnlineMirrorTestServer(t *testing.T) (*Handler, http.Handler)
 		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
 	}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
 	return handler, NewServer(quietLogger(), handler)
 }
 
@@ -75,6 +82,11 @@ func newProjectsCairnlineMetadataDefaultsAuthorityTestServer(t *testing.T) (*Han
 		},
 	}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
 	return handler, NewServer(quietLogger(), handler)
 }
 
@@ -367,6 +379,72 @@ func TestProjectsAPI_CairnlineReadsMatchHecateProjectProjection(t *testing.T) {
 		t.Fatalf("project list counts = hecate:%d cairnline:%d, want one each", len(hecateList), len(cairnlineList))
 	}
 	assertProjectProjectionParity(t, hecateList[0], cairnlineList[0], "list")
+}
+
+func TestProjectsAPI_CairnlineProjectListAndDetailUseEmbeddedMirrorMembership(t *testing.T) {
+	t.Parallel()
+
+	handler, server := newProjectsCairnlineMirrorTestServer(t)
+	handler.config.Projects.CairnlineReadSource = "embedded"
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		_, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:          "proj_cairnline_only",
+			Name:        "Cairnline only",
+			Description: "Exists only in the embedded Cairnline mirror",
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed embedded Cairnline project: %v", err)
+	}
+	seedCairnlineOnlyProjectGraphForTest(t, handler, "proj_cairnline_only")
+
+	items := listProjectsForTest(t, server)
+	if len(items) != 1 {
+		t.Fatalf("project list = %+v, want one Cairnline-backed project", items)
+	}
+	if items[0].ID != "proj_cairnline_only" || items[0].ReadBackend != "cairnline" || items[0].Name != "Cairnline only" {
+		t.Fatalf("project list item = %+v, want embedded Cairnline mirror membership", items[0])
+	}
+
+	detail := getProjectForTest(t, server, "proj_cairnline_only")
+	if detail.ID != "proj_cairnline_only" || detail.ReadBackend != "cairnline" || detail.Name != "Cairnline only" {
+		t.Fatalf("project detail = %+v, want embedded Cairnline mirror membership", detail)
+	}
+
+	cairnlineOnlyProjectRoutes := map[string][]string{
+		"/hecate/v1/projects/proj_cairnline_only/setup-readiness":                            {`"read_backend":"cairnline"`, `"role_count":1`, `"skill_count":1`},
+		"/hecate/v1/projects/proj_cairnline_only/health":                                     {`"read_backend":"cairnline"`, `"pending_memory_candidate_count":1`},
+		"/hecate/v1/projects/proj_cairnline_only/operations/brief":                           {`"read_backend":"cairnline"`, `"project_id":"proj_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/activity":                                   {`"read_backend":"cairnline"`, `"assignment_count":1`},
+		"/hecate/v1/projects/proj_cairnline_only/skills":                                     {`"read_backend":"cairnline"`, `"id":"skill_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/memory?include_disabled=1":                  {`"read_backend":"cairnline"`, `"id":"mem_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/memory/candidates?include_resolved=1":       {`"read_backend":"cairnline"`, `"id":"memcand_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/roles":                                      {`"read_backend":"cairnline"`, `"id":"role_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/work-items":                                 {`"read_backend":"cairnline"`, `"id":"work_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/work-items/work_cairnline_only":             {`"read_backend":"cairnline"`, `"id":"work_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/work-items/work_cairnline_only/readiness":   {`"read_backend":"cairnline"`, `"work_item_id":"work_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/work-items/work_cairnline_only/assignments": {`"read_backend":"cairnline"`, `"id":"asgn_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/work-items/work_cairnline_only/artifacts":   {`"read_backend":"cairnline"`, `"id":"ev_cairnline_only"`, `"id":"rev_cairnline_only"`},
+		"/hecate/v1/projects/proj_cairnline_only/work-items/work_cairnline_only/handoffs":    {`"read_backend":"cairnline"`, `"id":"handoff_cairnline_only"`},
+	}
+	for path, fragments := range cairnlineOnlyProjectRoutes {
+		assertProjectRouteOKContainsForTest(t, server, path, fragments...)
+	}
+}
+
+func assertProjectRouteOKContainsForTest(t *testing.T, server http.Handler, path string, fragments ...string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s status = %d body=%s, want 200", path, rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, fragment := range fragments {
+		if !strings.Contains(body, fragment) {
+			t.Fatalf("GET %s body = %s, want fragment %q", path, body, fragment)
+		}
+	}
 }
 
 func TestProjectsAPI_CairnlineConfiguredProjectDetailReadsEmbeddedMirror(t *testing.T) {
@@ -1085,6 +1163,41 @@ func TestProjectsAPI_CairnlineMetadataDefaultsAuthorityCommitsScopedUpdatesFirst
 	mirrored = getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
 	if mirrored.Name != "Mixed Root Replacement" || len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_replaced" {
 		t.Fatalf("mirrored mixed root patch = %+v, want root replacement still mirrored through Hecate-owned path", mirrored)
+	}
+}
+
+func TestProjectsAPI_CairnlineMetadataDefaultsAuthorityValidatesDefaultRootFromEmbeddedProject(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineMetadataDefaultsAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+
+	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
+		if _, err := service.CreateProject(t.Context(), cairnline.Project{
+			ID:   "proj_cairnline_defaults_only",
+			Name: "Cairnline defaults only",
+		}); err != nil {
+			return err
+		}
+		_, _, err := service.CreateRoot(t.Context(), "proj_cairnline_defaults_only", cairnline.Root{
+			ID:     "root_cairnline_defaults_only",
+			Path:   "/workspace/cairnline-defaults-only",
+			Kind:   "folder",
+			Active: true,
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed Cairnline-only defaults project: %v", err)
+	}
+
+	updated := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/proj_cairnline_defaults_only", projectJourneyJSON(t, map[string]any{
+		"default_root_id": "root_cairnline_defaults_only",
+	}))
+	if updated.Data.ID != "proj_cairnline_defaults_only" || updated.Data.DefaultRootID != "root_cairnline_defaults_only" {
+		t.Fatalf("updated project = %+v, want Cairnline default root", updated.Data)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, "proj_cairnline_defaults_only")
+	if mirrored.DefaultRootID != "root_cairnline_defaults_only" {
+		t.Fatalf("mirrored default_root_id = %q, want root_cairnline_defaults_only", mirrored.DefaultRootID)
 	}
 }
 
@@ -2111,6 +2224,110 @@ func seedCairnlineOnlyProjectGraphForTest(t *testing.T, handler *Handler, projec
 		Enabled: true,
 	}); err != nil {
 		t.Fatalf("CreateContextSource(cairnline-only): %v", err)
+	}
+	if _, err := service.CreateProjectSkill(t.Context(), cairnline.ProjectSkill{
+		ID:          "skill_cairnline_only",
+		ProjectID:   projectID,
+		Title:       "Cairnline-only skill",
+		Description: "Metadata-only portable skill.",
+		Path:        ".agents/skills/cairnline-only/SKILL.md",
+		RootID:      "root_cairnline_only",
+		Format:      cairnline.SkillFormatMarkdown,
+		Status:      cairnline.SkillStatusAvailable,
+		TrustLabel:  cairnline.SkillTrustWorkspace,
+		SourceRefs:  []string{"ctx_cairnline_only"},
+	}); err != nil {
+		t.Fatalf("CreateProjectSkill(cairnline-only): %v", err)
+	}
+	role, err := service.CreateRole(t.Context(), cairnline.Role{
+		ID:                   "role_cairnline_only",
+		ProjectID:            projectID,
+		Name:                 "Cairnline coordinator",
+		Description:          "Coordinates portable project work.",
+		DefaultSkillIDs:      []string{"skill_cairnline_only"},
+		DefaultExecutionMode: cairnline.ExecutionMCPPull,
+	})
+	if err != nil {
+		t.Fatalf("CreateRole(cairnline-only): %v", err)
+	}
+	work, err := service.CreateWorkItem(t.Context(), cairnline.WorkItem{
+		ID:              "work_cairnline_only",
+		ProjectID:       projectID,
+		Title:           "Coordinate Cairnline-only work",
+		Brief:           "Prove read routes do not require native Hecate rows.",
+		OwnerRoleID:     role.ID,
+		ReviewerRoleIDs: []string{role.ID},
+		RootID:          "root_cairnline_only",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkItem(cairnline-only): %v", err)
+	}
+	assignment, err := service.CreateAssignment(t.Context(), cairnline.Assignment{
+		ID:            "asgn_cairnline_only",
+		ProjectID:     projectID,
+		WorkItemID:    work.ID,
+		RoleID:        role.ID,
+		RootID:        "root_cairnline_only",
+		ExecutionMode: cairnline.ExecutionMCPPull,
+		DesiredAgent:  cairnline.DesiredAgent{Kind: cairnline.DesiredAgentAny, SkillIDs: []string{"skill_cairnline_only"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateAssignment(cairnline-only): %v", err)
+	}
+	if _, err := service.CreateEvidence(t.Context(), cairnline.Evidence{
+		ID:           "ev_cairnline_only",
+		ProjectID:    projectID,
+		WorkItemID:   work.ID,
+		AssignmentID: assignment.ID,
+		Title:        "Cairnline-only evidence",
+		Locator:      "https://example.test/cairnline-only",
+	}); err != nil {
+		t.Fatalf("CreateEvidence(cairnline-only): %v", err)
+	}
+	review, err := service.CreateReview(t.Context(), cairnline.Review{
+		ID:             "rev_cairnline_only",
+		ProjectID:      projectID,
+		WorkItemID:     work.ID,
+		AssignmentID:   assignment.ID,
+		ReviewerRoleID: role.ID,
+		Title:          "Cairnline-only review",
+		Body:           "Needs a follow-up to stay visible in health and operations.",
+		Verdict:        cairnline.ReviewVerdictChangesRequested,
+	})
+	if err != nil {
+		t.Fatalf("CreateReview(cairnline-only): %v", err)
+	}
+	if _, err := service.CreateHandoff(t.Context(), cairnline.Handoff{
+		ID:                 "handoff_cairnline_only",
+		ProjectID:          projectID,
+		WorkItemID:         work.ID,
+		SourceAssignmentID: assignment.ID,
+		FromRoleID:         role.ID,
+		ToRoleID:           role.ID,
+		Title:              "Cairnline-only handoff",
+		Body:               "Continue this portable project from Cairnline state.",
+		LinkedArtifactIDs:  []string{review.ID},
+	}); err != nil {
+		t.Fatalf("CreateHandoff(cairnline-only): %v", err)
+	}
+	if _, err := service.CreateMemoryEntry(t.Context(), cairnline.MemoryEntry{
+		ID:         "mem_cairnline_only",
+		ProjectID:  projectID,
+		Title:      "Cairnline-only memory",
+		Body:       "Portable project state is authoritative.",
+		TrustLabel: cairnline.MemoryTrustOperator,
+	}); err != nil {
+		t.Fatalf("CreateMemoryEntry(cairnline-only): %v", err)
+	}
+	if _, err := service.CreateMemoryCandidate(t.Context(), cairnline.MemoryCandidate{
+		ID:                  "memcand_cairnline_only",
+		ProjectID:           projectID,
+		Title:               "Cairnline-only candidate",
+		Body:                "Review this candidate from Cairnline state.",
+		SuggestedTrustLabel: cairnline.MemoryTrustGenerated,
+		SourceRefs:          []cairnline.MemoryCandidateSourceRef{{Kind: "assignment", ID: assignment.ID, Title: assignment.ID}},
+	}); err != nil {
+		t.Fatalf("CreateMemoryCandidate(cairnline-only): %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- claim embedded Cairnline assignments before non-strict Hecate task or external-agent dispatch when project-assignment authority is enabled
- release the Cairnline claim when launch setup fails before a committed runtime record exists
- allow memory/project-work routes to validate Cairnline-only project graphs where the read model is authoritative
- document the Cairnline claim boundary while keeping runtime dispatch Hecate-owned

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/cairnline-parity-bridge/.gocache" go test ./internal/api ./internal/config ./internal/projectassistant ./internal/projectassistantapp
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.worktrees/cairnline-parity-bridge/.gocache" go test -race -timeout 10m ./...