### PR TITLE
refactor(projects): rename preset api surface

### DIFF
--- a/internal/api/handler_agent_presets.go
+++ b/internal/api/handler_agent_presets.go
@@ -7,25 +7,25 @@ import (
 	"github.com/hecatehq/hecate/internal/agentprofiles"
 )
 
-func (h *Handler) HandleAgentProfiles(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) HandleAgentPresets(w http.ResponseWriter, r *http.Request) {
 	items, err := h.agentProfiles.List(r.Context())
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	data := make([]AgentProfileResponseItem, 0, len(items))
+	data := make([]AgentPresetResponseItem, 0, len(items))
 	for _, item := range items {
-		data = append(data, renderAgentProfile(item))
+		data = append(data, renderAgentPreset(item))
 	}
-	WriteJSON(w, http.StatusOK, AgentProfilesResponse{Object: "agent_presets", Data: data})
+	WriteJSON(w, http.StatusOK, AgentPresetsResponse{Object: "agent_presets", Data: data})
 }
 
-func (h *Handler) HandleCreateAgentProfile(w http.ResponseWriter, r *http.Request) {
-	var req CreateAgentProfileRequest
+func (h *Handler) HandleCreateAgentPreset(w http.ResponseWriter, r *http.Request) {
+	var req CreateAgentPresetRequest
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	profile := agentProfileFromCreate(req)
+	profile := agentPresetFromCreate(req)
 	if profile.ID == "" {
 		profile.ID = newOpaqueTaskResourceID("prof")
 	}
@@ -42,10 +42,10 @@ func (h *Handler) HandleCreateAgentProfile(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusCreated, AgentProfileResponse{Object: "agent_preset", Data: renderAgentProfile(profile)})
+	WriteJSON(w, http.StatusCreated, AgentPresetResponse{Object: "agent_preset", Data: renderAgentPreset(profile)})
 }
 
-func (h *Handler) HandleAgentProfile(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) HandleAgentPreset(w http.ResponseWriter, r *http.Request) {
 	profile, ok, err := h.agentProfiles.Get(r.Context(), r.PathValue("id"))
 	if err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
@@ -55,16 +55,16 @@ func (h *Handler) HandleAgentProfile(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent preset not found")
 		return
 	}
-	WriteJSON(w, http.StatusOK, AgentProfileResponse{Object: "agent_preset", Data: renderAgentProfile(profile)})
+	WriteJSON(w, http.StatusOK, AgentPresetResponse{Object: "agent_preset", Data: renderAgentPreset(profile)})
 }
 
-func (h *Handler) HandleUpdateAgentProfile(w http.ResponseWriter, r *http.Request) {
-	var req UpdateAgentProfileRequest
+func (h *Handler) HandleUpdateAgentPreset(w http.ResponseWriter, r *http.Request) {
+	var req UpdateAgentPresetRequest
 	if !decodeJSON(w, r, &req) {
 		return
 	}
 	profile, err := h.agentProfiles.Update(r.Context(), r.PathValue("id"), func(item *agentprofiles.Profile) {
-		applyAgentProfileUpdate(item, req)
+		applyAgentPresetUpdate(item, req)
 	})
 	if errors.Is(err, agentprofiles.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent preset not found")
@@ -82,10 +82,10 @@ func (h *Handler) HandleUpdateAgentProfile(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	WriteJSON(w, http.StatusOK, AgentProfileResponse{Object: "agent_preset", Data: renderAgentProfile(profile)})
+	WriteJSON(w, http.StatusOK, AgentPresetResponse{Object: "agent_preset", Data: renderAgentPreset(profile)})
 }
 
-func (h *Handler) HandleDeleteAgentProfile(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) HandleDeleteAgentPreset(w http.ResponseWriter, r *http.Request) {
 	profileID := r.PathValue("id")
 	if err := h.agentProfiles.Delete(r.Context(), profileID); errors.Is(err, agentprofiles.ErrNotFound) {
 		WriteError(w, http.StatusNotFound, errCodeNotFound, "agent preset not found")
@@ -100,7 +100,7 @@ func (h *Handler) HandleDeleteAgentProfile(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func agentProfileFromCreate(req CreateAgentProfileRequest) agentprofiles.Profile {
+func agentPresetFromCreate(req CreateAgentPresetRequest) agentprofiles.Profile {
 	return agentprofiles.Profile{
 		ID:                   req.ID,
 		Name:                 req.Name,
@@ -122,7 +122,7 @@ func agentProfileFromCreate(req CreateAgentProfileRequest) agentprofiles.Profile
 	}
 }
 
-func applyAgentProfileUpdate(profile *agentprofiles.Profile, req UpdateAgentProfileRequest) {
+func applyAgentPresetUpdate(profile *agentprofiles.Profile, req UpdateAgentPresetRequest) {
 	if req.Name != nil {
 		profile.Name = *req.Name
 	}
@@ -173,8 +173,8 @@ func applyAgentProfileUpdate(profile *agentprofiles.Profile, req UpdateAgentProf
 	}
 }
 
-func renderAgentProfile(profile agentprofiles.Profile) AgentProfileResponseItem {
-	return AgentProfileResponseItem{
+func renderAgentPreset(profile agentprofiles.Profile) AgentPresetResponseItem {
+	return AgentPresetResponseItem{
 		ID:                   profile.ID,
 		Name:                 profile.Name,
 		Description:          profile.Description,
@@ -191,14 +191,14 @@ func renderAgentProfile(profile agentprofiles.Profile) AgentProfileResponseItem 
 		ContextSourcePolicy:  profile.ContextSourcePolicy,
 		SkillIDs:             append([]string(nil), profile.SkillIDs...),
 		ExternalAgentKind:    profile.ExternalAgentKind,
-		ExternalAgentOptions: cloneAgentProfileOptions(profile.ExternalAgentOptions),
+		ExternalAgentOptions: cloneAgentPresetOptions(profile.ExternalAgentOptions),
 		BuiltIn:              profile.BuiltIn,
 		CreatedAt:            formatOptionalTime(profile.CreatedAt),
 		UpdatedAt:            formatOptionalTime(profile.UpdatedAt),
 	}
 }
 
-func cloneAgentProfileOptions(items map[string]string) map[string]string {
+func cloneAgentPresetOptions(items map[string]string) map[string]string {
 	if len(items) == 0 {
 		return nil
 	}

--- a/internal/api/handler_agent_presets_test.go
+++ b/internal/api/handler_agent_presets_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/hecatehq/hecate/internal/config"
 )
 
-func newAgentProfilesTestServer() http.Handler {
+func newAgentPresetsTestServer() http.Handler {
 	handler := NewHandler(config.Config{}, quietLogger(), nil, nil, nil, nil)
 	return NewServer(quietLogger(), handler)
 }
 
-func TestAgentProfilesAPI_CRUD(t *testing.T) {
+func TestAgentPresetsAPI_CRUD(t *testing.T) {
 	t.Parallel()
-	server := newAgentProfilesTestServer()
+	server := newAgentPresetsTestServer()
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-presets", bytes.NewReader([]byte(`{
@@ -43,15 +43,15 @@ func TestAgentProfilesAPI_CRUD(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
 	}
-	var created AgentProfileResponse
+	var created AgentPresetResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
 	if created.Object != "agent_preset" || created.Data.ID != "prof_backend" || created.Data.ExecutionProfile != "implementation" {
-		t.Fatalf("created = %+v, want profile envelope", created)
+		t.Fatalf("created = %+v, want preset envelope", created)
 	}
 	if created.Data.BuiltIn {
-		t.Fatalf("created profile is marked built-in")
+		t.Fatalf("created preset is marked built-in")
 	}
 	if !created.Data.ToolsEnabled || !created.Data.WritesAllowed || created.Data.NetworkAllowed {
 		t.Fatalf("posture = tools=%v writes=%v network=%v, want true/true/false", created.Data.ToolsEnabled, created.Data.WritesAllowed, created.Data.NetworkAllowed)
@@ -66,12 +66,12 @@ func TestAgentProfilesAPI_CRUD(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("patch status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
-	var updated AgentProfileResponse
+	var updated AgentPresetResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
 		t.Fatalf("decode patch response: %v", err)
 	}
 	if updated.Data.Name != "Backend reviewer" || updated.Data.WritesAllowed || updated.Data.ApprovalPolicy != "block" {
-		t.Fatalf("updated = %+v, want patched profile", updated.Data)
+		t.Fatalf("updated = %+v, want patched preset", updated.Data)
 	}
 
 	rec = httptest.NewRecorder()
@@ -79,12 +79,12 @@ func TestAgentProfilesAPI_CRUD(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("list status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
-	var listed AgentProfilesResponse
+	var listed AgentPresetsResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
 		t.Fatalf("decode list response: %v", err)
 	}
-	if listed.Object != "agent_presets" || !agentProfileResponseIDExists(listed.Data, "implementation") || !agentProfileResponseIDExists(listed.Data, "prof_backend") {
-		t.Fatalf("listed = %+v, want built-ins plus created profile", listed)
+	if listed.Object != "agent_presets" || !agentPresetResponseIDExists(listed.Data, "implementation") || !agentPresetResponseIDExists(listed.Data, "prof_backend") {
+		t.Fatalf("listed = %+v, want built-ins plus created preset", listed)
 	}
 
 	rec = httptest.NewRecorder()
@@ -94,9 +94,9 @@ func TestAgentProfilesAPI_CRUD(t *testing.T) {
 	}
 }
 
-func TestAgentProfilesAPI_OldProfileRouteRemoved(t *testing.T) {
+func TestAgentPresetsAPI_OldProfileRouteRemoved(t *testing.T) {
 	t.Parallel()
-	server := newAgentProfilesTestServer()
+	server := newAgentPresetsTestServer()
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/agent-profiles", nil))
@@ -105,21 +105,21 @@ func TestAgentProfilesAPI_OldProfileRouteRemoved(t *testing.T) {
 	}
 }
 
-func TestAgentProfilesAPI_BuiltInProfilesAreReadOnly(t *testing.T) {
+func TestAgentPresetsAPI_BuiltInPresetsAreReadOnly(t *testing.T) {
 	t.Parallel()
-	server := newAgentProfilesTestServer()
+	server := newAgentPresetsTestServer()
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hecate/v1/agent-presets/implementation", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("get built-in status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
-	var got AgentProfileResponse
+	var got AgentPresetResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode get response: %v", err)
 	}
 	if !got.Data.BuiltIn || got.Data.ExecutionProfile != "coding_agent" || !got.Data.WritesAllowed {
-		t.Fatalf("built-in profile = %+v, want implementation posture", got.Data)
+		t.Fatalf("built-in preset = %+v, want implementation posture", got.Data)
 	}
 
 	rec = httptest.NewRecorder()
@@ -139,9 +139,9 @@ func TestAgentProfilesAPI_BuiltInProfilesAreReadOnly(t *testing.T) {
 	}
 }
 
-func TestAgentProfilesAPI_RejectsInvalidEnums(t *testing.T) {
+func TestAgentPresetsAPI_RejectsInvalidEnums(t *testing.T) {
 	t.Parallel()
-	server := newAgentProfilesTestServer()
+	server := newAgentPresetsTestServer()
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-presets", bytes.NewReader([]byte(`{
@@ -154,7 +154,7 @@ func TestAgentProfilesAPI_RejectsInvalidEnums(t *testing.T) {
 	}
 }
 
-func agentProfileResponseIDExists(items []AgentProfileResponseItem, id string) bool {
+func agentPresetResponseIDExists(items []AgentPresetResponseItem, id string) bool {
 	for _, item := range items {
 		if item.ID == id {
 			return true
@@ -163,16 +163,16 @@ func agentProfileResponseIDExists(items []AgentProfileResponseItem, id string) b
 	return false
 }
 
-func TestAgentProfilesAPI_GeneratesIDsAndReturnsNotFound(t *testing.T) {
+func TestAgentPresetsAPI_GeneratesIDsAndReturnsNotFound(t *testing.T) {
 	t.Parallel()
-	server := newAgentProfilesTestServer()
+	server := newAgentPresetsTestServer()
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/agent-presets", bytes.NewReader([]byte(`{"name":"Generated"}`))))
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create status = %d body=%s, want 201", rec.Code, rec.Body.String())
 	}
-	var created AgentProfileResponse
+	var created AgentPresetResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}

--- a/internal/api/handler_project_cairnline_test.go
+++ b/internal/api/handler_project_cairnline_test.go
@@ -606,7 +606,7 @@ func TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney
 	writeProjectJourneyFile(t, root, "AGENTS.md", "# Project guidance\n\nUse small changes.\nSkill: `.hecate/skills/backend/SKILL.md`.\n")
 	writeProjectJourneyFile(t, root, ".hecate/skills/backend/SKILL.md", "---\nname: Backend\ndescription: Backend work.\n---\n# Backend\n")
 
-	profile := mustRequestJSONStatus[AgentProfileResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/agent-presets", projectJourneyJSON(t, map[string]any{
+	profile := mustRequestJSONStatus[AgentPresetResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/agent-presets", projectJourneyJSON(t, map[string]any{
 		"id":                    "live_profile",
 		"name":                  "Live Profile",
 		"surface":               agentprofiles.SurfaceHecateTask,

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -639,17 +639,17 @@ type ProjectCoordinationBackendWriteSwitchpoint struct {
 	Detail           string   `json:"detail"`
 }
 
-type AgentProfileResponse struct {
-	Object string                   `json:"object"`
-	Data   AgentProfileResponseItem `json:"data"`
+type AgentPresetResponse struct {
+	Object string                  `json:"object"`
+	Data   AgentPresetResponseItem `json:"data"`
 }
 
-type AgentProfilesResponse struct {
-	Object string                     `json:"object"`
-	Data   []AgentProfileResponseItem `json:"data"`
+type AgentPresetsResponse struct {
+	Object string                    `json:"object"`
+	Data   []AgentPresetResponseItem `json:"data"`
 }
 
-type AgentProfileResponseItem struct {
+type AgentPresetResponseItem struct {
 	ID                   string            `json:"id"`
 	Name                 string            `json:"name"`
 	Description          string            `json:"description,omitempty"`
@@ -672,7 +672,7 @@ type AgentProfileResponseItem struct {
 	UpdatedAt            string            `json:"updated_at,omitempty"`
 }
 
-type CreateAgentProfileRequest struct {
+type CreateAgentPresetRequest struct {
 	ID                   string            `json:"id,omitempty"`
 	Name                 string            `json:"name"`
 	Description          string            `json:"description,omitempty"`
@@ -692,7 +692,7 @@ type CreateAgentProfileRequest struct {
 	ExternalAgentOptions map[string]string `json:"external_agent_options,omitempty"`
 }
 
-type UpdateAgentProfileRequest struct {
+type UpdateAgentPresetRequest struct {
 	Name                 *string           `json:"name,omitempty"`
 	Description          *string           `json:"description,omitempty"`
 	Instructions         *string           `json:"instructions,omitempty"`

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -57,7 +57,7 @@ func TestProjectJourneyAPI_DiscoverStartInspectAndHandoff(t *testing.T) {
 		t.Fatalf("memory = %+v, want enabled project memory entry", memoryEntry.Data)
 	}
 
-	profile := mustRequestJSONStatus[AgentProfileResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/agent-presets", projectJourneyJSON(t, map[string]any{
+	profile := mustRequestJSONStatus[AgentPresetResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/agent-presets", projectJourneyJSON(t, map[string]any{
 		"id":                    "prof_backend",
 		"name":                  "Backend implementer",
 		"surface":               "hecate_task",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -158,11 +158,11 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 func registerHecateAgentRoutes(mux *http.ServeMux, handler *Handler) {
 	// External-agent adapters and agent-chat sessions are Hecate-native state:
 	// approvals, grants, diffs, and session streams.
-	mux.HandleFunc("GET /hecate/v1/agent-presets", handler.HandleAgentProfiles)
-	mux.HandleFunc("POST /hecate/v1/agent-presets", handler.HandleCreateAgentProfile)
-	mux.HandleFunc("GET /hecate/v1/agent-presets/{id}", handler.HandleAgentProfile)
-	mux.HandleFunc("PATCH /hecate/v1/agent-presets/{id}", handler.HandleUpdateAgentProfile)
-	mux.HandleFunc("DELETE /hecate/v1/agent-presets/{id}", handler.HandleDeleteAgentProfile)
+	mux.HandleFunc("GET /hecate/v1/agent-presets", handler.HandleAgentPresets)
+	mux.HandleFunc("POST /hecate/v1/agent-presets", handler.HandleCreateAgentPreset)
+	mux.HandleFunc("GET /hecate/v1/agent-presets/{id}", handler.HandleAgentPreset)
+	mux.HandleFunc("PATCH /hecate/v1/agent-presets/{id}", handler.HandleUpdateAgentPreset)
+	mux.HandleFunc("DELETE /hecate/v1/agent-presets/{id}", handler.HandleDeleteAgentPreset)
 	mux.HandleFunc("GET /hecate/v1/agent-adapters", handler.HandleAgentAdapters)
 	mux.HandleFunc("POST /hecate/v1/agent-adapters/{id}/probe", handler.HandleAgentAdapterProbe)
 	mux.HandleFunc("GET /hecate/v1/agent-adapters/{id}/health", handler.HandleAgentAdapterHealth)


### PR DESCRIPTION
## Summary
- rename the Hecate agent preset API response/request types and handler functions away from the old Agent Profile wording
- update the route wiring and API tests for the new handler names
- keep the internal storage package and default_agent_profile wire fields unchanged in this slice

## Validation
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api -run 'TestAgentPresetsAPI|TestProjectJourney|TestProjectCairnline'
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- just agent-docs-check
- git diff --check