### PR TITLE
feat(projects): verify cairnline sidecar resource templates

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -498,7 +498,8 @@ The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. `sidecar-probe` verifies MCP
-tool presence only. `sidecar-connect` keeps the process warm in Hecate's
+tool presence plus the portable Projects `resources/templates/list` contract.
+`sidecar-connect` keeps the process warm in Hecate's
 Cairnline-specific MCP client cache. `sidecar-read-smoke`,
 `sidecar-detail-smoke`, `sidecar-coordination-smoke`,
 `sidecar-assignment-context-smoke`, and `sidecar-launch-packet-smoke` use that

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3115,10 +3115,10 @@ Example response, with `write_switchpoints` shortened for readability:
 ### `POST /hecate/v1/projects/cairnline/sidecar-probe`
 
 Local-only standalone Cairnline MCP contract probe. It starts the configured
-stdio command once, lists MCP tools, and returns whether the process exposes the
-current portable Projects backend tool surface Hecate would need for a future
-sidecar backend. It does not keep a persistent client, proxy Projects reads or
-writes, or make Cairnline authoritative.
+stdio command once, lists MCP tools and resource templates, and returns whether
+the process exposes the current portable Projects backend contract Hecate would
+need for a future sidecar backend. It does not keep a persistent client, proxy
+Projects reads or writes, or make Cairnline authoritative.
 
 The probe is controlled by:
 
@@ -3206,6 +3206,17 @@ memory_candidates.reject
 memory_candidates.delete
 ```
 
+Required resource templates:
+
+```text
+cairnline://projects/{project_id}
+cairnline://projects/{project_id}/work-items/{work_item_id}
+cairnline://projects/{project_id}/work-items/{work_item_id}/closeout-readiness
+cairnline://projects/{project_id}/assignments/{assignment_id}
+cairnline://projects/{project_id}/assignments/{assignment_id}/launch-packet
+cairnline://projects/{project_id}/memory-candidates/{memory_candidate_id}
+```
+
 Example response, shortened:
 
 ```json
@@ -3214,7 +3225,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_probe_ready",
-    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
+    "detail": "Cairnline sidecar MCP server started and exposes the required portable Projects tool and resource-template contract. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
@@ -3222,6 +3233,12 @@ Example response, shortened:
     "tool_count": 81,
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
+    "resource_template_count": 6,
+    "required_resource_templates": ["cairnline://projects/{project_id}"],
+    "missing_resource_templates": [],
+    "resource_templates": [
+      { "uri_template": "cairnline://projects/{project_id}", "name": "project" }
+    ],
     "tools": [{ "name": "projects.list" }],
     "warnings": []
   }
@@ -3406,9 +3423,10 @@ Example response, shortened:
 Local-only standalone Cairnline MCP client connect/status surface. It uses the
 same command, database, timeout, and required-tool contract as
 `sidecar-probe`, but acquires the sidecar through Hecate's Cairnline-specific
-MCP client cache. A successful call leaves the sidecar process idle in that
-cache until the cache evicts it or Hecate shuts down. This connection alone
-does not change live Projects routing. Add
+MCP client cache. It also verifies the same required resource templates. A
+successful call leaves the sidecar process idle in that cache until the cache
+evicts it or Hecate shuts down. This connection alone does not change live
+Projects routing. Add
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar` to route the explicit sidecar
 read families through the standalone MCP client; write-authority switchpoints
 still require the embedded Cairnline connector.
@@ -3429,7 +3447,7 @@ Example response, shortened:
   "data": {
     "ready": true,
     "status": "sidecar_client_ready",
-    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
+    "detail": "Cairnline sidecar MCP client connected and exposes the required portable Projects tool and resource-template contract. Project writes stay on Hecate-native stores in sidecar mode; HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, operations-brief through the standalone Cairnline MCP client.",
     "command": "cairnline",
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -69,11 +69,20 @@ func cairnlineSidecarFixtureMain(mode string) {
 		case "initialize":
 			result = mcp.InitializeResult{
 				ProtocolVersion: mcp.DeclaredProtocolVersion,
-				Capabilities:    mcp.ServerCapabilities{Tools: &mcp.ToolsCapability{}},
-				ServerInfo:      mcp.ServerInfo{Name: "cairnline-fixture", Version: "test"},
+				Capabilities: mcp.ServerCapabilities{
+					Tools:     &mcp.ToolsCapability{},
+					Resources: &mcp.ResourcesCapability{},
+				},
+				ServerInfo: mcp.ServerInfo{Name: "cairnline-fixture", Version: "test"},
 			}
 		case "tools/list":
 			result = mcp.ListToolsResult{Tools: cairnlineSidecarFixtureTools(mode)}
+		case "resources/templates/list":
+			if cairnlineSidecarFixtureModeHas(mode, "resource-template-error") {
+				rpcErr = mcp.NewError(mcp.ErrCodeInternalError, "resource template fixture failure")
+				break
+			}
+			result = mcp.ListResourceTemplatesResult{ResourceTemplates: cairnlineSidecarFixtureResourceTemplates(mode)}
 		case "tools/call":
 			var params mcp.CallToolParams
 			if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -147,6 +156,25 @@ func cairnlineSidecarFixtureTools(mode string) []mcp.Tool {
 		})
 	}
 	return tools
+}
+
+func cairnlineSidecarFixtureResourceTemplates(mode string) []mcp.ResourceTemplate {
+	if cairnlineSidecarFixtureModeHas(mode, "missing-resource-template") {
+		return []mcp.ResourceTemplate{{
+			URITemplate: "cairnline://projects/{project_id}",
+			Name:        "project",
+			MIMEType:    "application/json",
+		}}
+	}
+	templates := make([]mcp.ResourceTemplate, 0, len(projectCairnlineSidecarRequiredResourceTemplates))
+	for _, uri := range projectCairnlineSidecarRequiredResourceTemplates {
+		templates = append(templates, mcp.ResourceTemplate{
+			URITemplate: uri,
+			Name:        strings.NewReplacer("cairnline://", "", "/", "_", "{", "", "}", "", "-", "_").Replace(uri),
+			MIMEType:    "application/json",
+		})
+	}
+	return templates
 }
 
 func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixtureState, params mcp.CallToolParams) (mcp.CallToolResult, *mcp.RPCError) {

--- a/internal/api/handler_admin.go
+++ b/internal/api/handler_admin.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hecatehq/hecate/internal/gateway"
 	"github.com/hecatehq/hecate/internal/governor"
+	"github.com/hecatehq/hecate/internal/mcp"
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/retention"
@@ -341,6 +342,20 @@ func renderMCPProbeTools(tools []mcpclient.NamespacedTool) []MCPProbeToolDescrip
 			UIResourceURI: t.UIResourceURI,
 			UIVisibility:  append([]string(nil), t.UIVisibility...),
 			ModelVisible:  t.ModelVisible,
+		})
+	}
+	return out
+}
+
+func renderMCPProbeResourceTemplates(templates []mcp.ResourceTemplate) []MCPProbeResourceTemplateDescriptor {
+	out := make([]MCPProbeResourceTemplateDescriptor, 0, len(templates))
+	for _, t := range templates {
+		out = append(out, MCPProbeResourceTemplateDescriptor{
+			URITemplate: t.URITemplate,
+			Name:        t.Name,
+			Title:       t.Title,
+			Description: t.Description,
+			MIMEType:    t.MIMEType,
 		})
 	}
 	return out

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -21,6 +21,15 @@ import (
 
 const projectCairnlineSidecarMCPServerName = "cairnline"
 
+var projectCairnlineSidecarRequiredResourceTemplates = []string{
+	"cairnline://projects/{project_id}",
+	"cairnline://projects/{project_id}/work-items/{work_item_id}",
+	"cairnline://projects/{project_id}/work-items/{work_item_id}/closeout-readiness",
+	"cairnline://projects/{project_id}/assignments/{assignment_id}",
+	"cairnline://projects/{project_id}/assignments/{assignment_id}/launch-packet",
+	"cairnline://projects/{project_id}/memory-candidates/{memory_candidate_id}",
+}
+
 var projectCairnlineSidecarRequiredTools = []string{
 	"projects.list",
 	"projects.get",
@@ -345,6 +354,10 @@ func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairn
 		DatabasePath:   dbPath,
 		ProbeTimeoutMS: timeout.Milliseconds(),
 		RequiredTools:  append([]string(nil), projectCairnlineSidecarRequiredTools...),
+		RequiredResourceTemplates: append(
+			[]string(nil),
+			projectCairnlineSidecarRequiredResourceTemplates...,
+		),
 	}
 	if h == nil {
 		response.Status = "sidecar_probe_failed"
@@ -360,7 +373,7 @@ func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairn
 
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	result, err := orchestrator.ProbeMCPServer(probeCtx, cfg, h.secretCipher)
+	result, err := orchestrator.ProbeMCPServerWithResourceTemplates(probeCtx, cfg, h.secretCipher)
 	if err != nil {
 		response.Status = "sidecar_probe_failed"
 		response.Detail = err.Error()
@@ -368,15 +381,29 @@ func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairn
 	}
 	response.Tools = renderMCPProbeTools(result.Tools)
 	response.ToolCount = len(response.Tools)
+	response.ResourceTemplates = renderMCPProbeResourceTemplates(result.ResourceTemplates)
+	response.ResourceTemplateCount = len(response.ResourceTemplates)
+	response.ResourceTemplateError = result.ResourceTemplateError
 	response.MissingTools = projectCairnlineSidecarMissingTools(projectCairnlineSidecarToolNames(response.Tools))
+	response.MissingResourceTemplates = projectCairnlineSidecarMissingResourceTemplates(projectCairnlineSidecarResourceTemplateURIs(response.ResourceTemplates))
 	if len(response.MissingTools) > 0 {
 		response.Status = "sidecar_contract_incomplete"
 		response.Detail = "Cairnline sidecar MCP server started, but it does not expose every tool Hecate needs for a future Projects backend connector."
 		return response
 	}
+	if response.ResourceTemplateError != "" {
+		response.Status = "sidecar_contract_incomplete"
+		response.Detail = "Cairnline sidecar MCP server started, but resources/templates/list failed; install Cairnline v0.1.0-alpha.2 or newer for the full portable Projects resource contract."
+		return response
+	}
+	if len(response.MissingResourceTemplates) > 0 {
+		response.Status = "sidecar_contract_incomplete"
+		response.Detail = "Cairnline sidecar MCP server started, but it does not expose every resource template Hecate expects for portable Projects diagnostics."
+		return response
+	}
 	response.Ready = true
 	response.Status = "sidecar_probe_ready"
-	response.Detail = "Cairnline sidecar MCP server started and exposes the required portable Projects tool contract. " + projectCairnlineSidecarLiveReadDetail()
+	response.Detail = "Cairnline sidecar MCP server started and exposes the required portable Projects tool and resource-template contract. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 
@@ -386,14 +413,18 @@ func (h *Handler) projectCairnlineSidecarConnect(ctx context.Context) ProjectCai
 	}
 	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
 	response := ProjectCairnlineSidecarProbeResponse{
-		Ready:                 false,
-		Status:                "sidecar_client_not_connected",
-		Detail:                "Cairnline sidecar client has not connected.",
-		Command:               cfg.Command,
-		Args:                  append([]string(nil), cfg.Args...),
-		DatabasePath:          dbPath,
-		ProbeTimeoutMS:        timeout.Milliseconds(),
-		RequiredTools:         append([]string(nil), projectCairnlineSidecarRequiredTools...),
+		Ready:          false,
+		Status:         "sidecar_client_not_connected",
+		Detail:         "Cairnline sidecar client has not connected.",
+		Command:        cfg.Command,
+		Args:           append([]string(nil), cfg.Args...),
+		DatabasePath:   dbPath,
+		ProbeTimeoutMS: timeout.Milliseconds(),
+		RequiredTools:  append([]string(nil), projectCairnlineSidecarRequiredTools...),
+		RequiredResourceTemplates: append(
+			[]string(nil),
+			projectCairnlineSidecarRequiredResourceTemplates...,
+		),
 		PersistentClient:      true,
 		ClientCacheConfigured: h != nil,
 	}
@@ -412,7 +443,7 @@ func (h *Handler) projectCairnlineSidecarConnect(ctx context.Context) ProjectCai
 	cache := h.projectCairnlineSidecarMCPClientCache()
 	connectCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	result, err := orchestrator.ProbeCachedMCPServer(connectCtx, cfg, h.secretCipher, cache)
+	result, err := orchestrator.ProbeCachedMCPServerWithResourceTemplates(connectCtx, cfg, h.secretCipher, cache)
 	if err != nil {
 		response.Status = "sidecar_client_failed"
 		response.Detail = err.Error()
@@ -421,16 +452,30 @@ func (h *Handler) projectCairnlineSidecarConnect(ctx context.Context) ProjectCai
 	}
 	response.Tools = renderMCPProbeTools(result.Tools)
 	response.ToolCount = len(response.Tools)
+	response.ResourceTemplates = renderMCPProbeResourceTemplates(result.ResourceTemplates)
+	response.ResourceTemplateCount = len(response.ResourceTemplates)
+	response.ResourceTemplateError = result.ResourceTemplateError
 	response.MissingTools = projectCairnlineSidecarMissingTools(projectCairnlineSidecarToolNames(response.Tools))
+	response.MissingResourceTemplates = projectCairnlineSidecarMissingResourceTemplates(projectCairnlineSidecarResourceTemplateURIs(response.ResourceTemplates))
 	response.setSidecarCacheStats(cache.Stats())
 	if len(response.MissingTools) > 0 {
 		response.Status = "sidecar_contract_incomplete"
 		response.Detail = "Cairnline sidecar MCP client connected, but it does not expose every tool Hecate needs for a future Projects backend connector."
 		return response
 	}
+	if response.ResourceTemplateError != "" {
+		response.Status = "sidecar_contract_incomplete"
+		response.Detail = "Cairnline sidecar MCP client connected, but resources/templates/list failed; install Cairnline v0.1.0-alpha.2 or newer for the full portable Projects resource contract."
+		return response
+	}
+	if len(response.MissingResourceTemplates) > 0 {
+		response.Status = "sidecar_contract_incomplete"
+		response.Detail = "Cairnline sidecar MCP client connected, but it does not expose every resource template Hecate expects for portable Projects diagnostics."
+		return response
+	}
 	response.Ready = true
 	response.Status = "sidecar_client_ready"
-	response.Detail = "Cairnline sidecar MCP client connected and exposes the required portable Projects tool contract. " + projectCairnlineSidecarLiveReadDetail()
+	response.Detail = "Cairnline sidecar MCP client connected and exposes the required portable Projects tool and resource-template contract. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 
@@ -4392,6 +4437,38 @@ func projectCairnlineSidecarMissingTools(toolNames []string) []string {
 	for _, name := range projectCairnlineSidecarRequiredTools {
 		if _, ok := seen[name]; !ok {
 			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func projectCairnlineSidecarResourceTemplateURIs(templates []MCPProbeResourceTemplateDescriptor) []string {
+	out := make([]string, 0, len(templates))
+	seen := make(map[string]struct{}, len(templates))
+	for _, template := range templates {
+		uri := strings.TrimSpace(template.URITemplate)
+		if uri == "" {
+			continue
+		}
+		if _, ok := seen[uri]; ok {
+			continue
+		}
+		seen[uri] = struct{}{}
+		out = append(out, uri)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func projectCairnlineSidecarMissingResourceTemplates(templateURIs []string) []string {
+	seen := make(map[string]struct{}, len(templateURIs))
+	for _, uri := range templateURIs {
+		seen[uri] = struct{}{}
+	}
+	var missing []string
+	for _, uri := range projectCairnlineSidecarRequiredResourceTemplates {
+		if _, ok := seen[uri]; !ok {
+			missing = append(missing, uri)
 		}
 	}
 	return missing

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -107,14 +107,23 @@ func TestProjectCairnlineSidecarProbe_Ready(t *testing.T) {
 	if got.ToolCount != len(projectCairnlineSidecarRequiredTools) {
 		t.Fatalf("tool count = %d, want %d", got.ToolCount, len(projectCairnlineSidecarRequiredTools))
 	}
+	if got.ResourceTemplateCount != len(projectCairnlineSidecarRequiredResourceTemplates) {
+		t.Fatalf("resource template count = %d, want %d", got.ResourceTemplateCount, len(projectCairnlineSidecarRequiredResourceTemplates))
+	}
 	if len(got.MissingTools) != 0 {
 		t.Fatalf("missing tools = %+v, want none", got.MissingTools)
+	}
+	if len(got.MissingResourceTemplates) != 0 || got.ResourceTemplateError != "" {
+		t.Fatalf("missing resource templates = %+v error=%q, want none", got.MissingResourceTemplates, got.ResourceTemplateError)
 	}
 	assertSidecarLiveReadDetail(t, got.Detail)
 	for _, name := range []string{"projects.update", "roots.create", "context_sources.update", "skills.update", "assignments.create", "memory_entries.create", "assistant.apply", "memory_candidates.delete"} {
 		if !containsString(got.RequiredTools, name) {
 			t.Fatalf("required tools = %+v, want %q", got.RequiredTools, name)
 		}
+	}
+	if !containsString(got.RequiredResourceTemplates, "cairnline://projects/{project_id}/assignments/{assignment_id}/launch-packet") {
+		t.Fatalf("required resource templates = %+v, want launch packet template", got.RequiredResourceTemplates)
 	}
 	if got.Command != os.Args[0] || len(got.Args) != 1 {
 		t.Fatalf("probe config = command %q args %+v, want fixture command", got.Command, got.Args)
@@ -143,6 +152,48 @@ func TestProjectCairnlineSidecarProbe_MissingRequiredTools(t *testing.T) {
 	}
 }
 
+func TestProjectCairnlineSidecarProbe_MissingRequiredResourceTemplates(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "missing-resource-template"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	got := handler.projectCairnlineSidecarProbe(t.Context())
+	if got.Ready || got.Status != "sidecar_contract_incomplete" {
+		t.Fatalf("probe = %+v, want incomplete contract", got)
+	}
+	if !containsString(got.MissingResourceTemplates, "cairnline://projects/{project_id}/assignments/{assignment_id}/launch-packet") ||
+		!containsString(got.MissingResourceTemplates, "cairnline://projects/{project_id}/memory-candidates/{memory_candidate_id}") {
+		t.Fatalf("missing resource templates = %+v, want representative missing templates", got.MissingResourceTemplates)
+	}
+	if got.ResourceTemplateError != "" {
+		t.Fatalf("resource template error = %q, want empty", got.ResourceTemplateError)
+	}
+}
+
+func TestProjectCairnlineSidecarProbe_ResourceTemplateListError(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "resource-template-error"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	got := handler.projectCairnlineSidecarProbe(t.Context())
+	if got.Ready || got.Status != "sidecar_contract_incomplete" {
+		t.Fatalf("probe = %+v, want incomplete contract", got)
+	}
+	if got.ResourceTemplateError == "" {
+		t.Fatalf("resource template error = empty, want resources/templates/list error")
+	}
+}
+
 func TestProjectCairnlineSidecarConnect_ReadyUsesPersistentClientCache(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{
@@ -166,6 +217,9 @@ func TestProjectCairnlineSidecarConnect_ReadyUsesPersistentClientCache(t *testin
 	}
 	if got.ToolCount != len(projectCairnlineSidecarRequiredTools) || len(got.MissingTools) != 0 {
 		t.Fatalf("tool count=%d missing=%+v, want full contract", got.ToolCount, got.MissingTools)
+	}
+	if got.ResourceTemplateCount != len(projectCairnlineSidecarRequiredResourceTemplates) || len(got.MissingResourceTemplates) != 0 {
+		t.Fatalf("resource template count=%d missing=%+v, want full contract", got.ResourceTemplateCount, got.MissingResourceTemplates)
 	}
 	assertSidecarLiveReadDetail(t, got.Detail)
 	for _, name := range []string{"projects.activity", "skills.discover", "work_items.closeout_readiness", "artifacts.create", "handoffs.update_status", "memory_candidates.promote"} {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -1701,6 +1701,14 @@ type MCPProbeToolDescriptor struct {
 	ModelVisible  bool            `json:"model_visible"`
 }
 
+type MCPProbeResourceTemplateDescriptor struct {
+	URITemplate string `json:"uri_template"`
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	MIMEType    string `json:"mime_type,omitempty"`
+}
+
 type ProjectCairnlineSidecarProbeEnvelope struct {
 	Object string                               `json:"object"`
 	Data   ProjectCairnlineSidecarProbeResponse `json:"data"`
@@ -1832,23 +1840,28 @@ type ProjectCairnlineSidecarAssistantRequest struct {
 }
 
 type ProjectCairnlineSidecarProbeResponse struct {
-	Ready                 bool                     `json:"ready"`
-	Status                string                   `json:"status"`
-	Detail                string                   `json:"detail"`
-	Command               string                   `json:"command"`
-	Args                  []string                 `json:"args,omitempty"`
-	DatabasePath          string                   `json:"database_path,omitempty"`
-	ProbeTimeoutMS        int64                    `json:"probe_timeout_ms"`
-	PersistentClient      bool                     `json:"persistent_client,omitempty"`
-	ClientCacheConfigured bool                     `json:"client_cache_configured,omitempty"`
-	ClientCacheEntries    int                      `json:"client_cache_entries,omitempty"`
-	ClientCacheInUse      int                      `json:"client_cache_in_use,omitempty"`
-	ClientCacheIdle       int                      `json:"client_cache_idle,omitempty"`
-	ToolCount             int                      `json:"tool_count"`
-	RequiredTools         []string                 `json:"required_tools"`
-	MissingTools          []string                 `json:"missing_tools,omitempty"`
-	Tools                 []MCPProbeToolDescriptor `json:"tools,omitempty"`
-	Warnings              []string                 `json:"warnings,omitempty"`
+	Ready                     bool                                 `json:"ready"`
+	Status                    string                               `json:"status"`
+	Detail                    string                               `json:"detail"`
+	Command                   string                               `json:"command"`
+	Args                      []string                             `json:"args,omitempty"`
+	DatabasePath              string                               `json:"database_path,omitempty"`
+	ProbeTimeoutMS            int64                                `json:"probe_timeout_ms"`
+	PersistentClient          bool                                 `json:"persistent_client,omitempty"`
+	ClientCacheConfigured     bool                                 `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries        int                                  `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse          int                                  `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle           int                                  `json:"client_cache_idle,omitempty"`
+	ToolCount                 int                                  `json:"tool_count"`
+	RequiredTools             []string                             `json:"required_tools"`
+	MissingTools              []string                             `json:"missing_tools,omitempty"`
+	Tools                     []MCPProbeToolDescriptor             `json:"tools,omitempty"`
+	ResourceTemplateCount     int                                  `json:"resource_template_count"`
+	RequiredResourceTemplates []string                             `json:"required_resource_templates"`
+	MissingResourceTemplates  []string                             `json:"missing_resource_templates,omitempty"`
+	ResourceTemplateError     string                               `json:"resource_template_error,omitempty"`
+	ResourceTemplates         []MCPProbeResourceTemplateDescriptor `json:"resource_templates,omitempty"`
+	Warnings                  []string                             `json:"warnings,omitempty"`
 }
 
 type ProjectCairnlineSidecarReadResponse struct {

--- a/internal/mcp/client/client.go
+++ b/internal/mcp/client/client.go
@@ -167,6 +167,20 @@ func (c *Client) ListResources(ctx context.Context) ([]mcp.Resource, error) {
 	return res.Resources, nil
 }
 
+// ListResourceTemplates fetches resources/templates/list. Templates are
+// metadata-only URI patterns; callers still decide which resources to read.
+func (c *Client) ListResourceTemplates(ctx context.Context) ([]mcp.ResourceTemplate, error) {
+	resp, err := c.call(ctx, "resources/templates/list", nil)
+	if err != nil {
+		return nil, fmt.Errorf("resources/templates/list: %w", err)
+	}
+	var res mcp.ListResourceTemplatesResult
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		return nil, fmt.Errorf("decode resources/templates/list result: %w", err)
+	}
+	return res.ResourceTemplates, nil
+}
+
 // ReadResource fetches a resource by URI. MCP Apps uses this for the
 // raw HTML ui:// resource referenced from tool _meta.ui.resourceUri.
 func (c *Client) ReadResource(ctx context.Context, uri string) (mcp.ReadResourceResult, error) {

--- a/internal/mcp/client/client_test.go
+++ b/internal/mcp/client/client_test.go
@@ -475,6 +475,42 @@ func TestClient_ListAndReadResources(t *testing.T) {
 	}
 }
 
+func TestClient_ListResourceTemplates(t *testing.T) {
+	t.Parallel()
+	transport := newMemTransport()
+	server := newFakeServer(t, transport)
+	server.handle("initialize", func(_ mcp.Request) (any, *mcp.RPCError) {
+		return mcp.InitializeResult{
+			ProtocolVersion: declaredClientProtocolVersion,
+			Capabilities:    mcp.ServerCapabilities{Resources: &mcp.ResourcesCapability{}},
+		}, nil
+	})
+	server.handle("resources/templates/list", func(_ mcp.Request) (any, *mcp.RPCError) {
+		return mcp.ListResourceTemplatesResult{ResourceTemplates: []mcp.ResourceTemplate{{
+			URITemplate: "cairnline://projects/{project_id}",
+			Name:        "project",
+			Title:       "Project",
+			MIMEType:    "application/json",
+		}}}, nil
+	})
+	server.start()
+
+	c := New(transport, mcp.ClientInfo{Name: "h"})
+	t.Cleanup(func() { _ = c.Close(); server.stop() })
+
+	ctx := context.Background()
+	if _, err := c.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	templates, err := c.ListResourceTemplates(ctx)
+	if err != nil {
+		t.Fatalf("ListResourceTemplates: %v", err)
+	}
+	if len(templates) != 1 || templates[0].URITemplate != "cairnline://projects/{project_id}" || templates[0].MIMEType != "application/json" {
+		t.Fatalf("templates = %+v, want project template", templates)
+	}
+}
+
 // TestClient_CallToolSurfacesIsError — tool-level failures arrive
 // as CallToolResult.IsError=true (NOT as a JSON-RPC error). The
 // model uses this to decide whether to retry or give up.

--- a/internal/mcp/client/pool.go
+++ b/internal/mcp/client/pool.go
@@ -461,6 +461,31 @@ func (p *Pool) AllTools() []NamespacedTool {
 	return out
 }
 
+// ListResourceTemplates asks one connected upstream for its URI templates.
+// Pool startup intentionally snapshots only tools; resource templates are
+// operator diagnostics, so callers fetch them on demand from the live client.
+func (p *Pool) ListResourceTemplates(ctx context.Context, serverName string) ([]mcp.ResourceTemplate, error) {
+	serverName = strings.TrimSpace(serverName)
+	p.mu.Lock()
+	pc := p.clients[serverName]
+	cache := p.cache
+	p.mu.Unlock()
+	if pc == nil {
+		return nil, fmt.Errorf("mcp pool: server %q is not connected", serverName)
+	}
+	templates, err := pc.client.ListResourceTemplates(ctx)
+	if err != nil {
+		if cache != nil && IsTransportClosedErr(err) {
+			cache.Evict(pc.cfg)
+		}
+		return nil, err
+	}
+	out := make([]mcp.ResourceTemplate, len(templates))
+	copy(out, templates)
+	sort.Slice(out, func(i, j int) bool { return out[i].URITemplate < out[j].URITemplate })
+	return out, nil
+}
+
 // Call dispatches a namespaced tool call. Returns:
 //   - text: the concatenated text content from the upstream
 //     CallToolResult (one block per line). MCP allows non-text

--- a/internal/mcp/client/pool_test.go
+++ b/internal/mcp/client/pool_test.go
@@ -32,6 +32,10 @@ func newPoolHarness(t *testing.T, serverTools map[string][]mcp.Tool, callHandler
 }
 
 func newPoolHarnessWithResources(t *testing.T, serverTools map[string][]mcp.Tool, callHandlers map[string]map[string]func(json.RawMessage) (mcp.CallToolResult, *mcp.RPCError), resources map[string]map[string]mcp.ResourceContents) *poolHarness {
+	return newPoolHarnessWithResourceTemplates(t, serverTools, callHandlers, resources, nil)
+}
+
+func newPoolHarnessWithResourceTemplates(t *testing.T, serverTools map[string][]mcp.Tool, callHandlers map[string]map[string]func(json.RawMessage) (mcp.CallToolResult, *mcp.RPCError), resources map[string]map[string]mcp.ResourceContents, resourceTemplates map[string][]mcp.ResourceTemplate) *poolHarness {
 	t.Helper()
 	h := &poolHarness{t: t}
 	pool := &Pool{
@@ -82,6 +86,10 @@ func newPoolHarnessWithResources(t *testing.T, serverTools map[string][]mcp.Tool
 				return nil, mcp.NewError(mcp.ErrCodeInvalidParams, "unknown resource: "+params.URI)
 			}
 			return mcp.ReadResourceResult{Contents: []mcp.ResourceContents{content}}, nil
+		})
+		templatesForServer := append([]mcp.ResourceTemplate(nil), resourceTemplates[name]...)
+		server.handle("resources/templates/list", func(req mcp.Request) (any, *mcp.RPCError) {
+			return mcp.ListResourceTemplatesResult{ResourceTemplates: templatesForServer}, nil
 		})
 		server.start()
 		h.stops = append(h.stops, server.stop)
@@ -229,6 +237,46 @@ func TestPool_TwoServersDistinctTools(t *testing.T) {
 	}
 	if !strings.Contains(text, "issue #1") {
 		t.Errorf("create_issue text = %q, want contains 'issue #1'", text)
+	}
+}
+
+func TestPool_ListResourceTemplates(t *testing.T) {
+	t.Parallel()
+	h := newPoolHarnessWithResourceTemplates(t,
+		map[string][]mcp.Tool{
+			"cairnline": {{Name: "projects.list", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+		},
+		map[string]map[string]func(json.RawMessage) (mcp.CallToolResult, *mcp.RPCError){
+			"cairnline": {
+				"projects.list": func(args json.RawMessage) (mcp.CallToolResult, *mcp.RPCError) {
+					return mcp.CallToolResult{Content: mcp.TextContent("[]")}, nil
+				},
+			},
+		},
+		nil,
+		map[string][]mcp.ResourceTemplate{
+			"cairnline": {
+				{URITemplate: "cairnline://projects/{project_id}/work-items/{work_item_id}", Name: "work_item"},
+				{URITemplate: "cairnline://projects/{project_id}", Name: "project"},
+			},
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	templates, err := h.pool.ListResourceTemplates(ctx, "cairnline")
+	if err != nil {
+		t.Fatalf("ListResourceTemplates: %v", err)
+	}
+	if len(templates) != 2 {
+		t.Fatalf("templates = %+v, want 2", templates)
+	}
+	if templates[0].URITemplate != "cairnline://projects/{project_id}" || templates[1].URITemplate != "cairnline://projects/{project_id}/work-items/{work_item_id}" {
+		t.Fatalf("templates = %+v, want sorted Cairnline templates", templates)
+	}
+	if _, err := h.pool.ListResourceTemplates(ctx, "missing"); err == nil {
+		t.Fatal("ListResourceTemplates(missing) error = nil, want error")
 	}
 }
 

--- a/internal/orchestrator/mcp_host.go
+++ b/internal/orchestrator/mcp_host.go
@@ -267,9 +267,11 @@ func NewAgentMCPClientCache(opts AgentMCPClientCacheOptions) *mcpclient.SharedCl
 // catalog with un-namespaced names (the operator-chosen alias does
 // the namespacing at task-spawn time).
 type MCPProbeResult struct {
-	ServerName    string
-	ServerVersion string
-	Tools         []mcpclient.NamespacedTool
+	ServerName            string
+	ServerVersion         string
+	Tools                 []mcpclient.NamespacedTool
+	ResourceTemplates     []mcp.ResourceTemplate
+	ResourceTemplateError string
 }
 
 // ProbeMCPServer brings up a single MCP server with cfg, calls
@@ -287,6 +289,17 @@ type MCPProbeResult struct {
 // admin endpoint passes a 10s context so a stuck upstream surfaces as
 // a clean error rather than wedging the request.
 func ProbeMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher) (*MCPProbeResult, error) {
+	return probeMCPServer(ctx, cfg, cipher, false)
+}
+
+// ProbeMCPServerWithResourceTemplates is the one-shot probe plus an
+// operator-diagnostic resources/templates/list call. Keep it explicit so the
+// general MCP dry-run probe remains a tools-only check.
+func ProbeMCPServerWithResourceTemplates(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher) (*MCPProbeResult, error) {
+	return probeMCPServer(ctx, cfg, cipher, true)
+}
+
+func probeMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher, includeResourceTemplates bool) (*MCPProbeResult, error) {
 	resolved, err := resolveEnvConfigs([]types.MCPServerConfig{cfg}, cipher)
 	if err != nil {
 		return nil, err
@@ -298,7 +311,15 @@ func ProbeMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secre
 	}
 	defer func() { _ = pool.Close() }()
 
-	return mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools()), nil
+	result := mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools())
+	if includeResourceTemplates {
+		if templates, err := pool.ListResourceTemplates(ctx, cfg.Name); err != nil {
+			result.ResourceTemplateError = err.Error()
+		} else {
+			result.ResourceTemplates = templates
+		}
+	}
+	return result, nil
 }
 
 // ProbeCachedMCPServer is the cached-client counterpart to
@@ -308,6 +329,16 @@ func ProbeMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secre
 // for operator-controlled infrastructure clients where "connect and
 // inspect" should leave a warm subprocess for future calls.
 func ProbeCachedMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher, cache *mcpclient.SharedClientCache) (*MCPProbeResult, error) {
+	return probeCachedMCPServer(ctx, cfg, cipher, cache, false)
+}
+
+// ProbeCachedMCPServerWithResourceTemplates is the cached-client counterpart to
+// ProbeMCPServerWithResourceTemplates.
+func ProbeCachedMCPServerWithResourceTemplates(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher, cache *mcpclient.SharedClientCache) (*MCPProbeResult, error) {
+	return probeCachedMCPServer(ctx, cfg, cipher, cache, true)
+}
+
+func probeCachedMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher, cache *mcpclient.SharedClientCache, includeResourceTemplates bool) (*MCPProbeResult, error) {
 	if cache == nil {
 		return nil, errors.New("mcp cached probe: cache is required")
 	}
@@ -322,7 +353,15 @@ func ProbeCachedMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher
 	}
 	defer func() { _ = pool.Close() }()
 
-	return mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools()), nil
+	result := mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools())
+	if includeResourceTemplates {
+		if templates, err := pool.ListResourceTemplates(ctx, cfg.Name); err != nil {
+			result.ResourceTemplateError = err.Error()
+		} else {
+			result.ResourceTemplates = templates
+		}
+	}
+	return result, nil
 }
 
 // CachedMCPToolCallResult is the diagnostic shape returned by


### PR DESCRIPTION
## Summary
- add MCP client/pool support for `resources/templates/list`
- make Cairnline sidecar probe/connect verify the expected portable Projects resource templates
- update sidecar fixture coverage and runtime/operator docs for the alpha-2 template contract

## Validation
- `go test ./internal/mcp/client -run 'TestClient_ListResourceTemplates|TestPool_ListResourceTemplates|TestPool_TwoServersDistinctTools|TestClient_ListAndReadResources'`
- `go test ./internal/api -run 'TestProjectCairnlineSidecar(Probe|Connect)'`
- `go test ./internal/mcp/client ./internal/orchestrator ./internal/api`
- `go vet ./internal/mcp/client ./internal/orchestrator ./internal/api`
- `just docs-check`
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...`
