### PR TITLE
fix(projects): align context preset wording

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -7565,6 +7565,7 @@ snapshot does not expose the full system prompt text.
 
 Section values currently used by the runtime are:
 
+- `profile` for resolved Hecate Agent Preset metadata and preset-resolution warnings
 - `instructions` for system-prompt, prompt-context, and instruction-layer metadata
 - `skills` for resolved, skipped, or chat-visible project skill metadata; `SKILL.md` bodies are not included
 - `memory` for project memory entries

--- a/internal/api/handler_chat_context.go
+++ b/internal/api/handler_chat_context.go
@@ -1072,12 +1072,12 @@ func appendResolvedAgentProfile(packet *chat.ContextPacket, profile projectworka
 		body = append(body, "Warnings: "+strings.Join(profile.Warnings, " "))
 	}
 	appendContextPacketSourceWithSection(packet, contextSectionProfile, chat.ContextSource{
-		Kind:   "agent_profile",
+		Kind:   "agent_preset",
 		Label:  firstNonEmptyString(profile.Name, profile.ID),
 		Detail: profile.ID,
 		Trust:  contextTrustRuntimeState,
 	}, chat.ContextItem{
-		Kind:            "agent_profile",
+		Kind:            "agent_preset",
 		TrustLevel:      contextTrustRuntimeState,
 		Origin:          profile.ID,
 		Title:           firstNonEmptyString(profile.Name, profile.ID),
@@ -1087,18 +1087,18 @@ func appendResolvedAgentProfile(packet *chat.ContextPacket, profile projectworka
 	})
 	for _, warning := range profile.Warnings {
 		appendContextPacketSourceWithSection(packet, contextSectionProfile, chat.ContextSource{
-			Kind:   "profile_warning",
-			Label:  "Profile warning",
+			Kind:   "agent_preset_warning",
+			Label:  "Agent preset warning",
 			Detail: profile.ID,
 			Trust:  contextTrustRuntimeState,
 		}, chat.ContextItem{
-			Kind:            "profile_warning",
+			Kind:            "agent_preset_warning",
 			TrustLevel:      contextTrustRuntimeState,
 			Origin:          profile.ID,
-			Title:           "Profile warning",
+			Title:           "Agent preset warning",
 			Body:            warning,
 			Included:        false,
-			InclusionReason: "Profile resolution warning",
+			InclusionReason: "Agent preset resolution warning",
 		})
 	}
 }
@@ -1185,7 +1185,7 @@ func appendProjectAssignmentPromptContext(packet *chat.ContextPacket, promptCont
 	appendContextPacketSourceWithSection(packet, contextSectionInstructions, chat.ContextSource{
 		Kind:   "prompt_context",
 		Label:  "Prompt context policy",
-		Detail: "project assignment profile policies",
+		Detail: "project assignment agent preset policies",
 		Trust:  contextTrustRuntimeState,
 	}, chat.ContextItem{
 		Kind:            "prompt_context",
@@ -1194,7 +1194,7 @@ func appendProjectAssignmentPromptContext(packet *chat.ContextPacket, promptCont
 		Title:           "Prompt context policy",
 		Body:            strings.Join(body, "\n"),
 		Included:        len(promptContext.Sections) > 0,
-		InclusionReason: "Profile memory/source policies applied to the native assignment prompt",
+		InclusionReason: "Agent Preset memory/source policies applied to the native assignment prompt",
 	})
 }
 
@@ -1254,8 +1254,8 @@ func appendExternalAgentAssignmentPromptPolicy(packet *chat.ContextPacket, profi
 		Body: strings.Join([]string{
 			"External Agent assignment start prepares a supervised chat session; it does not dispatch an adapter prompt.",
 			"Hecate records project launch metadata for inspection, but does not inject project memory bodies, project source bodies, host-specific guidance file bodies, or SKILL.md bodies into adapter prompts in V1.",
-			"Profile project_memory_policy: " + firstNonEmptyString(strings.TrimSpace(profile.ProjectMemoryPolicy), agentprofiles.MemoryInherit),
-			"Profile context_source_policy: " + firstNonEmptyString(strings.TrimSpace(profile.ContextSourcePolicy), agentprofiles.ContextInherit),
+			"Agent Preset project_memory_policy: " + firstNonEmptyString(strings.TrimSpace(profile.ProjectMemoryPolicy), agentprofiles.MemoryInherit),
+			"Agent Preset context_source_policy: " + firstNonEmptyString(strings.TrimSpace(profile.ContextSourcePolicy), agentprofiles.ContextInherit),
 		}, "\n"),
 		Included:        false,
 		InclusionReason: "Inspectable boundary note only; External Agent prompt packing is adapter-owned",

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -5492,7 +5492,7 @@ func TestProjectWorkAPI_StartExternalAgentAssignmentPreparesLinkedSession(t *tes
 	if policyItem == nil || policyItem.Included {
 		t.Fatalf("external assignment prompt policy item = %+v, want inspect-only policy note", policyItem)
 	}
-	for _, want := range []string{"does not dispatch an adapter prompt", "Profile project_memory_policy: include", "Profile context_source_policy: include_enabled"} {
+	for _, want := range []string{"does not dispatch an adapter prompt", "Agent Preset project_memory_policy: include", "Agent Preset context_source_policy: include_enabled"} {
 		if !strings.Contains(policyItem.Body, want) {
 			t.Fatalf("external assignment prompt policy body = %q, want %q", policyItem.Body, want)
 		}
@@ -5954,7 +5954,7 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsMissingProfileWarning(t *testing
 	if !strings.Contains(profileItem.Body, "agent preset \"prof_missing\" was not found") {
 		t.Fatalf("profile body = %q, want missing preset warning", profileItem.Body)
 	}
-	warning := findRenderedContextItemByKind(packetResp.Data, "profile_warning")
+	warning := findRenderedContextItemByKind(packetResp.Data, "agent_preset_warning")
 	if warning == nil || warning.Included || !strings.Contains(warning.Body, "agent preset \"prof_missing\" was not found") {
 		t.Fatalf("profile warning = %+v, want excluded warning item", warning)
 	}

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -757,7 +757,7 @@ function resetProjectWorkMocks() {
           kind: "agent_preset",
           trust_level: "runtime_state",
           origin: "implementation",
-          title: "Implementation profile",
+          title: "Implementation preset",
           body: "Tools enabled. Writes allowed.",
           included: true,
         },


### PR DESCRIPTION
## Summary
- rename project assignment context packet preset items from agent_profile/profile_warning to agent_preset/agent_preset_warning
- update prompt-policy copy to say Agent Preset instead of Profile
- document the profile context section as resolved Hecate Agent Preset metadata

## Tests
- go test ./internal/api -run 'TestProjectWorkAPI_(StartAssignmentSnapshotsResolvedAgentProfile|StartExternalAgentAssignmentPreparesLinkedSession|StartAssignmentSnapshotsMissingProfileWarning)'\n- cd ui && bun run test -- src/features/projects/ProjectsView.test.tsx\n- just docs-check\n- go test ./internal/api\n- go vet ./...\n- git diff --check\n- cd ui && bun run typecheck\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n- just test-projects-dogfood