### PR TITLE
fix(projects): rename preset attention action

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -5526,7 +5526,7 @@ show when lower-priority attention rows are hidden.
 
 Attention rows route to existing surfaces through a typed `action` object.
 Supported action types are shared with Project Operations where they overlap:
-`open_project_settings`, `open_memory_review`, `open_profiles`, `open_roles`,
+`open_project_settings`, `open_memory_review`, `open_agent_presets`, `open_roles`,
 `open_skills`, `open_work_item`, `open_task`, `open_activity_bucket`, and
 `review_memory_candidate`. The top-level `work_item_id`, `task_id`, `run_id`,
 `chat_id`, `candidate_id`, and `bucket` fields remain row metadata for compact
@@ -5644,6 +5644,12 @@ Known action types are:
 - `open_work_item`
 - `open_assignment_preflight`
 - `open_memory_review`
+- `open_agent_presets`
+- `open_roles`
+- `open_skills`
+- `open_task`
+- `open_activity_bucket`
+- `review_memory_candidate`
 - `draft_project_proposal`
 
 Actions do not directly mutate project state. `open_assignment_preflight` opens

--- a/internal/api/handler_project_actions.go
+++ b/internal/api/handler_project_actions.go
@@ -7,7 +7,7 @@ const (
 	projectActionOpenActivityBucket      = "open_activity_bucket"
 	projectActionOpenAssignmentPreflight = "open_assignment_preflight"
 	projectActionOpenMemoryReview        = "open_memory_review"
-	projectActionOpenProfiles            = "open_profiles"
+	projectActionOpenAgentPresets        = "open_agent_presets"
 	projectActionOpenProjectSettings     = "open_project_settings"
 	projectActionOpenRoles               = "open_roles"
 	projectActionOpenSkills              = "open_skills"
@@ -55,8 +55,8 @@ func newProjectActionOpenMemoryReview(projectID string) ProjectActionResponse {
 	return ProjectActionResponse{Type: projectActionOpenMemoryReview, ProjectID: strings.TrimSpace(projectID)}
 }
 
-func newProjectActionOpenProfiles(projectID string) ProjectActionResponse {
-	return ProjectActionResponse{Type: projectActionOpenProfiles, ProjectID: strings.TrimSpace(projectID)}
+func newProjectActionOpenAgentPresets(projectID string) ProjectActionResponse {
+	return ProjectActionResponse{Type: projectActionOpenAgentPresets, ProjectID: strings.TrimSpace(projectID)}
 }
 
 func newProjectActionOpenProjectSettings(projectID string) ProjectActionResponse {

--- a/internal/api/handler_project_health.go
+++ b/internal/api/handler_project_health.go
@@ -356,7 +356,7 @@ func projectHealthProfileAttentionItems(project projects.Project, roles []projec
 		Title:     "Agent Preset reference missing",
 		Detail:    "Project or role defaults reference " + projectHealthSummarizeIDs(missing) + ".",
 		Status:    "stale_unknown",
-		Action:    newProjectActionOpenProfiles(project.ID),
+		Action:    newProjectActionOpenAgentPresets(project.ID),
 	}}
 }
 

--- a/internal/api/handler_project_health_test.go
+++ b/internal/api/handler_project_health_test.go
@@ -609,7 +609,7 @@ func TestProjectHealth_ProfileAndSkillReferences(t *testing.T) {
 	}
 	assertProjectHealthItemsHaveActions(t, response.Data.Attention, "proj_refs")
 	profiles := findProjectHealthAttentionForTest(t, response.Data.Attention, "Agent Preset reference missing")
-	assertProjectHealthActionForTest(t, profiles, projectActionOpenProfiles, "proj_refs")
+	assertProjectHealthActionForTest(t, profiles, projectActionOpenAgentPresets, "proj_refs")
 	if !strings.Contains(profiles.Detail, "missing_profile") {
 		t.Fatalf("profile attention = %+v, want missing profile detail", profiles)
 	}

--- a/ui/src/features/projects/ProjectHealthPanel.tsx
+++ b/ui/src/features/projects/ProjectHealthPanel.tsx
@@ -104,7 +104,7 @@ export function ProjectHealthPanel({
       case "open_skills":
         onAttentionSkills();
         return;
-      case "open_profiles":
+      case "open_agent_presets":
         onAttentionPresets();
         return;
       case "open_roles":

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4709,6 +4709,39 @@ describe("ProjectsView cockpit", () => {
     expect(screen.getByDisplayValue("Backend")).toBeTruthy();
   });
 
+  it("opens agent presets from preset-related needs attention rows", async () => {
+    resetProjectWorkMocks();
+    vi.mocked(getProjectHealth).mockResolvedValue({
+      object: "project_health",
+      data: projectHealthData(project.id, [
+        {
+          id: `${project.id}:presets`,
+          project_id: project.id,
+          title: "Agent Preset reference missing",
+          detail: "Missing preset: implementation.",
+          status: "awaiting_approval",
+          action: projectHealthAction(project.id, "open_agent_presets"),
+        },
+      ]),
+    });
+    window.localStorage.setItem("hecate.project", project.id);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+
+    await screen.findByText("Work Queue");
+    const health = await openProjectAttentionMenu();
+    const presetAttentionItem = within(health).getByRole("button", {
+      name: "Open attention item Agent Preset reference missing",
+    });
+
+    await userEvent.click(presetAttentionItem);
+
+    expect(await screen.findByRole("dialog", { name: "Agent presets" })).toBeTruthy();
+  });
+
   it("surfaces stale and missing linked execution in needs attention", async () => {
     resetProjectWorkMocks();
     const staleAssignment: ProjectAssignmentRecord = {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1308,6 +1308,17 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenSettings, on
       case "open_memory_review":
         setWorkspaceTab("memory");
         return;
+      case "open_agent_presets":
+        setPresetsError("");
+        setAgentPresetsModalOpen(true);
+        return;
+      case "open_roles":
+        setRolesError("");
+        setRolesModalOpen(true);
+        return;
+      case "open_skills":
+        setWorkspaceTab("skills");
+        return;
       case "open_assignment_preflight":
         selectProjectWorkRoute(route);
         setPreparingAssignmentID(route.assignmentID);

--- a/ui/src/features/projects/projectActionRouting.test.ts
+++ b/ui/src/features/projects/projectActionRouting.test.ts
@@ -174,6 +174,13 @@ describe("projectActionRouting", () => {
     });
     expect(
       routeProjectHealthAttention(
+        attention({ action: { type: "open_agent_presets", project_id: "proj_1" } }),
+      ),
+    ).toEqual({
+      kind: "open_agent_presets",
+    });
+    expect(
+      routeProjectHealthAttention(
         attention({
           action: {
             type: "review_memory_candidate",

--- a/ui/src/features/projects/projectActionRouting.ts
+++ b/ui/src/features/projects/projectActionRouting.ts
@@ -23,7 +23,7 @@ export type ProjectActionRoute =
       workItemID?: string;
     }
   | { kind: "open_memory_review" }
-  | { kind: "open_profiles" }
+  | { kind: "open_agent_presets" }
   | { kind: "open_project_settings" }
   | { kind: "open_roles" }
   | { kind: "open_skills" }
@@ -90,8 +90,8 @@ export function routeProjectAction(
       return { kind: "open_project_settings" };
     case "open_memory_review":
       return { kind: "open_memory_review" };
-    case "open_profiles":
-      return { kind: "open_profiles" };
+    case "open_agent_presets":
+      return { kind: "open_agent_presets" };
     case "open_roles":
       return { kind: "open_roles" };
     case "open_skills":

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -1063,7 +1063,7 @@ export type ProjectActionType =
   | "open_activity_bucket"
   | "open_assignment_preflight"
   | "open_memory_review"
-  | "open_profiles"
+  | "open_agent_presets"
   | "open_project_settings"
   | "open_roles"
   | "open_skills"


### PR DESCRIPTION
## Summary
- rename the Projects action kind for Agent Presets from open_profiles to open_agent_presets
- route the renamed action through Project health and Projects UI modals
- update runtime API action docs and UI/backend regression coverage

## Validation
- go test ./internal/api -run 'TestProjectHealth'
- cd ui && bun run test -- src/features/projects/projectActionRouting.test.ts src/features/projects/ProjectsView.test.tsx
- just docs-check
- cd ui && bun run typecheck
- go test ./internal/api
- git diff --check
- go vet ./...
- GOCACHE="/Users/chicoxyzzy/dev/hecate/hecate/.gocache" go test -race -timeout 10m ./...
- just test-projects-dogfood