### PR TITLE
refactor(projects): remove sidecar profile compatibility

### DIFF
--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -185,13 +185,11 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			return cairnlineSidecarFixtureListResult(mode, fmt.Sprintf("Roles (%d)", len(roles)), roles)
 		}
 		return cairnlineSidecarFixtureListResult(mode, "Roles (1):\n- role_fixture: Fixture Reviewer", []ProjectCairnlineSidecarRoleItem{{
-			ProjectID:                 projectID,
-			ID:                        "role_fixture",
-			Name:                      "Fixture Reviewer",
-			DefaultProfileID:          "profile_fixture",
-			DefaultExecutionMode:      "mcp_pull",
-			DefaultSkillIDs:           []string{"skill_fixture"},
-			DefaultExecutionProfileID: "exec_fixture",
+			ProjectID:            projectID,
+			ID:                   "role_fixture",
+			Name:                 "Fixture Reviewer",
+			DefaultExecutionMode: "mcp_pull",
+			DefaultSkillIDs:      []string{"skill_fixture"},
 		}})
 	case "work_items.list":
 		projectID := cairnlineSidecarFixtureProjectID(params.Arguments)
@@ -218,11 +216,14 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			ID:            "asg_fixture",
 			WorkItemID:    "work_fixture",
 			RoleID:        "role_fixture",
-			ProfileID:     "profile_fixture",
 			ExecutionMode: "mcp_pull",
-			Status:        state.assignmentStatus,
-			ClaimedBy:     state.claimedBy,
-			ExecutionRef:  state.executionRef,
+			DesiredAgent: ProjectCairnlineSidecarDesiredAgentItem{
+				Kind:     "any",
+				SkillIDs: []string{"skill_fixture"},
+			},
+			Status:       state.assignmentStatus,
+			ClaimedBy:    state.claimedBy,
+			ExecutionRef: state.executionRef,
 		}})
 	case "projects.activity":
 		projectID := cairnlineSidecarFixtureProjectID(params.Arguments)
@@ -249,9 +250,12 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			"id":             "asg_fixture",
 			"work_item_id":   "work_fixture",
 			"role_id":        "role_fixture",
-			"profile_id":     "profile_fixture",
 			"execution_mode": "mcp_pull",
-			"status":         state.assignmentStatus,
+			"desired_agent": map[string]any{
+				"kind":      "any",
+				"skill_ids": []string{"skill_fixture"},
+			},
+			"status": state.assignmentStatus,
 		}})
 	case "assignments.claim":
 		if mode == "claim-tool-error" {
@@ -416,11 +420,14 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			ProjectID:     input.ProjectID,
 			WorkItemID:    "work_fixture",
 			RoleID:        "role_fixture",
-			ProfileID:     "profile_fixture",
 			ExecutionMode: "mcp_pull",
-			Status:        state.assignmentStatus,
-			ClaimedBy:     state.claimedBy,
-			ExecutionRef:  state.executionRef,
+			DesiredAgent: ProjectCairnlineSidecarDesiredAgentItem{
+				Kind:     "any",
+				SkillIDs: []string{"skill_fixture"},
+			},
+			Status:       state.assignmentStatus,
+			ClaimedBy:    state.claimedBy,
+			ExecutionRef: state.executionRef,
 		}
 		if stored, ok := state.assignments[input.ProjectID][input.AssignmentID]; ok {
 			assignment = stored
@@ -439,10 +446,8 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 				"id":   "launch_fixture",
 				"kind": "assignment_launch_packet",
 				"project": map[string]any{
-					"id":                           projectID,
-					"name":                         "Fixture Project",
-					"default_profile_id":           firstNonEmpty(assignment.ProfileID, "profile_fixture"),
-					"default_execution_profile_id": "exec_fixture",
+					"id":   projectID,
+					"name": "Fixture Project",
 				},
 				"work_item": map[string]any{
 					"id":         workItemID,
@@ -450,26 +455,23 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 					"title":      firstNonEmpty(cairnlineSidecarFixtureWorkItemTitle(state, input.ProjectID, workItemID), "Fixture Work"),
 				},
 				"role": map[string]any{
-					"id":                           assignment.RoleID,
-					"name":                         firstNonEmpty(cairnlineSidecarFixtureRoleName(state, input.ProjectID, assignment.RoleID), "Fixture Reviewer"),
-					"default_profile_id":           firstNonEmpty(assignment.ProfileID, "profile_fixture"),
-					"default_execution_profile_id": "exec_fixture",
+					"id":   assignment.RoleID,
+					"name": firstNonEmpty(cairnlineSidecarFixtureRoleName(state, input.ProjectID, assignment.RoleID), "Fixture Reviewer"),
 				},
 				"skills": []map[string]any{{
 					"id":    "skill_fixture",
 					"title": "Fixture Skill",
 				}},
 				"assignment": map[string]any{
-					"id":                   assignment.ID,
-					"project_id":           projectID,
-					"work_item_id":         workItemID,
-					"role_id":              assignment.RoleID,
-					"status":               assignment.Status,
-					"claimed_by":           assignment.ClaimedBy,
-					"execution_ref":        assignment.ExecutionRef,
-					"execution_mode":       assignment.ExecutionMode,
-					"profile_id":           firstNonEmpty(assignment.ProfileID, "profile_fixture"),
-					"execution_profile_id": "exec_fixture",
+					"id":             assignment.ID,
+					"project_id":     projectID,
+					"work_item_id":   workItemID,
+					"role_id":        assignment.RoleID,
+					"status":         assignment.Status,
+					"claimed_by":     assignment.ClaimedBy,
+					"execution_ref":  assignment.ExecutionRef,
+					"execution_mode": assignment.ExecutionMode,
+					"desired_agent":  assignment.DesiredAgent,
 				},
 				"artifacts":         []map[string]any{{"id": "artifact_fixture"}},
 				"evidence":          []map[string]any{{"id": "evidence_fixture"}},
@@ -731,14 +733,12 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		return mcp.CallToolResult{Content: mcp.TextContent(fmt.Sprintf("Assistant apply %s: %s actions=%d/%d", record.ID, result.Status, result.AppliedActionCount, result.TotalActionCount)), StructuredContent: mustRawJSON(result)}, nil
 	case "roles.create":
 		var input struct {
-			ProjectID                 string   `json:"project_id"`
-			Name                      string   `json:"name"`
-			Description               string   `json:"description"`
-			Instructions              string   `json:"instructions"`
-			DefaultProfileID          string   `json:"default_profile_id"`
-			DefaultExecutionProfileID string   `json:"default_execution_profile_id"`
-			DefaultSkillIDs           []string `json:"default_skill_ids"`
-			DefaultExecutionMode      string   `json:"default_execution_mode"`
+			ProjectID            string   `json:"project_id"`
+			Name                 string   `json:"name"`
+			Description          string   `json:"description"`
+			Instructions         string   `json:"instructions"`
+			DefaultSkillIDs      []string `json:"default_skill_ids"`
+			DefaultExecutionMode string   `json:"default_execution_mode"`
 		}
 		if err := json.Unmarshal(params.Arguments, &input); err != nil {
 			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid roles.create arguments")
@@ -749,15 +749,13 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		state.roleSequence++
 		id := fmt.Sprintf("role_write_fixture_%d", state.roleSequence)
 		role := ProjectCairnlineSidecarRoleItem{
-			ProjectID:                 input.ProjectID,
-			ID:                        id,
-			Name:                      input.Name,
-			Description:               input.Description,
-			Instructions:              input.Instructions,
-			DefaultProfileID:          input.DefaultProfileID,
-			DefaultExecutionProfileID: input.DefaultExecutionProfileID,
-			DefaultSkillIDs:           input.DefaultSkillIDs,
-			DefaultExecutionMode:      input.DefaultExecutionMode,
+			ProjectID:            input.ProjectID,
+			ID:                   id,
+			Name:                 input.Name,
+			Description:          input.Description,
+			Instructions:         input.Instructions,
+			DefaultSkillIDs:      input.DefaultSkillIDs,
+			DefaultExecutionMode: input.DefaultExecutionMode,
 		}
 		cairnlineSidecarFixtureEnsureRoles(state, input.ProjectID)[id] = role
 		return mcp.CallToolResult{Content: mcp.TextContent("Created role " + id + ": " + input.Name)}, nil
@@ -791,15 +789,13 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 		return mcp.CallToolResult{Content: mcp.TextContent("Created work item " + id + ": " + input.Title)}, nil
 	case "assignments.create":
 		var input struct {
-			ProjectID          string   `json:"project_id"`
-			WorkItemID         string   `json:"work_item_id"`
-			RoleID             string   `json:"role_id"`
-			RootID             string   `json:"root_id"`
-			ProfileID          string   `json:"profile_id"`
-			ExecutionProfileID string   `json:"execution_profile_id"`
-			ExecutionMode      string   `json:"execution_mode"`
-			DesiredAgentKind   string   `json:"desired_agent_kind"`
-			SkillIDs           []string `json:"skill_ids"`
+			ProjectID        string   `json:"project_id"`
+			WorkItemID       string   `json:"work_item_id"`
+			RoleID           string   `json:"role_id"`
+			RootID           string   `json:"root_id"`
+			ExecutionMode    string   `json:"execution_mode"`
+			DesiredAgentKind string   `json:"desired_agent_kind"`
+			SkillIDs         []string `json:"skill_ids"`
 		}
 		if err := json.Unmarshal(params.Arguments, &input); err != nil {
 			return mcp.CallToolResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "invalid assignments.create arguments")
@@ -814,10 +810,13 @@ func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixture
 			ID:            id,
 			WorkItemID:    input.WorkItemID,
 			RoleID:        input.RoleID,
-			ProfileID:     input.ProfileID,
+			RootID:        input.RootID,
 			ExecutionMode: input.ExecutionMode,
-			Status:        "queued",
-			SkillIDs:      input.SkillIDs,
+			DesiredAgent: ProjectCairnlineSidecarDesiredAgentItem{
+				Kind:     input.DesiredAgentKind,
+				SkillIDs: append([]string(nil), input.SkillIDs...),
+			},
+			Status: "queued",
 		}
 		cairnlineSidecarFixtureEnsureAssignments(state, input.ProjectID)[id] = assignment
 		return mcp.CallToolResult{Content: mcp.TextContent("Created assignment " + id)}, nil
@@ -2059,11 +2058,14 @@ func cairnlineSidecarFixtureProjectActivity(state *cairnlineSidecarFixtureState,
 			ID:            "asg_fixture",
 			WorkItemID:    "work_fixture",
 			RoleID:        "role_fixture",
-			ProfileID:     "profile_fixture",
 			ExecutionMode: "mcp_pull",
-			Status:        state.assignmentStatus,
-			ClaimedBy:     state.claimedBy,
-			ExecutionRef:  state.executionRef,
+			DesiredAgent: ProjectCairnlineSidecarDesiredAgentItem{
+				Kind:     "any",
+				SkillIDs: []string{"skill_fixture"},
+			},
+			Status:       state.assignmentStatus,
+			ClaimedBy:    state.claimedBy,
+			ExecutionRef: state.executionRef,
 		}}
 	}
 	items := make([]map[string]any, 0, len(assignments))

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hecatehq/cairnline"
-	"github.com/hecatehq/hecate/internal/agentprofiles"
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/orchestrator"
@@ -450,19 +449,6 @@ func projectHandoffsFromCairnlineSidecar(items []ProjectCairnlineSidecarHandoffI
 	return out
 }
 
-func projectAgentProfilesFromCairnlineSidecar(items []ProjectCairnlineSidecarAgentProfileItem) []agentprofiles.Profile {
-	out := make([]agentprofiles.Profile, 0, len(items))
-	for _, item := range items {
-		out = append(out, agentprofiles.Profile{
-			ID:          item.ID,
-			Name:        item.Name,
-			Description: item.Description,
-			SkillIDs:    append([]string(nil), item.SkillIDs...),
-		})
-	}
-	return out
-}
-
 func projectSkillsFromCairnlineSidecar(items []ProjectCairnlineSidecarSkillItem) []projectskills.Skill {
 	out := make([]projectskills.Skill, 0, len(items))
 	for _, item := range items {
@@ -570,27 +556,6 @@ func projectCairnlineSidecarTime(value string) time.Time {
 		return time.Time{}
 	}
 	return parsed.UTC()
-}
-
-func projectCairnlineSidecarStructuredAgentProfiles(raw json.RawMessage) ([]ProjectCairnlineSidecarAgentProfileItem, bool, error) {
-	if len(raw) == 0 {
-		return nil, false, nil
-	}
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 {
-		return nil, false, nil
-	}
-	if bytes.Equal(trimmed, []byte("null")) {
-		return []ProjectCairnlineSidecarAgentProfileItem{}, true, nil
-	}
-	var profiles []ProjectCairnlineSidecarAgentProfileItem
-	if err := json.Unmarshal(trimmed, &profiles); err != nil {
-		return nil, false, err
-	}
-	if profiles == nil {
-		profiles = []ProjectCairnlineSidecarAgentProfileItem{}
-	}
-	return profiles, true, nil
 }
 
 func projectCairnlineSidecarStructuredSkills(raw json.RawMessage) ([]ProjectCairnlineSidecarSkillItem, bool, error) {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -2025,14 +2025,12 @@ type ProjectCairnlineSidecarLaunchPacketResponse struct {
 }
 
 type ProjectCairnlineSidecarLaunchPacketIDs struct {
-	LaunchPacketID     string `json:"launch_packet_id,omitempty"`
-	Kind               string `json:"kind,omitempty"`
-	ProjectID          string `json:"project_id,omitempty"`
-	AssignmentID       string `json:"assignment_id,omitempty"`
-	WorkItemID         string `json:"work_item_id,omitempty"`
-	RoleID             string `json:"role_id,omitempty"`
-	ProfileID          string `json:"profile_id,omitempty"`
-	ExecutionProfileID string `json:"execution_profile_id,omitempty"`
+	LaunchPacketID string `json:"launch_packet_id,omitempty"`
+	Kind           string `json:"kind,omitempty"`
+	ProjectID      string `json:"project_id,omitempty"`
+	AssignmentID   string `json:"assignment_id,omitempty"`
+	WorkItemID     string `json:"work_item_id,omitempty"`
+	RoleID         string `json:"role_id,omitempty"`
 }
 
 type ProjectCairnlineSidecarLaunchPacketCounts struct {
@@ -2323,48 +2321,47 @@ type ProjectCairnlineSidecarWriteStep struct {
 }
 
 type ProjectCairnlineSidecarProjectItem struct {
-	ID                        string                              `json:"id"`
-	Name                      string                              `json:"name"`
-	Description               string                              `json:"description,omitempty"`
-	DefaultRootID             string                              `json:"default_root_id,omitempty"`
-	DefaultProfileID          string                              `json:"default_profile_id,omitempty"`
-	DefaultExecutionProfileID string                              `json:"default_execution_profile_id,omitempty"`
-	Roots                     []ProjectCairnlineSidecarRootItem   `json:"roots,omitempty"`
-	ContextSources            []ProjectCairnlineSidecarSourceItem `json:"context_sources,omitempty"`
-	CreatedAt                 string                              `json:"created_at,omitempty"`
-	UpdatedAt                 string                              `json:"updated_at,omitempty"`
+	ID             string                              `json:"id"`
+	Name           string                              `json:"name"`
+	Description    string                              `json:"description,omitempty"`
+	DefaultRootID  string                              `json:"default_root_id,omitempty"`
+	Roots          []ProjectCairnlineSidecarRootItem   `json:"roots,omitempty"`
+	ContextSources []ProjectCairnlineSidecarSourceItem `json:"context_sources,omitempty"`
+	CreatedAt      string                              `json:"created_at,omitempty"`
+	UpdatedAt      string                              `json:"updated_at,omitempty"`
 }
 
 type ProjectCairnlineSidecarAssignmentItem struct {
-	ID                 string   `json:"id"`
-	ProjectID          string   `json:"project_id,omitempty"`
-	WorkItemID         string   `json:"work_item_id,omitempty"`
-	RoleID             string   `json:"role_id,omitempty"`
-	RootID             string   `json:"root_id,omitempty"`
-	ProfileID          string   `json:"profile_id,omitempty"`
-	ExecutionProfileID string   `json:"execution_profile_id,omitempty"`
-	ExecutionMode      string   `json:"execution_mode,omitempty"`
-	Status             string   `json:"status,omitempty"`
-	ClaimedBy          string   `json:"claimed_by,omitempty"`
-	ExecutionRef       string   `json:"execution_ref,omitempty"`
-	ContextSnapshotID  string   `json:"context_snapshot_id,omitempty"`
-	SkillIDs           []string `json:"skill_ids,omitempty"`
-	CreatedAt          string   `json:"created_at,omitempty"`
-	UpdatedAt          string   `json:"updated_at,omitempty"`
-	StartedAt          string   `json:"started_at,omitempty"`
-	CompletedAt        string   `json:"completed_at,omitempty"`
+	ID                string                                  `json:"id"`
+	ProjectID         string                                  `json:"project_id,omitempty"`
+	WorkItemID        string                                  `json:"work_item_id,omitempty"`
+	RoleID            string                                  `json:"role_id,omitempty"`
+	RootID            string                                  `json:"root_id,omitempty"`
+	ExecutionMode     string                                  `json:"execution_mode,omitempty"`
+	Status            string                                  `json:"status,omitempty"`
+	DesiredAgent      ProjectCairnlineSidecarDesiredAgentItem `json:"desired_agent,omitempty"`
+	ClaimedBy         string                                  `json:"claimed_by,omitempty"`
+	ExecutionRef      string                                  `json:"execution_ref,omitempty"`
+	ContextSnapshotID string                                  `json:"context_snapshot_id,omitempty"`
+	CreatedAt         string                                  `json:"created_at,omitempty"`
+	UpdatedAt         string                                  `json:"updated_at,omitempty"`
+	StartedAt         string                                  `json:"started_at,omitempty"`
+	CompletedAt       string                                  `json:"completed_at,omitempty"`
+}
+
+type ProjectCairnlineSidecarDesiredAgentItem struct {
+	Kind     string   `json:"kind,omitempty"`
+	SkillIDs []string `json:"skill_ids,omitempty"`
 }
 
 type ProjectCairnlineSidecarRoleItem struct {
-	ID                        string   `json:"id"`
-	ProjectID                 string   `json:"project_id,omitempty"`
-	Name                      string   `json:"name"`
-	Description               string   `json:"description,omitempty"`
-	Instructions              string   `json:"instructions,omitempty"`
-	DefaultProfileID          string   `json:"default_profile_id,omitempty"`
-	DefaultExecutionProfileID string   `json:"default_execution_profile_id,omitempty"`
-	DefaultExecutionMode      string   `json:"default_execution_mode,omitempty"`
-	DefaultSkillIDs           []string `json:"default_skill_ids,omitempty"`
+	ID                   string   `json:"id"`
+	ProjectID            string   `json:"project_id,omitempty"`
+	Name                 string   `json:"name"`
+	Description          string   `json:"description,omitempty"`
+	Instructions         string   `json:"instructions,omitempty"`
+	DefaultExecutionMode string   `json:"default_execution_mode,omitempty"`
+	DefaultSkillIDs      []string `json:"default_skill_ids,omitempty"`
 }
 
 type ProjectCairnlineSidecarWorkItem struct {
@@ -2501,13 +2498,6 @@ type ProjectCairnlineSidecarMemoryCandidateItem struct {
 	PromotedMemoryID    string                                            `json:"promoted_memory_id,omitempty"`
 	CreatedAt           string                                            `json:"created_at,omitempty"`
 	UpdatedAt           string                                            `json:"updated_at,omitempty"`
-}
-
-type ProjectCairnlineSidecarAgentProfileItem struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name,omitempty"`
-	Description string   `json:"description,omitempty"`
-	SkillIDs    []string `json:"skill_ids,omitempty"`
 }
 
 type ProjectCairnlineSidecarMemoryCandidateSourceRef struct {


### PR DESCRIPTION
## Summary
- remove legacy profile/execution-profile fields from Cairnline sidecar response structs
- remove unused sidecar agent-profile parsing helpers
- update sidecar fixture tools and launch-packet fixtures to use portable desired-agent metadata

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestProjectCairnline|TestCairnlineSidecar|TestProjectCoordinationBackend'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- just agent-docs-check
- git diff --check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -count=1 -timeout 3m -v ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...

Note: the first full race attempt left an orphaned api.test process; after terminating it, focused API race and full race both passed.