### PR TITLE
refactor: keep runtime defaults out of cairnline

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -95,11 +95,10 @@ project/agent-preset/skills/work stores, convert that graph into Cairnline's
 versioned portable snapshot contract, then import it into a memory-backed or
 SQLite-backed Cairnline service:
 
-- project identity, roots, default root, project default Agent Preset/runtime
-  posture references, and context-source provenance metadata including format,
-  scope, source category, and trusted metadata labels;
-- Hecate-specific Agent Preset compatibility records and runtime posture
-  derived from Hecate Agent Presets and project/role defaults;
+- project identity, roots, default root, and context-source provenance metadata
+  including format, scope, source category, and trusted metadata labels;
+- Hecate-owned Agent Preset/provider/model/runtime posture stays in Hecate's
+  project runtime overlay and is not written into the portable Cairnline graph;
 - skills metadata, roles, work items, and root-scoped assignments;
 - assignment-scoped collaboration evidence links, reviews, handoffs with
   source/target refs, status-transition timestamps, and linked
@@ -349,16 +348,16 @@ Hecate-native compatibility project row before the Cairnline commit.
 current portable write-authority switchpoint for embedded dogfooding; Hecate
 runtime side effects and migration cutover remain separate gates.
 `project-metadata-defaults` is a scoped opt-in authority slice: project
-metadata/default-only PATCHes commit portable project metadata and launch
-defaults to embedded Cairnline first, persist Hecate-owned provider/model and
+metadata/default-only PATCHes commit portable project metadata and default-root
+metadata to embedded Cairnline first, persist Hecate-owned provider/model and
 runtime-default policy in Hecate's project runtime overlay, then best-effort
 shadow Hecate's compatibility project row. Armed embedded replacement mode
 skips that native project-row shadow. Project create/delete, roots, context sources,
 last-opened-only updates, and mixed metadata/root/source replacement PATCHes
 remain Hecate-owned unless their separate switchpoints are enabled.
 `project-identity` is a scoped authority slice: project create/delete commits
-portable identity, initial roots, context sources, launch defaults, and project
-identity removal to embedded Cairnline first, then best-effort shadows Hecate's
+portable identity, initial roots, context sources, default-root metadata, and
+project identity removal to embedded Cairnline first, then best-effort shadows Hecate's
 compatibility project row. Delete restores the Cairnline snapshot if Hecate
 compatibility cleanup fails. Identity delete can also target a Cairnline-only
 project graph and clean any Hecate compatibility shadow rows for that project
@@ -434,8 +433,8 @@ stricter read-side replacement-readiness probe because it verifies the live
 mirror can serve project projections directly.
 `GET /hecate/v1/projects/{id}/cairnline/parity-report` compares Hecate's
 native cockpit counts with that Cairnline read model and returns explicit
-differences for raw graph counts including execution-profile defaults,
-rendered work-item route shape including embedded assignments, collaboration
+differences for raw graph counts, rendered work-item route shape including
+embedded assignments, collaboration
 artifact/handoff route shape including artifact-kind and handoff-status counts,
 activity, rendered cockpit operations including action-kind counts, and the
 Project Assistant proposal ledger, plus portable launch-packet coverage, so
@@ -494,10 +493,10 @@ mirror to Cairnline. They can be switched to Cairnline-first authority with
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills`. Neither path loads,
 injects, or executes `SKILL.md` bodies.
 Project role and work-item create/update/delete routes also mirror coordination
-metadata into Cairnline after Hecate commits. When a mirrored role references
-an Agent Preset, Cairnline records that preset id as an opaque host hint rather
-than a portable profile row; Hecate remains responsible for resolving preset
-policy at launch. Role and work-item create/update/delete can be switched to
+metadata into Cairnline after Hecate commits. Hecate stores role-level
+provider/model/preset defaults in the project runtime overlay; Cairnline role
+records carry portable role metadata, default execution mode, and skill ids,
+not Hecate preset or runtime policy. Role and work-item create/update/delete can be switched to
 Cairnline-first authority with
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-roles,project-work-items`.
 Project skill discovery/update can be switched to Cairnline-first authority with
@@ -551,8 +550,7 @@ but they are still proofs, not the live Projects backend.
 
 The first non-authoritative write-adapter seams exist in `cairnlinebridge` for
 project identity, embedded roots, context sources, project defaults,
-project-level execution-profile cleanup, project skill metadata upserts,
-role upserts/deletes with role-level execution-profile cleanup, work-item
+project skill metadata upserts, role upserts/deletes, work-item
 upserts/deletes, assignment metadata upsert/delete plus lifecycle-status sync,
 and project memory entry/candidate upserts and deletes. Create-if-missing seams
 exist for generic collaboration artifacts, evidence links, and reviews because
@@ -691,8 +689,8 @@ after these gates are met:
   Cairnline-only project graph as the source of coordination inputs.
   Launch-readiness and preflight can inspect those inputs without native Hecate
   project/work stores, but Hecate-task launch/preflight still requires
-  Hecate-owned provider/model defaults because Cairnline runtime hint ids are
-  opaque.
+  Hecate-owned provider/model defaults from the project runtime overlay;
+  Cairnline host-hint ids, when supplied by an external sidecar, are opaque.
   Launch/preflight context also reads inspect-only collaboration artifact and
   handoff metadata from the active Cairnline read model, preserving
   evidence/review/handoff hints for Cairnline-only graphs.
@@ -878,8 +876,9 @@ Projects, roles, presets, and runtime profiles have separate jobs:
 In other words: a project can choose a default Agent Preset, a role can refine
 that preset for a responsibility, and Hecate resolves those choices into
 runtime launch behavior. Cairnline records portable coordination intent and
-legacy host hints; Hecate enforces provider/model, approval, sandbox, write,
-network, and adapter policy.
+may expose opaque host hints from external clients, but Hecate does not mirror
+its Agent Preset/runtime posture into Cairnline. Hecate enforces
+provider/model, approval, sandbox, write, network, and adapter policy.
 
 Local MCP exposure should use the same preset vocabulary rather than a separate
 taxonomy. The initial built-in MCP toolset presets are `readonly`, `operator`,

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -355,7 +355,7 @@ launch agents. Those remain explicit operator or orchestrator actions.
   typed sidecar `assignments.launch_packet` data before applying Hecate runtime
   validation. When matching Hecate-native project or role runtime rows exist,
   those sidecar reads overlay the local Hecate provider/model/tool/workspace
-  posture before validation; Cairnline runtime hint ids stay opaque. Other live
+  posture before validation; Cairnline host-hint ids stay opaque. Other live
   Projects reads, writes, mirrors, and write-authority switchpoints do not route
   through the sidecar yet; write-authority switchpoints require
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`.
@@ -459,7 +459,7 @@ launch agents. Those remain explicit operator or orchestrator actions.
   Hecate Agent Preset create/update/delete remains Hecate-owned.
   `project-identity` makes project
   create/delete commit portable identity, initial roots, context sources,
-  launch defaults, and project identity removal to Cairnline first before
+  default-root metadata, and project identity removal to Cairnline first before
   shadowing Hecate's compatibility project row. Delete restores the Cairnline
   snapshot if Hecate compatibility cleanup fails. Git worktree creation side effects,
   last-opened-only updates, mixed

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -529,7 +529,7 @@ mutations remain Hecate-owned unless one of the other alpha write-authority
 switchpoints is explicitly listed.
 Project metadata/default-only PATCHes also best-effort mirror after the Hecate
 store commit unless `project-metadata-defaults` is enabled, in which case those
-scoped updates commit portable metadata and launch defaults to Cairnline first,
+scoped updates commit portable metadata and default-root metadata to Cairnline first,
 persist Hecate-owned provider/model and runtime-default policy in Hecate's
 project runtime overlay, and then shadow Hecate's compatibility project row;
 armed embedded replacement mode skips that native project-row shadow. Project create/delete, roots,
@@ -537,7 +537,7 @@ context sources, last-opened-only updates, and mixed metadata/root/source
 replacement PATCHes remain Hecate-owned unless their separate switchpoints are
 enabled.
 Project create also best-effort mirrors portable identity, initial roots,
-context sources, and launch defaults after the Hecate store commit unless
+context sources, and default-root metadata after the Hecate store commit unless
 `project-identity` is enabled, in which case create/delete commits to Cairnline
 first and then shadows Hecate's compatibility project row. Delete restores the
 Cairnline snapshot if Hecate compatibility cleanup fails. Identity delete can

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -621,7 +621,7 @@ sequenceDiagram
   sources from the embedded Cairnline graph without a Hecate-native
   compatibility project row.
   `project-identity` makes project create/delete commit portable identity,
-  initial roots, context sources, launch defaults, and project identity removal
+  initial roots, context sources, default-root metadata, and project identity removal
   to Cairnline first, then best-effort shadows Hecate's compatibility project
   row. Delete restores the Cairnline snapshot if Hecate compatibility cleanup
   fails. All other Projects mutations remain Hecate-owned.
@@ -1866,11 +1866,11 @@ Lists projects ordered by recent activity, then update/create time.
 When `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline` and the backend status
 reports `read_model_switch_ready=true`, this endpoint renders portable project
 identity, roots, default root, and context-source metadata from the Cairnline
-read model and marks each item with `read_backend: "cairnline"`. Cairnline
-projects and roles may carry default preset ids and opaque runtime hint ids, but
-Hecate still owns provider/model interpretation, runtime profiles, adapter
-options, and launch/safety policy. Those Hecate-specific defaults are enriched
-from Hecate-native stores where available; Hecate-only timestamps such as
+read model and marks each item with `read_backend: "cairnline"`. Hecate-owned
+provider/model interpretation, Agent Presets, runtime profiles, adapter
+options, and launch/safety policy are enriched from Hecate's project runtime
+overlay or native compatibility stores where available; Hecate's bridge does
+not write those runtime defaults into Cairnline. Hecate-only timestamps such as
 `last_opened_at` remain enriched from Hecate's native project store. Create,
 update, delete, root, and context-source mutations still commit to
 Hecate-native stores first; when Cairnline is configured they also best-effort
@@ -2474,8 +2474,8 @@ replacement mode skips that native project-row source shadow. Hecate still
 performs the workspace scan for its operator UI. In source authority mode,
 context-source discovery can run against a Cairnline-only project graph.
 Adding `project-identity` makes project create/delete Cairnline-first for
-portable identity, initial roots, context sources, launch defaults, and project
-identity removal, then shadows the compatibility project row. Delete restores
+portable identity, initial roots, context sources, default-root metadata, and
+project identity removal, then shadows the compatibility project row. Delete restores
 the Cairnline snapshot if Hecate compatibility cleanup fails. Identity delete can
 also target a Cairnline-only project graph and clean any Hecate compatibility
 shadow rows for that project without requiring a matching native project row.
@@ -2640,7 +2640,7 @@ read smoke are verified, all portable write-authority gaps are closed, and
 reports the related mirror seams and whether that family still blocks portable
 write authority or remains Hecate-owned runtime behavior.
 Non-authoritative bridge seams currently cover project/root/source/defaults,
-Hecate-specific Agent Preset compatibility records, skills, roles, work items, assignment metadata upsert/delete plus
+skills, roles, work items, assignment metadata upsert/delete plus
 lifecycle-status sync, create-if-missing generic artifacts/evidence/reviews,
 handoffs, memory entries, memory candidates, Project Assistant proposal-ledger
 import, and all-project sync rehearsal. The
@@ -2649,7 +2649,7 @@ to Hecate stores first, then best-effort mirror the portable project identity
 shape into the embedded Cairnline database when Cairnline is configured.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-identity` makes project
 create/delete Cairnline-first for portable identity, initial roots, context
-sources, launch defaults, and project identity removal; delete restores the
+sources, default-root metadata, and project identity removal; delete restores the
 Cairnline snapshot if Hecate compatibility cleanup fails.
 `project-metadata-live-mirror` uses Cairnline's project-metadata seam for
 project name/description updates without replacing mirrored roots or sources;
@@ -2690,9 +2690,9 @@ write authority closed, Cairnline-authoritative skill discovery/update skips
 native project-skill compatibility rows and reads come from the active Cairnline
 read model. `project-roles-live-mirror` and
 `project-work-items-live-mirror` mirror role/work-item coordination metadata
-after Hecate commits. Role mirroring preserves referenced Agent Preset ids as
-opaque host-owned hints; it does not seed Hecate preset rows or preset-derived
-runtime posture into Cairnline.
+after Hecate commits. Role mirroring omits Hecate Agent Preset ids,
+provider/model defaults, and preset-derived runtime posture; Hecate stores
+those values in the project runtime overlay.
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-roles,project-work-items`
 makes role and work-item create/update/delete Cairnline-first and then shadows
 Hecate-native compatibility rows. Role authority stores Hecate-owned
@@ -4316,10 +4316,9 @@ Cairnline can reconstruct the portable operations brief and activity inbox from
 current Hecate state. It does not make Cairnline authoritative, does not proxy
 live Projects reads or writes, and does not migrate Hecate's stores. Agent
 Presets are Hecate runtime configuration and are excluded from the portable
-Cairnline graph; preset ids may still appear as opaque host hints on projects,
-roles, and assignments. Execution-profile counts cover only portable
-project-level and role-level launch-default records derived from Hecate
-project/role defaults.
+Cairnline graph; sidecar or legacy Cairnline records may still expose opaque
+host hints, but Hecate bridge snapshots no longer manufacture preset or
+execution-profile ids from Hecate project/role defaults.
 
 Example response:
 
@@ -4643,8 +4642,9 @@ ID differences without creating files. `match=false` means the existing mirror
 has count, record-ID, semantic-content, or launch-packet drift. Built-in
 project roles are included in the comparison because Hecate's replacement read
 model exposes them as durable portable coordination metadata. Agent Presets are
-not included as Cairnline profile rows; only opaque preset ids and
-project/role-level execution defaults participate in portable parity.
+not included as Cairnline profile rows, and Hecate's bridge does not
+manufacture opaque preset ids or execution-default records from Hecate
+project/role runtime posture.
 
 The response shape matches the sync response, except `object` is
 `project_cairnline_mirror_parity`, `database_exists` may be `false`, and
@@ -6094,7 +6094,7 @@ Launch-readiness and assignment preflight read typed `assignments.launch_packet`
 sidecar data before applying Hecate runtime validation. If matching
 Hecate-native project or role runtime rows exist, Hecate overlays their
 provider/model/tool/workspace settings onto the portable Cairnline coordination
-records before validation; Cairnline runtime hint ids remain opaque metadata.
+records before validation; Cairnline host-hint ids remain opaque metadata.
 Start/prepare and status mutation routes remain Hecate-owned.
 
 #### `POST /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments`
@@ -6294,7 +6294,7 @@ records from the Cairnline read model before applying Hecate-owned runtime
 validation. It also appends an inspect-only `runtime` /
 `cairnline_launch_packet` item. That item reports whether Cairnline can build a
 portable assignment launch packet and summarizes portable project/work/root,
-role, Hecate preset-id/runtime hints, skills, evidence, reviews,
+role, any sidecar-provided host hints, skills, evidence, reviews,
 handoffs, memory, and memory-candidate counts. It is replacement-readiness
 evidence only; Hecate still owns dispatch validation and the subsequent
 start/prepare mutation.
@@ -6303,8 +6303,8 @@ In strict embedded mode, preflight reads the launch packet directly from the
 embedded Cairnline database and does not require a matching Hecate-native
 project, work item, assignment, or role row to inspect coordination metadata.
 Hecate-task launch and preflight still require Hecate-owned provider/model
-defaults; Cairnline runtime hint ids are not interpreted as provider/model
-configuration.
+defaults from the project runtime overlay; Cairnline host-hint ids are not
+interpreted as provider/model configuration.
 
 The Projects cockpit uses this endpoint before `Start assignment`, `Prepare
 chat`, and `Start from handoff` so the operator can review the effective launch

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -1664,7 +1664,7 @@ func TestProjectAssistantAPI_CairnlineApplyProjectIdentityAuthorityDoesNotBlockO
 	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" || mirrored.Roots[0].Path != "/workspace/identity" {
 		t.Fatalf("Cairnline roots = %+v, want root_main", mirrored.Roots)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
+	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 	if _, ok, err := baseProjects.Get(t.Context(), "proj_pa_apply_project_identity_authority"); err != nil || ok {
 		t.Fatalf("shadow project ok=%v err=%v, want missing after injected shadow failure", ok, err)
 	}
@@ -1737,7 +1737,7 @@ func TestProjectAssistantAPI_CairnlineApplyProjectMetadataAuthorityDoesNotBlockO
 	if mirrored.Name != "Assistant Project Authority Updated" || mirrored.Description != "Cairnline owns this metadata update." || mirrored.DefaultRootID != "root_main" {
 		t.Fatalf("Cairnline project = %+v, want authoritative metadata/default update", mirrored)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
+	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 	native, ok, err := baseProjects.Get(t.Context(), project.ID)
 	if err != nil || !ok {
 		t.Fatalf("Get native project ok=%v err=%v", ok, err)
@@ -1875,7 +1875,7 @@ func TestProjectAssistantAPI_CairnlineApplyProjectIdentityAuthorityDoesNotRequir
 	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" || mirrored.Roots[0].Path != "/workspace/cairnline-only" {
 		t.Fatalf("Cairnline roots = %+v, want root_main", mirrored.Roots)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
+	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 
 	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/proj_pa_apply_project_identity_cairnline_only", "")
 	if project.Data.ReadBackend != "cairnline" || project.Data.ID != mirrored.ID {
@@ -1954,7 +1954,7 @@ func TestProjectAssistantAPI_CairnlineApplyProjectMetadataRootAuthorityDoesNotRe
 	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_attached") == nil || findMirroredCairnlineRootForTest(mirrored.Roots, "root_main") != nil {
 		t.Fatalf("Cairnline roots = %+v, want attached root only", mirrored.Roots)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
+	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 
 	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID, "")
 	if project.Data.ReadBackend != "cairnline" || project.Data.DefaultRootID != "root_attached" || len(project.Data.Roots) != 1 || project.Data.Roots[0].ID != "root_attached" {
@@ -2315,10 +2315,9 @@ func TestProjectAssistantAPI_ProjectSideEffectsMirrorThroughNarrowCairnlineSeams
 	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
 		t.Fatalf("mirrored sources = %+v, want Cairnline-only source preserved", mirrored.ContextSources)
 	}
-	if mirrored.DefaultRootID != "root_attached" || mirrored.DefaultProfileID != "architecture" {
-		t.Fatalf("mirrored defaults = %+v, want attached root and architecture profile", mirrored)
+	if mirrored.DefaultRootID != "root_attached" || mirrored.DefaultProfileID != "" || mirrored.DefaultExecutionProfileID != "" {
+		t.Fatalf("mirrored defaults = %+v, want attached root and omitted Hecate runtime hints", mirrored)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
 }
 
 func TestProjectAssistantAPI_DraftReviewFollowUpProposal(t *testing.T) {

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -751,7 +751,7 @@ func TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
 	if response.Data.Hecate.AgentProfiles != 0 || response.Data.Cairnline.AgentProfiles != 0 ||
 		response.Data.Hecate.ExecutionProfiles != 0 || response.Data.Cairnline.ExecutionProfiles != 0 ||
 		response.Data.Hecate.Roles == 0 || response.Data.Cairnline.Roles != response.Data.Hecate.Roles {
-		t.Fatalf("profile/role mirror counts = hecate %+v cairnline %+v, want roles mirrored with opaque runtime hints and no profile rows", response.Data.Hecate, response.Data.Cairnline)
+		t.Fatalf("profile/role mirror counts = hecate %+v cairnline %+v, want roles mirrored without profile rows or runtime hints", response.Data.Hecate, response.Data.Cairnline)
 	}
 
 	readModel := mustRequestJSONStatus[ProjectCairnlineReadModelResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID+"/cairnline/embedded-read-model", "")

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -193,7 +193,7 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 		BlocksAuthority:  true,
 		Seams:            []string{"project-roles-live-mirror"},
 		Gap:              "roles",
-		Detail:           "Role mutations still commit to Hecate first, then mirror coordination metadata and referenced Agent Preset posture into Cairnline bridge compatibility records.",
+		Detail:           "Role mutations still commit to Hecate first, then mirror portable coordination metadata into Cairnline while Agent Preset/provider/model posture stays in Hecate runtime overlays.",
 	},
 	{
 		Name:             "work-items",
@@ -1092,9 +1092,9 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			item.LiveMirror = true
 			item.BlocksAuthority = false
 			item.Gap = ""
-			item.Detail = "Project create/delete commits portable identity, roots, context sources, launch defaults, and project identity removal to the embedded Cairnline database first, then best-effort shadows Hecate's compatibility row; delete rolls the Cairnline snapshot back if Hecate compatibility cleanup fails."
+			item.Detail = "Project create/delete commits portable identity, roots, context sources, default-root metadata, and project identity removal to the embedded Cairnline database first, then best-effort shadows Hecate's compatibility row; Hecate runtime defaults stay in the project runtime overlay and delete rolls the Cairnline snapshot back if Hecate compatibility cleanup fails."
 			if nativeShadowSkipArmed {
-				item.Detail = "Project create/delete commits portable identity, roots, context sources, launch defaults, and project identity removal to the embedded Cairnline database first and, in armed embedded replacement mode, skips native project identity compatibility rows."
+				item.Detail = "Project create/delete commits portable identity, roots, context sources, default-root metadata, and project identity removal to the embedded Cairnline database first and, in armed embedded replacement mode, skips native project identity compatibility rows; Hecate runtime defaults stay in the project runtime overlay."
 			}
 		}
 		if projectMetadataDefaultsAuthoritative && item.Name == "project-metadata-defaults" {
@@ -1103,9 +1103,9 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			item.LiveMirror = true
 			item.BlocksAuthority = false
 			item.Gap = ""
-			item.Detail = "Project metadata/default-only update mutations commit portable project metadata and launch defaults to the embedded Cairnline database first, then best-effort shadow Hecate's compatibility row back into Hecate-native stores; project identity, roots, context sources, and mixed metadata/root/source replacement routes are controlled by separate switchpoints."
+			item.Detail = "Project metadata/default-only update mutations commit portable project metadata and default-root metadata to the embedded Cairnline database first, persist Hecate runtime defaults in the project runtime overlay, then best-effort shadow Hecate's compatibility row back into Hecate-native stores; project identity, roots, context sources, and mixed metadata/root/source replacement routes are controlled by separate switchpoints."
 			if nativeShadowSkipArmed {
-				item.Detail = "Project metadata/default-only update mutations commit portable project metadata and launch defaults to the embedded Cairnline database first and, in armed embedded replacement mode, skip native project-row compatibility shadows; project identity, roots, context sources, and mixed metadata/root/source replacement routes are controlled by separate switchpoints."
+				item.Detail = "Project metadata/default-only update mutations commit portable project metadata and default-root metadata to the embedded Cairnline database first, persist Hecate runtime defaults in the project runtime overlay, and, in armed embedded replacement mode, skip native project-row compatibility shadows; project identity, roots, context sources, and mixed metadata/root/source replacement routes are controlled by separate switchpoints."
 			}
 		}
 		if projectRootsAuthoritative && item.Name == "roots-and-worktrees" {

--- a/internal/api/handler_project_identity_authority.go
+++ b/internal/api/handler_project_identity_authority.go
@@ -149,7 +149,6 @@ func projectFromCairnlineProjectCreate(native projects.Project, written cairnlin
 	project.Roots = projectRootsFromCairnline(written.Roots, nil)
 	project.ContextSources = projectContextSourcesFromCairnline(written.ContextSources)
 	project.DefaultRootID = written.DefaultRootID
-	project.DefaultAgentProfile = strings.TrimSpace(written.DefaultProfileID)
 	project.CreatedAt = written.CreatedAt
 	project.UpdatedAt = written.UpdatedAt
 	return project

--- a/internal/api/handler_project_metadata_authority.go
+++ b/internal/api/handler_project_metadata_authority.go
@@ -23,7 +23,9 @@ func projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req updateProjectRequ
 	if req.Roots != nil || req.ContextSources != nil || req.LastOpenedAt != nil {
 		return false
 	}
-	return projectUpdateTouchesPortableMetadata(req) || projectUpdateTouchesPortableDefaults(req)
+	return projectUpdateTouchesPortableMetadata(req) ||
+		projectUpdateTouchesPortableDefaults(req) ||
+		projectUpdateTouchesHecateRuntimeDefaults(req)
 }
 
 func (h *Handler) updateProjectMetadataDefaultsWithCairnlineAuthority(ctx context.Context, projectID string, req updateProjectRequest) (projects.Project, error) {
@@ -44,24 +46,26 @@ func (h *Handler) updateProjectMetadataDefaultsWithCairnlineAuthority(ctx contex
 		return projects.Project{}, err
 	}
 
-	err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
-		if err := h.seedProjectMetadataDefaultsDependenciesForCairnlineAuthority(ctx, service, project); err != nil {
-			return err
-		}
-		if projectUpdateTouchesPortableMetadata(req) {
-			if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+	if projectUpdateTouchesPortableMetadata(req) || projectUpdateTouchesPortableDefaults(req) {
+		err = h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
+			if err := h.seedProjectMetadataDefaultsDependenciesForCairnlineAuthority(ctx, service, project); err != nil {
 				return err
 			}
-		}
-		if projectUpdateTouchesPortableDefaults(req) {
-			if _, err := cairnlinebridge.UpsertProjectDefaults(ctx, service, project); err != nil {
-				return err
+			if projectUpdateTouchesPortableMetadata(req) {
+				if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
+					return err
+				}
 			}
+			if projectUpdateTouchesPortableDefaults(req) {
+				if _, err := cairnlinebridge.UpsertProjectDefaults(ctx, service, project); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return projects.Project{}, err
 		}
-		return nil
-	})
-	if err != nil {
-		return projects.Project{}, err
 	}
 	if err := h.upsertProjectRuntimeDefaults(ctx, project); err != nil {
 		return projects.Project{}, err

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -903,7 +903,7 @@ func projectWorkRoleFromCairnline(item cairnline.Role, native projectwork.AgentR
 		DefaultDriverKind:   projectWorkAssignmentDriverFromCairnline(item.DefaultExecutionMode),
 		DefaultProvider:     native.DefaultProvider,
 		DefaultModel:        native.DefaultModel,
-		DefaultAgentProfile: item.DefaultProfileID,
+		DefaultAgentProfile: firstNonEmptyString(item.DefaultProfileID, native.DefaultAgentProfile),
 		SkillIDs:            append([]string(nil), item.DefaultSkillIDs...),
 		BuiltIn:             native.BuiltIn,
 		CreatedAt:           native.CreatedAt,

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1284,7 +1284,7 @@ func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineAndShadowsHecate(t 
 		t.Fatalf("created role timestamps = created:%q updated:%q, want Hecate shadow timestamps", created.Data.CreatedAt, created.Data.UpdatedAt)
 	}
 	mirroredRole := getMirroredCairnlineRoleForTest(t, handler, projectID, "role_authority")
-	if mirroredRole.Name != "Authority reviewer" || mirroredRole.DefaultProfileID != "safe_external_review" || mirroredRole.DefaultExecutionMode != cairnline.ExecutionExternalAdapter {
+	if mirroredRole.Name != "Authority reviewer" || mirroredRole.DefaultProfileID != "" || mirroredRole.DefaultExecutionProfileID != "" || mirroredRole.DefaultExecutionMode != cairnline.ExecutionExternalAdapter {
 		t.Fatalf("Cairnline role = %+v, want role authority record", mirroredRole)
 	}
 	if len(mirroredRole.DefaultSkillIDs) != 1 || mirroredRole.DefaultSkillIDs[0] != "review" {
@@ -1304,8 +1304,6 @@ func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineAndShadowsHecate(t 
 	if mirroredRole.Name != "Authority owner" || !containsString(mirroredRole.DefaultSkillIDs, "release") {
 		t.Fatalf("updated Cairnline role = %+v, want edited role authority record", mirroredRole)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirroredRole.DefaultExecutionProfileID)
-
 	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
 		"id":            "work_role_authority",
 		"title":         "Keep role history",
@@ -1840,14 +1838,12 @@ func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured
 		t.Fatalf("create role status = %d body=%s, want 201", rec.Code, rec.Body.String())
 	}
 	mirroredRole := getMirroredCairnlineRoleForTest(t, handler, project.Data.ID, "role_release")
-	if mirroredRole.Name != "Release captain" || mirroredRole.DefaultProfileID != "safe_external_review" || mirroredRole.DefaultExecutionMode != "external_adapter" {
+	if mirroredRole.Name != "Release captain" || mirroredRole.DefaultProfileID != "" || mirroredRole.DefaultExecutionProfileID != "" || mirroredRole.DefaultExecutionMode != "external_adapter" {
 		t.Fatalf("mirrored role = %+v, want release captain defaults", mirroredRole)
 	}
 	if len(mirroredRole.DefaultSkillIDs) != 1 || mirroredRole.DefaultSkillIDs[0] != "release" {
 		t.Fatalf("mirrored role skill ids = %+v, want release", mirroredRole.DefaultSkillIDs)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirroredRole.DefaultExecutionProfileID)
-
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+project.Data.ID+"/roles/role_release", bytes.NewReader([]byte(`{
 		"name":"Release owner",
@@ -1861,8 +1857,6 @@ func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured
 	if mirroredRole.Name != "Release owner" || !containsString(mirroredRole.DefaultSkillIDs, "release") || !containsString(mirroredRole.DefaultSkillIDs, "qa") {
 		t.Fatalf("mirrored updated role = %+v, want renamed role with two skills", mirroredRole)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirroredRole.DefaultExecutionProfileID)
-
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.Data.ID+"/work-items", bytes.NewReader([]byte(`{
 		"id":"work_release",
@@ -1906,7 +1900,7 @@ func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured
 		t.Fatalf("create assignment status = %d body=%s, want 201", rec.Code, rec.Body.String())
 	}
 	mirroredAssignment := getMirroredCairnlineAssignmentForTest(t, handler, project.Data.ID, "asgn_release")
-	if mirroredAssignment.Status != cairnline.AssignmentQueued || mirroredAssignment.RoleID != "role_release" || mirroredAssignment.WorkItemID != "work_release" || mirroredAssignment.ProfileID != "safe_external_review" {
+	if mirroredAssignment.Status != cairnline.AssignmentQueued || mirroredAssignment.RoleID != "role_release" || mirroredAssignment.WorkItemID != "work_release" || mirroredAssignment.ProfileID != "" || mirroredAssignment.ExecutionProfileID != "" {
 		t.Fatalf("mirrored assignment = %+v, want queued release assignment metadata", mirroredAssignment)
 	}
 	if mirroredAssignment.ExecutionMode != cairnline.ExecutionExternalAdapter || mirroredAssignment.DesiredAgent.Kind != cairnline.DesiredAgentAny || mirroredAssignment.ContextSnapshotID != "ctx_release" {
@@ -3798,8 +3792,9 @@ func TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHe
 		t.Fatalf("Hecate project store seeded ok=%v err=%v, want no project row", ok, err)
 	}
 	// Strict embedded launch-readiness and preflight are read-only Cairnline
-	// projections. Cairnline carries only opaque runtime hint IDs, so Hecate
-	// cannot launch or preflight a task without native provider/model defaults.
+	// projections. Hecate-owned runtime defaults live outside Cairnline, so
+	// Hecate cannot launch or preflight a task without local provider/model
+	// defaults.
 	handler.projects = nil
 	handler.projectWork = nil
 

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -136,6 +136,10 @@ func (h *Handler) HandleCreateProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	if err := h.upsertProjectRuntimeDefaults(r.Context(), project); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
 	h.mirrorProjectIdentityToCairnline(r.Context(), "project_create", project)
 	WriteJSON(w, http.StatusCreated, ProjectResponse{Object: "project", Data: renderProject(project)})
 }
@@ -313,6 +317,12 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	if projectUpdateTouchesHecateRuntimeDefaults(req) {
+		if err := h.upsertProjectRuntimeDefaults(r.Context(), project); err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+	}
 	if req.Roots != nil {
 		h.mirrorProjectRootListReplaceToCairnline(r.Context(), "project_roots_replace", project, project.Roots)
 	}
@@ -333,8 +343,11 @@ func projectUpdateTouchesPortableMetadata(req updateProjectRequest) bool {
 }
 
 func projectUpdateTouchesPortableDefaults(req updateProjectRequest) bool {
-	return req.DefaultRootID != nil ||
-		req.DefaultProvider != nil ||
+	return req.DefaultRootID != nil
+}
+
+func projectUpdateTouchesHecateRuntimeDefaults(req updateProjectRequest) bool {
+	return req.DefaultProvider != nil ||
 		req.DefaultModel != nil ||
 		req.DefaultAgentProfile != nil ||
 		req.DefaultToolsEnabled != nil ||

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -143,6 +143,53 @@ func newSeededProjectsTestServer(t *testing.T, cfg config.Config, project projec
 	return NewServer(quietLogger(), handler)
 }
 
+func TestProjectsAPI_ProjectUpdateSeparatesPortableAndRuntimeDefaults(t *testing.T) {
+	t.Parallel()
+
+	rootID := "root_main"
+	provider := "openai"
+	model := "gpt-5"
+	preset := "implementation"
+	toolsEnabled := false
+	workspaceMode := "worktree"
+	systemPrompt := "Use project context."
+	compactOutput := true
+
+	runtimeOnly := updateProjectRequest{
+		DefaultProvider:          &provider,
+		DefaultModel:             &model,
+		DefaultAgentProfile:      &preset,
+		DefaultToolsEnabled:      &toolsEnabled,
+		DefaultWorkspaceMode:     &workspaceMode,
+		DefaultSystemPrompt:      &systemPrompt,
+		DefaultCompactToolOutput: &compactOutput,
+	}
+	if projectUpdateTouchesPortableDefaults(runtimeOnly) {
+		t.Fatalf("runtime-only update was classified as portable defaults")
+	}
+	if !projectUpdateTouchesHecateRuntimeDefaults(runtimeOnly) {
+		t.Fatalf("runtime-only update was not classified as Hecate runtime defaults")
+	}
+	if !projectUpdateCanUseCairnlineMetadataDefaultsAuthority(runtimeOnly) {
+		t.Fatalf("runtime-only update cannot use Cairnline-authority path for Cairnline-owned projects")
+	}
+
+	portableOnly := updateProjectRequest{DefaultRootID: &rootID}
+	if !projectUpdateTouchesPortableDefaults(portableOnly) {
+		t.Fatalf("default-root update was not classified as portable defaults")
+	}
+	if projectUpdateTouchesHecateRuntimeDefaults(portableOnly) {
+		t.Fatalf("default-root update was classified as Hecate runtime defaults")
+	}
+
+	roots := []projectRootRequest{{ID: "root_next", Path: "/workspace/next"}}
+	mixedListReplacement := runtimeOnly
+	mixedListReplacement.Roots = &roots
+	if projectUpdateCanUseCairnlineMetadataDefaultsAuthority(mixedListReplacement) {
+		t.Fatalf("root list replacement with runtime defaults should use the list-replace path")
+	}
+}
+
 func TestProjectsAPI_CRUD(t *testing.T) {
 	t.Parallel()
 	server := newProjectsTestServer()
@@ -240,6 +287,66 @@ func TestProjectsAPI_CRUD(t *testing.T) {
 		deleted.Data.ProjectID != created.Data.ID ||
 		deleted.Data.ProjectName != "Renamed" {
 		t.Fatalf("delete response = %+v, want project id/name", deleted)
+	}
+}
+
+func TestProjectsAPI_HecateFirstCreateAndUpdatePersistRuntimeDefaults(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	created := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", `{
+		"name":"Runtime Defaults",
+		"default_provider":"openai",
+		"default_model":"gpt-5",
+		"default_agent_profile":"implementation",
+		"default_tools_enabled":true,
+		"default_workspace_mode":"worktree",
+		"default_system_prompt":"Use project context.",
+		"default_compact_tool_output":true
+	}`)
+	defaults, ok, err := handler.projectRuntime.GetProjectDefaults(t.Context(), created.Data.ID)
+	if err != nil || !ok {
+		t.Fatalf("project runtime defaults after create ok=%v err=%v, want stored defaults", ok, err)
+	}
+	if defaults.DefaultProvider != "openai" || defaults.DefaultModel != "gpt-5" || defaults.DefaultAgentProfile != "implementation" || defaults.DefaultWorkspaceMode != "worktree" || defaults.DefaultSystemPrompt != "Use project context." {
+		t.Fatalf("project runtime defaults after create = %+v, want created runtime defaults", defaults)
+	}
+	if defaults.DefaultToolsEnabled == nil || !*defaults.DefaultToolsEnabled || defaults.DefaultCompactToolOutput == nil || !*defaults.DefaultCompactToolOutput {
+		t.Fatalf("project runtime bool defaults after create = tools %v compact %v, want true/true", defaults.DefaultToolsEnabled, defaults.DefaultCompactToolOutput)
+	}
+
+	renamed := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, `{
+		"name":"Runtime Defaults Renamed"
+	}`)
+	if renamed.Data.DefaultProvider != "openai" || renamed.Data.DefaultModel != "gpt-5" {
+		t.Fatalf("metadata-only update response defaults = %+v, want runtime defaults preserved", renamed.Data)
+	}
+	defaults, ok, err = handler.projectRuntime.GetProjectDefaults(t.Context(), created.Data.ID)
+	if err != nil || !ok {
+		t.Fatalf("project runtime defaults after rename ok=%v err=%v, want stored defaults", ok, err)
+	}
+	if defaults.DefaultProvider != "openai" || defaults.DefaultModel != "gpt-5" || defaults.DefaultAgentProfile != "implementation" {
+		t.Fatalf("project runtime defaults after rename = %+v, want preserved defaults", defaults)
+	}
+
+	updated := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, `{
+		"default_provider":"anthropic",
+		"default_model":"claude-sonnet-4-5",
+		"default_agent_profile":"architecture",
+		"default_tools_enabled":false
+	}`)
+	if updated.Data.DefaultProvider != "anthropic" || updated.Data.DefaultModel != "claude-sonnet-4-5" || updated.Data.DefaultAgentProfile != "architecture" {
+		t.Fatalf("runtime update response defaults = %+v, want updated runtime defaults", updated.Data)
+	}
+	defaults, ok, err = handler.projectRuntime.GetProjectDefaults(t.Context(), created.Data.ID)
+	if err != nil || !ok {
+		t.Fatalf("project runtime defaults after update ok=%v err=%v, want stored defaults", ok, err)
+	}
+	if defaults.DefaultProvider != "anthropic" || defaults.DefaultModel != "claude-sonnet-4-5" || defaults.DefaultAgentProfile != "architecture" || defaults.DefaultToolsEnabled == nil || *defaults.DefaultToolsEnabled {
+		t.Fatalf("project runtime defaults after update = %+v, want updated runtime defaults", defaults)
 	}
 }
 
@@ -583,7 +690,7 @@ func TestProjectsAPI_MirrorsIdentityMutationsToCairnlineWhenConfigured(t *testin
 	if len(mirrored.ContextSources) != 1 || mirrored.ContextSources[0].ID != "ctx_agents" || mirrored.ContextSources[0].Locator != "AGENTS.md" {
 		t.Fatalf("mirrored context sources = %+v, want AGENTS.md source", mirrored.ContextSources)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
+	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
@@ -597,7 +704,7 @@ func TestProjectsAPI_MirrorsIdentityMutationsToCairnlineWhenConfigured(t *testin
 	if mirrored.Name != "Mirrored Rename" {
 		t.Fatalf("mirrored name = %q, want patched name", mirrored.Name)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
+	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+created.Data.ID+"/roots", bytes.NewReader([]byte(`{
@@ -729,7 +836,7 @@ func TestProjectsAPI_CairnlineIdentityAuthorityCommitsCreateFirst(t *testing.T) 
 	if mirrored.Name != "Identity Authority" || mirrored.Description != "created through Cairnline" || mirrored.DefaultRootID != "root_main" || len(mirrored.Roots) != 1 || len(mirrored.ContextSources) != 1 {
 		t.Fatalf("mirrored project = %+v, want identity create committed to Cairnline", mirrored)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
+	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 }
 
 func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *testing.T) {
@@ -764,7 +871,7 @@ func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *tes
 	if mirrored.Name != "Replacement Identity" || mirrored.Description != "created only in Cairnline" || mirrored.DefaultRootID != "root_main" || len(mirrored.Roots) != 1 {
 		t.Fatalf("mirrored project = %+v, want Cairnline-only replacement identity", mirrored)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
+	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 
 	listed := listProjectsForTest(t, server)
 	if len(listed) != 1 || listed[0].ID != created.Data.ID || listed[0].ReadBackend != "cairnline" {
@@ -1252,14 +1359,12 @@ func TestProjectsAPI_CairnlineMetadataDefaultsAuthorityCommitsScopedUpdatesFirst
 	}
 
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
-	if mirrored.Name != "Authority Rename" || mirrored.Description != "Cairnline owns scoped project settings." || mirrored.DefaultRootID != "root_main" || mirrored.DefaultProfileID != "architecture" {
+	if mirrored.Name != "Authority Rename" || mirrored.Description != "Cairnline owns scoped project settings." || mirrored.DefaultRootID != "root_main" || mirrored.DefaultProfileID != "" || mirrored.DefaultExecutionProfileID != "" {
 		t.Fatalf("mirrored project = %+v, want scoped metadata/default authority", mirrored)
 	}
 	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" {
 		t.Fatalf("mirrored roots = %+v, want existing root preserved", mirrored.Roots)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
-
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
 		"name":"Mixed Root Replacement",
@@ -1652,7 +1757,7 @@ func TestProjectsAPI_CairnlineContextSourceAuthorityCommitsListReplacementFirst(
 	}
 }
 
-func TestProjectsAPI_DefaultOnlyPatchMirrorsDefaultsWithoutReplacingCairnlineState(t *testing.T) {
+func TestProjectsAPI_RuntimeDefaultPatchPreservesCairnlinePortableState(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectsCairnlineMirrorTestServer(t)
 
@@ -1686,8 +1791,8 @@ func TestProjectsAPI_DefaultOnlyPatchMirrorsDefaultsWithoutReplacingCairnlineSta
 		t.Fatalf("defaults update status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
-	if mirrored.DefaultProfileID != "architecture" {
-		t.Fatalf("mirrored default profile = %q, want architecture", mirrored.DefaultProfileID)
+	if mirrored.DefaultProfileID != "" || mirrored.DefaultExecutionProfileID != "" {
+		t.Fatalf("mirrored runtime hints = profile:%q execution:%q, want Hecate-owned defaults omitted from Cairnline", mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 	}
 	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_cairnline_only") == nil {
 		t.Fatalf("mirrored roots = %+v, want Cairnline-only root preserved", mirrored.Roots)
@@ -1695,7 +1800,6 @@ func TestProjectsAPI_DefaultOnlyPatchMirrorsDefaultsWithoutReplacingCairnlineSta
 	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
 		t.Fatalf("mirrored context sources = %+v, want Cairnline-only source preserved", mirrored.ContextSources)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
 }
 
 func TestProjectsAPI_DefaultRootPatchCairnlineAuthorityUsesCairnlineOnlyRoots(t *testing.T) {
@@ -1796,8 +1900,8 @@ func TestProjectsAPI_MetadataPatchMirrorsMetadataWithoutReplacingCairnlineState(
 	if mirrored.Name != "Metadata Mirror Renamed" || mirrored.Description != "After" {
 		t.Fatalf("mirrored metadata = %+v, want renamed project with updated description", mirrored)
 	}
-	if mirrored.DefaultProfileID != "architecture" {
-		t.Fatalf("mirrored default profile = %q, want architecture", mirrored.DefaultProfileID)
+	if mirrored.DefaultProfileID != "" || mirrored.DefaultExecutionProfileID != "" {
+		t.Fatalf("mirrored runtime hints = profile:%q execution:%q, want Hecate-owned defaults omitted from Cairnline", mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 	}
 	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_cairnline_only") == nil {
 		t.Fatalf("mirrored roots = %+v, want Cairnline-only root preserved", mirrored.Roots)
@@ -1805,7 +1909,6 @@ func TestProjectsAPI_MetadataPatchMirrorsMetadataWithoutReplacingCairnlineState(
 	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
 		t.Fatalf("mirrored context sources = %+v, want Cairnline-only source preserved", mirrored.ContextSources)
 	}
-	assertMirroredExecutionProfileHintForTest(t, mirrored.DefaultExecutionProfileID)
 }
 
 func TestProjectsAPI_RootListPatchMirrorsRootReplacementWithoutReplacingSources(t *testing.T) {
@@ -2298,13 +2401,10 @@ func findMirroredCairnlineSourceForTest(sources []cairnline.Source, id string) *
 	return nil
 }
 
-func assertMirroredExecutionProfileHintForTest(t *testing.T, profileID string) {
+func assertNoMirroredRuntimeHintsForTest(t *testing.T, profileID, executionProfileID string) {
 	t.Helper()
-	if profileID == "" {
-		t.Fatalf("mirrored project missing default runtime hint id")
-	}
-	if !strings.HasPrefix(profileID, "project_exec_") && !strings.HasPrefix(profileID, "role_exec_") {
-		t.Fatalf("runtime hint id = %q, want Hecate-scoped project_exec_/role_exec_ id", profileID)
+	if profileID != "" || executionProfileID != "" {
+		t.Fatalf("mirrored runtime hints = profile:%q execution:%q, want omitted from portable Cairnline graph", profileID, executionProfileID)
 	}
 }
 

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -114,16 +114,14 @@ func seedProjectScopedSnapshot(ctx context.Context, service *cairnline.Service, 
 
 func Project(project projects.Project) cairnline.Project {
 	return cairnline.Project{
-		ID:                        strings.TrimSpace(project.ID),
-		Name:                      strings.TrimSpace(project.Name),
-		Description:               strings.TrimSpace(project.Description),
-		Roots:                     Roots(project.Roots),
-		DefaultRootID:             strings.TrimSpace(project.DefaultRootID),
-		DefaultProfileID:          strings.TrimSpace(project.DefaultAgentProfile),
-		DefaultExecutionProfileID: projectExecutionProfileID(project),
-		ContextSources:            Sources(project.ContextSources),
-		CreatedAt:                 project.CreatedAt,
-		UpdatedAt:                 project.UpdatedAt,
+		ID:             strings.TrimSpace(project.ID),
+		Name:           strings.TrimSpace(project.Name),
+		Description:    strings.TrimSpace(project.Description),
+		Roots:          Roots(project.Roots),
+		DefaultRootID:  strings.TrimSpace(project.DefaultRootID),
+		ContextSources: Sources(project.ContextSources),
+		CreatedAt:      project.CreatedAt,
+		UpdatedAt:      project.UpdatedAt,
 	}
 }
 
@@ -195,15 +193,13 @@ func ProjectSkill(skill projectskills.Skill) cairnline.ProjectSkill {
 
 func Role(role projectwork.AgentRoleProfile) cairnline.Role {
 	return cairnline.Role{
-		ID:                        strings.TrimSpace(role.ID),
-		ProjectID:                 strings.TrimSpace(role.ProjectID),
-		Name:                      strings.TrimSpace(role.Name),
-		Description:               strings.TrimSpace(role.Description),
-		Instructions:              strings.TrimSpace(role.Instructions),
-		DefaultProfileID:          strings.TrimSpace(role.DefaultAgentProfile),
-		DefaultExecutionProfileID: roleExecutionProfileID(role),
-		DefaultSkillIDs:           compactStrings(role.SkillIDs),
-		DefaultExecutionMode:      ExecutionMode(role.DefaultDriverKind),
+		ID:                   strings.TrimSpace(role.ID),
+		ProjectID:            strings.TrimSpace(role.ProjectID),
+		Name:                 strings.TrimSpace(role.Name),
+		Description:          strings.TrimSpace(role.Description),
+		Instructions:         strings.TrimSpace(role.Instructions),
+		DefaultSkillIDs:      compactStrings(role.SkillIDs),
+		DefaultExecutionMode: ExecutionMode(role.DefaultDriverKind),
 	}
 }
 
@@ -225,15 +221,13 @@ func WorkItem(item projectwork.WorkItem) cairnline.WorkItem {
 
 func Assignment(assignment projectwork.Assignment, role projectwork.AgentRoleProfile) cairnline.Assignment {
 	return cairnline.Assignment{
-		ID:                 strings.TrimSpace(assignment.ID),
-		ProjectID:          strings.TrimSpace(assignment.ProjectID),
-		WorkItemID:         strings.TrimSpace(assignment.WorkItemID),
-		RoleID:             strings.TrimSpace(assignment.RoleID),
-		RootID:             strings.TrimSpace(assignment.RootID),
-		ProfileID:          strings.TrimSpace(role.DefaultAgentProfile),
-		ExecutionProfileID: roleExecutionProfileID(role),
-		ExecutionMode:      ExecutionMode(assignment.DriverKind),
-		Status:             AssignmentStatus(assignment.Status),
+		ID:            strings.TrimSpace(assignment.ID),
+		ProjectID:     strings.TrimSpace(assignment.ProjectID),
+		WorkItemID:    strings.TrimSpace(assignment.WorkItemID),
+		RoleID:        strings.TrimSpace(assignment.RoleID),
+		RootID:        strings.TrimSpace(assignment.RootID),
+		ExecutionMode: ExecutionMode(assignment.DriverKind),
+		Status:        AssignmentStatus(assignment.Status),
 		DesiredAgent: cairnline.DesiredAgent{
 			Kind:     DesiredAgentKind(assignment.DriverKind),
 			SkillIDs: compactStrings(role.SkillIDs),
@@ -507,60 +501,6 @@ func claimedBy(assignment cairnline.Assignment) string {
 	return "external_adapter"
 }
 
-func roleExecutionProfileID(role projectwork.AgentRoleProfile) string {
-	if strings.TrimSpace(role.DefaultProvider) == "" && strings.TrimSpace(role.DefaultModel) == "" {
-		return ""
-	}
-	return roleExecutionProfileIDValue(role)
-}
-
-func roleExecutionProfileIDValue(role projectwork.AgentRoleProfile) string {
-	projectID := safeCairnlineIDPart(role.ProjectID)
-	roleID := safeCairnlineIDPart(role.ID)
-	if roleID == "" {
-		return ""
-	}
-	return "role_exec_" + firstNonEmpty(projectID, "project") + "_" + roleID
-}
-
-func projectExecutionProfileID(project projects.Project) string {
-	if strings.TrimSpace(project.DefaultProvider) == "" &&
-		strings.TrimSpace(project.DefaultModel) == "" &&
-		optionalBoolPolicy(project.DefaultToolsEnabled) == "" &&
-		len(projectExecutionAdapterOptions(project)) == 0 {
-		return ""
-	}
-	return projectExecutionProfileIDValue(project)
-}
-
-func projectExecutionProfileIDValue(project projects.Project) string {
-	projectID := safeCairnlineIDPart(project.ID)
-	if projectID == "" {
-		return ""
-	}
-	return "project_exec_" + projectID
-}
-
-func safeCairnlineIDPart(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	var builder strings.Builder
-	for _, r := range value {
-		switch {
-		case r >= 'a' && r <= 'z',
-			r >= 'A' && r <= 'Z',
-			r >= '0' && r <= '9',
-			r == '_', r == '-':
-			builder.WriteRune(r)
-		default:
-			builder.WriteByte('_')
-		}
-	}
-	return strings.Trim(builder.String(), "_")
-}
-
 func assignmentExecutionRef(ref projectwork.AssignmentExecutionRef) string {
 	return firstNonEmpty(
 		strings.TrimSpace(ref.RunID),
@@ -568,20 +508,6 @@ func assignmentExecutionRef(ref projectwork.AssignmentExecutionRef) string {
 		strings.TrimSpace(ref.ChatSessionID),
 		strings.TrimSpace(ref.ContextSnapshotID),
 	)
-}
-
-func boolPolicy(value bool) string {
-	if value {
-		return "allow"
-	}
-	return "block"
-}
-
-func optionalBoolPolicy(value *bool) string {
-	if value == nil {
-		return ""
-	}
-	return boolPolicy(*value)
 }
 
 func RequiredPermissions(permissions projectskills.RequiredPermissions) cairnline.RequiredPermissions {
@@ -598,23 +524,6 @@ func cloneBoolPointer(value *bool) *bool {
 	}
 	out := *value
 	return &out
-}
-
-func projectExecutionAdapterOptions(project projects.Project) map[string]any {
-	out := make(map[string]any)
-	if value := strings.TrimSpace(project.DefaultWorkspaceMode); value != "" {
-		out["workspace_mode"] = value
-	}
-	if value := strings.TrimSpace(project.DefaultSystemPrompt); value != "" {
-		out["system_prompt"] = value
-	}
-	if project.DefaultCompactToolOutput != nil {
-		out["compact_tool_output"] = *project.DefaultCompactToolOutput
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
 }
 
 func compactStrings(items []string) []string {

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -33,8 +33,8 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if packet.Project.ID != "proj_hecate" || packet.Project.DefaultRootID != "root_main" || packet.WorkItem.RootID != "root_main" {
 		t.Fatalf("packet project/work = %+v/%+v, want Hecate project with default root and root-scoped work", packet.Project, packet.WorkItem)
 	}
-	if packet.Project.DefaultProfileID != "bridge_implementation" || packet.Project.DefaultExecutionProfileID != projectExecutionProfileID(snapshot.Project) {
-		t.Fatalf("packet project defaults = %+v, want mapped project profile and execution defaults", packet.Project)
+	if packet.Project.DefaultProfileID != "" || packet.Project.DefaultExecutionProfileID != "" {
+		t.Fatalf("packet project defaults = %+v, want Hecate runtime defaults omitted from Cairnline", packet.Project)
 	}
 	if len(packet.Project.ContextSources) != 1 {
 		t.Fatalf("packet project sources = %+v, want one context source", packet.Project.ContextSources)
@@ -46,14 +46,11 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if packet.Role == nil || packet.Role.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
 		t.Fatalf("packet role = %+v, want orchestrated role from Hecate task driver", packet.Role)
 	}
-	if packet.Role.DefaultExecutionProfileID != roleExecutionProfileID(snapshot.Roles[0]) {
-		t.Fatalf("packet role = %+v, want role execution-profile default", packet.Role)
+	if packet.Role.DefaultProfileID != "" || packet.Role.DefaultExecutionProfileID != "" {
+		t.Fatalf("packet role defaults = %+v, want Hecate runtime defaults omitted from Cairnline", packet.Role)
 	}
-	if packet.Role.DefaultProfileID != "bridge_implementation" || packet.Assignment.ProfileID != "bridge_implementation" {
-		t.Fatalf("packet profile hints = role:%q assignment:%q, want unresolved Hecate preset id", packet.Role.DefaultProfileID, packet.Assignment.ProfileID)
-	}
-	if packet.Assignment.ExecutionProfileID != roleExecutionProfileID(snapshot.Roles[0]) {
-		t.Fatalf("packet assignment runtime profile = %q, want opaque role execution-profile hint", packet.Assignment.ExecutionProfileID)
+	if packet.Assignment.ProfileID != "" || packet.Assignment.ExecutionProfileID != "" {
+		t.Fatalf("packet assignment runtime hints = profile:%q execution:%q, want omitted Hecate runtime defaults", packet.Assignment.ProfileID, packet.Assignment.ExecutionProfileID)
 	}
 	if packet.Assignment.ExecutionMode != cairnline.ExecutionOrchestrated || packet.Assignment.RootID != "root_main" || packet.Assignment.ContextSnapshotID != "ctx_123" {
 		t.Fatalf("packet assignment = %+v, want orchestrated root-scoped assignment", packet.Assignment)
@@ -422,8 +419,8 @@ func TestUpsertProjectMirrorsProjectRootAndContextSourceMutations(t *testing.T) 
 	if err != nil {
 		t.Fatalf("UpsertProject(create) error = %v", err)
 	}
-	if created.ID != project.ID || created.DefaultRootID != "root_main" || created.DefaultProfileID != "implementation" || created.DefaultExecutionProfileID != projectExecutionProfileID(project) {
-		t.Fatalf("created project = %+v, want mapped Hecate project defaults", created)
+	if created.ID != project.ID || created.DefaultRootID != "root_main" || created.DefaultProfileID != "" || created.DefaultExecutionProfileID != "" {
+		t.Fatalf("created project = %+v, want portable project defaults without Hecate runtime hints", created)
 	}
 	if len(created.Roots) != 1 || created.Roots[0].Path != "/tmp/hecate-write" || created.Roots[0].GitBranch != "main" {
 		t.Fatalf("created roots = %+v, want portable root metadata", created.Roots)
@@ -529,8 +526,8 @@ func TestUpsertProjectDefaultsPreservesRootAndSourceState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertProjectDefaults(update) error = %v", err)
 	}
-	if updated.DefaultProfileID != "architecture" || updated.DefaultExecutionProfileID != projectExecutionProfileID(project) {
-		t.Fatalf("updated defaults = %+v, want portable project defaults", updated)
+	if updated.DefaultRootID != "root_main" || updated.DefaultProfileID != "" || updated.DefaultExecutionProfileID != "" {
+		t.Fatalf("updated defaults = %+v, want only portable defaults written to Cairnline", updated)
 	}
 	if findCairnlineRoot(updated.Roots, "root_cairnline_only") == nil {
 		t.Fatalf("updated roots = %+v, want Cairnline-only root preserved", updated.Roots)
@@ -1027,8 +1024,8 @@ func TestUpsertRoleMirrorsRoleAndExecutionDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertRole(create) error = %v", err)
 	}
-	if created.ID != "developer" || created.DefaultProfileID != "implementation" || created.DefaultExecutionProfileID != roleExecutionProfileID(role) || created.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
-		t.Fatalf("created role = %+v, want mapped role defaults", created)
+	if created.ID != "developer" || created.DefaultProfileID != "" || created.DefaultExecutionProfileID != "" || created.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
+		t.Fatalf("created role = %+v, want portable role defaults without Hecate runtime hints", created)
 	}
 	if len(created.DefaultSkillIDs) != 1 || created.DefaultSkillIDs[0] != "backend" {
 		t.Fatalf("created role skill ids = %+v, want compacted backend skill", created.DefaultSkillIDs)
@@ -1187,7 +1184,7 @@ func TestUpsertAssignmentCreatesAndSyncsLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertAssignment(queued) error = %v", err)
 	}
-	if queued.Status != cairnline.AssignmentQueued || queued.ProfileID != profileID || queued.ExecutionProfileID != roleExecutionProfileID(role) || queued.ExecutionMode != cairnline.ExecutionOrchestrated || queued.ContextSnapshotID != "ctx_queued" {
+	if queued.Status != cairnline.AssignmentQueued || queued.ProfileID != "" || queued.ExecutionProfileID != "" || queued.ExecutionMode != cairnline.ExecutionOrchestrated || queued.ContextSnapshotID != "ctx_queued" {
 		t.Fatalf("queued assignment = %+v, want created orchestrated assignment metadata", queued)
 	}
 	if queued.DesiredAgent.Kind != "hecate" || len(queued.DesiredAgent.SkillIDs) != 1 || queued.DesiredAgent.SkillIDs[0] != "backend" {
@@ -1736,8 +1733,8 @@ func TestSeedSnapshotsMirrorsMultipleProjectsWithPresetHintsOnly(t *testing.T) {
 		t.Fatalf("projects = %+v, want two seeded projects", projects)
 	}
 	for _, item := range projects {
-		if item.DefaultProfileID != "shared_architect" {
-			t.Fatalf("project = %+v, want opaque preset hint preserved", item)
+		if item.DefaultProfileID != "" || item.DefaultExecutionProfileID != "" {
+			t.Fatalf("project = %+v, want Hecate runtime hints omitted from Cairnline", item)
 		}
 	}
 }

--- a/internal/cairnlinebridge/project_write.go
+++ b/internal/cairnlinebridge/project_write.go
@@ -41,9 +41,9 @@ func UpsertProject(ctx context.Context, service *cairnline.Service, project proj
 	return written, nil
 }
 
-// UpsertProjectDefaults mirrors only the portable project launch defaults. It
-// preserves the existing Cairnline project identity, root, and context-source
-// records unless the project is missing and needs a full bootstrap write.
+// UpsertProjectDefaults mirrors only portable project defaults. Hecate-owned
+// runtime launch posture such as Agent Presets, provider/model hints, tools,
+// and workspace prompt policy stays in Hecate's runtime overlay.
 func UpsertProjectDefaults(ctx context.Context, service *cairnline.Service, project projects.Project) (cairnline.Project, error) {
 	if service == nil {
 		return cairnline.Project{}, errors.Join(ErrSourceNotConfigured, errors.New("cairnline service is required"))
@@ -60,8 +60,6 @@ func UpsertProjectDefaults(ctx context.Context, service *cairnline.Service, proj
 		return cairnline.Project{}, err
 	}
 	existing.DefaultRootID = item.DefaultRootID
-	existing.DefaultProfileID = item.DefaultProfileID
-	existing.DefaultExecutionProfileID = item.DefaultExecutionProfileID
 	updated, err := service.UpdateProject(ctx, existing)
 	if err != nil {
 		if errors.Is(err, cairnline.ErrNotFound) {


### PR DESCRIPTION
## Summary
- stop Hecate's Cairnline bridge from writing Agent Preset, provider/model, and execution-profile-derived runtime hints into portable Cairnline project, role, assignment, and launch-packet records
- keep Hecate-owned project runtime defaults in the project runtime overlay for Hecate-first create/update and Cairnline-authority runtime-only updates
- update Projects/Cairnline docs and backend status text to describe Cairnline as portable coordination while Hecate owns launch/safety policy

## Tests
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectsAPI_(ProjectUpdateSeparatesPortableAndRuntimeDefaults|RuntimeDefaultPatchPreservesCairnlinePortableState|DefaultRootPatchCairnlineAuthorityUsesCairnlineOnlyRoots|CairnlineReplacementModeSkipsNativeProjectRowShadows|CairnlineMetadataDefaultsAuthority)'
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./...
- just agent-docs-check
- git ls-files -z '*.md' '*.mdc' | xargs -0 ./ui/node_modules/.bin/oxfmt --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...