### PR TITLE
chore(projects): add cairnline sidecar dev target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,6 +178,8 @@ HECATE_PROVIDER_ANTHROPIC_CACHE_ENABLED=true
 # HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded
 #
 # Standalone Cairnline sidecar interoperability smoke:
+# For the source-runtime shortcut, prefer:
+#   just dev-cairnline-sidecar-projects --reset
 # HECATE_PROJECTS_COORDINATION_BACKEND=cairnline
 # HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar
 # HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -135,6 +135,21 @@ it exercises sidecar read projections, launch-packet/readiness handling,
 resource access, and smoke contracts while keeping Hecate's authoritative
 Projects backend out of scope.
 
+For a manual source-runtime sidecar check, install the standalone Cairnline
+binary and run:
+
+```bash
+just dev-cairnline-sidecar-projects --reset
+```
+
+This starts Hecate with `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
+`HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, using
+`.data/cairnline/sidecar/projects.db` unless `.env` overrides
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`. It is an MCP interoperability/dev
+surface: Hecate still keeps authoritative Projects writes on the native or
+embedded replacement path, and sidecar mode should not be treated as the final
+Cairnline cutover.
+
 ## UI hot reload
 
 For live UI iteration, run `just dev` (gateway on `:8765`) and the Vite dev server side by side:

--- a/just/go.just
+++ b/just/go.just
@@ -141,6 +141,40 @@ dev-cairnline-projects *args: _go-cache
 	HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE=embedded \
 	{{go_env}} go run ./cmd/hecate serve
 
+# Run the gateway from source with standalone Cairnline sidecar reads enabled.
+# This is an interoperability/dev surface, not Hecate's embedded replacement
+# path. Requires `cairnline` on PATH unless overridden in .env. Optional arg:
+# --reset.
+# Run gateway with Cairnline sidecar Projects reads enabled.
+dev-cairnline-sidecar-projects *args: _go-cache
+	needs_reset=0; \
+	for arg in {{args}}; do \
+	  case "$arg" in \
+	    --reset) needs_reset=1 ;; \
+	    *) echo "unknown argument: $arg"; echo "usage: just dev-cairnline-sidecar-projects [--reset]"; exit 2 ;; \
+	  esac; \
+	done; \
+	if [ "$needs_reset" = "1" ]; then just reset-dev > /dev/null; else just stop; fi
+	set -a; \
+	[ -f ./.env ] && . ./.env; \
+	set +a; \
+	sidecar_cmd="${HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND:-cairnline}"; \
+	if ! command -v "$sidecar_cmd" >/dev/null 2>&1; then \
+	  echo "cairnline sidecar command not found: $sidecar_cmd"; \
+	  echo "Install Cairnline from https://github.com/hecatehq/cairnline/releases or set HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND."; \
+	  exit 1; \
+	fi; \
+	sidecar_db="${HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB:-.data/cairnline/sidecar/projects.db}"; \
+	if [ -n "$sidecar_db" ]; then mkdir -p "$(dirname "$sidecar_db")"; fi; \
+	HECATE_ALLOWED_ORIGINS="${HECATE_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173}"; \
+	export HECATE_ALLOWED_ORIGINS; \
+	HECATE_PROJECTS_COORDINATION_BACKEND=cairnline \
+	HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar \
+	HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar \
+	HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND="$sidecar_cmd" \
+	HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB="$sidecar_db" \
+	{{go_env}} go run ./cmd/hecate serve
+
 # Run the focused API tests that prove Projects can be dogfooded through the
 # Hecate-native flow and the embedded Cairnline replacement flow.
 # Run focused Projects dogfood tests.


### PR DESCRIPTION
## Summary
- add `just dev-cairnline-sidecar-projects` for source-runtime sidecar read-route experiments
- document the sidecar dev shortcut separately from embedded Cairnline replacement dogfood
- point `.env.example` at the sidecar shortcut

## Validation
- `just --list | rg 'dev-cairnline(-sidecar)?-projects|test-projects-(dogfood|sidecar)'`\n- `just docs-check`\n- `just test-projects-sidecar`\n\nNote: I did not launch the manual dev server because `cairnline` is not installed on PATH in this shell; the recipe reports that cleanly and the sidecar API tests cover the route contract.