### PR TITLE
feat(projects): preview cairnline next action

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -68,9 +68,11 @@ When Cairnline dogfood or replacement mode is configured, the Projects cockpit
 also shows a compact **Project coordination** strip above the workspace. It is
 read-only status from `GET /hecate/v1/projects/backend-status`; use it to
 confirm whether portable project coordination is still Hecate-native, in
-Cairnline dogfood, or reporting Cairnline authoritative. Use **Backend
-settings** to jump to the global Settings workspace for full gates, probes, and
-copyable configuration hints.
+Cairnline dogfood, or reporting Cairnline authoritative. The strip previews the
+server-recommended next replacement action, target, probe count, and copyable
+environment hints when backend status provides them. Use **Backend settings** to
+jump to the global Settings workspace for full gates, ordered probe checklists,
+and migration evidence.
 
 The Work Coordination tab starts with Project Operations when the server finds
 actionable project state: missing launch defaults, pending approvals, blocked

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -474,6 +474,14 @@ describe("ProjectWorkspaceView", () => {
           label: "Move next authority",
           detail: "Move the next portable write authority.",
           target: "skills",
+          config_hints: [
+            {
+              env: "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY",
+              value: "project-skills",
+              detail: "Enable skill metadata writes.",
+            },
+          ],
+          probes: [{ method: "GET", url: "/hecate/v1/projects/{id}/cairnline/read-model" }],
         },
       }),
     });
@@ -484,6 +492,14 @@ describe("ProjectWorkspaceView", () => {
     expect(within(strip).getByText("1 portable gap")).toBeTruthy();
     expect(within(strip).getByText("1 migration blocker")).toBeTruthy();
     expect(within(strip).getByText("1 runtime boundary")).toBeTruthy();
+    expect(within(strip).getByText("Next")).toBeTruthy();
+    expect(within(strip).getByText("Move next authority")).toBeTruthy();
+    expect(within(strip).getByText("skills")).toBeTruthy();
+    expect(within(strip).getByText("1 probe")).toBeTruthy();
+    expect(
+      within(strip).getByText("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills"),
+    ).toBeTruthy();
+    expect(within(strip).getByRole("button", { name: "copy" })).toBeTruthy();
 
     await userEvent.click(within(strip).getByRole("button", { name: "Backend settings" }));
     expect(handlers.onOpenSystemSettings).toHaveBeenCalledTimes(1);

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -23,7 +23,7 @@ import type {
   ProjectWorkRoleRecord,
   UpdateProjectSkillPayload,
 } from "../../types/project";
-import { Badge, Icon, Icons, InlineError } from "../shared/ui";
+import { Badge, CopyBtn, Icon, Icons, InlineError } from "../shared/ui";
 import { ProjectAssistantPanel } from "./ProjectAssistantPanel";
 import { ProjectMemoryPanel } from "./ProjectMemoryPanel";
 import { ProjectSkillsPanel } from "./ProjectSkillsPanel";
@@ -531,7 +531,12 @@ function ProjectCoordinationStatusStrip({
     : status.write_adapter_ready
       ? "Cairnline portable writes ready"
       : "Cairnline dogfood active";
-  const detail = status.next_replacement_action?.detail || status.detail;
+  const nextAction = status.next_replacement_action;
+  const detail = nextAction?.detail || status.detail;
+  const configHints = nextAction?.config_hints ?? [];
+  const probeCount = nextAction
+    ? (nextAction.probes?.length ?? nextAction.probe_urls?.length ?? 0)
+    : 0;
 
   return (
     <section aria-label="Project coordination backend" style={projectCoordinationStripStyle}>
@@ -543,6 +548,29 @@ function ProjectCoordinationStatusStrip({
           <div style={titleStyle}>{title}</div>
         </div>
         <div style={subtleTextStyle}>{detail}</div>
+        {nextAction && (
+          <div style={projectCoordinationNextActionStyle}>
+            <span style={sectionLabelStyle}>Next</span>
+            <span style={projectCoordinationNextTitleStyle}>{nextAction.label}</span>
+            {nextAction.target && (
+              <span className="badge badge-muted">{nextAction.target.replaceAll("-", " ")}</span>
+            )}
+            {probeCount > 0 && (
+              <span className="badge badge-muted">
+                {probeCount} probe{probeCount === 1 ? "" : "s"}
+              </span>
+            )}
+            {configHints.map((hint) => {
+              const assignment = `${hint.env}=${hint.value}`;
+              return (
+                <span key={assignment} style={projectCoordinationHintStyle}>
+                  <code style={projectCoordinationHintCodeStyle}>{assignment}</code>
+                  <CopyBtn text={assignment} />
+                </span>
+              );
+            })}
+          </div>
+        )}
       </div>
       <div style={projectCoordinationStripMetaStyle}>
         <span className="badge badge-muted">reads {status.cairnline_read_source ?? "auto"}</span>
@@ -1357,6 +1385,41 @@ const projectCoordinationStripMainStyle: CSSProperties = {
   flex: "1 1 320px",
   gap: 5,
   minWidth: 0,
+};
+
+const projectCoordinationNextActionStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 6,
+  minWidth: 0,
+  paddingTop: 2,
+};
+
+const projectCoordinationNextTitleStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 12,
+  fontWeight: 650,
+};
+
+const projectCoordinationHintStyle: CSSProperties = {
+  alignItems: "center",
+  background: "var(--bg3)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "inline-flex",
+  gap: 5,
+  maxWidth: "100%",
+  minWidth: 0,
+  padding: "3px 4px 3px 7px",
+};
+
+const projectCoordinationHintCodeStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  overflowWrap: "anywhere",
+  whiteSpace: "normal",
 };
 
 const projectCoordinationStripMetaStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- show the backend-status next Cairnline replacement action directly in the Projects coordination strip
- render target/probe count and copyable env hints when provided
- update operator docs for the cockpit preview

## Tests
- cd ui && bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx
- cd ui && bun run typecheck
- just docs-check