### PR TITLE
feat(projects): add cairnline dogfood evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="docs/assets/brand/hecate-lockup-horizontal-dark-2x.png" alt="Hecate - Local AI Operations Console" width="720">
+  <img src="docs/assets/brand/hecate-lockup-horizontal-dark-2x.png" alt="Hecate - Agent Operations Console" width="720">
 </h1>
 
 [![Latest release](https://img.shields.io/github/v/release/hecatehq/hecate?include_prereleases)](https://github.com/hecatehq/hecate/releases)
@@ -11,9 +11,9 @@
 [![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-enabled-f5a800?logo=opentelemetry&logoColor=white)](https://opentelemetry.io/)
 
 <p align="center">
-  <strong>Local AI operations console for supervised agent work.</strong><br>
-  Run Hecate on your machine between AI clients, model providers, coding agents,
-  and workspace tools so project work can be coordinated, routed, approved,
+  <strong>Agent operations console and local runtime control plane.</strong><br>
+  Run Hecate between operators, AI clients, agent runtimes, model providers,
+  and local workspaces so agent work can be routed, supervised, approved,
   traced, and reviewable.
 </p>
 
@@ -27,6 +27,7 @@
 ## Contents
 
 - [What Hecate Is](#what-hecate-is)
+- [Positioning](#positioning)
 - [System Shape](#system-shape)
 - [Current Capabilities](#current-capabilities)
 - [Quick Start](#quick-start)
@@ -39,16 +40,19 @@
 
 ## What Hecate Is
 
-Hecate is a local AI operations console for running, supervising, and
-coordinating AI work. It combines a model gateway, chat workspace, task runtime,
-external-agent console, project orchestration, project context and memory,
-approval gates, artifacts, usage, and OpenTelemetry traces into one operator
-surface.
+Hecate is the operator-facing runtime layer for AI work. It gives you one local
+place to talk to models, run Hecate-native agent tasks, supervise external agent
+CLIs, inspect project context, approve risky actions, collect evidence, and see
+what happened after the run.
 
 Hecate is local-first in the operational sense: the runtime and UI run on your
 machine, Hecate-owned state is stored locally, and the gateway binds to loopback
 by default. It is not local-only: you can route to cloud providers and supervise
 external coding-agent CLIs that use their own accounts.
+
+Hecate is not trying to be the only agent framework in your stack. It is the
+place where agents, agent frameworks, model calls, local tools, and project
+coordination become visible and controllable by the operator.
 
 The short version:
 
@@ -57,14 +61,14 @@ The short version:
   health, and usage visibility.
 - **Console:** a React operator UI for Chats, Connections, Tasks, Projects,
   Usage, Observability, and Settings.
-- **Runtime:** queued task runs, tool-calling `agent_loop`, approvals,
+- **Native runtime:** queued task runs, tool-calling `agent_loop`, approvals,
   per-call sandbox policy, artifacts, retries, resumes, and event streams.
 - **External Agent supervision:** long-lived local ACP sessions for coding-agent
   CLIs, with readiness checks, approvals, adapter diagnostics, and Git diff
   review.
-- **Project orchestration:** durable project identity, roles, work records,
-  assignments, handoffs, activity health, project-scoped memory, context packet
-  snapshots, project skill metadata, and explicit memory promotion.
+- **Agent orchestration:** project work, roles, assignments, handoffs, review
+  artifacts, activity health, context snapshots, memory candidates, and
+  operator-gated follow-up.
 - **Evidence:** traces, route reports, task artifacts, diffs, logs, screenshots
   where available, and final run output close to the decision that produced it.
 
@@ -72,6 +76,35 @@ The product goal is not just to make model calls. It is to give the operator a
 single place to coordinate project-scoped agent work and understand what is
 happening, what context it used, what it changed, what it cost, what needs
 approval, and where the evidence lives.
+
+## Positioning
+
+Hecate sits beside agent frameworks and agent CLIs rather than replacing all of
+them.
+
+| Question                                 | Hecate answer                                                                                                                                             |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Is Hecate an agent?**                  | It includes a native task agent loop, but Hecate itself is the operator console and runtime boundary around agent work, not a single autonomous persona.  |
+| **Is Hecate an orchestrator?**           | Yes, when it coordinates projects, assignments, native tasks, external-agent sessions, approvals, handoffs, and reviews. The operator remains in control. |
+| **Is Hecate an agent framework?**        | Not primarily. Hecate exposes APIs and runtime contracts, but it does not require teams to rewrite their agents into a Hecate SDK.                        |
+| **Is Hecate a model gateway?**           | Yes, but the gateway is one subsystem. It exists so chats, tasks, external tools, and compatible clients share routing, policy, usage, and observability. |
+| **Is Hecate a project-management tool?** | No. Projects are a coordination graph for AI work: context, assignments, evidence, memory candidates, reviews, handoffs, and runtime links.               |
+
+The practical model is:
+
+```text
+operator
+  -> Hecate console / runtime control plane
+    -> model gateway
+    -> Hecate-native task agent loop
+    -> supervised external agent CLIs
+    -> portable project coordination state
+    -> approvals, artifacts, traces, and review evidence
+```
+
+That makes Hecate useful whether the work is done by Hecate's own task runtime,
+an external coding-agent CLI, a local app using `/v1`, or a future agent system
+that claims project assignments through a portable coordination server.
 
 ## System Shape
 
@@ -86,22 +119,25 @@ flowchart LR
         Gateway["Model gateway<br/>routing · failover · usage"]
         TaskRuntime["Hecate task runtime<br/>queue · agent_loop<br/>retry/resume"]
         AgentSupervisor["External Agent supervisor<br/>ACP sessions · diagnostics"]
-        State["Local state<br/>chats · projects · memory<br/>tasks · settings"]
+        State["Local state<br/>chats · tasks · settings<br/>runtime overlays"]
+        Projects["Project coordination<br/>native today · Cairnline extraction path"]
         Evidence["Evidence + observability<br/>approvals · artifacts · events<br/>route reports · trace export"]
 
         HTTP --> Gateway
         HTTP --> TaskRuntime
         HTTP --> AgentSupervisor
         HTTP --> State
+        HTTP --> Projects
         Gateway --> Evidence
         TaskRuntime --> Evidence
         AgentSupervisor --> Evidence
+        Projects --> Evidence
         State --> Evidence
     end
 
     Providers["Cloud + local model providers"]
     Tools["Sandboxed workspace tools<br/>WorkspaceFS · ProcessRunner · GitRunner"]
-    ExternalCLIs["External Agent CLIs<br/>own accounts · own runtime"]
+    ExternalCLIs["External Agent CLIs / frameworks<br/>own accounts · own runtime"]
 
     Console --> HTTP
     APIClients --> HTTP
@@ -117,17 +153,17 @@ matters.
 
 ## Current Capabilities
 
-| Surface            | What works today                                                                                                                                                                                                                                                 |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Model gateway**  | OpenAI-compatible Chat Completions, Anthropic-shaped Messages, streaming, vision, model discovery, provider health, failover, retry, usage events, and custom OpenAI-compatible endpoints.                                                                       |
-| **Connections**    | Cloud presets plus Ollama, LM Studio, LocalAI, llama.cpp-compatible servers, local discovery, health checks, credentials, external-agent readiness, and durable approval grants.                                                                                 |
-| **Chats**          | Direct model turns, tools-on task-backed turns, queued prompts, task/run/trace links, inline approvals, inline MCP Apps views, context packet snapshots, project-aware history, and workspace changes with rich per-file diffs.                                  |
-| **Projects**       | Durable project identity, roots, context-source metadata, project activity, work items, assignments, handoffs, project memory entries, and memory candidates that require explicit operator promotion.                                                           |
-| **Tasks**          | Native `agent_loop` runs, queue/lease execution, blocking approvals, streamed activity, artifacts, retry/resume, stale-run recovery, MCP tool/App integration, MCP probe, and MCP registry discovery.                                                            |
-| **External Agent** | Supervised local ACP sessions for Codex, Claude Code, Cursor Agent, and Grok Build, including readiness/version checks, prompt-first approvals, adapter diagnostics, cancellation, and Git diff inspect/revert. External agents keep their own accounts/billing. |
-| **Observability**  | OpenTelemetry traces/metrics/logs, response trace headers, local trace view, route reports, runtime stats, timing, token usage, and provider-reported cost where available.                                                                                      |
-| **Desktop app**    | Native bundles run the Hecate runtime as a sidecar. macOS Apple Silicon is launch-tested; Linux and Windows bundles are CI-built but still experimental.                                                                                                         |
-| **Sandbox policy** | WorkspaceFS boundaries, ProcessRunner/GitRunner seams, env sanitisation, output caps, timeouts, and `bwrap` / `sandbox-exec` wrappers where available. This is not container-level isolation.                                                                    |
+| Surface            | What works today                                                                                                                                                                                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Model gateway**  | OpenAI-compatible Chat Completions, Anthropic-shaped Messages, streaming, vision, model discovery, provider health, failover, retry, usage events, and custom OpenAI-compatible endpoints.                                                                        |
+| **Connections**    | Cloud presets plus Ollama, LM Studio, LocalAI, llama.cpp-compatible servers, local discovery, health checks, credentials, external-agent readiness, and durable approval grants.                                                                                  |
+| **Chats**          | Direct model turns, tools-on task-backed turns, queued prompts, task/run/trace links, inline approvals, inline MCP Apps views, context packet snapshots, project-aware history, and workspace changes with rich per-file diffs.                                   |
+| **Projects**       | Durable project identity, roots, context-source metadata, project activity, work items, assignments, handoffs, project memory entries, and memory candidates that require explicit operator promotion. Portable coordination is being extracted toward Cairnline. |
+| **Tasks**          | Native `agent_loop` runs, queue/lease execution, blocking approvals, streamed activity, artifacts, retry/resume, stale-run recovery, MCP tool/App integration, MCP probe, and MCP registry discovery.                                                             |
+| **External Agent** | Supervised local ACP sessions for Codex, Claude Code, Cursor Agent, and Grok Build, including readiness/version checks, prompt-first approvals, adapter diagnostics, cancellation, and Git diff inspect/revert. External agents keep their own accounts/billing.  |
+| **Observability**  | OpenTelemetry traces/metrics/logs, response trace headers, local trace view, route reports, runtime stats, timing, token usage, and provider-reported cost where available.                                                                                       |
+| **Desktop app**    | Native bundles run the Hecate runtime as a sidecar. macOS Apple Silicon is launch-tested; Linux and Windows bundles are CI-built but still experimental.                                                                                                          |
+| **Sandbox policy** | WorkspaceFS boundaries, ProcessRunner/GitRunner seams, env sanitisation, output caps, timeouts, and `bwrap` / `sandbox-exec` wrappers where available. This is not container-level isolation.                                                                     |
 
 Design direction that is not yet a runtime contract:
 
@@ -265,6 +301,14 @@ support. A project can start without a workspace; a workspace is the concrete
 filesystem root used later by a chat, task, or external-agent session when local
 files matter.
 
+Hecate currently ships the operator cockpit and runtime integration for this
+flow. Portable project coordination is being extracted toward
+[Cairnline](docs/design/proposals/cairnline-portable-project-coordination.md),
+an agent-neutral local coordination server. The intended split is simple:
+Cairnline owns durable project/work/memory/evidence coordination; Hecate owns
+runtime launch, model routing, approvals, sandboxing, traces, External Agent
+supervision, and the richer operator UI.
+
 ![Projects workspace showing work queue, closeout checks, assignment evidence, and pending review](docs/screenshots/projects.png)
 
 ```mermaid
@@ -347,18 +391,21 @@ Operator guides:
 ## Status And Roadmap
 
 Hecate is public-alpha software. The fastest-moving areas are project-scoped
-work, memory/context visibility, External Agent ergonomics, desktop packaging,
-workflow runbook experiments, and sandbox hardening.
+work, the Cairnline project-coordination split, memory/context visibility,
+External Agent ergonomics, desktop packaging, workflow runbook experiments, and
+sandbox hardening.
 
 Near-term design direction:
 
-1. Keep projects, context packets, memory, artifacts, approvals, and traces as
+1. Finish the Cairnline delegation path for portable project coordination while
+   keeping Hecate as the operator cockpit and runtime/orchestration layer.
+2. Keep projects, context packets, memory, artifacts, approvals, and traces as
    the shared substrate for all agent work.
-2. Prototype one report-only `qa` workflow using existing task runs before
+3. Prototype one report-only `qa` workflow using existing task runs before
    adding a standalone workflow engine.
-3. Start browser support with conservative evidence capture and explicit state
+4. Start browser support with conservative evidence capture and explicit state
    isolation.
-4. Promote successful workflow lessons only as memory candidates with
+5. Promote successful workflow lessons only as memory candidates with
    provenance and operator approval.
 
 The broader alpha-to-beta gate lives in

--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -78,6 +78,10 @@ When embedded replacement mode is armed, prefer that Cairnline runtime path even
 if a compatibility project-work store is configured, and keep task/run or
 chat-session refs in the runtime overlay instead of advancing the native
 assignment shadow.
+Use `just dev-cairnline-projects --reset` for a clean local runtime with the
+embedded Cairnline dogfood posture already applied, and `just
+test-projects-dogfood` for the focused API confidence check before returning to
+non-Projects work.
 Assignment launch/preflight context must read inspect-only collaboration
 artifact and handoff metadata from the active Cairnline read model before
 falling back to Hecate-native project-work rows.

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -94,6 +94,36 @@ The gateway and the operator UI are both served from `http://127.0.0.1:8765`. `j
 
 For iterative changes that don't touch the embed boundary, skip the binary build and run from source: `just run` is `go run` with quick defaults; `just dev` is the same but sources `.env` when present so provider keys are available.
 
+## Cairnline Projects dogfood
+
+Projects should not block runtime, chat, gateway, adapter, or observability
+work. When you need to verify the current Cairnline-backed Projects path, use
+the focused dogfood recipe instead of assembling the environment by hand:
+
+```bash
+just dev-cairnline-projects --reset
+```
+
+This starts the source runtime with embedded Cairnline as the explicit
+Projects coordination backend, embedded read source, all portable write
+authority enabled, and embedded replacement mode armed. Use `--reset` for a
+clean local dogfood store; omit it only when intentionally checking an existing
+`.data/` directory. Then open `http://127.0.0.1:8765`, create or inspect a
+project, and confirm **Settings → Project coordination** reports Cairnline as
+authoritative before trusting the run.
+
+For automated confidence before or after manual dogfood, run:
+
+```bash
+just test-projects-dogfood
+```
+
+That target exercises the native Projects journey, the embedded Cairnline
+replacement task journey, the External Agent assignment-preparation path,
+runtime-overlay closeout readiness, backend-status gates, and representative
+mirror parity. It is intentionally narrower than `just test-race`; run the
+race suite as usual for backend/runtime changes.
+
 ## UI hot reload
 
 For live UI iteration, run `just dev` (gateway on `:8765`) and the Vite dev server side by side:

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -551,13 +551,14 @@ between direct model turns and new task-backed segments in one transcript.
 Project assignments can also prepare External Agent sessions. Starting a
 `driver_kind="external_agent"` assignment from Projects creates and prepares the
 linked External Agent chat session, records assignment/profile/workspace context,
-and stores the session link on the assignment. It does not append a visible chat
-message, create a `message_id`, or send the assignment prompt automatically; the
-operator stays in control of the first turn from the linked chat. Project
-assignment and activity rows project the linked chat's latest assistant-message
-status, session status, adapter identity, and missing-session diagnostics so the
-Projects cockpit can show follow-through state without embedding the full chat
-transcript. When the External Agent turn settles, Hecate also best-effort
+stores the ACP adapter metadata, advertised command list, and session link on
+the assignment-linked chat. It does not append a visible chat message, create a
+`message_id`, or send the assignment prompt automatically; the operator stays in
+control of the first turn from the linked chat. Project assignment and activity
+rows project the linked chat's latest assistant-message status, session status,
+adapter identity, and missing-session diagnostics so the Projects cockpit can
+show follow-through state without embedding the full chat transcript. When the
+External Agent turn settles, Hecate also best-effort
 reconciles the linked assignment row to the chat outcome, including the
 assistant `message_id` and terminal status. Handoffs created from these
 assignments can carry the source assignment, chat session, message, run, and

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -5330,6 +5330,9 @@ enrich the Hecate cockpit projection. Text-only sidecar output is rejected.
             "id": "chat_...",
             "title": "Backend substrate - External implementer",
             "agent_id": "codex",
+            "agent_title": "Codex ACP Adapter",
+            "agent_version": "0.1.0-alpha.33",
+            "available_command_count": 3,
             "driver_kind": "acp",
             "native_session_id": "native_...",
             "status": "running",
@@ -5417,8 +5420,9 @@ summarized artifact is assignment-scoped; work-item-level artifacts omit it.
 `linked_chat` is present when an assignment points at a Chat or External Agent
 session. It is a compact activity projection, not a full chat transcript:
 clients use it for session status, last-message status/error,
-adapter/session identity, and missing linked-session diagnostics, then open the
-chat endpoint for full transcript state. When a handoff is created from an
+adapter/session identity, ACP implementation summary, advertised command count,
+and missing linked-session diagnostics, then open the chat endpoint for full
+transcript state. When a handoff is created from an
 assignment, clients may copy the assignment, run, chat, message, and context
 refs into the handoff source fields so later follow-up assignments preserve
 provenance without auto-dispatching work.

--- a/internal/api/handler_project_activity.go
+++ b/internal/api/handler_project_activity.go
@@ -62,20 +62,23 @@ type ProjectActivityItemResponse struct {
 }
 
 type ProjectActivityLinkedChatResponse struct {
-	ID              string `json:"id"`
-	Title           string `json:"title,omitempty"`
-	AgentID         string `json:"agent_id,omitempty"`
-	DriverKind      string `json:"driver_kind,omitempty"`
-	NativeSessionID string `json:"native_session_id,omitempty"`
-	Status          string `json:"status,omitempty"`
-	LatestMessageID string `json:"latest_message_id,omitempty"`
-	LatestRole      string `json:"latest_role,omitempty"`
-	LatestStatus    string `json:"latest_status,omitempty"`
-	LatestError     string `json:"latest_error,omitempty"`
-	MessageCount    int    `json:"message_count,omitempty"`
-	CreatedAt       string `json:"created_at,omitempty"`
-	UpdatedAt       string `json:"updated_at,omitempty"`
-	Missing         bool   `json:"missing,omitempty"`
+	ID                    string `json:"id"`
+	Title                 string `json:"title,omitempty"`
+	AgentID               string `json:"agent_id,omitempty"`
+	AgentTitle            string `json:"agent_title,omitempty"`
+	AgentVersion          string `json:"agent_version,omitempty"`
+	AvailableCommandCount int    `json:"available_command_count,omitempty"`
+	DriverKind            string `json:"driver_kind,omitempty"`
+	NativeSessionID       string `json:"native_session_id,omitempty"`
+	Status                string `json:"status,omitempty"`
+	LatestMessageID       string `json:"latest_message_id,omitempty"`
+	LatestRole            string `json:"latest_role,omitempty"`
+	LatestStatus          string `json:"latest_status,omitempty"`
+	LatestError           string `json:"latest_error,omitempty"`
+	MessageCount          int    `json:"message_count,omitempty"`
+	CreatedAt             string `json:"created_at,omitempty"`
+	UpdatedAt             string `json:"updated_at,omitempty"`
+	Missing               bool   `json:"missing,omitempty"`
 }
 
 type ProjectActivityWorkItemResponse struct {
@@ -232,15 +235,20 @@ func missingProjectActivityLinkedChat(chatID string) *ProjectActivityLinkedChatR
 
 func renderProjectActivityLinkedChat(session chat.Session) *ProjectActivityLinkedChatResponse {
 	item := &ProjectActivityLinkedChatResponse{
-		ID:              session.ID,
-		Title:           session.Title,
-		AgentID:         renderChatAgentID(session),
-		DriverKind:      session.DriverKind,
-		NativeSessionID: session.NativeSessionID,
-		Status:          session.Status,
-		MessageCount:    len(session.Messages),
-		CreatedAt:       formatOptionalTime(session.CreatedAt),
-		UpdatedAt:       formatOptionalTime(session.UpdatedAt),
+		ID:                    session.ID,
+		Title:                 session.Title,
+		AgentID:               renderChatAgentID(session),
+		AvailableCommandCount: len(session.AvailableCommands),
+		DriverKind:            session.DriverKind,
+		NativeSessionID:       session.NativeSessionID,
+		Status:                session.Status,
+		MessageCount:          len(session.Messages),
+		CreatedAt:             formatOptionalTime(session.CreatedAt),
+		UpdatedAt:             formatOptionalTime(session.UpdatedAt),
+	}
+	if session.AgentInfo != nil {
+		item.AgentTitle = firstNonEmptyString(session.AgentInfo.Title, session.AgentInfo.Name)
+		item.AgentVersion = session.AgentInfo.Version
 	}
 	if latest := latestProjectActivityChatMessage(session.Messages); latest != nil {
 		item.LatestMessageID = latest.ID

--- a/internal/api/handler_project_activity_test.go
+++ b/internal/api/handler_project_activity_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/agentcontrols"
+	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/projectwork"
 )
 
@@ -150,6 +152,31 @@ func TestProjectActivityProjection_ItemStatusSummaryAndBucket(t *testing.T) {
 	}, role, nil, nil, missingProjectActivityLinkedChat("chat-missing"))
 	if missingChat.BlockingSignal != "stale_unknown" || missingChat.StatusSummary != "linked chat missing" || projectActivityBucket(missingChat) != "blocked" {
 		t.Fatalf("missing chat item = %+v, want stale linked-chat signal", missingChat)
+	}
+}
+
+func TestProjectActivityProjection_LinkedChatIncludesAdapterEvidence(t *testing.T) {
+	session := chat.Session{
+		ID:       "chat-agent",
+		Title:    "Agent session",
+		AgentID:  "codex",
+		Status:   "idle",
+		Messages: []chat.Message{{ID: "msg-1", Role: "assistant", Status: "completed"}},
+		AgentInfo: &agentcontrols.ImplementationInfo{
+			Name:    "codex-acp-adapter",
+			Title:   "Codex ACP Adapter",
+			Version: "0.1.0-test",
+		},
+		AvailableCommands: []agentcontrols.Command{{
+			Name:        "review",
+			Description: "Review current changes",
+			InputHint:   "scope",
+		}},
+	}
+
+	linked := renderProjectActivityLinkedChat(session)
+	if linked.AgentTitle != "Codex ACP Adapter" || linked.AgentVersion != "0.1.0-test" || linked.AvailableCommandCount != 1 {
+		t.Fatalf("linked chat = %+v, want adapter metadata and command count", linked)
 	}
 }
 

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -1337,7 +1337,11 @@ func (h *Handler) startStrictEmbeddedCairnlineExternalAgentAssignment(ctx contex
 	session, err = h.agentChat.UpdateSession(ctx, session.ID, func(item *chat.Session) {
 		item.DriverKind = prepared.DriverKind
 		item.NativeSessionID = prepared.NativeSessionID
+		item.AgentInfo = prepared.AgentInfo
 		item.ConfigOptions = prepared.ConfigOptions
+		if prepared.AvailableCommandsKnown {
+			item.AvailableCommands = prepared.AvailableCommands
+		}
 	})
 	if err != nil {
 		h.cleanupStrictEmbeddedExternalAgentSession(session.ID)

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -4102,7 +4102,20 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelLaunc
 			CairnlineReadSource: "embedded",
 		},
 	}, quietLogger(), nil, nil, nil, nil)
-	runner := &fakeAgentChatRunner{nativeSessionID: "native_embedded_external"}
+	runner := &fakeAgentChatRunner{
+		nativeSessionID: "native_embedded_external",
+		agentInfo: &agentcontrols.ImplementationInfo{
+			Name:    "codex-acp-adapter",
+			Title:   "Codex ACP Adapter",
+			Version: "0.1.0-test",
+		},
+		availableCommands: []agentcontrols.Command{{
+			Name:        "review",
+			Description: "Review current changes",
+			InputHint:   "scope",
+		}},
+		availableCommandsKnown: true,
+	}
 	handler.SetAgentChatRunner(runner)
 	// External Agent starts prepare chat sessions, so they should not require
 	// the native Hecate task runtime to be configured.
@@ -4213,6 +4226,12 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentStrictEmbeddedReadModelLaunc
 	}
 	if session.ProjectID != projectID || session.AgentID != "codex" || session.NativeSessionID != "native_embedded_external" {
 		t.Fatalf("session = %+v, want prepared external agent session for Cairnline project", session)
+	}
+	if session.AgentInfo == nil || session.AgentInfo.Name != "codex-acp-adapter" || session.AgentInfo.Version != "0.1.0-test" {
+		t.Fatalf("session agent info = %#v, want prepared adapter metadata", session.AgentInfo)
+	}
+	if len(session.AvailableCommands) != 1 || session.AvailableCommands[0].Name != "review" || session.AvailableCommands[0].InputHint != "scope" {
+		t.Fatalf("session available commands = %#v, want prepared commands", session.AvailableCommands)
 	}
 	runtime, ok, err := handler.projectRuntime.Get(t.Context(), projectID, "asgn_embedded_external_start")
 	if err != nil || !ok {

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -786,7 +786,11 @@ func (app *Application) StartExternalAgentAssignment(ctx context.Context, cmd St
 	session, err = app.chatStore.UpdateSession(ctx, session.ID, func(item *chat.Session) {
 		item.DriverKind = prepared.DriverKind
 		item.NativeSessionID = prepared.NativeSessionID
+		item.AgentInfo = prepared.AgentInfo
 		item.ConfigOptions = prepared.ConfigOptions
+		if prepared.AvailableCommandsKnown {
+			item.AvailableCommands = prepared.AvailableCommands
+		}
 	})
 	if err != nil {
 		app.cleanupExternalSession(session.ID)

--- a/internal/projectworkapp/application_test.go
+++ b/internal/projectworkapp/application_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
+	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/projectruntime"
@@ -745,7 +746,18 @@ func (r *recordingAgentRunner) PrepareSession(_ context.Context, req agentadapte
 	return agentadapters.PrepareSessionResult{
 		DriverKind:      agentadapters.DriverKindACP,
 		NativeSessionID: "native_" + req.SessionID,
-		ConfigOptions:   req.ConfigOptions,
+		AgentInfo: &agentcontrols.ImplementationInfo{
+			Name:    "codex-acp-adapter",
+			Title:   "Codex ACP Adapter",
+			Version: "0.1.0-test",
+		},
+		ConfigOptions: req.ConfigOptions,
+		AvailableCommands: []agentcontrols.Command{{
+			Name:        "review",
+			Description: "Review current changes",
+			InputHint:   "scope",
+		}},
+		AvailableCommandsKnown: true,
 	}, nil
 }
 
@@ -833,6 +845,12 @@ func TestApplication_StartExternalAgentAssignmentPreparesAndLinksSession(t *test
 	}
 	if session.NativeSessionID != "native_chat_ext" || session.DriverKind != agentadapters.DriverKindACP {
 		t.Fatalf("session = %+v, want prepared native metadata", session)
+	}
+	if session.AgentInfo == nil || session.AgentInfo.Name != "codex-acp-adapter" || session.AgentInfo.Version != "0.1.0-test" {
+		t.Fatalf("session agent info = %#v, want prepared adapter metadata", session.AgentInfo)
+	}
+	if len(session.AvailableCommands) != 1 || session.AvailableCommands[0].Name != "review" || session.AvailableCommands[0].InputHint != "scope" {
+		t.Fatalf("session available commands = %#v, want prepared commands", session.AvailableCommands)
 	}
 }
 

--- a/just/go.just
+++ b/just/go.just
@@ -115,6 +115,38 @@ dev *args: _go-cache
 	export HECATE_ALLOWED_ORIGINS; \
 	{{go_env}} go run ./cmd/hecate serve
 
+# Run the gateway from source with embedded Cairnline as the authoritative
+# Projects coordination dogfood path. This is intentionally explicit: it arms
+# replacement mode for local verification without changing normal `just dev`.
+# Optional arg: --reset.
+# Run gateway with Cairnline-backed Projects dogfood enabled.
+dev-cairnline-projects *args: _go-cache
+	needs_reset=0; \
+	for arg in {{args}}; do \
+	  case "$arg" in \
+	    --reset) needs_reset=1 ;; \
+	    *) echo "unknown argument: $arg"; echo "usage: just dev-cairnline-projects [--reset]"; exit 2 ;; \
+	  esac; \
+	done; \
+	if [ "$needs_reset" = "1" ]; then just reset-dev > /dev/null; else just stop; fi
+	set -a; \
+	[ -f ./.env ] && . ./.env; \
+	set +a; \
+	HECATE_ALLOWED_ORIGINS="${HECATE_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173}"; \
+	export HECATE_ALLOWED_ORIGINS; \
+	HECATE_PROJECTS_COORDINATION_BACKEND=cairnline \
+	HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded \
+	HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded \
+	HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=all-portable \
+	HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded \
+	{{go_env}} go run ./cmd/hecate serve
+
+# Run the focused API tests that prove Projects can be dogfooded through the
+# Hecate-native flow and the embedded Cairnline replacement flow.
+# Run focused Projects dogfood tests.
+test-projects-dogfood: _go-cache
+	{{go_env}} go test ./internal/api -run 'TestProjectJourneyAPI_(DiscoverStartInspectAndHandoff|CairnlineReplacementModeStartsTaskWithRuntimeDefaultsOverlay|CairnlineReplacementModeStartsExternalAgentWithoutAdvancingNativeShadow|CairnlineReplacementCloseoutReadinessUsesRuntimeOverlay)$|TestProjectCoordinationBackendStatus_(DefaultHecateAuthoritative|EnableDogfoodHintsEmbeddedReadSourceFromSidecar|CairnlineAllPortableWriteAuthorityAliasConfigured|CairnlineEmbeddedReplacementModeArmed|EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover)$|TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney$'
+
 # Run the gateway from source with external-agent adapter visuals forced to a
 # known state. This is visual-only: it changes discovery/probe readiness
 # surfaces but does not create fake adapter processes or make chat sends

--- a/ui/src/features/projects/projectAssignmentViewModels.test.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.test.ts
@@ -244,6 +244,9 @@ describe("projectAssignmentViewModels", () => {
       linked_chat_id: "chat_1",
       linked_chat: {
         id: "chat_1",
+        agent_title: "Codex ACP Adapter",
+        agent_version: "0.1.0-test",
+        available_command_count: 1,
         missing: true,
         latest_error: "adapter exited",
       },
@@ -262,6 +265,11 @@ describe("projectAssignmentViewModels", () => {
         expect.objectContaining({ label: "Chat", value: "chat_1" }),
         expect.objectContaining({ label: "Message", value: "msg_1" }),
         expect.objectContaining({ label: "Context snapshot", value: "ctx_1" }),
+        expect.objectContaining({
+          label: "Agent implementation",
+          value: "Codex ACP Adapter 0.1.0-test",
+        }),
+        expect.objectContaining({ label: "Commands", value: "1" }),
         expect.objectContaining({ label: "Provider / model", value: "anthropic / claude-sonnet" }),
         expect.objectContaining({ label: "Steps", value: "3" }),
         expect.objectContaining({ label: "Artifacts", value: "2" }),

--- a/ui/src/features/projects/projectAssignmentViewModels.ts
+++ b/ui/src/features/projects/projectAssignmentViewModels.ts
@@ -131,6 +131,24 @@ export function toProjectAssignmentEvidenceViewModel(
   pushEvidenceItem(items, "message", "Message", execution.messageID);
   pushEvidenceItem(items, "context", "Context snapshot", execution.contextSnapshotID);
   pushEvidenceItem(items, "trace", "Trace", execution.traceID);
+  if (activityItem?.linked_chat) {
+    pushEvidenceItem(
+      items,
+      "agent_implementation",
+      "Agent implementation",
+      [activityItem.linked_chat.agent_title, activityItem.linked_chat.agent_version]
+        .filter(Boolean)
+        .join(" "),
+    );
+    pushEvidenceItem(
+      items,
+      "available_commands",
+      "Commands",
+      typeof activityItem.linked_chat.available_command_count === "number"
+        ? String(activityItem.linked_chat.available_command_count)
+        : "",
+    );
+  }
   pushEvidenceItem(
     items,
     "provider_model",

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -991,6 +991,9 @@ export type ProjectActivityLinkedChatRecord = {
   id: string;
   title?: string;
   agent_id?: string;
+  agent_title?: string;
+  agent_version?: string;
+  available_command_count?: number;
   driver_kind?: string;
   native_session_id?: string;
   status?: string;


### PR DESCRIPTION
## Summary

- add Cairnline dogfood helper recipes and document the local validation path
- persist External Agent ACP metadata during project assignment preparation
- surface linked-chat adapter evidence in project activity projections and UI view models
- reposition the README around Hecate as an agent operations console and local runtime control plane

## Why

This keeps the Cairnline replacement path easier to dogfood while making External Agent assignment evidence more inspectable. The README update clarifies that Hecate is not primarily another agent framework: it is the operator/runtime layer around native tasks, supervised external agents, model routing, approvals, artifacts, traces, and project coordination.

## Validation

- `just test-projects-dogfood`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
- `GOCACHE="$PWD/.gocache" go vet ./...`
- `just go-format-check`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `just docs-check`
