### PR TITLE
fix(projects): skip native collaboration shadows in replacement mode

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -146,10 +146,11 @@ Projects coordination state. In that armed mode with all portable
 write-authority gaps closed, Cairnline-authoritative project identity create no
 longer creates a native Hecate project identity row; strict embedded reads serve
 the project from Cairnline, while Hecate keeps only the runtime/workspace
-compatibility shadows it still owns. Role, work-item, and assignment record
-mutations also stop creating native project-work compatibility rows in this
-posture; assignment execution refs, context packets, and launch timestamps stay
-in Hecate's runtime overlay because Hecate still owns supervised execution. The
+compatibility state it still owns. Role, work-item, assignment, collaboration
+artifact, and handoff record mutations also stop creating native project-work
+compatibility rows in this posture; assignment execution refs, context packets,
+and launch timestamps stay in Hecate's runtime overlay because Hecate still owns
+supervised execution. The
 Project Assistant apply path uses the same embedded Cairnline read model for
 confirmed-action preflight, so proposal application can validate and update
 Cairnline-only roles, work items, assignments, artifacts, and handoffs without
@@ -696,8 +697,8 @@ after these gates are met:
   context packets, and timestamps in Hecate's runtime overlay when the native
   project-work store is absent or embedded replacement mode is armed; it does
   not create a native project identity row, and it does not create or advance
-  role, work-item, or assignment compatibility rows with coordination/runtime
-  state.
+  role, work-item, assignment, collaboration artifact, or handoff
+  compatibility rows with coordination/runtime state.
   Linked external-agent chat reconciliation can update embedded Cairnline and
   the runtime overlay in the same no-native-project-work posture. Committed
   start and linked-chat reconciliation results may be mirrored only as

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2708,6 +2708,13 @@ assignment record mutations skip the native project-work compatibility row;
 Hecate still writes assignment execution refs, context packets, and timestamps
 to its runtime overlay. Mirror failures are logged outside that replacement
 posture.
+`project-collaboration-live-mirror` mirrors collaboration artifact, evidence,
+review, and handoff records after Hecate commits unless
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-collaboration` makes those
+records Cairnline-first. In armed embedded replacement mode with all portable
+write authority closed, Cairnline-authoritative collaboration mutations skip
+native project-work artifact and handoff compatibility rows; collaboration reads
+come from the active Cairnline read model.
 `project-assignment-start-result-live-mirror` best-effort mirrors
 committed assignment-start results after Hecate-owned dispatch completes or
 returns a committed cleanup/conflict state; it is replacement evidence, not
@@ -2721,9 +2728,9 @@ in embedded Cairnline and persist only Hecate-owned task/run or chat-session
 refs, context packets, and launch timestamps in the assignment runtime overlay
 when the native project-work store is absent or embedded replacement mode is
 armed. They do not require or advance a native Hecate project identity row, and
-they do not create or advance role, work-item, or assignment compatibility rows
-with coordination/runtime state; runtime dispatch, task execution, and
-external-agent supervision remain Hecate-owned.
+they do not create or advance role, work-item, assignment, collaboration
+artifact, or handoff compatibility rows with coordination/runtime state; runtime
+dispatch, task execution, and external-agent supervision remain Hecate-owned.
 Assignment launch/preflight context uses the active Cairnline read model for
 inspect-only collaboration artifact and handoff metadata, so Cairnline-only
 project graphs preserve the same evidence/review/handoff hints as native

--- a/internal/api/handler_project_collaboration_authority.go
+++ b/internal/api/handler_project_collaboration_authority.go
@@ -408,6 +408,9 @@ func (h *Handler) shadowProjectWorkArtifactToHecate(ctx context.Context, operati
 	if h == nil || h.projectWork == nil {
 		return
 	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		return
+	}
 	if _, err := h.projectWork.CreateArtifact(ctx, artifact); err != nil && !errors.Is(err, projectwork.ErrDuplicate) {
 		h.logProjectCollaborationShadowError(ctx, operation, artifact.ProjectID, artifact.ID, err)
 	}
@@ -415,6 +418,9 @@ func (h *Handler) shadowProjectWorkArtifactToHecate(ctx context.Context, operati
 
 func (h *Handler) shadowProjectHandoffToHecate(ctx context.Context, operation string, handoff projectwork.Handoff) {
 	if h == nil || h.projectWork == nil {
+		return
+	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
 		return
 	}
 	if existing, err := h.projectWork.UpdateHandoff(ctx, handoff.ProjectID, handoff.WorkItemID, handoff.ID, func(item *projectwork.Handoff) {

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -302,6 +302,7 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if evidence.Data.Kind != projectwork.ArtifactKindEvidenceLink || evidence.Data.AssignmentID != "asgn_replacement" || evidence.Data.EvidenceURL != "https://example.invalid/hecate/cairnline-replacement" {
 		t.Fatalf("evidence = %+v, want assignment evidence response", evidence.Data)
 	}
+	assertNoNativeProjectWorkArtifactForJourney(t, handler, projectID, "work_replacement", "artifact_replacement_evidence")
 	mirroredEvidence := getMirroredCairnlineEvidenceForTest(t, handler, projectID, "work_replacement", "artifact_replacement_evidence")
 	if mirroredEvidence.Locator != "https://example.invalid/hecate/cairnline-replacement" || mirroredEvidence.Provider != "operator" {
 		t.Fatalf("mirrored evidence = %+v, want Cairnline-backed assignment evidence", mirroredEvidence)
@@ -322,6 +323,7 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if review.Data.ReviewVerdict != projectwork.ReviewVerdictApproved || review.Data.ReviewFollowUpRequired {
 		t.Fatalf("review = %+v, want approved review response without follow-up", review.Data)
 	}
+	assertNoNativeProjectWorkArtifactForJourney(t, handler, projectID, "work_replacement", "artifact_replacement_review")
 	mirroredReview := getMirroredCairnlineReviewForTest(t, handler, projectID, "work_replacement", "artifact_replacement_review")
 	if mirroredReview.Verdict != projectwork.ReviewVerdictApproved || mirroredReview.Risk != projectwork.ReviewRiskLow {
 		t.Fatalf("mirrored review = %+v, want approved Cairnline-backed review without follow-up", mirroredReview)
@@ -344,6 +346,7 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if handoff.Data.Status != projectwork.HandoffStatusPending || handoff.Data.TargetRoleID != "role_reviewer" {
 		t.Fatalf("handoff = %+v, want pending review handoff response", handoff.Data)
 	}
+	assertNoNativeProjectHandoffForJourney(t, handler, projectID, "work_replacement", "handoff_replacement_review")
 	mirroredHandoff := getMirroredCairnlineHandoffForTest(t, handler, projectID, "work_replacement", "handoff_replacement_review")
 	if mirroredHandoff.ToRoleID != "role_reviewer" || mirroredHandoff.Status != "open" {
 		t.Fatalf("mirrored handoff = %+v, want pending Cairnline-backed review handoff", mirroredHandoff)
@@ -352,6 +355,7 @@ func TestProjectJourneyAPI_CairnlineReplacementModeCreatesWorkAndStartsWithoutNa
 	if accepted.Data.Status != projectwork.HandoffStatusAccepted {
 		t.Fatalf("accepted handoff = %+v, want accepted handoff response", accepted.Data)
 	}
+	assertNoNativeProjectHandoffForJourney(t, handler, projectID, "work_replacement", "handoff_replacement_review")
 	mirroredHandoff = getMirroredCairnlineHandoffForTest(t, handler, projectID, "work_replacement", "handoff_replacement_review")
 	if mirroredHandoff.Status != projectwork.HandoffStatusAccepted {
 		t.Fatalf("mirrored accepted handoff = %+v, want accepted Cairnline-backed handoff", mirroredHandoff)
@@ -612,6 +616,38 @@ func assertNoNativeProjectWorkAssignmentForJourney(t *testing.T, handler *Handle
 	for _, assignment := range assignments {
 		if assignment.ID == assignmentID {
 			t.Fatalf("native project-work assignment %q exists in replacement mode: %+v", assignmentID, assignment)
+		}
+	}
+}
+
+func assertNoNativeProjectWorkArtifactForJourney(t *testing.T, handler *Handler, projectID, workItemID, artifactID string) {
+	t.Helper()
+	artifacts, err := handler.projectWork.ListArtifacts(t.Context(), projectwork.ArtifactFilter{
+		ProjectID:  projectID,
+		WorkItemID: workItemID,
+	})
+	if err != nil {
+		t.Fatalf("ListArtifacts(%q, %q): %v", projectID, workItemID, err)
+	}
+	for _, artifact := range artifacts {
+		if artifact.ID == artifactID {
+			t.Fatalf("native project-work artifact %q exists in replacement mode: %+v", artifactID, artifact)
+		}
+	}
+}
+
+func assertNoNativeProjectHandoffForJourney(t *testing.T, handler *Handler, projectID, workItemID, handoffID string) {
+	t.Helper()
+	handoffs, err := handler.projectWork.ListHandoffs(t.Context(), projectwork.HandoffFilter{
+		ProjectID:  projectID,
+		WorkItemID: workItemID,
+	})
+	if err != nil {
+		t.Fatalf("ListHandoffs(%q, %q): %v", projectID, workItemID, err)
+	}
+	for _, handoff := range handoffs {
+		if handoff.ID == handoffID {
+			t.Fatalf("native project handoff %q exists in replacement mode: %+v", handoffID, handoff)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- skip native project-work collaboration artifact shadows when embedded Cairnline replacement mode is armed
- skip native handoff compatibility shadows in the same posture while preserving stale-row delete cleanup
- extend the Cairnline replacement journey test to prove evidence, review, and handoff mutations stay Cairnline-backed with no native project-work rows
- update Projects and runtime API docs for the broadened no-native-shadow boundary

## Validation
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectJourneyAPI_CairnlineReplacement|TestProjectWorkAPI_CairnlineCollaborationAuthority'`
- `GOCACHE="$(pwd)/.gocache" go vet ./internal/api`
- `just agent-docs-check`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
