### PR TITLE
chore(projects): verify cairnline sidecar version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,6 +180,7 @@ HECATE_PROVIDER_ANTHROPIC_CACHE_ENABLED=true
 # Standalone Cairnline sidecar interoperability smoke:
 # For the source-runtime shortcut, prefer:
 #   just dev-cairnline-sidecar-projects --reset
+# The shortcut verifies `cairnline -version` before starting Hecate.
 # HECATE_PROJECTS_COORDINATION_BACKEND=cairnline
 # HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar
 # HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -145,10 +145,12 @@ just dev-cairnline-sidecar-projects --reset
 This starts Hecate with `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=sidecar`, using
 `.data/cairnline/sidecar/projects.db` unless `.env` overrides
-`HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`. It is an MCP interoperability/dev
-surface: Hecate still keeps authoritative Projects writes on the native or
-embedded replacement path, and sidecar mode should not be treated as the final
-Cairnline cutover.
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`. The recipe prints the detected
+Cairnline version before launch, so binaries that do not support the version
+probe fail before Hecate starts. It is an MCP interoperability/dev surface:
+Hecate still keeps authoritative Projects writes on the native or embedded
+replacement path, and sidecar mode should not be treated as the final Cairnline
+cutover.
 
 ## UI hot reload
 

--- a/just/go.just
+++ b/just/go.just
@@ -164,6 +164,11 @@ dev-cairnline-sidecar-projects *args: _go-cache
 	  echo "Install Cairnline from https://github.com/hecatehq/cairnline/releases or set HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND."; \
 	  exit 1; \
 	fi; \
+	if ! "$sidecar_cmd" -version; then \
+	  echo "could not read Cairnline sidecar version from: $sidecar_cmd"; \
+	  echo "Install Cairnline v0.1.0-alpha.4 or newer from https://github.com/hecatehq/cairnline/releases."; \
+	  exit 1; \
+	fi; \
 	sidecar_db="${HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB:-.data/cairnline/sidecar/projects.db}"; \
 	if [ -n "$sidecar_db" ]; then mkdir -p "$(dirname "$sidecar_db")"; fi; \
 	HECATE_ALLOWED_ORIGINS="${HECATE_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173}"; \


### PR DESCRIPTION
## Summary
- print `cairnline -version` before starting the sidecar Projects dev runtime
- fail early when the configured sidecar command cannot answer the version probe
- document the preflight in env and contributor docs

## Validation
- just --dry-run dev-cairnline-sidecar-projects --reset
- just docs-check