### PR TITLE
fix(projects): clarify cairnline assignment start status

### DIFF
--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -1176,7 +1176,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, migratio
 			item.LiveMirror = true
 			item.BlocksAuthority = false
 			item.Gap = ""
-			item.Detail = "Assignment create, update, and delete record mutations commit to the embedded Cairnline database first, then best-effort shadow portable assignment state back into Hecate-native stores for compatibility; assignment start remains Hecate-owned."
+			item.Detail = "Assignment create, update, and delete record mutations commit to the embedded Cairnline database first, then best-effort shadow portable assignment state back into Hecate-native stores for compatibility; assignment start claims the Cairnline coordination record before Hecate-owned dispatch and releases that claim when launch setup fails before a runtime record is committed."
 		}
 		if projectAssistantProposalsAuthoritative && item.Name == "project-assistant-proposal-ledger" {
 			item.CurrentAuthority = "cairnline"
@@ -1328,7 +1328,7 @@ func projectCairnlineProjectWorkItemWriteWarning(writeAuthority []string) string
 
 func projectCairnlineProjectAssignmentWriteWarning(writeAuthority []string) string {
 	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssignments) {
-		return "Project assignment create/update/delete record mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results."
+		return "Project assignment create/update/delete record mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; assignment start claims the Cairnline coordination record before Hecate-owned dispatch, releases that claim on pre-runtime setup failure, and best-effort mirrors committed start and linked-chat reconciliation results."
 	}
 	return "Project assignment create/update/delete mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results."
 }

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -911,8 +911,10 @@ func TestProjectCoordinationBackendStatus_CairnlineProjectAssignmentsAuthorityCo
 		t.Fatalf("replacement_ready = true, want false until remaining write and migration gates are ready")
 	}
 	warnings := strings.Join(status.Warnings, "\n")
-	if !strings.Contains(warnings, "Project assignment create/update/delete record mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "assignment start remains Hecate-owned") {
-		t.Fatalf("warnings = %+v, want assignment authority plus Hecate-owned start warning", status.Warnings)
+	if !strings.Contains(warnings, "Project assignment create/update/delete record mutations are opt-in Cairnline-authoritative") ||
+		!strings.Contains(warnings, "assignment start claims the Cairnline coordination record before Hecate-owned dispatch") ||
+		!strings.Contains(warnings, "releases that claim on pre-runtime setup failure") {
+		t.Fatalf("warnings = %+v, want assignment authority plus Cairnline claim/Hecate-owned dispatch warning", status.Warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary
- update backend-status assignment authority wording to describe Cairnline claim/release before Hecate-owned dispatch
- assert the status warning includes the new claim/release boundary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCoordinationBackendStatus_CairnlineProjectAssignmentsAuthorityConfigured'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api

Docs note: runtime/design docs already describe the claim/release boundary from the preceding change; this patch aligns the live status text with that documented contract.