### PR TITLE
Prove embedded Cairnline replacement mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 > **Status: public alpha.** Hecate is useful today for model-provider routing,
 > Hecate Chat, External Agent sessions, project-scoped work, approvals,
 > artifacts, usage, and observability. It is not production-stable
-> infrastructure yet: workflow runbooks, richer agent profiles, browser QA, and
+> infrastructure yet: workflow runbooks, richer Agent Presets, browser QA, and
 > sandbox hardening are still design or early-alpha work. Read
 > [known limitations](docs/operator/known-limitations.md) before depending on it.
 
@@ -134,7 +134,7 @@ Design direction that is not yet a runtime contract:
 - Named workflow modes such as `review`, `investigate`, `qa`, `ship`,
   `security-audit`, and `design-review`.
 - Browser-backed QA evidence and design review.
-- Richer agent profiles and preset workflows.
+- Richer Agent Presets and preset workflows.
 - Broader context-window management and external memory provider selection.
 - A first-class workflow/runbook API if the v0 experiments prove valuable.
 

--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -129,22 +129,25 @@ is actually authoritative. It also reports `replacement_ready`,
 ready read routes from strict embedded probe work, non-authoritative live
 mirrors, still-Hecate-owned dispatch, and missing migration/rollback authority.
 When configured for the embedded connector, strict embedded read source, and a
-runtime data directory, the strict embedded read-smoke gate is backed by the
-read-only mirror-parity probe: missing mirrors, drift, probe errors, and verified
-route smoke are reflected directly in backend status instead of relying only on
-manual checklist prose. Backend status also carries the mirror-parity
-`migration_rehearsal` object when available, so the replacement gate can inspect
-snapshot-import/parity/smoke checks and rollback notes as structured evidence.
-The migration/rollback gate depends on that read-smoke and rehearsal evidence:
-it waits for verified strict embedded reads first, reports incomplete rehearsal
-evidence separately, then reports the remaining missing authoritative
-cutover/rollback switch. Once strict
-embedded reads are verified, all portable write-authority gaps are closed, and
+runtime data directory before cutover, the strict embedded read-smoke gate is
+backed by the read-only mirror-parity probe: missing mirrors, drift, probe
+errors, and verified route smoke are reflected directly in backend status
+instead of relying only on manual checklist prose. Backend status also carries
+the mirror-parity `migration_rehearsal` object when available, so the
+replacement gate can inspect snapshot-import/parity/smoke checks and rollback
+notes as structured evidence. Once
 `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed, backend status
-treats that replacement mode as the explicit embedded cutover switch, clears the
-migration blocker, and reports embedded Cairnline as authoritative for portable
-Projects coordination state. In that armed mode with all portable
-write-authority gaps closed, Cairnline-authoritative project identity create no
+stops judging cutover by Hecate-store mirror parity and instead runs a live
+embedded Cairnline read smoke over the current Cairnline database. That status
+uses `migration_rehearsal.operation=embedded_replacement_smoke` and
+`source_authority=embedded_cairnline_authoritative` as the rollback evidence.
+The migration/rollback gate depends on the relevant read-smoke and rehearsal
+evidence: it waits for verified strict embedded reads first, reports incomplete
+rehearsal or live-smoke evidence separately, then becomes ready when replacement
+mode is armed and the live embedded Cairnline smoke plus rollback evidence are
+clean. In that posture backend status clears the migration blocker and reports
+embedded Cairnline as authoritative for portable Projects coordination state. In
+that armed mode, Cairnline-authoritative project identity create no
 longer creates a native Hecate project identity row; strict embedded reads serve
 the project from Cairnline, while Hecate keeps only the runtime/workspace
 compatibility state it still owns. Project skill discovery/update also stops
@@ -173,8 +176,9 @@ standalone sidecar as the external MCP/server boundary. That keeps Hecate's
 operator UI and compatibility shadow stable while the portable contract is
 proven locally. `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is the
 explicit operator arm for that embedded contract; it is valid only with the
-embedded connector and strict embedded read source, and it does not bypass read,
-write-authority, migration, rollback, or Hecate-owned runtime side-effect gates.
+embedded connector and strict embedded read source and implies all portable
+write-authority switchpoints, but it does not bypass read, migration, rollback,
+or Hecate-owned runtime side-effect gates.
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded` is the current live-route
 dogfood connector. `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` exposes
 local-only standalone Cairnline MCP contract probe/connect surfaces at
@@ -332,8 +336,8 @@ Hecate-specific runtime enrichment and setup/action wording remain in Hecate,
 and the Cairnline-backed operations brief uses Cairnline activity/service rows
 plus Hecate cockpit action helpers so operator-facing actions stay
 parity-checked with the native route.
-`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is the first
-disabled-by-default Cairnline write-authority dogfood switch. When enabled,
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` is an opt-in
+Cairnline write-authority dogfood switch. When enabled,
 accepted project memory entry create/update/delete commits to embedded
 Cairnline first, then best-effort shadows the entry into Hecate-native memory
 stores for compatibility. Adding `memory-candidates` to that setting makes
@@ -380,24 +384,24 @@ Cairnline first, then best-effort shadow the portable records into Hecate-native
 project-work stores for compatibility. While that alpha switch is enabled,
 review artifacts must carry a supported verdict because Cairnline does not have
 a verdict-less review state and Hecate must not silently rewrite that shape.
-`project-skills` is a third opt-in authority slice: project skill discovery and
+`project-skills` is an opt-in authority slice: project skill discovery and
 metadata updates commit metadata-only skill records to embedded Cairnline first,
 then best-effort shadow the records into Hecate-native project-skill stores for
 compatibility. Skill discovery/update can validate project identity, roots, and
 context sources from the embedded Cairnline graph without a matching
 Hecate-native project row. Skill bodies are still not loaded, injected,
 executed, or treated as permissions.
-`project-roles` is a fourth opt-in authority slice: role create/update/delete
+`project-roles` is an opt-in authority slice: role create/update/delete
 commits to embedded Cairnline first, preserves Hecate's built-in-role
 protection, persists Hecate-owned provider/model/preset defaults in Hecate's
 project runtime overlay, then best-effort shadows portable role defaults into
 Hecate-native project-work stores for compatibility. Deleting a custom role
 preserves historical assignments that still carry the deleted `role_id`.
-`project-work-items` is a fifth opt-in authority slice: work-item
+`project-work-items` is an opt-in authority slice: work-item
 create/update/delete commits to embedded Cairnline first, preserves Hecate's
 `backlog` default and closeout-readiness gate, then best-effort shadows the
 portable work item into Hecate-native project-work stores for compatibility.
-`project-assignments` is a sixth opt-in authority slice: assignment
+`project-assignments` is an opt-in authority slice: assignment
 create/update/delete record mutations commit to embedded Cairnline first, then
 best-effort shadow portable assignment state into Hecate-native project-work
 stores for compatibility. When this authority slice is enabled, assignment
@@ -406,7 +410,7 @@ that claim when Hecate-owned launch setup fails before a runtime record is
 committed. Assignment runtime dispatch remains Hecate-owned; committed start
 results, cleanup/conflict states, and linked-chat reconciliation updates are
 mirrored as replacement evidence.
-`project-assistant-proposals` is a seventh opt-in authority slice: Project
+`project-assistant-proposals` is an opt-in authority slice: Project
 Assistant draft/propose/apply-attempt ledger records commit to embedded
 Cairnline first, then best-effort shadow Hecate's proposal store for
 compatibility; armed embedded replacement mode skips those native proposal
@@ -711,7 +715,12 @@ after these gates are met:
   coverage; `write_adapter_gaps` remains a broad diagnostic list, while
   `portable_write_gaps` is the machine-readable blocker list for mutation
   families that still need live switch points before portable write authority
-  can move.
+  can move. `next_replacement_action` intentionally applies a narrower
+  dogfood recommendation order over that blocker list, so metadata-only
+  context-source and skill authority can be proven before project identity
+  cutover. Write-authority config hints preserve existing enabled
+  switchpoints in the suggested env value so the operator can add the next slice
+  without disabling prior dogfood authority.
 - Import/export or migration covers existing Hecate local stores and can be
   rolled back during alpha; the embedded Cairnline sync database proves a
   durable all-project seed through Cairnline's native snapshot import with
@@ -725,13 +734,15 @@ after these gates are met:
   interoperability evidence, but they are not the first Hecate replacement
   target.
 - The embedded cutover contract is explicitly armed with
-  `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` after the read,
-  write-authority, migration, and rollback gates are ready; enabling all
-  portable write-authority switchpoints alone does not replace the backend.
-  Replacement mode plus all portable write authority can make new project
-  identity creates Cairnline-only, but `replacement_ready` remains false until
-  strict embedded read smoke and migration/rollback gates are clean. Once those
-  gates are clean, the `migration-cutover` switchpoint reports
+  `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` after the pre-cutover
+  read, migration, and rollback rehearsal gates are ready. That mode implies
+  all portable write-authority switchpoints; enabling all portable
+  write-authority switchpoints alone does not replace the backend. Replacement
+  mode can make new project identity creates Cairnline-only, and backend status
+  then verifies live embedded Cairnline state instead of Hecate-store mirror
+  parity. `replacement_ready` remains false until strict embedded read smoke and
+  migration/rollback gates are clean.
+  Once those gates are clean, the `migration-cutover` switchpoint reports
   `embedded_cutover_armed` instead of a blocking Hecate-owned cutover gap.
   At that point backend status reports `status=cairnline_authoritative`; any
   warnings should describe the remaining Hecate-owned runtime/workspace

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -543,9 +543,9 @@ first and then shadows Hecate's compatibility project row. Delete restores the
 Cairnline snapshot if Hecate compatibility cleanup fails. Identity delete can
 also target a Cairnline-only project graph and clean Hecate compatibility shadow
 rows without requiring a matching native project row. When embedded replacement
-mode is armed with all portable write-authority gaps closed, project-identity
-create returns the Cairnline record without creating a native Hecate project
-identity row; strict embedded reads then serve the new project from Cairnline.
+mode is armed, project-identity create returns the Cairnline record without
+creating a native Hecate project identity row because portable write authority
+is implied; strict embedded reads then serve the new project from Cairnline.
 Project root create/update/delete and root list replacement mutations also
 best-effort mirror after the Hecate store commit unless `project-roots` is
 enabled, in which case those root mutations plus discovery-result replacement
@@ -626,9 +626,9 @@ Cairnline authority seams for project create, project metadata/default, root,
 role, work-item, assignment, handoff, and memory-candidate actions, but
 chat/runtime effects remain Hecate-owned orchestrator capabilities outside
 Cairnline core.
-Other live Projects reads/writes still use Hecate-native
-stores until the remaining read routes, write adapter, and migration path are
-ready. Current bridge write experiments cover non-authoritative
+Hecate-owned runtime/workspace side effects still remain outside Cairnline core,
+even when portable project-state write authority is ready. Current bridge write
+experiments cover non-authoritative
 project/root/source/defaults, skills, roles, work items,
 assignment metadata upsert/delete, assignment-start result and linked-chat
 reconciliation sync, memory, memory-candidate, create-only collaboration
@@ -657,30 +657,37 @@ also reports `replacement_ready`, `next_replacement_action`,
 `replacement_gates`, and `write_switchpoints` so operators can see the
 suggested next step, relevant env-var hints, and the exact read-route,
 strict-embedded-read-smoke, write-authority, and migration blockers without
-parsing warning prose. Gates and next actions include method-aware `probes`
-alongside compatibility `probe_urls`, so Settings can turn the next action into
-an ordered, copyable probe checklist and distinguish POST smoke/rehearsal routes
-from GET read checks. When the embedded connector, strict embedded read source,
-and a configured data directory are active, the strict read-smoke gate is driven
-by the same read-only mirror-parity evidence returned by
+parsing warning prose. The next action keeps the blocker list separate from the
+recommended dogfood order, so metadata-only context-source and skill authority
+can be suggested before broader project identity cutover. Write-authority
+`config_hints` preserve already-enabled switchpoints in the suggested env value,
+so operators can copy the whole value without dropping prior dogfood authority.
+Gates and next actions include method-aware `probes` alongside compatibility
+`probe_urls`, so Settings can turn the next action into an ordered, copyable
+probe checklist and distinguish POST smoke/rehearsal routes from GET read
+checks. When the embedded connector, strict embedded read source, and a
+configured data directory are active before cutover, the strict read-smoke gate
+is driven by the same read-only mirror-parity evidence returned by
 `GET /hecate/v1/projects/cairnline/mirror-parity`: a missing mirror reports
-`not_run`, mirror drift reports `drift_detected`, and an exact mirror with passing
-strict embedded route smoke reports `verified`. Backend status also exposes the
-same mirror-parity `migration_rehearsal` object so operators can inspect the
-snapshot-import checklist, rollback notes, and strict embedded smoke details
-without calling the probe endpoint separately. The migration/rollback gate then
-reports `waiting_for_read_smoke` until read evidence is verified,
-`rehearsal_incomplete` when the attached rehearsal evidence is missing or
-incomplete, and `cutover_switch_missing` once the rehearsal evidence is clean
-but the explicit authoritative storage cutover switch still does not exist. When
-`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed after strict
-embedded reads are verified and all portable write-authority gaps are closed,
-backend status treats that mode as the explicit embedded cutover switch, clears
-the migration blocker, marks the `migration-cutover` write switchpoint as
-`embedded_cutover_armed`, and reports Cairnline as authoritative for portable
-Projects coordination state. In that armed mode with all portable
-write-authority gaps closed, new Cairnline-authoritative project identity
-creates no longer manufacture native Hecate project identity rows;
+`not_run`, mirror drift reports `drift_detected`, and an exact mirror with
+passing strict embedded route smoke reports `verified`. Backend status also
+exposes that mirror-parity `migration_rehearsal` object so operators can
+inspect the snapshot-import checklist, rollback notes, and strict embedded
+smoke details without calling the probe endpoint separately. Once
+`HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded` is armed, backend status
+stops judging cutover by Hecate-store mirror parity and instead runs a live
+embedded Cairnline read smoke over the current Cairnline database. That status
+uses `migration_rehearsal.operation=embedded_replacement_smoke` with
+`source_authority=embedded_cairnline_authoritative` as the rollback evidence.
+The migration/rollback gate reports `waiting_for_read_smoke` until the relevant
+read evidence is verified, `rehearsal_incomplete` when the attached rehearsal
+or live-smoke evidence is missing or incomplete, and `ready` once live
+replacement smoke, rollback notes, and the explicit embedded cutover switch are
+clean. In that ready posture backend status clears the migration blocker, marks
+the `migration-cutover` write switchpoint as `embedded_cutover_armed`, and
+reports Cairnline as authoritative for portable Projects coordination state. In
+that armed mode, new Cairnline-authoritative project identity creates no longer
+manufacture native Hecate project identity rows;
 compatibility shadows remain limited to Hecate-owned runtime/workspace needs.
 Once all replacement gates are ready, backend status reports
 `status=cairnline_authoritative` and keeps warnings focused on Hecate-owned
@@ -704,21 +711,24 @@ target is embedded Cairnline first: Hecate should make the embedded Cairnline
 database the Projects source of truth before treating an external sidecar as the
 standalone/interoperability boundary. `replacement_mode=disabled|embedded`
 reports the explicit operator cutover arm; `embedded` is only valid with the
-embedded connector and strict embedded read source, and it does not bypass the
-read, write-authority, migration, rollback, or Hecate-owned runtime side-effect
-gates. The initial embedded dogfood and sidecar-to-embedded connector next
+embedded connector and strict embedded read source and implies all portable
+write-authority switchpoints, but it does not bypass the read, migration,
+rollback, or Hecate-owned runtime side-effect gates. The initial embedded
+dogfood and sidecar-to-embedded connector next
 actions point at backend-status and embedded read-model diagnostics; sidecar
 probe/connect routes remain separate standalone MCP diagnostics. Once portable
-write gaps are closed, the next action becomes `run-strict-embedded-read-smoke` until strict
-embedded mirror parity and route-smoke evidence are verified; that action
-reports strict embedded rehearsal hints for
-`HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
-`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and
-`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`; after strict embedded
-read smoke is verified, the next action becomes implementing the missing
-migration cutover switch by arming
+write gaps are closed before replacement mode is armed, the next action becomes
+`run-strict-embedded-read-smoke` until strict embedded mirror parity and
+route-smoke evidence are verified; that action reports strict embedded
+rehearsal hints for `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`. After strict embedded read
+smoke is verified, the next action becomes implementing the missing migration
+cutover switch by arming
 `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded`; backend status includes
-that env var as a copyable next-action config hint. That status cutover does not
+that env var as a copyable next-action config hint. Once replacement mode is
+armed, `run-strict-embedded-read-smoke` points at backend status itself because
+the proof is live embedded Cairnline state, not a Hecate-store mirror-parity
+rehearsal. That status cutover does not
 move Hecate-owned runtime/workspace capabilities such as assignment dispatch or
 Project Assistant apply side effects into Cairnline core. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -629,11 +629,12 @@ sequenceDiagram
   explicit cutover-mode arm. The default is `disabled`. `embedded` is accepted
   only with `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`,
   `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`, and
-  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`. It does not bypass read,
-  write-authority, strict embedded smoke, migration, rollback, or Hecate-owned
-  runtime side-effect gates; backend status reports the mode as an explicit
-  replacement gate so operators can distinguish "all portable writes are
-  Cairnline-first" from "the embedded replacement contract is armed."
+  `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`. It implies all portable
+  write-authority switchpoints, but it does not bypass read, strict embedded
+  smoke, migration, rollback, or Hecate-owned runtime side-effect gates; backend
+  status reports the mode as an explicit replacement gate so operators can
+  distinguish "portable writes are Cairnline-first" from "every replacement
+  proof is complete."
 - `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`, `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
   `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
   `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT` configure the standalone
@@ -2407,8 +2408,8 @@ current portable write-authority switchpoint for dogfooding the embedded
 Cairnline authority path. It is not a migration or runtime cutover switch:
 Hecate-owned root scan/worktree, assignment-start, Project Assistant chat/runtime
 side effects, and migration/rollback gates still remain separate.
-`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables the first
-disabled-by-default write authority switchpoint: accepted project memory entries
+`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables an
+opt-in write authority switchpoint: accepted project memory entries
 commit to embedded Cairnline first and are then shadowed back into Hecate-native
 memory stores. In this authority mode, memory writes can validate the project
 from the embedded Cairnline graph and do not require a Hecate-native
@@ -2527,10 +2528,13 @@ Cairnline first, then keep the standalone Cairnline sidecar as the later
 interoperability and external-server boundary. `replacement_mode` and
 `replacement_mode_armed` reflect
 `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE`; the mode is a human/operator
-cutover arm, not permission to skip the other gates. `write_adapter_ready=true` means
-all portable project-state write-authority gaps known to this Hecate build are
-closed through explicit Cairnline switchpoints; it does not mean Hecate runtime
-side effects, migration, rollback, or final replacement are ready.
+cutover arm. When set to `embedded`, it implies all portable write-authority
+switchpoints known to this Hecate build, but it is not permission to skip read,
+migration, rollback, or Hecate-owned runtime/workspace gates.
+`write_adapter_ready=true` means all portable project-state write-authority gaps
+known to this Hecate build are closed through explicit or replacement-mode
+Cairnline authority; it does not mean Hecate runtime side effects, migration,
+rollback, or final replacement are ready.
 `write_adapter_seams`
 lists non-authoritative bridge proofs that can write Cairnline-shaped records
 during tests or local sync rehearsals;
@@ -2549,13 +2553,18 @@ guaranteed to be exclusive: for example, `roots` can appear in
 `portable_write_gaps` until root metadata writes are Cairnline-authoritative and
 can remain in `orchestrator_capabilities` while Hecate still owns discovery
 scans and Git worktree creation.
-`replacement_ready` stays `false` until read parity, strict embedded mirror
-probes, write-authority switchpoints, migration/rollback gates, and explicit
-embedded replacement mode are all ready. `next_replacement_action` is an
+`replacement_ready` stays `false` until read parity, strict embedded smoke,
+portable write authority, migration/rollback gates, and explicit embedded
+replacement mode are all ready. `next_replacement_action` is an
 advisory next operator step derived from the same status snapshot; it is not a
-command, permission, gate result, or proof that replacement is safe. It can
-include `config_hints`, which are environment setting suggestions such as a specific
-`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY` value; clients must treat them as
+command, permission, gate result, or proof that replacement is safe. For
+portable write authority, the advisory action uses a recommendation order rather
+than the raw `portable_write_gaps` order so operators can dogfood narrower setup
+metadata surfaces such as context sources and skills before broad project
+identity cutover. It can include `config_hints`, which are environment setting
+suggestions such as a specific `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY`
+value; write-authority hint values preserve already-enabled switchpoints so
+they can be presented as whole copyable env values. Clients must treat them as
 operator guidance, not as mutations to apply automatically. `replacement_gates`
 reports those high-level gates as structured checklist items so clients do not
 need to parse warning prose. Each gate and next action may include `probes`, a
@@ -2565,42 +2574,46 @@ to run and are not proof that the gate has already passed unless the gate
 status itself is ready/verified. Clients can use the method-aware list to render
 operator-safe probe checklists, with POST routes presented as smoke/rehearsal
 actions and GET routes presented as read checks. The
-`strict-embedded-read-smoke` gate is
-evidence-backed when Hecate is configured with the embedded connector,
-`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and a data directory: backend
-status runs the read-only mirror-parity check and reports `not_run` for a
-missing mirror, `drift_detected` for parity drift, `probe_error` when the
-inspection cannot run, and `verified` only when the existing mirror matches
-Hecate stores and strict embedded route smoke passes. The
-same backend-status response includes `migration_rehearsal` when that
-mirror-parity probe can run. That object is the same structured rehearsal
+`strict-embedded-read-smoke` gate is evidence-backed when Hecate is configured
+with the embedded connector, `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`,
+and a data directory. Before replacement mode is armed, backend status runs the
+read-only mirror-parity check and reports `not_run` for a missing mirror,
+`drift_detected` for parity drift, `probe_error` when the inspection cannot
+run, and `verified` only when the existing mirror matches Hecate stores and
+strict embedded route smoke passes. In that pre-cutover posture, the
+backend-status response includes the same mirror-parity `migration_rehearsal`
 evidence returned by `/hecate/v1/projects/cairnline/mirror-parity`: snapshot
 import mode, snapshot version, checklist, rollback notes, and strict embedded
-smoke details. The `migration-and-rollback` gate uses this object directly
-rather than only relying on prose. It treats missing evidence, non-verified
-mirror parity, incomplete import/parity/smoke checks, missing rollback steps, or
-non-passing embedded smoke as `rehearsal_incomplete`.
+smoke details. Once `replacement_mode=embedded` is armed, backend status stops
+judging cutover by Hecate-store mirror parity and instead smokes live embedded
+Cairnline project state. That response uses
+`migration_rehearsal.operation=embedded_replacement_smoke` and
+`source_authority=embedded_cairnline_authoritative`; the gate's probe points at
+backend status because the status read performs the live smoke. The
+`migration-and-rollback` gate uses the attached mirror-parity or live-smoke
+evidence directly rather than only relying on prose. It treats missing evidence,
+non-verified mirror parity or replacement smoke, incomplete smoke/checklist
+items, missing rollback steps, or non-passing embedded smoke as
+`rehearsal_incomplete`.
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
 it is driven by `portable_write_gaps` and ignores Hecate-owned orchestrator
 capabilities and the separate `migration-cutover` gap because those are reported
 by their own status fields/gates. The `migration-and-rollback` gate reports
-`waiting_for_read_smoke` until strict embedded read-smoke evidence is verified;
-after that, with complete migration rehearsal evidence attached, it reports
-`cutover_switch_missing` until Hecate has an explicit authoritative Cairnline
-storage cutover and rollback switch. When strict
-embedded reads are verified, all portable write-authority gaps are closed, and
-`replacement_mode=embedded`, backend status treats replacement mode as that
-explicit embedded cutover switch: `migration_blockers` is empty, the
+`waiting_for_read_smoke` until strict embedded read-smoke evidence is verified.
+In pre-cutover rehearsal it then reports `cutover_switch_missing` until Hecate
+has an explicit authoritative Cairnline storage cutover and rollback switch. In
+armed replacement mode, successful live embedded smoke plus rollback evidence
+makes the gate `ready`: `migration_blockers` is empty, the
 `migration-and-rollback` gate is `ready`, and `authoritative_backend` reports
 `cairnline` for portable Projects coordination state. In armed embedded
-replacement mode with all portable write-authority gaps closed,
+replacement mode,
 Cairnline-authoritative project identity create returns the Cairnline record
 with `read_backend: "cairnline"` and without creating a native Hecate project
 identity row; strict embedded read routes serve the new project from Cairnline.
 That identity-shadow behavior is a write-path switch, not the full readiness
 verdict: clients should use `replacement_ready` and `replacement_gates` to tell
-whether mirror parity, strict read smoke, migration, and rollback are actually
-clean.
+whether the relevant strict read smoke, migration, and rollback evidence is
+actually clean.
 When every replacement gate is ready, `status` becomes
 `cairnline_authoritative`, `detail` describes Cairnline as authoritative for
 portable Projects coordination state, and warnings are limited to the remaining
@@ -2609,21 +2622,23 @@ Hecate-store authority warnings. At that point `migration-cutover` is also
 removed from `write_adapter_gaps`; Hecate-owned runtime/workspace capabilities
 such as `assignment-start` can still remain in `write_adapter_gaps` and
 `orchestrator_capabilities` because they are not portable Cairnline core.
-When all portable write-authority gaps are closed but strict embedded mirror
-evidence is not yet verified, the next action is
-`run-strict-embedded-read-smoke`; `config_hints` identify the strict embedded
-dogfood posture expected for the rehearsal:
+When all portable write-authority gaps are closed before replacement mode is
+armed but strict embedded mirror evidence is not yet verified, the next action
+is `run-strict-embedded-read-smoke`; `config_hints` identify the strict
+embedded dogfood posture expected for the rehearsal:
 `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded`,
-`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`, and
-`HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable`. These are still
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded`. These are still
 operator-applied settings and do not flip Hecate into a replaced backend by
-themselves. Once strict embedded mirror parity and route smoke are verified, the
-next action becomes `implement-migration-cutover`, which is intentionally an
-operator-controlled configuration step rather than an automatic mutation. That
-action includes the `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded`
+themselves. Once strict embedded mirror parity and route smoke are verified,
+the next action becomes `implement-migration-cutover`, which is intentionally
+an operator-controlled configuration step rather than an automatic mutation.
+That action includes the `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded`
 configuration hint so clients can render the cutover arm as a copyable operator
-step. Once the cutover is armed and all replacement gates are ready, the next
-action becomes `monitor-cairnline-backend`.
+step. Once replacement mode is armed, `run-strict-embedded-read-smoke` points
+at backend status itself because the proof is live embedded Cairnline state,
+not a Hecate-store mirror-parity rehearsal. Once the cutover is armed and all
+replacement gates are ready, the next action becomes
+`monitor-cairnline-backend`.
 The initial embedded dogfood and sidecar-to-embedded connector actions point at
 backend-status plus embedded read-model diagnostics. If the current runtime is
 still using `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, those actions also
@@ -2633,9 +2648,9 @@ configuration matches the embedded probe set.
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
 `snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled
 alpha write-authority switchpoints, or `partial_authoritative_opt_in` when only
-some routes in a family have moved). When strict embedded mirror parity and
-read smoke are verified, all portable write-authority gaps are closed, and
-`replacement_mode=embedded`, the `migration-cutover` switchpoint reports
+some routes in a family have moved). When strict embedded smoke and replacement
+evidence are verified and `replacement_mode=embedded`, the
+`migration-cutover` switchpoint reports
 `embedded_cutover_armed` and no longer blocks authority. Each switchpoint also
 reports the related mirror seams and whether that family still blocks portable
 write authority or remains Hecate-owned runtime behavior.
@@ -2713,7 +2728,7 @@ record create/update/delete mutations Cairnline-first and then shadows portable
 assignment state back into Hecate-native project-work stores. Assignment
 authority uses Cairnline-owned work item, role, and root records when present,
 so direct create/update/delete can operate on a Cairnline-only project graph.
-In armed embedded replacement mode with all portable write authority closed,
+In armed embedded replacement mode,
 assignment record mutations skip the native project-work compatibility row;
 Hecate still writes assignment execution refs, context packets, and timestamps
 to its runtime overlay. Mirror failures are logged outside that replacement
@@ -3049,7 +3064,7 @@ Example response, with `write_switchpoints` shortened for readability:
       }
     ],
     "status": "cairnline_read_routes_ready",
-    "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Configured read routes prefer the embedded mirror database when it already contains the requested project or proposal record; otherwise they fall back to the snapshot-seeded in-memory bridge projection. Hecate stores remain authoritative until the remaining live read routes, writes, and migration are ready.",
+    "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Configured read routes prefer the embedded mirror database when it already contains the requested project or proposal record; otherwise they fall back to the snapshot-seeded in-memory bridge projection. Hecate stores remain authoritative until the remaining portable writes and migration are ready.",
     "warnings": [
       "Only the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, and operations brief live read routes use Cairnline.",
       "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto makes configured Cairnline read-model service reads prefer the embedded mirror database when it already contains the requested project or proposal record, and otherwise use a snapshot-seeded in-memory Cairnline bridge projection.",

--- a/internal/api/handler_chat_context_cairnline.go
+++ b/internal/api/handler_chat_context_cairnline.go
@@ -16,6 +16,8 @@ import (
 
 const cairnlineAssignmentContextReason = "Inspectable Cairnline read-model launch packet; Hecate has not created a task/chat execution snapshot for this assignment"
 const cairnlineAssignmentLaunchEvidenceReason = "Portable Cairnline launch packet evidence for replacement-readiness review"
+const cairnlineAssignmentContextHecateAuthorityLine = "Preview only: Hecate stores remain authoritative and no task, chat session, or external-agent run is created by this context read."
+const cairnlineAssignmentContextReplacementAuthorityLine = "Preview only: portable project-state is Cairnline-authoritative in embedded replacement mode; no task, chat session, or external-agent run is created by this context read."
 
 func (h *Handler) contextPacketForCairnlineProjectAssignment(ctx context.Context, assignment projectwork.Assignment) (chat.ContextPacket, bool, error) {
 	if h == nil || !h.projectReadRoutesUseCairnlineReadModel() {
@@ -28,7 +30,7 @@ func (h *Handler) contextPacketForCairnlineProjectAssignment(ctx context.Context
 	if err != nil {
 		return chat.ContextPacket{}, false, err
 	}
-	return cairnlineAssignmentLaunchContextPacket(launch), true, nil
+	return cairnlineAssignmentLaunchContextPacket(launch, h.cairnlineAssignmentContextAuthorityLine()), true, nil
 }
 
 func (h *Handler) cairnlineAssignmentLaunchPacket(ctx context.Context, assignment projectwork.Assignment) (cairnline.AssignmentLaunchPacket, error) {
@@ -62,7 +64,7 @@ func (h *Handler) contextPacketForStrictEmbeddedCairnlineProjectAssignment(ctx c
 	if cairnlineSidecarAssignmentContextRouteMismatch(context, projectID, workItemID, assignmentID) {
 		return chat.ContextPacket{}, false, nil
 	}
-	return cairnlineAssignmentContextPacket(context), true, nil
+	return cairnlineAssignmentContextPacket(context, h.cairnlineAssignmentContextAuthorityLine()), true, nil
 }
 
 func (h *Handler) contextPacketForCairnlineSidecarProjectAssignment(ctx context.Context, projectID, workItemID, assignmentID string) (chat.ContextPacket, bool, error) {
@@ -86,7 +88,7 @@ func (h *Handler) contextPacketForCairnlineSidecarProjectAssignment(ctx context.
 	if cairnlineSidecarAssignmentContextRouteMismatch(context, projectID, workItemID, assignmentID) {
 		return chat.ContextPacket{}, false, nil
 	}
-	return cairnlineAssignmentContextPacket(context), true, nil
+	return cairnlineAssignmentContextPacket(context, cairnlineAssignmentContextHecateAuthorityLine), true, nil
 }
 
 func cairnlineSidecarAssignmentContextRouteMismatch(context cairnline.AssignmentContext, projectID, workItemID, assignmentID string) bool {
@@ -122,7 +124,14 @@ func cairnlineSidecarAssignmentContextRouteMismatch(context cairnline.Assignment
 	return false
 }
 
-func cairnlineAssignmentContextPacket(context cairnline.AssignmentContext) chat.ContextPacket {
+func (h *Handler) cairnlineAssignmentContextAuthorityLine() string {
+	if h != nil && h.projectCairnlineEmbeddedReplacementModeArmed() {
+		return cairnlineAssignmentContextReplacementAuthorityLine
+	}
+	return cairnlineAssignmentContextHecateAuthorityLine
+}
+
+func cairnlineAssignmentContextPacket(context cairnline.AssignmentContext, authorityLine string) chat.ContextPacket {
 	root, rootOK, rootSelection := selectedCairnlineRoot(context.Project, context.WorkItem, context.Assignment)
 	workspace := ""
 	if rootOK {
@@ -147,11 +156,11 @@ func cairnlineAssignmentContextPacket(context cairnline.AssignmentContext) chat.
 	if context.Role != nil {
 		appendCairnlineRole(&packet, *context.Role)
 	}
-	appendCairnlineAssignmentContextRuntime(&packet, context)
+	appendCairnlineAssignmentContextRuntime(&packet, context, authorityLine)
 	return packet
 }
 
-func cairnlineAssignmentLaunchContextPacket(launch cairnline.AssignmentLaunchPacket) chat.ContextPacket {
+func cairnlineAssignmentLaunchContextPacket(launch cairnline.AssignmentLaunchPacket, authorityLine string) chat.ContextPacket {
 	root, rootOK, rootSelection := selectedCairnlineRoot(launch.Project, launch.WorkItem, launch.Assignment)
 	workspace := ""
 	if rootOK {
@@ -183,7 +192,7 @@ func cairnlineAssignmentLaunchContextPacket(launch cairnline.AssignmentLaunchPac
 	appendCairnlineProjectSources(&packet, launch.Project.ContextSources)
 	appendCairnlineAssignmentArtifacts(&packet, launch)
 	appendCairnlineAssignmentHandoffs(&packet, launch)
-	appendCairnlineLaunchRuntime(&packet, launch)
+	appendCairnlineLaunchRuntime(&packet, launch, authorityLine)
 	return packet
 }
 
@@ -599,12 +608,13 @@ func appendCairnlineAssignmentHandoffs(packet *chat.ContextPacket, launch cairnl
 	appendProjectAssignmentHandoffs(packet, filterAssignmentHandoffs(items, launch.Assignment.ID, launch.Assignment.RoleID), false, "Handoff metadata is inspectable Cairnline project evidence; not injected into a model prompt")
 }
 
-func appendCairnlineLaunchRuntime(packet *chat.ContextPacket, launch cairnline.AssignmentLaunchPacket) {
+func appendCairnlineLaunchRuntime(packet *chat.ContextPacket, launch cairnline.AssignmentLaunchPacket, authorityLine string) {
+	authorityLine = firstNonEmptyString(strings.TrimSpace(authorityLine), cairnlineAssignmentContextHecateAuthorityLine)
 	body := []string{
 		"Read backend: cairnline",
 		"Launch packet kind: " + firstNonEmptyString(strings.TrimSpace(launch.Kind), "assignment"),
 		"Portable execution mode: " + firstNonEmptyString(strings.TrimSpace(launch.Assignment.ExecutionMode), cairnline.ExecutionMCPPull),
-		"Preview only: Hecate stores remain authoritative and no task, chat session, or external-agent run is created by this context read.",
+		authorityLine,
 	}
 	if launchID := strings.TrimSpace(launch.ID); launchID != "" {
 		body = append(body, "Cairnline launch packet: "+launchID)
@@ -632,12 +642,13 @@ func appendCairnlineLaunchRuntime(packet *chat.ContextPacket, launch cairnline.A
 	})
 }
 
-func appendCairnlineAssignmentContextRuntime(packet *chat.ContextPacket, context cairnline.AssignmentContext) {
+func appendCairnlineAssignmentContextRuntime(packet *chat.ContextPacket, context cairnline.AssignmentContext, authorityLine string) {
+	authorityLine = firstNonEmptyString(strings.TrimSpace(authorityLine), cairnlineAssignmentContextHecateAuthorityLine)
 	body := []string{
 		"Read backend: cairnline",
 		"Source tool: assignments.context",
 		"Portable execution mode: " + firstNonEmptyString(strings.TrimSpace(context.Assignment.ExecutionMode), cairnline.ExecutionMCPPull),
-		"Preview only: Hecate stores remain authoritative and no task, chat session, or external-agent run is created by this context read.",
+		authorityLine,
 	}
 	if contextID := strings.TrimSpace(context.ID); contextID != "" {
 		body = append(body, "Cairnline assignment context: "+contextID)

--- a/internal/api/handler_project_assistant_test.go
+++ b/internal/api/handler_project_assistant_test.go
@@ -1292,7 +1292,6 @@ func TestProjectAssistantAPI_CairnlineReplacementModeSkipsNativeProposalShadows(
 	handler, server := newProjectAssistantCairnlineMirrorTestHandler(t)
 	handler.config.Projects.CairnlineConnector = "embedded"
 	handler.config.Projects.CairnlineReadSource = "embedded"
-	handler.config.Projects.CairnlineWriteAuthority = "all-portable"
 	handler.config.Projects.CairnlineReplacementMode = "embedded"
 	client := newAPITestClient(t, server)
 	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", `{

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -573,7 +573,94 @@ func projectCairnlineMigrationRehearsal(operation string, databaseExists, match 
 	}
 }
 
+type projectCairnlineStrictEmbeddedSmokeTarget struct {
+	project             projects.Project
+	workItemID          string
+	assignmentID        string
+	assistantProposalID string
+}
+
 func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snapshots []cairnlinebridge.Snapshot) *ProjectCairnlineMigrationEmbeddedSmoke {
+	targets := make([]projectCairnlineStrictEmbeddedSmokeTarget, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		target := projectCairnlineStrictEmbeddedSmokeTarget{project: snapshot.Project}
+		if workItemID, ok := projectCairnlineSmokeFirstWorkItemID(snapshot); ok {
+			target.workItemID = workItemID
+			if assignmentID, ok := projectCairnlineSmokeFirstAssignmentID(snapshot, workItemID); ok {
+				target.assignmentID = assignmentID
+			}
+		}
+		if proposalID, ok := projectCairnlineSmokeFirstAssistantProposalID(snapshot); ok {
+			target.assistantProposalID = proposalID
+		}
+		targets = append(targets, target)
+	}
+	return h.projectCairnlineStrictEmbeddedSmokeTargets(ctx, targets)
+}
+
+func (h *Handler) projectCairnlineStrictEmbeddedLiveSmoke(ctx context.Context) (string, *ProjectCairnlineMigrationEmbeddedSmoke, error) {
+	dbPath, service, store, err := h.openCairnlineEmbeddedService(ctx)
+	if err != nil {
+		return h.cairnlineEmbeddedDatabasePath(), nil, err
+	}
+	projectItems, err := service.ListProjects(ctx)
+	if err != nil {
+		_ = store.Close()
+		return dbPath, nil, err
+	}
+	targets := make([]projectCairnlineStrictEmbeddedSmokeTarget, 0, len(projectItems))
+	for _, projectItem := range projectItems {
+		projected, err := h.projectWithHecateRuntimeOverlay(ctx, projectFromCairnline(projectItem, projects.Project{}))
+		if err != nil {
+			_ = store.Close()
+			return dbPath, nil, err
+		}
+		target := projectCairnlineStrictEmbeddedSmokeTarget{project: projected}
+		workItems, err := service.ListWorkItems(ctx, projectItem.ID)
+		if err != nil {
+			_ = store.Close()
+			return dbPath, nil, err
+		}
+		for _, item := range workItems {
+			if id := strings.TrimSpace(item.ID); id != "" {
+				target.workItemID = id
+				break
+			}
+		}
+		assignments, err := service.ListAssignments(ctx, projectItem.ID)
+		if err != nil {
+			_ = store.Close()
+			return dbPath, nil, err
+		}
+		for _, item := range assignments {
+			if target.workItemID != "" && strings.TrimSpace(item.WorkItemID) != target.workItemID {
+				continue
+			}
+			if id := strings.TrimSpace(item.ID); id != "" {
+				target.assignmentID = id
+				break
+			}
+		}
+		proposals, err := service.ListAssistantProposals(ctx, projectItem.ID)
+		if err != nil {
+			_ = store.Close()
+			return dbPath, nil, err
+		}
+		for _, item := range proposals {
+			if id := strings.TrimSpace(item.ID); id != "" {
+				target.assistantProposalID = id
+				break
+			}
+		}
+		targets = append(targets, target)
+	}
+	if err := store.Close(); err != nil {
+		return dbPath, nil, err
+	}
+	return dbPath, h.projectCairnlineStrictEmbeddedSmokeTargets(ctx, targets), nil
+}
+
+func (h *Handler) projectCairnlineStrictEmbeddedSmokeTargets(ctx context.Context, targets []projectCairnlineStrictEmbeddedSmokeTarget) *ProjectCairnlineMigrationEmbeddedSmoke {
 	smoke := &ProjectCairnlineMigrationEmbeddedSmoke{Status: "passed"}
 	if h == nil {
 		smoke.Status = "failed"
@@ -590,15 +677,15 @@ func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snaps
 		_, err := strict.renderStrictEmbeddedCairnlineProjects(ctx)
 		return err
 	})
-	for _, snapshot := range snapshots {
-		projectID := strings.TrimSpace(snapshot.Project.ID)
+	for _, target := range targets {
+		projectID := strings.TrimSpace(target.project.ID)
 		if projectID == "" {
 			continue
 		}
 		smoke.ProjectCount++
 		smoke.CheckedProjectIDs = append(smoke.CheckedProjectIDs, projectID)
 		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "project-detail", func() error {
-			_, err := strict.renderCairnlineProject(ctx, snapshot.Project)
+			_, err := strict.renderCairnlineProject(ctx, target.project)
 			return err
 		})
 		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "setup-readiness", func() error {
@@ -629,7 +716,7 @@ func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snaps
 			_, err := strict.renderCairnlineProjectWorkItems(ctx, projectID)
 			return err
 		})
-		if workItemID, ok := projectCairnlineSmokeFirstWorkItemID(snapshot); ok {
+		if workItemID := strings.TrimSpace(target.workItemID); workItemID != "" {
 			checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "assignment-list", func() error {
 				_, err := strict.renderCairnlineProjectWorkAssignments(ctx, projectID, workItemID)
 				return err
@@ -642,7 +729,7 @@ func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snaps
 				_, err := strict.renderCairnlineProjectWorkItemReadiness(ctx, projectID, workItemID)
 				return err
 			})
-			if assignmentID, ok := projectCairnlineSmokeFirstAssignmentID(snapshot, workItemID); ok {
+			if assignmentID := strings.TrimSpace(target.assignmentID); assignmentID != "" {
 				checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "assignment-context", func() error {
 					_, ok, err := strict.contextPacketForStrictEmbeddedCairnlineProjectAssignment(ctx, projectID, workItemID, assignmentID)
 					if err != nil {
@@ -657,17 +744,19 @@ func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snaps
 					_, err := strict.renderCairnlineProjectAssignmentLaunchReadiness(ctx, projectID, workItemID, assignmentID)
 					return err
 				})
-				checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "assignment-preflight", func() error {
-					inputs, err := strict.cairnlineProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
-					if err != nil {
+				if projectCairnlineSmokeHasWorkspaceRoot(target.project) {
+					checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "assignment-preflight", func() error {
+						inputs, err := strict.cairnlineProjectAssignmentLaunchInputs(ctx, projectID, workItemID, assignmentID)
+						if err != nil {
+							return err
+						}
+						if !inputs.RoleOK {
+							return errors.New("embedded Cairnline assignment role not found")
+						}
+						_, err = strict.projectAssignmentPreflightContext(ctx, inputs.Project, inputs.WorkItem, inputs.Assignment, inputs.Role)
 						return err
-					}
-					if !inputs.RoleOK {
-						return errors.New("embedded Cairnline assignment role not found")
-					}
-					_, err = strict.projectAssignmentPreflightContext(ctx, inputs.Project, inputs.WorkItem, inputs.Assignment, inputs.Role)
-					return err
-				})
+					})
+				}
 			}
 		}
 		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "handoff-list", func() error {
@@ -679,7 +768,7 @@ func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snaps
 			return err
 		})
 		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "operations-brief", func() error {
-			_, err := strict.renderCairnlineProjectOperationsBrief(ctx, snapshot.Project.ID)
+			_, err := strict.renderCairnlineProjectOperationsBrief(ctx, target.project.ID)
 			return err
 		})
 		checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "project-chat-prelude", func() error {
@@ -708,7 +797,7 @@ func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snaps
 			})
 			return err
 		})
-		if proposalID, ok := projectCairnlineSmokeFirstAssistantProposalID(snapshot); ok {
+		if proposalID := strings.TrimSpace(target.assistantProposalID); proposalID != "" {
 			checkProjectCairnlineEmbeddedSmoke(smoke, projectID, "project-assistant-proposal", func() error {
 				_, ok, err := strict.cairnlineProjectAssistantProposal(ctx, proposalID)
 				if err != nil {
@@ -739,6 +828,15 @@ func (h *Handler) projectCairnlineStrictEmbeddedSmoke(ctx context.Context, snaps
 		smoke.Status = "failed"
 	}
 	return smoke
+}
+
+func projectCairnlineSmokeHasWorkspaceRoot(project projects.Project) bool {
+	for _, root := range project.Roots {
+		if strings.TrimSpace(root.ID) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func projectCairnlineSmokeFirstWorkItemID(snapshot cairnlinebridge.Snapshot) (string, bool) {

--- a/internal/api/handler_project_context_discovery_test.go
+++ b/internal/api/handler_project_context_discovery_test.go
@@ -402,7 +402,6 @@ func TestProjectContextDiscovery_CairnlineReplacementModeSkipsMissingCompatibili
 			CoordinationBackend:      "cairnline",
 			CairnlineConnector:       "embedded",
 			CairnlineReadSource:      "embedded",
-			CairnlineWriteAuthority:  "all-portable",
 			CairnlineReplacementMode: "embedded",
 		},
 	}, logger, nil, nil, nil, nil)

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/hecatehq/cairnline"
 )
 
 const projectCoordinationBackendStatusURL = "/hecate/v1/projects/backend-status"
@@ -132,6 +135,21 @@ var projectCairnlineWriteAdapterGapNames = []string{
 	"project-assistant-proposals",
 	"project-assistant-apply-side-effects",
 	"migration-cutover",
+}
+
+var projectCairnlinePortableWriteRecommendationOrder = []string{
+	"context-sources",
+	"skills",
+	"roles",
+	"work-items",
+	"assignments",
+	"artifacts",
+	"handoffs",
+	"memory",
+	"memory-candidates",
+	"roots",
+	"projects",
+	"project-assistant-proposals",
 }
 
 var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchpoint{
@@ -360,7 +378,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 	switch configured {
 	case "cairnline":
 		readReady, sourceWarnings := h.cairnlineReadModelReadiness()
-		strictEmbeddedReadGate, migrationRehearsal := h.projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx, connectorReady, readSource, readReady)
+		strictEmbeddedReadGate, migrationRehearsal := h.projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx, connectorReady, readSource, readReady, replacementMode)
 		response.MigrationRehearsal = migrationRehearsal
 		writeAuthority := h.config.ProjectsCairnlineWriteAuthority()
 		effectiveWriteAuthority := writeAuthority
@@ -389,7 +407,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 					projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
 					"Full Cairnline replacement remains blocked on authoritative write migration.",
 				}
-				return projectCairnlineStatusWithNextAction(response)
+				return projectCairnlineStatusWithNextAction(response, effectiveWriteAuthority)
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
@@ -398,31 +416,39 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 				projectCairnlineConnectorWarning(connector),
 				projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
 			}
-			return projectCairnlineStatusWithNextAction(response)
+			return projectCairnlineStatusWithNextAction(response, effectiveWriteAuthority)
 		}
 		response.ReadModelSwitchReady = readReady
 		if readReady {
 			response.ReadRoutes = append([]string(nil), projectCairnlineReadRouteNames...)
 			response.Status = "cairnline_read_routes_ready"
-			response.Detail = "Cairnline is configured as the future Projects coordination backend, and the " + projectCairnlineReadRouteList(projectCairnlineReadRouteNames) + " read routes are served from the Cairnline read model. " + projectCairnlineReadSourceDetail(readSource) + " Hecate stores remain authoritative until the remaining writes and migration are ready."
+			response.Detail = projectCairnlineReadRoutesReadyDetail(readSource, response.WriteAdapterReady, replacementMode)
 			response.Warnings = []string{
 				"Only the " + projectCairnlineReadRouteList(projectCairnlineReadRouteNames) + " live read routes use Cairnline.",
 				projectCairnlineReadSourceWarning(readSource),
-				projectCairnlineProjectIdentityWriteWarning(writeAuthority),
-				projectCairnlineProjectMetadataDefaultsWriteWarning(writeAuthority, nativeShadowSkipArmed),
-				projectCairnlineProjectRootWriteWarning(writeAuthority, nativeShadowSkipArmed),
-				projectCairnlineProjectContextSourceWriteWarning(writeAuthority, nativeShadowSkipArmed),
-				projectCairnlineProjectSkillWriteWarning(writeAuthority),
-				projectCairnlineProjectWorkItemWriteWarning(writeAuthority),
-				projectCairnlineProjectAssignmentWriteWarning(writeAuthority),
-				projectCairnlineProjectCollaborationWriteWarning(writeAuthority),
-				projectCairnlineProjectMemoryWriteWarning(writeAuthority),
-				projectCairnlineProjectAssistantProposalWriteWarning(writeAuthority, nativeShadowSkipArmed),
-				projectCairnlineProjectAssistantApplyWriteWarning(writeAuthority),
-				"Other project mutation routes still write only Hecate-native stores.",
-				"Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready.",
+				projectCairnlineProjectIdentityWriteWarning(effectiveWriteAuthority, nativeShadowSkipArmed),
+				projectCairnlineProjectMetadataDefaultsWriteWarning(effectiveWriteAuthority, nativeShadowSkipArmed),
+				projectCairnlineProjectRootWriteWarning(effectiveWriteAuthority, nativeShadowSkipArmed),
+				projectCairnlineProjectContextSourceWriteWarning(effectiveWriteAuthority, nativeShadowSkipArmed),
+				projectCairnlineProjectSkillWriteWarning(effectiveWriteAuthority),
+				projectCairnlineProjectWorkItemWriteWarning(effectiveWriteAuthority),
+				projectCairnlineProjectAssignmentWriteWarning(effectiveWriteAuthority),
+				projectCairnlineProjectCollaborationWriteWarning(effectiveWriteAuthority),
+				projectCairnlineProjectMemoryWriteWarning(effectiveWriteAuthority),
+				projectCairnlineProjectAssistantProposalWriteWarning(effectiveWriteAuthority, nativeShadowSkipArmed),
+				projectCairnlineProjectAssistantApplyWriteWarning(effectiveWriteAuthority),
 			}
-			return projectCairnlineStatusWithNextAction(response)
+			if response.WriteAdapterReady {
+				response.Warnings = append(response.Warnings,
+					"Portable project-state write authority is Cairnline-ready; Hecate-owned runtime/workspace side effects and migration/rollback gates remain separate.",
+				)
+			} else {
+				response.Warnings = append(response.Warnings,
+					"Other project mutation routes still write only Hecate-native stores.",
+					"Cairnline write-adapter seams are non-authoritative proofs; live write authority and migration path are not ready.",
+				)
+			}
+			return projectCairnlineStatusWithNextAction(response, effectiveWriteAuthority)
 		}
 		response.Status = "cairnline_configured_read_adapter_missing_sources"
 		response.Detail = "Cairnline is configured as the future Projects coordination backend, but the read adapter cannot project the full Hecate project graph from the currently wired stores."
@@ -434,10 +460,10 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 		response.Status = "hecate_authoritative"
 		response.Detail = "Hecate-native project stores are authoritative. Cairnline bridge endpoints are available for replacement-readiness checks."
 	}
-	return projectCairnlineStatusWithNextAction(response)
+	return projectCairnlineStatusWithNextAction(response, nil)
 }
 
-func projectCairnlineStatusWithNextAction(response ProjectCoordinationBackendStatusResponse) ProjectCoordinationBackendStatusResponse {
+func projectCairnlineStatusWithNextAction(response ProjectCoordinationBackendStatusResponse, writeAuthority []string) ProjectCoordinationBackendStatusResponse {
 	response.ReplacementReady = projectCairnlineReplacementGatesReady(response.ReplacementGates)
 	if response.ReplacementReady {
 		response.AuthoritativeBackend = "cairnline"
@@ -446,7 +472,7 @@ func projectCairnlineStatusWithNextAction(response ProjectCoordinationBackendSta
 		response.Detail = projectCairnlineReplacementReadyDetail()
 		response.Warnings = projectCairnlineReplacementReadyWarnings(response.OrchestratorCapabilities)
 	}
-	response.NextReplacementAction = projectCairnlineNextReplacementAction(response)
+	response.NextReplacementAction = projectCairnlineNextReplacementAction(response, writeAuthority)
 	projectCairnlineHydrateProbeMetadata(&response)
 	return response
 }
@@ -521,7 +547,7 @@ func projectCairnlineReplacementReadyWarnings(orchestratorCapabilities []string)
 	return warnings
 }
 
-func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStatusResponse) *ProjectCoordinationBackendNextAction {
+func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStatusResponse, writeAuthority []string) *ProjectCoordinationBackendNextAction {
 	if status.ReplacementReady {
 		return &ProjectCoordinationBackendNextAction{
 			ID:     "monitor-cairnline-backend",
@@ -576,16 +602,25 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 		}
 	}
 	if len(status.PortableWriteGaps) > 0 {
-		target := status.PortableWriteGaps[0]
+		target := projectCairnlineNextPortableWriteGap(status.PortableWriteGaps)
 		return &ProjectCoordinationBackendNextAction{
 			ID:          "move-portable-write-authority",
 			Label:       "Move the next portable write authority",
-			Detail:      "Close the next portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
+			Detail:      "Close the next recommended portable project-state gap by adding a Cairnline-authoritative switchpoint while keeping Hecate as compatibility shadow.",
 			Target:      target,
-			ConfigHints: projectCairnlineWriteAuthorityHintsForGap(target),
+			ConfigHints: projectCairnlineWriteAuthorityHintsForGapWithExisting(target, writeAuthority),
 		}
 	}
 	if gate := projectCoordinationBackendReplacementGateByID(status.ReplacementGates, "strict-embedded-read-smoke"); gate != nil && !gate.Ready {
+		if status.ReplacementMode == "embedded" {
+			return &ProjectCoordinationBackendNextAction{
+				ID:        "run-strict-embedded-read-smoke",
+				Label:     "Run strict embedded read smoke",
+				Detail:    "Portable project-state writes are Cairnline-authoritative; rerun backend status to smoke live embedded Cairnline project state before treating the backend as fully delegated.",
+				Target:    "strict-embedded-read-smoke",
+				ProbeURLs: append([]string(nil), gate.ProbeURLs...),
+			}
+		}
 		return &ProjectCoordinationBackendNextAction{
 			ID:          "run-strict-embedded-read-smoke",
 			Label:       "Run strict embedded read smoke",
@@ -646,6 +681,28 @@ func projectCairnlineNextReplacementAction(status ProjectCoordinationBackendStat
 	}
 }
 
+func projectCairnlineNextPortableWriteGap(gaps []string) string {
+	remaining := make(map[string]struct{}, len(gaps))
+	for _, gap := range gaps {
+		gap = strings.TrimSpace(gap)
+		if gap == "" {
+			continue
+		}
+		remaining[gap] = struct{}{}
+	}
+	for _, candidate := range projectCairnlinePortableWriteRecommendationOrder {
+		if _, ok := remaining[candidate]; ok {
+			return candidate
+		}
+	}
+	for _, gap := range gaps {
+		if strings.TrimSpace(gap) != "" {
+			return gap
+		}
+	}
+	return ""
+}
+
 func projectCoordinationBackendReplacementGateByID(gates []ProjectCoordinationBackendReplacementGate, id string) *ProjectCoordinationBackendReplacementGate {
 	for i := range gates {
 		if gates[i].ID == id {
@@ -657,7 +714,7 @@ func projectCoordinationBackendReplacementGateByID(gates []ProjectCoordinationBa
 
 func projectCairnlineReplacementModeHints() []ProjectCoordinationBackendActionConfigHint {
 	return []ProjectCoordinationBackendActionConfigHint{
-		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE", "embedded", "Arm the explicit embedded Cairnline replacement contract after read, write-authority, migration, and rollback gates are ready."),
+		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE", "embedded", "Arm the explicit embedded Cairnline replacement contract after read, migration, and rollback gates are ready; portable write authority is implied by this mode."),
 	}
 }
 
@@ -665,7 +722,6 @@ func projectCairnlineMigrationCutoverHints() []ProjectCoordinationBackendActionC
 	return []ProjectCoordinationBackendActionConfigHint{
 		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_CONNECTOR", "embedded", "Use the embedded connector for current write-authority and migration rehearsal paths."),
 		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_READ_SOURCE", "embedded", "Force configured project reads to fail loudly when the embedded mirror is missing or stale during cutover rehearsal."),
-		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", "all-portable", "Keep all portable write-authority switchpoints enabled while rehearsing migration and rollback."),
 	}
 }
 
@@ -688,17 +744,48 @@ func projectCairnlineConfigHint(env, value, detail string) ProjectCoordinationBa
 }
 
 func projectCairnlineWriteAuthorityHintsForGap(gap string) []ProjectCoordinationBackendActionConfigHint {
+	return projectCairnlineWriteAuthorityHintsForGapWithExisting(gap, nil)
+}
+
+func projectCairnlineWriteAuthorityHintsForGapWithExisting(gap string, existing []string) []ProjectCoordinationBackendActionConfigHint {
 	values := projectCairnlineWriteAuthorityValuesForGap(gap)
 	if len(values) == 0 {
 		return nil
 	}
+	nextValue := projectCairnlineMergedWriteAuthorityValue(existing, values)
 	detail := "Add this value to HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY for embedded Cairnline write-authority dogfooding."
 	if len(values) > 1 {
 		detail = "Add these comma-separated values to HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY; this gap requires the switchpoints together."
 	}
-	return []ProjectCoordinationBackendActionConfigHint{
-		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", strings.Join(values, ","), detail),
+	if len(existing) > 0 {
+		detail = "Set HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY to this additive comma-separated value; it preserves already-enabled Cairnline write-authority switchpoints."
 	}
+	return []ProjectCoordinationBackendActionConfigHint{
+		projectCairnlineConfigHint("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", nextValue, detail),
+	}
+}
+
+func projectCairnlineMergedWriteAuthorityValue(existing, values []string) string {
+	out := make([]string, 0, len(existing))
+	seen := make(map[string]struct{}, len(existing))
+	appendValue := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" || value == "none" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	for _, value := range existing {
+		appendValue(value)
+	}
+	for _, value := range values {
+		appendValue(value)
+	}
+	return strings.Join(out, ",")
 }
 
 func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
@@ -760,7 +847,7 @@ func projectCairnlineStrictEmbeddedReadSmokeDefaultGate() ProjectCoordinationBac
 	}
 }
 
-func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx context.Context, connectorReady bool, readSource string, readRoutesReady bool) (ProjectCoordinationBackendReplacementGate, *ProjectCairnlineMigrationRehearsal) {
+func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx context.Context, connectorReady bool, readSource string, readRoutesReady bool, replacementMode string) (ProjectCoordinationBackendReplacementGate, *ProjectCairnlineMigrationRehearsal) {
 	gate := projectCairnlineStrictEmbeddedReadSmokeDefaultGate()
 	if !connectorReady {
 		gate.Status = "blocked"
@@ -779,6 +866,38 @@ func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx con
 	if strings.TrimSpace(h.config.Server.DataDir) == "" {
 		gate.Detail = "Run backend status with a configured Hecate data directory, then run the embedded sync/parity/smoke probes with HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded before treating the mirror database as a cutover candidate."
 		return gate, nil
+	}
+	if replacementMode == "embedded" {
+		gate.ProbeURLs = []string{projectCoordinationBackendStatusURL}
+		dbPath, smoke, err := h.projectCairnlineStrictEmbeddedLiveSmoke(ctx)
+		if err != nil {
+			migrationRehearsal := projectCairnlineEmbeddedReplacementModeRehearsal(dbPath, false, nil)
+			if errors.Is(err, cairnline.ErrNotFound) {
+				gate.Status = "not_run"
+				gate.Detail = "No embedded Cairnline replacement database exists yet; create or import portable project state before treating Cairnline as the authoritative Projects backend."
+				return gate, &migrationRehearsal
+			}
+			gate.Status = "probe_error"
+			gate.Detail = "Strict embedded live read smoke could not inspect embedded Cairnline state: " + err.Error()
+			return gate, &migrationRehearsal
+		}
+		migrationRehearsal := projectCairnlineEmbeddedReplacementModeRehearsal(dbPath, true, smoke)
+		if smoke == nil || smoke.Status != "passed" {
+			gate.Status = "failed"
+			if smoke != nil && smoke.Status != "" {
+				gate.Status = smoke.Status
+			}
+			errorCount := 0
+			if smoke != nil {
+				errorCount = len(smoke.Errors)
+			}
+			gate.Detail = fmt.Sprintf("Embedded Cairnline replacement-mode live read smoke reported %s with %d error(s).", gate.Status, errorCount)
+			return gate, &migrationRehearsal
+		}
+		gate.Ready = true
+		gate.Status = "verified"
+		gate.Detail = fmt.Sprintf("Embedded Cairnline replacement-mode live read smoke passed across %d project(s) and %d route check(s).", smoke.ProjectCount, smoke.ReadRouteChecks)
+		return gate, &migrationRehearsal
 	}
 	item, err := h.projectCairnlineMirrorParity(ctx)
 	if err != nil {
@@ -817,6 +936,58 @@ func (h *Handler) projectCairnlineStrictEmbeddedReadSmokeReplacementGate(ctx con
 	return gate, &migrationRehearsal
 }
 
+func projectCairnlineEmbeddedReplacementModeRehearsal(dbPath string, databaseExists bool, smoke *ProjectCairnlineMigrationEmbeddedSmoke) ProjectCairnlineMigrationRehearsal {
+	status := "not_run"
+	if databaseExists {
+		status = "failed"
+		if smoke != nil && smoke.Status != "" {
+			status = smoke.Status
+		}
+		if smoke != nil && smoke.Status == "passed" {
+			status = "verified"
+		}
+	}
+	return ProjectCairnlineMigrationRehearsal{
+		Operation:       "embedded_replacement_smoke",
+		ImportMode:      "embedded_cairnline_live",
+		SnapshotVersion: cairnline.SnapshotVersion,
+		SourceAuthority: "embedded_cairnline_authoritative",
+		Target:          "embedded_cairnline_sqlite",
+		RefreshesTarget: false,
+		Authoritative:   databaseExists,
+		CutoverReady:    status == "verified",
+		Status:          status,
+		Checklist: []ProjectCairnlineMigrationRehearsalCheck{
+			{
+				ID:     "open-embedded-cairnline",
+				Status: projectCairnlineMigrationCheckStatus(databaseExists, "complete", "not_run"),
+				Detail: "Opened the embedded Cairnline SQLite database that now owns portable project state in replacement mode.",
+			},
+			{
+				ID:     "strict-embedded-read-smoke",
+				Status: projectCairnlineMigrationSmokeStatus(smoke),
+				Detail: "Exercised Hecate's configured strict embedded read routes against live Cairnline project state.",
+			},
+			{
+				ID:     "rollback-plan",
+				Status: "documented",
+				Detail: "Rollback disables embedded replacement mode and keeps Hecate runtime/workspace side effects on Hecate-owned overlays.",
+			},
+			{
+				ID:     "authoritative-switchpoint",
+				Status: projectCairnlineMigrationCheckStatus(status == "verified", "complete", "blocked"),
+				Detail: "HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded is the explicit operator cutover switch for portable project state.",
+			},
+		},
+		Rollback: []string{
+			"Disable HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded to stop reporting Cairnline as the authoritative Projects backend.",
+			"Keep Hecate-owned runtime/workspace side effects such as task/chat execution, approvals, traces, root discovery, and Git worktree creation on Hecate overlays.",
+			"Restore or replace the embedded Cairnline SQLite database at " + strings.TrimSpace(dbPath) + " if portable project state must be rolled back.",
+		},
+		EmbeddedSmoke: smoke,
+	}
+}
+
 func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool) ProjectCoordinationBackendReplacementGate {
 	gate := ProjectCoordinationBackendReplacementGate{
 		ID:        "migration-and-rollback",
@@ -825,10 +996,18 @@ func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate Pro
 		Detail:    "Strict embedded mirror parity and read smoke must be verified before migration and rollback can be treated as rehearsed.",
 		ProbeURLs: []string{projectCoordinationBackendSyncReadinessURL, projectCoordinationBackendMirrorParityURL, projectCoordinationBackendExportURL},
 	}
+	if migrationRehearsal != nil && migrationRehearsal.Operation == "embedded_replacement_smoke" {
+		gate.Detail = "Embedded Cairnline live read smoke must be verified before replacement-mode rollback evidence can be treated as rehearsed."
+		gate.ProbeURLs = []string{projectCoordinationBackendStatusURL}
+	}
 	if migrationCutoverArmed && projectCairnlineMigrationRollbackEvidenceReady(migrationRehearsal) {
 		gate.Ready = true
 		gate.Status = "ready"
-		gate.Detail = "Strict embedded mirror parity, route smoke, snapshot-import evidence, and rollback notes are verified; all portable write-authority gaps are closed; embedded replacement mode is the explicit cutover switch."
+		if migrationRehearsal != nil && migrationRehearsal.Operation == "embedded_replacement_smoke" {
+			gate.Detail = "Embedded Cairnline live route smoke and rollback notes are verified; embedded replacement mode is the explicit cutover switch and implies portable write authority."
+			return gate
+		}
+		gate.Detail = "Strict embedded mirror parity, route smoke, snapshot-import evidence, and rollback notes are verified; embedded replacement mode is the explicit cutover switch and implies portable write authority."
 		return gate
 	}
 	if !strictEmbeddedReadGate.Ready {
@@ -840,6 +1019,10 @@ func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate Pro
 		return gate
 	}
 	gate.Status = "cutover_switch_missing"
+	if migrationRehearsal != nil && migrationRehearsal.Operation == "embedded_replacement_smoke" {
+		gate.Detail = "Embedded Cairnline live route smoke and rollback notes are verified, but embedded replacement mode is not armed."
+		return gate
+	}
 	gate.Detail = "Strict embedded mirror parity, route smoke, snapshot-import evidence, and rollback notes are verified, but no explicit authoritative Cairnline storage cutover switch is armed yet."
 	return gate
 }
@@ -850,7 +1033,10 @@ func projectCairnlineMigrationRollbackEvidenceReady(migrationRehearsal *ProjectC
 
 func projectCairnlineMigrationRollbackEvidenceBlocker(migrationRehearsal *ProjectCairnlineMigrationRehearsal) string {
 	if migrationRehearsal == nil {
-		return "backend status does not include mirror-parity rehearsal evidence"
+		return "backend status does not include migration or replacement smoke evidence"
+	}
+	if migrationRehearsal.Operation == "embedded_replacement_smoke" {
+		return projectCairnlineEmbeddedReplacementModeEvidenceBlocker(migrationRehearsal)
 	}
 	if migrationRehearsal.Operation != "mirror_parity" {
 		return "expected mirror_parity rehearsal evidence, got " + migrationRehearsal.Operation
@@ -864,6 +1050,33 @@ func projectCairnlineMigrationRollbackEvidenceBlocker(migrationRehearsal *Projec
 		{ID: "parity-check", Status: "complete"},
 		{ID: "strict-embedded-read-smoke", Status: "complete"},
 		{ID: "rollback-plan", Status: "documented"},
+	}
+	for _, check := range requiredChecks {
+		if !projectCairnlineMigrationChecklistHas(migrationRehearsal.Checklist, check.ID, check.Status) {
+			return fmt.Sprintf("check %q is not %q", check.ID, check.Status)
+		}
+	}
+	if len(migrationRehearsal.Rollback) == 0 {
+		return "rollback steps are missing"
+	}
+	if migrationRehearsal.EmbeddedSmoke == nil {
+		return "strict embedded smoke details are missing"
+	}
+	if migrationRehearsal.EmbeddedSmoke.Status != "passed" {
+		return "strict embedded smoke status is " + migrationRehearsal.EmbeddedSmoke.Status
+	}
+	return ""
+}
+
+func projectCairnlineEmbeddedReplacementModeEvidenceBlocker(migrationRehearsal *ProjectCairnlineMigrationRehearsal) string {
+	if migrationRehearsal.Status != "verified" {
+		return "embedded replacement smoke status is " + migrationRehearsal.Status
+	}
+	requiredChecks := []ProjectCairnlineMigrationRehearsalCheck{
+		{ID: "open-embedded-cairnline", Status: "complete"},
+		{ID: "strict-embedded-read-smoke", Status: "complete"},
+		{ID: "rollback-plan", Status: "documented"},
+		{ID: "authoritative-switchpoint", Status: "complete"},
 	}
 	for _, check := range requiredChecks {
 		if !projectCairnlineMigrationChecklistHas(migrationRehearsal.Checklist, check.ID, check.Status) {
@@ -897,7 +1110,7 @@ func projectCairnlineReplacementModeGate(replacementMode string) ProjectCoordina
 			ID:     "embedded-replacement-mode",
 			Ready:  true,
 			Status: "armed",
-			Detail: "HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded is set, so the operator has explicitly armed the embedded Cairnline cutover contract. This does not bypass read, write, migration, rollback, or Hecate-owned runtime side-effect gates.",
+			Detail: "HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded is set, so the operator has explicitly armed the embedded Cairnline cutover contract and the portable write-authority switchpoints. This does not bypass read, migration, rollback, or Hecate-owned runtime side-effect gates.",
 		}
 	}
 	return ProjectCoordinationBackendReplacementGate{
@@ -910,7 +1123,7 @@ func projectCairnlineReplacementModeGate(replacementMode string) ProjectCoordina
 
 func projectCairnlineReplacementModeDetail(replacementMode string) string {
 	if replacementMode == "embedded" {
-		return "Embedded Cairnline replacement mode is armed, but status still requires the read, write-authority, migration, rollback, and runtime-boundary gates before any backend can be considered replaceable."
+		return "Embedded Cairnline replacement mode is armed and implies all portable write-authority switchpoints, but status still requires the read, migration, rollback, and runtime-boundary gates before any backend can be considered replaceable."
 	}
 	return "Embedded Cairnline replacement mode is disabled; Hecate will not report Projects as replaceable without an explicit operator cutover-mode opt-in."
 }
@@ -1239,7 +1452,7 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			item.CairnlineState = "embedded_cutover_armed"
 			item.BlocksAuthority = false
 			item.Gap = ""
-			item.Detail = "Strict embedded mirror parity and read smoke are verified, all portable write-authority gaps are closed, and embedded replacement mode is armed as the explicit Cairnline cutover switch."
+			item.Detail = "Strict embedded mirror parity and read smoke are verified, and embedded replacement mode is armed as the explicit Cairnline cutover switch with portable write authority implied."
 		}
 		item.Seams = append([]string(nil), item.Seams...)
 		out = append(out, item)
@@ -1284,8 +1497,11 @@ func projectCairnlineProjectMetadataDefaultsWriteWarning(writeAuthority []string
 	return "Project metadata/default-root updates still write Hecate-native stores first, then best-effort mirror through Cairnline's project-metadata and project-defaults seams; provider/model/preset posture stays in Hecate runtime overlays."
 }
 
-func projectCairnlineProjectIdentityWriteWarning(writeAuthority []string) string {
+func projectCairnlineProjectIdentityWriteWarning(writeAuthority []string, nativeShadowSkipArmed bool) string {
 	if projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectIdentity) {
+		if nativeShadowSkipArmed {
+			return "Project create/delete mutations are opt-in Cairnline-authoritative and skip native project identity compatibility rows in armed embedded replacement mode; Hecate runtime defaults stay in the project runtime overlay."
+		}
 		return "Project create/delete mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores for compatibility; delete restores the Cairnline snapshot if Hecate compatibility cleanup fails."
 	}
 	return "Project create/delete still write Hecate-native stores first, then best-effort mirror portable project identity into the embedded Cairnline database."
@@ -1390,6 +1606,17 @@ func projectCairnlineReadSourceDetail(source string) string {
 	default:
 		return "Configured read routes prefer the embedded mirror database when it already contains the requested project or proposal record; otherwise they fall back to the snapshot-seeded in-memory bridge projection."
 	}
+}
+
+func projectCairnlineReadRoutesReadyDetail(readSource string, writeAdapterReady bool, replacementMode string) string {
+	detail := "Cairnline is configured as the future Projects coordination backend, and the " + projectCairnlineReadRouteList(projectCairnlineReadRouteNames) + " read routes are served from the Cairnline read model. " + projectCairnlineReadSourceDetail(readSource) + " "
+	if writeAdapterReady && replacementMode == "embedded" {
+		return detail + "Portable project-state writes are Cairnline-authoritative in embedded replacement mode; Hecate still owns runtime/workspace side effects until strict read smoke, migration, and rollback gates are ready."
+	}
+	if writeAdapterReady {
+		return detail + "Portable project-state write authority is Cairnline-ready, but Hecate remains the reported backend until replacement mode, migration, and rollback gates are ready."
+	}
+	return detail + "Hecate stores remain authoritative until the remaining portable writes and migration are ready."
 }
 
 func projectCairnlineReadSourceWarning(source string) string {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -403,11 +403,11 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if status.MirrorParityURL != projectCoordinationBackendMirrorParityURL {
 		t.Fatalf("mirror parity URL = %q, want %q", status.MirrorParityURL, projectCoordinationBackendMirrorParityURL)
 	}
-	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "move-portable-write-authority" || status.NextReplacementAction.Target != "projects" {
-		t.Fatalf("next action = %+v, want first portable write authority gap", status.NextReplacementAction)
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "move-portable-write-authority" || status.NextReplacementAction.Target != "context-sources" {
+		t.Fatalf("next action = %+v, want recommended portable write authority gap", status.NextReplacementAction)
 	}
-	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY"); hint == nil || hint.Value != "project-identity,project-metadata-defaults" {
-		t.Fatalf("next action config hints = %+v, want project identity + metadata defaults write authority", status.NextReplacementAction.ConfigHints)
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY"); hint == nil || hint.Value != "project-context-sources" {
+		t.Fatalf("next action config hints = %+v, want context-source write authority", status.NextReplacementAction.ConfigHints)
 	}
 }
 
@@ -498,7 +498,6 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 			CoordinationBackend:      "cairnline",
 			CairnlineConnector:       "embedded",
 			CairnlineReadSource:      "embedded",
-			CairnlineWriteAuthority:  "all-portable",
 			CairnlineReplacementMode: "embedded",
 		},
 	}, quietLogger(), nil, nil, nil, nil)
@@ -510,10 +509,33 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 	server := NewServer(quietLogger(), handler)
 	client := newAPITestClient(t, server)
 
-	mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
-		"name": "Backend Status Embedded Replacement",
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name":             "Backend Status Embedded Replacement",
+		"default_provider": "anthropic",
+		"default_model":    "claude-sonnet-4",
 	}))
-	mustRequestJSONStatus[ProjectCairnlineSyncResponse](client, http.StatusOK, http.MethodPost, "/hecate/v1/projects/cairnline/sync", "")
+	projectID := project.Data.ID
+	if _, ok, err := handler.projects.Get(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after replacement create, want Cairnline-only project identity", ok, err)
+	}
+	mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                  "role_delegate",
+		"name":                "Delegate",
+		"default_driver_kind": "hecate_task",
+		"default_provider":    "anthropic",
+		"default_model":       "claude-sonnet-4",
+	}))
+	mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_delegate",
+		"title":         "Delegate Projects to Cairnline",
+		"brief":         "Verify replacement-mode status uses live Cairnline state.",
+		"owner_role_id": "role_delegate",
+	}))
+	mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/work_delegate/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_delegate",
+		"role_id":     "role_delegate",
+		"driver_kind": "hecate_task",
+	}))
 
 	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
 	if !status.ReplacementReady || status.AuthoritativeBackend != "cairnline" || !status.CairnlineAuthoritative {
@@ -562,8 +584,17 @@ func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeReportsCairnlin
 	if status.MigrationRehearsal == nil || !projectCairnlineMigrationRollbackEvidenceReady(status.MigrationRehearsal) || len(status.MigrationRehearsal.Rollback) == 0 {
 		t.Fatalf("migration rehearsal = %+v, want replacement-ready status to expose verified rollback evidence", status.MigrationRehearsal)
 	}
+	if status.MigrationRehearsal.Operation != "embedded_replacement_smoke" || status.MigrationRehearsal.SourceAuthority != "embedded_cairnline_authoritative" || !status.MigrationRehearsal.Authoritative {
+		t.Fatalf("migration rehearsal = %+v, want live embedded replacement smoke evidence instead of Hecate mirror parity", status.MigrationRehearsal)
+	}
+	if status.MigrationRehearsal.EmbeddedSmoke == nil || !containsString(status.MigrationRehearsal.EmbeddedSmoke.CheckedProjectIDs, projectID) {
+		t.Fatalf("embedded smoke = %+v, want Cairnline-only project checked", status.MigrationRehearsal.EmbeddedSmoke)
+	}
 	if gate := findReplacementGate(status.ReplacementGates, "migration-and-rollback"); gate == nil || !gate.Ready || gate.Status != "ready" {
 		t.Fatalf("migration gate = %+v, want ready migration gate after embedded replacement cutover is armed", gate)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "strict-embedded-read-smoke"); gate == nil || !gate.Ready || !containsString(gate.ProbeURLs, projectCoordinationBackendStatusURL) || containsString(gate.ProbeURLs, projectCoordinationBackendMirrorParityURL) {
+		t.Fatalf("strict embedded gate = %+v, want replacement-mode live status smoke without Hecate mirror-parity probe", gate)
 	}
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CurrentAuthority != "cairnline" || point.CairnlineState != "embedded_cutover_armed" || point.BlocksAuthority || point.Gap != "" {
 		t.Fatalf("migration cutover switchpoint = %+v, want armed Cairnline cutover switchpoint after replacement is ready", point)
@@ -792,6 +823,12 @@ func TestProjectCoordinationBackendStatus_CairnlineDirectRootSourceAuthorityConf
 	}
 	if !strings.Contains(warnings, "Context-source create/update/delete, list replacement, and discovery-result replacement mutations are opt-in Cairnline-authoritative") || !strings.Contains(warnings, "resolve project identity, roots, and existing sources from the embedded Cairnline graph") || !strings.Contains(warnings, "Hecate still performs the workspace scan") {
 		t.Fatalf("warnings = %+v, want context-source authority plus scan caveat", status.Warnings)
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.Target != "skills" {
+		t.Fatalf("next action = %+v, want skills after root/source authority", status.NextReplacementAction)
+	}
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY"); hint == nil || hint.Value != "project-roots,project-context-sources,project-skills" {
+		t.Fatalf("next action hints = %+v, want additive root/source/skills value", status.NextReplacementAction.ConfigHints)
 	}
 }
 
@@ -1031,6 +1068,9 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	if !status.WriteAdapterReady {
 		t.Fatalf("write_adapter_ready = false, want true when all portable write gaps are closed")
 	}
+	if !strings.Contains(status.Detail, "Portable project-state write authority is Cairnline-ready") || strings.Contains(status.Detail, "embedded replacement mode") {
+		t.Fatalf("detail = %q, want all-portable authority detail without replacement-mode cutover wording", status.Detail)
+	}
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false until migration and cutover gates are ready")
 	}
@@ -1064,8 +1104,8 @@ func TestProjectCoordinationBackendStatus_CairnlineAllPortableWriteAuthorityAlia
 	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_READ_SOURCE"); hint == nil || hint.Value != "embedded" {
 		t.Fatalf("next action config hints = %+v, want strict embedded read-source hint", status.NextReplacementAction.ConfigHints)
 	}
-	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY"); hint == nil || hint.Value != "all-portable" {
-		t.Fatalf("next action config hints = %+v, want all-portable authority hint", status.NextReplacementAction.ConfigHints)
+	if hint := findConfigHint(status.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY"); hint != nil {
+		t.Fatalf("next action config hints = %+v, did not expect redundant all-portable authority hint", status.NextReplacementAction.ConfigHints)
 	}
 }
 
@@ -1076,7 +1116,6 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 			CoordinationBackend:      "cairnline",
 			CairnlineConnector:       "embedded",
 			CairnlineReadSource:      "embedded",
-			CairnlineWriteAuthority:  "all-portable",
 			CairnlineReplacementMode: "embedded",
 		},
 	}, quietLogger(), nil, nil, nil, nil)
@@ -1088,8 +1127,14 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 	if status.ReplacementReady {
 		t.Fatalf("replacement_ready = true, want false while migration/cutover blockers remain")
 	}
-	if gate := findReplacementGate(status.ReplacementGates, "embedded-replacement-mode"); gate == nil || !gate.Ready || gate.Status != "armed" || !strings.Contains(gate.Detail, "does not bypass") {
-		t.Fatalf("embedded replacement mode gate = %+v, want armed explicit-mode gate", gate)
+	if !status.WriteAdapterReady || len(status.PortableWriteGaps) != 0 {
+		t.Fatalf("write adapter ready=%v portable gaps=%+v, want replacement mode to imply portable write authority without explicit write-authority env", status.WriteAdapterReady, status.PortableWriteGaps)
+	}
+	if !strings.Contains(status.Detail, "Portable project-state writes are Cairnline-authoritative in embedded replacement mode") || strings.Contains(status.Detail, "Hecate stores remain authoritative") {
+		t.Fatalf("detail = %q, want replacement-mode Cairnline-authoritative detail without stale Hecate-authoritative wording", status.Detail)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "embedded-replacement-mode"); gate == nil || !gate.Ready || gate.Status != "armed" || !strings.Contains(gate.Detail, "portable write-authority") || !strings.Contains(gate.Detail, "does not bypass read") {
+		t.Fatalf("embedded replacement mode gate = %+v, want armed explicit-mode gate with portable authority boundary", gate)
 	}
 	for _, tc := range []struct {
 		name string
@@ -1113,9 +1158,11 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 	}
 	warnings := strings.Join(status.Warnings, "\n")
 	for _, want := range []string{
+		"skip native project identity compatibility rows in armed embedded replacement mode",
 		"skip native project-row compatibility shadows in armed embedded replacement mode",
 		"skip native project-row root compatibility shadows in armed embedded replacement mode",
 		"skip native project-row context-source compatibility shadows in armed embedded replacement mode",
+		"Portable project-state write authority is Cairnline-ready",
 	} {
 		if !strings.Contains(warnings, want) {
 			t.Fatalf("warnings = %+v, want warning containing %q", status.Warnings, want)
@@ -1126,6 +1173,15 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 	}
 	if strings.Contains(warnings, "Project Assistant proposal ledger mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores") {
 		t.Fatalf("warnings = %+v, want no stale Project Assistant native-shadow wording", status.Warnings)
+	}
+	for _, stale := range []string{
+		"Other project mutation routes still write only Hecate-native stores",
+		"live write authority and migration path are not ready",
+		"Project create/delete mutations are opt-in Cairnline-authoritative and then best-effort shadowed into Hecate-native stores",
+	} {
+		if strings.Contains(warnings, stale) {
+			t.Fatalf("warnings = %+v, want no stale warning containing %q", status.Warnings, stale)
+		}
 	}
 	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "run-strict-embedded-read-smoke" {
 		t.Fatalf("next action = %+v, want strict embedded smoke still prioritized while mode is armed", status.NextReplacementAction)
@@ -1152,7 +1208,7 @@ func TestProjectCoordinationBackendStatus_WriteAuthorityGateUsesPortableGaps(t *
 func TestProjectCoordinationBackendStatus_MigrationRollbackGateRequiresRehearsalEvidence(t *testing.T) {
 	strictGate := ProjectCoordinationBackendReplacementGate{ID: "strict-embedded-read-smoke", Ready: true, Status: "verified"}
 	gate := projectCairnlineMigrationRollbackReplacementGate(strictGate, nil, false)
-	if gate.Ready || gate.Status != "rehearsal_incomplete" || !strings.Contains(gate.Detail, "does not include mirror-parity") {
+	if gate.Ready || gate.Status != "rehearsal_incomplete" || !strings.Contains(gate.Detail, "does not include migration or replacement smoke") {
 		t.Fatalf("migration gate = %+v, want missing rehearsal evidence blocker", gate)
 	}
 
@@ -1196,6 +1252,64 @@ func TestProjectCoordinationBackendStatus_NextActionWriteAuthorityHints(t *testi
 	}
 	if hints := projectCairnlineWriteAuthorityHintsForGap("assignment-start"); len(hints) != 0 {
 		t.Fatalf("assignment-start hints = %+v, want none because dispatch is not a portable write-authority switchpoint", hints)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_NextActionWriteAuthorityHintsPreserveExistingValues(t *testing.T) {
+	hints := projectCairnlineWriteAuthorityHintsForGapWithExisting("memory-candidates", []string{
+		projectCairnlineWriteAuthorityProjectContextSources,
+		"project-memory",
+	})
+	hint := findConfigHint(hints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY")
+	if hint == nil {
+		t.Fatalf("hints = %+v, want write authority hint", hints)
+	}
+	if hint.Value != "project-context-sources,project-memory,memory-candidates" {
+		t.Fatalf("hint value = %q, want additive value preserving existing switchpoints", hint.Value)
+	}
+	if !strings.Contains(hint.Detail, "preserves already-enabled") {
+		t.Fatalf("hint detail = %q, want additive preservation wording", hint.Detail)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_NextPortableWriteGapRecommendationOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		gaps []string
+		want string
+	}{
+		{
+			name: "prefers smaller metadata surfaces over project identity",
+			gaps: []string{"projects", "roots", "context-sources", "skills"},
+			want: "context-sources",
+		},
+		{
+			name: "moves to work graph after setup metadata",
+			gaps: []string{"projects", "roots", "roles", "work-items", "assignments"},
+			want: "roles",
+		},
+		{
+			name: "prefers a known recommendation over unknown gaps",
+			gaps: []string{"future-gap", "projects"},
+			want: "projects",
+		},
+		{
+			name: "falls back to first unknown gap when no recommendation matches",
+			gaps: []string{"future-gap"},
+			want: "future-gap",
+		},
+		{
+			name: "empty gaps return empty target",
+			gaps: nil,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := projectCairnlineNextPortableWriteGap(tt.gaps); got != tt.want {
+				t.Fatalf("projectCairnlineNextPortableWriteGap(%+v) = %q, want %q", tt.gaps, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -1256,7 +1370,7 @@ func TestProjectCoordinationBackendStatus_NextActionReplacementModeHints(t *test
 		ReplacementMode:         "disabled",
 	}
 
-	action := projectCairnlineNextReplacementAction(status)
+	action := projectCairnlineNextReplacementAction(status, nil)
 	if action == nil || action.ID != "arm-embedded-replacement-mode" || action.Target != "embedded-replacement-mode" {
 		t.Fatalf("next action = %+v, want embedded replacement mode arming action", action)
 	}

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -292,7 +292,7 @@ func TestProjectWorkAPI_CairnlineReadSourceEmbeddedRequiresMirror(t *testing.T) 
 	}
 }
 
-func TestProjectWorkAPI_StrictEmbeddedRuntimeRequiresReplacementAuthority(t *testing.T) {
+func TestProjectWorkAPI_StrictEmbeddedRuntimeUsesReplacementAuthority(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{
 		Server: config.ServerConfig{DataDir: t.TempDir()},
@@ -304,16 +304,16 @@ func TestProjectWorkAPI_StrictEmbeddedRuntimeRequiresReplacementAuthority(t *tes
 		},
 	}, quietLogger(), nil, nil, nil, nil)
 	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
-	if handler.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(true) {
-		t.Fatal("strict embedded runtime = true, want false until portable write authority gaps are closed")
-	}
-
-	handler.config.Projects.CairnlineWriteAuthority = "all-portable"
 	if !handler.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(true) {
-		t.Fatal("strict embedded runtime = false, want true when replacement mode is armed and portable write gaps are closed")
+		t.Fatal("strict embedded runtime = false, want true when replacement mode is armed because it implies portable write authority")
 	}
 	if handler.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(false) {
 		t.Fatal("strict embedded runtime = true without strict embedded reads")
+	}
+
+	handler.config.Projects.CairnlineReplacementMode = "disabled"
+	if handler.projectAssignmentStartUsesStrictEmbeddedCairnlineRuntime(true) {
+		t.Fatal("strict embedded runtime = true, want false until replacement mode or explicit portable write authority is armed")
 	}
 }
 
@@ -4433,6 +4433,7 @@ func TestProjectWorkAPI_AssignmentContextUsesCairnlineSidecarWhenConfigured(t *t
 		"Read backend: cairnline",
 		"Source tool: assignments.context",
 		"Portable execution mode: mcp_pull",
+		cairnlineAssignmentContextHecateAuthorityLine,
 	} {
 		if !strings.Contains(item.Body, want) {
 			t.Fatalf("sidecar assignment context body = %q, want %q", item.Body, want)
@@ -4452,8 +4453,9 @@ func TestProjectWorkAPI_AssignmentContextStrictEmbeddedReadModelReadsWithoutHeca
 	handler := NewHandler(config.Config{
 		Server: config.ServerConfig{DataDir: t.TempDir()},
 		Projects: config.ProjectsConfig{
-			CoordinationBackend: "cairnline",
-			CairnlineReadSource: "embedded",
+			CoordinationBackend:      "cairnline",
+			CairnlineReadSource:      "embedded",
+			CairnlineReplacementMode: "embedded",
 		},
 	}, quietLogger(), nil, nil, nil, nil)
 	server := NewServer(quietLogger(), handler)
@@ -4523,6 +4525,12 @@ func TestProjectWorkAPI_AssignmentContextStrictEmbeddedReadModelReadsWithoutHeca
 	item := findRenderedContextItemByOrigin(packetResp.Data, "cairnline.assignments.context")
 	if item == nil || item.Section != contextSectionRuntime || item.Included || item.Metadata["read_backend"] != "cairnline" || item.Metadata["source_tool"] != "assignments.context" {
 		t.Fatalf("embedded assignment context runtime item = %+v, want inspect-only assignments.context metadata", item)
+	}
+	if !strings.Contains(item.Body, cairnlineAssignmentContextReplacementAuthorityLine) {
+		t.Fatalf("embedded assignment context runtime body = %q, want replacement-mode authority line", item.Body)
+	}
+	if strings.Contains(item.Body, cairnlineAssignmentContextHecateAuthorityLine) {
+		t.Fatalf("embedded assignment context runtime body = %q, want no stale Hecate authority line", item.Body)
 	}
 	workItem := findRenderedContextItemByOrigin(packetResp.Data, "work_embedded_assignment_context")
 	if workItem == nil || workItem.Section != contextSectionProjectWork || !workItem.Included {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -111,7 +111,6 @@ func newProjectsCairnlineReplacementIdentityAuthorityTestServer(t *testing.T) (*
 			CoordinationBackend:      "cairnline",
 			CairnlineConnector:       "embedded",
 			CairnlineReadSource:      "embedded",
-			CairnlineWriteAuthority:  "all-portable",
 			CairnlineReplacementMode: "embedded",
 		},
 	}, quietLogger(), nil, nil, nil, nil)
@@ -1042,7 +1041,7 @@ func TestProjectsAPI_CairnlineReplacementModeSkipsNativeProjectRowShadows(t *tes
 	}
 }
 
-func TestProjectsAPI_CairnlineReplacementModeWithoutPortableAuthorityKeepsNativeIdentityShadow(t *testing.T) {
+func TestProjectsAPI_CairnlineReplacementModeImpliesPortableAuthority(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{
 		Server: config.ServerConfig{DataDir: t.TempDir()},
@@ -1050,7 +1049,6 @@ func TestProjectsAPI_CairnlineReplacementModeWithoutPortableAuthorityKeepsNative
 			CoordinationBackend:      "cairnline",
 			CairnlineConnector:       "embedded",
 			CairnlineReadSource:      "embedded",
-			CairnlineWriteAuthority:  projectCairnlineWriteAuthorityProjectIdentity,
 			CairnlineReplacementMode: "embedded",
 		},
 	}, quietLogger(), nil, nil, nil, nil)
@@ -1059,8 +1057,8 @@ func TestProjectsAPI_CairnlineReplacementModeWithoutPortableAuthorityKeepsNative
 
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects", bytes.NewReader([]byte(`{
-		"name":"Replacement Identity With Shadow",
-		"description":"replacement mode is armed, but portable write authority is incomplete",
+		"name":"Replacement Identity",
+		"description":"replacement mode implies portable write authority",
 		"default_provider":"openai",
 		"default_model":"gpt-5"
 	}`))))
@@ -1071,15 +1069,25 @@ func TestProjectsAPI_CairnlineReplacementModeWithoutPortableAuthorityKeepsNative
 	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
-	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || !ok {
-		t.Fatalf("Hecate project store ok=%v err=%v after replacement-mode create, want compatibility identity shadow while portable authority is incomplete", ok, err)
+	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after replacement-mode create, want no native identity shadow", ok, err)
+	}
+	mirrored := getMirroredCairnlineProjectForTest(t, handler, created.Data.ID)
+	if mirrored.Name != "Replacement Identity" || mirrored.Description != "replacement mode implies portable write authority" {
+		t.Fatalf("mirrored project = %+v, want Cairnline-owned replacement identity", mirrored)
 	}
 	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
-	if status.ReplacementReady {
-		t.Fatalf("replacement_ready = true, want false while only project identity authority is enabled")
+	if !status.ReplacementReady || status.AuthoritativeBackend != "cairnline" {
+		t.Fatalf("status = %+v, want replacement-mode live smoke to prove Cairnline authoritative project state", status)
 	}
-	if !containsString(status.PortableWriteGaps, "memory") || !containsString(status.PortableWriteGaps, "work-items") {
-		t.Fatalf("portable write gaps = %+v, want remaining portable blockers", status.PortableWriteGaps)
+	if len(status.PortableWriteGaps) != 0 {
+		t.Fatalf("portable write gaps = %+v, want embedded replacement mode to imply portable write authority", status.PortableWriteGaps)
+	}
+	if len(status.MigrationBlockers) != 0 {
+		t.Fatalf("migration blockers = %+v, want live embedded replacement smoke to clear migration blocker", status.MigrationBlockers)
+	}
+	if status.MigrationRehearsal == nil || status.MigrationRehearsal.Operation != "embedded_replacement_smoke" || status.MigrationRehearsal.SourceAuthority != "embedded_cairnline_authoritative" {
+		t.Fatalf("migration rehearsal = %+v, want live embedded replacement smoke evidence", status.MigrationRehearsal)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -289,7 +289,26 @@ func (c Config) ProjectsCairnlineReplacementMode() string {
 }
 
 func (c Config) ProjectsCairnlineWriteAuthority() []string {
-	return normalizeProjectsCairnlineWriteAuthority(c.Projects.CairnlineWriteAuthority)
+	out := normalizeProjectsCairnlineWriteAuthority(c.Projects.CairnlineWriteAuthority)
+	if c.ProjectsCairnlineReplacementMode() != "embedded" {
+		return out
+	}
+	seen := make(map[string]struct{}, len(out))
+	merged := make([]string, 0, len(out))
+	appendValue := func(value string) {
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		merged = append(merged, value)
+	}
+	for _, value := range out {
+		appendValue(value)
+	}
+	for _, value := range projectsCairnlineAllPortableWriteAuthority {
+		appendValue(value)
+	}
+	return merged
 }
 
 func (c Config) ProjectsCairnlineWriteAuthorityEnabled(name string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -611,6 +611,9 @@ func TestLoadFromEnvProjectsCairnlineReplacementMode(t *testing.T) {
 	if got := cfg.ProjectsCairnlineReplacementMode(); got != "embedded" {
 		t.Fatalf("ProjectsCairnlineReplacementMode() = %q, want embedded", got)
 	}
+	if !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-context-sources") || !cfg.ProjectsCairnlineWriteAuthorityEnabled("project-identity") {
+		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want embedded replacement mode to imply all portable write authority", cfg.ProjectsCairnlineWriteAuthority())
+	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil for embedded Cairnline replacement mode opt-in", err)
 	}
@@ -714,6 +717,11 @@ func TestLoadFromEnvProjectsCairnlineWriteAuthority(t *testing.T) {
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil for all-portable Cairnline write authority alias", err)
+	}
+
+	cfg.Projects.CairnlineReplacementMode = "embedded"
+	if got := cfg.ProjectsCairnlineWriteAuthority(); len(got) != 12 || got[0] != "project-memory" || got[1] != "memory-candidates" || got[11] != "project-assistant-proposals" {
+		t.Fatalf("ProjectsCairnlineWriteAuthority() = %+v, want embedded replacement mode to preserve all-portable expansion", got)
 	}
 }
 
@@ -835,6 +843,23 @@ func TestValidateRejectsEmbeddedProjectsCairnlineReplacementModeWithoutStrictEmb
 
 func TestValidateRejectsInvalidProjectsCairnlineWriteAuthority(t *testing.T) {
 	cfg := LoadFromEnv()
+	cfg.Projects.CairnlineWriteAuthority = "project-memory,assignments"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid projects Cairnline write authority error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY") {
+		t.Fatalf("Validate() error = %q, want HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY", err)
+	}
+}
+
+func TestValidateRejectsInvalidProjectsCairnlineWriteAuthorityWithReplacementMode(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Projects.CoordinationBackend = "cairnline"
+	cfg.Projects.CairnlineConnector = "embedded"
+	cfg.Projects.CairnlineReadSource = "embedded"
+	cfg.Projects.CairnlineReplacementMode = "embedded"
 	cfg.Projects.CairnlineWriteAuthority = "project-memory,assignments"
 
 	err := cfg.Validate()


### PR DESCRIPTION
## Summary
- make embedded replacement mode imply portable project-state write authority while keeping Hecate-owned runtime/workspace side effects separate
- verify armed replacement mode with live embedded Cairnline smoke instead of Hecate-store mirror parity
- surface replacement smoke evidence, rollback metadata, and cleaner next-action/status wording in API docs and design docs

## Verification
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test ./internal/config ./internal/api
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go vet ./...
- just agent-docs-check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- live HTTP smoke against embedded replacement mode: create Cairnline-only project/role/work/assignment, read assignment context, confirm backend status reports cairnline_authoritative with embedded_replacement_smoke evidence