### PR TITLE
fix(projects): skip native skill shadows in replacement mode

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -146,11 +146,12 @@ Projects coordination state. In that armed mode with all portable
 write-authority gaps closed, Cairnline-authoritative project identity create no
 longer creates a native Hecate project identity row; strict embedded reads serve
 the project from Cairnline, while Hecate keeps only the runtime/workspace
-compatibility state it still owns. Role, work-item, assignment, collaboration
-artifact, and handoff record mutations also stop creating native project-work
-compatibility rows in this posture; assignment execution refs, context packets,
-and launch timestamps stay in Hecate's runtime overlay because Hecate still owns
-supervised execution. The
+compatibility state it still owns. Project skill discovery/update also stops
+creating native project-skill compatibility rows in this posture. Role,
+work-item, assignment, collaboration artifact, and handoff record mutations also
+stop creating native project-work compatibility rows; assignment execution refs,
+context packets, and launch timestamps stay in Hecate's runtime overlay because
+Hecate still owns supervised execution. The
 Project Assistant apply path uses the same embedded Cairnline read model for
 confirmed-action preflight, so proposal application can validate and update
 Cairnline-only roles, work items, assignments, artifacts, and handoffs without
@@ -594,7 +595,9 @@ graph;
 `agent-profiles-live-mirror` covers global
 agent-profile create/update/delete metadata and can be switched to Cairnline
 authority with `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles`;
-`project-skills-live-mirror` covers project skill discovery/update metadata;
+`project-skills-live-mirror` covers project skill discovery/update metadata,
+with native skill-registry compatibility rows skipped in armed embedded
+replacement mode;
 `project-roles-live-mirror`, `project-work-items-live-mirror`,
 `project-assignments-live-mirror`,
 `project-assignment-start-result-live-mirror`,
@@ -696,8 +699,8 @@ after these gates are met:
   assignment in Cairnline and persist only task/run or chat-session refs,
   context packets, and timestamps in Hecate's runtime overlay when the native
   project-work store is absent or embedded replacement mode is armed; it does
-  not create a native project identity row, and it does not create or advance
-  role, work-item, assignment, collaboration artifact, or handoff
+  not create a native project identity row, native project-skill compatibility
+  rows, or role, work-item, assignment, collaboration artifact, or handoff
   compatibility rows with coordination/runtime state.
   Linked external-agent chat reconciliation can update embedded Cairnline and
   the runtime overlay in the same no-native-project-work posture. Committed

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2673,7 +2673,10 @@ Cairnline-first; it does not load, inject, or execute `SKILL.md` bodies, and
 preserves suggested tool names plus nullable permission hints as inspectable
 metadata only. Those authority routes can validate the project, roots, and
 context sources from the embedded Cairnline graph without creating a
-Hecate-native project row. `agent-profiles-live-mirror` mirrors
+Hecate-native project row. In armed embedded replacement mode with all portable
+write authority closed, Cairnline-authoritative skill discovery/update skips
+native project-skill compatibility rows and reads come from the active Cairnline
+read model. `agent-profiles-live-mirror` mirrors
 global agent-profile create/update/delete metadata and execution posture after
 Hecate commits unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=agent-profiles` is enabled. With
@@ -2728,9 +2731,10 @@ in embedded Cairnline and persist only Hecate-owned task/run or chat-session
 refs, context packets, and launch timestamps in the assignment runtime overlay
 when the native project-work store is absent or embedded replacement mode is
 armed. They do not require or advance a native Hecate project identity row, and
-they do not create or advance role, work-item, assignment, collaboration
-artifact, or handoff compatibility rows with coordination/runtime state; runtime
-dispatch, task execution, and external-agent supervision remain Hecate-owned.
+they do not create or advance native project-skill compatibility rows or role,
+work-item, assignment, collaboration artifact, or handoff compatibility rows
+with coordination/runtime state; runtime dispatch, task execution, and
+external-agent supervision remain Hecate-owned.
 Assignment launch/preflight context uses the active Cairnline read model for
 inspect-only collaboration artifact and handoff metadata, so Cairnline-only
 project graphs preserve the same evidence/review/handoff hints as native

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -1153,6 +1153,9 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, migratio
 			item.BlocksAuthority = false
 			item.Gap = ""
 			item.Detail = "Project skill discovery and update mutations commit metadata-only skill records to the embedded Cairnline database first, using Cairnline-owned roots and context sources when no Hecate-native project row exists, then best-effort shadow them back into Hecate-native stores for compatibility."
+			if migrationCutoverArmed {
+				item.Detail = "Project skill discovery and update mutations commit metadata-only skill records to the embedded Cairnline database first and, in armed embedded replacement mode, skip native project-skill compatibility rows."
+			}
 		}
 		if projectRolesAuthoritative && item.Name == "roles" {
 			item.CurrentAuthority = "cairnline"

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -530,6 +530,9 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 	if len(status.Warnings) == 0 || !strings.Contains(strings.Join(status.Warnings, "\n"), "Hecate still owns runtime/workspace side effects") {
 		t.Fatalf("warnings = %+v, want runtime/workspace side-effect boundary after replacement is ready", status.Warnings)
 	}
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "skills"); point == nil || !strings.Contains(point.Detail, "skip native project-skill compatibility rows") {
+		t.Fatalf("skills switchpoint = %+v, want armed replacement-mode no-native-skill-shadow detail", point)
+	}
 	if len(status.MigrationBlockers) != 0 {
 		t.Fatalf("migration blockers = %+v, want none after embedded replacement cutover is armed", status.MigrationBlockers)
 	}

--- a/internal/api/handler_project_skill_authority.go
+++ b/internal/api/handler_project_skill_authority.go
@@ -125,6 +125,9 @@ func (h *Handler) shadowProjectSkillsToHecate(ctx context.Context, operation, pr
 	if h == nil || h.projectSkills == nil || len(skills) == 0 {
 		return
 	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		return
+	}
 	if _, err := h.projectSkills.UpsertDiscovered(ctx, projectID, skills); err != nil {
 		h.logCairnlineMirrorError(ctx, operation, projectID, err)
 	}
@@ -132,6 +135,9 @@ func (h *Handler) shadowProjectSkillsToHecate(ctx context.Context, operation, pr
 
 func (h *Handler) shadowProjectSkillUpdateToHecate(ctx context.Context, operation, projectID string, skill projectskills.Skill) {
 	if h == nil || h.projectSkills == nil {
+		return
+	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
 		return
 	}
 	_, err := h.projectSkills.Update(ctx, projectID, skill.ID, func(item *projectskills.Skill) {

--- a/internal/api/handler_project_skills_test.go
+++ b/internal/api/handler_project_skills_test.go
@@ -655,6 +655,65 @@ description: Build backend changes.
 	}
 }
 
+func TestProjectSkillsAPI_CairnlineReplacementModeSkipsNativeSkillShadows(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+	root := t.TempDir()
+	writeProjectSkillAPITestFile(t, root, ".agents/skills/backend/SKILL.md", `---
+name: Backend
+description: Build backend changes.
+---
+`)
+	created := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Replacement skills",
+		"roots": []map[string]any{{
+			"id":     "root_replacement_skills",
+			"path":   root,
+			"kind":   "git",
+			"active": true,
+		}},
+	}))
+	projectID := created.Data.ID
+	if projectID == "" || created.Data.ReadBackend != "cairnline" {
+		t.Fatalf("created project = %+v, want Cairnline replacement identity", created.Data)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("native project exists = %t err=%v, want missing after replacement create", ok, err)
+	}
+
+	discovered := mustRequestJSONStatus[ProjectSkillsResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+projectID+"/skills/discover", "")
+	backend := projectSkillResponseFor(discovered.Data, "backend")
+	if backend == nil || backend.ReadBackend != "cairnline" || backend.ProjectID != projectID || backend.RootID != "root_replacement_skills" {
+		t.Fatalf("discovered backend = %+v, want Cairnline-backed replacement skill", backend)
+	}
+	mirrored := getMirroredCairnlineProjectSkillForTest(t, handler, projectID, "backend")
+	if mirrored.Title != "Backend" || mirrored.ProjectID != projectID {
+		t.Fatalf("Cairnline skill = %+v, want authoritative replacement skill", mirrored)
+	}
+	assertNoNativeProjectSkillForTest(t, handler, projectID, "backend")
+
+	patched := mustRequestJSONStatus[ProjectSkillResponse](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID+"/skills/backend", projectJourneyJSON(t, map[string]any{
+		"enabled":     false,
+		"title":       "Backend Owner",
+		"trust_label": "operator_curated_skill",
+	}))
+	if patched.Data.ReadBackend != "cairnline" || patched.Data.Enabled || patched.Data.Title != "Backend Owner" || patched.Data.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("patched skill = %+v, want patched Cairnline replacement skill", patched.Data)
+	}
+	mirrored = getMirroredCairnlineProjectSkillForTest(t, handler, projectID, "backend")
+	if mirrored.Enabled || mirrored.Title != "Backend Owner" || mirrored.TrustLabel != "operator_curated_skill" {
+		t.Fatalf("patched Cairnline skill = %+v, want operator override", mirrored)
+	}
+	assertNoNativeProjectSkillForTest(t, handler, projectID, "backend")
+
+	listed := mustRequestJSONStatus[ProjectSkillsResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/skills", "")
+	listedBackend := projectSkillResponseFor(listed.Data, "backend")
+	if listedBackend == nil || listedBackend.ReadBackend != "cairnline" || listedBackend.Enabled || listedBackend.Title != "Backend Owner" {
+		t.Fatalf("listed skills = %+v, want Cairnline read model with patched backend skill", listed.Data)
+	}
+}
+
 func TestProjectSkillsAPI_MirrorRefreshesSkillSourceRefsOnRediscovery(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{
@@ -757,6 +816,17 @@ func projectSkillResponseFor(items []ProjectSkillResponseItem, id string) *Proje
 		}
 	}
 	return nil
+}
+
+func assertNoNativeProjectSkillForTest(t *testing.T, handler *Handler, projectID, skillID string) {
+	t.Helper()
+	items, err := handler.projectSkills.List(t.Context(), projectID)
+	if err != nil {
+		t.Fatalf("List native skills: %v", err)
+	}
+	if skill := projectSkillResponseFor(renderProjectSkills(items, "hecate"), skillID); skill != nil {
+		t.Fatalf("native project skill %q exists in replacement mode: %+v", skillID, *skill)
+	}
 }
 
 func assertProjectSkillsProjectionParity(t *testing.T, hecate, cairnline []ProjectSkillResponseItem) {


### PR DESCRIPTION
## Summary
- skip native project-skill compatibility shadows when embedded Cairnline replacement mode is armed
- add replacement-mode API coverage for skill discovery, patch, Cairnline reads, and absence of native skill rows
- update backend-status wording and docs so skill registry rows are included in the no-native-shadow replacement boundary

## Validation
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectSkillsAPI_Cairnline|TestProjectCoordinationBackendStatus_(CairnlineProjectSkillsAuthorityConfigured|EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover)'`
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api`
- `GOCACHE="$(pwd)/.gocache" go vet ./internal/api`
- `just agent-docs-check`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
