### PR TITLE
docs(projects): link cairnline sidecar release

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -486,6 +486,13 @@ best-effort mirror into the embedded Cairnline database through
 their identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.
+For sidecar experiments, install the standalone `cairnline` binary from the
+[Cairnline `v0.1.0-alpha.2` prerelease](https://github.com/hecatehq/cairnline/releases/tag/v0.1.0-alpha.2)
+or build it with `go install github.com/hecatehq/cairnline/cmd/cairnline@v0.1.0-alpha.2`,
+then point `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND` at that binary if it is
+not already on `PATH`. The sidecar path is for MCP interoperability evidence;
+embedded Cairnline remains the replacement target for Hecate's own Projects
+backend.
 The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`,
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,


### PR DESCRIPTION
## Summary
- document installing the standalone Cairnline v0.1.0-alpha.2 binary for Hecate sidecar experiments
- clarify that sidecar mode is interoperability evidence while embedded Cairnline remains Hecate Projects replacement target

## Validation
- just docs-check
- git diff --check