### PR TITLE
fix(projects): skip native work shadows in replacement mode

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -146,10 +146,18 @@ Projects coordination state. In that armed mode with all portable
 write-authority gaps closed, Cairnline-authoritative project identity create no
 longer creates a native Hecate project identity row; strict embedded reads serve
 the project from Cairnline, while Hecate keeps only the runtime/workspace
-compatibility shadows it still owns. The identity-create shadow switch is
-config-gated by replacement mode plus portable write authority; backend status
-remains the operator-facing readiness signal and still reports not-ready when
-strict embedded mirror/read-smoke evidence is missing or stale.
+compatibility shadows it still owns. Role, work-item, and assignment record
+mutations also stop creating native project-work compatibility rows in this
+posture; assignment execution refs, context packets, and launch timestamps stay
+in Hecate's runtime overlay because Hecate still owns supervised execution. The
+Project Assistant apply path uses the same embedded Cairnline read model for
+confirmed-action preflight, so proposal application can validate and update
+Cairnline-only roles, work items, assignments, artifacts, and handoffs without
+recreating native project-work rows. The
+identity/create and project-work shadow switches are config-gated by replacement
+mode plus portable write authority; backend status remains the operator-facing
+readiness signal and still reports not-ready when strict embedded
+mirror/read-smoke evidence is missing or stale.
 It keeps `write_adapter_gaps` as the broad diagnostic list and also groups
 that list into `portable_write_gaps`, `orchestrator_capabilities`, and
 `migration_blockers`, so operator tooling can tell durable coordination-state
@@ -687,8 +695,9 @@ after these gates are met:
   assignment in Cairnline and persist only task/run or chat-session refs,
   context packets, and timestamps in Hecate's runtime overlay when the native
   project-work store is absent or embedded replacement mode is armed; it does
-  not create a native project identity row, and it does not advance
-  compatibility assignment rows with runtime refs.
+  not create a native project identity row, and it does not create or advance
+  role, work-item, or assignment compatibility rows with coordination/runtime
+  state.
   Linked external-agent chat reconciliation can update embedded Cairnline and
   the runtime overlay in the same no-native-project-work posture. Committed
   start and linked-chat reconciliation results may be mirrored only as

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2691,7 +2691,9 @@ makes role and work-item create/update/delete Cairnline-first and then shadows
 Hecate-native compatibility rows. When the embedded Cairnline graph already
 contains the project, those authority routes do not require a matching
 Hecate-native project row; Hecate's project-work rows remain a best-effort
-compatibility shadow.
+compatibility shadow. In armed embedded replacement mode with all portable write
+authority closed, these routes skip native project-work compatibility rows and
+serve their mutation responses from Cairnline instead.
 `project-assignments-live-mirror` mirrors assignment create/update/delete
 coordination metadata, lifecycle status, and Hecate-provided
 started/completed timestamps after Hecate commits without manufacturing missing
@@ -2701,7 +2703,11 @@ record create/update/delete mutations Cairnline-first and then shadows portable
 assignment state back into Hecate-native project-work stores. Assignment
 authority uses Cairnline-owned work item, role, and root records when present,
 so direct create/update/delete can operate on a Cairnline-only project graph.
-Mirror failures are logged.
+In armed embedded replacement mode with all portable write authority closed,
+assignment record mutations skip the native project-work compatibility row;
+Hecate still writes assignment execution refs, context packets, and timestamps
+to its runtime overlay. Mirror failures are logged outside that replacement
+posture.
 `project-assignment-start-result-live-mirror` best-effort mirrors
 committed assignment-start results after Hecate-owned dispatch completes or
 returns a committed cleanup/conflict state; it is replacement evidence, not
@@ -2715,12 +2721,17 @@ in embedded Cairnline and persist only Hecate-owned task/run or chat-session
 refs, context packets, and launch timestamps in the assignment runtime overlay
 when the native project-work store is absent or embedded replacement mode is
 armed. They do not require or advance a native Hecate project identity row, and
-they do not advance compatibility assignment rows with runtime refs; runtime
-dispatch, task execution, and external-agent supervision remain Hecate-owned.
+they do not create or advance role, work-item, or assignment compatibility rows
+with coordination/runtime state; runtime dispatch, task execution, and
+external-agent supervision remain Hecate-owned.
 Assignment launch/preflight context uses the active Cairnline read model for
 inspect-only collaboration artifact and handoff metadata, so Cairnline-only
 project graphs preserve the same evidence/review/handoff hints as native
 project-work rows.
+Project Assistant confirmed apply preflight also reads the embedded Cairnline
+work graph in this posture, which lets confirmed proposals close, hand off, or
+extend Cairnline-only work without depending on native project-work
+compatibility rows.
 `project-assignment-chat-reconcile-live-mirror`
 best-effort mirrors assignment status/ref updates committed by linked
 external-agent chat reconciliation, and strict embedded reconciliation can

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -101,7 +101,7 @@ func (h *Handler) projectAssistantApplication() *projectassistantapp.Application
 			Projects:                 h.projects,
 			ProjectAuthority:         h.projectAssistantProjectAuthorityForApplication(),
 			Chats:                    h.agentChat,
-			Work:                     h.projectWork,
+			Work:                     h.projectAssistantWorkStoreForApplication(),
 			WorkAuthority:            h.projectAssistantWorkAuthorityForApplication(),
 			WorkApplication:          h.projectWorkApplication(),
 			ProjectSkills:            h.projectSkills,

--- a/internal/api/handler_project_assignment_authority.go
+++ b/internal/api/handler_project_assignment_authority.go
@@ -288,6 +288,10 @@ func (h *Handler) shadowProjectAssignmentToHecate(ctx context.Context, operation
 	if h == nil {
 		return
 	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		h.shadowProjectAssignmentRuntimeToHecate(ctx, operation, assignment)
+		return
+	}
 	if h.projectWork == nil {
 		h.shadowProjectAssignmentRuntimeToHecate(ctx, operation, assignment)
 		return

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -3240,6 +3240,7 @@ func TestProjectAssistantAPI_ApplyDoneUsesCairnlineProjectAuthority(t *testing.T
 		"name":                "Assistant closer",
 		"default_driver_kind": projectwork.AssignmentDriverHecateTask,
 	}))
+	assertNoNativeProjectWorkRoleForJourney(t, handler, projectID, "role_assistant_closeout")
 	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
 		"id":            "work_assistant_cairnline_closeout",
 		"title":         "Assistant Cairnline closeout",
@@ -3250,12 +3251,14 @@ func TestProjectAssistantAPI_ApplyDoneUsesCairnlineProjectAuthority(t *testing.T
 	if work.Data.ReadBackend != "cairnline" {
 		t.Fatalf("work = %+v, want Cairnline-backed work item", work.Data)
 	}
+	assertNoNativeProjectWorkItemForJourney(t, handler, projectID, "work_assistant_cairnline_closeout")
 	mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_assistant_cairnline_closeout/assignments", projectJourneyJSON(t, map[string]any{
 		"id":          "asgn_assistant_cairnline_closeout",
 		"role_id":     "role_assistant_closeout",
 		"driver_kind": projectwork.AssignmentDriverHecateTask,
 		"status":      projectwork.AssignmentStatusCompleted,
 	}))
+	assertNoNativeProjectWorkAssignmentForJourney(t, handler, projectID, "work_assistant_cairnline_closeout", "asgn_assistant_cairnline_closeout")
 	mustRequestJSONStatus[ProjectWorkArtifactEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_assistant_cairnline_closeout/artifacts", projectJourneyJSON(t, map[string]any{
 		"id":                   "artifact_assistant_cairnline_evidence",
 		"assignment_id":        "asgn_assistant_cairnline_closeout",
@@ -3270,6 +3273,28 @@ func TestProjectAssistantAPI_ApplyDoneUsesCairnlineProjectAuthority(t *testing.T
 	readiness := mustRequestJSONStatus[ProjectWorkItemReadinessEnvelope](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/work-items/work_assistant_cairnline_closeout/readiness", "")
 	if !readiness.Data.Ready || readiness.Data.ReadBackend != "cairnline" || readiness.Data.CompletedAssignments != 1 {
 		t.Fatalf("readiness = %+v, want Cairnline-backed ready closeout", readiness.Data)
+	}
+	assistantWork := handler.projectAssistantWorkStoreForApplication()
+	if assistantWork.Backend() != "cairnline" {
+		t.Fatalf("Project Assistant work backend = %q, want cairnline", assistantWork.Backend())
+	}
+	assistantRoles, err := assistantWork.ListRoles(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("Project Assistant ListRoles: %v", err)
+	}
+	if !projectAssistantRoleSeenForTest(assistantRoles, "role_assistant_closeout", false) || !projectAssistantRoleSeenForTest(assistantRoles, "reviewer_qa", true) {
+		t.Fatalf("Project Assistant roles = %+v, want Cairnline custom role plus built-in reviewer", assistantRoles)
+	}
+	if assistantItem, ok, err := assistantWork.GetWorkItem(t.Context(), projectID, "work_assistant_cairnline_closeout"); err != nil || !ok || assistantItem.Status != projectwork.WorkItemStatusReview {
+		t.Fatalf("Project Assistant GetWorkItem ok=%v err=%v item=%+v, want Cairnline work item", ok, err, assistantItem)
+	}
+	assistantAssignments, err := assistantWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{ProjectID: projectID, WorkItemID: "work_assistant_cairnline_closeout"})
+	if err != nil || len(assistantAssignments) != 1 || assistantAssignments[0].ID != "asgn_assistant_cairnline_closeout" {
+		t.Fatalf("Project Assistant assignments = %+v err=%v, want Cairnline assignment", assistantAssignments, err)
+	}
+	assistantArtifacts, err := assistantWork.ListArtifacts(t.Context(), projectwork.ArtifactFilter{ProjectID: projectID, WorkItemID: "work_assistant_cairnline_closeout", AssignmentID: "asgn_assistant_cairnline_closeout"})
+	if err != nil || len(assistantArtifacts) != 1 || assistantArtifacts[0].ID != "artifact_assistant_cairnline_evidence" {
+		t.Fatalf("Project Assistant artifacts = %+v err=%v, want Cairnline evidence artifact", assistantArtifacts, err)
 	}
 
 	proposal := projectassistant.Proposal{
@@ -3299,9 +3324,21 @@ func TestProjectAssistantAPI_ApplyDoneUsesCairnlineProjectAuthority(t *testing.T
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
 		t.Fatalf("Hecate project store ok=%v err=%v after assistant closeout, want no native project identity row", ok, err)
 	}
+	assertNoNativeProjectWorkRoleForJourney(t, handler, projectID, "role_assistant_closeout")
+	assertNoNativeProjectWorkItemForJourney(t, handler, projectID, "work_assistant_cairnline_closeout")
+	assertNoNativeProjectWorkAssignmentForJourney(t, handler, projectID, "work_assistant_cairnline_closeout", "asgn_assistant_cairnline_closeout")
 	if mirroredWork := getMirroredCairnlineWorkItemForTest(t, handler, projectID, "work_assistant_cairnline_closeout"); mirroredWork.Status != projectwork.WorkItemStatusDone {
 		t.Fatalf("mirrored Cairnline work = %+v, want done", mirroredWork)
 	}
+}
+
+func projectAssistantRoleSeenForTest(items []projectwork.AgentRoleProfile, id string, builtIn bool) bool {
+	for _, item := range items {
+		if item.ID == id && item.BuiltIn == builtIn {
+			return true
+		}
+	}
+	return false
 }
 
 func TestProjectAssistantAPI_ApplyCreateWorkUsesCairnlineProjectAuthority(t *testing.T) {

--- a/internal/api/handler_project_assistant_work_store.go
+++ b/internal/api/handler_project_assistant_work_store.go
@@ -1,0 +1,326 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) projectAssistantWorkStoreForApplication() projectwork.Store {
+	if h == nil {
+		return nil
+	}
+	if h.projectReadRoutesUseCairnlineReadModel() && h.requiresEmbeddedCairnlineProjectReads() {
+		return projectAssistantCairnlineWorkReadStore{
+			Store:   h.projectWork,
+			handler: h,
+		}
+	}
+	return h.projectWork
+}
+
+type projectAssistantCairnlineWorkReadStore struct {
+	projectwork.Store
+	handler *Handler
+}
+
+func (store projectAssistantCairnlineWorkReadStore) Backend() string {
+	if store.usesCairnlineReads() {
+		return "cairnline"
+	}
+	if store.Store != nil {
+		return store.Store.Backend()
+	}
+	return ""
+}
+
+func (store projectAssistantCairnlineWorkReadStore) ListRoles(ctx context.Context, projectID string) ([]projectwork.AgentRoleProfile, error) {
+	if !store.usesCairnlineReads() {
+		return store.Store.ListRoles(ctx, projectID)
+	}
+	view, err := store.handler.cairnlineProjectWorkView(ctx, projectID)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	defer view.Close()
+	roles, err := view.service.ListRoles(ctx, view.snapshot.Project.ID)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	executionProfiles, err := view.service.ListExecutionProfiles(ctx)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	nativeRoles := append([]projectwork.AgentRoleProfile(nil), view.snapshot.Roles...)
+	nativeRoles = append(nativeRoles, projectwork.BuiltInRoleProfiles(view.snapshot.Project.ID)...)
+	nativeByID := projectWorkRolesByID(nativeRoles)
+	executionProfilesByID := cairnlineExecutionProfilesByID(executionProfiles)
+	seen := make(map[string]struct{}, len(roles))
+	out := make([]projectwork.AgentRoleProfile, 0, len(roles))
+	for _, role := range roles {
+		seen[role.ID] = struct{}{}
+		out = append(out, projectWorkRoleFromCairnline(role, executionProfilesByID, nativeByID[role.ID]))
+	}
+	for _, role := range projectwork.BuiltInRoleProfiles(view.snapshot.Project.ID) {
+		if _, ok := seen[role.ID]; ok {
+			continue
+		}
+		out = append(out, role)
+	}
+	sortProjectAssistantRoles(out)
+	return out, nil
+}
+
+func (store projectAssistantCairnlineWorkReadStore) ListWorkItems(ctx context.Context, projectID string, options ...projectwork.ListOptions) ([]projectwork.WorkItem, error) {
+	if !store.usesCairnlineReads() {
+		return store.Store.ListWorkItems(ctx, projectID, options...)
+	}
+	view, err := store.handler.cairnlineProjectWorkView(ctx, projectID)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	defer view.Close()
+	items, err := view.service.ListWorkItems(ctx, view.snapshot.Project.ID)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	out := make([]projectwork.WorkItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, projectWorkItemFromCairnline(item))
+	}
+	return projectAssistantFilterWorkItems(out, options...), nil
+}
+
+func (store projectAssistantCairnlineWorkReadStore) GetWorkItem(ctx context.Context, projectID, id string) (projectwork.WorkItem, bool, error) {
+	if !store.usesCairnlineReads() {
+		return store.Store.GetWorkItem(ctx, projectID, id)
+	}
+	view, err := store.handler.cairnlineProjectWorkView(ctx, projectID)
+	if err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return projectwork.WorkItem{}, false, nil
+		}
+		return projectwork.WorkItem{}, false, projectAssistantWorkReadError(err)
+	}
+	defer view.Close()
+	item, err := view.service.GetWorkItem(ctx, view.snapshot.Project.ID, strings.TrimSpace(id))
+	if err != nil {
+		if errors.Is(err, cairnline.ErrNotFound) {
+			return projectwork.WorkItem{}, false, nil
+		}
+		return projectwork.WorkItem{}, false, projectAssistantWorkReadError(err)
+	}
+	return projectWorkItemFromCairnline(item), true, nil
+}
+
+func (store projectAssistantCairnlineWorkReadStore) ListAssignments(ctx context.Context, filter projectwork.AssignmentFilter, options ...projectwork.ListOptions) ([]projectwork.Assignment, error) {
+	if !store.usesCairnlineReads() {
+		return store.Store.ListAssignments(ctx, filter, options...)
+	}
+	view, err := store.handler.cairnlineProjectWorkView(ctx, filter.ProjectID)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	defer view.Close()
+	items, err := view.service.ListAssignments(ctx, view.snapshot.Project.ID)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	assignments := projectWorkAssignmentsFromCairnline(items, view.snapshot.Assignments)
+	projected, err := store.handler.applyRuntimeForCairnlineReadiness(ctx, assignments)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	return projectAssistantFilterAssignments(projected, filter, options...), nil
+}
+
+func (store projectAssistantCairnlineWorkReadStore) ListArtifacts(ctx context.Context, filter projectwork.ArtifactFilter) ([]projectwork.CollaborationArtifact, error) {
+	if !store.usesCairnlineReads() {
+		return store.Store.ListArtifacts(ctx, filter)
+	}
+	view, err := store.handler.cairnlineProjectWorkView(ctx, filter.ProjectID)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	defer view.Close()
+	items, err := store.listCairnlineArtifacts(ctx, view, filter)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	return projectAssistantFilterArtifacts(items, filter), nil
+}
+
+func (store projectAssistantCairnlineWorkReadStore) ListHandoffs(ctx context.Context, filter projectwork.HandoffFilter) ([]projectwork.Handoff, error) {
+	if !store.usesCairnlineReads() {
+		return store.Store.ListHandoffs(ctx, filter)
+	}
+	view, err := store.handler.cairnlineProjectWorkView(ctx, filter.ProjectID)
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	defer view.Close()
+	items, err := cairnlineProjectHandoffs(ctx, view.service, view.snapshot.Project.ID, strings.TrimSpace(filter.WorkItemID), strings.TrimSpace(filter.Status))
+	if err != nil {
+		return nil, projectAssistantWorkReadError(err)
+	}
+	return items, nil
+}
+
+func (store projectAssistantCairnlineWorkReadStore) usesCairnlineReads() bool {
+	return store.handler != nil &&
+		store.handler.projectReadRoutesUseCairnlineReadModel() &&
+		store.handler.requiresEmbeddedCairnlineProjectReads()
+}
+
+func (store projectAssistantCairnlineWorkReadStore) listCairnlineArtifacts(ctx context.Context, view *cairnlineProjectWorkView, filter projectwork.ArtifactFilter) ([]projectwork.CollaborationArtifact, error) {
+	workItemID := strings.TrimSpace(filter.WorkItemID)
+	if workItemID != "" {
+		return cairnlineProjectWorkArtifacts(ctx, view.service, view.snapshot.Project.ID, workItemID)
+	}
+	workItems, err := view.service.ListWorkItems(ctx, view.snapshot.Project.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]projectwork.CollaborationArtifact, 0)
+	for _, workItem := range workItems {
+		items, err := cairnlineProjectWorkArtifacts(ctx, view.service, view.snapshot.Project.ID, workItem.ID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, items...)
+	}
+	sortProjectAssistantArtifacts(out)
+	return out, nil
+}
+
+func projectAssistantWorkReadError(err error) error {
+	if errors.Is(err, cairnline.ErrNotFound) {
+		return projectwork.ErrNotFound
+	}
+	return err
+}
+
+func projectAssistantFilterWorkItems(items []projectwork.WorkItem, options ...projectwork.ListOptions) []projectwork.WorkItem {
+	statuses, limit := projectAssistantListOptions(options)
+	out := make([]projectwork.WorkItem, 0, len(items))
+	for _, item := range items {
+		if len(statuses) > 0 {
+			if _, ok := statuses[item.Status]; !ok {
+				continue
+			}
+		}
+		out = append(out, item)
+	}
+	sortProjectAssistantWorkItems(out)
+	return projectAssistantLimitWorkItems(out, limit)
+}
+
+func projectAssistantFilterAssignments(items []projectwork.Assignment, filter projectwork.AssignmentFilter, options ...projectwork.ListOptions) []projectwork.Assignment {
+	workItemID := strings.TrimSpace(filter.WorkItemID)
+	statuses, limit := projectAssistantListOptions(options)
+	out := make([]projectwork.Assignment, 0, len(items))
+	for _, item := range items {
+		if workItemID != "" && strings.TrimSpace(item.WorkItemID) != workItemID {
+			continue
+		}
+		if len(statuses) > 0 {
+			if _, ok := statuses[item.Status]; !ok {
+				continue
+			}
+		}
+		out = append(out, item)
+	}
+	sortProjectAssistantAssignments(out)
+	return projectAssistantLimitAssignments(out, limit)
+}
+
+func projectAssistantFilterArtifacts(items []projectwork.CollaborationArtifact, filter projectwork.ArtifactFilter) []projectwork.CollaborationArtifact {
+	workItemID := strings.TrimSpace(filter.WorkItemID)
+	assignmentID := strings.TrimSpace(filter.AssignmentID)
+	out := make([]projectwork.CollaborationArtifact, 0, len(items))
+	for _, item := range items {
+		if workItemID != "" && strings.TrimSpace(item.WorkItemID) != workItemID {
+			continue
+		}
+		if assignmentID != "" && strings.TrimSpace(item.AssignmentID) != assignmentID {
+			continue
+		}
+		out = append(out, item)
+	}
+	sortProjectAssistantArtifacts(out)
+	return out
+}
+
+func projectAssistantListOptions(options []projectwork.ListOptions) (map[string]struct{}, int) {
+	statuses := make(map[string]struct{})
+	limit := 0
+	for _, option := range options {
+		if option.Limit > 0 {
+			limit = option.Limit
+		}
+		for _, status := range option.Statuses {
+			status = strings.TrimSpace(status)
+			if status != "" {
+				statuses[status] = struct{}{}
+			}
+		}
+	}
+	if len(statuses) == 0 {
+		statuses = nil
+	}
+	return statuses, limit
+}
+
+func projectAssistantLimitWorkItems(items []projectwork.WorkItem, limit int) []projectwork.WorkItem {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+	return items[:limit]
+}
+
+func projectAssistantLimitAssignments(items []projectwork.Assignment, limit int) []projectwork.Assignment {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+	return items[:limit]
+}
+
+func sortProjectAssistantRoles(items []projectwork.AgentRoleProfile) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].BuiltIn != items[j].BuiltIn {
+			return items[i].BuiltIn
+		}
+		if items[i].Name != items[j].Name {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortProjectAssistantWorkItems(items []projectwork.WorkItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if !items[i].UpdatedAt.Equal(items[j].UpdatedAt) {
+			return items[i].UpdatedAt.After(items[j].UpdatedAt)
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortProjectAssistantAssignments(items []projectwork.Assignment) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if !items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].CreatedAt.Before(items[j].CreatedAt)
+		}
+		return items[i].ID < items[j].ID
+	})
+}
+
+func sortProjectAssistantArtifacts(items []projectwork.CollaborationArtifact) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return projectWorkArtifactProjectionLess(items[i], items[j])
+	})
+}

--- a/internal/api/handler_project_role_authority.go
+++ b/internal/api/handler_project_role_authority.go
@@ -237,6 +237,9 @@ func (h *Handler) shadowProjectRoleToHecate(ctx context.Context, operation strin
 	if h == nil || h.projectWork == nil {
 		return projectwork.AgentRoleProfile{}, false
 	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		return projectwork.AgentRoleProfile{}, false
+	}
 	if updated, err := h.projectWork.UpdateRole(ctx, role.ProjectID, role.ID, func(existing *projectwork.AgentRoleProfile) {
 		*existing = role
 	}); err == nil {

--- a/internal/api/handler_project_work_item_authority.go
+++ b/internal/api/handler_project_work_item_authority.go
@@ -296,6 +296,9 @@ func (h *Handler) shadowProjectWorkItemToHecate(ctx context.Context, operation s
 	if h == nil || h.projectWork == nil {
 		return
 	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		return
+	}
 	if _, err := h.projectWork.UpdateWorkItem(ctx, item.ProjectID, item.ID, func(existing *projectwork.WorkItem) {
 		*existing = item
 	}); err == nil {

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -218,6 +218,8 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if reviewer.Data.ID != "role_reviewer" || reviewer.Data.ProjectID != projectID || reviewer.Data.ReadBackend != "cairnline" {
 		t.Fatalf("reviewer role = %+v, want replacement reviewer role", reviewer.Data)
 	}
+	assertNoNativeProjectWorkRoleForJourney(t, handler, projectID, "role_replacement")
+	assertNoNativeProjectWorkRoleForJourney(t, handler, projectID, "role_reviewer")
 
 	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
 		"id":                "work_replacement",
@@ -231,6 +233,7 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if work.Data.ID != "work_replacement" || work.Data.ReadBackend != "cairnline" || work.Data.RootID != "root_replacement" {
 		t.Fatalf("work = %+v, want Cairnline replacement work item", work.Data)
 	}
+	assertNoNativeProjectWorkItemForJourney(t, handler, projectID, "work_replacement")
 
 	assignment := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments", projectJourneyJSON(t, map[string]any{
 		"id":          "asgn_replacement",
@@ -241,6 +244,7 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if assignment.Data.ID != "asgn_replacement" || assignment.Data.ReadBackend != "cairnline" || assignment.Data.Status != projectwork.AssignmentStatusQueued {
 		t.Fatalf("assignment = %+v, want queued Cairnline replacement assignment", assignment.Data)
 	}
+	assertNoNativeProjectWorkAssignmentForJourney(t, handler, projectID, "work_replacement", "asgn_replacement")
 
 	started := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments/asgn_replacement/start", `{}`)
 	ref := assignmentExecutionRefForTest(t, started.Data)
@@ -275,10 +279,7 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if runtime.ExecutionRef.RunID != ref.RunID || runtime.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
 		t.Fatalf("Hecate runtime overlay = %+v, want run/context %q/%q", runtime.ExecutionRef, ref.RunID, ref.ContextSnapshotID)
 	}
-	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_replacement", "asgn_replacement")
-	if shadow.ExecutionRef.RunID != "" || shadow.ExecutionRef.ContextSnapshotID != "" {
-		t.Fatalf("Hecate compatibility shadow assignment = %+v, want replacement-mode start refs to live only in runtime overlay", shadow.ExecutionRef)
-	}
+	assertNoNativeProjectWorkAssignmentForJourney(t, handler, projectID, "work_replacement", "asgn_replacement")
 
 	completed := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments/asgn_replacement", projectJourneyJSON(t, map[string]any{
 		"status": projectwork.AssignmentStatusCompleted,
@@ -469,10 +470,7 @@ func TestProjectJourneyAPI_CairnlineReplacementModeStartsExternalAgentWithoutAdv
 	if runtime.ExecutionRef.ChatSessionID != ref.ChatSessionID || runtime.ExecutionRef.ContextSnapshotID != ref.ContextSnapshotID {
 		t.Fatalf("Hecate runtime overlay = %+v, want chat/context %q/%q", runtime.ExecutionRef, ref.ChatSessionID, ref.ContextSnapshotID)
 	}
-	shadow := getStoredProjectWorkAssignmentForTest(t, handler, projectID, "work_replacement_external", "asgn_replacement_external")
-	if shadow.ExecutionRef.ChatSessionID != "" || shadow.ExecutionRef.ContextSnapshotID != "" {
-		t.Fatalf("Hecate compatibility shadow assignment = %+v, want replacement-mode external start refs to live only in runtime overlay", shadow.ExecutionRef)
-	}
+	assertNoNativeProjectWorkAssignmentForJourney(t, handler, projectID, "work_replacement_external", "asgn_replacement_external")
 }
 
 func TestProjectJourneyAPI_CairnlineReplacementCloseoutReadinessUsesRuntimeOverlay(t *testing.T) {
@@ -576,6 +574,46 @@ func projectJourneyHasContextSource(items []ProjectContextSourceResponseItem, pa
 		}
 	}
 	return false
+}
+
+func assertNoNativeProjectWorkRoleForJourney(t *testing.T, handler *Handler, projectID, roleID string) {
+	t.Helper()
+	roles, err := handler.projectWork.ListRoles(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("ListRoles(%q): %v", projectID, err)
+	}
+	for _, role := range roles {
+		if role.ID == roleID && !role.BuiltIn {
+			t.Fatalf("native project-work role %q exists in replacement mode: %+v", roleID, role)
+		}
+	}
+}
+
+func assertNoNativeProjectWorkItemForJourney(t *testing.T, handler *Handler, projectID, workItemID string) {
+	t.Helper()
+	item, ok, err := handler.projectWork.GetWorkItem(t.Context(), projectID, workItemID)
+	if err != nil {
+		t.Fatalf("GetWorkItem(%q, %q): %v", projectID, workItemID, err)
+	}
+	if ok {
+		t.Fatalf("native project-work item %q exists in replacement mode: %+v", workItemID, item)
+	}
+}
+
+func assertNoNativeProjectWorkAssignmentForJourney(t *testing.T, handler *Handler, projectID, workItemID, assignmentID string) {
+	t.Helper()
+	assignments, err := handler.projectWork.ListAssignments(t.Context(), projectwork.AssignmentFilter{
+		ProjectID:  projectID,
+		WorkItemID: workItemID,
+	})
+	if err != nil {
+		t.Fatalf("ListAssignments(%q, %q): %v", projectID, workItemID, err)
+	}
+	for _, assignment := range assignments {
+		if assignment.ID == assignmentID {
+			t.Fatalf("native project-work assignment %q exists in replacement mode: %+v", assignmentID, assignment)
+		}
+	}
 }
 
 func assertJourneyContextItem(t *testing.T, packet ChatContextPacketItem, origin, section string, included bool) {


### PR DESCRIPTION
## Summary
- skip native project-work role/work-item/assignment compatibility shadows when embedded Cairnline replacement mode is fully armed
- keep assignment runtime refs/context/timestamps in Hecate's runtime overlay for supervised execution
- give Project Assistant apply preflight a Cairnline-backed work read adapter so confirmed proposals can validate Cairnline-only work graphs
- update Projects architecture/runtime docs for the replacement-mode boundary

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_ApplyDoneUsesCairnlineProjectAuthority|TestProjectJourneyAPI_CairnlineReplacement|TestProjectWorkAPI_Cairnline(Role|WorkItem|Assignment)Authority|TestProjectWorkAPI_StrictEmbeddedRuntimeRequiresReplacementAuthority'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./internal/api
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...