### PR TITLE
refactor: overlay hecate runtime defaults on cairnline reads

### DIFF
--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -353,9 +353,12 @@ launch agents. Those remain explicit operator or orchestrator actions.
   MCP client. Assignment-context reads consume typed sidecar
   `assignments.context` data. Launch-readiness and assignment preflight consume
   typed sidecar `assignments.launch_packet` data before applying Hecate runtime
-  validation. Other live Projects reads, writes, mirrors, and write-authority
-  switchpoints do not route through the sidecar yet; write-authority
-  switchpoints require `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`.
+  validation. When matching Hecate-native project or role runtime rows exist,
+  those sidecar reads overlay the local Hecate provider/model/tool/workspace
+  posture before validation; Cairnline runtime hint ids stay opaque. Other live
+  Projects reads, writes, mirrors, and write-authority switchpoints do not route
+  through the sidecar yet; write-authority switchpoints require
+  `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`.
 - Current Hecate embed experiments can serve project list/detail, setup
   readiness, health, skills, memory, memory candidates, roles, work items,
   assignment lists, assignment context, launch-readiness, assignment preflight,

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -465,7 +465,10 @@ remain Hecate-owned because write-authority switchpoints require
 Assignment-context reads use typed sidecar `assignments.context` data.
 Launch-readiness and assignment preflight use the typed sidecar
 `assignments.launch_packet` response as their coordination input, then apply
-Hecate runtime validation; assignment start/prepare remains Hecate-owned.
+Hecate runtime validation. If matching Hecate-native project or role runtime
+rows exist, Hecate overlays their local provider/model/tool/workspace posture
+before validating or rendering readiness; assignment start/prepare remains
+Hecate-owned.
 Work-item list/detail, assignment-list,
 artifact-list, handoff-list, activity, closeout-readiness, and operations brief
 reads render the work graph from Cairnline service records and overlay

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -6073,8 +6073,11 @@ endpoint validates the work item through typed `work_items.list` and reads
 assignments through typed `assignments.list` on the standalone Cairnline MCP
 client. Assignment context reads typed `assignments.context` sidecar data.
 Launch-readiness and assignment preflight read typed `assignments.launch_packet`
-sidecar data before applying Hecate runtime validation. Start/prepare and
-status mutation routes remain Hecate-owned.
+sidecar data before applying Hecate runtime validation. If matching
+Hecate-native project or role runtime rows exist, Hecate overlays their
+provider/model/tool/workspace settings onto the portable Cairnline coordination
+records before validation; Cairnline runtime hint ids remain opaque metadata.
+Start/prepare and status mutation routes remain Hecate-owned.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
 

--- a/internal/api/handler_chat_project_prompt_cairnline.go
+++ b/internal/api/handler_chat_project_prompt_cairnline.go
@@ -40,6 +40,10 @@ func (h *Handler) sidecarCairnlineProjectSummary(ctx context.Context, projectID 
 		return nil, true
 	}
 	project := projectFromCairnlineSidecar(item)
+	project, err = h.projectWithHecateRuntimeOverlay(ctx, project)
+	if err != nil {
+		return nil, true
+	}
 	return &project, true
 }
 
@@ -65,7 +69,11 @@ func (h *Handler) sidecarCairnlineProjectChatRoles(ctx context.Context, projectI
 	if err != nil {
 		return nil, true
 	}
-	return projectRolesFromCairnlineSidecar(roles), true
+	out, err := h.projectRolesWithHecateRuntimeOverlay(ctx, projectRolesFromCairnlineSidecar(roles))
+	if err != nil {
+		return nil, true
+	}
+	return out, true
 }
 
 func (h *Handler) strictEmbeddedCairnlineProjectChatRoles(ctx context.Context, projectID string) ([]projectwork.AgentRoleProfile, bool) {
@@ -82,8 +90,9 @@ func (h *Handler) strictEmbeddedCairnlineProjectChatRoles(ctx context.Context, p
 		return nil, true
 	}
 	out := make([]projectwork.AgentRoleProfile, 0, len(roles))
+	nativeByID := projectWorkRolesByID(view.snapshot.Roles)
 	for _, role := range roles {
-		out = append(out, projectWorkRoleFromCairnline(role, projectwork.AgentRoleProfile{}))
+		out = append(out, projectWorkRoleFromCairnline(role, nativeByID[role.ID]))
 	}
 	return out, true
 }

--- a/internal/api/handler_project_activity_cairnline.go
+++ b/internal/api/handler_project_activity_cairnline.go
@@ -77,7 +77,11 @@ func (h *Handler) renderCairnlineSidecarProjectActivity(ctx context.Context, pro
 			projectedAssignments[assignment.ID] = assignment
 		}
 	}
-	rolesByID := projectWorkRolesByID(projectRolesFromCairnlineSidecar(roleItems))
+	roles, err := h.projectRolesWithHecateRuntimeOverlay(ctx, projectRolesFromCairnlineSidecar(roleItems))
+	if err != nil {
+		return ProjectActivityDataResponse{}, err
+	}
+	rolesByID := projectWorkRolesByID(roles)
 	linkedChats := h.projectActivityLinkedChats(ctx, project.ID, assignments)
 	artifactsByAssignment, artifactsByWorkItem := groupProjectActivityArtifacts(projectArtifactsFromCairnlineSidecar(artifactItems, evidenceItems, reviewItems))
 	handoffsByAssignment, handoffsByWorkItem := groupProjectActivityHandoffs(projectHandoffsFromCairnlineSidecar(handoffItems))

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -490,6 +490,10 @@ func (h *Handler) cairnlineSidecarProjectAssignmentLaunchInputs(ctx context.Cont
 		return projectAssignmentLaunchInputs{}, newProjectAssignmentPreflightError(http.StatusNotFound, errCodeNotFound, "assignment not found")
 	}
 	nativeProject := projectFromCairnlineSidecar(projectItem)
+	nativeProject, err = h.projectWithHecateRuntimeOverlay(ctx, nativeProject)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
 	project := projectFromCairnline(launch.Project, nativeProject)
 	if len(project.Roots) == 0 {
 		project.Roots = nativeProject.Roots
@@ -500,6 +504,10 @@ func (h *Handler) cairnlineSidecarProjectAssignmentLaunchInputs(ctx context.Cont
 	workItem := projectWorkItemFromCairnline(launch.WorkItem)
 	assignment := projectWorkAssignmentFromCairnline(launch.Assignment)
 	role, roleOK := cairnlineSidecarLaunchRole(launch)
+	role, err = h.projectRoleWithHecateRuntimeOverlay(ctx, role)
+	if err != nil {
+		return projectAssignmentLaunchInputs{}, err
+	}
 	return projectAssignmentLaunchInputs{
 		Project:               project,
 		WorkItem:              workItem,

--- a/internal/api/handler_project_assignment_launch_readiness_test.go
+++ b/internal/api/handler_project_assignment_launch_readiness_test.go
@@ -207,6 +207,38 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessUsesCairnlineSidecarWhenConfigu
 	}
 }
 
+func TestProjectWorkAPI_AssignmentLaunchReadinessCairnlineSidecarOverlaysNativeRuntimeDefaults(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root")
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:                  "proj_fixture",
+		Name:                "Fixture Project",
+		DefaultProvider:     "openai",
+		DefaultModel:        "gpt-5",
+		DefaultAgentProfile: "project_fixture",
+	}); err != nil {
+		t.Fatalf("Create native project runtime overlay: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:                  "role_fixture",
+		ProjectID:           "proj_fixture",
+		Name:                "Fixture Reviewer",
+		DefaultProvider:     "anthropic",
+		DefaultModel:        "claude-sonnet-4",
+		DefaultAgentProfile: "role_fixture_preset",
+	}); err != nil {
+		t.Fatalf("Create native role runtime overlay: %v", err)
+	}
+
+	readiness := mustRequestJSON[ProjectAssignmentLaunchReadinessEnvelope](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/launch-readiness", "")
+	if readiness.Data.ReadBackend != "cairnline" || !readiness.Data.Ready || readiness.Data.Status != projectAssignmentLaunchReadinessStatusReady {
+		t.Fatalf("readiness = %+v, want ready sidecar projection with Hecate runtime overlay", readiness.Data)
+	}
+	if readiness.Data.Provider != "anthropic" || readiness.Data.Model != "claude-sonnet-4" || readiness.Data.ExecutionProfile != "profile_fixture" {
+		t.Fatalf("launch hints = provider/model/profile %q/%q/%q, want role runtime overlay plus Cairnline preset hint", readiness.Data.Provider, readiness.Data.Model, readiness.Data.ExecutionProfile)
+	}
+}
+
 func TestProjectWorkAPI_AssignmentLaunchReadinessCairnlineSidecarRequiresStructuredLaunchPacket(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineSidecarReadTestServer(t, "assignments.launch_packet-text-only")

--- a/internal/api/handler_project_assistant_cairnline.go
+++ b/internal/api/handler_project_assistant_cairnline.go
@@ -145,6 +145,10 @@ func (h *Handler) cairnlineSidecarProjectAssistantContextSeed(ctx context.Contex
 		return seed, projectassistant.ErrNotFound
 	}
 	project := projectFromCairnlineSidecar(projectItem)
+	project, err = h.projectWithHecateRuntimeOverlay(ctx, project)
+	if err != nil {
+		return seed, err
+	}
 	if project.ID != requestedProjectID {
 		return seed, projectassistant.ErrNotFound
 	}
@@ -212,7 +216,11 @@ func (h *Handler) seedCairnlineSidecarProjectAssistantWork(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	for _, role := range projectRolesFromCairnlineSidecar(roleItems) {
+	roles, err := h.projectRolesWithHecateRuntimeOverlay(ctx, projectRolesFromCairnlineSidecar(roleItems))
+	if err != nil {
+		return err
+	}
+	for _, role := range roles {
 		if projectwork.IsBuiltInRoleID(role.ID) {
 			continue
 		}

--- a/internal/api/handler_project_cairnline_sidecar_health.go
+++ b/internal/api/handler_project_cairnline_sidecar_health.go
@@ -17,6 +17,10 @@ func (h *Handler) renderCairnlineSidecarProjectHealth(ctx context.Context, proje
 		return ProjectHealthResponse{}, projects.ErrNotFound
 	}
 	project := projectFromCairnlineSidecar(projectItem)
+	project, err = h.projectWithHecateRuntimeOverlay(ctx, project)
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
 	activity, err := h.renderCairnlineSidecarProjectActivity(ctx, project.ID)
 	if err != nil {
 		return ProjectHealthResponse{}, err
@@ -71,11 +75,15 @@ func (h *Handler) renderCairnlineSidecarProjectHealth(ctx context.Context, proje
 	convertedMemoryCandidates := projectMemoryCandidatesFromCairnlineSidecar(memoryCandidates)
 	staleAssignments := projectHealthStaleAssignments(project, activity, convertedWorkItems, convertedAssignments, now)
 	summary := projectHealthSummary(project, convertedMemoryEntries, convertedMemoryCandidates, convertedHandoffs, convertedArtifacts, staleAssignments)
+	convertedRoles, err := h.projectRolesWithHecateRuntimeOverlay(ctx, projectRolesFromCairnlineSidecar(roles))
+	if err != nil {
+		return ProjectHealthResponse{}, err
+	}
 	attention := projectHealthAttentionItems(
 		project,
 		activity,
 		convertedWorkItems,
-		projectRolesFromCairnlineSidecar(roles),
+		convertedRoles,
 		convertedHandoffs,
 		convertedArtifacts,
 		convertedMemoryEntries,

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -66,7 +66,12 @@ func (h *Handler) renderCairnlineSidecarProjects(ctx context.Context) ([]Project
 	}
 	data := make([]ProjectResponseItem, 0, len(projects))
 	for _, project := range projects {
-		data = append(data, renderProjectFromCairnlineSidecar(project))
+		converted := projectFromCairnlineSidecar(project)
+		converted, err = h.projectWithHecateRuntimeOverlay(ctx, converted)
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, renderProjectWithBackend(converted, "cairnline"))
 	}
 	return data, nil
 }
@@ -79,7 +84,12 @@ func (h *Handler) renderCairnlineSidecarProject(ctx context.Context, projectID s
 	if !ok {
 		return nil, nil
 	}
-	rendered := renderProjectFromCairnlineSidecar(project)
+	converted := projectFromCairnlineSidecar(project)
+	converted, err = h.projectWithHecateRuntimeOverlay(ctx, converted)
+	if err != nil {
+		return nil, err
+	}
+	rendered := renderProjectWithBackend(converted, "cairnline")
 	return &rendered, nil
 }
 
@@ -235,11 +245,6 @@ func (h *Handler) cairnlineSidecarAssignmentContext(ctx context.Context, project
 		return cairnline.AssignmentContext{}, false, projectCairnlineSidecarReadFailure("assignments.context did not return typed structuredContent")
 	}
 	return packet, true, nil
-}
-
-func renderProjectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectItem) ProjectResponseItem {
-	converted := projectFromCairnlineSidecar(project)
-	return renderProjectWithBackend(converted, "cairnline")
 }
 
 func projectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectItem) projects.Project {

--- a/internal/api/handler_project_cairnline_sidecar_setup_readiness.go
+++ b/internal/api/handler_project_cairnline_sidecar_setup_readiness.go
@@ -17,6 +17,10 @@ func (h *Handler) renderCairnlineSidecarProjectSetupReadiness(ctx context.Contex
 		return ProjectSetupReadinessResponse{}, projects.ErrNotFound
 	}
 	project := projectFromCairnlineSidecar(projectItem)
+	project, err = h.projectWithHecateRuntimeOverlay(ctx, project)
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
 	roles, err := h.cairnlineSidecarProjectRoles(ctx, project.ID)
 	if err != nil {
 		return ProjectSetupReadinessResponse{}, err
@@ -38,10 +42,14 @@ func (h *Handler) renderCairnlineSidecarProjectSetupReadiness(ctx context.Contex
 		return ProjectSetupReadinessResponse{}, err
 	}
 
+	convertedRoles, err := h.projectRolesWithHecateRuntimeOverlay(ctx, projectRolesFromCairnlineSidecar(roles))
+	if err != nil {
+		return ProjectSetupReadinessResponse{}, err
+	}
 	summary := projectSetupReadinessSummary(
 		project,
 		projectWorkItemsFromCairnlineSidecar(workItems),
-		projectRolesFromCairnlineSidecar(roles),
+		convertedRoles,
 		projectSkillsFromCairnlineSidecar(skills),
 		projectMemoryEntriesFromCairnlineSidecar(entries),
 		projectMemoryCandidatesFromCairnlineSidecar(candidates),

--- a/internal/api/handler_project_runtime_overlay.go
+++ b/internal/api/handler_project_runtime_overlay.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"context"
+
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func (h *Handler) projectWithHecateRuntimeOverlay(ctx context.Context, project projects.Project) (projects.Project, error) {
+	if h == nil || h.projects == nil || project.ID == "" {
+		return project, nil
+	}
+	native, ok, err := h.projects.Get(ctx, project.ID)
+	if err != nil || !ok {
+		return project, err
+	}
+	return overlayProjectHecateRuntime(project, native), nil
+}
+
+func overlayProjectHecateRuntime(project, native projects.Project) projects.Project {
+	project.DefaultProvider = native.DefaultProvider
+	project.DefaultModel = native.DefaultModel
+	if project.DefaultAgentProfile == "" {
+		project.DefaultAgentProfile = native.DefaultAgentProfile
+	}
+	project.DefaultToolsEnabled = cloneBool(native.DefaultToolsEnabled)
+	project.DefaultWorkspaceMode = native.DefaultWorkspaceMode
+	project.DefaultSystemPrompt = native.DefaultSystemPrompt
+	project.DefaultCompactToolOutput = cloneBool(native.DefaultCompactToolOutput)
+	return project
+}
+
+func (h *Handler) projectRoleWithHecateRuntimeOverlay(ctx context.Context, role projectwork.AgentRoleProfile) (projectwork.AgentRoleProfile, error) {
+	if h == nil || h.projectWork == nil || role.ProjectID == "" || role.ID == "" {
+		return role, nil
+	}
+	native, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, role.ProjectID, role.ID)
+	if err != nil || !ok {
+		return role, err
+	}
+	return overlayProjectRoleHecateRuntime(role, native), nil
+}
+
+func (h *Handler) projectRolesWithHecateRuntimeOverlay(ctx context.Context, roles []projectwork.AgentRoleProfile) ([]projectwork.AgentRoleProfile, error) {
+	out := make([]projectwork.AgentRoleProfile, 0, len(roles))
+	for _, role := range roles {
+		overlaid, err := h.projectRoleWithHecateRuntimeOverlay(ctx, role)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, overlaid)
+	}
+	return out, nil
+}
+
+func overlayProjectRoleHecateRuntime(role, native projectwork.AgentRoleProfile) projectwork.AgentRoleProfile {
+	role.DefaultProvider = native.DefaultProvider
+	role.DefaultModel = native.DefaultModel
+	if role.DefaultAgentProfile == "" {
+		role.DefaultAgentProfile = native.DefaultAgentProfile
+	}
+	role.BuiltIn = native.BuiltIn
+	role.CreatedAt = native.CreatedAt
+	role.UpdatedAt = native.UpdatedAt
+	return role
+}

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -152,8 +152,12 @@ func (h *Handler) renderCairnlineSidecarProjectWorkRoles(ctx context.Context, pr
 	if err != nil {
 		return nil, err
 	}
+	convertedRoles, err := h.projectRolesWithHecateRuntimeOverlay(ctx, projectRolesFromCairnlineSidecar(roles))
+	if err != nil {
+		return nil, err
+	}
 	data := make([]ProjectWorkRoleResponse, 0, len(roles))
-	for _, role := range projectRolesFromCairnlineSidecar(roles) {
+	for _, role := range convertedRoles {
 		projected := renderProjectWorkRole(role)
 		projected.ReadBackend = "cairnline"
 		data = append(data, projected)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -2087,6 +2087,38 @@ func TestProjectWorkAPI_RolesUseCairnlineSidecarWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestProjectWorkAPI_RolesCairnlineSidecarOverlayNativeRuntimeDefaults(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full")
+	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:                  "role_fixture",
+		ProjectID:           "proj_fixture",
+		Name:                "Fixture Reviewer",
+		DefaultProvider:     "anthropic",
+		DefaultModel:        "claude-sonnet-4",
+		DefaultAgentProfile: "role_fixture_preset",
+	}); err != nil {
+		t.Fatalf("Create native role runtime overlay: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/projects/proj_fixture/roles", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("roles status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var response ProjectWorkRolesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode roles response: %v", err)
+	}
+	role := findProjectWorkRoleForTest(t, response.Data, "role_fixture")
+	if role.ReadBackend != "cairnline" || role.DefaultProvider != "anthropic" || role.DefaultModel != "claude-sonnet-4" {
+		t.Fatalf("role = %+v, want sidecar role with native Hecate runtime overlay", role)
+	}
+	if role.DefaultAgentProfile != "profile_fixture" {
+		t.Fatalf("role preset = %q, want Cairnline preset hint to remain authoritative", role.DefaultAgentProfile)
+	}
+}
+
 func TestProjectWorkAPI_StrictEmbeddedReadModelReadsRolesWithoutHecateProject(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{
@@ -3649,6 +3681,39 @@ func TestProjectWorkAPI_PreflightAssignmentUsesCairnlineSidecarLaunchPacketWhenC
 	if len(tasks) != 0 {
 		t.Fatalf("tasks = %+v, want no task created by sidecar preflight", tasks)
 	}
+}
+
+func TestProjectWorkAPI_PreflightAssignmentCairnlineSidecarOverlaysNativeRuntimeDefaults(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineSidecarReadTestServer(t, "full+temp-root")
+	if _, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:                  "proj_fixture",
+		Name:                "Fixture Project",
+		DefaultProvider:     "openai",
+		DefaultModel:        "gpt-5",
+		DefaultAgentProfile: "project_fixture",
+	}); err != nil {
+		t.Fatalf("Create native project runtime overlay: %v", err)
+	}
+	if _, err := handler.projectWork.CreateRole(t.Context(), projectwork.AgentRoleProfile{
+		ID:                  "role_fixture",
+		ProjectID:           "proj_fixture",
+		Name:                "Fixture Reviewer",
+		DefaultProvider:     "anthropic",
+		DefaultModel:        "claude-sonnet-4",
+		DefaultAgentProfile: "role_fixture_preset",
+	}); err != nil {
+		t.Fatalf("Create native role runtime overlay: %v", err)
+	}
+
+	preflight := mustRequestJSON[ChatContextPacketResponse](newAPITestClient(t, server), http.MethodGet, "/hecate/v1/projects/proj_fixture/work-items/work_fixture/assignments/asg_fixture/preflight", "")
+	if preflight.Data.ExecutionMode != chat.ExecutionModeHecateTask || preflight.Data.Provider != "anthropic" || preflight.Data.Model != "claude-sonnet-4" {
+		t.Fatalf("sidecar preflight launch shape = %q/%q/%q, want Hecate runtime overlay", preflight.Data.ExecutionMode, preflight.Data.Provider, preflight.Data.Model)
+	}
+	if preflight.Data.ExecutionProfile != "profile_fixture" {
+		t.Fatalf("sidecar preflight execution_profile = %q, want Cairnline preset hint", preflight.Data.ExecutionProfile)
+	}
+	assertCairnlineSidecarLaunchPacketEvidenceForTest(t, preflight.Data)
 }
 
 func TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHecateProject(t *testing.T) {
@@ -8274,6 +8339,38 @@ func assertCairnlineLaunchPacketEvidenceForTest(t *testing.T, packet ChatContext
 	} {
 		if item.Metadata[key] != want {
 			t.Fatalf("Cairnline launch packet metadata[%q] = %q, want %q in %+v", key, item.Metadata[key], want, item.Metadata)
+		}
+	}
+}
+
+func assertCairnlineSidecarLaunchPacketEvidenceForTest(t *testing.T, packet ChatContextPacketItem) {
+	t.Helper()
+	item := findRenderedContextItemByKind(packet, "cairnline_launch_packet")
+	if item == nil || item.Section != contextSectionRuntime || item.Included {
+		t.Fatalf("Cairnline sidecar launch packet item = %+v, want inspect-only runtime evidence", item)
+	}
+	for _, want := range []string{
+		"Ready: true",
+		"Assignment: asg_fixture",
+		"Execution mode: mcp_pull",
+		"Agent preset: profile_fixture",
+		"Runtime profile: exec_fixture",
+	} {
+		if !strings.Contains(item.Body, want) {
+			t.Fatalf("Cairnline sidecar launch packet body = %q, want %q", item.Body, want)
+		}
+	}
+	for key, want := range map[string]string{
+		"read_backend":   "cairnline",
+		"ready":          "true",
+		"project_id":     "proj_fixture",
+		"work_item_id":   "work_fixture",
+		"assignment_id":  "asg_fixture",
+		"role_id":        "role_fixture",
+		"execution_mode": "mcp_pull",
+	} {
+		if item.Metadata[key] != want {
+			t.Fatalf("Cairnline sidecar launch packet metadata[%q] = %q, want %q in %+v", key, item.Metadata[key], want, item.Metadata)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add a small Hecate runtime overlay helper for Cairnline-backed project and role projections
- apply the overlay to sidecar project/detail, roles, health, setup readiness, activity, chat prelude/context, Project Assistant seed, and assignment launch inputs
- cover sidecar launch-readiness, preflight, and role-list behavior where Cairnline coordination stays authoritative but Hecate provider/model defaults are local overlays

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-runtime-overlays/.gocache" go test ./internal/api -run 'TestProjectWorkAPI_(AssignmentLaunchReadinessCairnlineSidecar|PreflightAssignmentCairnlineSidecar|RolesCairnlineSidecar)'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-runtime-overlays/.gocache" go test ./internal/cairnlinebridge ./internal/projectworkapp ./internal/api
- just agent-docs-check
- git ls-files -z '*.md' '*.mdc' | xargs -0 /Users/chicoxyzzy/dev/hecate/hecate/ui/node_modules/.bin/oxfmt --check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-runtime-overlays/.gocache" go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate-runtime-overlays/.gocache" go test -race -timeout 10m ./...