### PR TITLE
fix(projects): skip assistant proposal shadows in replacement mode

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -402,10 +402,11 @@ mirrored as replacement evidence.
 `project-assistant-proposals` is a seventh opt-in authority slice: Project
 Assistant draft/propose/apply-attempt ledger records commit to embedded
 Cairnline first, then best-effort shadow Hecate's proposal store for
-compatibility. Confirmed apply uses the enabled Cairnline authority seams for
-project create, project metadata/default, root, role, work-item, assignment,
-handoff, and memory-candidate actions, but chat/runtime effects remain
-Hecate-owned orchestrator capabilities outside Cairnline core. In strict
+compatibility; armed embedded replacement mode skips those native proposal
+compatibility shadows. Confirmed apply uses the enabled Cairnline authority
+seams for project create, project metadata/default, root, role, work-item,
+assignment, handoff, and memory-candidate actions, but chat/runtime effects
+remain Hecate-owned orchestrator capabilities outside Cairnline core. In strict
 embedded mode, the Project Assistant project authority can create project
 identity and mutate portable project metadata, defaults, and roots from the
 embedded Cairnline graph without requiring a Hecate-native compatibility
@@ -533,7 +534,8 @@ for compatibility. The delete mirror removes only the profile record because
 execution-profile posture can be shared. Project Assistant draft/propose/apply
 routes mirror the proposal ledger and committed apply side effects after Hecate
 commits proposal records and apply attempts unless `project-assistant-proposals`
-is enabled, in which case the proposal ledger commits to Cairnline first while
+is enabled, in which case the proposal ledger commits to Cairnline first,
+skips native proposal shadows in armed embedded replacement mode, and
 confirmed apply uses enabled project create, project metadata/default, root,
 role/work-item/assignment/handoff, and memory-candidate authority seams and
 leaves remaining chat/runtime effects as Hecate-owned orchestrator capabilities

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -617,10 +617,12 @@ Project Assistant draft/propose/apply
 ledger mutations likewise best-effort mirror proposal records and apply attempts
 after Hecate commits unless `project-assistant-proposals` is enabled, in which
 case the proposal ledger commits to Cairnline first and shadows Hecate's
-proposal store for compatibility. Confirmed apply uses the enabled Cairnline
-authority seams for project create, project metadata/default, root, role,
-work-item, assignment, handoff, and memory-candidate actions, but chat/runtime
-effects remain Hecate-owned orchestrator capabilities outside Cairnline core.
+proposal store for compatibility; armed embedded replacement mode skips those
+native proposal compatibility shadows. Confirmed apply uses the enabled
+Cairnline authority seams for project create, project metadata/default, root,
+role, work-item, assignment, handoff, and memory-candidate actions, but
+chat/runtime effects remain Hecate-owned orchestrator capabilities outside
+Cairnline core.
 Other live Projects reads/writes still use Hecate-native
 stores until the remaining read routes, write adapter, and migration path are
 ready. Current bridge write experiments cover non-authoritative

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -595,7 +595,8 @@ sequenceDiagram
   mixed metadata/root/source replacement PATCHes remain Hecate-owned.
   `project-assistant-proposals` makes Project Assistant draft/propose/apply-attempt
   ledger records Cairnline-first, then best-effort shadows Hecate's proposal
-  store for compatibility. Confirmed Project Assistant apply uses enabled
+  store for compatibility; armed embedded replacement mode skips those native
+  proposal compatibility shadows. Confirmed Project Assistant apply uses enabled
   project create, project metadata/default, root,
   role/work-item/assignment/handoff, and memory-candidate authority seams and
   can use a Cairnline-only project graph for project
@@ -6686,8 +6687,9 @@ Hecate-native project row. Draft generation uses the same
 Cairnline-projected context so preview and proposal assembly do not drift,
 while proposal ledger writes remain Hecate-owned unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-assistant-proposals` is
-enabled. Confirmed apply uses enabled project create, project metadata/default,
-root, role/work-item/assignment/handoff, and memory-candidate
+enabled; armed embedded replacement mode then skips native proposal ledger
+compatibility shadows. Confirmed apply uses enabled project create, project
+metadata/default, root, role/work-item/assignment/handoff, and memory-candidate
 Cairnline-authority seams and leaves remaining chat/runtime effects as
 Hecate-owned orchestrator capabilities outside Cairnline core. In strict
 embedded mode, confirmed apply can create project identity and update portable

--- a/internal/api/handler_project_assistant_authority.go
+++ b/internal/api/handler_project_assistant_authority.go
@@ -117,7 +117,7 @@ func (s cairnlineProjectAssistantProposalAuthorityStore) UpdateProposalApplyStat
 	if err != nil {
 		return projectassistant.ProposalRecord{}, projectAssistantCairnlineAuthorityError(err)
 	}
-	if s.shadow != nil {
+	if !s.skipHecateCompatibilityShadow() && s.shadow != nil {
 		if shadowed, err := s.shadow.UpdateProposalApplyState(ctx, proposalID, result); err == nil {
 			return shadowed, nil
 		} else if s.handler != nil {
@@ -149,7 +149,7 @@ func (s cairnlineProjectAssistantProposalAuthorityStore) RecordApplyAttempt(ctx 
 	if err != nil {
 		return projectassistant.ProposalRecord{}, projectAssistantCairnlineAuthorityError(err)
 	}
-	if s.shadow != nil {
+	if !s.skipHecateCompatibilityShadow() && s.shadow != nil {
 		if shadowed, err := s.shadow.RecordApplyAttempt(ctx, attempt); err == nil {
 			return shadowed, nil
 		} else if s.handler != nil {
@@ -237,7 +237,7 @@ func (s cairnlineProjectAssistantProposalAuthorityStore) writeRecord(ctx context
 }
 
 func (s cairnlineProjectAssistantProposalAuthorityStore) shadowProposalRecord(ctx context.Context, operation string, record projectassistant.ProposalRecord) (projectassistant.ProposalRecord, bool) {
-	if s.shadow == nil {
+	if s.skipHecateCompatibilityShadow() || s.shadow == nil {
 		return projectassistant.ProposalRecord{}, false
 	}
 	shadowed, err := s.shadow.UpsertProposal(ctx, record)
@@ -248,6 +248,10 @@ func (s cairnlineProjectAssistantProposalAuthorityStore) shadowProposalRecord(ct
 		return projectassistant.ProposalRecord{}, false
 	}
 	return shadowed, true
+}
+
+func (s cairnlineProjectAssistantProposalAuthorityStore) skipHecateCompatibilityShadow() bool {
+	return s.handler != nil && s.handler.projectCairnlineEmbeddedReplacementModeArmed()
 }
 
 func normalizeProjectAssistantProposalRecordForAuthority(record projectassistant.ProposalRecord) (projectassistant.ProposalRecord, error) {

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -1287,6 +1287,67 @@ func TestProjectAssistantAPI_CairnlineProposalAuthorityCommitsLedgerFirst(t *tes
 	}
 }
 
+func TestProjectAssistantAPI_CairnlineReplacementModeSkipsNativeProposalShadows(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
+	handler.config.Projects.CairnlineConnector = "embedded"
+	handler.config.Projects.CairnlineReadSource = "embedded"
+	handler.config.Projects.CairnlineWriteAuthority = "all-portable"
+	handler.config.Projects.CairnlineReplacementMode = "embedded"
+	client := newAPITestClient(t, server)
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", `{
+		"name":"Assistant Replacement Proposal"
+	}`)
+
+	proposed := mustRequestJSON[projectAssistantProposalResponse](client, http.MethodPost, "/hecate/v1/project-assistant/propose", projectJourneyJSON(t, map[string]any{
+		"id":      "pa_replacement_no_shadow",
+		"title":   "Create replacement work",
+		"summary": "The Project Assistant proposal ledger should not create a native compatibility shadow in replacement mode.",
+		"actions": []map[string]any{{
+			"kind":   "create_work_item",
+			"reason": "Capture the first reviewable task.",
+			"patch": map[string]any{
+				"id":         "work_replacement_no_shadow",
+				"project_id": project.Data.ID,
+				"title":      "Replacement assistant work",
+				"brief":      "Verify apply can use the Cairnline-only proposal ledger.",
+				"status":     "ready",
+			},
+		}},
+	}))
+	written := getMirroredCairnlineAssistantProposalForTest(t, handler, proposed.Data.ID)
+	if written.Status != cairnline.AssistantProposalStatusProposed || written.ProjectID != project.Data.ID {
+		t.Fatalf("Cairnline proposal = %+v, want proposed replacement-mode ledger record", written)
+	}
+	if _, ok, err := handler.projectAssistantProposals.GetProposal(t.Context(), proposed.Data.ID); err != nil || ok {
+		t.Fatalf("native proposal = ok %v err %v, want no compatibility shadow after propose", ok, err)
+	}
+
+	record := mustRequestJSON[projectAssistantProposalRecordResponse](client, http.MethodGet, "/hecate/v1/project-assistant/proposals/"+proposed.Data.ID, "")
+	if record.Data.ID != proposed.Data.ID || record.Data.ProjectID != project.Data.ID {
+		t.Fatalf("proposal record = %+v, want strict embedded Cairnline proposal", record.Data)
+	}
+	authorityRecord, ok, err := handler.projectAssistantProposalStoreForApplication().GetProposal(t.Context(), proposed.Data.ID)
+	if err != nil || !ok || authorityRecord.Fingerprint == "" {
+		t.Fatalf("authority proposal = %+v ok %v err %v, want Cairnline proposal with internal fingerprint", authorityRecord, ok, err)
+	}
+
+	applied := mustRequestJSON[projectAssistantApplyResponse](client, http.MethodPost, "/hecate/v1/project-assistant/apply", projectJourneyJSON(t, map[string]any{
+		"proposal": proposed.Data,
+		"confirm":  true,
+	}))
+	if applied.Data.Status != projectassistant.ApplyStatusApplied || !applied.Data.Applied || applied.Data.CommittedActionCount != 1 {
+		t.Fatalf("apply response = %+v, want applied Cairnline-only proposal ledger", applied.Data)
+	}
+	appliedLedger := getMirroredCairnlineAssistantProposalForTest(t, handler, proposed.Data.ID)
+	if appliedLedger.Status != cairnline.AssistantProposalStatusApplied || appliedLedger.LatestResult == nil || !appliedLedger.LatestResult.Applied || len(appliedLedger.ApplyAttempts) != 1 {
+		t.Fatalf("Cairnline applied proposal = %+v, want applied ledger result and attempt", appliedLedger)
+	}
+	if _, ok, err := handler.projectAssistantProposals.GetProposal(t.Context(), proposed.Data.ID); err != nil || ok {
+		t.Fatalf("native proposal after apply = ok %v err %v, want no compatibility shadow", ok, err)
+	}
+}
+
 func TestProjectAssistantAPI_CairnlineProposalAuthorityDoesNotBlockOnShadowUpsertFailure(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -431,7 +431,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 				projectCairnlineProjectAssignmentWriteWarning(writeAuthority),
 				projectCairnlineProjectCollaborationWriteWarning(writeAuthority),
 				projectCairnlineProjectMemoryWriteWarning(writeAuthority),
-				projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority),
+				projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority, nativeShadowSkipArmed),
 				projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority),
 				"Other project mutation routes still write only Hecate-native stores.",
 				"Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready.",
@@ -1204,6 +1204,9 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			if projectAssistantPortableEffectsAuthoritative {
 				item.Detail = "Project Assistant draft/propose/apply-attempt ledger records commit to the embedded Cairnline database first, then best-effort shadow Hecate's proposal store for compatibility; confirmed apply is mixed-authority when enabled portable actions route through Cairnline."
 			}
+			if nativeShadowSkipArmed {
+				item.Detail = "Project Assistant draft/propose/apply-attempt ledger records commit to the embedded Cairnline database first and, in armed embedded replacement mode, skip native proposal ledger compatibility rows; confirmed apply remains mixed-authority when enabled portable actions route through Cairnline."
+			}
 		}
 		if projectAssistantPortableEffectsAuthoritative && item.Name == "project-assistant-apply-side-effects" {
 			item.CurrentAuthority = "mixed"
@@ -1355,8 +1358,14 @@ func projectCairnlineProjectAssignmentWriteWarning(writeAuthority []string) stri
 	return "Project assignment create/update/delete mutations still write Hecate-native stores first, then best-effort mirror coordination metadata into Cairnline; assignment start remains Hecate-owned and best-effort mirrors committed start and linked-chat reconciliation results."
 }
 
-func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []string) string {
+func projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority []string, nativeShadowSkipArmed bool) string {
 	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectAssistantProposals) {
+		if nativeShadowSkipArmed {
+			if projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority) {
+				return "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and skip native proposal ledger compatibility rows in armed embedded replacement mode; confirmed apply is mixed-authority when enabled portable actions route through Cairnline."
+			}
+			return "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and skip native proposal ledger compatibility rows in armed embedded replacement mode; confirmed apply side effects still execute through Hecate-owned project mutation services."
+		}
 		if projectCairnlineAssistantApplyPortableEffectsAuthoritative(writeAuthority) {
 			return "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; confirmed apply is mixed-authority when enabled portable actions route through Cairnline."
 		}

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -543,6 +543,7 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 		{name: "assignments", want: "skip native project-work assignment compatibility rows"},
 		{name: "collaboration-artifacts", want: "skips native project-work artifact compatibility rows"},
 		{name: "handoffs", want: "skip native project-work handoff compatibility rows"},
+		{name: "project-assistant-proposal-ledger", want: "skip native proposal ledger compatibility rows"},
 	} {
 		point := findWriteSwitchpoint(status.WriteSwitchpoints, tc.name)
 		if point == nil || !strings.Contains(point.Detail, tc.want) {
@@ -1133,6 +1134,13 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 		if point == nil || !strings.Contains(point.Detail, tc.want) {
 			t.Fatalf("%s switchpoint = %+v, want armed replacement-mode detail containing %q", tc.name, point, tc.want)
 		}
+	}
+	warnings := strings.Join(status.Warnings, "\n")
+	if !strings.Contains(warnings, "skip native proposal ledger compatibility rows in armed embedded replacement mode") {
+		t.Fatalf("warnings = %+v, want Project Assistant proposal warning to report no native proposal shadow", status.Warnings)
+	}
+	if strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores") {
+		t.Fatalf("warnings = %+v, want no stale Project Assistant native-shadow wording", status.Warnings)
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "run-strict-embedded-read-smoke" {
 		t.Fatalf("next action = %+v, want strict embedded smoke still prioritized while mode is armed", status.NextReplacementAction)


### PR DESCRIPTION
## Summary

- skip Hecate-native Project Assistant proposal ledger compatibility shadows once embedded Cairnline replacement mode is armed
- keep the existing Cairnline-first plus best-effort native shadow behavior for ordinary opt-in proposal authority mode
- update backend status and docs so replacement mode reports the no-native-shadow proposal ledger boundary

## Validation

- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectAssistantAPI_Cairnline(ProposalAuthorityCommitsLedgerFirst|ReplacementModeSkipsNativeProposalShadows)|TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover'`
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api`
- `GOCACHE="$(pwd)/.gocache" go vet ./internal/api`
- `just agent-docs-check`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
