### PR TITLE
refactor(projects): consume portable cairnline roles

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3797,9 +3797,7 @@ Example response, shortened:
       "project_id": "proj_123",
       "assignment_id": "asg_123",
       "work_item_id": "work_123",
-      "role_id": "role_reviewer",
-      "profile_id": "profile_review",
-      "execution_profile_id": "exec_local"
+      "role_id": "role_reviewer"
     },
     "structured_counts": {
       "skills": 1,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260703234719-d1eeeb2f9ee8
+	github.com/hecatehq/cairnline v0.0.0-20260704022043-0bccf15c2e31
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.0.0-20260703234719-d1eeeb2f9ee8 h1:LxzaSM8cSdtpV7OLui+3UItRWk/KpKxjpE1MKG601SI=
-github.com/hecatehq/cairnline v0.0.0-20260703234719-d1eeeb2f9ee8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260704022043-0bccf15c2e31 h1:Y3hn5t5KjCiO5fSvaDedCPv2oTby8DrdRAof0qOU4Do=
+github.com/hecatehq/cairnline v0.0.0-20260704022043-0bccf15c2e31/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_chat_context_cairnline.go
+++ b/internal/api/handler_chat_context_cairnline.go
@@ -130,7 +130,6 @@ func cairnlineAssignmentContextPacket(context cairnline.AssignmentContext) chat.
 	}
 	packet := baseChatContextPacket(firstNonEmptyString(strings.TrimSpace(context.Assignment.ExecutionMode), cairnline.ExecutionMCPPull), "", "", workspace)
 	packet.ID = firstNonEmptyString(strings.TrimSpace(context.Assignment.ContextSnapshotID), strings.TrimSpace(context.ID), "cairnline_assignment_context_"+strings.TrimSpace(context.Assignment.ID))
-	packet.ExecutionProfile = strings.TrimSpace(context.Assignment.ExecutionProfileID)
 	packet.SystemPromptIncluded = false
 	packet.Refs = &chat.ContextRefs{
 		ProjectID:    strings.TrimSpace(context.Project.ID),
@@ -158,11 +157,9 @@ func cairnlineAssignmentLaunchContextPacket(launch cairnline.AssignmentLaunchPac
 	if rootOK {
 		workspace = strings.TrimSpace(root.Path)
 	}
-	executionProfile := strings.TrimSpace(launch.Assignment.ExecutionProfileID)
 	provider, model := "", ""
 	packet := baseChatContextPacket(firstNonEmptyString(strings.TrimSpace(launch.Assignment.ExecutionMode), cairnline.ExecutionMCPPull), provider, model, workspace)
 	packet.ID = firstNonEmptyString(strings.TrimSpace(launch.Assignment.ContextSnapshotID), "cairnline_assignment_context_"+strings.TrimSpace(launch.Assignment.ID))
-	packet.ExecutionProfile = executionProfile
 	packet.SystemPromptIncluded = false
 	packet.Refs = &chat.ContextRefs{
 		ProjectID:    strings.TrimSpace(launch.Project.ID),
@@ -211,8 +208,6 @@ func appendCairnlineAssignmentLaunchPacketEvidenceItem(packet *chat.ContextPacke
 		rootPath = strings.TrimSpace(root.Path)
 		rootDetail = firstNonEmptyString(rootID, "unresolved") + " (" + firstNonEmptyString(rootPath, "no path") + "; " + firstNonEmptyString(rootSelection, "fallback") + ")"
 	}
-	profileID := strings.TrimSpace(launch.Assignment.ProfileID)
-	executionProfileID := strings.TrimSpace(launch.Assignment.ExecutionProfileID)
 	roleLabel := strings.TrimSpace(launch.Assignment.RoleID)
 	if launch.Role != nil && strings.TrimSpace(launch.Role.Name) != "" {
 		roleLabel = firstNonEmptyString(roleLabel, strings.TrimSpace(launch.Role.ID)) + " (" + strings.TrimSpace(launch.Role.Name) + ")"
@@ -225,8 +220,6 @@ func appendCairnlineAssignmentLaunchPacketEvidenceItem(packet *chat.ContextPacke
 		"Execution mode: " + firstNonEmptyString(strings.TrimSpace(launch.Assignment.ExecutionMode), cairnline.ExecutionMCPPull),
 		"Role: " + firstNonEmptyString(roleLabel, "none"),
 		"Desired agent: " + firstNonEmptyString(strings.TrimSpace(launch.Assignment.DesiredAgent.Kind), cairnline.DesiredAgentAny),
-		"Agent preset: " + firstNonEmptyString(profileID, "inherit"),
-		"Runtime profile: " + firstNonEmptyString(executionProfileID, "inherit"),
 		"Root: " + rootDetail,
 		fmt.Sprintf("Skills: %d; artifacts: %d; evidence: %d; reviews: %d; handoffs: %d; memory: %d; memory candidates: %d",
 			len(launch.Skills),
@@ -300,8 +293,6 @@ func cairnlineAssignmentLaunchPacketEvidenceMetadata(launch cairnline.Assignment
 		"root_path":              strings.TrimSpace(rootPath),
 		"execution_mode":         firstNonEmptyString(strings.TrimSpace(launch.Assignment.ExecutionMode), cairnline.ExecutionMCPPull),
 		"desired_agent":          firstNonEmptyString(strings.TrimSpace(launch.Assignment.DesiredAgent.Kind), cairnline.DesiredAgentAny),
-		"profile_id":             strings.TrimSpace(launch.Assignment.ProfileID),
-		"execution_profile_id":   strings.TrimSpace(launch.Assignment.ExecutionProfileID),
 		"skill_count":            fmt.Sprintf("%d", len(launch.Skills)),
 		"artifact_count":         fmt.Sprintf("%d", len(launch.Artifacts)),
 		"evidence_count":         fmt.Sprintf("%d", len(launch.Evidence)),
@@ -381,8 +372,6 @@ func appendCairnlineAssignment(packet *chat.ContextPacket, item cairnline.Assign
 		"Execution mode: " + firstNonEmptyString(strings.TrimSpace(item.ExecutionMode), cairnline.ExecutionMCPPull),
 		"Role: " + firstNonEmptyString(strings.TrimSpace(item.RoleID), "none"),
 		"Desired agent: " + firstNonEmptyString(strings.TrimSpace(item.DesiredAgent.Kind), cairnline.DesiredAgentAny),
-		"Agent preset: " + firstNonEmptyString(strings.TrimSpace(item.ProfileID), "inherit"),
-		"Runtime profile: " + firstNonEmptyString(strings.TrimSpace(item.ExecutionProfileID), "inherit"),
 	}
 	if rootID := strings.TrimSpace(item.RootID); rootID != "" {
 		body = append(body, "Root override: "+rootID)
@@ -449,8 +438,6 @@ func appendCairnlineRole(packet *chat.ContextPacket, role cairnline.Role) {
 	body := []string{
 		"Description: " + firstNonEmptyString(strings.TrimSpace(role.Description), "No description recorded."),
 		"Instructions: " + firstNonEmptyString(strings.TrimSpace(role.Instructions), "No role instructions recorded."),
-		"Default preset: " + firstNonEmptyString(strings.TrimSpace(role.DefaultProfileID), "none"),
-		"Default runtime profile: " + firstNonEmptyString(strings.TrimSpace(role.DefaultExecutionProfileID), "none"),
 		"Default execution mode: " + firstNonEmptyString(strings.TrimSpace(role.DefaultExecutionMode), "inherit"),
 	}
 	if skills := compactContextIDs(role.DefaultSkillIDs); len(skills) > 0 {

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -593,6 +593,12 @@ func cairnlineLaunchRole(ctx context.Context, service *cairnline.Service, snapsh
 		return projectwork.AgentRoleProfile{ID: strings.TrimSpace(launch.Assignment.RoleID)}, false, nil
 	}
 	role := projectWorkRoleFromCairnline(*launch.Role, projectWorkRolesByID(snapshot.Roles)[launch.Role.ID])
+	if strings.TrimSpace(role.ProjectID) == "" {
+		role.ProjectID = strings.TrimSpace(firstNonEmpty(launch.Role.ProjectID, launch.Assignment.ProjectID, launch.Project.ID))
+	}
+	if strings.TrimSpace(role.DefaultDriverKind) == "" {
+		role.DefaultDriverKind = projectWorkAssignmentDriverFromCairnline(launch.Assignment.ExecutionMode)
+	}
 	return role, true, nil
 }
 
@@ -603,9 +609,6 @@ func cairnlineSidecarLaunchRole(launch cairnline.AssignmentLaunchPacket) (projec
 	role := projectWorkRoleFromCairnline(*launch.Role, projectwork.AgentRoleProfile{})
 	if strings.TrimSpace(role.ProjectID) == "" {
 		role.ProjectID = strings.TrimSpace(firstNonEmpty(launch.Role.ProjectID, launch.Assignment.ProjectID, launch.Project.ID))
-	}
-	if strings.TrimSpace(role.DefaultAgentProfile) == "" {
-		role.DefaultAgentProfile = strings.TrimSpace(launch.Assignment.ProfileID)
 	}
 	if strings.TrimSpace(role.DefaultDriverKind) == "" {
 		role.DefaultDriverKind = projectWorkAssignmentDriverFromCairnline(launch.Assignment.ExecutionMode)

--- a/internal/api/handler_project_assignment_launch_readiness_test.go
+++ b/internal/api/handler_project_assignment_launch_readiness_test.go
@@ -234,8 +234,8 @@ func TestProjectWorkAPI_AssignmentLaunchReadinessCairnlineSidecarOverlaysNativeR
 	if readiness.Data.ReadBackend != "cairnline" || !readiness.Data.Ready || readiness.Data.Status != projectAssignmentLaunchReadinessStatusReady {
 		t.Fatalf("readiness = %+v, want ready sidecar projection with Hecate runtime overlay", readiness.Data)
 	}
-	if readiness.Data.Provider != "anthropic" || readiness.Data.Model != "claude-sonnet-4" || readiness.Data.ExecutionProfile != "profile_fixture" {
-		t.Fatalf("launch hints = provider/model/profile %q/%q/%q, want role runtime overlay plus Cairnline preset hint", readiness.Data.Provider, readiness.Data.Model, readiness.Data.ExecutionProfile)
+	if readiness.Data.Provider != "anthropic" || readiness.Data.Model != "claude-sonnet-4" || readiness.Data.ExecutionProfile != "role_fixture_preset" {
+		t.Fatalf("launch hints = provider/model/profile %q/%q/%q, want Hecate role runtime overlay", readiness.Data.Provider, readiness.Data.Model, readiness.Data.ExecutionProfile)
 	}
 }
 

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -1664,7 +1664,6 @@ func TestProjectAssistantAPI_CairnlineApplyProjectIdentityAuthorityDoesNotBlockO
 	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" || mirrored.Roots[0].Path != "/workspace/identity" {
 		t.Fatalf("Cairnline roots = %+v, want root_main", mirrored.Roots)
 	}
-	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 	if _, ok, err := baseProjects.Get(t.Context(), "proj_pa_apply_project_identity_authority"); err != nil || ok {
 		t.Fatalf("shadow project ok=%v err=%v, want missing after injected shadow failure", ok, err)
 	}
@@ -1737,7 +1736,6 @@ func TestProjectAssistantAPI_CairnlineApplyProjectMetadataAuthorityDoesNotBlockO
 	if mirrored.Name != "Assistant Project Authority Updated" || mirrored.Description != "Cairnline owns this metadata update." || mirrored.DefaultRootID != "root_main" {
 		t.Fatalf("Cairnline project = %+v, want authoritative metadata/default update", mirrored)
 	}
-	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 	native, ok, err := baseProjects.Get(t.Context(), project.ID)
 	if err != nil || !ok {
 		t.Fatalf("Get native project ok=%v err=%v", ok, err)
@@ -1875,8 +1873,6 @@ func TestProjectAssistantAPI_CairnlineApplyProjectIdentityAuthorityDoesNotRequir
 	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" || mirrored.Roots[0].Path != "/workspace/cairnline-only" {
 		t.Fatalf("Cairnline roots = %+v, want root_main", mirrored.Roots)
 	}
-	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
-
 	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/proj_pa_apply_project_identity_cairnline_only", "")
 	if project.Data.ReadBackend != "cairnline" || project.Data.ID != mirrored.ID {
 		t.Fatalf("project response = %+v, want strict embedded Cairnline project", project.Data)
@@ -1954,8 +1950,6 @@ func TestProjectAssistantAPI_CairnlineApplyProjectMetadataRootAuthorityDoesNotRe
 	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_attached") == nil || findMirroredCairnlineRootForTest(mirrored.Roots, "root_main") != nil {
 		t.Fatalf("Cairnline roots = %+v, want attached root only", mirrored.Roots)
 	}
-	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
-
 	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/"+projectID, "")
 	if project.Data.ReadBackend != "cairnline" || project.Data.DefaultRootID != "root_attached" || len(project.Data.Roots) != 1 || project.Data.Roots[0].ID != "root_attached" {
 		t.Fatalf("project response = %+v, want strict embedded Cairnline project with attached root", project.Data)
@@ -2315,7 +2309,7 @@ func TestProjectAssistantAPI_ProjectSideEffectsMirrorThroughNarrowCairnlineSeams
 	if findMirroredCairnlineSourceForTest(mirrored.ContextSources, "ctx_cairnline_only") == nil {
 		t.Fatalf("mirrored sources = %+v, want Cairnline-only source preserved", mirrored.ContextSources)
 	}
-	if mirrored.DefaultRootID != "root_attached" || mirrored.DefaultProfileID != "" || mirrored.DefaultExecutionProfileID != "" {
+	if mirrored.DefaultRootID != "root_attached" {
 		t.Fatalf("mirrored defaults = %+v, want attached root and omitted Hecate runtime hints", mirrored)
 	}
 }

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -4099,23 +4099,17 @@ func projectCairnlineSidecarStructuredLaunchPacket(raw json.RawMessage) (Project
 		ID      string `json:"id"`
 		Kind    string `json:"kind"`
 		Project struct {
-			ID                        string `json:"id"`
-			DefaultProfileID          string `json:"default_profile_id"`
-			DefaultExecutionProfileID string `json:"default_execution_profile_id"`
+			ID string `json:"id"`
 		} `json:"project"`
 		WorkItem struct {
 			ID string `json:"id"`
 		} `json:"work_item"`
 		Role struct {
-			ID                        string `json:"id"`
-			DefaultProfileID          string `json:"default_profile_id"`
-			DefaultExecutionProfileID string `json:"default_execution_profile_id"`
+			ID string `json:"id"`
 		} `json:"role"`
 		Assignment struct {
-			ID                 string `json:"id"`
-			ProjectID          string `json:"project_id"`
-			ProfileID          string `json:"profile_id"`
-			ExecutionProfileID string `json:"execution_profile_id"`
+			ID        string `json:"id"`
+			ProjectID string `json:"project_id"`
 		} `json:"assignment"`
 		Skills           []json.RawMessage `json:"skills"`
 		Artifacts        []json.RawMessage `json:"artifacts"`
@@ -4130,14 +4124,12 @@ func projectCairnlineSidecarStructuredLaunchPacket(raw json.RawMessage) (Project
 		return ProjectCairnlineSidecarLaunchPacketIDs{}, ProjectCairnlineSidecarLaunchPacketCounts{}, nil, false, err
 	}
 	ids := ProjectCairnlineSidecarLaunchPacketIDs{
-		LaunchPacketID:     strings.TrimSpace(packet.ID),
-		Kind:               strings.TrimSpace(packet.Kind),
-		ProjectID:          firstNonEmpty(strings.TrimSpace(packet.Project.ID), strings.TrimSpace(packet.Assignment.ProjectID)),
-		AssignmentID:       strings.TrimSpace(packet.Assignment.ID),
-		WorkItemID:         strings.TrimSpace(packet.WorkItem.ID),
-		RoleID:             strings.TrimSpace(packet.Role.ID),
-		ProfileID:          firstNonEmpty(strings.TrimSpace(packet.Assignment.ProfileID), strings.TrimSpace(packet.Role.DefaultProfileID), strings.TrimSpace(packet.Project.DefaultProfileID)),
-		ExecutionProfileID: firstNonEmpty(strings.TrimSpace(packet.Assignment.ExecutionProfileID), strings.TrimSpace(packet.Role.DefaultExecutionProfileID), strings.TrimSpace(packet.Project.DefaultExecutionProfileID)),
+		LaunchPacketID: strings.TrimSpace(packet.ID),
+		Kind:           strings.TrimSpace(packet.Kind),
+		ProjectID:      firstNonEmpty(strings.TrimSpace(packet.Project.ID), strings.TrimSpace(packet.Assignment.ProjectID)),
+		AssignmentID:   strings.TrimSpace(packet.Assignment.ID),
+		WorkItemID:     strings.TrimSpace(packet.WorkItem.ID),
+		RoleID:         strings.TrimSpace(packet.Role.ID),
 	}
 	counts := ProjectCairnlineSidecarLaunchPacketCounts{
 		Skills:           len(packet.Skills),

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -691,9 +691,6 @@ func TestProjectCairnlineSidecarLaunchPacketSmoke_SelectsAssignmentFromStructure
 	if got.StructuredIDs.LaunchPacketID != "launch_fixture" || got.StructuredIDs.Kind != "assignment_launch_packet" || got.StructuredIDs.ProjectID != "proj_fixture" || got.StructuredIDs.AssignmentID != "asg_fixture" || got.StructuredIDs.WorkItemID != "work_fixture" || got.StructuredIDs.RoleID != "role_fixture" {
 		t.Fatalf("structured ids = %+v, want launch/project/assignment/work/role ids", got.StructuredIDs)
 	}
-	if got.StructuredIDs.ProfileID != "profile_fixture" || got.StructuredIDs.ExecutionProfileID != "exec_fixture" {
-		t.Fatalf("structured profile ids = %+v, want profile/execution ids", got.StructuredIDs)
-	}
 	if got.StructuredCounts.Skills != 1 || got.StructuredCounts.Artifacts != 1 || got.StructuredCounts.Evidence != 1 || got.StructuredCounts.Reviews != 1 || got.StructuredCounts.Handoffs != 1 || got.StructuredCounts.Memory != 1 || got.StructuredCounts.MemoryCandidates != 1 || got.StructuredCounts.Warnings != 1 {
 		t.Fatalf("structured counts = %+v, want one item in every launch-packet bucket", got.StructuredCounts)
 	}

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -249,15 +249,14 @@ func (h *Handler) cairnlineSidecarAssignmentContext(ctx context.Context, project
 
 func projectFromCairnlineSidecar(project ProjectCairnlineSidecarProjectItem) projects.Project {
 	return projects.Project{
-		ID:                  project.ID,
-		Name:                project.Name,
-		Description:         project.Description,
-		Roots:               projectRootsFromCairnlineSidecar(project.Roots),
-		ContextSources:      projectContextSourcesFromCairnlineSidecar(project.ContextSources),
-		DefaultRootID:       project.DefaultRootID,
-		DefaultAgentProfile: project.DefaultProfileID,
-		CreatedAt:           projectCairnlineSidecarTime(project.CreatedAt),
-		UpdatedAt:           projectCairnlineSidecarTime(project.UpdatedAt),
+		ID:             project.ID,
+		Name:           project.Name,
+		Description:    project.Description,
+		Roots:          projectRootsFromCairnlineSidecar(project.Roots),
+		ContextSources: projectContextSourcesFromCairnlineSidecar(project.ContextSources),
+		DefaultRootID:  project.DefaultRootID,
+		CreatedAt:      projectCairnlineSidecarTime(project.CreatedAt),
+		UpdatedAt:      projectCairnlineSidecarTime(project.UpdatedAt),
 	}
 }
 
@@ -299,14 +298,13 @@ func projectRolesFromCairnlineSidecar(items []ProjectCairnlineSidecarRoleItem) [
 	out := make([]projectwork.AgentRoleProfile, 0, len(items))
 	for _, item := range items {
 		out = append(out, projectwork.AgentRoleProfile{
-			ID:                  item.ID,
-			ProjectID:           item.ProjectID,
-			Name:                item.Name,
-			Description:         item.Description,
-			Instructions:        item.Instructions,
-			DefaultDriverKind:   item.DefaultExecutionMode,
-			DefaultAgentProfile: item.DefaultProfileID,
-			SkillIDs:            append([]string(nil), item.DefaultSkillIDs...),
+			ID:                item.ID,
+			ProjectID:         item.ProjectID,
+			Name:              item.Name,
+			Description:       item.Description,
+			Instructions:      item.Instructions,
+			DefaultDriverKind: item.DefaultExecutionMode,
+			SkillIDs:          append([]string(nil), item.DefaultSkillIDs...),
 		})
 	}
 	return out

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -276,12 +276,10 @@ func TestProjectHealth_StrictEmbeddedReadModelReadsWithoutHecateProject(t *testi
 
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		if _, err := service.CreateProject(t.Context(), cairnline.Project{
-			ID:                        projectID,
-			Name:                      "Embedded Health",
-			Description:               "Coordinate health from embedded Cairnline.",
-			DefaultRootID:             "root_embedded_health",
-			DefaultProfileID:          "profile_embedded_health",
-			DefaultExecutionProfileID: "exec_embedded_health",
+			ID:            projectID,
+			Name:          "Embedded Health",
+			Description:   "Coordinate health from embedded Cairnline.",
+			DefaultRootID: "root_embedded_health",
 			Roots: []cairnline.Root{{
 				ID:     "root_embedded_health",
 				Path:   "/workspace/embedded-health",
@@ -301,11 +299,10 @@ func TestProjectHealth_StrictEmbeddedReadModelReadsWithoutHecateProject(t *testi
 			return err
 		}
 		if _, err := service.CreateRole(t.Context(), cairnline.Role{
-			ID:               "role_embedded_health",
-			ProjectID:        projectID,
-			Name:             "Health Reviewer",
-			DefaultProfileID: "profile_embedded_health",
-			DefaultSkillIDs:  []string{"health"},
+			ID:              "role_embedded_health",
+			ProjectID:       projectID,
+			Name:            "Health Reviewer",
+			DefaultSkillIDs: []string{"health"},
 		}); err != nil {
 			return err
 		}
@@ -343,7 +340,6 @@ func TestProjectHealth_StrictEmbeddedReadModelReadsWithoutHecateProject(t *testi
 			WorkItemID:    "work_embedded_health",
 			RoleID:        "role_embedded_health",
 			RootID:        "root_embedded_health",
-			ProfileID:     "profile_embedded_health",
 			ExecutionMode: cairnline.ExecutionMCPPull,
 		}); err != nil {
 			return err

--- a/internal/api/handler_project_operations_test.go
+++ b/internal/api/handler_project_operations_test.go
@@ -279,11 +279,10 @@ func TestProjectOperationsBrief_StrictEmbeddedReadModelReadsWithoutHecateProject
 
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		if _, err := service.CreateProject(t.Context(), cairnline.Project{
-			ID:                        projectID,
-			Name:                      "Embedded Operations",
-			Description:               "Coordinate operations from embedded Cairnline.",
-			DefaultRootID:             "root_embedded_operations",
-			DefaultExecutionProfileID: "exec_embedded_operations",
+			ID:            projectID,
+			Name:          "Embedded Operations",
+			Description:   "Coordinate operations from embedded Cairnline.",
+			DefaultRootID: "root_embedded_operations",
 			Roots: []cairnline.Root{{
 				ID:     "root_embedded_operations",
 				Path:   "/workspace/embedded-operations",

--- a/internal/api/handler_project_setup_readiness_cairnline.go
+++ b/internal/api/handler_project_setup_readiness_cairnline.go
@@ -84,14 +84,13 @@ func projectSetupRolesFromCairnline(items []cairnline.Role) []projectwork.AgentR
 	out := make([]projectwork.AgentRoleProfile, 0, len(items))
 	for _, item := range items {
 		out = append(out, projectwork.AgentRoleProfile{
-			ID:                  item.ID,
-			ProjectID:           item.ProjectID,
-			Name:                item.Name,
-			Description:         item.Description,
-			Instructions:        item.Instructions,
-			DefaultAgentProfile: item.DefaultProfileID,
-			DefaultDriverKind:   item.DefaultExecutionMode,
-			SkillIDs:            append([]string(nil), item.DefaultSkillIDs...),
+			ID:                item.ID,
+			ProjectID:         item.ProjectID,
+			Name:              item.Name,
+			Description:       item.Description,
+			Instructions:      item.Instructions,
+			DefaultDriverKind: item.DefaultExecutionMode,
+			SkillIDs:          append([]string(nil), item.DefaultSkillIDs...),
 		})
 	}
 	return out

--- a/internal/api/handler_project_setup_readiness_test.go
+++ b/internal/api/handler_project_setup_readiness_test.go
@@ -274,11 +274,10 @@ func TestProjectSetupReadiness_StrictEmbeddedReadModelReadsWithoutHecateProject(
 
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		if _, err := service.CreateProject(t.Context(), cairnline.Project{
-			ID:                        projectID,
-			Name:                      "Embedded Setup",
-			Description:               "Coordinate setup from embedded Cairnline.",
-			DefaultRootID:             "root_embedded_setup",
-			DefaultExecutionProfileID: "exec_embedded_setup",
+			ID:            projectID,
+			Name:          "Embedded Setup",
+			Description:   "Coordinate setup from embedded Cairnline.",
+			DefaultRootID: "root_embedded_setup",
 			Roots: []cairnline.Root{{
 				ID:     "root_embedded_setup",
 				Path:   "/workspace/embedded-setup",

--- a/internal/api/handler_project_work_cairnline.go
+++ b/internal/api/handler_project_work_cairnline.go
@@ -903,7 +903,7 @@ func projectWorkRoleFromCairnline(item cairnline.Role, native projectwork.AgentR
 		DefaultDriverKind:   projectWorkAssignmentDriverFromCairnline(item.DefaultExecutionMode),
 		DefaultProvider:     native.DefaultProvider,
 		DefaultModel:        native.DefaultModel,
-		DefaultAgentProfile: firstNonEmptyString(item.DefaultProfileID, native.DefaultAgentProfile),
+		DefaultAgentProfile: native.DefaultAgentProfile,
 		SkillIDs:            append([]string(nil), item.DefaultSkillIDs...),
 		BuiltIn:             native.BuiltIn,
 		CreatedAt:           native.CreatedAt,

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -1284,7 +1284,7 @@ func TestProjectWorkAPI_CairnlineRoleAuthorityWritesCairnlineAndShadowsHecate(t 
 		t.Fatalf("created role timestamps = created:%q updated:%q, want Hecate shadow timestamps", created.Data.CreatedAt, created.Data.UpdatedAt)
 	}
 	mirroredRole := getMirroredCairnlineRoleForTest(t, handler, projectID, "role_authority")
-	if mirroredRole.Name != "Authority reviewer" || mirroredRole.DefaultProfileID != "" || mirroredRole.DefaultExecutionProfileID != "" || mirroredRole.DefaultExecutionMode != cairnline.ExecutionExternalAdapter {
+	if mirroredRole.Name != "Authority reviewer" || mirroredRole.DefaultExecutionMode != cairnline.ExecutionExternalAdapter {
 		t.Fatalf("Cairnline role = %+v, want role authority record", mirroredRole)
 	}
 	if len(mirroredRole.DefaultSkillIDs) != 1 || mirroredRole.DefaultSkillIDs[0] != "review" {
@@ -1838,7 +1838,7 @@ func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured
 		t.Fatalf("create role status = %d body=%s, want 201", rec.Code, rec.Body.String())
 	}
 	mirroredRole := getMirroredCairnlineRoleForTest(t, handler, project.Data.ID, "role_release")
-	if mirroredRole.Name != "Release captain" || mirroredRole.DefaultProfileID != "" || mirroredRole.DefaultExecutionProfileID != "" || mirroredRole.DefaultExecutionMode != "external_adapter" {
+	if mirroredRole.Name != "Release captain" || mirroredRole.DefaultExecutionMode != "external_adapter" {
 		t.Fatalf("mirrored role = %+v, want release captain defaults", mirroredRole)
 	}
 	if len(mirroredRole.DefaultSkillIDs) != 1 || mirroredRole.DefaultSkillIDs[0] != "release" {
@@ -1900,7 +1900,7 @@ func TestProjectWorkAPI_MirrorsRoleAndWorkItemMutationsToCairnlineWhenConfigured
 		t.Fatalf("create assignment status = %d body=%s, want 201", rec.Code, rec.Body.String())
 	}
 	mirroredAssignment := getMirroredCairnlineAssignmentForTest(t, handler, project.Data.ID, "asgn_release")
-	if mirroredAssignment.Status != cairnline.AssignmentQueued || mirroredAssignment.RoleID != "role_release" || mirroredAssignment.WorkItemID != "work_release" || mirroredAssignment.ProfileID != "" || mirroredAssignment.ExecutionProfileID != "" {
+	if mirroredAssignment.Status != cairnline.AssignmentQueued || mirroredAssignment.RoleID != "role_release" || mirroredAssignment.WorkItemID != "work_release" {
 		t.Fatalf("mirrored assignment = %+v, want queued release assignment metadata", mirroredAssignment)
 	}
 	if mirroredAssignment.ExecutionMode != cairnline.ExecutionExternalAdapter || mirroredAssignment.DesiredAgent.Kind != cairnline.DesiredAgentAny || mirroredAssignment.ContextSnapshotID != "ctx_release" {
@@ -2089,7 +2089,7 @@ func TestProjectWorkAPI_RolesUseCairnlineSidecarWhenConfigured(t *testing.T) {
 	if role.ProjectID != "proj_fixture" || role.ReadBackend != "cairnline" || role.BuiltIn {
 		t.Fatalf("role = %+v, want sidecar Cairnline non-built-in fixture role", role)
 	}
-	if role.Name != "Fixture Reviewer" || role.DefaultDriverKind != "mcp_pull" || role.DefaultAgentProfile != "profile_fixture" {
+	if role.Name != "Fixture Reviewer" || role.DefaultDriverKind != "mcp_pull" || role.DefaultAgentProfile != "" {
 		t.Fatalf("role defaults = %+v, want portable sidecar role defaults", role)
 	}
 	if !reflect.DeepEqual(role.SkillIDs, []string{"skill_fixture"}) {
@@ -2124,8 +2124,8 @@ func TestProjectWorkAPI_RolesCairnlineSidecarOverlayNativeRuntimeDefaults(t *tes
 	if role.ReadBackend != "cairnline" || role.DefaultProvider != "anthropic" || role.DefaultModel != "claude-sonnet-4" {
 		t.Fatalf("role = %+v, want sidecar role with native Hecate runtime overlay", role)
 	}
-	if role.DefaultAgentProfile != "profile_fixture" {
-		t.Fatalf("role preset = %q, want Cairnline preset hint to remain authoritative", role.DefaultAgentProfile)
+	if role.DefaultAgentProfile != "role_fixture_preset" {
+		t.Fatalf("role preset = %q, want Hecate runtime overlay preset", role.DefaultAgentProfile)
 	}
 }
 
@@ -2149,15 +2149,13 @@ func TestProjectWorkAPI_StrictEmbeddedReadModelReadsRolesWithoutHecateProject(t 
 			return err
 		}
 		_, err := service.CreateRole(t.Context(), cairnline.Role{
-			ID:                        "role_reviewer",
-			ProjectID:                 projectID,
-			Name:                      "Reviewer",
-			Description:               "Reviews completed assignments.",
-			Instructions:              "Inspect evidence before approving.",
-			DefaultProfileID:          "profile_review",
-			DefaultExecutionProfileID: "exec_external",
-			DefaultSkillIDs:           []string{"review"},
-			DefaultExecutionMode:      cairnline.ExecutionExternalAdapter,
+			ID:                   "role_reviewer",
+			ProjectID:            projectID,
+			Name:                 "Reviewer",
+			Description:          "Reviews completed assignments.",
+			Instructions:         "Inspect evidence before approving.",
+			DefaultSkillIDs:      []string{"review"},
+			DefaultExecutionMode: cairnline.ExecutionExternalAdapter,
 		})
 		return err
 	}); err != nil {
@@ -2181,7 +2179,7 @@ func TestProjectWorkAPI_StrictEmbeddedReadModelReadsRolesWithoutHecateProject(t 
 	if role.ProjectID != projectID || role.ReadBackend != "cairnline" || role.BuiltIn {
 		t.Fatalf("role = %+v, want embedded Cairnline non-built-in role", role)
 	}
-	if role.Name != "Reviewer" || role.DefaultDriverKind != projectwork.AssignmentDriverExternalAgent || role.DefaultAgentProfile != "profile_review" {
+	if role.Name != "Reviewer" || role.DefaultDriverKind != projectwork.AssignmentDriverExternalAgent || role.DefaultAgentProfile != "" {
 		t.Fatalf("role defaults = %+v, want embedded Cairnline role defaults", role)
 	}
 	if role.DefaultProvider != "" || role.DefaultModel != "" {
@@ -3720,8 +3718,8 @@ func TestProjectWorkAPI_PreflightAssignmentCairnlineSidecarOverlaysNativeRuntime
 	if preflight.Data.ExecutionMode != chat.ExecutionModeHecateTask || preflight.Data.Provider != "anthropic" || preflight.Data.Model != "claude-sonnet-4" {
 		t.Fatalf("sidecar preflight launch shape = %q/%q/%q, want Hecate runtime overlay", preflight.Data.ExecutionMode, preflight.Data.Provider, preflight.Data.Model)
 	}
-	if preflight.Data.ExecutionProfile != "profile_fixture" {
-		t.Fatalf("sidecar preflight execution_profile = %q, want Cairnline preset hint", preflight.Data.ExecutionProfile)
+	if preflight.Data.ExecutionProfile != "role_fixture_preset" {
+		t.Fatalf("sidecar preflight execution_profile = %q, want Hecate runtime overlay preset", preflight.Data.ExecutionProfile)
 	}
 	assertCairnlineSidecarLaunchPacketEvidenceForTest(t, preflight.Data)
 }
@@ -3741,11 +3739,10 @@ func TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHe
 
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		if _, err := service.CreateProject(t.Context(), cairnline.Project{
-			ID:                        projectID,
-			Name:                      "Embedded Launch Preflight",
-			Description:               "Coordinate launch preflight from embedded Cairnline.",
-			DefaultRootID:             "root_embedded_launch_preflight",
-			DefaultExecutionProfileID: "exec_embedded_launch_preflight",
+			ID:            projectID,
+			Name:          "Embedded Launch Preflight",
+			Description:   "Coordinate launch preflight from embedded Cairnline.",
+			DefaultRootID: "root_embedded_launch_preflight",
 			Roots: []cairnline.Root{{
 				ID:     "root_embedded_launch_preflight",
 				Path:   workspace,
@@ -3756,11 +3753,10 @@ func TestProjectWorkAPI_PreflightAssignmentStrictEmbeddedReadModelReadsWithoutHe
 			return err
 		}
 		if _, err := service.CreateRole(t.Context(), cairnline.Role{
-			ID:                        "role_embedded_launch_preflight",
-			ProjectID:                 projectID,
-			Name:                      "Launch Reviewer",
-			DefaultExecutionProfileID: "exec_embedded_launch_preflight",
-			DefaultExecutionMode:      cairnline.ExecutionMCPPull,
+			ID:                   "role_embedded_launch_preflight",
+			ProjectID:            projectID,
+			Name:                 "Launch Reviewer",
+			DefaultExecutionMode: cairnline.ExecutionMCPPull,
 		}); err != nil {
 			return err
 		}
@@ -3911,11 +3907,10 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineO
 
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		if _, err := service.CreateProject(t.Context(), cairnline.Project{
-			ID:                        projectID,
-			Name:                      "Embedded Launch Start",
-			Description:               "Coordinate assignment launch from embedded Cairnline.",
-			DefaultRootID:             "root_embedded_launch_start",
-			DefaultExecutionProfileID: "exec_embedded_launch_start",
+			ID:            projectID,
+			Name:          "Embedded Launch Start",
+			Description:   "Coordinate assignment launch from embedded Cairnline.",
+			DefaultRootID: "root_embedded_launch_start",
 			Roots: []cairnline.Root{{
 				ID:     "root_embedded_launch_start",
 				Path:   workspace,
@@ -3926,12 +3921,11 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelLaunchesCairnlineO
 			return err
 		}
 		if _, err := service.CreateRole(t.Context(), cairnline.Role{
-			ID:                        "role_embedded_launch_start",
-			ProjectID:                 projectID,
-			Name:                      "Launch Implementer",
-			Instructions:              "Use the embedded Cairnline graph.",
-			DefaultExecutionProfileID: "exec_embedded_launch_start",
-			DefaultExecutionMode:      cairnline.ExecutionOrchestrated,
+			ID:                   "role_embedded_launch_start",
+			ProjectID:            projectID,
+			Name:                 "Launch Implementer",
+			Instructions:         "Use the embedded Cairnline graph.",
+			DefaultExecutionMode: cairnline.ExecutionOrchestrated,
 		}); err != nil {
 			return err
 		}
@@ -4030,11 +4024,10 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelBlocksBeforeClaimW
 
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		if _, err := service.CreateProject(t.Context(), cairnline.Project{
-			ID:                        projectID,
-			Name:                      "Embedded Launch Task Create Fail",
-			Description:               "Coordinate failed assignment launch from embedded Cairnline.",
-			DefaultRootID:             "root_embedded_launch_task_create_fail",
-			DefaultExecutionProfileID: "exec_embedded_launch_task_create_fail",
+			ID:            projectID,
+			Name:          "Embedded Launch Task Create Fail",
+			Description:   "Coordinate failed assignment launch from embedded Cairnline.",
+			DefaultRootID: "root_embedded_launch_task_create_fail",
 			Roots: []cairnline.Root{{
 				ID:     "root_embedded_launch_task_create_fail",
 				Path:   workspace,
@@ -4045,12 +4038,11 @@ func TestProjectWorkAPI_StartAssignmentStrictEmbeddedReadModelBlocksBeforeClaimW
 			return err
 		}
 		if _, err := service.CreateRole(t.Context(), cairnline.Role{
-			ID:                        "role_embedded_launch_task_create_fail",
-			ProjectID:                 projectID,
-			Name:                      "Launch Implementer",
-			Instructions:              "Use the embedded Cairnline graph.",
-			DefaultExecutionProfileID: "exec_embedded_launch_task_create_fail",
-			DefaultExecutionMode:      cairnline.ExecutionOrchestrated,
+			ID:                   "role_embedded_launch_task_create_fail",
+			ProjectID:            projectID,
+			Name:                 "Launch Implementer",
+			Instructions:         "Use the embedded Cairnline graph.",
+			DefaultExecutionMode: cairnline.ExecutionOrchestrated,
 		}); err != nil {
 			return err
 		}
@@ -4129,6 +4121,13 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelLaunc
 	}); err != nil {
 		t.Fatalf("Create external profile: %v", err)
 	}
+	if _, err := handler.projectRuntime.UpsertRoleDefaults(t.Context(), projectruntime.RoleDefaults{
+		ProjectID:           projectID,
+		RoleID:              "role_embedded_external_start",
+		DefaultAgentProfile: "prof_embedded_external",
+	}); err != nil {
+		t.Fatalf("Upsert external role runtime defaults: %v", err)
+	}
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		if _, err := service.CreateProject(t.Context(), cairnline.Project{
 			ID:            projectID,
@@ -4149,7 +4148,6 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelLaunc
 			ProjectID:            projectID,
 			Name:                 "External Implementer",
 			Instructions:         "Use the embedded Cairnline graph before preparing the adapter session.",
-			DefaultProfileID:     "prof_embedded_external",
 			DefaultExecutionMode: cairnline.ExecutionExternalAdapter,
 		}); err != nil {
 			return err
@@ -4281,6 +4279,13 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelClean
 	}); err != nil {
 		t.Fatalf("Create external profile: %v", err)
 	}
+	if _, err := handler.projectRuntime.UpsertRoleDefaults(t.Context(), projectruntime.RoleDefaults{
+		ProjectID:           projectID,
+		RoleID:              "role_embedded_external_claim_lost",
+		DefaultAgentProfile: "prof_embedded_external_claim_lost",
+	}); err != nil {
+		t.Fatalf("Upsert external role runtime defaults: %v", err)
+	}
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		if _, err := service.CreateProject(t.Context(), cairnline.Project{
 			ID:            projectID,
@@ -4301,7 +4306,6 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelClean
 			ProjectID:            projectID,
 			Name:                 "External Implementer",
 			Instructions:         "Use the embedded Cairnline graph before preparing the adapter session.",
-			DefaultProfileID:     "prof_embedded_external_claim_lost",
 			DefaultExecutionMode: cairnline.ExecutionExternalAdapter,
 		}); err != nil {
 			return err
@@ -8364,8 +8368,7 @@ func assertCairnlineSidecarLaunchPacketEvidenceForTest(t *testing.T, packet Chat
 		"Ready: true",
 		"Assignment: asg_fixture",
 		"Execution mode: mcp_pull",
-		"Agent preset: profile_fixture",
-		"Runtime profile: exec_fixture",
+		"Desired agent: any",
 	} {
 		if !strings.Contains(item.Body, want) {
 			t.Fatalf("Cairnline sidecar launch packet body = %q, want %q", item.Body, want)

--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -910,7 +910,7 @@ func projectFromCairnline(item cairnline.Project, native projects.Project) proje
 		DefaultRootID:            item.DefaultRootID,
 		DefaultProvider:          native.DefaultProvider,
 		DefaultModel:             native.DefaultModel,
-		DefaultAgentProfile:      firstNonEmpty(item.DefaultProfileID, native.DefaultAgentProfile),
+		DefaultAgentProfile:      native.DefaultAgentProfile,
 		DefaultToolsEnabled:      cloneBool(native.DefaultToolsEnabled),
 		DefaultWorkspaceMode:     native.DefaultWorkspaceMode,
 		DefaultSystemPrompt:      native.DefaultSystemPrompt,

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -617,12 +617,10 @@ func TestProjectsAPI_StrictEmbeddedReadModelReadsProjectsWithoutHecateStore(t *t
 
 	if err := handler.withCairnlineEmbeddedMirrorService(t.Context(), func(service *cairnline.Service) error {
 		_, err := service.CreateProject(t.Context(), cairnline.Project{
-			ID:                        projectID,
-			Name:                      "Embedded Project",
-			Description:               "Read directly from Cairnline.",
-			DefaultRootID:             "root_main",
-			DefaultProfileID:          "profile_architect",
-			DefaultExecutionProfileID: "exec_embedded",
+			ID:            projectID,
+			Name:          "Embedded Project",
+			Description:   "Read directly from Cairnline.",
+			DefaultRootID: "root_main",
 			Roots: []cairnline.Root{{
 				ID:        "root_main",
 				Path:      "/workspace/embedded",
@@ -690,8 +688,6 @@ func TestProjectsAPI_MirrorsIdentityMutationsToCairnlineWhenConfigured(t *testin
 	if len(mirrored.ContextSources) != 1 || mirrored.ContextSources[0].ID != "ctx_agents" || mirrored.ContextSources[0].Locator != "AGENTS.md" {
 		t.Fatalf("mirrored context sources = %+v, want AGENTS.md source", mirrored.ContextSources)
 	}
-	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
-
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, bytes.NewReader([]byte(`{
 		"name":"Mirrored Rename",
@@ -704,8 +700,6 @@ func TestProjectsAPI_MirrorsIdentityMutationsToCairnlineWhenConfigured(t *testin
 	if mirrored.Name != "Mirrored Rename" {
 		t.Fatalf("mirrored name = %q, want patched name", mirrored.Name)
 	}
-	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
-
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+created.Data.ID+"/roots", bytes.NewReader([]byte(`{
 		"id":"root_worktree",
@@ -836,7 +830,6 @@ func TestProjectsAPI_CairnlineIdentityAuthorityCommitsCreateFirst(t *testing.T) 
 	if mirrored.Name != "Identity Authority" || mirrored.Description != "created through Cairnline" || mirrored.DefaultRootID != "root_main" || len(mirrored.Roots) != 1 || len(mirrored.ContextSources) != 1 {
 		t.Fatalf("mirrored project = %+v, want identity create committed to Cairnline", mirrored)
 	}
-	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 }
 
 func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *testing.T) {
@@ -871,8 +864,6 @@ func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *tes
 	if mirrored.Name != "Replacement Identity" || mirrored.Description != "created only in Cairnline" || mirrored.DefaultRootID != "root_main" || len(mirrored.Roots) != 1 {
 		t.Fatalf("mirrored project = %+v, want Cairnline-only replacement identity", mirrored)
 	}
-	assertNoMirroredRuntimeHintsForTest(t, mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
-
 	listed := listProjectsForTest(t, server)
 	if len(listed) != 1 || listed[0].ID != created.Data.ID || listed[0].ReadBackend != "cairnline" {
 		t.Fatalf("listed projects = %+v, want strict embedded Cairnline read of replacement identity", listed)
@@ -1359,7 +1350,7 @@ func TestProjectsAPI_CairnlineMetadataDefaultsAuthorityCommitsScopedUpdatesFirst
 	}
 
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
-	if mirrored.Name != "Authority Rename" || mirrored.Description != "Cairnline owns scoped project settings." || mirrored.DefaultRootID != "root_main" || mirrored.DefaultProfileID != "" || mirrored.DefaultExecutionProfileID != "" {
+	if mirrored.Name != "Authority Rename" || mirrored.Description != "Cairnline owns scoped project settings." || mirrored.DefaultRootID != "root_main" {
 		t.Fatalf("mirrored project = %+v, want scoped metadata/default authority", mirrored)
 	}
 	if len(mirrored.Roots) != 1 || mirrored.Roots[0].ID != "root_main" {
@@ -1791,9 +1782,6 @@ func TestProjectsAPI_RuntimeDefaultPatchPreservesCairnlinePortableState(t *testi
 		t.Fatalf("defaults update status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
-	if mirrored.DefaultProfileID != "" || mirrored.DefaultExecutionProfileID != "" {
-		t.Fatalf("mirrored runtime hints = profile:%q execution:%q, want Hecate-owned defaults omitted from Cairnline", mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
-	}
 	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_cairnline_only") == nil {
 		t.Fatalf("mirrored roots = %+v, want Cairnline-only root preserved", mirrored.Roots)
 	}
@@ -1899,9 +1887,6 @@ func TestProjectsAPI_MetadataPatchMirrorsMetadataWithoutReplacingCairnlineState(
 	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
 	if mirrored.Name != "Metadata Mirror Renamed" || mirrored.Description != "After" {
 		t.Fatalf("mirrored metadata = %+v, want renamed project with updated description", mirrored)
-	}
-	if mirrored.DefaultProfileID != "" || mirrored.DefaultExecutionProfileID != "" {
-		t.Fatalf("mirrored runtime hints = profile:%q execution:%q, want Hecate-owned defaults omitted from Cairnline", mirrored.DefaultProfileID, mirrored.DefaultExecutionProfileID)
 	}
 	if findMirroredCairnlineRootForTest(mirrored.Roots, "root_cairnline_only") == nil {
 		t.Fatalf("mirrored roots = %+v, want Cairnline-only root preserved", mirrored.Roots)
@@ -2159,7 +2144,7 @@ func assertStrictEmbeddedProjectProjectionForTest(t *testing.T, project ProjectR
 	if project.ID != projectID || project.ReadBackend != "cairnline" || project.Name != "Embedded Project" || project.Description != "Read directly from Cairnline." {
 		t.Fatalf("project = %+v, want direct embedded Cairnline project %s", project, projectID)
 	}
-	if project.DefaultRootID != "root_main" || project.DefaultAgentProfile != "profile_architect" {
+	if project.DefaultRootID != "root_main" || project.DefaultAgentProfile != "" {
 		t.Fatalf("project defaults = %+v, want Cairnline project defaults", project)
 	}
 	if project.DefaultProvider != "" || project.DefaultModel != "" || project.DefaultWorkspaceMode != "" {
@@ -2399,13 +2384,6 @@ func findMirroredCairnlineSourceForTest(sources []cairnline.Source, id string) *
 		}
 	}
 	return nil
-}
-
-func assertNoMirroredRuntimeHintsForTest(t *testing.T, profileID, executionProfileID string) {
-	t.Helper()
-	if profileID != "" || executionProfileID != "" {
-		t.Fatalf("mirrored runtime hints = profile:%q execution:%q, want omitted from portable Cairnline graph", profileID, executionProfileID)
-	}
 }
 
 type failingProjectSkillDeleteStore struct {

--- a/internal/cairnlinebridge/assistant.go
+++ b/internal/cairnlinebridge/assistant.go
@@ -174,7 +174,6 @@ func AssistantAction(action projectassistant.Action) (cairnline.AssistantAction,
 			Name:                 strings.TrimSpace(patch.Name),
 			Description:          strings.TrimSpace(patch.Description),
 			Instructions:         strings.TrimSpace(patch.Instructions),
-			DefaultProfileID:     strings.TrimSpace(patch.DefaultAgentProfile),
 			DefaultSkillIDs:      compactStrings(patch.SkillIDs),
 			DefaultExecutionMode: ExecutionMode(patch.DefaultDriverKind),
 		}
@@ -353,14 +352,13 @@ func ProjectAssistantAction(action cairnline.AssistantAction) (projectassistant.
 			return projectassistant.Action{}, false
 		}
 		patch, ok = projectAssistantRawPatch(assistantRolePatch{
-			ID:                  strings.TrimSpace(action.Role.ID),
-			ProjectID:           strings.TrimSpace(action.Role.ProjectID),
-			Name:                strings.TrimSpace(action.Role.Name),
-			Description:         strings.TrimSpace(action.Role.Description),
-			Instructions:        strings.TrimSpace(action.Role.Instructions),
-			DefaultDriverKind:   DriverKind(action.Role.DefaultExecutionMode),
-			DefaultAgentProfile: strings.TrimSpace(action.Role.DefaultProfileID),
-			SkillIDs:            compactStrings(action.Role.DefaultSkillIDs),
+			ID:                strings.TrimSpace(action.Role.ID),
+			ProjectID:         strings.TrimSpace(action.Role.ProjectID),
+			Name:              strings.TrimSpace(action.Role.Name),
+			Description:       strings.TrimSpace(action.Role.Description),
+			Instructions:      strings.TrimSpace(action.Role.Instructions),
+			DefaultDriverKind: DriverKind(action.Role.DefaultExecutionMode),
+			SkillIDs:          compactStrings(action.Role.DefaultSkillIDs),
 		})
 	case cairnline.AssistantActionCreateWorkItem:
 		if action.WorkItem == nil {

--- a/internal/cairnlinebridge/bridge_test.go
+++ b/internal/cairnlinebridge/bridge_test.go
@@ -33,9 +33,6 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	if packet.Project.ID != "proj_hecate" || packet.Project.DefaultRootID != "root_main" || packet.WorkItem.RootID != "root_main" {
 		t.Fatalf("packet project/work = %+v/%+v, want Hecate project with default root and root-scoped work", packet.Project, packet.WorkItem)
 	}
-	if packet.Project.DefaultProfileID != "" || packet.Project.DefaultExecutionProfileID != "" {
-		t.Fatalf("packet project defaults = %+v, want Hecate runtime defaults omitted from Cairnline", packet.Project)
-	}
 	if len(packet.Project.ContextSources) != 1 {
 		t.Fatalf("packet project sources = %+v, want one context source", packet.Project.ContextSources)
 	}
@@ -45,12 +42,6 @@ func TestSeedMirrorsProjectWorkIntoCairnline(t *testing.T) {
 	}
 	if packet.Role == nil || packet.Role.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
 		t.Fatalf("packet role = %+v, want orchestrated role from Hecate task driver", packet.Role)
-	}
-	if packet.Role.DefaultProfileID != "" || packet.Role.DefaultExecutionProfileID != "" {
-		t.Fatalf("packet role defaults = %+v, want Hecate runtime defaults omitted from Cairnline", packet.Role)
-	}
-	if packet.Assignment.ProfileID != "" || packet.Assignment.ExecutionProfileID != "" {
-		t.Fatalf("packet assignment runtime hints = profile:%q execution:%q, want omitted Hecate runtime defaults", packet.Assignment.ProfileID, packet.Assignment.ExecutionProfileID)
 	}
 	if packet.Assignment.ExecutionMode != cairnline.ExecutionOrchestrated || packet.Assignment.RootID != "root_main" || packet.Assignment.ContextSnapshotID != "ctx_123" {
 		t.Fatalf("packet assignment = %+v, want orchestrated root-scoped assignment", packet.Assignment)
@@ -419,7 +410,7 @@ func TestUpsertProjectMirrorsProjectRootAndContextSourceMutations(t *testing.T) 
 	if err != nil {
 		t.Fatalf("UpsertProject(create) error = %v", err)
 	}
-	if created.ID != project.ID || created.DefaultRootID != "root_main" || created.DefaultProfileID != "" || created.DefaultExecutionProfileID != "" {
+	if created.ID != project.ID || created.DefaultRootID != "root_main" {
 		t.Fatalf("created project = %+v, want portable project defaults without Hecate runtime hints", created)
 	}
 	if len(created.Roots) != 1 || created.Roots[0].Path != "/tmp/hecate-write" || created.Roots[0].GitBranch != "main" {
@@ -456,7 +447,7 @@ func TestUpsertProjectMirrorsProjectRootAndContextSourceMutations(t *testing.T) 
 	if err != nil {
 		t.Fatalf("UpsertProject(update) error = %v", err)
 	}
-	if updated.Name != "Write Adapter Updated" || updated.DefaultRootID != "root_docs" || updated.DefaultExecutionProfileID != "" {
+	if updated.Name != "Write Adapter Updated" || updated.DefaultRootID != "root_docs" {
 		t.Fatalf("updated project = %+v, want updated project and removed execution default", updated)
 	}
 	if len(updated.Roots) != 1 || updated.Roots[0].ID != "root_docs" {
@@ -526,7 +517,7 @@ func TestUpsertProjectDefaultsPreservesRootAndSourceState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertProjectDefaults(update) error = %v", err)
 	}
-	if updated.DefaultRootID != "root_main" || updated.DefaultProfileID != "" || updated.DefaultExecutionProfileID != "" {
+	if updated.DefaultRootID != "root_main" {
 		t.Fatalf("updated defaults = %+v, want only portable defaults written to Cairnline", updated)
 	}
 	if findCairnlineRoot(updated.Roots, "root_cairnline_only") == nil {
@@ -545,9 +536,6 @@ func TestUpsertProjectDefaultsPreservesRootAndSourceState(t *testing.T) {
 	updated, err = UpsertProjectDefaults(ctx, service, project)
 	if err != nil {
 		t.Fatalf("UpsertProjectDefaults(clear) error = %v", err)
-	}
-	if updated.DefaultExecutionProfileID != "" {
-		t.Fatalf("cleared defaults = %+v, want no execution profile default", updated)
 	}
 }
 
@@ -1024,7 +1012,7 @@ func TestUpsertRoleMirrorsRoleAndExecutionDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertRole(create) error = %v", err)
 	}
-	if created.ID != "developer" || created.DefaultProfileID != "" || created.DefaultExecutionProfileID != "" || created.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
+	if created.ID != "developer" || created.DefaultExecutionMode != cairnline.ExecutionOrchestrated {
 		t.Fatalf("created role = %+v, want portable role defaults without Hecate runtime hints", created)
 	}
 	if len(created.DefaultSkillIDs) != 1 || created.DefaultSkillIDs[0] != "backend" {
@@ -1038,7 +1026,7 @@ func TestUpsertRoleMirrorsRoleAndExecutionDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertRole(update) error = %v", err)
 	}
-	if updated.Name != "Developer Updated" || updated.DefaultExecutionProfileID != "" || len(updated.DefaultSkillIDs) != 1 || updated.DefaultSkillIDs[0] != "frontend" {
+	if updated.Name != "Developer Updated" || len(updated.DefaultSkillIDs) != 1 || updated.DefaultSkillIDs[0] != "frontend" {
 		t.Fatalf("updated role = %+v, want updated role and removed execution default", updated)
 	}
 	if err := DeleteRole(ctx, service, role); err != nil {
@@ -1184,7 +1172,7 @@ func TestUpsertAssignmentCreatesAndSyncsLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertAssignment(queued) error = %v", err)
 	}
-	if queued.Status != cairnline.AssignmentQueued || queued.ProfileID != "" || queued.ExecutionProfileID != "" || queued.ExecutionMode != cairnline.ExecutionOrchestrated || queued.ContextSnapshotID != "ctx_queued" {
+	if queued.Status != cairnline.AssignmentQueued || queued.ExecutionMode != cairnline.ExecutionOrchestrated || queued.ContextSnapshotID != "ctx_queued" {
 		t.Fatalf("queued assignment = %+v, want created orchestrated assignment metadata", queued)
 	}
 	if queued.DesiredAgent.Kind != "hecate" || len(queued.DesiredAgent.SkillIDs) != 1 || queued.DesiredAgent.SkillIDs[0] != "backend" {
@@ -1731,11 +1719,6 @@ func TestSeedSnapshotsMirrorsMultipleProjectsWithPresetHintsOnly(t *testing.T) {
 	}
 	if len(projects) != 2 {
 		t.Fatalf("projects = %+v, want two seeded projects", projects)
-	}
-	for _, item := range projects {
-		if item.DefaultProfileID != "" || item.DefaultExecutionProfileID != "" {
-			t.Fatalf("project = %+v, want Hecate runtime hints omitted from Cairnline", item)
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- bump Cairnline to the version that removes legacy profile/execution-profile fields
- stop projecting Cairnline profile hints into Hecate Projects; keep Agent Presets/runtime defaults in Hecate overlays
- update Cairnline context/evidence rendering, tests, and runtime API docs for the portable role/assignment shape

## Tests
- GOCACHE="$(pwd)/.gocache" go test ./internal/cairnlinebridge ./internal/api -run 'TestCairnline|TestProject.*Cairnline|TestProjectsAPI|TestProjectCoordinationBackend|TestProjectHealth|TestProjectOperations|TestProjectSetup'\n- GOCACHE="$(pwd)/.gocache" go test ./internal/cairnlinebridge ./internal/api\n- GOCACHE="$(pwd)/.gocache" go test ./...\n- go vet ./...\n- just agent-docs-check\n- git diff --check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n