### PR TITLE
fix(projects): align cairnline runtime boundary text

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -663,7 +663,7 @@ Hecate is ready to replace its internal Projects backend with Cairnline only
 after these gates are met:
 
 - Cairnline has durable storage and MCP/API parity for Hecate's project, role,
-  host-owned preset hints, context-source provenance metadata, skill, work item, assignment,
+  context-source provenance metadata, skill, work item, assignment,
   artifact, handoff, accepted-memory, memory-candidate, and assistant-proposal
   ledger flows.
 - Hecate has feature-flagged adapters that can run all read/write Projects

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -4299,10 +4299,10 @@ Local-only experimental bridge endpoint. It loads the selected project from
 Hecate's authoritative Projects stores, seeds an in-memory Cairnline service,
 and returns Cairnline's portable read projections for the project without
 writing an export database. The seeded project preserves roots,
-`default_root_id`, project default agent-preset/runtime references, and
-context-source provenance metadata including source format, scope, category,
-trust label, and metadata labels so replacement-readiness checks exercise
-Hecate's workspace, launch-default, and context-control inputs. It also imports
+`default_root_id`, and context-source provenance metadata including source
+format, scope, category, trust label, and metadata labels so
+replacement-readiness checks exercise Hecate's workspace and context-control
+inputs without writing Hecate runtime posture into Cairnline. It also imports
 portable Project Assistant proposal ledger records,
 including root/default-root actions, proposal warnings, latest apply results,
 and apply attempts, without replaying proposal actions. The read model attempts
@@ -4331,7 +4331,7 @@ Example response:
     "root_count": 1,
     "context_source_count": 2,
     "agent_profile_count": 0,
-    "execution_profile_count": 2,
+    "execution_profile_count": 0,
     "skill_count": 3,
     "role_count": 6,
     "work_item_count": 2,
@@ -4605,7 +4605,7 @@ Example response:
     "root_count": 1,
     "context_source_count": 2,
     "agent_profile_count": 0,
-    "execution_profile_count": 2,
+    "execution_profile_count": 0,
     "skill_count": 3,
     "role_count": 6,
     "work_item_count": 2,
@@ -4868,7 +4868,7 @@ Example response:
     "root_count": 1,
     "context_source_count": 2,
     "agent_profile_count": 0,
-    "execution_profile_count": 2,
+    "execution_profile_count": 0,
     "skill_count": 3,
     "role_count": 6,
     "work_item_count": 2,

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -153,7 +153,7 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 		BlocksAuthority:  true,
 		Seams:            []string{"project-metadata-live-mirror", "project-defaults-live-mirror"},
 		Gap:              "projects",
-		Detail:           "Project metadata and default posture mutations still commit to Hecate first, then mirror through Cairnline metadata/default seams.",
+		Detail:           "Project metadata and default-root mutations still commit to Hecate first, then mirror through Cairnline metadata/default seams; provider/model/preset posture stays in Hecate runtime overlays.",
 	},
 	{
 		Name:             "roots-and-worktrees",


### PR DESCRIPTION
## Summary
- update backend status text so project metadata/defaults distinguishes portable default-root data from Hecate runtime overlays
- remove stale host-preset hint wording from the Projects replacement gate
- correct Cairnline read/parity/export examples to show zero Hecate-manufactured execution-profile records

## Tests
- git ls-files -z '*.md' '*.mdc' | xargs -0 ./ui/node_modules/.bin/oxfmt --check
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run TestProjectCoordinationBackend
- git diff --check