### PR TITLE
refactor: persist project runtime defaults

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -350,9 +350,10 @@ current portable write-authority switchpoint for embedded dogfooding; Hecate
 runtime side effects and migration cutover remain separate gates.
 `project-metadata-defaults` is a scoped opt-in authority slice: project
 metadata/default-only PATCHes commit portable project metadata and launch
-defaults to embedded Cairnline first, then best-effort shadow Hecate's
-compatibility project row. Armed embedded replacement mode skips that native
-project-row shadow. Project create/delete, roots, context sources,
+defaults to embedded Cairnline first, persist Hecate-owned provider/model and
+runtime-default policy in Hecate's project runtime overlay, then best-effort
+shadow Hecate's compatibility project row. Armed embedded replacement mode
+skips that native project-row shadow. Project create/delete, roots, context sources,
 last-opened-only updates, and mixed metadata/root/source replacement PATCHes
 remain Hecate-owned unless their separate switchpoints are enabled.
 `project-identity` is a scoped authority slice: project create/delete commits
@@ -389,9 +390,10 @@ Hecate-native project row. Skill bodies are still not loaded, injected,
 executed, or treated as permissions.
 `project-roles` is a fourth opt-in authority slice: role create/update/delete
 commits to embedded Cairnline first, preserves Hecate's built-in-role
-protection, then best-effort shadows portable role defaults into Hecate-native
-project-work stores for compatibility. Deleting a custom role preserves
-historical assignments that still carry the deleted `role_id`.
+protection, persists Hecate-owned provider/model/preset defaults in Hecate's
+project runtime overlay, then best-effort shadows portable role defaults into
+Hecate-native project-work stores for compatibility. Deleting a custom role
+preserves historical assignments that still carry the deleted `role_id`.
 `project-work-items` is a fifth opt-in authority slice: work-item
 create/update/delete commits to embedded Cairnline first, preserves Hecate's
 `backlog` default and closeout-readiness gate, then best-effort shadows the

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -529,9 +529,10 @@ mutations remain Hecate-owned unless one of the other alpha write-authority
 switchpoints is explicitly listed.
 Project metadata/default-only PATCHes also best-effort mirror after the Hecate
 store commit unless `project-metadata-defaults` is enabled, in which case those
-scoped updates commit portable metadata and launch defaults to Cairnline first
-and then shadow Hecate's compatibility project row; armed embedded replacement
-mode skips that native project-row shadow. Project create/delete, roots,
+scoped updates commit portable metadata and launch defaults to Cairnline first,
+persist Hecate-owned provider/model and runtime-default policy in Hecate's
+project runtime overlay, and then shadow Hecate's compatibility project row;
+armed embedded replacement mode skips that native project-row shadow. Project create/delete, roots,
 context sources, last-opened-only updates, and mixed metadata/root/source
 replacement PATCHes remain Hecate-owned unless their separate switchpoints are
 enabled.
@@ -574,7 +575,10 @@ can use roots and context sources from the embedded Cairnline graph without a
 Hecate-native compatibility project row. Neither path loads, injects, executes,
 or grants permissions from skill bodies. Project role and work-item mutations
 likewise mirror coordination metadata after Hecate commits unless
-`project-roles` or `project-work-items` is enabled, respectively. Assignment create/update/delete
+`project-roles` or `project-work-items` is enabled, respectively. With role
+authority enabled, Hecate persists provider/model/preset defaults in the
+project runtime overlay before any optional native role compatibility shadow.
+Assignment create/update/delete
 mutations likewise mirror portable metadata after Hecate commits unless
 `project-assignments` is enabled, in which case assignment record mutations
 commit to Cairnline first and shadow back into Hecate. When these role,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -585,8 +585,12 @@ sequenceDiagram
   preserved in Hecate's separate project assignment runtime overlay even when no
   native compatibility assignment row exists. Assignment start/dispatch remains
   Hecate-owned and writes that runtime overlay before any compatibility shadow
-  or replacement-evidence mirror. `project-metadata-defaults` makes project metadata/default-only
-  PATCHes Cairnline-first, then shadows Hecate's compatibility project row;
+  or replacement-evidence mirror. Project and role provider/model/preset
+  defaults are Hecate-owned runtime defaults; Cairnline-authoritative create and
+  update paths persist them in Hecate's project runtime overlay so embedded or
+  sidecar reads do not depend on stale compatibility rows. `project-metadata-defaults`
+  makes project metadata/default-only PATCHes Cairnline-first, writes those
+  Hecate runtime defaults, then shadows Hecate's compatibility project row;
   armed embedded replacement mode skips that native project-row shadow. Project
   create/delete, roots, context sources, last-opened-only updates, and mixed
   metadata/root/source replacement PATCHes remain Hecate-owned.
@@ -801,7 +805,7 @@ POST /hecate/v1/mcp/probe
 
 Tool names come back un-namespaced — the operator wants to see what the upstream itself calls them, not the gateway's runtime alias. MCP Apps metadata is preserved when present: `_meta` is the raw upstream object, `ui_resource_uri` and `ui_visibility` are derived convenience fields, and `model_visible: false` means the tool is app-only and will not be shown to the agent-loop model. Bounded by a 10-second deadline; a stuck upstream surfaces as a 400 with the diagnostic rather than wedging the request.
 
-`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, Hecate-owned project assignment runtime overlays, plugin registry records, Agent Preset rows, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are asked to delete their native ACP session before their rows disappear. If an adapter does not support `session/delete`, Hecate falls back to `session/close` and still tears down the owned process. When SQLite or Postgres is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. It also removes the embedded Cairnline mirror database files under the Hecate data directory so replacement-readiness mirrors cannot resurrect stale project state after reset. Workspace files and external CLI auth files are not touched. The endpoint is local-only and blocked in remote runtime mode: non-loopback sockets and forwarded-client headers are rejected.
+`POST /hecate/v1/system/reset-data` resets local operator state without restarting the gateway. It deletes chat sessions, projects, project memory entries and candidates, project work-coordination rows, Hecate-owned project runtime overlays, plugin registry records, Agent Preset rows, tasks, configured providers, policy rules, and saved external-agent approval grants. Chat sessions are deleted through the normal chat-delete path first, so live external-agent sessions are asked to delete their native ACP session before their rows disappear. If an adapter does not support `session/delete`, Hecate falls back to `session/close` and still tears down the owned process. When SQLite or Postgres is configured, it then clears remaining Hecate-prefixed database table rows while preserving schemas. It also removes the embedded Cairnline mirror database files under the Hecate data directory so replacement-readiness mirrors cannot resurrect stale project state after reset. Workspace files and external CLI auth files are not touched. The endpoint is local-only and blocked in remote runtime mode: non-loopback sockets and forwarded-client headers are rejected.
 
 ```json
 → 200
@@ -2356,7 +2360,7 @@ POST /hecate/v1/projects/proj_.../context-sources/discover
 
 Deletes the project catalog entry, its roots, and chat sessions scoped to that
 project. It also deletes project memory entries, memory candidates, project
-work-coordination rows, and Hecate-owned assignment runtime overlay rows for
+work-coordination rows, and Hecate-owned project runtime overlay rows for
 that project. Project-scoped External Agent chats are deleted through
 the normal chat-delete path, so Hecate asks the adapter to delete the native ACP
 session where supported. This does not delete workspace files. Unprojected
@@ -2446,9 +2450,14 @@ helpers prefer the embedded Cairnline project graph over any Hecate-native
 compatibility shadow so stale shadows cannot override authoritative project/root
 metadata. Runtime hint ids from that graph remain opaque; Hecate-owned
 provider/model defaults and launch policy still come from Hecate runtime state.
+Cairnline-authoritative project and role writes persist those Hecate runtime
+defaults in the project runtime overlay before any optional compatibility row
+shadow, and Cairnline read projections prefer that overlay before falling back
+to older native compatibility rows.
 Adding `project-metadata-defaults` makes project metadata/default-only PATCHes
-Cairnline-first, then shadows Hecate's compatibility project row; armed
-embedded replacement mode skips that native project-row shadow. Project
+Cairnline-first, writes Hecate runtime defaults, then shadows Hecate's
+compatibility project row; armed embedded replacement mode skips that native
+project-row shadow. Project
 create/delete, roots, context sources, last-opened-only updates, and mixed
 root/source replacement PATCHes remain Hecate-owned.
 Adding `project-roots` makes project root create/update/delete plus root list
@@ -2686,8 +2695,11 @@ opaque host-owned hints; it does not seed Hecate preset rows or preset-derived
 runtime posture into Cairnline.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-roles,project-work-items`
 makes role and work-item create/update/delete Cairnline-first and then shadows
-Hecate-native compatibility rows. When the embedded Cairnline graph already
-contains the project, those authority routes do not require a matching
+Hecate-native compatibility rows. Role authority stores Hecate-owned
+provider/model/preset defaults in the project runtime overlay before any
+optional native role shadow, because Cairnline role records carry only portable
+coordination intent and opaque host hints. When the embedded Cairnline graph
+already contains the project, those authority routes do not require a matching
 Hecate-native project row; Hecate's project-work rows remain a best-effort
 compatibility shadow. In armed embedded replacement mode with all portable write
 authority closed, these routes skip native project-work compatibility rows and

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -456,6 +456,12 @@ func (h *Handler) cairnlineProjectAssignmentLaunchInputs(ctx context.Context, pr
 	if err != nil {
 		return projectAssignmentLaunchInputs{}, err
 	}
+	if roleOK {
+		role, err = h.projectRoleWithHecateRuntimeOverlay(ctx, role)
+		if err != nil {
+			return projectAssignmentLaunchInputs{}, err
+		}
+	}
 	return projectAssignmentLaunchInputs{
 		Project:    project,
 		WorkItem:   workItem,

--- a/internal/api/handler_project_identity_authority.go
+++ b/internal/api/handler_project_identity_authority.go
@@ -62,6 +62,9 @@ func (h *Handler) createProjectWithCairnlineAuthority(ctx context.Context, proje
 		return projects.Project{}, err
 	}
 	shadow := projectFromCairnlineProjectCreate(project, written)
+	if err := h.upsertProjectRuntimeDefaults(ctx, shadow); err != nil {
+		return projects.Project{}, err
+	}
 	if h.projectCairnlineEmbeddedReplacementModeArmed() {
 		return shadow, nil
 	}

--- a/internal/api/handler_project_metadata_authority.go
+++ b/internal/api/handler_project_metadata_authority.go
@@ -31,6 +31,11 @@ func (h *Handler) updateProjectMetadataDefaultsWithCairnlineAuthority(ctx contex
 	if err != nil {
 		return projects.Project{}, err
 	}
+	if overlaid, err := h.projectWithHecateRuntimeOverlay(ctx, project); err != nil {
+		return projects.Project{}, err
+	} else {
+		project = overlaid
+	}
 	applyProjectMetadataDefaultsUpdate(&project, req)
 	if err := validateProjectDefaultRoot(project.DefaultRootID, project.Roots); err != nil {
 		return projects.Project{}, errors.Join(projects.ErrInvalid, err)
@@ -56,6 +61,9 @@ func (h *Handler) updateProjectMetadataDefaultsWithCairnlineAuthority(ctx contex
 		return nil
 	})
 	if err != nil {
+		return projects.Project{}, err
+	}
+	if err := h.upsertProjectRuntimeDefaults(ctx, project); err != nil {
 		return projects.Project{}, err
 	}
 	if shadowed, ok := h.shadowProjectMetadataDefaultsToHecate(ctx, "project_metadata_defaults_cairnline_authority_update", project); ok {

--- a/internal/api/handler_project_role_authority.go
+++ b/internal/api/handler_project_role_authority.go
@@ -62,6 +62,9 @@ func (h *Handler) createProjectWorkRoleWithCairnlineAuthority(ctx context.Contex
 	if err != nil {
 		return projectwork.AgentRoleProfile{}, err
 	}
+	if err := h.upsertProjectRoleRuntimeDefaults(ctx, created); err != nil {
+		return projectwork.AgentRoleProfile{}, err
+	}
 	if shadowed, ok := h.shadowProjectRoleToHecate(ctx, "project_role_cairnline_authority_create", created); ok {
 		created = shadowed
 	}
@@ -86,7 +89,8 @@ func (h *Handler) updateProjectWorkRoleWithCairnlineAuthority(ctx context.Contex
 		if err != nil {
 			return err
 		}
-		role, err := h.projectWorkRoleFromCairnlineAuthority(ctx, service, existing, projectwork.AgentRoleProfile{})
+		role := projectWorkRoleFromCairnline(existing, projectwork.AgentRoleProfile{})
+		role, err = h.projectRoleWithHecateRuntimeOverlay(ctx, role)
 		if err != nil {
 			return err
 		}
@@ -103,6 +107,9 @@ func (h *Handler) updateProjectWorkRoleWithCairnlineAuthority(ctx context.Contex
 		return err
 	})
 	if err != nil {
+		return projectwork.AgentRoleProfile{}, err
+	}
+	if err := h.upsertProjectRoleRuntimeDefaults(ctx, updated); err != nil {
 		return projectwork.AgentRoleProfile{}, err
 	}
 	if shadowed, ok := h.shadowProjectRoleToHecate(ctx, "project_role_cairnline_authority_update", updated); ok {
@@ -127,6 +134,9 @@ func (h *Handler) deleteProjectWorkRoleWithCairnlineAuthority(ctx context.Contex
 		}
 		return cairnlinebridge.DeleteRole(ctx, service, deleted)
 	}); err != nil {
+		return err
+	}
+	if err := h.deleteProjectRoleRuntimeDefaults(ctx, projectID, roleID); err != nil {
 		return err
 	}
 	h.shadowProjectRoleDeleteToHecate(ctx, "project_role_cairnline_authority_delete", projectID, roleID)

--- a/internal/api/handler_project_runtime_overlay.go
+++ b/internal/api/handler_project_runtime_overlay.go
@@ -2,13 +2,28 @@ package api
 
 import (
 	"context"
+	"errors"
+	"strings"
 
+	"github.com/hecatehq/hecate/internal/projectruntime"
 	"github.com/hecatehq/hecate/internal/projects"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
 func (h *Handler) projectWithHecateRuntimeOverlay(ctx context.Context, project projects.Project) (projects.Project, error) {
-	if h == nil || h.projects == nil || project.ID == "" {
+	if h == nil || project.ID == "" {
+		return project, nil
+	}
+	if h.projectRuntime != nil {
+		defaults, ok, err := h.projectRuntime.GetProjectDefaults(ctx, project.ID)
+		if err != nil {
+			return project, err
+		}
+		if ok {
+			return overlayProjectRuntimeDefaults(project, defaults), nil
+		}
+	}
+	if h.projects == nil {
 		return project, nil
 	}
 	native, ok, err := h.projects.Get(ctx, project.ID)
@@ -31,8 +46,33 @@ func overlayProjectHecateRuntime(project, native projects.Project) projects.Proj
 	return project
 }
 
+func overlayProjectRuntimeDefaults(project projects.Project, defaults projectruntime.ProjectDefaults) projects.Project {
+	project.DefaultProvider = defaults.DefaultProvider
+	project.DefaultModel = defaults.DefaultModel
+	if project.DefaultAgentProfile == "" {
+		project.DefaultAgentProfile = defaults.DefaultAgentProfile
+	}
+	project.DefaultToolsEnabled = cloneBool(defaults.DefaultToolsEnabled)
+	project.DefaultWorkspaceMode = defaults.DefaultWorkspaceMode
+	project.DefaultSystemPrompt = defaults.DefaultSystemPrompt
+	project.DefaultCompactToolOutput = cloneBool(defaults.DefaultCompactToolOutput)
+	return project
+}
+
 func (h *Handler) projectRoleWithHecateRuntimeOverlay(ctx context.Context, role projectwork.AgentRoleProfile) (projectwork.AgentRoleProfile, error) {
-	if h == nil || h.projectWork == nil || role.ProjectID == "" || role.ID == "" {
+	if h == nil || role.ProjectID == "" || role.ID == "" {
+		return role, nil
+	}
+	if h.projectRuntime != nil {
+		defaults, ok, err := h.projectRuntime.GetRoleDefaults(ctx, role.ProjectID, role.ID)
+		if err != nil {
+			return role, err
+		}
+		if ok {
+			return overlayProjectRoleRuntimeDefaults(role, defaults), nil
+		}
+	}
+	if h.projectWork == nil {
 		return role, nil
 	}
 	native, ok, err := h.loadProjectWorkRoleForCairnlineMirror(ctx, role.ProjectID, role.ID)
@@ -54,6 +94,15 @@ func (h *Handler) projectRolesWithHecateRuntimeOverlay(ctx context.Context, role
 	return out, nil
 }
 
+func overlayProjectRoleRuntimeDefaults(role projectwork.AgentRoleProfile, defaults projectruntime.RoleDefaults) projectwork.AgentRoleProfile {
+	role.DefaultProvider = defaults.DefaultProvider
+	role.DefaultModel = defaults.DefaultModel
+	if role.DefaultAgentProfile == "" {
+		role.DefaultAgentProfile = defaults.DefaultAgentProfile
+	}
+	return role
+}
+
 func overlayProjectRoleHecateRuntime(role, native projectwork.AgentRoleProfile) projectwork.AgentRoleProfile {
 	role.DefaultProvider = native.DefaultProvider
 	role.DefaultModel = native.DefaultModel
@@ -64,4 +113,82 @@ func overlayProjectRoleHecateRuntime(role, native projectwork.AgentRoleProfile) 
 	role.CreatedAt = native.CreatedAt
 	role.UpdatedAt = native.UpdatedAt
 	return role
+}
+
+func projectRuntimeDefaultsFromProject(project projects.Project) projectruntime.ProjectDefaults {
+	return projectruntime.ProjectDefaults{
+		ProjectID:                project.ID,
+		DefaultProvider:          project.DefaultProvider,
+		DefaultModel:             project.DefaultModel,
+		DefaultAgentProfile:      project.DefaultAgentProfile,
+		DefaultToolsEnabled:      cloneBool(project.DefaultToolsEnabled),
+		DefaultWorkspaceMode:     project.DefaultWorkspaceMode,
+		DefaultSystemPrompt:      project.DefaultSystemPrompt,
+		DefaultCompactToolOutput: cloneBool(project.DefaultCompactToolOutput),
+	}
+}
+
+func projectRuntimeDefaultsFromRole(role projectwork.AgentRoleProfile) projectruntime.RoleDefaults {
+	return projectruntime.RoleDefaults{
+		ProjectID:           role.ProjectID,
+		RoleID:              role.ID,
+		DefaultProvider:     role.DefaultProvider,
+		DefaultModel:        role.DefaultModel,
+		DefaultAgentProfile: role.DefaultAgentProfile,
+	}
+}
+
+func (h *Handler) upsertProjectRuntimeDefaults(ctx context.Context, project projects.Project) error {
+	if h == nil || h.projectRuntime == nil {
+		return nil
+	}
+	defaults := projectRuntimeDefaultsFromProject(project)
+	if !projectRuntimeDefaultsHasValues(defaults) {
+		if _, ok, err := h.projectRuntime.GetProjectDefaults(ctx, defaults.ProjectID); err != nil || !ok {
+			return err
+		}
+	}
+	_, err := h.projectRuntime.UpsertProjectDefaults(ctx, defaults)
+	return err
+}
+
+func (h *Handler) upsertProjectRoleRuntimeDefaults(ctx context.Context, role projectwork.AgentRoleProfile) error {
+	if h == nil || h.projectRuntime == nil {
+		return nil
+	}
+	defaults := projectRuntimeDefaultsFromRole(role)
+	if !projectRoleRuntimeDefaultsHasValues(defaults) {
+		if _, ok, err := h.projectRuntime.GetRoleDefaults(ctx, defaults.ProjectID, defaults.RoleID); err != nil || !ok {
+			return err
+		}
+	}
+	_, err := h.projectRuntime.UpsertRoleDefaults(ctx, defaults)
+	return err
+}
+
+func (h *Handler) deleteProjectRoleRuntimeDefaults(ctx context.Context, projectID, roleID string) error {
+	if h == nil || h.projectRuntime == nil {
+		return nil
+	}
+	err := h.projectRuntime.DeleteRoleDefaults(ctx, projectID, roleID)
+	if errors.Is(err, projectruntime.ErrNotFound) {
+		return nil
+	}
+	return err
+}
+
+func projectRuntimeDefaultsHasValues(defaults projectruntime.ProjectDefaults) bool {
+	return strings.TrimSpace(defaults.DefaultProvider) != "" ||
+		strings.TrimSpace(defaults.DefaultModel) != "" ||
+		strings.TrimSpace(defaults.DefaultAgentProfile) != "" ||
+		defaults.DefaultToolsEnabled != nil ||
+		strings.TrimSpace(defaults.DefaultWorkspaceMode) != "" ||
+		strings.TrimSpace(defaults.DefaultSystemPrompt) != "" ||
+		defaults.DefaultCompactToolOutput != nil
+}
+
+func projectRoleRuntimeDefaultsHasValues(defaults projectruntime.RoleDefaults) bool {
+	return strings.TrimSpace(defaults.DefaultProvider) != "" ||
+		strings.TrimSpace(defaults.DefaultModel) != "" ||
+		strings.TrimSpace(defaults.DefaultAgentProfile) != ""
 }

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -178,7 +178,11 @@ func (h *Handler) renderCairnlineProjectWorkRoles(ctx context.Context, projectID
 	nativeByID := projectWorkRolesByID(view.snapshot.Roles)
 	data := make([]ProjectWorkRoleResponse, 0, len(roles))
 	for _, role := range roles {
-		projected := renderProjectWorkRole(projectWorkRoleFromCairnline(role, nativeByID[role.ID]))
+		converted, err := h.projectRoleWithHecateRuntimeOverlay(ctx, projectWorkRoleFromCairnline(role, nativeByID[role.ID]))
+		if err != nil {
+			return nil, err
+		}
+		projected := renderProjectWorkRole(converted)
 		projected.ReadBackend = "cairnline"
 		data = append(data, projected)
 	}
@@ -779,10 +783,15 @@ func (h *Handler) cairnlineEmbeddedProjectWorkView(ctx context.Context, projectI
 		}
 		return nil, err
 	}
+	projected, err := h.projectWithHecateRuntimeOverlay(ctx, projectFromCairnline(project, projects.Project{}))
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
 	return &cairnlineProjectWorkView{
 		service: service,
 		snapshot: cairnlinebridge.Snapshot{
-			Project: projectFromCairnline(project, projects.Project{}),
+			Project: projected,
 		},
 		close: store.Close,
 	}, nil

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1495,13 +1495,23 @@ func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineOnlyProject(t *test
 	handler.projectWork = nil
 
 	created := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
-		"id":                  "role_cairnline_only",
-		"name":                "Cairnline-only reviewer",
-		"default_driver_kind": projectwork.AssignmentDriverExternalAgent,
-		"skill_ids":           []string{"review"},
+		"id":                    "role_cairnline_only",
+		"name":                  "Cairnline-only reviewer",
+		"default_driver_kind":   projectwork.AssignmentDriverExternalAgent,
+		"default_provider":      "anthropic",
+		"default_model":         "claude-sonnet-4",
+		"default_agent_profile": "review",
+		"skill_ids":             []string{"review"},
 	}))
-	if created.Data.ID != "role_cairnline_only" || created.Data.ProjectID != projectID || created.Data.DefaultDriverKind != projectwork.AssignmentDriverExternalAgent {
+	if created.Data.ID != "role_cairnline_only" || created.Data.ProjectID != projectID || created.Data.DefaultDriverKind != projectwork.AssignmentDriverExternalAgent || created.Data.DefaultProvider != "anthropic" || created.Data.DefaultModel != "claude-sonnet-4" {
 		t.Fatalf("created role response = %+v, want Cairnline-only project role", created.Data)
+	}
+	roleDefaults, ok, err := handler.projectRuntime.GetRoleDefaults(t.Context(), projectID, "role_cairnline_only")
+	if err != nil || !ok {
+		t.Fatalf("role runtime defaults ok=%v err=%v, want Hecate role defaults", ok, err)
+	}
+	if roleDefaults.DefaultProvider != "anthropic" || roleDefaults.DefaultModel != "claude-sonnet-4" || roleDefaults.DefaultAgentProfile != "review" {
+		t.Fatalf("role runtime defaults = %+v, want provider/model/profile overlay", roleDefaults)
 	}
 	mirroredRole := getMirroredCairnlineRoleForTest(t, handler, projectID, "role_cairnline_only")
 	if mirroredRole.Name != "Cairnline-only reviewer" || mirroredRole.DefaultExecutionMode != cairnline.ExecutionExternalAdapter {
@@ -1518,9 +1528,15 @@ func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineOnlyProject(t *test
 	if updated.Data.Name != "Updated Cairnline-only reviewer" || !containsString(updated.Data.SkillIDs, "qa") {
 		t.Fatalf("updated role response = %+v, want edited Cairnline-only role", updated.Data)
 	}
+	if updated.Data.DefaultProvider != "anthropic" || updated.Data.DefaultModel != "claude-sonnet-4" || updated.Data.DefaultAgentProfile != "review" {
+		t.Fatalf("updated role defaults = provider/model/profile %q/%q/%q, want preserved Hecate runtime defaults", updated.Data.DefaultProvider, updated.Data.DefaultModel, updated.Data.DefaultAgentProfile)
+	}
 	client.mustRequestStatus(http.StatusNoContent, http.MethodDelete, "/hecate/v1/projects/"+projectID+"/roles/role_cairnline_only", "")
 	if role := mirroredCairnlineRoleForTest(t, handler, projectID, "role_cairnline_only"); role != nil {
 		t.Fatalf("deleted Cairnline-only role = %+v, want missing", role)
+	}
+	if _, ok, err := handler.projectRuntime.GetRoleDefaults(t.Context(), projectID, "role_cairnline_only"); err != nil || ok {
+		t.Fatalf("role runtime defaults after delete ok=%v err=%v, want removed", ok, err)
 	}
 }
 

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -822,7 +822,11 @@ func (h *Handler) renderCairnlineProject(ctx context.Context, native projects.Pr
 }
 
 func (h *Handler) renderCairnlineProjectFromService(ctx context.Context, service *cairnline.Service, project cairnline.Project, native projects.Project) (ProjectResponseItem, error) {
-	rendered := renderProject(projectFromCairnline(project, native))
+	projected, err := h.projectWithHecateRuntimeOverlay(ctx, projectFromCairnline(project, native))
+	if err != nil {
+		return ProjectResponseItem{}, err
+	}
+	rendered := renderProject(projected)
 	rendered.ReadBackend = "cairnline"
 	return rendered, nil
 }

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -875,6 +875,27 @@ func TestProjectsAPI_CairnlineReplacementModeSkipsNativeProjectRowShadows(t *tes
 	if native.Name != "Stale native row" || native.DefaultProvider != "native" || native.DefaultRootID != "root_native" {
 		t.Fatalf("native compatibility row after metadata update = %+v, want stale row unchanged", native)
 	}
+	runtimeDefaults, ok, err := handler.projectRuntime.GetProjectDefaults(t.Context(), projectID)
+	if err != nil || !ok {
+		t.Fatalf("project runtime defaults ok=%v err=%v, want Hecate runtime defaults", ok, err)
+	}
+	if runtimeDefaults.DefaultProvider != "anthropic" || runtimeDefaults.DefaultModel != "claude-sonnet-4-5" {
+		t.Fatalf("project runtime defaults = %+v, want provider/model runtime overlay", runtimeDefaults)
+	}
+
+	renamed := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+projectID, `{
+		"description":"Rename without changing runtime defaults."
+	}`)
+	if renamed.Data.DefaultProvider != "anthropic" || renamed.Data.DefaultModel != "claude-sonnet-4-5" {
+		t.Fatalf("metadata-only update defaults = provider/model %q/%q, want preserved runtime overlay", renamed.Data.DefaultProvider, renamed.Data.DefaultModel)
+	}
+	runtimeDefaults, ok, err = handler.projectRuntime.GetProjectDefaults(t.Context(), projectID)
+	if err != nil || !ok {
+		t.Fatalf("project runtime defaults after metadata-only update ok=%v err=%v, want preserved defaults", ok, err)
+	}
+	if runtimeDefaults.DefaultProvider != "anthropic" || runtimeDefaults.DefaultModel != "claude-sonnet-4-5" {
+		t.Fatalf("project runtime defaults after metadata-only update = %+v, want preserved provider/model", runtimeDefaults)
+	}
 
 	withRoot := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roots", `{
 		"id":"root_feature",

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -171,7 +171,7 @@ func TestProjectJourneyAPI_DiscoverStartInspectAndHandoff(t *testing.T) {
 	}
 }
 
-func TestProjectJourneyAPI_CairnlineReplacementModeBlocksTaskStartWithoutNativeRuntimeDefaults(t *testing.T) {
+func TestProjectJourneyAPI_CairnlineReplacementModeStartsTaskWithRuntimeDefaultsOverlay(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
 	client := newAPITestClient(t, server)
@@ -246,26 +246,23 @@ func TestProjectJourneyAPI_CairnlineReplacementModeBlocksTaskStartWithoutNativeR
 	}
 	assertNoNativeProjectWorkAssignmentForJourney(t, handler, projectID, "work_replacement", "asgn_replacement")
 
-	blocked := mustRequestJSONStatus[projectWorkErrorResponse](client, http.StatusUnprocessableEntity, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments/asgn_replacement/start", `{}`)
-	if blocked.Error.Type != errCodeModelNotConfigured {
-		t.Fatalf("blocked start = %+v, want model_not_configured without native Hecate runtime defaults", blocked.Error)
-	}
-	if tasks, err := handler.taskStore.ListTasks(t.Context(), taskstateFilterAll()); err != nil || len(tasks) != 0 {
-		t.Fatalf("tasks = %+v err=%v, want no Hecate task without runtime defaults", tasks, err)
+	started := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_replacement/assignments/asgn_replacement/start", `{}`)
+	if started.Data.ExecutionRef.TaskID == "" || started.Data.ExecutionRef.RunID == "" {
+		t.Fatalf("started assignment = %+v, want Hecate task/run from runtime defaults overlay", started.Data)
 	}
 	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
-		t.Fatalf("Hecate project store ok=%v err=%v after blocked start, want no native project identity row", ok, err)
+		t.Fatalf("Hecate project store ok=%v err=%v after start, want no native project identity row", ok, err)
 	}
 	mirrored := getMirroredCairnlineAssignmentForTest(t, handler, projectID, "asgn_replacement")
-	if mirrored.Status != projectwork.AssignmentStatusQueued || mirrored.ExecutionRef != "" || mirrored.ContextSnapshotID != "" {
-		t.Fatalf("mirrored Cairnline assignment = %+v, want queued without runtime refs after blocked start", mirrored)
+	if mirrored.ExecutionRef == "" || mirrored.ContextSnapshotID == "" || mirrored.ClaimedBy != "hecate" {
+		t.Fatalf("mirrored Cairnline assignment = %+v, want claimed replacement runtime refs after start", mirrored)
 	}
 	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_replacement")
 	if err != nil || !ok {
-		t.Fatalf("Hecate runtime overlay ok=%v err=%v after assignment create, want queued runtime shell", ok, err)
+		t.Fatalf("Hecate runtime overlay ok=%v err=%v after assignment start, want runtime refs", ok, err)
 	}
-	if runtime.ExecutionRef.TaskID != "" || runtime.ExecutionRef.RunID != "" || runtime.ExecutionRef.ContextSnapshotID != "" {
-		t.Fatalf("Hecate runtime overlay = %+v, want no task/run/context refs after blocked start", runtime.ExecutionRef)
+	if runtime.ExecutionRef.TaskID == "" || runtime.ExecutionRef.RunID == "" || runtime.ExecutionRef.ContextSnapshotID == "" {
+		t.Fatalf("Hecate runtime overlay = %+v, want task/run/context refs after start", runtime.ExecutionRef)
 	}
 	assertNoNativeProjectWorkAssignmentForJourney(t, handler, projectID, "work_replacement", "asgn_replacement")
 

--- a/internal/projectruntime/sqlite.go
+++ b/internal/projectruntime/sqlite.go
@@ -14,9 +14,11 @@ import (
 )
 
 type SQLiteStore struct {
-	client  storage.SQLClient
-	backend string
-	table   string
+	client               storage.SQLClient
+	backend              string
+	table                string
+	projectDefaultsTable string
+	roleDefaultsTable    string
 }
 
 func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLiteStore, error) {
@@ -32,9 +34,11 @@ func newSQLStore(ctx context.Context, client storage.SQLClient) (*SQLiteStore, e
 		return nil, errors.New("sql client is required")
 	}
 	store := &SQLiteStore{
-		client:  client,
-		backend: client.Backend(),
-		table:   client.QualifiedTable("project_assignment_runtime"),
+		client:               client,
+		backend:              client.Backend(),
+		table:                client.QualifiedTable("project_assignment_runtime"),
+		projectDefaultsTable: client.QualifiedTable("project_runtime_defaults"),
+		roleDefaultsTable:    client.QualifiedTable("project_role_runtime_defaults"),
 	}
 	if err := store.migrate(ctx); err != nil {
 		return nil, err
@@ -46,7 +50,7 @@ func (s *SQLiteStore) Backend() string { return s.backend }
 
 func (s *SQLiteStore) migrate(ctx context.Context) error {
 	timestampColumn := storage.TimestampColumnDefaultZero(s.client)
-	_, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`
+	if _, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`
 CREATE TABLE IF NOT EXISTS %s (
 	project_id TEXT NOT NULL,
 	assignment_id TEXT NOT NULL,
@@ -56,7 +60,33 @@ CREATE TABLE IF NOT EXISTS %s (
 	completed_at %s,
 	updated_at %s,
 	PRIMARY KEY(project_id, assignment_id)
-)`, s.table, timestampColumn, timestampColumn, timestampColumn))
+)`, s.table, timestampColumn, timestampColumn, timestampColumn)); err != nil {
+		return err
+	}
+	if _, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	project_id TEXT NOT NULL PRIMARY KEY,
+	default_provider TEXT NOT NULL DEFAULT '',
+	default_model TEXT NOT NULL DEFAULT '',
+	default_agent_profile TEXT NOT NULL DEFAULT '',
+	default_tools_enabled TEXT NOT NULL DEFAULT '',
+	default_workspace_mode TEXT NOT NULL DEFAULT '',
+	default_system_prompt TEXT NOT NULL DEFAULT '',
+	default_compact_tool_output TEXT NOT NULL DEFAULT '',
+	updated_at %s
+)`, s.projectDefaultsTable, timestampColumn)); err != nil {
+		return err
+	}
+	_, err := s.client.DB().ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	project_id TEXT NOT NULL,
+	role_id TEXT NOT NULL,
+	default_provider TEXT NOT NULL DEFAULT '',
+	default_model TEXT NOT NULL DEFAULT '',
+	default_agent_profile TEXT NOT NULL DEFAULT '',
+	updated_at %s,
+	PRIMARY KEY(project_id, role_id)
+)`, s.roleDefaultsTable, timestampColumn))
 	return err
 }
 
@@ -127,16 +157,167 @@ func (s *SQLiteStore) Delete(ctx context.Context, projectID, assignmentID string
 	return nil
 }
 
-func (s *SQLiteStore) DeleteProject(ctx context.Context, projectID string) (int, error) {
-	res, err := s.client.DB().ExecContext(ctx, `DELETE FROM `+s.table+` WHERE project_id = ?`, strings.TrimSpace(projectID))
+func (s *SQLiteStore) GetProjectDefaults(ctx context.Context, projectID string) (ProjectDefaults, bool, error) {
+	row := s.client.DB().QueryRowContext(ctx, selectProjectDefaultsSQL(s.projectDefaultsTable)+` WHERE project_id = ?`, strings.TrimSpace(projectID))
+	defaults, err := scanProjectDefaults(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ProjectDefaults{}, false, nil
+	}
 	if err != nil {
-		return 0, err
+		return ProjectDefaults{}, false, err
+	}
+	return cloneProjectDefaults(defaults), true, nil
+}
+
+func (s *SQLiteStore) UpsertProjectDefaults(ctx context.Context, defaults ProjectDefaults) (ProjectDefaults, error) {
+	defaults = normalizeProjectDefaults(defaults, time.Now().UTC())
+	if err := validateProjectDefaults(defaults); err != nil {
+		return ProjectDefaults{}, err
+	}
+	_, err := s.client.DB().ExecContext(ctx, `
+INSERT INTO `+s.projectDefaultsTable+` (
+	project_id, default_provider, default_model, default_agent_profile, default_tools_enabled,
+	default_workspace_mode, default_system_prompt, default_compact_tool_output, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id) DO UPDATE SET
+	default_provider = excluded.default_provider,
+	default_model = excluded.default_model,
+	default_agent_profile = excluded.default_agent_profile,
+	default_tools_enabled = excluded.default_tools_enabled,
+	default_workspace_mode = excluded.default_workspace_mode,
+	default_system_prompt = excluded.default_system_prompt,
+	default_compact_tool_output = excluded.default_compact_tool_output,
+	updated_at = excluded.updated_at`,
+		defaults.ProjectID,
+		defaults.DefaultProvider,
+		defaults.DefaultModel,
+		defaults.DefaultAgentProfile,
+		formatRuntimeBoolPtr(defaults.DefaultToolsEnabled),
+		defaults.DefaultWorkspaceMode,
+		defaults.DefaultSystemPrompt,
+		formatRuntimeBoolPtr(defaults.DefaultCompactToolOutput),
+		formatRuntimeTime(defaults.UpdatedAt),
+	)
+	if err != nil {
+		return ProjectDefaults{}, err
+	}
+	stored, ok, err := s.GetProjectDefaults(ctx, defaults.ProjectID)
+	if err != nil {
+		return ProjectDefaults{}, err
+	}
+	if !ok {
+		return ProjectDefaults{}, ErrNotFound
+	}
+	return stored, nil
+}
+
+func (s *SQLiteStore) DeleteProjectDefaults(ctx context.Context, projectID string) error {
+	res, err := s.client.DB().ExecContext(ctx, `DELETE FROM `+s.projectDefaultsTable+` WHERE project_id = ?`, strings.TrimSpace(projectID))
+	if err != nil {
+		return err
 	}
 	deleted, err := res.RowsAffected()
 	if err != nil {
+		return err
+	}
+	if deleted == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetRoleDefaults(ctx context.Context, projectID, roleID string) (RoleDefaults, bool, error) {
+	row := s.client.DB().QueryRowContext(ctx, selectRoleDefaultsSQL(s.roleDefaultsTable)+` WHERE project_id = ? AND role_id = ?`, strings.TrimSpace(projectID), strings.TrimSpace(roleID))
+	defaults, err := scanRoleDefaults(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return RoleDefaults{}, false, nil
+	}
+	if err != nil {
+		return RoleDefaults{}, false, err
+	}
+	return cloneRoleDefaults(defaults), true, nil
+}
+
+func (s *SQLiteStore) UpsertRoleDefaults(ctx context.Context, defaults RoleDefaults) (RoleDefaults, error) {
+	defaults = normalizeRoleDefaults(defaults, time.Now().UTC())
+	if err := validateRoleDefaults(defaults); err != nil {
+		return RoleDefaults{}, err
+	}
+	_, err := s.client.DB().ExecContext(ctx, `
+INSERT INTO `+s.roleDefaultsTable+` (
+	project_id, role_id, default_provider, default_model, default_agent_profile, updated_at
+) VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id, role_id) DO UPDATE SET
+	default_provider = excluded.default_provider,
+	default_model = excluded.default_model,
+	default_agent_profile = excluded.default_agent_profile,
+	updated_at = excluded.updated_at`,
+		defaults.ProjectID,
+		defaults.RoleID,
+		defaults.DefaultProvider,
+		defaults.DefaultModel,
+		defaults.DefaultAgentProfile,
+		formatRuntimeTime(defaults.UpdatedAt),
+	)
+	if err != nil {
+		return RoleDefaults{}, err
+	}
+	stored, ok, err := s.GetRoleDefaults(ctx, defaults.ProjectID, defaults.RoleID)
+	if err != nil {
+		return RoleDefaults{}, err
+	}
+	if !ok {
+		return RoleDefaults{}, ErrNotFound
+	}
+	return stored, nil
+}
+
+func (s *SQLiteStore) DeleteRoleDefaults(ctx context.Context, projectID, roleID string) error {
+	res, err := s.client.DB().ExecContext(ctx, `DELETE FROM `+s.roleDefaultsTable+` WHERE project_id = ? AND role_id = ?`, strings.TrimSpace(projectID), strings.TrimSpace(roleID))
+	if err != nil {
+		return err
+	}
+	deleted, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if deleted == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteProject(ctx context.Context, projectID string) (int, error) {
+	projectID = strings.TrimSpace(projectID)
+	deleted := 0
+	res, err := s.client.DB().ExecContext(ctx, `DELETE FROM `+s.table+` WHERE project_id = ?`, projectID)
+	if err != nil {
 		return 0, err
 	}
-	return int(deleted), nil
+	count, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	deleted += int(count)
+	res, err = s.client.DB().ExecContext(ctx, `DELETE FROM `+s.projectDefaultsTable+` WHERE project_id = ?`, projectID)
+	if err != nil {
+		return 0, err
+	}
+	count, err = res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	deleted += int(count)
+	res, err = s.client.DB().ExecContext(ctx, `DELETE FROM `+s.roleDefaultsTable+` WHERE project_id = ?`, projectID)
+	if err != nil {
+		return 0, err
+	}
+	count, err = res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	deleted += int(count)
+	return deleted, nil
 }
 
 func (s *SQLiteStore) Clear(ctx context.Context) (int, error) {
@@ -144,15 +325,43 @@ func (s *SQLiteStore) Clear(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	deleted, err := res.RowsAffected()
+	deleted := 0
+	count, err := res.RowsAffected()
 	if err != nil {
 		return 0, err
 	}
-	return int(deleted), nil
+	deleted += int(count)
+	res, err = s.client.DB().ExecContext(ctx, `DELETE FROM `+s.projectDefaultsTable)
+	if err != nil {
+		return 0, err
+	}
+	count, err = res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	deleted += int(count)
+	res, err = s.client.DB().ExecContext(ctx, `DELETE FROM `+s.roleDefaultsTable)
+	if err != nil {
+		return 0, err
+	}
+	count, err = res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	deleted += int(count)
+	return deleted, nil
 }
 
 func selectRuntimeSQL(table string) string {
 	return `SELECT project_id, assignment_id, execution_ref, context_packet, started_at, completed_at, updated_at FROM ` + table
+}
+
+func selectProjectDefaultsSQL(table string) string {
+	return `SELECT project_id, default_provider, default_model, default_agent_profile, default_tools_enabled, default_workspace_mode, default_system_prompt, default_compact_tool_output, updated_at FROM ` + table
+}
+
+func selectRoleDefaultsSQL(table string) string {
+	return `SELECT project_id, role_id, default_provider, default_model, default_agent_profile, updated_at FROM ` + table
 }
 
 type scanner interface {
@@ -181,6 +390,55 @@ func scanRuntime(row scanner) (AssignmentRuntime, error) {
 		return AssignmentRuntime{}, err
 	}
 	return cloneRuntime(runtime), nil
+}
+
+func scanProjectDefaults(row scanner) (ProjectDefaults, error) {
+	var defaults ProjectDefaults
+	var toolsEnabled, compactToolOutput, updatedAt string
+	if err := row.Scan(
+		&defaults.ProjectID,
+		&defaults.DefaultProvider,
+		&defaults.DefaultModel,
+		&defaults.DefaultAgentProfile,
+		&toolsEnabled,
+		&defaults.DefaultWorkspaceMode,
+		&defaults.DefaultSystemPrompt,
+		&compactToolOutput,
+		&updatedAt,
+	); err != nil {
+		return ProjectDefaults{}, err
+	}
+	var err error
+	if defaults.DefaultToolsEnabled, err = parseRuntimeBoolPtr(toolsEnabled); err != nil {
+		return ProjectDefaults{}, err
+	}
+	if defaults.DefaultCompactToolOutput, err = parseRuntimeBoolPtr(compactToolOutput); err != nil {
+		return ProjectDefaults{}, err
+	}
+	if defaults.UpdatedAt, err = parseRuntimeTime(updatedAt); err != nil {
+		return ProjectDefaults{}, err
+	}
+	return cloneProjectDefaults(defaults), nil
+}
+
+func scanRoleDefaults(row scanner) (RoleDefaults, error) {
+	var defaults RoleDefaults
+	var updatedAt string
+	if err := row.Scan(
+		&defaults.ProjectID,
+		&defaults.RoleID,
+		&defaults.DefaultProvider,
+		&defaults.DefaultModel,
+		&defaults.DefaultAgentProfile,
+		&updatedAt,
+	); err != nil {
+		return RoleDefaults{}, err
+	}
+	var err error
+	if defaults.UpdatedAt, err = parseRuntimeTime(updatedAt); err != nil {
+		return RoleDefaults{}, err
+	}
+	return cloneRoleDefaults(defaults), nil
 }
 
 func encodeRuntimeExecutionRef(ref projectwork.AssignmentExecutionRef) (string, error) {
@@ -221,4 +479,29 @@ func parseRuntimeTime(value string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return parsed.UTC(), nil
+}
+
+func formatRuntimeBoolPtr(value *bool) string {
+	if value == nil {
+		return ""
+	}
+	if *value {
+		return "true"
+	}
+	return "false"
+}
+
+func parseRuntimeBoolPtr(value string) (*bool, error) {
+	switch strings.TrimSpace(value) {
+	case "":
+		return nil, nil
+	case "true":
+		result := true
+		return &result, nil
+	case "false":
+		result := false
+		return &result, nil
+	default:
+		return nil, fmt.Errorf("%w: invalid bool value %q", ErrInvalid, value)
+	}
 }

--- a/internal/projectruntime/store.go
+++ b/internal/projectruntime/store.go
@@ -26,22 +26,55 @@ type AssignmentRuntime struct {
 	UpdatedAt     time.Time
 }
 
+type ProjectDefaults struct {
+	ProjectID                string
+	DefaultProvider          string
+	DefaultModel             string
+	DefaultAgentProfile      string
+	DefaultToolsEnabled      *bool
+	DefaultWorkspaceMode     string
+	DefaultSystemPrompt      string
+	DefaultCompactToolOutput *bool
+	UpdatedAt                time.Time
+}
+
+type RoleDefaults struct {
+	ProjectID           string
+	RoleID              string
+	DefaultProvider     string
+	DefaultModel        string
+	DefaultAgentProfile string
+	UpdatedAt           time.Time
+}
+
 type Store interface {
 	Backend() string
 	Get(ctx context.Context, projectID, assignmentID string) (AssignmentRuntime, bool, error)
 	Upsert(ctx context.Context, runtime AssignmentRuntime) (AssignmentRuntime, error)
 	Delete(ctx context.Context, projectID, assignmentID string) error
+	GetProjectDefaults(ctx context.Context, projectID string) (ProjectDefaults, bool, error)
+	UpsertProjectDefaults(ctx context.Context, defaults ProjectDefaults) (ProjectDefaults, error)
+	DeleteProjectDefaults(ctx context.Context, projectID string) error
+	GetRoleDefaults(ctx context.Context, projectID, roleID string) (RoleDefaults, bool, error)
+	UpsertRoleDefaults(ctx context.Context, defaults RoleDefaults) (RoleDefaults, error)
+	DeleteRoleDefaults(ctx context.Context, projectID, roleID string) error
 	DeleteProject(ctx context.Context, projectID string) (int, error)
 	Clear(ctx context.Context) (int, error)
 }
 
 type MemoryStore struct {
-	mu       sync.Mutex
-	runtimes map[string]AssignmentRuntime
+	mu              sync.Mutex
+	runtimes        map[string]AssignmentRuntime
+	projectDefaults map[string]ProjectDefaults
+	roleDefaults    map[string]RoleDefaults
 }
 
 func NewMemoryStore() *MemoryStore {
-	return &MemoryStore{runtimes: make(map[string]AssignmentRuntime)}
+	return &MemoryStore{
+		runtimes:        make(map[string]AssignmentRuntime),
+		projectDefaults: make(map[string]ProjectDefaults),
+		roleDefaults:    make(map[string]RoleDefaults),
+	}
 }
 
 func (s *MemoryStore) Backend() string { return "memory" }
@@ -78,6 +111,70 @@ func (s *MemoryStore) Delete(_ context.Context, projectID, assignmentID string) 
 	return nil
 }
 
+func (s *MemoryStore) GetProjectDefaults(_ context.Context, projectID string) (ProjectDefaults, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defaults, ok := s.projectDefaults[projectDefaultsKey(projectID)]
+	if !ok {
+		return ProjectDefaults{}, false, nil
+	}
+	return cloneProjectDefaults(defaults), true, nil
+}
+
+func (s *MemoryStore) UpsertProjectDefaults(_ context.Context, defaults ProjectDefaults) (ProjectDefaults, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defaults = normalizeProjectDefaults(defaults, time.Now().UTC())
+	if err := validateProjectDefaults(defaults); err != nil {
+		return ProjectDefaults{}, err
+	}
+	s.projectDefaults[projectDefaultsKey(defaults.ProjectID)] = cloneProjectDefaults(defaults)
+	return cloneProjectDefaults(defaults), nil
+}
+
+func (s *MemoryStore) DeleteProjectDefaults(_ context.Context, projectID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := projectDefaultsKey(projectID)
+	if _, ok := s.projectDefaults[key]; !ok {
+		return ErrNotFound
+	}
+	delete(s.projectDefaults, key)
+	return nil
+}
+
+func (s *MemoryStore) GetRoleDefaults(_ context.Context, projectID, roleID string) (RoleDefaults, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defaults, ok := s.roleDefaults[roleDefaultsKey(projectID, roleID)]
+	if !ok {
+		return RoleDefaults{}, false, nil
+	}
+	return cloneRoleDefaults(defaults), true, nil
+}
+
+func (s *MemoryStore) UpsertRoleDefaults(_ context.Context, defaults RoleDefaults) (RoleDefaults, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defaults = normalizeRoleDefaults(defaults, time.Now().UTC())
+	if err := validateRoleDefaults(defaults); err != nil {
+		return RoleDefaults{}, err
+	}
+	s.roleDefaults[roleDefaultsKey(defaults.ProjectID, defaults.RoleID)] = cloneRoleDefaults(defaults)
+	return cloneRoleDefaults(defaults), nil
+}
+
+func (s *MemoryStore) DeleteRoleDefaults(_ context.Context, projectID, roleID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := roleDefaultsKey(projectID, roleID)
+	if _, ok := s.roleDefaults[key]; !ok {
+		return ErrNotFound
+	}
+	delete(s.roleDefaults, key)
+	return nil
+}
+
 func (s *MemoryStore) DeleteProject(_ context.Context, projectID string) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -90,14 +187,27 @@ func (s *MemoryStore) DeleteProject(_ context.Context, projectID string) (int, e
 		delete(s.runtimes, key)
 		deleted++
 	}
+	if _, ok := s.projectDefaults[projectDefaultsKey(projectID)]; ok {
+		delete(s.projectDefaults, projectDefaultsKey(projectID))
+		deleted++
+	}
+	for key, defaults := range s.roleDefaults {
+		if defaults.ProjectID != projectID {
+			continue
+		}
+		delete(s.roleDefaults, key)
+		deleted++
+	}
 	return deleted, nil
 }
 
 func (s *MemoryStore) Clear(context.Context) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	deleted := len(s.runtimes)
+	deleted := len(s.runtimes) + len(s.projectDefaults) + len(s.roleDefaults)
 	s.runtimes = make(map[string]AssignmentRuntime)
+	s.projectDefaults = make(map[string]ProjectDefaults)
+	s.roleDefaults = make(map[string]RoleDefaults)
 	return deleted, nil
 }
 
@@ -152,13 +262,77 @@ func validateRuntime(runtime AssignmentRuntime) error {
 	return nil
 }
 
+func normalizeProjectDefaults(defaults ProjectDefaults, now time.Time) ProjectDefaults {
+	defaults.ProjectID = strings.TrimSpace(defaults.ProjectID)
+	defaults.DefaultProvider = strings.TrimSpace(defaults.DefaultProvider)
+	defaults.DefaultModel = strings.TrimSpace(defaults.DefaultModel)
+	defaults.DefaultAgentProfile = strings.TrimSpace(defaults.DefaultAgentProfile)
+	defaults.DefaultToolsEnabled = cloneBoolPtr(defaults.DefaultToolsEnabled)
+	defaults.DefaultWorkspaceMode = strings.TrimSpace(defaults.DefaultWorkspaceMode)
+	defaults.DefaultSystemPrompt = strings.TrimSpace(defaults.DefaultSystemPrompt)
+	defaults.DefaultCompactToolOutput = cloneBoolPtr(defaults.DefaultCompactToolOutput)
+	defaults.UpdatedAt = normalizeTime(defaults.UpdatedAt)
+	if defaults.UpdatedAt.IsZero() {
+		defaults.UpdatedAt = normalizeTime(now)
+	}
+	return defaults
+}
+
+func validateProjectDefaults(defaults ProjectDefaults) error {
+	if strings.TrimSpace(defaults.ProjectID) == "" {
+		return fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	return nil
+}
+
+func normalizeRoleDefaults(defaults RoleDefaults, now time.Time) RoleDefaults {
+	defaults.ProjectID = strings.TrimSpace(defaults.ProjectID)
+	defaults.RoleID = strings.TrimSpace(defaults.RoleID)
+	defaults.DefaultProvider = strings.TrimSpace(defaults.DefaultProvider)
+	defaults.DefaultModel = strings.TrimSpace(defaults.DefaultModel)
+	defaults.DefaultAgentProfile = strings.TrimSpace(defaults.DefaultAgentProfile)
+	defaults.UpdatedAt = normalizeTime(defaults.UpdatedAt)
+	if defaults.UpdatedAt.IsZero() {
+		defaults.UpdatedAt = normalizeTime(now)
+	}
+	return defaults
+}
+
+func validateRoleDefaults(defaults RoleDefaults) error {
+	if strings.TrimSpace(defaults.ProjectID) == "" {
+		return fmt.Errorf("%w: project_id is required", ErrInvalid)
+	}
+	if strings.TrimSpace(defaults.RoleID) == "" {
+		return fmt.Errorf("%w: role_id is required", ErrInvalid)
+	}
+	return nil
+}
+
 func cloneRuntime(runtime AssignmentRuntime) AssignmentRuntime {
 	runtime.ContextPacket = append([]byte(nil), runtime.ContextPacket...)
 	return runtime
 }
 
+func cloneProjectDefaults(defaults ProjectDefaults) ProjectDefaults {
+	defaults.DefaultToolsEnabled = cloneBoolPtr(defaults.DefaultToolsEnabled)
+	defaults.DefaultCompactToolOutput = cloneBoolPtr(defaults.DefaultCompactToolOutput)
+	return defaults
+}
+
+func cloneRoleDefaults(defaults RoleDefaults) RoleDefaults {
+	return defaults
+}
+
 func runtimeKey(projectID, assignmentID string) string {
 	return strings.TrimSpace(projectID) + "\x00" + strings.TrimSpace(assignmentID)
+}
+
+func projectDefaultsKey(projectID string) string {
+	return strings.TrimSpace(projectID)
+}
+
+func roleDefaultsKey(projectID, roleID string) string {
+	return strings.TrimSpace(projectID) + "\x00" + strings.TrimSpace(roleID)
 }
 
 func normalizeTime(value time.Time) time.Time {
@@ -166,4 +340,12 @@ func normalizeTime(value time.Time) time.Time {
 		return time.Time{}
 	}
 	return value.UTC()
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }

--- a/internal/projectruntime/store_test.go
+++ b/internal/projectruntime/store_test.go
@@ -125,6 +125,117 @@ func TestStoreConformance_AssignmentRuntimeLifecycle(t *testing.T) {
 	}
 }
 
+func TestStoreConformance_RuntimeDefaultsLifecycle(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		new  func(*testing.T) Store
+	}{
+		{name: "memory", new: func(t *testing.T) Store { return NewMemoryStore() }},
+		{name: "sqlite", new: func(t *testing.T) Store { return newSQLiteTestStore(t) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := tc.new(t)
+			toolsEnabled := false
+			compactOutput := true
+
+			projectDefaults, err := store.UpsertProjectDefaults(ctx, ProjectDefaults{
+				ProjectID:                " proj_alpha ",
+				DefaultProvider:          " openai ",
+				DefaultModel:             " gpt-5 ",
+				DefaultAgentProfile:      " implementation ",
+				DefaultToolsEnabled:      &toolsEnabled,
+				DefaultWorkspaceMode:     " worktree ",
+				DefaultSystemPrompt:      " Stay crisp. ",
+				DefaultCompactToolOutput: &compactOutput,
+			})
+			if err != nil {
+				t.Fatalf("UpsertProjectDefaults() error = %v", err)
+			}
+			if projectDefaults.ProjectID != "proj_alpha" || projectDefaults.DefaultProvider != "openai" || projectDefaults.DefaultModel != "gpt-5" || projectDefaults.DefaultWorkspaceMode != "worktree" || projectDefaults.DefaultSystemPrompt != "Stay crisp." {
+				t.Fatalf("project defaults = %+v, want normalized runtime defaults", projectDefaults)
+			}
+			if projectDefaults.DefaultToolsEnabled == nil || *projectDefaults.DefaultToolsEnabled || projectDefaults.DefaultCompactToolOutput == nil || !*projectDefaults.DefaultCompactToolOutput {
+				t.Fatalf("project bool defaults = tools %v compact %v, want false/true", projectDefaults.DefaultToolsEnabled, projectDefaults.DefaultCompactToolOutput)
+			}
+			projectDefaults.DefaultToolsEnabled = nil
+			gotProjectDefaults, ok, err := store.GetProjectDefaults(ctx, "proj_alpha")
+			if err != nil || !ok {
+				t.Fatalf("GetProjectDefaults() ok=%v error=%v, want defaults", ok, err)
+			}
+			if gotProjectDefaults.DefaultToolsEnabled == nil || *gotProjectDefaults.DefaultToolsEnabled {
+				t.Fatalf("stored project defaults mutated to %+v", gotProjectDefaults.DefaultToolsEnabled)
+			}
+
+			roleDefaults, err := store.UpsertRoleDefaults(ctx, RoleDefaults{
+				ProjectID:           " proj_alpha ",
+				RoleID:              " role_impl ",
+				DefaultProvider:     " anthropic ",
+				DefaultModel:        " claude-sonnet-4 ",
+				DefaultAgentProfile: " architecture ",
+			})
+			if err != nil {
+				t.Fatalf("UpsertRoleDefaults() error = %v", err)
+			}
+			if roleDefaults.ProjectID != "proj_alpha" || roleDefaults.RoleID != "role_impl" || roleDefaults.DefaultProvider != "anthropic" || roleDefaults.DefaultModel != "claude-sonnet-4" {
+				t.Fatalf("role defaults = %+v, want normalized role runtime defaults", roleDefaults)
+			}
+			if _, ok, err := store.GetRoleDefaults(ctx, "proj_alpha", "role_impl"); err != nil || !ok {
+				t.Fatalf("GetRoleDefaults() ok=%v error=%v, want defaults", ok, err)
+			}
+
+			if _, err := store.UpsertProjectDefaults(ctx, ProjectDefaults{}); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("UpsertProjectDefaults(missing project) error = %v, want ErrInvalid", err)
+			}
+			if _, err := store.UpsertRoleDefaults(ctx, RoleDefaults{ProjectID: "proj_alpha"}); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("UpsertRoleDefaults(missing role) error = %v, want ErrInvalid", err)
+			}
+
+			if err := store.DeleteRoleDefaults(ctx, "proj_alpha", "role_impl"); err != nil {
+				t.Fatalf("DeleteRoleDefaults() error = %v", err)
+			}
+			if _, ok, err := store.GetRoleDefaults(ctx, "proj_alpha", "role_impl"); err != nil || ok {
+				t.Fatalf("GetRoleDefaults(deleted) ok=%v error=%v, want not found", ok, err)
+			}
+			if err := store.DeleteRoleDefaults(ctx, "proj_alpha", "role_impl"); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("DeleteRoleDefaults(missing) error = %v, want ErrNotFound", err)
+			}
+
+			if _, err := store.UpsertRoleDefaults(ctx, RoleDefaults{ProjectID: "proj_alpha", RoleID: "role_one"}); err != nil {
+				t.Fatalf("UpsertRoleDefaults(one) error = %v", err)
+			}
+			if _, err := store.UpsertRoleDefaults(ctx, RoleDefaults{ProjectID: "proj_other", RoleID: "role_other"}); err != nil {
+				t.Fatalf("UpsertRoleDefaults(other) error = %v", err)
+			}
+			if _, err := store.Upsert(ctx, AssignmentRuntime{ProjectID: "proj_alpha", AssignmentID: "asgn_one"}); err != nil {
+				t.Fatalf("Upsert(runtime) error = %v", err)
+			}
+			deleted, err := store.DeleteProject(ctx, "proj_alpha")
+			if err != nil {
+				t.Fatalf("DeleteProject() error = %v", err)
+			}
+			if deleted != 3 {
+				t.Fatalf("DeleteProject() deleted = %d, want project defaults + role defaults + assignment runtime", deleted)
+			}
+			if _, ok, err := store.GetProjectDefaults(ctx, "proj_alpha"); err != nil || ok {
+				t.Fatalf("GetProjectDefaults(deleted project) ok=%v error=%v, want not found", ok, err)
+			}
+			if _, ok, err := store.GetRoleDefaults(ctx, "proj_other", "role_other"); err != nil || !ok {
+				t.Fatalf("GetRoleDefaults(other) ok=%v error=%v, want untouched", ok, err)
+			}
+			deleted, err = store.Clear(ctx)
+			if err != nil {
+				t.Fatalf("Clear() error = %v", err)
+			}
+			if deleted != 1 {
+				t.Fatalf("Clear() deleted = %d, want remaining role defaults", deleted)
+			}
+		})
+	}
+}
+
 func TestApply_OverlaysRuntimeOnAssignment(t *testing.T) {
 	assignment := projectwork.Assignment{
 		ID:          "asgn_1",


### PR DESCRIPTION
## Summary

- add Hecate-owned project and role runtime-default rows to the project runtime store
- make Cairnline read projections prefer runtime-default overlays before stale native compatibility rows
- persist project/role provider, model, and preset defaults during Cairnline-authoritative create/update paths
- update replacement-mode tests and docs for runtime defaults living outside Cairnline coordination state

## Validation

- GOCACHE="$(pwd)/.gocache" go test ./internal/projectruntime ./internal/projectworkapp ./internal/projectapp ./internal/api
- GOCACHE="$(pwd)/.gocache" go vet ./...
- just agent-docs-check
- git ls-files -z "*.md" "*.mdc" | xargs -0 ./ui/node_modules/.bin/oxfmt --check
- git diff --check
- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...
