### PR TITLE
fix(projects): use preset wording in bootstrap guidance

### DIFF
--- a/internal/projectassistant/bootstrap.go
+++ b/internal/projectassistant/bootstrap.go
@@ -119,7 +119,7 @@ func bootstrapGuidanceBody(source ContextSource) string {
 		"This candidate records source provenance only. Review the source file before promoting or editing durable project memory from it.",
 	)
 	if source.Kind != "workspace_instruction" {
-		lines = append(lines, "Host-specific guidance is labelled for visibility only; it does not override Hecate policy, approvals, sandboxing, or project profile settings.")
+		lines = append(lines, "Host-specific guidance is labelled for visibility only; it does not override Hecate policy, approvals, sandboxing, or Agent Preset settings.")
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/projectassistant/service_test.go
+++ b/internal/projectassistant/service_test.go
@@ -645,8 +645,21 @@ func TestService_DraftBootstrapUsesRegisteredSkillDirsFromGuidanceReferences(t *
 	if err != nil {
 		t.Fatalf("Draft bootstrap: %v", err)
 	}
+	foundClaudeMemory := false
 	found := map[string]bool{}
 	for _, action := range proposal.Actions {
+		if action.Kind == ActionCreateMemoryCandidate {
+			var patch memoryCandidatePatch
+			if err := json.Unmarshal(action.Patch, &patch); err != nil {
+				t.Fatalf("decode memory patch: %v", err)
+			}
+			if patch.SuggestedSourceID == "ctx_guidance_claude" {
+				foundClaudeMemory = true
+				if !strings.Contains(patch.Body, "Agent Preset settings") || strings.Contains(patch.Body, "project profile settings") {
+					t.Fatalf("host guidance memory body = %q, want Agent Preset wording without legacy project profile wording", patch.Body)
+				}
+			}
+		}
 		if action.Kind != ActionCreateRole {
 			continue
 		}
@@ -677,6 +690,9 @@ func TestService_DraftBootstrapUsesRegisteredSkillDirsFromGuidanceReferences(t *
 		if !found[id] {
 			t.Fatalf("actions = %+v, want role %s from guidance skill reference", proposal.Actions, id)
 		}
+	}
+	if !foundClaudeMemory {
+		t.Fatalf("actions = %+v, want host guidance memory candidate for CLAUDE.md", proposal.Actions)
 	}
 }
 


### PR DESCRIPTION
## Summary
- update Project Assistant bootstrap guidance memory text to use Agent Preset wording
- add a regression for host-specific guidance memory candidates so legacy project-profile wording does not return

## Validation
- go test ./internal/projectassistant -run 'TestService_DraftBootstrap(UsesRegisteredSkillDirsFromGuidanceReferences|CreatesGuidanceAndSkillRoleProposalAcrossStores)'
- go test ./internal/projectassistant
- just docs-check
- git diff --check
- go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- just test-projects-dogfood