### PR TITLE
docs(projects): document cairnline env presets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,29 @@ HECATE_PROVIDER_ANTHROPIC_CACHE_ENABLED=true
 # Projects live in the storage backend selected by HECATE_BACKEND.
 # Durable project identities for future project-scoped defaults, memory,
 # context assembly, and chat/task grouping.
+#
+# Cairnline is Hecate's portable Projects coordination backend. Defaults stay
+# Hecate-native; use the presets below only when dogfooding the Cairnline path.
+# For the full source-runtime shortcut, prefer:
+#   just dev-cairnline-projects --reset
+#
+# Embedded Cairnline dogfood:
+# HECATE_PROJECTS_COORDINATION_BACKEND=cairnline
+# HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded
+# HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=auto
+#
+# Embedded Cairnline replacement-mode dogfood:
+# HECATE_PROJECTS_COORDINATION_BACKEND=cairnline
+# HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded
+# HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded
+# HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded
+#
+# Standalone Cairnline sidecar interoperability smoke:
+# HECATE_PROJECTS_COORDINATION_BACKEND=cairnline
+# HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar
+# HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar
+# HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND=cairnline
+# HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB=.data/cairnline/sidecar/projects.db
 
 # Chat sessions
 # Chat state lives in the storage backend selected by HECATE_BACKEND:


### PR DESCRIPTION
## Summary
- document commented Cairnline Projects env presets in `.env.example`
- point operators at the existing `just dev-cairnline-projects --reset` shortcut
- keep defaults unchanged by leaving every Cairnline setting commented out

## Validation
- `just docs-check`
