### PR TITLE
feat(projects): align skill discovery roots

### DIFF
--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -68,9 +68,9 @@ only when backend status reports `replacement_ready=true` and
   assistant-proposal ledger and committed apply side effects, root, and
   closeout flows.
 - Cairnline skill discovery remains compatible with Hecate's current
-  `.agents/skills`, `.hecate/skills`, and enabled guidance-linked local skill
-  roots while keeping Cairnline-native `.cairnline/skills` available for
-  standalone projects.
+  `.agents/skills`, `.cairnline/skills`, `.claude/skills`, `.gemini/skills`,
+  `.hecate/skills`, and enabled guidance-linked local skill roots while keeping
+  discovery metadata-only for standalone projects.
 - Hecate project-level and role-level Agent Preset/provider/model posture stays
   Hecate-owned. Replacement reviews should compare Cairnline coordination
   records with Hecate launch readiness/context evidence so portable assignment

--- a/docs/design/proposals/workspace-instructions-skills-and-profiles.md
+++ b/docs/design/proposals/workspace-instructions-skills-and-profiles.md
@@ -25,7 +25,7 @@ Presets V1 and before implementing planner/runbook features.
 
 ## External Alignment
 
-Facts, accessed 2026-06-08:
+Facts, accessed 2026-06-08 unless noted:
 
 - Codex documents `AGENTS.md` as its project-instruction surface and includes
   feature-flagged hierarchy/precedence behavior for nested agent guidance.
@@ -33,7 +33,8 @@ Facts, accessed 2026-06-08:
 - Claude Code skills use a skill folder with `SKILL.md`, optional supporting
   resources, and progressive disclosure. Claude Code also supports an
   `allowed-tools` frontmatter field that can grant tool access while the skill
-  is active. Source: <https://docs.claude.com/en/docs/claude-code/skills>.
+  is active. Source: <https://code.claude.com/docs/en/skills> (accessed
+  2026-07-04).
 - Claude Code memory/instruction files include organization, user, and project
   `CLAUDE.md` locations, including project `./CLAUDE.md` and
   `./.claude/CLAUDE.md`. Source:
@@ -63,6 +64,10 @@ Facts, accessed 2026-06-08:
   custom slash commands from user/project `.gemini/commands/*.toml` sources.
   Source:
   <https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/commands.md>.
+- Gemini CLI Agent Skills documents workspace skill discovery from
+  `.gemini/skills` and `.agents/skills`, with the `.agents/skills` alias taking
+  precedence. Source: <https://geminicli.com/docs/cli/skills/> (accessed
+  2026-07-04).
 - Windsurf/Cascade separates Memories, Rules, Workflows, and Skills; it
   recommends durable reusable knowledge be stored as Rules or `AGENTS.md`, and
   currently prefers `.devin/rules/*.md` with legacy `.windsurf/rules/*.md`
@@ -213,8 +218,11 @@ Hecate V1 supports persisted project-local skill metadata:
 
 ```text
 .agents/skills/<skill-id>/SKILL.md       # cross-agent compatibility source
+.cairnline/skills/<skill-id>/SKILL.md    # portable coordination source
+.claude/skills/<skill-id>/SKILL.md       # Claude-compatible metadata source
+.gemini/skills/<skill-id>/SKILL.md       # Gemini-compatible metadata source
 .hecate/skills/<skill-id>/SKILL.md       # Hecate-native/project-local source
-AGENTS.md / CLAUDE.md linked local roots # explicit project guidance references
+guidance-linked local roots              # explicit project guidance references
 ```
 
 Better alignment target:
@@ -222,17 +230,21 @@ Better alignment target:
 ```text
 .hecate/skills/<skill-id>/SKILL.md       # Hecate-native source of truth
 .agents/skills/<skill-id>/SKILL.md       # cross-agent compatibility candidate
+.cairnline/skills/<skill-id>/SKILL.md    # portable coordination candidate
 .claude/skills/<skill-id>/SKILL.md       # Claude-compatible import candidate
+.gemini/skills/<skill-id>/SKILL.md       # Gemini-compatible import candidate
 .opencode/skills/<skill-id>/SKILL.md     # OpenCode-compatible import candidate
 ~/.agents/skills/<skill-id>/SKILL.md     # future user-global import candidate
 ~/.claude/skills/<skill-id>/SKILL.md     # future user-global import candidate
 ```
 
-V1 scans `.agents/skills`, `.hecate/skills`, and local skill roots explicitly
-linked from enabled `AGENTS.md` / `CLAUDE.md` context sources. Compatibility
-scanning for `.claude/skills`, `.opencode/skills`, or global skill directories
-should remain explicit opt-in, because those skills can carry host-specific
-assumptions or permission fields.
+V1 scans `.agents/skills`, `.cairnline/skills`, `.claude/skills`,
+`.gemini/skills`, `.hecate/skills`, and local skill roots explicitly linked
+from enabled guidance context sources. Hecate stores metadata only: host-specific
+skill bodies are not injected, executed, installed, or treated as policy
+authority. Compatibility scanning for `.opencode/skills` or global skill
+directories should remain explicit opt-in because those skills can carry
+host-specific assumptions or permission fields.
 
 Common frontmatter:
 
@@ -423,10 +435,10 @@ Recommended sequence:
 
 3. **Skills Registry V1 Core**
    - Implemented: project-scoped memory/SQLite store parity.
-   - Implemented: project-local `.agents/skills` and `.hecate/skills`
-     discovery.
+   - Implemented: project-local `.agents/skills`, `.cairnline/skills`,
+     `.claude/skills`, `.gemini/skills`, and `.hecate/skills` discovery.
    - Implemented: local skill roots explicitly linked from enabled `AGENTS.md`
-     or `CLAUDE.md` guidance.
+     or compatible guidance.
    - Implemented: safe metadata parsing, conflict/missing/invalid statuses, and
      operator override preservation.
    - Implemented: list/discover/patch API and Project Skills UI.
@@ -483,7 +495,8 @@ or merely saw generated/runtime evidence.
 - Should Hecate support global user-local skills before project-local skills?
 - What is the minimum built-in skill set: `code-review`, `diff-aware-qa`,
   `investigate`, `handoff`, `release-check`?
-- Should compatibility import from `.claude/skills` be read-only preview first?
+- Should additional host-specific roots such as `.opencode/skills` become
+  metadata-only discovery sources, or require explicit import?
 - How should conflicting nested `AGENTS.md` files be shown when a task touches
   multiple directories?
 - Should skill bodies be included in context by default, or only skill summary

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -299,11 +299,12 @@ uses enabled `workspace_guidance` context-source metadata to propose memory
 candidates with source provenance, and uses enabled, available project skills
 from `/hecate/v1/projects/{id}/skills`. The skill registry is refreshed through
 `POST /hecate/v1/projects/{id}/skills/discover`, which reads bounded local
-metadata from `.agents/skills`, `.hecate/skills`, and enabled `AGENTS.md` /
-`CLAUDE.md` context-source references. The refresh ignores nested worktree
-containers such as `.worktrees` and `.claude/worktrees`; linked worktrees should
-be explicit project roots, not inherited onboarding input. Bootstrap itself does
-not perform a second filesystem scan. Skill capability hints such as suggested
+metadata from `.agents/skills`, `.cairnline/skills`, `.claude/skills`,
+`.gemini/skills`, `.hecate/skills`, and enabled guidance context-source
+references. The refresh ignores nested worktree containers such as `.worktrees`
+and `.claude/worktrees`; linked worktrees should be explicit project roots, not
+inherited onboarding input. Bootstrap itself does not perform a second
+filesystem scan. Skill capability hints such as suggested
 tools and required tools/writes/network posture remain advisory metadata for
 launch-readiness warnings; they do not grant capabilities. Bootstrap deduplicates
 against existing role ids and existing memory/candidate source refs. It does

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1836,9 +1836,10 @@ enabled). Chat message context packets include enabled sources as itemized
 `workspace_guidance` metadata for inspection, but Hecate does not inject those
 files into prompts yet. Projects also have a project-scoped skills registry
 for local `SKILL.md` metadata discovered from `.agents/skills`,
-`.hecate/skills`, and enabled guidance-linked local skill roots. The registry
-stores ids, title/description metadata, path, root, status, trust label, and
-warnings; it does not store or return skill bodies. Project work-coordination
+`.cairnline/skills`, `.claude/skills`, `.gemini/skills`, `.hecate/skills`,
+and enabled guidance-linked local skill roots. The registry stores ids,
+title/description metadata, path, root, status, trust label, and warnings; it
+does not store or return skill bodies. Project work-coordination
 endpoints can persist roles, work items, assignments, and collaboration
 artifacts under a project. Assignments may record links to existing task runs
 or chat messages, but creating an assignment does not start a task, open a
@@ -5795,9 +5796,12 @@ Refreshes the project skills registry from active absolute project roots.
 Discovery scans:
 
 - `.agents/skills/*/SKILL.md`
+- `.cairnline/skills/*/SKILL.md`
+- `.claude/skills/*/SKILL.md`
+- `.gemini/skills/*/SKILL.md`
 - `.hecate/skills/*/SKILL.md`
-- local skill roots explicitly linked from enabled `AGENTS.md` or `CLAUDE.md`
-  context sources.
+- local skill roots explicitly linked from enabled guidance context sources,
+  including `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`.
 
 Discovery ignores nested worktree containers such as `.worktrees` and
 `.claude/worktrees` when reading guidance-linked skill roots. Add a linked

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.0.0-20260704022043-0bccf15c2e31
+	github.com/hecatehq/cairnline v0.0.0-20260704173634-6ef7164c0ba3
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.0.0-20260704022043-0bccf15c2e31 h1:Y3hn5t5KjCiO5fSvaDedCPv2oTby8DrdRAof0qOU4Do=
-github.com/hecatehq/cairnline v0.0.0-20260704022043-0bccf15c2e31/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.0.0-20260704173634-6ef7164c0ba3 h1:12ZEM/LIFIGRZgsuZKXAsAgIC7otARenJ3yij77kgYE=
+github.com/hecatehq/cairnline v0.0.0-20260704173634-6ef7164c0ba3/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/projectskills/discovery.go
+++ b/internal/projectskills/discovery.go
@@ -81,11 +81,17 @@ func sortedSkillMap(items map[string]Skill) []Skill {
 func skillBaseDirs(fsys *workspacefs.FS, root projects.Root, sources []projects.ContextSource, warnings *[]string) []skillBaseDir {
 	dirs := []skillBaseDir{
 		{Path: ".agents/skills"},
+		{Path: ".cairnline/skills"},
+		{Path: ".claude/skills"},
+		{Path: ".gemini/skills"},
 		{Path: ".hecate/skills"},
 	}
 	seen := map[string]int{
-		".agents/skills": 0,
-		".hecate/skills": 1,
+		".agents/skills":    0,
+		".cairnline/skills": 1,
+		".claude/skills":    2,
+		".gemini/skills":    3,
+		".hecate/skills":    4,
 	}
 	for _, source := range sources {
 		if !guidanceSourceForRoot(source, root.ID) {
@@ -126,11 +132,11 @@ func guidanceSourceForRoot(source projects.ContextSource, rootID string) bool {
 			return false
 		}
 	}
-	if source.Kind == "workspace_instruction" || source.Format == "agents_md" || source.Format == "claude_md" {
+	if source.Kind == "workspace_instruction" || source.Format == "agents_md" || source.Format == "claude_md" || source.Format == "gemini_md" {
 		return true
 	}
 	base := strings.ToLower(path.Base(filepath.ToSlash(source.Path)))
-	return base == "agents.md" || base == "claude.md" || base == "claude.local.md"
+	return base == "agents.md" || base == "claude.md" || base == "claude.local.md" || base == "gemini.md"
 }
 
 func readGuidanceSource(fsys *workspacefs.FS, source projects.ContextSource, warnings *[]string) (string, bool) {

--- a/internal/projectskills/discovery_test.go
+++ b/internal/projectskills/discovery_test.go
@@ -16,12 +16,17 @@ func TestDiscoverFindsLocalAndGuidanceLinkedSkillMetadata(t *testing.T) {
 	root := t.TempDir()
 	writeSkillFile(t, root, ".agents/skills/backend/SKILL.md", "---\nname: Backend Engineer\ndescription: Build backend slices.\n---\n# Ignored\n")
 	writeSkillFile(t, root, ".hecate/skills/qa/SKILL.md", "# QA Review\n")
+	writeSkillFile(t, root, ".cairnline/skills/planning/SKILL.md", "# Planning\n")
+	writeSkillFile(t, root, ".claude/skills/debug/SKILL.md", "# Claude Debug\n")
+	writeSkillFile(t, root, ".gemini/skills/research-gemini/SKILL.md", "# Gemini Research\n")
 	writeSkillFile(t, root, "docs-ai/skills/research/SKILL.md", "# Research\n")
 	writeSkillFile(t, root, "claude-skills/review/SKILL.md", "---\ntitle: Claude Review\ndescription: Host-specific review posture.\n---\n")
+	writeSkillFile(t, root, "gemini-skills/release/SKILL.md", "# Release Coordination\n")
 	writeSkillFile(t, root, ".worktrees/refactor/docs-ai/skills/backend/SKILL.md", "# Worktree Backend\n")
 	writeSkillFile(t, root, ".claude/worktrees/refactor/docs-ai/skills/qa/SKILL.md", "# Claude Worktree QA\n")
 	writeFileForDiscoveryTest(t, root, "AGENTS.md", "Use [`docs-ai/skills/research/SKILL.md`](docs-ai/skills/research/SKILL.md).")
 	writeFileForDiscoveryTest(t, root, "CLAUDE.md", "Use [`claude-skills/review/SKILL.md`](claude-skills/review/SKILL.md).")
+	writeFileForDiscoveryTest(t, root, "GEMINI.md", "Use [`gemini-skills/release/SKILL.md`](gemini-skills/release/SKILL.md).")
 	writeFileForDiscoveryTest(t, root, ".worktrees/refactor/AGENTS.md", "Use `.worktrees/refactor/docs-ai/skills/backend/SKILL.md`.")
 	writeFileForDiscoveryTest(t, root, ".claude/worktrees/refactor/AGENTS.md", "Use `.claude/worktrees/refactor/docs-ai/skills/qa/SKILL.md`.")
 	writeSkillFile(t, root, "unreferenced/skills/ignore/SKILL.md", "# Ignore\n")
@@ -56,6 +61,16 @@ func TestDiscoverFindsLocalAndGuidanceLinkedSkillMetadata(t *testing.T) {
 				},
 			},
 			{
+				ID:      "ctx_gemini",
+				Kind:    "host_instruction",
+				Path:    "GEMINI.md",
+				Enabled: true,
+				Format:  "gemini_md",
+				Metadata: map[string]string{
+					"root_id": "root_a",
+				},
+			},
+			{
 				ID:      "ctx_worktree",
 				Kind:    "workspace_instruction",
 				Path:    ".worktrees/refactor/AGENTS.md",
@@ -80,13 +95,17 @@ func TestDiscoverFindsLocalAndGuidanceLinkedSkillMetadata(t *testing.T) {
 	if len(warnings) != 0 {
 		t.Fatalf("warnings = %+v, want none", warnings)
 	}
-	if len(skills) != 4 {
-		t.Fatalf("skills = %+v, want four discovered skills", skills)
+	if len(skills) != 8 {
+		t.Fatalf("skills = %+v, want eight discovered skills", skills)
 	}
 	assertSkillForDiscoveryTest(t, skills, "backend", "Backend Engineer", "Build backend slices.", ".agents/skills/backend/SKILL.md", nil)
 	assertSkillForDiscoveryTest(t, skills, "qa", "QA Review", "", ".hecate/skills/qa/SKILL.md", nil)
+	assertSkillForDiscoveryTest(t, skills, "planning", "Planning", "", ".cairnline/skills/planning/SKILL.md", nil)
+	assertSkillForDiscoveryTest(t, skills, "debug", "Claude Debug", "", ".claude/skills/debug/SKILL.md", nil)
+	assertSkillForDiscoveryTest(t, skills, "research_gemini", "Gemini Research", "", ".gemini/skills/research-gemini/SKILL.md", nil)
 	assertSkillForDiscoveryTest(t, skills, "research", "Research", "", "docs-ai/skills/research/SKILL.md", []string{"ctx_agents"})
 	assertSkillForDiscoveryTest(t, skills, "review", "Claude Review", "Host-specific review posture.", "claude-skills/review/SKILL.md", []string{"ctx_claude"})
+	assertSkillForDiscoveryTest(t, skills, "release", "Release Coordination", "", "gemini-skills/release/SKILL.md", []string{"ctx_gemini"})
 	if findSkillForTest(skills, "ignore") != nil {
 		t.Fatalf("skills = %+v, want unreferenced skill root ignored", skills)
 	}

--- a/ui/src/features/projects/ProjectSkillsPanel.test.tsx
+++ b/ui/src/features/projects/ProjectSkillsPanel.test.tsx
@@ -113,7 +113,7 @@ describe("ProjectSkillsPanel", () => {
     expect(screen.getByText("No project skills registered")).toBeTruthy();
     expect(
       screen.getByText(
-        "Discover skills from AGENTS.md / CLAUDE.md references, .agents/skills, or .hecate/skills.",
+        "Discover skills from guidance-linked roots, .agents/skills, .cairnline/skills, .claude/skills, .gemini/skills, or .hecate/skills.",
       ),
     ).toBeTruthy();
   });

--- a/ui/src/features/projects/ProjectSkillsPanel.tsx
+++ b/ui/src/features/projects/ProjectSkillsPanel.tsx
@@ -76,7 +76,7 @@ export function ProjectSkillsPanel({
         {skills.length === 0 && !loading ? (
           <EmptyBlock
             title="No project skills registered"
-            detail="Discover skills from AGENTS.md / CLAUDE.md references, .agents/skills, or .hecate/skills."
+            detail="Discover skills from guidance-linked roots, .agents/skills, .cairnline/skills, .claude/skills, .gemini/skills, or .hecate/skills."
           />
         ) : (
           <div style={{ display: "grid", gap: 8 }}>


### PR DESCRIPTION
## Summary
- bump Cairnline to the skill-root compatibility build from hecatehq/cairnline#64
- align Hecate-native project skill discovery with Cairnline for .agents/skills, .cairnline/skills, .claude/skills, .gemini/skills, and .hecate/skills
- allow enabled GEMINI.md context sources to contribute metadata-only skill references
- update Projects Skills UI copy and runtime/design docs with source access dates

## Validation
- go test ./internal/projectskills
- go test ./internal/api -run 'TestProjectSkillsAPI|TestProjectAssistantAPI_.*Skills|TestProjectCoordinationBackendStatus'
- cd ui && bun run test -- src/features/projects/ProjectSkillsPanel.test.tsx
- just docs-check
- go vet ./...
- cd ui && bun run typecheck && bun run lint && bun run format:check
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- git diff --check

## External sources
- Claude Code Skills docs, accessed July 4, 2026: https://code.claude.com/docs/en/skills
- Gemini CLI Agent Skills docs, accessed July 4, 2026: https://geminicli.com/docs/cli/skills/