### PR TITLE
fix(projects): skip project row shadows in replacement mode

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -351,7 +351,8 @@ runtime side effects and migration cutover remain separate gates.
 `project-metadata-defaults` is a scoped opt-in authority slice: project
 metadata/default-only PATCHes commit portable project metadata and launch
 defaults to embedded Cairnline first, then best-effort shadow Hecate's
-compatibility project row. Project create/delete, roots, context sources,
+compatibility project row. Armed embedded replacement mode skips that native
+project-row shadow. Project create/delete, roots, context sources,
 last-opened-only updates, and mixed metadata/root/source replacement PATCHes
 remain Hecate-owned unless their separate switchpoints are enabled.
 `project-identity` is a scoped authority slice: project create/delete commits
@@ -366,10 +367,11 @@ slices: project root create/update/delete, root list replacement, root
 discovery-result replacement, context-source create/update/delete,
 context-source list replacement, and context-source discovery-result
 replacement can commit to embedded Cairnline first, then best-effort shadow
-Hecate's compatibility project row. Worktree-created root records also move
+Hecate's compatibility project row. Armed embedded replacement mode skips those
+native project-row root/source shadows. Worktree-created root records also move
 with `project-roots`, but Hecate still performs root discovery scans and Git
-worktree creation as orchestrator capabilities outside Cairnline core. In
-these authority modes, root discovery, worktree-created root record mutations,
+worktree creation as orchestrator capabilities outside Cairnline core. In these
+authority modes, root discovery, worktree-created root record mutations,
 and context-source discovery can resolve the starting project graph from
 embedded Cairnline without a matching Hecate-native project row.
 `project-collaboration` is another opt-in authority slice: collaboration

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -530,8 +530,9 @@ switchpoints is explicitly listed.
 Project metadata/default-only PATCHes also best-effort mirror after the Hecate
 store commit unless `project-metadata-defaults` is enabled, in which case those
 scoped updates commit portable metadata and launch defaults to Cairnline first
-and then shadow Hecate's compatibility project row. Project create/delete,
-roots, context sources, last-opened-only updates, and mixed metadata/root/source
+and then shadow Hecate's compatibility project row; armed embedded replacement
+mode skips that native project-row shadow. Project create/delete, roots,
+context sources, last-opened-only updates, and mixed metadata/root/source
 replacement PATCHes remain Hecate-owned unless their separate switchpoints are
 enabled.
 Project create also best-effort mirrors portable identity, initial roots,
@@ -548,7 +549,8 @@ Project root create/update/delete and root list replacement mutations also
 best-effort mirror after the Hecate store commit unless `project-roots` is
 enabled, in which case those root mutations plus discovery-result replacement
 and worktree-created root record mutations commit to Cairnline first and then
-shadow Hecate's compatibility project row. Hecate still performs the root
+shadow Hecate's compatibility project row; armed embedded replacement mode
+skips that native project-row root shadow. Hecate still performs the root
 discovery scan and Git worktree creation side effect. In root authority mode,
 discovery and worktree-created root record mutations can resolve project
 identity and roots from the embedded Cairnline graph without a Hecate-native
@@ -557,8 +559,9 @@ Context-source create/update/delete and list replacement mutations likewise
 mirror after Hecate commits unless
 `project-context-sources` is enabled, in which case those source mutations
 plus discovery-result replacement commit to Cairnline first and then shadow
-Hecate's compatibility project row. Hecate still performs the workspace scan
-for its operator UI. In source authority mode, context-source discovery can use
+Hecate's compatibility project row; armed embedded replacement mode skips that
+native project-row source shadow. Hecate still performs the workspace scan for
+its operator UI. In source authority mode, context-source discovery can use
 project identity, roots, and existing sources from the embedded Cairnline graph
 without a Hecate-native compatibility project row.
 Project skill discovery and

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -587,8 +587,9 @@ sequenceDiagram
   Hecate-owned and writes that runtime overlay before any compatibility shadow
   or replacement-evidence mirror. `project-metadata-defaults` makes project metadata/default-only
   PATCHes Cairnline-first, then shadows Hecate's compatibility project row;
-  project create/delete, roots, context sources, last-opened-only updates, and
-  mixed metadata/root/source replacement PATCHes remain Hecate-owned.
+  armed embedded replacement mode skips that native project-row shadow. Project
+  create/delete, roots, context sources, last-opened-only updates, and mixed
+  metadata/root/source replacement PATCHes remain Hecate-owned.
   `project-assistant-proposals` makes Project Assistant draft/propose/apply-attempt
   ledger records Cairnline-first, then best-effort shadows Hecate's proposal
   store for compatibility; armed embedded replacement mode skips those native
@@ -602,13 +603,15 @@ sequenceDiagram
   `project-roots` makes project root create/update/delete plus root list
   replacement plus discovery-result replacement and worktree-created root
   record mutations Cairnline-first, then shadows Hecate's compatibility project
-  row; Hecate still performs the root discovery scan and Git worktree creation
-  side effect. In root authority mode, discovery and worktree-created root
-  record mutations can resolve project identity and roots from the embedded
-  Cairnline graph without a Hecate-native compatibility project row.
+  row; armed embedded replacement mode skips that native project-row root
+  shadow. Hecate still performs the root discovery scan and Git worktree
+  creation side effect. In root authority mode, discovery and worktree-created
+  root record mutations can resolve project identity and roots from the
+  embedded Cairnline graph without a Hecate-native compatibility project row.
   `project-context-sources` makes context-source create/update/delete plus
   context-source list replacement and discovery-result replacement
-  Cairnline-first, then shadows Hecate's compatibility project row; Hecate
+  Cairnline-first, then shadows Hecate's compatibility project row; armed
+  embedded replacement mode skips that native project-row source shadow. Hecate
   still performs the workspace scan for its operator UI. In source authority
   mode, context-source discovery can use project identity, roots, and existing
   sources from the embedded Cairnline graph without a Hecate-native
@@ -2444,18 +2447,21 @@ compatibility shadow so stale shadows cannot override authoritative project/root
 metadata. Runtime hint ids from that graph remain opaque; Hecate-owned
 provider/model defaults and launch policy still come from Hecate runtime state.
 Adding `project-metadata-defaults` makes project metadata/default-only PATCHes
-Cairnline-first, then shadows Hecate's compatibility project row; project
+Cairnline-first, then shadows Hecate's compatibility project row; armed
+embedded replacement mode skips that native project-row shadow. Project
 create/delete, roots, context sources, last-opened-only updates, and mixed
 root/source replacement PATCHes remain Hecate-owned.
 Adding `project-roots` makes project root create/update/delete plus root list
 replacement, discovery-result replacement, and worktree-created root record
-mutations Cairnline-first, then shadows the compatibility project row. Hecate
-still performs the root discovery scan and Git worktree creation side effect.
-In root authority mode, discovery and worktree-created root record mutations
-can run against a Cairnline-only project graph.
+mutations Cairnline-first, then shadows the compatibility project row; armed
+embedded replacement mode skips that native project-row root shadow. Hecate
+still performs the root discovery scan and Git worktree creation side effect. In
+root authority mode, discovery and worktree-created root record mutations can
+run against a Cairnline-only project graph.
 Adding `project-context-sources` makes context-source create/update/delete plus
 context-source list replacement and discovery-result replacement
-Cairnline-first, then shadows the compatibility project row. Hecate still
+Cairnline-first, then shadows the compatibility project row; armed embedded
+replacement mode skips that native project-row source shadow. Hecate still
 performs the workspace scan for its operator UI. In source authority mode,
 context-source discovery can run against a Cairnline-only project graph.
 Adding `project-identity` makes project create/delete Cairnline-first for

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -409,9 +409,9 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 				"Only the " + projectCairnlineReadRouteList(projectCairnlineReadRouteNames) + " live read routes use Cairnline.",
 				projectCairnlineReadSourceWarning(readSource),
 				projectCairnlineProjectIdentityWriteWarning(writeAuthority),
-				projectCairnlineProjectMetadataDefaultsWriteWarning(writeAuthority),
-				projectCairnlineProjectRootWriteWarning(writeAuthority),
-				projectCairnlineProjectContextSourceWriteWarning(writeAuthority),
+				projectCairnlineProjectMetadataDefaultsWriteWarning(writeAuthority, nativeShadowSkipArmed),
+				projectCairnlineProjectRootWriteWarning(writeAuthority, nativeShadowSkipArmed),
+				projectCairnlineProjectContextSourceWriteWarning(writeAuthority, nativeShadowSkipArmed),
 				projectCairnlineProjectSkillWriteWarning(writeAuthority),
 				projectCairnlineProjectWorkItemWriteWarning(writeAuthority),
 				projectCairnlineProjectAssignmentWriteWarning(writeAuthority),
@@ -1104,6 +1104,9 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			item.BlocksAuthority = false
 			item.Gap = ""
 			item.Detail = "Project metadata/default-only update mutations commit portable project metadata and launch defaults to the embedded Cairnline database first, then best-effort shadow Hecate's compatibility row back into Hecate-native stores; project identity, roots, context sources, and mixed metadata/root/source replacement routes are controlled by separate switchpoints."
+			if nativeShadowSkipArmed {
+				item.Detail = "Project metadata/default-only update mutations commit portable project metadata and launch defaults to the embedded Cairnline database first and, in armed embedded replacement mode, skip native project-row compatibility shadows; project identity, roots, context sources, and mixed metadata/root/source replacement routes are controlled by separate switchpoints."
+			}
 		}
 		if projectRootsAuthoritative && item.Name == "roots-and-worktrees" {
 			item.CurrentAuthority = "mixed"
@@ -1112,6 +1115,9 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			item.BlocksAuthority = false
 			item.Gap = "roots"
 			item.Detail = "Project root create/update/delete, root list replacement, discovery-result replacement, and worktree-created root record mutations commit to the embedded Cairnline database first, then best-effort shadow Hecate's compatibility row; discovery and worktree-created root record mutations can resolve project identity and roots from the embedded Cairnline graph, while Hecate still performs root discovery scans and Git worktree creation side effects."
+			if nativeShadowSkipArmed {
+				item.Detail = "Project root create/update/delete, root list replacement, discovery-result replacement, and worktree-created root record mutations commit to the embedded Cairnline database first and, in armed embedded replacement mode, skip native project-row root compatibility shadows; discovery and worktree-created root record mutations can resolve project identity and roots from the embedded Cairnline graph, while Hecate still performs root discovery scans and Git worktree creation side effects."
+			}
 		}
 		if projectContextSourcesAuthoritative && item.Name == "context-sources" {
 			item.CurrentAuthority = "cairnline"
@@ -1120,6 +1126,9 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			item.BlocksAuthority = false
 			item.Gap = ""
 			item.Detail = "Context-source create/update/delete, list replacement, and discovery-result replacement mutations commit to the embedded Cairnline database first, then best-effort shadow Hecate's compatibility row; discovery can resolve project identity, roots, and existing sources from the embedded Cairnline graph, while Hecate still performs the workspace scan for its operator UI."
+			if nativeShadowSkipArmed {
+				item.Detail = "Context-source create/update/delete, list replacement, and discovery-result replacement mutations commit to the embedded Cairnline database first and, in armed embedded replacement mode, skip native project-row context-source compatibility shadows; discovery can resolve project identity, roots, and existing sources from the embedded Cairnline graph, while Hecate still performs the workspace scan for its operator UI."
+			}
 		}
 		if projectSkillsAuthoritative && item.Name == "skills" {
 			item.CurrentAuthority = "cairnline"
@@ -1265,8 +1274,11 @@ func projectCairnlineProjectCollaborationWriteWarning(writeAuthority []string) s
 	return "Project collaboration artifact creation and handoff mutations still write Hecate-native stores first, then best-effort mirror portable collaboration metadata into Cairnline."
 }
 
-func projectCairnlineProjectMetadataDefaultsWriteWarning(writeAuthority []string) string {
+func projectCairnlineProjectMetadataDefaultsWriteWarning(writeAuthority []string, nativeShadowSkipArmed bool) string {
 	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectMetadataDefaults) {
+		if nativeShadowSkipArmed {
+			return "Project metadata/default-only update mutations are opt-in Cairnline-authoritative and skip native project-row compatibility shadows in armed embedded replacement mode; project identity, roots, context sources, and mixed root/source replacement routes are controlled by separate switchpoints."
+		}
 		return "Project metadata/default-only update mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; project identity, roots, context sources, and mixed root/source replacement routes are controlled by separate switchpoints."
 	}
 	return "Project metadata/default updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata and project-defaults seams."
@@ -1279,15 +1291,21 @@ func projectCairnlineProjectIdentityWriteWarning(writeAuthority []string) string
 	return "Project create/delete still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database."
 }
 
-func projectCairnlineProjectRootWriteWarning(writeAuthority []string) string {
+func projectCairnlineProjectRootWriteWarning(writeAuthority []string, nativeShadowSkipArmed bool) string {
 	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectRoots) {
+		if nativeShadowSkipArmed {
+			return "Project root create/update/delete, root list replacement, discovery-result replacement, and worktree-created root record mutations are opt-in Cairnline-authoritative and skip native project-row root compatibility shadows in armed embedded replacement mode; discovery and worktree-created root record mutations can resolve project identity and roots from the embedded Cairnline graph, while Hecate still performs root discovery scans and Git worktree creation side effects."
+		}
 		return "Project root create/update/delete, root list replacement, discovery-result replacement, and worktree-created root record mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; discovery and worktree-created root record mutations can resolve project identity and roots from the embedded Cairnline graph, while Hecate still performs root discovery scans and Git worktree creation side effects."
 	}
 	return "Root create/update/delete, root list replacement, root discovery, and worktree-created root record mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's root-level API; Hecate owns the Git worktree creation side effect."
 }
 
-func projectCairnlineProjectContextSourceWriteWarning(writeAuthority []string) string {
+func projectCairnlineProjectContextSourceWriteWarning(writeAuthority []string, nativeShadowSkipArmed bool) string {
 	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectContextSources) {
+		if nativeShadowSkipArmed {
+			return "Context-source create/update/delete, list replacement, and discovery-result replacement mutations are opt-in Cairnline-authoritative and skip native project-row context-source compatibility shadows in armed embedded replacement mode; discovery can resolve project identity, roots, and existing sources from the embedded Cairnline graph, while Hecate still performs the workspace scan for its operator UI."
+		}
 		return "Context-source create/update/delete, list replacement, and discovery-result replacement mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; discovery can resolve project identity, roots, and existing sources from the embedded Cairnline graph, while Hecate still performs the workspace scan for its operator UI."
 	}
 	return "Direct context-source create/update/delete, context-source list replacement, and discovery mutations still write Hecate-native stores first, then best-effort mirror through Cairnline's source-level API."

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -1096,6 +1096,9 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 		want string
 	}{
 		{name: "project-identity", want: "skips native project identity compatibility rows"},
+		{name: "project-metadata-defaults", want: "skip native project-row compatibility shadows"},
+		{name: "roots-and-worktrees", want: "skip native project-row root compatibility shadows"},
+		{name: "context-sources", want: "skip native project-row context-source compatibility shadows"},
 		{name: "skills", want: "skip native project-skill compatibility rows"},
 		{name: "roles", want: "skip native project-work role compatibility rows"},
 		{name: "work-items", want: "skip native project-work item compatibility rows"},
@@ -1109,6 +1112,15 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 		}
 	}
 	warnings := strings.Join(status.Warnings, "\n")
+	for _, want := range []string{
+		"skip native project-row compatibility shadows in armed embedded replacement mode",
+		"skip native project-row root compatibility shadows in armed embedded replacement mode",
+		"skip native project-row context-source compatibility shadows in armed embedded replacement mode",
+	} {
+		if !strings.Contains(warnings, want) {
+			t.Fatalf("warnings = %+v, want warning containing %q", status.Warnings, want)
+		}
+	}
 	if !strings.Contains(warnings, "skip native proposal ledger compatibility rows in armed embedded replacement mode") {
 		t.Fatalf("warnings = %+v, want Project Assistant proposal warning to report no native proposal shadow", status.Warnings)
 	}

--- a/internal/api/handler_project_metadata_authority.go
+++ b/internal/api/handler_project_metadata_authority.go
@@ -176,6 +176,9 @@ func (h *Handler) shadowProjectMetadataDefaultsToHecate(ctx context.Context, ope
 	if h == nil || h.projects == nil {
 		return project, false
 	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		return project, false
+	}
 	updated, err := h.projects.Update(ctx, project.ID, func(item *projects.Project) {
 		item.Name = project.Name
 		item.Description = project.Description

--- a/internal/api/handler_project_root_source_authority.go
+++ b/internal/api/handler_project_root_source_authority.go
@@ -590,6 +590,10 @@ func (h *Handler) shadowProjectRootsToHecate(ctx context.Context, operation stri
 		root, _ := findProjectRootByID(project.Roots, rootID)
 		return project, root
 	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		root, _ := findProjectRootByID(project.Roots, rootID)
+		return project, root
+	}
 	shadowed, err := h.projects.Update(ctx, project.ID, func(item *projects.Project) {
 		item.Roots = append([]projects.Root(nil), project.Roots...)
 		item.DefaultRootID = project.DefaultRootID
@@ -610,6 +614,10 @@ func (h *Handler) shadowProjectRootsToHecate(ctx context.Context, operation stri
 func (h *Handler) shadowProjectContextSourcesToHecate(ctx context.Context, operation string, project projects.Project, written cairnline.Project, sourceID string) (projects.Project, projects.ContextSource) {
 	project.ContextSources = projectContextSourcesFromCairnline(written.ContextSources)
 	if h == nil || h.projects == nil {
+		source, _ := findProjectContextSourceByID(project.ContextSources, sourceID)
+		return project, source
+	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
 		source, _ := findProjectContextSourceByID(project.ContextSources, sourceID)
 		return project, source
 	}
@@ -644,6 +652,9 @@ func projectFromCairnlineRootSourceListReplace(project projects.Project, written
 func (h *Handler) shadowProjectRootSourceListsToHecate(ctx context.Context, operation string, project projects.Project, written cairnline.Project, replaceRoots, replaceSources bool) (projects.Project, bool) {
 	project = projectFromCairnlineRootSourceListReplace(project, written, replaceRoots, replaceSources)
 	if h == nil || h.projects == nil {
+		return project, false
+	}
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
 		return project, false
 	}
 	shadowed, err := h.projects.Update(ctx, project.ID, func(item *projects.Project) {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -820,6 +820,109 @@ func TestProjectsAPI_CairnlineReplacementModeRejectsDuplicateNameAndRootPath(t *
 	}
 }
 
+func TestProjectsAPI_CairnlineReplacementModeSkipsNativeProjectRowShadows(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+
+	created := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", `{
+		"name":"Replacement Project Row",
+		"roots":[{"id":"root_main","path":"/workspace/replacement-row","kind":"git","git_branch":"main"}]
+	}`)
+	projectID := created.Data.ID
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:          projectID,
+		Name:        "Stale native row",
+		Description: "This compatibility row should not be refreshed.",
+		Roots: []projects.Root{{
+			ID:     "root_native",
+			Path:   "/workspace/native-row",
+			Kind:   "git",
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_native",
+			Path:    "NATIVE.md",
+			Kind:    "doc",
+			Title:   "Native",
+			Enabled: true,
+		}},
+		DefaultRootID:   "root_native",
+		DefaultProvider: "native",
+		DefaultModel:    "native-model",
+	}); err != nil {
+		t.Fatalf("seed native compatibility project row: %v", err)
+	}
+
+	updated := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID, `{
+		"name":"Replacement Project Row Updated",
+		"description":"Cairnline owns the replacement row.",
+		"default_root_id":"root_main",
+		"default_provider":"anthropic",
+		"default_model":"claude-sonnet-4-5"
+	}`)
+	if updated.Data.Name != "Replacement Project Row Updated" || updated.Data.DefaultRootID != "root_main" || updated.Data.DefaultProvider != "anthropic" {
+		t.Fatalf("metadata update response = %+v, want Cairnline-updated metadata/defaults", updated.Data)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, projectID)
+	if mirrored.Name != "Replacement Project Row Updated" || mirrored.DefaultRootID != "root_main" {
+		t.Fatalf("Cairnline project after metadata update = %+v, want updated portable row", mirrored)
+	}
+	native, ok, err := handler.projects.Get(t.Context(), projectID)
+	if err != nil || !ok {
+		t.Fatalf("native compatibility row = ok %v err %v, want seeded stale row", ok, err)
+	}
+	if native.Name != "Stale native row" || native.DefaultProvider != "native" || native.DefaultRootID != "root_native" {
+		t.Fatalf("native compatibility row after metadata update = %+v, want stale row unchanged", native)
+	}
+
+	withRoot := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roots", `{
+		"id":"root_feature",
+		"path":"/workspace/replacement-row-feature",
+		"kind":"git_worktree",
+		"git_branch":"feature/replacement-row",
+		"active":false
+	}`)
+	if findProjectResponseRootForTest(withRoot.Data.Roots, "root_feature") == nil {
+		t.Fatalf("root create response roots = %+v, want Cairnline-created root_feature", withRoot.Data.Roots)
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, projectID)
+	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_feature") == nil {
+		t.Fatalf("Cairnline roots after root create = %+v, want root_feature", mirrored.Roots)
+	}
+	native, ok, err = handler.projects.Get(t.Context(), projectID)
+	if err != nil || !ok {
+		t.Fatalf("native compatibility row after root create = ok %v err %v, want seeded stale row", ok, err)
+	}
+	if findProjectRootByIDForTest(native.Roots, "root_feature") != nil || findProjectRootByIDForTest(native.Roots, "root_native") == nil {
+		t.Fatalf("native roots after root create = %+v, want stale native roots only", native.Roots)
+	}
+
+	withSource := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/context-sources", `{
+		"id":"ctx_agents",
+		"path":"AGENTS.md",
+		"kind":"workspace_instruction",
+		"title":"AGENTS.md",
+		"format":"agents_md",
+		"scope":"workspace",
+		"trust_label":"workspace_guidance"
+	}`)
+	if findProjectResponseContextSourceForTest(withSource.Data.ContextSources, "ctx_agents") == nil {
+		t.Fatalf("source create response sources = %+v, want ctx_agents", withSource.Data.ContextSources)
+	}
+	mirrored = getMirroredCairnlineProjectForTest(t, handler, projectID)
+	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_agents") == nil {
+		t.Fatalf("Cairnline sources after source create = %+v, want ctx_agents", mirrored.ContextSources)
+	}
+	native, ok, err = handler.projects.Get(t.Context(), projectID)
+	if err != nil || !ok {
+		t.Fatalf("native compatibility row after source create = ok %v err %v, want seeded stale row", ok, err)
+	}
+	if findProjectContextSourceByIDForTest(native.ContextSources, "ctx_agents") != nil || findProjectContextSourceByIDForTest(native.ContextSources, "ctx_native") == nil {
+		t.Fatalf("native sources after source create = %+v, want stale native sources only", native.ContextSources)
+	}
+}
+
 func TestProjectsAPI_CairnlineReplacementModeWithoutPortableAuthorityKeepsNativeIdentityShadow(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{
@@ -2138,7 +2241,25 @@ func findProjectResponseRootForTest(roots []ProjectRootResponseItem, id string) 
 	return nil
 }
 
+func findProjectRootByIDForTest(roots []projects.Root, id string) *projects.Root {
+	for idx := range roots {
+		if roots[idx].ID == id {
+			return &roots[idx]
+		}
+	}
+	return nil
+}
+
 func findProjectResponseContextSourceForTest(sources []ProjectContextSourceResponseItem, id string) *ProjectContextSourceResponseItem {
+	for idx := range sources {
+		if sources[idx].ID == id {
+			return &sources[idx]
+		}
+	}
+	return nil
+}
+
+func findProjectContextSourceByIDForTest(sources []projects.ContextSource, id string) *projects.ContextSource {
 	for idx := range sources {
 		if sources[idx].ID == id {
 			return &sources[idx]


### PR DESCRIPTION
## Summary

- skip native Hecate project-row shadows for metadata/default, root, and context-source authority writes when embedded Cairnline replacement mode is armed
- keep ordinary opt-in authority mode behavior unchanged, including compatibility shadows before replacement mode is armed
- update backend-status warnings/switchpoint details and operator/runtime/design docs for the no-native-project-row shadow behavior

## Validation

- `GOCACHE="$(pwd)/.gocache" go test ./internal/api -run 'TestProjectsAPI_CairnlineReplacementModeSkipsNativeProjectRowShadows|TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed'`
- `GOCACHE="$(pwd)/.gocache" go test ./internal/api`
- `GOCACHE="$(pwd)/.gocache" go vet ./internal/api`
- `just agent-docs-check`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
