### PR TITLE
chore(projects): bump cairnline to alpha 4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.1.0-alpha.2
+	github.com/hecatehq/cairnline v0.1.0-alpha.4
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.1.0-alpha.2 h1:DQcsvgHURoMc9hhToFahr6SVP/Q5E/dU/rEzT8XhOjQ=
-github.com/hecatehq/cairnline v0.1.0-alpha.2/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.1.0-alpha.4 h1:xJ/L15HiRhb7d7EFP/TQ4/z2xiWvdUllDF6u0twNoo0=
+github.com/hecatehq/cairnline v0.1.0-alpha.4/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
## Summary
- bump the embedded Cairnline Go module to v0.1.0-alpha.4
- align Hecate's embedded dependency with the sidecar setup docs and latest Cairnline release

## Validation
- go test ./internal/cairnlinebridge ./internal/api -run 'Cairnline|Sidecar'\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...