### PR TITLE
docs(projects): point sidecar setup at cairnline alpha 3

### DIFF
--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -136,7 +136,7 @@ resource access, and smoke contracts while keeping Hecate's authoritative
 Projects backend out of scope.
 
 For a manual source-runtime sidecar check, install the standalone Cairnline
-binary and run:
+`v0.1.0-alpha.3` binary or newer, confirm `cairnline -version`, and run:
 
 ```bash
 just dev-cairnline-sidecar-projects --reset

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -490,12 +490,12 @@ their identity/metadata/root/source/default seams unless their explicit
 write-authority switchpoints are enabled; this is replacement-readiness
 evidence, not write authority.
 For sidecar experiments, install the standalone `cairnline` binary from the
-[Cairnline `v0.1.0-alpha.2` prerelease](https://github.com/hecatehq/cairnline/releases/tag/v0.1.0-alpha.2)
-or build it with `go install github.com/hecatehq/cairnline/cmd/cairnline@v0.1.0-alpha.2`,
-then point `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND` at that binary if it is
-not already on `PATH`. The sidecar path is for MCP interoperability evidence;
-embedded Cairnline remains the replacement target for Hecate's own Projects
-backend.
+[Cairnline `v0.1.0-alpha.3` prerelease](https://github.com/hecatehq/cairnline/releases/tag/v0.1.0-alpha.3)
+or build it with `go install github.com/hecatehq/cairnline/cmd/cairnline@v0.1.0-alpha.3`,
+then run `cairnline -version` and point
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND` at that binary if it is not already
+on `PATH`. The sidecar path is for MCP interoperability evidence; embedded
+Cairnline remains the replacement target for Hecate's own Projects backend.
 The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`,
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,


### PR DESCRIPTION
## Summary
- update Hecate sidecar install guidance to Cairnline `v0.1.0-alpha.3`
- tell operators/contributors to verify the sidecar binary with `cairnline -version`

## Validation
- `just docs-check`