### PR TITLE
Clarify Cairnline delegation stop line

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -751,6 +751,13 @@ after these gates are met:
   the embedded cutover switch is armed, while non-portable runtime/workspace
   capabilities such as `assignment-start` can remain visible as Hecate-owned
   boundaries.
+- Delegation stop-line: once embedded replacement mode is armed and
+  `replacement_ready=true`, Cairnline owns portable Projects coordination state
+  for that runtime. Hecate still should not flip the default configuration for
+  every local runtime until real dogfood keeps those gates green and existing
+  Hecate-native project stores have an operator-visible migration/rollback
+  path. This is a product/defaulting decision, not a blocker for returning to
+  Hecate runtime, chat, gateway, adapter, and observability work.
 - Context packets, setup/health/operations summaries, activity projections, and
   closeout gates match current Hecate behavior or have documented intentional
   differences.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -743,6 +743,15 @@ artifact/handoff route-shape counts; and
 `POST /hecate/v1/projects/cairnline/sync` remains the explicit all-project
 rebuild/rehearsal action.
 
+Delegation stop-line: an armed runtime with `replacement_ready=true` can treat
+embedded Cairnline as authoritative for portable Projects coordination state.
+That does not automatically make Cairnline the default Projects backend for
+every local runtime. Keep the default flip as an explicit product decision until
+real dogfood keeps backend-status gates green and existing Hecate-native project
+stores have an operator-visible migration/rollback path. Hecate feature work on
+the model gateway, chat, tasks, External Agent supervision, approvals, traces,
+and workspace/runtime side effects can continue independently of that cleanup.
+
 Deployment-specific notes:
 
 - The docker image **defaults to `sqlite`** for every durable subsystem,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2622,6 +2622,12 @@ Hecate-store authority warnings. At that point `migration-cutover` is also
 removed from `write_adapter_gaps`; Hecate-owned runtime/workspace capabilities
 such as `assignment-start` can still remain in `write_adapter_gaps` and
 `orchestrator_capabilities` because they are not portable Cairnline core.
+This is the delegation stop-line for the current runtime, not an automatic
+global default flip: clients and operators should treat `replacement_ready=true`
+as proof that the configured runtime has delegated portable Projects
+coordination state to embedded Cairnline, while defaulting all local runtimes to
+Cairnline still needs real dogfood confidence and an operator-visible
+migration/rollback path for existing Hecate-native project stores.
 When all portable write-authority gaps are closed before replacement mode is
 armed but strict embedded mirror evidence is not yet verified, the next action
 is `run-strict-embedded-read-smoke`; `config_hints` identify the strict


### PR DESCRIPTION
## Summary
- document that replacement_ready=true means the configured runtime has delegated portable Projects state to embedded Cairnline
- clarify that making Cairnline the default backend for every local runtime remains a separate product/migration decision
- keep Hecate runtime/workspace responsibilities distinct from portable project coordination state

## Verification
- just agent-docs-check
- git diff --check