### PR TITLE
refactor(projects): rename preset ui surface

### DIFF
--- a/ui/src/features/projects/AgentPresetsModal.test.tsx
+++ b/ui/src/features/projects/AgentPresetsModal.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import type { AgentProfileRecord } from "../../types/agent-profile";
+import type { AgentPresetRecord } from "../../types/agent-preset";
 import type { ProjectRecord, ProjectSkillRecord, ProjectWorkRoleRecord } from "../../types/project";
-import { ProfilesModal } from "./ProfilesModal";
+import { AgentPresetsModal } from "./AgentPresetsModal";
 
 function project(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
   return {
@@ -17,7 +17,7 @@ function project(overrides: Partial<ProjectRecord> = {}): ProjectRecord {
   };
 }
 
-function profile(overrides: Partial<AgentProfileRecord> = {}): AgentProfileRecord {
+function preset(overrides: Partial<AgentPresetRecord> = {}): AgentPresetRecord {
   return {
     id: "implementation",
     name: "Implementation",
@@ -62,15 +62,15 @@ function role(overrides: Partial<ProjectWorkRoleRecord> = {}): ProjectWorkRoleRe
   };
 }
 
-describe("ProfilesModal", () => {
-  it("creates a profile with selected project skills", async () => {
-    const onCreate = vi.fn(async (form) => profile({ id: form.id, name: form.name }));
+describe("AgentPresetsModal", () => {
+  it("creates a preset with selected project skills", async () => {
+    const onCreate = vi.fn(async (form) => preset({ id: form.id, name: form.name }));
 
     render(
-      <ProfilesModal
+      <AgentPresetsModal
         error=""
         pending={false}
-        profiles={[]}
+        presets={[]}
         project={project()}
         projectSkills={[skill()]}
         roles={[]}
@@ -97,16 +97,16 @@ describe("ProfilesModal", () => {
     );
   });
 
-  it("updates the selected profile", async () => {
-    const onUpdate = vi.fn(async (profileID, form) =>
-      profile({ id: profileID, name: form.name, instructions: form.instructions }),
+  it("updates the selected preset", async () => {
+    const onUpdate = vi.fn(async (presetID, form) =>
+      preset({ id: presetID, name: form.name, instructions: form.instructions }),
     );
 
     render(
-      <ProfilesModal
+      <AgentPresetsModal
         error=""
         pending={false}
-        profiles={[profile()]}
+        presets={[preset()]}
         project={project()}
         projectSkills={[]}
         roles={[]}
@@ -131,13 +131,13 @@ describe("ProfilesModal", () => {
     );
   });
 
-  it("shows built-in profiles as read-only", () => {
+  it("shows built-in presets as read-only", () => {
     render(
-      <ProfilesModal
+      <AgentPresetsModal
         error=""
         pending={false}
-        profiles={[
-          profile({
+        presets={[
+          preset({
             id: "implementation",
             name: "Implementation",
             built_in: true,
@@ -166,10 +166,10 @@ describe("ProfilesModal", () => {
     const onDelete = vi.fn(async () => true);
 
     render(
-      <ProfilesModal
+      <AgentPresetsModal
         error=""
         pending={false}
-        profiles={[profile()]}
+        presets={[preset()]}
         project={project({ default_agent_profile: "implementation" })}
         projectSkills={[]}
         roles={[role({ default_agent_profile: "implementation" })]}

--- a/ui/src/features/projects/AgentPresetsModal.tsx
+++ b/ui/src/features/projects/AgentPresetsModal.tsx
@@ -1,49 +1,49 @@
 import { useState } from "react";
 
-import type { AgentProfileRecord } from "../../types/agent-profile";
+import type { AgentPresetRecord } from "../../types/agent-preset";
 import type { ProjectRecord, ProjectSkillRecord, ProjectWorkRoleRecord } from "../../types/project";
 import { ConfirmModal, Icon, Icons, InlineError, Modal } from "../shared/ui";
 import { ProjectSkillPicker } from "./ProjectSkillPicker";
 import {
-  emptyAgentProfileForm,
-  profileFormFromRecord,
-  profileReferenceSummary,
-  type AgentProfileForm,
-} from "./projectProfilesRoles";
+  emptyAgentPresetForm,
+  presetFormFromRecord,
+  presetReferenceSummary,
+  type AgentPresetForm,
+} from "./projectPresetsRoles";
 import {
-  profileRoleCheckboxLabelStyle,
-  profileRoleFieldLabelStyle,
-  profileRoleFieldStyle,
-  profileRoleSubtleTextStyle,
-} from "./projectProfileRoleStyles";
+  presetRoleCheckboxLabelStyle,
+  presetRoleFieldLabelStyle,
+  presetRoleFieldStyle,
+  presetRoleSubtleTextStyle,
+} from "./projectPresetRoleStyles";
 
-const AGENT_PROFILE_SURFACES = ["any", "hecate_chat", "hecate_task", "external_agent"];
-const AGENT_PROFILE_APPROVAL_POLICIES = ["inherit", "require", "block", "allow"];
-const AGENT_PROFILE_MEMORY_POLICIES = ["inherit", "include", "visible_only", "exclude"];
-const AGENT_PROFILE_CONTEXT_POLICIES = ["inherit", "include_enabled", "visible_only", "exclude"];
+const AGENT_PRESET_SURFACES = ["any", "hecate_chat", "hecate_task", "external_agent"];
+const AGENT_PRESET_APPROVAL_POLICIES = ["inherit", "require", "block", "allow"];
+const AGENT_PRESET_MEMORY_POLICIES = ["inherit", "include", "visible_only", "exclude"];
+const AGENT_PRESET_CONTEXT_POLICIES = ["inherit", "include_enabled", "visible_only", "exclude"];
 
-type ProfilesModalProps = {
+type AgentPresetsModalProps = {
   error: string;
   pending: boolean;
-  profiles: AgentProfileRecord[];
+  presets: AgentPresetRecord[];
   project: ProjectRecord;
   projectSkills: ProjectSkillRecord[];
   roles: ProjectWorkRoleRecord[];
   onClose: () => void;
   onCreate: (
-    form: AgentProfileForm,
-  ) => AgentProfileRecord | undefined | Promise<AgentProfileRecord | undefined>;
-  onDelete: (profile: AgentProfileRecord) => boolean | Promise<boolean>;
+    form: AgentPresetForm,
+  ) => AgentPresetRecord | undefined | Promise<AgentPresetRecord | undefined>;
+  onDelete: (preset: AgentPresetRecord) => boolean | Promise<boolean>;
   onUpdate: (
-    profileID: string,
-    form: AgentProfileForm,
-  ) => AgentProfileRecord | undefined | Promise<AgentProfileRecord | undefined>;
+    presetID: string,
+    form: AgentPresetForm,
+  ) => AgentPresetRecord | undefined | Promise<AgentPresetRecord | undefined>;
 };
 
-export function ProfilesModal({
+export function AgentPresetsModal({
   error,
   pending,
-  profiles,
+  presets,
   project,
   projectSkills,
   roles,
@@ -51,50 +51,50 @@ export function ProfilesModal({
   onCreate,
   onDelete,
   onUpdate,
-}: ProfilesModalProps) {
-  const [selectedProfileID, setSelectedProfileID] = useState(profiles[0]?.id ?? "new");
-  const selectedProfile = profiles.find((profile) => profile.id === selectedProfileID) ?? null;
-  const editingNew = selectedProfileID === "new";
-  const editingBuiltIn = Boolean(selectedProfile?.built_in);
-  const [deleteProfile, setDeleteProfile] = useState<AgentProfileRecord | null>(null);
-  const [form, setForm] = useState<AgentProfileForm>(() =>
-    selectedProfile ? profileFormFromRecord(selectedProfile) : emptyAgentProfileForm(),
+}: AgentPresetsModalProps) {
+  const [selectedPresetID, setSelectedPresetID] = useState(presets[0]?.id ?? "new");
+  const selectedPreset = presets.find((preset) => preset.id === selectedPresetID) ?? null;
+  const editingNew = selectedPresetID === "new";
+  const editingBuiltIn = Boolean(selectedPreset?.built_in);
+  const [deletePreset, setDeletePreset] = useState<AgentPresetRecord | null>(null);
+  const [form, setForm] = useState<AgentPresetForm>(() =>
+    selectedPreset ? presetFormFromRecord(selectedPreset) : emptyAgentPresetForm(),
   );
 
-  function selectProfile(profileID: string) {
-    setSelectedProfileID(profileID);
-    const profile = profiles.find((item) => item.id === profileID) ?? null;
-    setForm(profile ? profileFormFromRecord(profile) : emptyAgentProfileForm());
+  function selectPreset(presetID: string) {
+    setSelectedPresetID(presetID);
+    const preset = presets.find((item) => item.id === presetID) ?? null;
+    setForm(preset ? presetFormFromRecord(preset) : emptyAgentPresetForm());
   }
 
-  function selectProfileRecord(profile: AgentProfileRecord) {
-    setSelectedProfileID(profile.id);
-    setForm(profileFormFromRecord(profile));
+  function selectPresetRecord(preset: AgentPresetRecord) {
+    setSelectedPresetID(preset.id);
+    setForm(presetFormFromRecord(preset));
   }
 
   const canSave = !editingBuiltIn && form.name.trim().length > 0;
   const submit = async () => {
     if (!canSave) return;
     if (editingNew) {
-      const profile = await onCreate(form);
-      if (profile) selectProfileRecord(profile);
+      const preset = await onCreate(form);
+      if (preset) selectPresetRecord(preset);
       return;
     }
-    const profile = await onUpdate(selectedProfileID, form);
-    if (profile) selectProfileRecord(profile);
+    const preset = await onUpdate(selectedPresetID, form);
+    if (preset) selectPresetRecord(preset);
   };
 
-  async function deleteSelectedProfile(profile: AgentProfileRecord) {
-    const deleted = await onDelete(profile);
+  async function deleteSelectedPreset(preset: AgentPresetRecord) {
+    const deleted = await onDelete(preset);
     if (!deleted) return;
-    setDeleteProfile(null);
-    const nextProfile = profiles.find((item) => item.id !== profile.id) ?? null;
-    if (nextProfile) {
-      selectProfileRecord(nextProfile);
+    setDeletePreset(null);
+    const nextPreset = presets.find((item) => item.id !== preset.id) ?? null;
+    if (nextPreset) {
+      selectPresetRecord(nextPreset);
       return;
     }
-    setSelectedProfileID("new");
-    setForm(emptyAgentProfileForm());
+    setSelectedPresetID("new");
+    setForm(emptyAgentPresetForm());
   }
 
   return (
@@ -110,12 +110,12 @@ export function ProfilesModal({
                 Built-in preset
               </span>
             )}
-            {selectedProfile && !editingNew && !editingBuiltIn && (
+            {selectedPreset && !editingNew && !editingBuiltIn && (
               <button
                 className="btn btn-ghost"
                 type="button"
                 disabled={pending}
-                onClick={() => setDeleteProfile(selectedProfile)}
+                onClick={() => setDeletePreset(selectedPreset)}
                 style={{ color: "var(--red)" }}
               >
                 Delete preset
@@ -147,31 +147,29 @@ export function ProfilesModal({
           >
             <button
               className={
-                selectedProfileID === "new" ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
+                selectedPresetID === "new" ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
               }
               type="button"
-              onClick={() => selectProfile("new")}
+              onClick={() => selectPreset("new")}
               style={{ justifyContent: "flex-start" }}
             >
               <Icon d={Icons.plus} size={12} />
               New preset
             </button>
-            {profiles.map((profile) => (
+            {presets.map((preset) => (
               <button
-                key={profile.id}
+                key={preset.id}
                 className={
-                  selectedProfileID === profile.id
-                    ? "btn btn-primary btn-sm"
-                    : "btn btn-ghost btn-sm"
+                  selectedPresetID === preset.id ? "btn btn-primary btn-sm" : "btn btn-ghost btn-sm"
                 }
                 type="button"
-                onClick={() => selectProfile(profile.id)}
+                onClick={() => selectPreset(preset.id)}
                 style={{ justifyContent: "flex-start", minWidth: 0 }}
               >
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
-                  {profile.name || profile.id}
+                  {preset.name || preset.id}
                 </span>
-                {profile.built_in && <span className="badge badge-muted">built-in</span>}
+                {preset.built_in && <span className="badge badge-muted">built-in</span>}
               </button>
             ))}
           </div>
@@ -184,8 +182,8 @@ export function ProfilesModal({
           >
             {error && <InlineError message={error} />}
             <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: 10 }}>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Preset id</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Preset id</span>
                 <input
                   className="input"
                   value={form.id}
@@ -196,8 +194,8 @@ export function ProfilesModal({
                   }
                 />
               </label>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Name</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Name</span>
                 <input
                   className="input"
                   value={form.name}
@@ -209,8 +207,8 @@ export function ProfilesModal({
                 />
               </label>
             </div>
-            <label style={profileRoleFieldStyle}>
-              <span style={profileRoleFieldLabelStyle}>Description</span>
+            <label style={presetRoleFieldStyle}>
+              <span style={presetRoleFieldLabelStyle}>Description</span>
               <textarea
                 className="input"
                 value={form.description}
@@ -221,8 +219,8 @@ export function ProfilesModal({
                 }
               />
             </label>
-            <label style={profileRoleFieldStyle}>
-              <span style={profileRoleFieldLabelStyle}>Instructions</span>
+            <label style={presetRoleFieldStyle}>
+              <span style={presetRoleFieldLabelStyle}>Instructions</span>
               <textarea
                 className="input"
                 value={form.instructions}
@@ -234,8 +232,8 @@ export function ProfilesModal({
               />
             </label>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Surface</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Surface</span>
                 <select
                   className="input"
                   value={form.surface}
@@ -244,15 +242,15 @@ export function ProfilesModal({
                     setForm((current) => ({ ...current, surface: event.target.value }))
                   }
                 >
-                  {AGENT_PROFILE_SURFACES.map((surface) => (
+                  {AGENT_PRESET_SURFACES.map((surface) => (
                     <option key={surface} value={surface}>
                       {surface}
                     </option>
                   ))}
                 </select>
               </label>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Runtime profile</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Runtime profile</span>
                 <input
                   className="input"
                   value={form.executionProfile}
@@ -263,8 +261,8 @@ export function ProfilesModal({
                   }
                 />
               </label>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Provider hint</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Provider hint</span>
                 <input
                   className="input"
                   value={form.providerHint}
@@ -275,8 +273,8 @@ export function ProfilesModal({
                   }
                 />
               </label>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Model hint</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Model hint</span>
                 <input
                   className="input"
                   value={form.modelHint}
@@ -289,7 +287,7 @@ export function ProfilesModal({
               </label>
             </div>
             <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-              <label style={profileRoleCheckboxLabelStyle}>
+              <label style={presetRoleCheckboxLabelStyle}>
                 <input
                   type="checkbox"
                   checked={form.toolsEnabled}
@@ -300,7 +298,7 @@ export function ProfilesModal({
                 />
                 Tools enabled
               </label>
-              <label style={profileRoleCheckboxLabelStyle}>
+              <label style={presetRoleCheckboxLabelStyle}>
                 <input
                   type="checkbox"
                   checked={form.writesAllowed}
@@ -311,7 +309,7 @@ export function ProfilesModal({
                 />
                 Writes allowed
               </label>
-              <label style={profileRoleCheckboxLabelStyle}>
+              <label style={presetRoleCheckboxLabelStyle}>
                 <input
                   type="checkbox"
                   checked={form.networkAllowed}
@@ -324,8 +322,8 @@ export function ProfilesModal({
               </label>
             </div>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Approval policy</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Approval policy</span>
                 <select
                   className="input"
                   value={form.approvalPolicy}
@@ -334,15 +332,15 @@ export function ProfilesModal({
                     setForm((current) => ({ ...current, approvalPolicy: event.target.value }))
                   }
                 >
-                  {AGENT_PROFILE_APPROVAL_POLICIES.map((policy) => (
+                  {AGENT_PRESET_APPROVAL_POLICIES.map((policy) => (
                     <option key={policy} value={policy}>
                       {policy}
                     </option>
                   ))}
                 </select>
               </label>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Memory policy</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Memory policy</span>
                 <select
                   className="input"
                   value={form.projectMemoryPolicy}
@@ -351,15 +349,15 @@ export function ProfilesModal({
                     setForm((current) => ({ ...current, projectMemoryPolicy: event.target.value }))
                   }
                 >
-                  {AGENT_PROFILE_MEMORY_POLICIES.map((policy) => (
+                  {AGENT_PRESET_MEMORY_POLICIES.map((policy) => (
                     <option key={policy} value={policy}>
                       {policy}
                     </option>
                   ))}
                 </select>
               </label>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>Context source policy</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>Context source policy</span>
                 <select
                   className="input"
                   value={form.contextSourcePolicy}
@@ -368,15 +366,15 @@ export function ProfilesModal({
                     setForm((current) => ({ ...current, contextSourcePolicy: event.target.value }))
                   }
                 >
-                  {AGENT_PROFILE_CONTEXT_POLICIES.map((policy) => (
+                  {AGENT_PRESET_CONTEXT_POLICIES.map((policy) => (
                     <option key={policy} value={policy}>
                       {policy}
                     </option>
                   ))}
                 </select>
               </label>
-              <label style={profileRoleFieldStyle}>
-                <span style={profileRoleFieldLabelStyle}>External agent kind</span>
+              <label style={presetRoleFieldStyle}>
+                <span style={presetRoleFieldLabelStyle}>External agent kind</span>
                 <input
                   className="input"
                   value={form.externalAgentKind}
@@ -394,25 +392,25 @@ export function ProfilesModal({
               skills={projectSkills}
               value={form.skillIDs}
             />
-            <div style={profileRoleSubtleTextStyle}>
+            <div style={presetRoleSubtleTextStyle}>
               Presets set runtime posture and skill references. Skills do not grant tools, writes,
               network, or approvals.
             </div>
           </form>
         </div>
       </Modal>
-      {deleteProfile && (
+      {deletePreset && (
         <ConfirmModal
           title="Delete agent preset"
           danger
           pending={pending}
           confirmLabel="Delete agent preset"
-          onClose={() => setDeleteProfile(null)}
-          onConfirm={() => void deleteSelectedProfile(deleteProfile)}
+          onClose={() => setDeletePreset(null)}
+          onConfirm={() => void deleteSelectedPreset(deletePreset)}
           message={
             <>
-              Delete <strong>{deleteProfile.name || deleteProfile.id}</strong>.{" "}
-              {profileReferenceSummary(deleteProfile, project, roles)} Other projects may also
+              Delete <strong>{deletePreset.name || deletePreset.id}</strong>.{" "}
+              {presetReferenceSummary(deletePreset, project, roles)} Other projects may also
               reference this global preset.
             </>
           }

--- a/ui/src/features/projects/ProjectHealthPanel.test.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.test.tsx
@@ -114,7 +114,7 @@ function renderPanel(overrides: Partial<Parameters<typeof ProjectHealthPanel>[0]
     onAttentionDefaults: vi.fn(),
     onAttentionError: vi.fn(),
     onAttentionMemory: vi.fn(),
-    onAttentionProfiles: vi.fn(),
+    onAttentionPresets: vi.fn(),
     onAttentionReviewCandidate: vi.fn(),
     onAttentionRoles: vi.fn(),
     onAttentionSkills: vi.fn(),

--- a/ui/src/features/projects/ProjectHealthPanel.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.tsx
@@ -28,7 +28,7 @@ export type ProjectHealthPanelProps = {
   onAttentionDefaults: () => void;
   onAttentionError?: (message: string) => void;
   onAttentionMemory: () => void;
-  onAttentionProfiles: () => void;
+  onAttentionPresets: () => void;
   onAttentionReviewCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
   onAttentionRoles: () => void;
   onAttentionSkills: () => void;
@@ -48,7 +48,7 @@ export function ProjectHealthPanel({
   onAttentionDefaults,
   onAttentionError,
   onAttentionMemory,
-  onAttentionProfiles,
+  onAttentionPresets,
   onAttentionReviewCandidate,
   onAttentionRoles,
   onAttentionSkills,
@@ -105,7 +105,7 @@ export function ProjectHealthPanel({
         onAttentionSkills();
         return;
       case "open_profiles":
-        onAttentionProfiles();
+        onAttentionPresets();
         return;
       case "open_roles":
         onAttentionRoles();

--- a/ui/src/features/projects/ProjectSettingsPanel.test.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.test.tsx
@@ -53,8 +53,8 @@ describe("ProjectSettingsPanel", () => {
 
     render(
       <ProjectSettingsPanel
-        agentProfiles={[]}
-        agentProfilesError=""
+        agentPresets={[]}
+        agentPresetsError=""
         error=""
         models={[]}
         pending={false}
@@ -95,8 +95,8 @@ describe("ProjectSettingsPanel", () => {
 
     render(
       <ProjectSettingsPanel
-        agentProfiles={[]}
-        agentProfilesError=""
+        agentPresets={[]}
+        agentPresetsError=""
         error=""
         models={[]}
         pending={false}

--- a/ui/src/features/projects/ProjectSettingsPanel.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from
 
 import { chooseWorkspaceDirectory } from "../../lib/api";
 import { projectDefaultWorkspaceFromRoots } from "../../lib/project-workspace";
-import type { AgentProfileRecord } from "../../types/agent-profile";
+import type { AgentPresetRecord } from "../../types/agent-preset";
 import type { ModelRecord } from "../../types/model";
 import type { ProjectRecord } from "../../types/project";
 import type { ProviderPresetRecord } from "../../types/provider";
@@ -23,8 +23,8 @@ import {
 } from "./projectSettings";
 
 export function ProjectSettingsPanel({
-  agentProfiles,
-  agentProfilesError,
+  agentPresets,
+  agentPresetsError,
   error,
   models,
   pending,
@@ -36,8 +36,8 @@ export function ProjectSettingsPanel({
   onOpenCreateWorktree,
   onSave,
 }: {
-  agentProfiles: AgentProfileRecord[];
-  agentProfilesError: string;
+  agentPresets: AgentPresetRecord[];
+  agentPresetsError: string;
   error: string;
   models: ModelRecord[];
   pending: boolean;
@@ -60,9 +60,9 @@ export function ProjectSettingsPanel({
     if (!form.provider) return models;
     return models.filter((model) => model.metadata?.provider === form.provider);
   }, [form.provider, models]);
-  const selectedProfile = useMemo(
-    () => agentProfiles.find((profile) => profile.id === form.defaultAgentProfile) ?? null,
-    [agentProfiles, form.defaultAgentProfile],
+  const selectedPreset = useMemo(
+    () => agentPresets.find((preset) => preset.id === form.defaultAgentPreset) ?? null,
+    [agentPresets, form.defaultAgentPreset],
   );
 
   function handleProviderChange(provider: string) {
@@ -172,7 +172,7 @@ export function ProjectSettingsPanel({
         >
           {error && <InlineError message={error} />}
           {rootChooseError && <InlineError message={rootChooseError} />}
-          {agentProfilesError && <InlineError message={agentProfilesError} />}
+          {agentPresetsError && <InlineError message={agentPresetsError} />}
           <ProjectSettingsSection title="Assignment defaults">
             <div style={{ ...subtleTextStyle, marginBottom: 12 }}>
               Native Hecate assignments copy these defaults when creating the backing task.
@@ -205,23 +205,23 @@ export function ProjectSettingsPanel({
                 <select
                   aria-label="Default agent preset"
                   className="input"
-                  value={form.defaultAgentProfile}
+                  value={form.defaultAgentPreset}
                   onChange={(event) =>
                     setForm((current) => ({
                       ...current,
-                      defaultAgentProfile: event.target.value,
+                      defaultAgentPreset: event.target.value,
                     }))
                   }
                   style={{ fontFamily: "var(--font-mono)", fontSize: 12, minHeight: 36 }}
                 >
                   <option value="">built-in project_assignment</option>
-                  {agentProfiles.map((profile) => (
-                    <option key={profile.id} value={profile.id}>
-                      {profile.name || profile.id} ({profile.id})
+                  {agentPresets.map((preset) => (
+                    <option key={preset.id} value={preset.id}>
+                      {preset.name || preset.id} ({preset.id})
                     </option>
                   ))}
                 </select>
-                <ProfilePosturePreview profile={selectedProfile} />
+                <PresetPosturePreview preset={selectedPreset} />
               </div>
               <div style={fieldStyle}>
                 <span style={fieldLabelStyle}>Workspace mode</span>
@@ -414,8 +414,8 @@ function ProjectSettingsSection({ title, children }: { title: string; children: 
   );
 }
 
-function ProfilePosturePreview({ profile }: { profile: AgentProfileRecord | null }) {
-  if (!profile) {
+function PresetPosturePreview({ preset }: { preset: AgentPresetRecord | null }) {
+  if (!preset) {
     return (
       <div style={{ ...subtleTextStyle, marginTop: 4 }}>
         Uses the built-in project_assignment posture until a saved preset is selected.
@@ -423,17 +423,17 @@ function ProfilePosturePreview({ profile }: { profile: AgentProfileRecord | null
     );
   }
   const details = [
-    profile.surface,
-    profile.execution_profile ? `runtime ${profile.execution_profile}` : "",
-    profile.provider_hint || profile.model_hint
-      ? `hints ${[profile.provider_hint, profile.model_hint].filter(Boolean).join("/")}`
+    preset.surface,
+    preset.execution_profile ? `runtime ${preset.execution_profile}` : "",
+    preset.provider_hint || preset.model_hint
+      ? `hints ${[preset.provider_hint, preset.model_hint].filter(Boolean).join("/")}`
       : "",
-    `tools ${profile.tools_enabled ? "on" : "off"}`,
-    `writes ${profile.writes_allowed ? "on" : "off"}`,
-    `network ${profile.network_allowed ? "on" : "off"}`,
-    `approval ${profile.approval_policy}`,
-    `memory ${profile.project_memory_policy}`,
-    `sources ${profile.context_source_policy}`,
+    `tools ${preset.tools_enabled ? "on" : "off"}`,
+    `writes ${preset.writes_allowed ? "on" : "off"}`,
+    `network ${preset.network_allowed ? "on" : "off"}`,
+    `approval ${preset.approval_policy}`,
+    `memory ${preset.project_memory_policy}`,
+    `sources ${preset.context_source_policy}`,
   ].filter(Boolean);
   return <div style={{ ...subtleTextStyle, marginTop: 4 }}>{details.join(" · ")}</div>;
 }

--- a/ui/src/features/projects/ProjectSkillPicker.tsx
+++ b/ui/src/features/projects/ProjectSkillPicker.tsx
@@ -4,13 +4,13 @@ import {
   projectSkillSelectionWarnings,
   sortProjectSkillsForPicker,
   uniqueSkillIDs,
-} from "./projectProfilesRoles";
+} from "./projectPresetsRoles";
 import {
-  profileRoleFieldLabelStyle,
-  profileRoleFieldStyle,
-  profileRoleSubtleTextStyle,
-  profileRoleTitleStyle,
-} from "./projectProfileRoleStyles";
+  presetRoleFieldLabelStyle,
+  presetRoleFieldStyle,
+  presetRoleSubtleTextStyle,
+  presetRoleTitleStyle,
+} from "./projectPresetRoleStyles";
 import { splitIDs } from "./projectUtils";
 
 type ProjectSkillPickerProps = {
@@ -40,10 +40,10 @@ export function ProjectSkillPicker({
   }
 
   return (
-    <div style={profileRoleFieldStyle}>
+    <div style={presetRoleFieldStyle}>
       {sortedSkills.length > 0 && (
         <div style={{ display: "grid", gap: 6 }}>
-          <span style={profileRoleFieldLabelStyle}>Project skills</span>
+          <span style={presetRoleFieldLabelStyle}>Project skills</span>
           <div style={{ display: "grid", gap: 6 }}>
             {sortedSkills.map((skill) => (
               <label
@@ -67,20 +67,20 @@ export function ProjectSkillPicker({
                 />
                 <span style={{ display: "grid", gap: 4, minWidth: 0 }}>
                   <span style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
-                    <span style={profileRoleTitleStyle}>{skill.title || skill.id}</span>
+                    <span style={presetRoleTitleStyle}>{skill.title || skill.id}</span>
                     <span className={projectSkillBadgeClass(skill)}>{skill.status}</span>
                     {!skill.enabled && <span className="badge badge-muted">disabled</span>}
                     <span className="badge badge-muted">{skill.id}</span>
                   </span>
-                  <span style={profileRoleSubtleTextStyle}>{skill.path}</span>
+                  <span style={presetRoleSubtleTextStyle}>{skill.path}</span>
                 </span>
               </label>
             ))}
           </div>
         </div>
       )}
-      <label style={{ ...profileRoleFieldStyle, marginTop: sortedSkills.length > 0 ? 8 : 0 }}>
-        <span style={profileRoleFieldLabelStyle}>Skill ids</span>
+      <label style={{ ...presetRoleFieldStyle, marginTop: sortedSkills.length > 0 ? 8 : 0 }}>
+        <span style={presetRoleFieldLabelStyle}>Skill ids</span>
         <input
           className="input"
           value={value}
@@ -92,7 +92,7 @@ export function ProjectSkillPicker({
       {warnings.length > 0 && (
         <div style={{ display: "grid", gap: 3 }}>
           {warnings.map((warning) => (
-            <div key={warning} style={{ ...profileRoleSubtleTextStyle, color: "var(--amber)" }}>
+            <div key={warning} style={{ ...presetRoleSubtleTextStyle, color: "var(--amber)" }}>
               {warning}
             </div>
           ))}

--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -258,7 +258,7 @@ function renderDetail(overrides: Partial<ProjectWorkItemDetailProps> = {}) {
     onEditAssignment: vi.fn(),
     onEditHandoff: vi.fn(),
     onEditWorkItem: vi.fn(),
-    onManageProfiles: vi.fn(),
+    onManagePresets: vi.fn(),
     onManageRoles: vi.fn(),
     onOpenChat: vi.fn(),
     onOpenConnections: vi.fn(),

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -75,7 +75,7 @@ type AssignmentLaunchReadinessNoticeRecord = {
 };
 
 type AssignmentLaunchRepairActions = {
-  onManageProfiles?: () => void;
+  onManagePresets?: () => void;
   onManageRoles?: () => void;
   onOpenConnections?: () => void;
   onOpenProjectSettings?: () => void;
@@ -119,7 +119,7 @@ export type ProjectWorkItemDetailProps = {
   onEditAssignment: (assignment: ProjectAssignmentRecord) => void;
   onEditHandoff: (handoff: ProjectHandoffRecord) => void;
   onEditWorkItem: (item: ProjectWorkItemRecord) => void;
-  onManageProfiles: () => void;
+  onManagePresets: () => void;
   onManageRoles: () => void;
   onOpenChat?: (request: ProjectAssignmentChatLaunchRequest) => void;
   onOpenConnections?: () => void;
@@ -168,7 +168,7 @@ export function ProjectWorkItemDetail({
   onEditAssignment,
   onEditHandoff,
   onEditWorkItem,
-  onManageProfiles,
+  onManagePresets,
   onManageRoles,
   onOpenChat,
   onOpenConnections,
@@ -377,7 +377,7 @@ export function ProjectWorkItemDetail({
                       }
                       project={project}
                       repairActions={{
-                        onManageProfiles,
+                        onManagePresets,
                         onManageRoles,
                         onOpenConnections,
                         onOpenProjectSettings: onOpenSettings,
@@ -533,7 +533,7 @@ export function ProjectWorkItemDetail({
                       onSetStatus={(status) => onSetHandoffStatus(handoff, status)}
                       onStart={() => onStartHandoff(handoff)}
                       repairActions={{
-                        onManageProfiles,
+                        onManagePresets,
                         onManageRoles,
                         onOpenConnections,
                         onOpenProjectSettings: onOpenSettings,
@@ -1437,7 +1437,7 @@ function AssignmentLaunchReadinessNotice({
       onClick: repairActions?.onOpenProjectSettings,
     },
     { key: "roles", label: "Manage roles", onClick: repairActions?.onManageRoles },
-    { key: "profiles", label: "Agent presets", onClick: repairActions?.onManageProfiles },
+    { key: "profiles", label: "Agent presets", onClick: repairActions?.onManagePresets },
     { key: "connections", label: "Open Connections", onClick: repairActions?.onOpenConnections },
   ].filter((action) => action.onClick);
   return (
@@ -1858,7 +1858,7 @@ function projectAssignmentLaunchDraft({
     role?.default_driver_kind,
     "hecate_task",
   );
-  const resolvedProfile = firstNonEmpty(role?.default_agent_profile, project.default_agent_profile);
+  const resolvedPreset = firstNonEmpty(role?.default_agent_profile, project.default_agent_profile);
   const lines = [
     "Launch context",
     "",
@@ -1890,7 +1890,7 @@ function projectAssignmentLaunchDraft({
     `- Driver: ${resolvedDriver}`,
     `- Provider: ${firstNonEmpty(provider, "auto")}`,
     `- Model: ${firstNonEmpty(model, "project/runtime default")}`,
-    `- Agent preset: ${firstNonEmpty(resolvedProfile, "none")}`,
+    `- Agent preset: ${firstNonEmpty(resolvedPreset, "none")}`,
     `- Role defaults: ${formatHintList([
       ["driver", role?.default_driver_kind],
       ["provider", role?.default_provider],
@@ -1957,9 +1957,9 @@ function assignmentLaunchPostureRows(
       value: `${firstNonEmpty(readiness.provider, "auto")} / ${firstNonEmpty(readiness.model, "auto")}`,
     });
   }
-  const profile = assignmentLaunchProfilePosture(readiness);
-  if (profile) {
-    rows.push({ label: "Preset", value: profile });
+  const preset = assignmentLaunchPresetPosture(readiness);
+  if (preset) {
+    rows.push({ label: "Preset", value: preset });
   }
   const capabilities = assignmentLaunchCapabilityPosture(readiness);
   if (capabilities) {
@@ -1995,14 +1995,14 @@ function assignmentLaunchDriverLabel(kind: string): string {
   }
 }
 
-function assignmentLaunchProfilePosture(readiness: ProjectAssignmentLaunchReadinessRecord): string {
+function assignmentLaunchPresetPosture(readiness: ProjectAssignmentLaunchReadinessRecord): string {
   const posture = readiness.profile_posture;
-  const profile = firstNonEmpty(
+  const preset = firstNonEmpty(
     readiness.execution_profile,
     labelWithID(posture?.name, posture?.id ?? ""),
   );
-  if (!profile) return "";
-  return posture?.missing ? `${profile} (preset missing)` : profile;
+  if (!preset) return "";
+  return posture?.missing ? `${preset} (preset missing)` : preset;
 }
 
 function assignmentLaunchCapabilityPosture(

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -283,7 +283,7 @@ function renderWorkspace(overrides: Partial<ProjectWorkspaceViewProps> = {}) {
     onEditMemory: vi.fn(),
     onEditSource: vi.fn(),
     onEditWorkItem: vi.fn(),
-    onManageProfiles: vi.fn(),
+    onManagePresets: vi.fn(),
     onManageRoles: vi.fn(),
     onNewMemory: vi.fn(),
     onNewSource: vi.fn(),

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -103,7 +103,7 @@ export type ProjectWorkspaceViewProps = {
   onEditMemory: (entry: ProjectMemoryRecord) => void;
   onEditSource: (source: ProjectContextSourceRecord) => void;
   onEditWorkItem: (item: ProjectWorkItemRecord) => void;
-  onManageProfiles: () => void;
+  onManagePresets: () => void;
   onManageRoles: () => void;
   onNewMemory: () => void;
   onNewSource: () => void;
@@ -200,7 +200,7 @@ export function ProjectWorkspaceView({
   onEditMemory,
   onEditSource,
   onEditWorkItem,
-  onManageProfiles,
+  onManagePresets,
   onManageRoles,
   onNewMemory,
   onNewSource,
@@ -400,7 +400,7 @@ export function ProjectWorkspaceView({
                         onEditAssignment={onEditAssignment}
                         onEditWorkItem={onEditWorkItem}
                         onDeleteAssignment={onDeleteAssignment}
-                        onManageProfiles={onManageProfiles}
+                        onManagePresets={onManagePresets}
                         onManageRoles={onManageRoles}
                         onOpenChat={onOpenChat}
                         onOpenConnections={onOpenConnections}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -10,7 +10,7 @@ import {
   ApiError,
   applyProjectAssistant,
   chooseWorkspaceDirectory,
-  createAgentProfile,
+  createAgentPreset,
   createProjectCollaborationArtifact,
   createProjectAssignment,
   createProjectHandoff,
@@ -21,7 +21,7 @@ import {
   createProjectWorkRole,
   createProjectWorkItem,
   deleteProjectAssignment,
-  deleteAgentProfile,
+  deleteAgentPreset,
   deleteProjectHandoff,
   deleteProjectContextSource,
   deleteProjectMemory,
@@ -34,7 +34,7 @@ import {
   getProjectActivity,
   getProjectHealth,
   getProjectOperationsBrief,
-  getAgentProfiles,
+  getAgentPresets,
   getProjectAssignmentContext,
   getProjectAssignmentLaunchReadiness,
   getProjectAssignmentPreflight,
@@ -55,7 +55,7 @@ import {
   rejectProjectMemoryCandidate,
   startProjectAssignment,
   updateProject,
-  updateAgentProfile,
+  updateAgentPreset,
   updateProjectContextSource,
   updateProjectRoot,
   updateProjectAssignment,
@@ -362,10 +362,10 @@ vi.mock("../../lib/api", async (importOriginal) => {
       data: [],
     })),
     getProjectSkills: vi.fn(async () => ({ object: "project_skills", data: [] })),
-    getAgentProfiles: vi.fn(async () => ({ object: "agent_presets", data: [] })),
-    createAgentProfile: vi.fn(async () => ({ object: "agent_preset", data: null })),
-    updateAgentProfile: vi.fn(async () => ({ object: "agent_preset", data: null })),
-    deleteAgentProfile: vi.fn(async () => undefined),
+    getAgentPresets: vi.fn(async () => ({ object: "agent_presets", data: [] })),
+    createAgentPreset: vi.fn(async () => ({ object: "agent_preset", data: null })),
+    updateAgentPreset: vi.fn(async () => ({ object: "agent_preset", data: null })),
+    deleteAgentPreset: vi.fn(async () => undefined),
     draftProjectAssistant: vi.fn(async () => ({
       object: "project_assistant.proposal",
       data: {
@@ -953,7 +953,7 @@ function resetProjectWorkMocks() {
     object: "project_memory_candidates",
     data: [],
   });
-  vi.mocked(getAgentProfiles).mockResolvedValue({
+  vi.mocked(getAgentPresets).mockResolvedValue({
     object: "agent_presets",
     data: [
       {
@@ -979,7 +979,7 @@ function resetProjectWorkMocks() {
       },
     ],
   });
-  vi.mocked(createAgentProfile).mockImplementation(async (payload) => ({
+  vi.mocked(createAgentPreset).mockImplementation(async (payload) => ({
     object: "agent_preset",
     data: {
       id: payload.id || "profile_new",
@@ -1003,7 +1003,7 @@ function resetProjectWorkMocks() {
       updated_at: "2026-06-04T12:00:00Z",
     },
   }));
-  vi.mocked(updateAgentProfile).mockImplementation(async (id, payload) => ({
+  vi.mocked(updateAgentPreset).mockImplementation(async (id, payload) => ({
     object: "agent_preset",
     data: {
       id,
@@ -1027,7 +1027,7 @@ function resetProjectWorkMocks() {
       updated_at: "2026-06-04T12:00:00Z",
     },
   }));
-  vi.mocked(deleteAgentProfile).mockResolvedValue(undefined);
+  vi.mocked(deleteAgentPreset).mockResolvedValue(undefined);
   vi.mocked(draftProjectAssistant).mockResolvedValue({
     object: "project_assistant.proposal",
     data: {
@@ -1267,10 +1267,10 @@ afterEach(() => {
   vi.mocked(getProjectMemory).mockReset();
   vi.mocked(getProjectMemoryCandidates).mockReset();
   vi.mocked(getProjectSkills).mockReset();
-  vi.mocked(getAgentProfiles).mockReset();
-  vi.mocked(createAgentProfile).mockReset();
-  vi.mocked(updateAgentProfile).mockReset();
-  vi.mocked(deleteAgentProfile).mockReset();
+  vi.mocked(getAgentPresets).mockReset();
+  vi.mocked(createAgentPreset).mockReset();
+  vi.mocked(updateAgentPreset).mockReset();
+  vi.mocked(deleteAgentPreset).mockReset();
   vi.mocked(draftProjectAssistant).mockReset();
   vi.mocked(applyProjectAssistant).mockReset();
   vi.mocked(chooseWorkspaceDirectory).mockReset();
@@ -6083,7 +6083,7 @@ describe("ProjectsView cockpit", () => {
     await userEvent.click(await within(dialog).findByLabelText("Use skill Backend"));
     await userEvent.click(within(dialog).getByRole("button", { name: "Create preset" }));
 
-    expect(createAgentProfile).toHaveBeenCalledWith({
+    expect(createAgentPreset).toHaveBeenCalledWith({
       id: "reviewer",
       name: "Reviewer",
       description: "Reviews implementation assignments.",
@@ -6119,7 +6119,7 @@ describe("ProjectsView cockpit", () => {
     });
     await userEvent.click(within(dialog).getByRole("button", { name: "Save preset" }));
 
-    expect(updateAgentProfile).toHaveBeenCalledWith(
+    expect(updateAgentPreset).toHaveBeenCalledWith(
       "implementation",
       expect.objectContaining({
         name: "Implementation reviewer",
@@ -6130,10 +6130,10 @@ describe("ProjectsView cockpit", () => {
     );
 
     await userEvent.click(await within(dialog).findByRole("button", { name: "Delete preset" }));
-    expect(deleteAgentProfile).not.toHaveBeenCalled();
+    expect(deleteAgentPreset).not.toHaveBeenCalled();
     expect(screen.getByText(/Other projects may also reference this global preset/i)).toBeTruthy();
     await userEvent.click(screen.getByRole("button", { name: "Delete agent preset" }));
-    expect(deleteAgentProfile).toHaveBeenCalledWith("implementation");
+    expect(deleteAgentPreset).toHaveBeenCalledWith("implementation");
   });
 
   it("edits and deletes assignments from the selected work item", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -6,7 +6,7 @@ import { useSettings } from "../../app/state/settings";
 import {
   ApiError,
   chooseWorkspaceDirectory,
-  createAgentProfile,
+  createAgentPreset,
   createProjectAssignment,
   createProjectCollaborationArtifact,
   createProjectHandoff,
@@ -27,7 +27,7 @@ import {
   deleteProjectWorkRole,
   deleteProjectWorkItem,
   getProjectActivity,
-  getAgentProfiles,
+  getAgentPresets,
   getProjectAssignments,
   getProjectCollaborationArtifacts,
   getProjectHandoffs,
@@ -42,11 +42,11 @@ import {
   getProjectWorkItems,
   getProjectWorkRoles,
   startProjectAssignment,
-  deleteAgentProfile,
+  deleteAgentPreset,
   promoteProjectMemoryCandidate,
   rejectProjectMemoryCandidate,
   updateProject,
-  updateAgentProfile,
+  updateAgentPreset,
   updateProjectContextSource,
   updateProjectRoot,
   updateProjectAssignment,
@@ -85,7 +85,7 @@ import {
   type ProjectWorkspaceTab,
   type WorkItemSummary,
 } from "./ProjectWorkspaceView";
-import { ProfilesModal } from "./ProfilesModal";
+import { AgentPresetsModal } from "./AgentPresetsModal";
 import { EditWorkItemModal, NewWorkItemModal } from "./ProjectWorkItemModals";
 import { RolesModal } from "./RolesModal";
 import { useProjectAssistantController } from "./useProjectAssistantController";
@@ -112,7 +112,7 @@ import type {
   UpdateProjectPayload,
   UpdateProjectSkillPayload,
 } from "../../types/project";
-import type { AgentProfileRecord } from "../../types/agent-profile";
+import type { AgentPresetRecord } from "../../types/agent-preset";
 import { ConfirmModal, Icon, Icons, InlineError, type ProviderOption } from "../shared/ui";
 import { ProjectSettingsPanel } from "./ProjectSettingsPanel";
 import { ProjectEvidenceLinkModal } from "./ProjectEvidenceLinkModal";
@@ -125,13 +125,13 @@ import {
   type ProjectDefaultsForm,
 } from "./projectSettings";
 import {
-  profileCreatePayloadFromForm,
-  profileUpdatePayloadFromForm,
+  presetCreatePayloadFromForm,
+  presetUpdatePayloadFromForm,
   projectSkillStatusRank,
   rolePayloadFromForm,
-  type AgentProfileForm,
+  type AgentPresetForm,
   type RoleForm,
-} from "./projectProfilesRoles";
+} from "./projectPresetsRoles";
 import { projectSourcePayloadFromForm, type ProjectSourceForm } from "./projectSources";
 import {
   assignmentCreatePayloadFromForm,
@@ -294,11 +294,11 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
   const [skillsError, setSkillsError] = useState("");
   const [discoveringSkills, setDiscoveringSkills] = useState(false);
   const [updatingSkillID, setUpdatingSkillID] = useState("");
-  const [agentProfiles, setAgentProfiles] = useState<AgentProfileRecord[]>([]);
-  const [agentProfilesError, setAgentProfilesError] = useState("");
-  const [profilesModalOpen, setProfilesModalOpen] = useState(false);
-  const [profilesPending, setProfilesPending] = useState(false);
-  const [profilesError, setProfilesError] = useState("");
+  const [agentPresets, setAgentPresets] = useState<AgentPresetRecord[]>([]);
+  const [agentPresetsError, setAgentPresetsError] = useState("");
+  const [presetsModalOpen, setAgentPresetsModalOpen] = useState(false);
+  const [presetsPending, setPresetsPending] = useState(false);
+  const [presetsError, setPresetsError] = useState("");
   const [discoveringContext, setDiscoveringContext] = useState(false);
   const [memoryLoadState, setMemoryLoadState] = useState<LoadState>("idle");
   const [memoryError, setMemoryError] = useState("");
@@ -360,25 +360,25 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     [loadProjectHealth, loadProjectSetupReadiness],
   );
 
-  const loadAgentProfiles = useCallback(async (cancelled?: () => boolean) => {
+  const loadAgentPresets = useCallback(async (cancelled?: () => boolean) => {
     try {
-      const payload = await getAgentProfiles();
+      const payload = await getAgentPresets();
       if (cancelled?.()) return;
-      setAgentProfiles(payload.data ?? []);
-      setAgentProfilesError("");
+      setAgentPresets(payload.data ?? []);
+      setAgentPresetsError("");
     } catch (error) {
       if (cancelled?.()) return;
-      setAgentProfilesError(errorMessage(error, "Failed to load agent presets."));
+      setAgentPresetsError(errorMessage(error, "Failed to load agent presets."));
     }
   }, []);
 
   useEffect(() => {
     let cancelled = false;
-    void loadAgentProfiles(() => cancelled);
+    void loadAgentPresets(() => cancelled);
     return () => {
       cancelled = true;
     };
-  }, [loadAgentProfiles]);
+  }, [loadAgentPresets]);
   const pendingDeleteProject =
     projects.state.projects.find((project) => project.id === deleteProjectID) ?? null;
   const roleByID = useMemo(() => new Map(roles.map((role) => [role.id, role])), [roles]);
@@ -709,7 +709,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     const patch: UpdateProjectPayload = {
       default_provider: form.provider.trim(),
       default_model: form.model.trim(),
-      default_agent_profile: form.defaultAgentProfile.trim(),
+      default_agent_profile: form.defaultAgentPreset.trim(),
       default_workspace_mode: form.workspaceMode.trim(),
       default_root_id: form.defaultRootID.trim(),
     };
@@ -864,55 +864,55 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
     }
   }
 
-  async function handleCreateAgentProfile(form: AgentProfileForm) {
+  async function handleCreateAgentPreset(form: AgentPresetForm) {
     const name = form.name.trim();
     if (!name) return undefined;
-    setProfilesPending(true);
-    setProfilesError("");
+    setPresetsPending(true);
+    setPresetsError("");
     try {
-      const payload = await createAgentProfile(profileCreatePayloadFromForm(form));
-      setAgentProfiles((current) => upsertAgentProfile(current, payload.data));
+      const payload = await createAgentPreset(presetCreatePayloadFromForm(form));
+      setAgentPresets((current) => upsertAgentPreset(current, payload.data));
       refreshProjectHealth(selectedProjectID);
       return payload.data;
     } catch (error) {
-      setProfilesError(errorMessage(error, "Failed to create agent preset."));
+      setPresetsError(errorMessage(error, "Failed to create agent preset."));
       return undefined;
     } finally {
-      setProfilesPending(false);
+      setPresetsPending(false);
     }
   }
 
-  async function handleUpdateAgentProfile(profileID: string, form: AgentProfileForm) {
+  async function handleUpdateAgentPreset(presetID: string, form: AgentPresetForm) {
     const name = form.name.trim();
     if (!name) return undefined;
-    setProfilesPending(true);
-    setProfilesError("");
+    setPresetsPending(true);
+    setPresetsError("");
     try {
-      const payload = await updateAgentProfile(profileID, profileUpdatePayloadFromForm(form));
-      setAgentProfiles((current) => upsertAgentProfile(current, payload.data));
+      const payload = await updateAgentPreset(presetID, presetUpdatePayloadFromForm(form));
+      setAgentPresets((current) => upsertAgentPreset(current, payload.data));
       refreshProjectHealth(selectedProjectID);
       return payload.data;
     } catch (error) {
-      setProfilesError(errorMessage(error, "Failed to update agent preset."));
+      setPresetsError(errorMessage(error, "Failed to update agent preset."));
       return undefined;
     } finally {
-      setProfilesPending(false);
+      setPresetsPending(false);
     }
   }
 
-  async function handleDeleteAgentProfile(profile: AgentProfileRecord) {
-    setProfilesPending(true);
-    setProfilesError("");
+  async function handleDeleteAgentPreset(preset: AgentPresetRecord) {
+    setPresetsPending(true);
+    setPresetsError("");
     try {
-      await deleteAgentProfile(profile.id);
-      setAgentProfiles((current) => current.filter((item) => item.id !== profile.id));
+      await deleteAgentPreset(preset.id);
+      setAgentPresets((current) => current.filter((item) => item.id !== preset.id));
       refreshProjectHealth(selectedProjectID);
       return true;
     } catch (error) {
-      setProfilesError(errorMessage(error, "Failed to delete agent preset."));
+      setPresetsError(errorMessage(error, "Failed to delete agent preset."));
       return false;
     } finally {
-      setProfilesPending(false);
+      setPresetsPending(false);
     }
   }
 
@@ -1668,9 +1668,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
           }}
           onAttentionError={setWorkError}
           onAttentionMemory={() => setWorkspaceTab("memory")}
-          onAttentionProfiles={() => {
-            setProfilesError("");
-            setProfilesModalOpen(true);
+          onAttentionPresets={() => {
+            setPresetsError("");
+            setAgentPresetsModalOpen(true);
           }}
           onAttentionReviewCandidate={setPromotingCandidate}
           onAttentionRoles={() => {
@@ -1689,9 +1689,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             setDefaultsError("");
             setSettingsPanelOpen((open) => !open);
           }}
-          onManageProfiles={() => {
-            setProfilesError("");
-            setProfilesModalOpen(true);
+          onManagePresets={() => {
+            setPresetsError("");
+            setAgentPresetsModalOpen(true);
           }}
           onManageRoles={() => {
             setRolesError("");
@@ -1821,9 +1821,9 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
             }}
             onOpenChat={onOpenChat}
             onOpenConnections={onOpenConnections}
-            onManageProfiles={() => {
-              setProfilesError("");
-              setProfilesModalOpen(true);
+            onManagePresets={() => {
+              setPresetsError("");
+              setAgentPresetsModalOpen(true);
             }}
             onManageRoles={() => {
               setRolesError("");
@@ -1881,8 +1881,8 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
               onWidthChange={setRightPanelWidth}
             >
               <ProjectSettingsPanel
-                agentProfiles={agentProfiles}
-                agentProfilesError={agentProfilesError}
+                agentPresets={agentPresets}
+                agentPresetsError={agentPresetsError}
                 error={defaultsError}
                 models={providersAndModels.state.models}
                 pending={defaultsPending}
@@ -1903,7 +1903,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
 
         {selectedProject && rolesModalOpen && (
           <RolesModal
-            agentProfiles={agentProfiles}
+            agentPresets={agentPresets}
             error={rolesError}
             pending={rolesPending}
             projectSkills={projectSkills}
@@ -1915,18 +1915,18 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenTask }: Prop
           />
         )}
 
-        {selectedProject && profilesModalOpen && (
-          <ProfilesModal
-            error={profilesError}
-            pending={profilesPending}
-            profiles={agentProfiles}
+        {selectedProject && presetsModalOpen && (
+          <AgentPresetsModal
+            error={presetsError}
+            pending={presetsPending}
+            presets={agentPresets}
             project={selectedProject}
             projectSkills={projectSkills}
             roles={roles}
-            onClose={() => setProfilesModalOpen(false)}
-            onCreate={handleCreateAgentProfile}
-            onDelete={handleDeleteAgentProfile}
-            onUpdate={handleUpdateAgentProfile}
+            onClose={() => setAgentPresetsModalOpen(false)}
+            onCreate={handleCreateAgentPreset}
+            onDelete={handleDeleteAgentPreset}
+            onUpdate={handleUpdateAgentPreset}
           />
         )}
 
@@ -2326,14 +2326,14 @@ function ProjectHeader({
   onAttentionDefaults,
   onAttentionError,
   onAttentionMemory,
-  onAttentionProfiles,
+  onAttentionPresets,
   onAttentionReviewCandidate,
   onAttentionRoles,
   onAttentionSkills,
   onAttentionTask,
   onAttentionWorkItem,
   onEditDefaults,
-  onManageProfiles,
+  onManagePresets,
   onManageRoles,
   onRefresh,
 }: {
@@ -2347,14 +2347,14 @@ function ProjectHeader({
   onAttentionDefaults: () => void;
   onAttentionError?: (message: string) => void;
   onAttentionMemory: () => void;
-  onAttentionProfiles: () => void;
+  onAttentionPresets: () => void;
   onAttentionReviewCandidate: (candidate: ProjectMemoryCandidateRecord) => void;
   onAttentionRoles: () => void;
   onAttentionSkills: () => void;
   onAttentionTask?: (taskID: string, runID?: string) => void;
   onAttentionWorkItem: (workItemID: string) => void;
   onEditDefaults: () => void;
-  onManageProfiles: () => void;
+  onManagePresets: () => void;
   onManageRoles: () => void;
   onRefresh: () => void;
 }) {
@@ -2388,7 +2388,7 @@ function ProjectHeader({
             onAttentionDefaults={onAttentionDefaults}
             onAttentionError={onAttentionError}
             onAttentionMemory={onAttentionMemory}
-            onAttentionProfiles={onAttentionProfiles}
+            onAttentionPresets={onAttentionPresets}
             onAttentionReviewCandidate={onAttentionReviewCandidate}
             onAttentionRoles={onAttentionRoles}
             onAttentionSkills={onAttentionSkills}
@@ -2412,7 +2412,7 @@ function ProjectHeader({
             type="button"
             aria-label="Agent presets"
             title="Agent presets"
-            onClick={onManageProfiles}
+            onClick={onManagePresets}
             disabled={!project}
             style={projectHeaderActionButtonStyle}
           >
@@ -2463,7 +2463,7 @@ function upsertRole(items: ProjectWorkRoleRecord[], item: ProjectWorkRoleRecord)
   });
 }
 
-function upsertAgentProfile(items: AgentProfileRecord[], item: AgentProfileRecord) {
+function upsertAgentPreset(items: AgentPresetRecord[], item: AgentPresetRecord) {
   const index = items.findIndex((current) => current.id === item.id);
   const next = index === -1 ? [item, ...items] : items.slice();
   if (index !== -1) {

--- a/ui/src/features/projects/RolesModal.test.tsx
+++ b/ui/src/features/projects/RolesModal.test.tsx
@@ -2,11 +2,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import type { AgentProfileRecord } from "../../types/agent-profile";
+import type { AgentPresetRecord } from "../../types/agent-preset";
 import type { ProjectSkillRecord, ProjectWorkRoleRecord } from "../../types/project";
 import { RolesModal } from "./RolesModal";
 
-function profile(overrides: Partial<AgentProfileRecord> = {}): AgentProfileRecord {
+function preset(overrides: Partial<AgentPresetRecord> = {}): AgentPresetRecord {
   return {
     id: "implementation",
     name: "Implementation",
@@ -57,7 +57,7 @@ describe("RolesModal", () => {
 
     render(
       <RolesModal
-        agentProfiles={[profile()]}
+        agentPresets={[preset()]}
         error=""
         pending={false}
         projectSkills={[skill()]}
@@ -83,7 +83,7 @@ describe("RolesModal", () => {
       expect.objectContaining({
         name: "Designer",
         defaultDriverKind: "hecate_task",
-        defaultAgentProfile: "implementation",
+        defaultAgentPreset: "implementation",
         skillIDs: "backend",
       }),
     );
@@ -96,7 +96,7 @@ describe("RolesModal", () => {
 
     render(
       <RolesModal
-        agentProfiles={[]}
+        agentPresets={[]}
         error=""
         pending={false}
         projectSkills={[]}
@@ -124,7 +124,7 @@ describe("RolesModal", () => {
   it("keeps built-in roles read-only", async () => {
     render(
       <RolesModal
-        agentProfiles={[]}
+        agentPresets={[]}
         error=""
         pending={false}
         projectSkills={[]}

--- a/ui/src/features/projects/RolesModal.tsx
+++ b/ui/src/features/projects/RolesModal.tsx
@@ -1,18 +1,18 @@
 import { useState } from "react";
 
-import type { AgentProfileRecord } from "../../types/agent-profile";
+import type { AgentPresetRecord } from "../../types/agent-preset";
 import type { ProjectSkillRecord, ProjectWorkRoleRecord } from "../../types/project";
 import { Icon, Icons, InlineError, Modal } from "../shared/ui";
 import { ProjectSkillPicker } from "./ProjectSkillPicker";
-import { emptyRoleForm, roleFormFromRecord, type RoleForm } from "./projectProfilesRoles";
+import { emptyRoleForm, roleFormFromRecord, type RoleForm } from "./projectPresetsRoles";
 import {
-  profileRoleFieldLabelStyle,
-  profileRoleFieldStyle,
-  profileRoleSubtleTextStyle,
-} from "./projectProfileRoleStyles";
+  presetRoleFieldLabelStyle,
+  presetRoleFieldStyle,
+  presetRoleSubtleTextStyle,
+} from "./projectPresetRoleStyles";
 
 type RolesModalProps = {
-  agentProfiles: AgentProfileRecord[];
+  agentPresets: AgentPresetRecord[];
   error: string;
   pending: boolean;
   projectSkills: ProjectSkillRecord[];
@@ -29,7 +29,7 @@ type RolesModalProps = {
 };
 
 export function RolesModal({
-  agentProfiles,
+  agentPresets,
   error,
   pending,
   projectSkills,
@@ -161,13 +161,13 @@ export function RolesModal({
         >
           {error && <InlineError message={error} />}
           {editingBuiltIn && (
-            <div style={profileRoleSubtleTextStyle}>
+            <div style={presetRoleSubtleTextStyle}>
               Built-in roles are read-only. Create a custom role to override instructions or
               execution defaults for this project.
             </div>
           )}
-          <label style={profileRoleFieldStyle}>
-            <span style={profileRoleFieldLabelStyle}>Name</span>
+          <label style={presetRoleFieldStyle}>
+            <span style={presetRoleFieldLabelStyle}>Name</span>
             <input
               className="input"
               value={form.name}
@@ -176,8 +176,8 @@ export function RolesModal({
               autoFocus={editingNew}
             />
           </label>
-          <label style={profileRoleFieldStyle}>
-            <span style={profileRoleFieldLabelStyle}>Description</span>
+          <label style={presetRoleFieldStyle}>
+            <span style={presetRoleFieldLabelStyle}>Description</span>
             <textarea
               className="input"
               value={form.description}
@@ -188,8 +188,8 @@ export function RolesModal({
               }
             />
           </label>
-          <label style={profileRoleFieldStyle}>
-            <span style={profileRoleFieldLabelStyle}>Instructions</span>
+          <label style={presetRoleFieldStyle}>
+            <span style={presetRoleFieldLabelStyle}>Instructions</span>
             <textarea
               className="input"
               value={form.instructions}
@@ -201,8 +201,8 @@ export function RolesModal({
             />
           </label>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-            <label style={profileRoleFieldStyle}>
-              <span style={profileRoleFieldLabelStyle}>Default driver</span>
+            <label style={presetRoleFieldStyle}>
+              <span style={presetRoleFieldLabelStyle}>Default driver</span>
               <select
                 className="input"
                 value={form.defaultDriverKind}
@@ -216,29 +216,29 @@ export function RolesModal({
                 <option value="external_agent">external_agent</option>
               </select>
             </label>
-            <label style={profileRoleFieldStyle}>
-              <span style={profileRoleFieldLabelStyle}>Default preset</span>
+            <label style={presetRoleFieldStyle}>
+              <span style={presetRoleFieldLabelStyle}>Default preset</span>
               <select
                 className="input"
-                value={form.defaultAgentProfile}
+                value={form.defaultAgentPreset}
                 disabled={editingBuiltIn}
                 onChange={(event) =>
                   setForm((current) => ({
                     ...current,
-                    defaultAgentProfile: event.target.value,
+                    defaultAgentPreset: event.target.value,
                   }))
                 }
               >
                 <option value="">inherit project default</option>
-                {agentProfiles.map((profile) => (
-                  <option key={profile.id} value={profile.id}>
-                    {profile.name || profile.id} ({profile.id})
+                {agentPresets.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.name || preset.id} ({preset.id})
                   </option>
                 ))}
               </select>
             </label>
-            <label style={profileRoleFieldStyle}>
-              <span style={profileRoleFieldLabelStyle}>Default provider</span>
+            <label style={presetRoleFieldStyle}>
+              <span style={presetRoleFieldLabelStyle}>Default provider</span>
               <input
                 className="input"
                 value={form.defaultProvider}
@@ -249,8 +249,8 @@ export function RolesModal({
                 }
               />
             </label>
-            <label style={profileRoleFieldStyle}>
-              <span style={profileRoleFieldLabelStyle}>Default model</span>
+            <label style={presetRoleFieldStyle}>
+              <span style={presetRoleFieldLabelStyle}>Default model</span>
               <input
                 className="input"
                 value={form.defaultModel}
@@ -268,7 +268,7 @@ export function RolesModal({
             skills={projectSkills}
             value={form.skillIDs}
           />
-          <div style={profileRoleSubtleTextStyle}>
+          <div style={presetRoleSubtleTextStyle}>
             Role defaults are execution hints. Assignments can still override the driver, and
             project defaults remain the fallback.
           </div>

--- a/ui/src/features/projects/projectPresetRoleStyles.ts
+++ b/ui/src/features/projects/projectPresetRoleStyles.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 
-export const profileRoleTitleStyle: CSSProperties = {
+export const presetRoleTitleStyle: CSSProperties = {
   color: "var(--t0)",
   fontSize: 13,
   fontWeight: 600,
@@ -9,25 +9,25 @@ export const profileRoleTitleStyle: CSSProperties = {
   whiteSpace: "nowrap",
 };
 
-export const profileRoleSubtleTextStyle: CSSProperties = {
+export const presetRoleSubtleTextStyle: CSSProperties = {
   color: "var(--t3)",
   fontSize: 12,
   lineHeight: 1.4,
 };
 
-export const profileRoleFieldStyle: CSSProperties = {
+export const presetRoleFieldStyle: CSSProperties = {
   display: "grid",
   gap: 6,
 };
 
-export const profileRoleFieldLabelStyle: CSSProperties = {
+export const presetRoleFieldLabelStyle: CSSProperties = {
   color: "var(--t2)",
   fontFamily: "var(--font-mono)",
   fontSize: 11,
   textTransform: "uppercase",
 };
 
-export const profileRoleCheckboxLabelStyle: CSSProperties = {
+export const presetRoleCheckboxLabelStyle: CSSProperties = {
   alignItems: "center",
   color: "var(--t1)",
   display: "inline-flex",

--- a/ui/src/features/projects/projectPresetsRoles.ts
+++ b/ui/src/features/projects/projectPresetsRoles.ts
@@ -1,12 +1,12 @@
 import type {
-  AgentProfileRecord,
-  CreateAgentProfilePayload,
-  UpdateAgentProfilePayload,
-} from "../../types/agent-profile";
+  AgentPresetRecord,
+  CreateAgentPresetPayload,
+  UpdateAgentPresetPayload,
+} from "../../types/agent-preset";
 import type { ProjectRecord, ProjectSkillRecord, ProjectWorkRoleRecord } from "../../types/project";
 import { splitIDs } from "./projectUtils";
 
-export type AgentProfileForm = {
+export type AgentPresetForm = {
   id: string;
   name: string;
   description: string;
@@ -33,7 +33,7 @@ export type RoleForm = {
   defaultDriverKind: string;
   defaultProvider: string;
   defaultModel: string;
-  defaultAgentProfile: string;
+  defaultAgentPreset: string;
   skillIDs: string;
 };
 
@@ -46,12 +46,12 @@ export function emptyRoleForm(): RoleForm {
     defaultDriverKind: "",
     defaultProvider: "",
     defaultModel: "",
-    defaultAgentProfile: "",
+    defaultAgentPreset: "",
     skillIDs: "",
   };
 }
 
-export function emptyAgentProfileForm(): AgentProfileForm {
+export function emptyAgentPresetForm(): AgentPresetForm {
   return {
     id: "",
     name: "",
@@ -72,35 +72,35 @@ export function emptyAgentProfileForm(): AgentProfileForm {
   };
 }
 
-export function profileFormFromRecord(profile: AgentProfileRecord): AgentProfileForm {
+export function presetFormFromRecord(preset: AgentPresetRecord): AgentPresetForm {
   return {
-    id: profile.id,
-    name: profile.name,
-    description: profile.description ?? "",
-    instructions: profile.instructions ?? "",
-    surface: profile.surface || "any",
-    providerHint: profile.provider_hint ?? "",
-    modelHint: profile.model_hint ?? "",
-    executionProfile: profile.execution_profile ?? "",
-    toolsEnabled: profile.tools_enabled,
-    writesAllowed: profile.writes_allowed,
-    networkAllowed: profile.network_allowed,
-    approvalPolicy: profile.approval_policy || "inherit",
-    projectMemoryPolicy: profile.project_memory_policy || "inherit",
-    contextSourcePolicy: profile.context_source_policy || "inherit",
-    skillIDs: (profile.skill_ids ?? []).join(", "),
-    externalAgentKind: profile.external_agent_kind ?? "",
+    id: preset.id,
+    name: preset.name,
+    description: preset.description ?? "",
+    instructions: preset.instructions ?? "",
+    surface: preset.surface || "any",
+    providerHint: preset.provider_hint ?? "",
+    modelHint: preset.model_hint ?? "",
+    executionProfile: preset.execution_profile ?? "",
+    toolsEnabled: preset.tools_enabled,
+    writesAllowed: preset.writes_allowed,
+    networkAllowed: preset.network_allowed,
+    approvalPolicy: preset.approval_policy || "inherit",
+    projectMemoryPolicy: preset.project_memory_policy || "inherit",
+    contextSourcePolicy: preset.context_source_policy || "inherit",
+    skillIDs: (preset.skill_ids ?? []).join(", "),
+    externalAgentKind: preset.external_agent_kind ?? "",
   };
 }
 
-export function profileCreatePayloadFromForm(form: AgentProfileForm): CreateAgentProfilePayload {
-  const payload = profileUpdatePayloadFromForm(form) as CreateAgentProfilePayload;
+export function presetCreatePayloadFromForm(form: AgentPresetForm): CreateAgentPresetPayload {
+  const payload = presetUpdatePayloadFromForm(form) as CreateAgentPresetPayload;
   const id = form.id.trim();
   if (id) payload.id = id;
   return payload;
 }
 
-export function profileUpdatePayloadFromForm(form: AgentProfileForm): UpdateAgentProfilePayload {
+export function presetUpdatePayloadFromForm(form: AgentPresetForm): UpdateAgentPresetPayload {
   return {
     name: form.name.trim(),
     description: form.description.trim(),
@@ -120,17 +120,17 @@ export function profileUpdatePayloadFromForm(form: AgentProfileForm): UpdateAgen
   };
 }
 
-export function profileReferenceSummary(
-  profile: AgentProfileRecord,
+export function presetReferenceSummary(
+  preset: AgentPresetRecord,
   project: ProjectRecord,
   roles: ProjectWorkRoleRecord[],
 ) {
   const references: string[] = [];
-  if (project.default_agent_profile === profile.id) {
+  if (project.default_agent_profile === preset.id) {
     references.push("this project's default preset");
   }
   const roleNames = roles
-    .filter((role) => role.default_agent_profile === profile.id)
+    .filter((role) => role.default_agent_profile === preset.id)
     .map((role) => role.name || role.id);
   if (roleNames.length > 0) {
     references.push(`roles ${roleNames.join(", ")}`);
@@ -150,7 +150,7 @@ export function roleFormFromRecord(role: ProjectWorkRoleRecord): RoleForm {
     defaultDriverKind: role.default_driver_kind ?? "",
     defaultProvider: role.default_provider ?? "",
     defaultModel: role.default_model ?? "",
-    defaultAgentProfile: role.default_agent_profile ?? "",
+    defaultAgentPreset: role.default_agent_profile ?? "",
     skillIDs: (role.skill_ids ?? []).join(", "),
   };
 }
@@ -163,7 +163,7 @@ export function rolePayloadFromForm(form: RoleForm) {
     default_driver_kind: form.defaultDriverKind.trim(),
     default_provider: form.defaultProvider.trim(),
     default_model: form.defaultModel.trim(),
-    default_agent_profile: form.defaultAgentProfile.trim(),
+    default_agent_profile: form.defaultAgentPreset.trim(),
     skill_ids: uniqueSkillIDs(splitIDs(form.skillIDs)),
   };
 }

--- a/ui/src/features/projects/projectSettings.ts
+++ b/ui/src/features/projects/projectSettings.ts
@@ -15,7 +15,7 @@ export type CreateProjectForm = {
 export type ProjectDefaultsForm = {
   provider: string;
   model: string;
-  defaultAgentProfile: string;
+  defaultAgentPreset: string;
   workspaceMode: string;
   defaultRootID: string;
   roots: ProjectRootPayload[];
@@ -54,7 +54,7 @@ export function projectDefaultsFormFromProject(project: ProjectRecord): ProjectD
   return {
     provider: project.default_provider ?? "",
     model: project.default_model ?? "",
-    defaultAgentProfile: project.default_agent_profile ?? "",
+    defaultAgentPreset: project.default_agent_profile ?? "",
     workspaceMode: project.default_workspace_mode || "in_place",
     defaultRootID: project.default_root_id || project.roots[0]?.id || "",
     roots: project.roots.map(projectRootPayloadFromRecord),

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -21,11 +21,11 @@ import type {
   AgentAdapterResponse,
 } from "../types/agent-adapter";
 import type {
-  AgentProfileResponse,
-  AgentProfilesResponse,
-  CreateAgentProfilePayload,
-  UpdateAgentProfilePayload,
-} from "../types/agent-profile";
+  AgentPresetResponse,
+  AgentPresetsResponse,
+  CreateAgentPresetPayload,
+  UpdateAgentPresetPayload,
+} from "../types/agent-preset";
 import type {
   ChatApprovalRequestedEvent,
   ChatApprovalResolvedEvent,
@@ -900,30 +900,30 @@ export async function discoverProjectContextSources(projectID: string): Promise<
   );
 }
 
-export async function getAgentProfiles(): Promise<AgentProfilesResponse> {
-  return fetchJSON<AgentProfilesResponse>(`${HECATE_API}/agent-presets`);
+export async function getAgentPresets(): Promise<AgentPresetsResponse> {
+  return fetchJSON<AgentPresetsResponse>(`${HECATE_API}/agent-presets`);
 }
 
-export async function createAgentProfile(
-  payload: CreateAgentProfilePayload,
-): Promise<AgentProfileResponse> {
-  return fetchJSON<AgentProfileResponse>(`${HECATE_API}/agent-presets`, {
+export async function createAgentPreset(
+  payload: CreateAgentPresetPayload,
+): Promise<AgentPresetResponse> {
+  return fetchJSON<AgentPresetResponse>(`${HECATE_API}/agent-presets`, {
     method: "POST",
     body: payload,
   });
 }
 
-export async function updateAgentProfile(
+export async function updateAgentPreset(
   id: string,
-  payload: UpdateAgentProfilePayload,
-): Promise<AgentProfileResponse> {
-  return fetchJSON<AgentProfileResponse>(`${HECATE_API}/agent-presets/${encodeURIComponent(id)}`, {
+  payload: UpdateAgentPresetPayload,
+): Promise<AgentPresetResponse> {
+  return fetchJSON<AgentPresetResponse>(`${HECATE_API}/agent-presets/${encodeURIComponent(id)}`, {
     method: "PATCH",
     body: payload,
   });
 }
 
-export async function deleteAgentProfile(id: string): Promise<void> {
+export async function deleteAgentPreset(id: string): Promise<void> {
   return fetchJSON<void>(`${HECATE_API}/agent-presets/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });

--- a/ui/src/types/agent-preset.ts
+++ b/ui/src/types/agent-preset.ts
@@ -1,11 +1,11 @@
-export type AgentProfileSurface = "any" | "hecate_chat" | "hecate_task" | "external_agent";
+export type AgentPresetSurface = "any" | "hecate_chat" | "hecate_task" | "external_agent";
 
-export type AgentProfileRecord = {
+export type AgentPresetRecord = {
   id: string;
   name: string;
   description?: string;
   instructions?: string;
-  surface: AgentProfileSurface | string;
+  surface: AgentPresetSurface | string;
   provider_hint?: string;
   model_hint?: string;
   execution_profile?: string;
@@ -23,17 +23,17 @@ export type AgentProfileRecord = {
   updated_at?: string;
 };
 
-export type AgentProfileResponse = {
+export type AgentPresetResponse = {
   object: string;
-  data: AgentProfileRecord;
+  data: AgentPresetRecord;
 };
 
-export type AgentProfilesResponse = {
+export type AgentPresetsResponse = {
   object: string;
-  data: AgentProfileRecord[];
+  data: AgentPresetRecord[];
 };
 
-export type CreateAgentProfilePayload = {
+export type CreateAgentPresetPayload = {
   id?: string;
   name: string;
   description?: string;
@@ -53,4 +53,4 @@ export type CreateAgentProfilePayload = {
   external_agent_options?: Record<string, string>;
 };
 
-export type UpdateAgentProfilePayload = Partial<CreateAgentProfilePayload>;
+export type UpdateAgentPresetPayload = Partial<CreateAgentPresetPayload>;


### PR DESCRIPTION
## Summary
- rename the Projects frontend Agent Profile surface to Agent Preset types, helpers, modal, and client calls
- keep existing backend JSON fields such as default_agent_profile and profile_posture unchanged
- update Projects tests and shared UI helper names to use preset terminology

## Validation
- cd ui && bun run test
- cd ui && bun run test -- src/features/projects/AgentPresetsModal.test.tsx src/features/projects/RolesModal.test.tsx src/features/projects/ProjectSettingsPanel.test.tsx src/features/projects/ProjectWorkItemDetail.test.tsx src/features/projects/ProjectsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- just agent-docs-check
- git diff --check