### PR TITLE
feat(projects): delegate skill discovery to Cairnline authority

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -569,9 +569,10 @@ Project skill discovery and
 metadata updates also best-effort mirror metadata-only skill records after the
 Hecate store commit unless
 `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills` is enabled, in which
-case skill discovery/update commits metadata-only skill records to Cairnline
-first and then shadows them back into Hecate. In skill authority mode, discovery
-can use roots and context sources from the embedded Cairnline graph without a
+case skill discovery runs through Cairnline's metadata-only scanner, skill
+discovery/update commits metadata-only skill records to Cairnline first, and
+then shadows them back into Hecate. In skill authority mode, discovery can use
+roots and context sources from the embedded Cairnline graph without a
 Hecate-native compatibility project row. Neither path loads, injects, executes,
 or grants permissions from skill bodies. Project role and work-item mutations
 likewise mirror coordination metadata after Hecate commits unless

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -5793,7 +5793,7 @@ requires typed `structuredContent`; text-only sidecar output is rejected.
 #### `POST /hecate/v1/projects/{id}/skills/discover`
 
 Refreshes the project skills registry from active absolute project roots.
-Discovery scans:
+In native-authoritative mode, Hecate's native scanner scans:
 
 - `.agents/skills/*/SKILL.md`
 - `.cairnline/skills/*/SKILL.md`
@@ -5802,6 +5802,12 @@ Discovery scans:
 - `.hecate/skills/*/SKILL.md`
 - local skill roots explicitly linked from enabled guidance context sources,
   including `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`.
+
+When `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills` is enabled with
+the embedded Cairnline connector, discovery is delegated to Cairnline's
+metadata-only scanner and then projected through the Hecate API response shape.
+That authority path can use Cairnline-supported guidance formats beyond the
+native Hecate subset while Hecate remains responsible for runtime policy.
 
 Discovery ignores nested worktree containers such as `.worktrees` and
 `.claude/worktrees` when reading guidance-linked skill roots. Add a linked

--- a/internal/api/handler_project_skill_authority.go
+++ b/internal/api/handler_project_skill_authority.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
@@ -38,24 +37,13 @@ func (h *Handler) projectForProjectSkillMutation(ctx context.Context, projectID 
 	return project, nil
 }
 
-func (h *Handler) upsertDiscoveredProjectSkillsWithCairnlineAuthority(ctx context.Context, project projects.Project, discovered []projectskills.Skill, warnings []string) ([]projectskills.Skill, error) {
+func (h *Handler) discoverProjectSkillsWithCairnlineAuthority(ctx context.Context, project projects.Project) ([]projectskills.Skill, error) {
 	var recorded []projectskills.Skill
 	err := h.withCairnlineEmbeddedMirrorService(ctx, func(service *cairnline.Service) error {
 		if _, err := cairnlinebridge.UpsertProjectMetadata(ctx, service, project); err != nil {
 			return err
 		}
-		existing, err := service.ListProjectSkills(ctx, project.ID)
-		if err != nil {
-			return err
-		}
-		existingSkills := projectSkillsFromCairnline(existing)
-		merged := projectskills.MergeDiscovered(existingSkills, discovered, project.ID, time.Now().UTC())
-		if len(warnings) > 0 {
-			for idx := range merged {
-				merged[idx].Warnings = appendUniqueProjectSkillWarnings(merged[idx].Warnings, warnings...)
-			}
-		}
-		items, err := cairnlinebridge.UpsertProjectSkills(ctx, service, merged)
+		items, err := service.DiscoverProjectSkills(ctx, project.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/api/handler_project_skills.go
+++ b/internal/api/handler_project_skills.go
@@ -57,15 +57,15 @@ func (h *Handler) HandleDiscoverProjectSkills(w http.ResponseWriter, r *http.Req
 	if writeProjectSkillProjectError(w, err) {
 		return
 	}
-	discovered, warnings := projectskills.Discover(r.Context(), project)
 	if usesCairnlineAuthority {
-		items, err := h.upsertDiscoveredProjectSkillsWithCairnlineAuthority(r.Context(), project, discovered, warnings)
+		items, err := h.discoverProjectSkillsWithCairnlineAuthority(r.Context(), project)
 		if writeProjectSkillAuthorityError(w, err) {
 			return
 		}
 		WriteJSON(w, http.StatusOK, ProjectSkillsResponse{Object: "project_skills", Data: renderProjectSkills(items, "cairnline")})
 		return
 	}
+	discovered, warnings := projectskills.Discover(r.Context(), project)
 	items, err := h.projectSkills.UpsertDiscovered(r.Context(), project.ID, discovered)
 	if errors.Is(err, projectskills.ErrInvalid) {
 		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, err.Error())

--- a/internal/api/handler_project_skills_test.go
+++ b/internal/api/handler_project_skills_test.go
@@ -561,6 +561,67 @@ hecate:
 	}
 }
 
+func TestProjectSkillsAPI_CairnlineWriteAuthorityUsesCairnlineDiscovery(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:     "cairnline",
+			CairnlineWriteAuthority: projectCairnlineWriteAuthorityProjectSkills,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	root := t.TempDir()
+	writeProjectSkillAPITestFile(t, root, ".github/instructions/local-skills/review/SKILL.md", "# Review\n")
+	writeProjectSkillAPITestFile(t, root, ".github/instructions/project.instructions.md", "Use local-skills/review/SKILL.md.\n")
+	project, err := handler.projects.Create(t.Context(), projects.Project{
+		ID:   "proj_skills_cairnline_discovery",
+		Name: "Cairnline Discovery",
+		Roots: []projects.Root{{
+			ID:     "root_skills_cairnline_discovery",
+			Path:   root,
+			Active: true,
+		}},
+		ContextSources: []projects.ContextSource{{
+			ID:      "ctx_github",
+			Kind:    "host_instruction",
+			Title:   "GitHub instructions",
+			Path:    ".github/instructions/project.instructions.md",
+			Enabled: true,
+			Format:  "github_instruction",
+			Metadata: map[string]string{
+				"root_id": "root_skills_cairnline_discovery",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create project: %v", err)
+	}
+
+	discoverRec := httptest.NewRecorder()
+	server.ServeHTTP(discoverRec, httptest.NewRequest(http.MethodPost, "/hecate/v1/projects/"+project.ID+"/skills/discover", nil))
+	if discoverRec.Code != http.StatusOK {
+		t.Fatalf("discover status = %d body=%s, want 200", discoverRec.Code, discoverRec.Body.String())
+	}
+	var discovered ProjectSkillsResponse
+	if err := json.Unmarshal(discoverRec.Body.Bytes(), &discovered); err != nil {
+		t.Fatalf("decode discover response: %v", err)
+	}
+	review := projectSkillResponseFor(discovered.Data, "review")
+	if review == nil || review.ReadBackend != "cairnline" || review.Path != ".github/instructions/local-skills/review/SKILL.md" {
+		t.Fatalf("discovered skills = %+v, want Cairnline-discovered GitHub instruction skill", discovered.Data)
+	}
+	if len(review.SourceContextSourceIDs) != 1 || review.SourceContextSourceIDs[0] != "ctx_github" {
+		t.Fatalf("review source refs = %+v, want ctx_github", review.SourceContextSourceIDs)
+	}
+	mirrored := getMirroredCairnlineProjectSkillForTest(t, handler, project.ID, "review")
+	if mirrored.Title != "Review" || len(mirrored.SourceRefs) != 1 || mirrored.SourceRefs[0] != "ctx_github" {
+		t.Fatalf("Cairnline skill = %+v, want delegated discovery result", mirrored)
+	}
+}
+
 func TestProjectSkillsAPI_CairnlineWriteAuthorityAcceptsCairnlineOnlyProject(t *testing.T) {
 	t.Parallel()
 	handler := NewHandler(config.Config{


### PR DESCRIPTION
## Summary
- delegate project skill discovery to embedded Cairnline when the `project-skills` write-authority switchpoint is enabled
- keep native Hecate discovery for native-authoritative mode
- add a regression proving Cairnline-authoritative discovery can use Cairnline-supported guidance sources such as GitHub instructions
- document the authority-mode discovery behavior

## Validation
- `go test ./internal/api -run 'TestProjectSkillsAPI_(CairnlineWriteAuthority|CairnlineReplacementMode|Discover|ListUsesCairnline)'`
- `go test ./internal/api -run 'TestProjectSkillsAPI|TestProjectCoordinationBackendStatus_CairnlineProjectSkillsAuthorityConfigured|TestProjectJourneyAPI_(DiscoverStartInspectAndHandoff|CairnlineReplacementModeStartsTaskWithRuntimeDefaultsOverlay|CairnlineReplacementModeStartsExternalAgentWithoutAdvancingNativeShadow|CairnlineReplacementCloseoutReadinessUsesRuntimeOverlay)'`
- `go test ./internal/projectskills ./internal/cairnlinebridge`
- `just docs-check`
- `just test-projects-dogfood`
- `go vet ./...`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
- `git diff --check`
