### PR TITLE
docs(projects): align readiness preset wording

### DIFF
--- a/docs/design/accepted/projects.md
+++ b/docs/design/accepted/projects.md
@@ -1038,10 +1038,10 @@ Agent chat, while preflight itself creates no task, run, chat session, artifact,
 memory entry, or assignment update.
 Assignment launch readiness is a separate server-owned projection at
 `GET /hecate/v1/projects/{id}/work-items/{work_item_id}/assignments/{assignment_id}/launch-readiness`.
-The Projects UI uses its typed `ready`, `blockers`, resolved workspace/profile
-hints, and provider/model readiness fields to gate explicit start/prepare
-confirmation, while the preflight context packet remains inspectable evidence
-rather than client-parsed authority.
+The Projects UI uses its typed `ready`, `blockers`, resolved workspace,
+Agent Preset, runtime, and provider/model readiness fields to gate explicit
+start/prepare confirmation, while the preflight context packet remains
+inspectable evidence rather than client-parsed authority.
 Project roots now model concrete checkouts for assignment execution: work items
 and assignments can select a root by `root_id`, and launch resolution uses
 assignment root, work-item root, project default root, then first active root.


### PR DESCRIPTION
## Summary

Aligns the accepted Projects launch-readiness wording with the current Agent Preset vocabulary.

The launch-readiness UI contract now names workspace, Agent Preset, runtime, and provider/model readiness instead of the older workspace/profile wording.

## Validation

- `just docs-check`
- `git diff --check`
