### PR TITLE
feat(projects): add Cairnline sidecar resource smoke

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -365,6 +365,9 @@ cached standalone Cairnline MCP client. Operators can then run
 read-only `projects.list` MCP tool, or
 `POST /hecate/v1/projects/cairnline/sidecar-detail-smoke` to call read-only
 `projects.get`, through that persistent client. Operators can also run
+`POST /hecate/v1/projects/cairnline/sidecar-resource-smoke` to read a concrete
+`cairnline://projects/...` MCP resource through that persistent client.
+Operators can also run
 `POST /hecate/v1/projects/cairnline/sidecar-coordination-smoke` to call the
 read-only portable coordination list tools (`projects.list`, `skills.list`,
 `roles.list`, `work_items.list`, and `assignments.list`) and confirm Hecate can parse their typed
@@ -501,10 +504,11 @@ The sidecar probe/connect surfaces are configured with
 tool presence plus the portable Projects `resources/templates/list` contract.
 `sidecar-connect` keeps the process warm in Hecate's
 Cairnline-specific MCP client cache. `sidecar-read-smoke`,
-`sidecar-detail-smoke`, `sidecar-coordination-smoke`,
-`sidecar-assignment-context-smoke`, and `sidecar-launch-packet-smoke` use that
-cached client to call read-only Cairnline MCP tools and return diagnostic
-evidence. `sidecar-lifecycle-smoke` is opt-in mutation evidence for the
+`sidecar-detail-smoke`, `sidecar-resource-smoke`,
+`sidecar-coordination-smoke`, `sidecar-assignment-context-smoke`, and
+`sidecar-launch-packet-smoke` use that cached client to call read-only
+Cairnline MCP tools/resources and return diagnostic evidence.
+`sidecar-lifecycle-smoke` is opt-in mutation evidence for the
 standalone sidecar assignment lifecycle. `sidecar-write-smoke`,
 `sidecar-setup-smoke`, `sidecar-work-smoke`,
 `sidecar-collaboration-smoke`, `sidecar-memory-smoke`, and

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -48,7 +48,7 @@ context, exposed from `GET /hecate/v1/whoami` as `data.remote_identity`, added t
 the top-level HTTP span attributes, and accepted in place of the local
 runtime/inference shared tokens. Remote mode rejects local-only endpoints for
 workspace picker/open, reset-data, shutdown, MCP probe, Cairnline sidecar
-probe/connect/read/detail/coordination/assignment-context/launch-packet,
+probe/connect/read/detail/resource/coordination/assignment-context/launch-packet,
 Cairnline sidecar lifecycle/write/setup/work/collaboration/memory/assistant
 smokes, plugin-registry management, agent-adapter authenticate, and local
 provider and MCP registry discovery. Hecate-native `/hecate/v1/*` routes are
@@ -471,11 +471,13 @@ sequenceDiagram
   embedded Cairnline Go package bridge and optional embedded mirror database.
   `sidecar` can start a standalone Cairnline MCP process through the
   local-only `sidecar-probe` endpoint, connect a cached client through
-  `POST /hecate/v1/projects/cairnline/sidecar-connect`, or call read-only
+  `POST /hecate/v1/projects/cairnline/sidecar-connect`, call read-only
   `projects.list` / `projects.get` through the `sidecar-read-smoke` and
-  `sidecar-detail-smoke` endpoints. `sidecar-coordination-smoke` also calls
-  the read-only portable coordination list tools and checks their typed
-  `structuredContent` arrays. `sidecar-assignment-context-smoke` calls
+  `sidecar-detail-smoke` endpoints, or call `resources/read` through
+  `sidecar-resource-smoke` for the selected Cairnline project resource.
+  `sidecar-coordination-smoke` also calls the read-only portable coordination
+  list tools and checks their typed `structuredContent` arrays.
+  `sidecar-assignment-context-smoke` calls
   read-only `assignments.context`, and `sidecar-launch-packet-smoke` calls
   read-only `assignments.launch_packet`; both check typed MCP-pull assignment
   metadata. `sidecar-lifecycle-smoke` is the assignment mutation smoke: after
@@ -2819,13 +2821,16 @@ the local-only read smoke that calls Cairnline's read-only `projects.list` tool
 through that cached client. `cairnline_sidecar_detail_url` points at the
 local-only detail smoke that calls Cairnline's read-only `projects.get` tool,
 using either an explicit `project_id` or the first typed project from
-`projects.list`. The remaining sidecar smoke URLs cover coordination list
-tools, assignment context, launch packets, the explicitly confirmed standalone
-assignment lifecycle, the explicitly confirmed temporary-project write smoke,
-the explicitly confirmed temporary root/context-source setup smoke, and the
-explicitly confirmed temporary role/work/assignment/context/launch-packet work
-smoke, plus confirmed collaboration, memory, and Project Assistant
-proposal/apply smokes. None of these changes live route authority.
+`projects.list`. `cairnline_sidecar_resource_url` points at a local-only
+resource smoke that reads a concrete `cairnline://projects/...` resource
+through MCP `resources/read`. The remaining sidecar smoke URLs cover
+coordination list tools, assignment context, launch packets, the explicitly
+confirmed standalone assignment lifecycle, the explicitly confirmed
+temporary-project write smoke, the explicitly confirmed temporary
+root/context-source setup smoke, and the explicitly confirmed temporary
+role/work/assignment/context/launch-packet work smoke, plus confirmed
+collaboration, memory, and Project Assistant proposal/apply smokes. None of
+these changes live route authority.
 
 Example response, with `write_switchpoints` shortened for readability:
 
@@ -3098,6 +3103,7 @@ Example response, with `write_switchpoints` shortened for readability:
     "cairnline_sidecar_connect_url": "/hecate/v1/projects/cairnline/sidecar-connect",
     "cairnline_sidecar_read_url": "/hecate/v1/projects/cairnline/sidecar-read-smoke",
     "cairnline_sidecar_detail_url": "/hecate/v1/projects/cairnline/sidecar-detail-smoke",
+    "cairnline_sidecar_resource_url": "/hecate/v1/projects/cairnline/sidecar-resource-smoke",
     "cairnline_sidecar_coordination_url": "/hecate/v1/projects/cairnline/sidecar-coordination-smoke",
     "cairnline_sidecar_assignment_context_url": "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke",
     "cairnline_sidecar_launch_packet_url": "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke",
@@ -3623,6 +3629,58 @@ Example response, shortened:
       ]
     },
     "warnings": []
+  }
+}
+```
+
+### `POST /hecate/v1/projects/cairnline/sidecar-resource-smoke`
+
+Local-only standalone Cairnline MCP resource-read smoke. It uses the same
+sidecar command, database, timeout, and Cairnline-specific MCP client cache as
+`sidecar-connect`. With an empty body, Hecate first calls read-only
+`projects.list`, selects the first typed project id, and reads
+`cairnline://projects/{project_id}` through MCP `resources/read`. A request can
+also provide `{"project_id":"proj_123"}` or a concrete
+`{"resource_uri":"cairnline://projects/proj_123"}`.
+
+This endpoint is diagnostic only. It proves the standalone Cairnline sidecar
+can serve concrete MCP resources after advertising resource templates. It does
+not switch live Projects routing, mirroring, dispatch, approvals, or write
+authority.
+
+The response reports:
+
+- `requested_project_id` and `requested_resource_uri` when supplied.
+- `selected_project_id`, `selected_project_source`, and `resource_uri`.
+- `list_*` fields when Hecate had to call `projects.list` to select a project.
+- `contents` and `content_count` from MCP `resources/read`.
+- `structured_ready` and `structured_project_id` when Hecate can parse a
+  project resource body.
+- The same persistent-client cache counters as `sidecar-connect`.
+
+Example response, shortened:
+
+```json
+{
+  "object": "project_cairnline_sidecar_resource",
+  "data": {
+    "ready": true,
+    "status": "sidecar_resource_ready",
+    "command": "cairnline",
+    "read_only": true,
+    "selected_project_id": "proj_123",
+    "selected_project_source": "projects.list",
+    "resource_uri": "cairnline://projects/proj_123",
+    "content_count": 1,
+    "contents": [
+      {
+        "uri": "cairnline://projects/proj_123",
+        "mime_type": "application/json",
+        "text": "{\n  \"project\": {\"id\": \"proj_123\"}\n}"
+      }
+    ],
+    "structured_ready": true,
+    "structured_project_id": "proj_123"
   }
 }
 ```

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -83,6 +83,13 @@ func cairnlineSidecarFixtureMain(mode string) {
 				break
 			}
 			result = mcp.ListResourceTemplatesResult{ResourceTemplates: cairnlineSidecarFixtureResourceTemplates(mode)}
+		case "resources/read":
+			var params mcp.ReadResourceParams
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				rpcErr = mcp.NewError(mcp.ErrCodeInvalidParams, "invalid resources/read params")
+				break
+			}
+			result, rpcErr = cairnlineSidecarFixtureReadResource(mode, state, params.URI)
 		case "tools/call":
 			var params mcp.CallToolParams
 			if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -175,6 +182,43 @@ func cairnlineSidecarFixtureResourceTemplates(mode string) []mcp.ResourceTemplat
 		})
 	}
 	return templates
+}
+
+func cairnlineSidecarFixtureReadResource(mode string, state *cairnlineSidecarFixtureState, uri string) (mcp.ReadResourceResult, *mcp.RPCError) {
+	if cairnlineSidecarFixtureModeHas(mode, "resource-read-error") {
+		return mcp.ReadResourceResult{}, mcp.NewError(mcp.ErrCodeInternalError, "resource read fixture failure")
+	}
+	const prefix = "cairnline://projects/"
+	projectID := strings.TrimPrefix(strings.TrimSpace(uri), prefix)
+	if projectID == uri || projectID == "" || strings.Contains(projectID, "/") {
+		return mcp.ReadResourceResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "unsupported fixture resource uri")
+	}
+	project := ProjectCairnlineSidecarProjectItem{
+		ID:   "proj_fixture",
+		Name: "Fixture Project",
+	}
+	if items := cairnlineSidecarFixtureProjects(mode, state); len(items) > 0 {
+		for _, item := range items {
+			if item.ID == projectID {
+				project = item
+				break
+			}
+		}
+	}
+	if project.ID != projectID {
+		return mcp.ReadResourceResult{}, mcp.NewError(mcp.ErrCodeInvalidParams, "fixture project not found")
+	}
+	raw, err := json.MarshalIndent(map[string]any{
+		"project": project,
+	}, "", "  ")
+	if err != nil {
+		return mcp.ReadResourceResult{}, mcp.NewError(mcp.ErrCodeInternalError, err.Error())
+	}
+	return mcp.ReadResourceResult{Contents: []mcp.ResourceContents{{
+		URI:      uri,
+		MIMEType: "application/json",
+		Text:     string(raw),
+	}}}, nil
 }
 
 func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixtureState, params mcp.CallToolParams) (mcp.CallToolResult, *mcp.RPCError) {

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -139,7 +139,7 @@ func projectCairnlineConnectorReady(mode string) bool {
 func projectCairnlineConnectorDetail(mode string) string {
 	switch mode {
 	case "sidecar":
-		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " through the standalone Cairnline MCP client; writes and migration remain on Hecate-native stores or embedded dogfood paths."
+		return "Cairnline sidecar connector is configured and can be exercised through local-only probe/connect/read/detail/resource/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics. HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar routes only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " through the standalone Cairnline MCP client; writes and migration remain on Hecate-native stores or embedded dogfood paths."
 	default:
 		return "Hecate is using the embedded Cairnline Go package bridge for replacement-readiness dogfood."
 	}
@@ -149,7 +149,7 @@ func projectCairnlineConnectorWarning(mode string) string {
 	if mode != "sidecar" {
 		return ""
 	}
-	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " through the sidecar."
+	return "HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar enables standalone Cairnline MCP probe/connect/read/detail/resource/coordination/assignment-context/launch-packet/lifecycle/write/setup/work/collaboration/memory/assistant diagnostics; add HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar to route only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " through the sidecar."
 }
 
 func projectCairnlineSidecarLiveReadDetail() string {
@@ -197,6 +197,20 @@ func (h *Handler) HandleProjectCairnlineSidecarDetailSmoke(w http.ResponseWriter
 	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarDetailEnvelope{
 		Object: "project_cairnline_sidecar_detail",
 		Data:   h.projectCairnlineSidecarDetailSmoke(r.Context(), req),
+	})
+}
+
+func (h *Handler) HandleProjectCairnlineSidecarResourceSmoke(w http.ResponseWriter, r *http.Request) {
+	if !requireLoopbackClient(w, r, "Cairnline sidecar resource smoke") {
+		return
+	}
+	var req ProjectCairnlineSidecarResourceRequest
+	if !decodeOptionalJSON(w, r, &req) {
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineSidecarResourceEnvelope{
+		Object: "project_cairnline_sidecar_resource",
+		Data:   h.projectCairnlineSidecarResourceSmoke(r.Context(), req),
 	})
 }
 
@@ -666,6 +680,135 @@ func (h *Handler) projectCairnlineSidecarDetailSmoke(ctx context.Context, req Pr
 	response.Ready = true
 	response.Status = "sidecar_detail_ready"
 	response.Detail = "Hecate called the read-only Cairnline sidecar projects.get tool through the persistent sidecar client. " + projectCairnlineSidecarLiveReadDetail()
+	return response
+}
+
+func (h *Handler) projectCairnlineSidecarResourceSmoke(ctx context.Context, req ProjectCairnlineSidecarResourceRequest) ProjectCairnlineSidecarResourceResponse {
+	const listToolName = "projects.list"
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg, dbPath, timeout := h.projectCairnlineSidecarMCPConfig()
+	requestedProjectID := strings.TrimSpace(req.ProjectID)
+	requestedResourceURI := strings.TrimSpace(req.ResourceURI)
+	response := ProjectCairnlineSidecarResourceResponse{
+		Ready:                 false,
+		Status:                "sidecar_resource_not_run",
+		Detail:                "Cairnline sidecar resource smoke has not run.",
+		Command:               cfg.Command,
+		Args:                  append([]string(nil), cfg.Args...),
+		DatabasePath:          dbPath,
+		ProbeTimeoutMS:        timeout.Milliseconds(),
+		PersistentClient:      true,
+		ClientCacheConfigured: h != nil,
+		ReadOnly:              true,
+		RequestedProjectID:    requestedProjectID,
+		RequestedResourceURI:  requestedResourceURI,
+	}
+	if h == nil {
+		response.Status = "sidecar_resource_failed"
+		response.Detail = "Cairnline sidecar resource smoke requires an API handler."
+		return response
+	}
+	if h.projectCairnlineConnectorMode() != "sidecar" {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_CONNECTOR is not sidecar; this resource smoke does not affect live Projects routing.")
+	}
+	if dbPath != "" && len(h.config.ProjectsCairnlineSidecarArgs()) > 0 {
+		response.Warnings = append(response.Warnings, "HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS is set, so HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB is reported but not appended automatically.")
+	}
+
+	cache := h.projectCairnlineSidecarMCPClientCache()
+	resourceCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	resourceURI := requestedResourceURI
+	projectID := requestedProjectID
+	if resourceURI != "" {
+		if !strings.HasPrefix(resourceURI, "cairnline://projects/") {
+			response.Status = "sidecar_resource_invalid_uri"
+			response.Detail = "Cairnline sidecar resource smoke only reads cairnline://projects/... resource URIs."
+			response.setSidecarCacheStats(cache.Stats())
+			return response
+		}
+		if projectID == "" {
+			projectID = projectCairnlineSidecarProjectIDFromResourceURI(resourceURI)
+			if projectID != "" {
+				response.SelectedProjectSource = "resource_uri"
+			}
+		}
+	} else {
+		if projectID == "" {
+			listResult, err := orchestrator.CallCachedMCPServerTool(resourceCtx, cfg, h.secretCipher, cache, listToolName, json.RawMessage(`{}`))
+			if err != nil {
+				response.Status = "sidecar_resource_failed"
+				response.Detail = err.Error()
+				response.setSidecarCacheStats(cache.Stats())
+				return response
+			}
+			response.ListToolText = listResult.Text
+			response.ListToolIsError = listResult.IsError
+			response.ListStructuredContent = listResult.Result.StructuredContent
+			response.ListMeta = listResult.Result.Meta
+			if listResult.IsError {
+				response.Status = "sidecar_resource_list_tool_failed"
+				response.Detail = "Cairnline sidecar projects.list returned a tool-level error before Hecate could select a project resource. " + projectCairnlineSidecarLiveReadDetail()
+				response.setSidecarCacheStats(cache.Stats())
+				return response
+			}
+			projects, structuredReady, structuredErr := projectCairnlineSidecarStructuredProjects(listResult.Result.StructuredContent)
+			response.ListStructuredReady = structuredReady
+			response.ListProjectCount = len(projects)
+			if structuredErr != nil {
+				response.ListStructuredParseError = structuredErr.Error()
+				response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list returned structuredContent that Hecate could not parse as a project list.")
+			} else if !structuredReady {
+				response.Warnings = append(response.Warnings, "Cairnline sidecar projects.list did not return structuredContent, so Hecate could not select a project resource.")
+			} else if len(projects) > 0 {
+				projectID = strings.TrimSpace(projects[0].ID)
+				response.SelectedProjectSource = "projects.list"
+			}
+			if projectID == "" {
+				response.Status = "sidecar_resource_no_project"
+				response.Detail = "Hecate called Cairnline sidecar projects.list through the persistent sidecar client, but no typed project id was available for resources/read."
+				response.setSidecarCacheStats(cache.Stats())
+				return response
+			}
+		} else {
+			response.SelectedProjectSource = "request"
+		}
+		resourceURI = "cairnline://projects/" + projectID
+	}
+	response.SelectedProjectID = projectID
+	response.ResourceURI = resourceURI
+
+	result, err := orchestrator.ReadCachedMCPServerResource(resourceCtx, cfg, h.secretCipher, cache, resourceURI)
+	if err != nil {
+		response.Status = "sidecar_resource_failed"
+		response.Detail = err.Error()
+		response.setSidecarCacheStats(cache.Stats())
+		return response
+	}
+	response.Contents = renderMCPResourceContents(result.Result.Contents)
+	response.ContentCount = len(response.Contents)
+	response.setSidecarCacheStats(cache.Stats())
+	if response.ContentCount == 0 {
+		response.Status = "sidecar_resource_empty"
+		response.Detail = "Cairnline sidecar resources/read returned no content for the selected resource."
+		return response
+	}
+	if projectIDFromBody, ok, err := projectCairnlineSidecarProjectResourceID(response.Contents); err != nil {
+		response.StructuredParseError = err.Error()
+		response.Warnings = append(response.Warnings, "Cairnline sidecar project resource returned JSON that Hecate could not parse.")
+	} else if ok {
+		response.StructuredReady = true
+		response.StructuredProjectID = projectIDFromBody
+		if projectID != "" && projectIDFromBody != projectID {
+			response.Warnings = append(response.Warnings, "Cairnline sidecar project resource returned a project id different from the selected id.")
+		}
+	}
+	response.Ready = true
+	response.Status = "sidecar_resource_ready"
+	response.Detail = "Hecate read a Cairnline MCP resource through the persistent sidecar client. " + projectCairnlineSidecarLiveReadDetail()
 	return response
 }
 
@@ -4280,6 +4423,15 @@ func (r *ProjectCairnlineSidecarDetailResponse) setSidecarCacheStats(stats mcpcl
 	r.ClientCacheIdle = stats.Idle
 }
 
+func (r *ProjectCairnlineSidecarResourceResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
+	if r == nil {
+		return
+	}
+	r.ClientCacheEntries = stats.Entries
+	r.ClientCacheInUse = stats.InUse
+	r.ClientCacheIdle = stats.Idle
+}
+
 func (r *ProjectCairnlineSidecarCoordinationResponse) setSidecarCacheStats(stats mcpclient.CacheStats) {
 	if r == nil {
 		return
@@ -4408,6 +4560,49 @@ func (h *Handler) cairnlineSidecarDatabasePath() string {
 		path = abs
 	}
 	return path
+}
+
+func renderMCPResourceContents(contents []mcp.ResourceContents) []ProjectCairnlineSidecarResourceContent {
+	out := make([]ProjectCairnlineSidecarResourceContent, 0, len(contents))
+	for _, content := range contents {
+		out = append(out, ProjectCairnlineSidecarResourceContent{
+			URI:      content.URI,
+			MIMEType: content.MIMEType,
+			Text:     content.Text,
+			Blob:     content.Blob,
+			Meta:     append(json.RawMessage(nil), content.Meta...),
+		})
+	}
+	return out
+}
+
+func projectCairnlineSidecarProjectIDFromResourceURI(uri string) string {
+	const prefix = "cairnline://projects/"
+	rest := strings.TrimPrefix(strings.TrimSpace(uri), prefix)
+	if rest == "" || rest == uri || strings.Contains(rest, "/") {
+		return ""
+	}
+	return rest
+}
+
+func projectCairnlineSidecarProjectResourceID(contents []ProjectCairnlineSidecarResourceContent) (string, bool, error) {
+	for _, content := range contents {
+		text := strings.TrimSpace(content.Text)
+		if text == "" {
+			continue
+		}
+		var payload struct {
+			Project struct {
+				ID string `json:"id"`
+			} `json:"project"`
+		}
+		if err := json.Unmarshal([]byte(text), &payload); err != nil {
+			return "", false, err
+		}
+		id := strings.TrimSpace(payload.Project.ID)
+		return id, id != "", nil
+	}
+	return "", false, nil
 }
 
 func projectCairnlineSidecarToolNames(tools []MCPProbeToolDescriptor) []string {

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -406,6 +406,61 @@ func TestProjectCairnlineSidecarDetailSmoke_UsesRequestedProjectID(t *testing.T)
 	}
 }
 
+func TestProjectCairnlineSidecarResourceSmoke_ReadsSelectedProjectResource(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarResourceSmoke(t.Context(), ProjectCairnlineSidecarResourceRequest{})
+	if !got.Ready || got.Status != "sidecar_resource_ready" {
+		t.Fatalf("resource smoke = %+v, want ready", got)
+	}
+	if !got.ReadOnly || got.SelectedProjectID != "proj_fixture" || got.SelectedProjectSource != "projects.list" {
+		t.Fatalf("selection = read_only:%t project:%q source:%q, want projects.list-selected read-only resource", got.ReadOnly, got.SelectedProjectID, got.SelectedProjectSource)
+	}
+	if got.ResourceURI != "cairnline://projects/proj_fixture" {
+		t.Fatalf("resource uri = %q, want project resource", got.ResourceURI)
+	}
+	if got.ContentCount != 1 || len(got.Contents) != 1 {
+		t.Fatalf("content count = %d contents=%+v, want one resource content", got.ContentCount, got.Contents)
+	}
+	if got.Contents[0].MIMEType != "application/json" || !strings.Contains(got.Contents[0].Text, "Fixture Project") {
+		t.Fatalf("content = %+v, want JSON fixture project", got.Contents[0])
+	}
+	if !got.StructuredReady || got.StructuredProjectID != "proj_fixture" {
+		t.Fatalf("structured = ready:%t project:%q parse:%q, want fixture project id", got.StructuredReady, got.StructuredProjectID, got.StructuredParseError)
+	}
+	if got.ClientCacheEntries != 1 || got.ClientCacheInUse != 0 || got.ClientCacheIdle != 1 {
+		t.Fatalf("cache stats = entries:%d in_use:%d idle:%d, want 1/0/1", got.ClientCacheEntries, got.ClientCacheInUse, got.ClientCacheIdle)
+	}
+}
+
+func TestProjectCairnlineSidecarResourceSmoke_RejectsNonCairnlineURI(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "full"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarResourceSmoke(t.Context(), ProjectCairnlineSidecarResourceRequest{ResourceURI: "https://example.com/not-a-resource"})
+	if got.Ready || got.Status != "sidecar_resource_invalid_uri" {
+		t.Fatalf("resource smoke = %+v, want invalid uri status", got)
+	}
+	if got.ContentCount != 0 || len(got.Contents) != 0 {
+		t.Fatalf("contents = count:%d %+v, want no sidecar read", got.ContentCount, got.Contents)
+	}
+}
+
 func TestProjectCairnlineSidecarDetailSmoke_TextOnlyListCannotSelectProject(t *testing.T) {
 	handler := NewHandler(config.Config{
 		Projects: config.ProjectsConfig{

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -17,6 +17,7 @@ const projectCoordinationBackendSidecarProbeURL = "/hecate/v1/projects/cairnline
 const projectCoordinationBackendSidecarConnectURL = "/hecate/v1/projects/cairnline/sidecar-connect"
 const projectCoordinationBackendSidecarReadURL = "/hecate/v1/projects/cairnline/sidecar-read-smoke"
 const projectCoordinationBackendSidecarDetailURL = "/hecate/v1/projects/cairnline/sidecar-detail-smoke"
+const projectCoordinationBackendSidecarResourceURL = "/hecate/v1/projects/cairnline/sidecar-resource-smoke"
 const projectCoordinationBackendSidecarCoordinationURL = "/hecate/v1/projects/cairnline/sidecar-coordination-smoke"
 const projectCoordinationBackendSidecarAssignmentContextURL = "/hecate/v1/projects/cairnline/sidecar-assignment-context-smoke"
 const projectCoordinationBackendSidecarLaunchPacketURL = "/hecate/v1/projects/cairnline/sidecar-launch-packet-smoke"
@@ -360,6 +361,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 		CairnlineSidecarConnectURL:           projectCoordinationBackendSidecarConnectURL,
 		CairnlineSidecarReadURL:              projectCoordinationBackendSidecarReadURL,
 		CairnlineSidecarDetailURL:            projectCoordinationBackendSidecarDetailURL,
+		CairnlineSidecarResourceURL:          projectCoordinationBackendSidecarResourceURL,
 		CairnlineSidecarCoordinationURL:      projectCoordinationBackendSidecarCoordinationURL,
 		CairnlineSidecarAssignmentContextURL: projectCoordinationBackendSidecarAssignmentContextURL,
 		CairnlineSidecarLaunchPacketURL:      projectCoordinationBackendSidecarLaunchPacketURL,
@@ -517,6 +519,7 @@ func projectCairnlineProbeMethod(url string) string {
 		projectCoordinationBackendSidecarConnectURL,
 		projectCoordinationBackendSidecarReadURL,
 		projectCoordinationBackendSidecarDetailURL,
+		projectCoordinationBackendSidecarResourceURL,
 		projectCoordinationBackendSidecarCoordinationURL,
 		projectCoordinationBackendSidecarAssignmentContextURL,
 		projectCoordinationBackendSidecarLaunchPacketURL,

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -582,6 +582,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	CairnlineSidecarConnectURL           string                                       `json:"cairnline_sidecar_connect_url,omitempty"`
 	CairnlineSidecarReadURL              string                                       `json:"cairnline_sidecar_read_url,omitempty"`
 	CairnlineSidecarDetailURL            string                                       `json:"cairnline_sidecar_detail_url,omitempty"`
+	CairnlineSidecarResourceURL          string                                       `json:"cairnline_sidecar_resource_url,omitempty"`
 	CairnlineSidecarCoordinationURL      string                                       `json:"cairnline_sidecar_coordination_url,omitempty"`
 	CairnlineSidecarAssignmentContextURL string                                       `json:"cairnline_sidecar_assignment_context_url,omitempty"`
 	CairnlineSidecarLaunchPacketURL      string                                       `json:"cairnline_sidecar_launch_packet_url,omitempty"`
@@ -1729,6 +1730,11 @@ type ProjectCairnlineSidecarDetailEnvelope struct {
 	Data   ProjectCairnlineSidecarDetailResponse `json:"data"`
 }
 
+type ProjectCairnlineSidecarResourceEnvelope struct {
+	Object string                                  `json:"object"`
+	Data   ProjectCairnlineSidecarResourceResponse `json:"data"`
+}
+
 type ProjectCairnlineSidecarCoordinationEnvelope struct {
 	Object string                                      `json:"object"`
 	Data   ProjectCairnlineSidecarCoordinationResponse `json:"data"`
@@ -1781,6 +1787,11 @@ type ProjectCairnlineSidecarAssistantEnvelope struct {
 
 type ProjectCairnlineSidecarDetailRequest struct {
 	ProjectID string `json:"project_id,omitempty"`
+}
+
+type ProjectCairnlineSidecarResourceRequest struct {
+	ProjectID   string `json:"project_id,omitempty"`
+	ResourceURI string `json:"resource_uri,omitempty"`
 }
 
 type ProjectCairnlineSidecarCoordinationRequest struct {
@@ -1923,6 +1934,48 @@ type ProjectCairnlineSidecarDetailResponse struct {
 	StructuredProject        ProjectCairnlineSidecarProjectItem `json:"structured_project,omitempty"`
 	StructuredParseError     string                             `json:"structured_parse_error,omitempty"`
 	Warnings                 []string                           `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarResourceResponse struct {
+	Ready                    bool                                     `json:"ready"`
+	Status                   string                                   `json:"status"`
+	Detail                   string                                   `json:"detail"`
+	Command                  string                                   `json:"command"`
+	Args                     []string                                 `json:"args,omitempty"`
+	DatabasePath             string                                   `json:"database_path,omitempty"`
+	ProbeTimeoutMS           int64                                    `json:"probe_timeout_ms"`
+	PersistentClient         bool                                     `json:"persistent_client,omitempty"`
+	ClientCacheConfigured    bool                                     `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries       int                                      `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse         int                                      `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle          int                                      `json:"client_cache_idle,omitempty"`
+	ReadOnly                 bool                                     `json:"read_only"`
+	RequestedProjectID       string                                   `json:"requested_project_id,omitempty"`
+	RequestedResourceURI     string                                   `json:"requested_resource_uri,omitempty"`
+	SelectedProjectID        string                                   `json:"selected_project_id,omitempty"`
+	SelectedProjectSource    string                                   `json:"selected_project_source,omitempty"`
+	ResourceURI              string                                   `json:"resource_uri,omitempty"`
+	ListToolText             string                                   `json:"list_tool_text,omitempty"`
+	ListToolIsError          bool                                     `json:"list_tool_is_error,omitempty"`
+	ListStructuredContent    json.RawMessage                          `json:"list_structured_content,omitempty"`
+	ListMeta                 json.RawMessage                          `json:"list_meta,omitempty"`
+	ListStructuredReady      bool                                     `json:"list_structured_ready"`
+	ListProjectCount         int                                      `json:"list_project_count"`
+	ListStructuredParseError string                                   `json:"list_structured_parse_error,omitempty"`
+	ContentCount             int                                      `json:"content_count"`
+	Contents                 []ProjectCairnlineSidecarResourceContent `json:"contents,omitempty"`
+	StructuredReady          bool                                     `json:"structured_ready"`
+	StructuredProjectID      string                                   `json:"structured_project_id,omitempty"`
+	StructuredParseError     string                                   `json:"structured_parse_error,omitempty"`
+	Warnings                 []string                                 `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineSidecarResourceContent struct {
+	URI      string          `json:"uri"`
+	MIMEType string          `json:"mime_type,omitempty"`
+	Text     string          `json:"text,omitempty"`
+	Blob     string          `json:"blob,omitempty"`
+	Meta     json.RawMessage `json:"meta,omitempty"`
 }
 
 type ProjectCairnlineSidecarCoordinationResponse struct {

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -34,6 +34,7 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-memory-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-probe"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-read-smoke"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-resource-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-setup-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-write-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-work-smoke"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -93,6 +93,7 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-assistant-smoke", handler.HandleProjectCairnlineSidecarAssistantSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-probe", handler.HandleProjectCairnlineSidecarProbe)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-read-smoke", handler.HandleProjectCairnlineSidecarReadSmoke)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-resource-smoke", handler.HandleProjectCairnlineSidecarResourceSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-setup-smoke", handler.HandleProjectCairnlineSidecarSetupSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-write-smoke", handler.HandleProjectCairnlineSidecarWriteSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-work-smoke", handler.HandleProjectCairnlineSidecarWorkSmoke)

--- a/internal/mcp/client/pool.go
+++ b/internal/mcp/client/pool.go
@@ -486,6 +486,37 @@ func (p *Pool) ListResourceTemplates(ctx context.Context, serverName string) ([]
 	return out, nil
 }
 
+// ReadResource asks one connected upstream for a concrete resource URI.
+// Resource reads are operator diagnostics / MCP Apps plumbing, not part of
+// model-origin tool dispatch.
+func (p *Pool) ReadResource(ctx context.Context, serverName, uri string) (mcp.ReadResourceResult, error) {
+	serverName = strings.TrimSpace(serverName)
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return mcp.ReadResourceResult{}, errors.New("mcp pool: resource uri is required")
+	}
+	p.mu.Lock()
+	pc := p.clients[serverName]
+	cache := p.cache
+	p.mu.Unlock()
+	if pc == nil {
+		return mcp.ReadResourceResult{}, fmt.Errorf("mcp pool: server %q is not connected", serverName)
+	}
+	read, err := pc.client.ReadResource(ctx, uri)
+	if err != nil {
+		if cache != nil && IsTransportClosedErr(err) {
+			cache.Evict(pc.cfg)
+		}
+		return mcp.ReadResourceResult{}, err
+	}
+	out := mcp.ReadResourceResult{Contents: make([]mcp.ResourceContents, len(read.Contents))}
+	for i, content := range read.Contents {
+		out.Contents[i] = content
+		out.Contents[i].Meta = cloneRawMessage(content.Meta)
+	}
+	return out, nil
+}
+
 // Call dispatches a namespaced tool call. Returns:
 //   - text: the concatenated text content from the upstream
 //     CallToolResult (one block per line). MCP allows non-text

--- a/internal/mcp/client/pool_test.go
+++ b/internal/mcp/client/pool_test.go
@@ -280,6 +280,48 @@ func TestPool_ListResourceTemplates(t *testing.T) {
 	}
 }
 
+func TestPool_ReadResource(t *testing.T) {
+	t.Parallel()
+	h := newPoolHarnessWithResources(t,
+		map[string][]mcp.Tool{
+			"cairnline": {{Name: "projects.list", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+		},
+		map[string]map[string]func(json.RawMessage) (mcp.CallToolResult, *mcp.RPCError){
+			"cairnline": {
+				"projects.list": func(args json.RawMessage) (mcp.CallToolResult, *mcp.RPCError) {
+					return mcp.CallToolResult{Content: mcp.TextContent("[]")}, nil
+				},
+			},
+		},
+		map[string]map[string]mcp.ResourceContents{
+			"cairnline": {
+				"cairnline://projects/proj_1": {
+					URI:      "cairnline://projects/proj_1",
+					MIMEType: "application/json",
+					Text:     `{"project":{"id":"proj_1","name":"Fixture"}}`,
+				},
+			},
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	read, err := h.pool.ReadResource(ctx, "cairnline", "cairnline://projects/proj_1")
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	if len(read.Contents) != 1 || read.Contents[0].URI != "cairnline://projects/proj_1" || !strings.Contains(read.Contents[0].Text, `"proj_1"`) {
+		t.Fatalf("contents = %+v, want project resource", read.Contents)
+	}
+	if _, err := h.pool.ReadResource(ctx, "missing", "cairnline://projects/proj_1"); err == nil {
+		t.Fatal("ReadResource(missing server) error = nil, want error")
+	}
+	if _, err := h.pool.ReadResource(ctx, "cairnline", ""); err == nil {
+		t.Fatal("ReadResource(empty uri) error = nil, want error")
+	}
+}
+
 func TestPool_MCPAppsVisibilityHidesAppOnlyToolsFromModel(t *testing.T) {
 	t.Parallel()
 	h := newPoolHarness(t,

--- a/internal/orchestrator/mcp_host.go
+++ b/internal/orchestrator/mcp_host.go
@@ -375,6 +375,14 @@ type CachedMCPToolCallResult struct {
 	Result   mcp.CallToolResult
 }
 
+// CachedMCPResourceReadResult is the diagnostic shape returned by
+// ReadCachedMCPServerResource. It proves a persistent MCP client can read
+// concrete resources without wiring model-origin dispatch to that sidecar.
+type CachedMCPResourceReadResult struct {
+	URI    string
+	Result mcp.ReadResourceResult
+}
+
 // CallCachedMCPServerTool invokes a single tool on one MCP server through a
 // SharedClientCache. It is intentionally a narrow operator-diagnostic seam: the
 // agent loop still uses AgentMCPHostFactory, while sidecar/readiness probes can
@@ -407,6 +415,38 @@ func CallCachedMCPServerTool(ctx context.Context, cfg types.MCPServerConfig, cip
 		Text:     result.Text,
 		IsError:  result.IsError,
 		Result:   result.Result,
+	}, nil
+}
+
+// ReadCachedMCPServerResource reads a concrete resource from one MCP server
+// through a SharedClientCache. It intentionally stays separate from the
+// agent-loop host seam; resources are operator/client diagnostics, not LLM tool
+// calls.
+func ReadCachedMCPServerResource(ctx context.Context, cfg types.MCPServerConfig, cipher secrets.Cipher, cache *mcpclient.SharedClientCache, uri string) (*CachedMCPResourceReadResult, error) {
+	if cache == nil {
+		return nil, errors.New("cached mcp resource read requires a client cache")
+	}
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return nil, errors.New("cached mcp resource read requires a resource uri")
+	}
+	resolved, err := resolveEnvConfigs([]types.MCPServerConfig{cfg}, cipher)
+	if err != nil {
+		return nil, err
+	}
+	clientCfgs := toClientServerConfigs(resolved)
+	pool, err := mcpclient.NewPoolWithCache(ctx, clientCfgs, cache)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = pool.Close() }()
+	result, err := pool.ReadResource(ctx, strings.TrimSpace(cfg.Name), uri)
+	if err != nil {
+		return nil, err
+	}
+	return &CachedMCPResourceReadResult{
+		URI:    uri,
+		Result: result,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- add a local-only Cairnline sidecar resource smoke route for MCP `resources/read`
- extend the shared MCP client cache path with concrete resource reads
- document the new diagnostic URL and sidecar evidence path

## Tests
- go test ./internal/mcp/client -run 'TestPool_(ReadResource|ListResourceTemplates)'\n- go test ./internal/api -run 'TestProjectCairnlineSidecar(ResourceSmoke|Probe|Connect)|TestRemoteRuntimePolicy|TestRegisteredRoutes'\n- go test ./internal/mcp/client ./internal/orchestrator ./internal/api\n- go vet ./internal/mcp/client ./internal/orchestrator ./internal/api\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n