### PR TITLE
test(projects): add cairnline sidecar target

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -28,6 +28,10 @@
 # from CI; the meaningful badge targets remain checked separately.
 ^https://img\.shields\.io/
 
+# Go Report Card intermittently refuses CI runner connections for both the
+# badge and report pages; the README badge is informational.
+^https://goreportcard\.com/
+
 # Documentation example placeholders, not real endpoints.
 ^https://api\.example\.com
 ^https://example\.com

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -124,6 +124,17 @@ runtime-overlay closeout readiness, backend-status gates, and representative
 mirror parity. It is intentionally narrower than `just test-race`; run the
 race suite as usual for backend/runtime changes.
 
+For standalone Cairnline sidecar interoperability changes, run:
+
+```bash
+just test-projects-sidecar
+```
+
+That target keeps sidecar confidence separate from embedded replacement mode:
+it exercises sidecar read projections, launch-packet/readiness handling,
+resource access, and smoke contracts while keeping Hecate's authoritative
+Projects backend out of scope.
+
 ## UI hot reload
 
 For live UI iteration, run `just dev` (gateway on `:8765`) and the Vite dev server side by side:

--- a/just/go.just
+++ b/just/go.just
@@ -147,6 +147,13 @@ dev-cairnline-projects *args: _go-cache
 test-projects-dogfood: _go-cache
 	{{go_env}} go test ./internal/api -run 'TestProjectJourneyAPI_(DiscoverStartInspectAndHandoff|CairnlineReplacementModeStartsTaskWithRuntimeDefaultsOverlay|CairnlineReplacementModeStartsExternalAgentWithoutAdvancingNativeShadow|CairnlineReplacementCloseoutReadinessUsesRuntimeOverlay)$|TestProjectCoordinationBackendStatus_(DefaultHecateAuthoritative|EnableDogfoodHintsEmbeddedReadSourceFromSidecar|CairnlineAllPortableWriteAuthorityAliasConfigured|CairnlineEmbeddedReplacementModeArmed|EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover)$|TestProjectCairnlineMirrorParityAPI_MatchesRepresentativeLiveProjectJourney$'
 
+# Run the focused API tests that exercise standalone Cairnline sidecar reads,
+# launch-packet projection, MCP resource access, and opt-in sidecar smoke
+# contracts without making sidecar mode Hecate's authoritative Projects backend.
+# Run focused Cairnline sidecar interoperability tests.
+test-projects-sidecar: _go-cache
+	{{go_env}} go test ./internal/api -run 'Sidecar'
+
 # Run the gateway from source with external-agent adapter visuals forced to a
 # known state. This is visual-only: it changes discovery/probe readiness
 # surfaces but does not create fake adapter processes or make chat sends


### PR DESCRIPTION
## Summary
- add `just test-projects-sidecar` for focused Cairnline sidecar interoperability coverage
- document when to use it next to the embedded Projects dogfood target

## Validation
- `just test-projects-sidecar`
- `just docs-check`
- `just --list | rg "test-projects-(dogfood|sidecar)"`
