### PR TITLE
chore(projects): surface cairnline sidecar server info

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -502,7 +502,9 @@ The sidecar probe/connect surfaces are configured with
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_ARGS`,
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`, and
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_PROBE_TIMEOUT`. `sidecar-probe` verifies MCP
-tool presence plus the portable Projects `resources/templates/list` contract.
+tool presence plus the portable Projects `resources/templates/list` contract
+and reports the sidecar's MCP initialize `serverInfo` as `server_name` /
+`server_version`.
 `sidecar-connect` keeps the process warm in Hecate's
 Cairnline-specific MCP client cache. `sidecar-read-smoke`,
 `sidecar-detail-smoke`, `sidecar-resource-smoke`,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -760,7 +760,7 @@ GET /hecate/v1/mcp/registry/servers?search=weather&limit=10
 
 Registry discovery does not install packages, spawn servers, or call `tools/list`; it only returns catalog metadata and Hecate-specific connection hints. Use `POST /hecate/v1/mcp/probe` on a selected config to inspect the live tool catalog before committing it to a task.
 
-`POST /hecate/v1/mcp/probe` is the dry-run discovery surface for an MCP server config. It accepts a single MCP server entry (same shape as one item in the task-create `mcp_servers` array — `name` defaults to `probe` when omitted), brings the server up the way an `agent_loop` run would (same secret resolution, same uncached spawn path), calls `tools/list`, and tears it down. Returns the upstream's tool catalog so operators can confirm the config before committing it to a task. The endpoint is local-only: non-loopback sockets and forwarded-client headers are rejected before command handling.
+`POST /hecate/v1/mcp/probe` is the dry-run discovery surface for an MCP server config. It accepts a single MCP server entry (same shape as one item in the task-create `mcp_servers` array — `name` defaults to `probe` when omitted), brings the server up the way an `agent_loop` run would (same secret resolution, same uncached spawn path), calls `tools/list`, and tears it down. Returns the upstream's initialize `serverInfo` plus tool catalog so operators can confirm the config before committing it to a task. The endpoint is local-only: non-loopback sockets and forwarded-client headers are rejected before command handling.
 
 ```json
 POST /hecate/v1/mcp/probe
@@ -773,6 +773,8 @@ POST /hecate/v1/mcp/probe
 {
   "object": "mcp_probe",
   "data": {
+    "server_name": "filesystem",
+    "server_version": "0.6.2",
     "tools": [
       {
         "name": "get_weather",
@@ -3236,6 +3238,8 @@ Example response, shortened:
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
     "probe_timeout_ms": 10000,
+    "server_name": "cairnline",
+    "server_version": "v0.1.0-alpha.4",
     "tool_count": 81,
     "required_tools": ["projects.list", "projects.get", "projects.create"],
     "missing_tools": [],
@@ -3458,6 +3462,8 @@ Example response, shortened:
     "args": ["-db", "/Users/alice/.local/share/hecate/cairnline/projects.db"],
     "database_path": "/Users/alice/.local/share/hecate/cairnline/projects.db",
     "probe_timeout_ms": 10000,
+    "server_name": "cairnline",
+    "server_version": "v0.1.0-alpha.4",
     "persistent_client": true,
     "client_cache_configured": true,
     "client_cache_entries": 1,

--- a/internal/api/handler_admin.go
+++ b/internal/api/handler_admin.go
@@ -280,12 +280,9 @@ func (h *Handler) HandleMCPProbe(w http.ResponseWriter, r *http.Request) {
 	WriteJSON(w, http.StatusOK, MCPProbeResponse{
 		Object: "mcp_probe",
 		Data: MCPProbeResponseItem{
-			// ServerName / ServerVersion not surfaced from Pool.Tools
-			// today (the namespacing is alias-based); leaving them
-			// empty until the client package exposes the upstream
-			// initialize result. Tools alone is the headline value
-			// operators want.
-			Tools: renderMCPProbeTools(result.Tools),
+			ServerName:    result.ServerName,
+			ServerVersion: result.ServerVersion,
+			Tools:         renderMCPProbeTools(result.Tools),
 		},
 	})
 }

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -393,6 +393,8 @@ func (h *Handler) projectCairnlineSidecarProbe(ctx context.Context) ProjectCairn
 		response.Detail = err.Error()
 		return response
 	}
+	response.ServerName = result.ServerName
+	response.ServerVersion = result.ServerVersion
 	response.Tools = renderMCPProbeTools(result.Tools)
 	response.ToolCount = len(response.Tools)
 	response.ResourceTemplates = renderMCPProbeResourceTemplates(result.ResourceTemplates)
@@ -464,6 +466,8 @@ func (h *Handler) projectCairnlineSidecarConnect(ctx context.Context) ProjectCai
 		response.setSidecarCacheStats(cache.Stats())
 		return response
 	}
+	response.ServerName = result.ServerName
+	response.ServerVersion = result.ServerVersion
 	response.Tools = renderMCPProbeTools(result.Tools)
 	response.ToolCount = len(response.Tools)
 	response.ResourceTemplates = renderMCPProbeResourceTemplates(result.ResourceTemplates)

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -107,6 +107,9 @@ func TestProjectCairnlineSidecarProbe_Ready(t *testing.T) {
 	if got.ToolCount != len(projectCairnlineSidecarRequiredTools) {
 		t.Fatalf("tool count = %d, want %d", got.ToolCount, len(projectCairnlineSidecarRequiredTools))
 	}
+	if got.ServerName != "cairnline-fixture" || got.ServerVersion != "test" {
+		t.Fatalf("server identity = %q/%q, want cairnline-fixture/test", got.ServerName, got.ServerVersion)
+	}
 	if got.ResourceTemplateCount != len(projectCairnlineSidecarRequiredResourceTemplates) {
 		t.Fatalf("resource template count = %d, want %d", got.ResourceTemplateCount, len(projectCairnlineSidecarRequiredResourceTemplates))
 	}
@@ -217,6 +220,9 @@ func TestProjectCairnlineSidecarConnect_ReadyUsesPersistentClientCache(t *testin
 	}
 	if got.ToolCount != len(projectCairnlineSidecarRequiredTools) || len(got.MissingTools) != 0 {
 		t.Fatalf("tool count=%d missing=%+v, want full contract", got.ToolCount, got.MissingTools)
+	}
+	if got.ServerName != "cairnline-fixture" || got.ServerVersion != "test" {
+		t.Fatalf("server identity = %q/%q, want cairnline-fixture/test", got.ServerName, got.ServerVersion)
 	}
 	if got.ResourceTemplateCount != len(projectCairnlineSidecarRequiredResourceTemplates) || len(got.MissingResourceTemplates) != 0 {
 		t.Fatalf("resource template count=%d missing=%+v, want full contract", got.ResourceTemplateCount, got.MissingResourceTemplates)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -1858,6 +1858,8 @@ type ProjectCairnlineSidecarProbeResponse struct {
 	Args                      []string                             `json:"args,omitempty"`
 	DatabasePath              string                               `json:"database_path,omitempty"`
 	ProbeTimeoutMS            int64                                `json:"probe_timeout_ms"`
+	ServerName                string                               `json:"server_name,omitempty"`
+	ServerVersion             string                               `json:"server_version,omitempty"`
 	PersistentClient          bool                                 `json:"persistent_client,omitempty"`
 	ClientCacheConfigured     bool                                 `json:"client_cache_configured,omitempty"`
 	ClientCacheEntries        int                                  `json:"client_cache_entries,omitempty"`

--- a/internal/mcp/client/pool.go
+++ b/internal/mcp/client/pool.go
@@ -93,12 +93,13 @@ type ToolCallAppResource struct {
 //     as a non-nil error.
 //   - Close shuts every client down. Idempotent.
 type Pool struct {
-	mu       sync.Mutex
-	cache    *SharedClientCache               // optional; nil = per-run lifetime
-	clients  map[string]*pooledClient         // server name → client + cache release
-	tools    []NamespacedTool                 // sorted, stable
-	allTools []NamespacedTool                 // includes app-only MCP Apps tools
-	bind     map[string]namespacedToolBinding // namespaced name → routing info
+	mu         sync.Mutex
+	cache      *SharedClientCache               // optional; nil = per-run lifetime
+	clients    map[string]*pooledClient         // server name → client + cache release
+	serverInfo map[string]mcp.ServerInfo        // server name → initialize serverInfo
+	tools      []NamespacedTool                 // sorted, stable
+	allTools   []NamespacedTool                 // includes app-only MCP Apps tools
+	bind       map[string]namespacedToolBinding // namespaced name → routing info
 }
 
 // pooledClient pairs a Client with the bookkeeping the Pool needs to
@@ -177,8 +178,9 @@ type clientFactory func(ctx context.Context, cfg ServerConfig) (*Client, []mcp.T
 // dispatch.
 func buildPool(ctx context.Context, configs []ServerConfig, factory clientFactory) (*Pool, error) {
 	p := &Pool{
-		clients: make(map[string]*pooledClient, len(configs)),
-		bind:    make(map[string]namespacedToolBinding),
+		clients:    make(map[string]*pooledClient, len(configs)),
+		serverInfo: make(map[string]mcp.ServerInfo, len(configs)),
+		bind:       make(map[string]namespacedToolBinding),
 	}
 	seenToolNames := make(map[string]struct{})
 	// Cleanup on partial-failure aborts: tear down whatever's already
@@ -207,8 +209,14 @@ func buildPool(ctx context.Context, configs []ServerConfig, factory clientFactor
 			cleanup()
 			return nil, fmt.Errorf("mcp pool: server %q: %w", name, err)
 		}
+		initRes, err := client.Initialize(ctx)
+		if err != nil {
+			cleanup()
+			return nil, fmt.Errorf("mcp pool: server %q initialize result: %w", name, err)
+		}
 
 		p.clients[name] = &pooledClient{client: client, cfg: cfg, release: release}
+		p.serverInfo[name] = initRes.ServerInfo
 		for _, t := range serverTools {
 			nt := namespacedToolFromMCP(name, t)
 			if _, dup := seenToolNames[nt.Name]; dup {
@@ -230,6 +238,19 @@ func buildPool(ctx context.Context, configs []ServerConfig, factory clientFactor
 	sort.Slice(p.tools, func(i, j int) bool { return p.tools[i].Name < p.tools[j].Name })
 	sort.Slice(p.allTools, func(i, j int) bool { return p.allTools[i].Name < p.allTools[j].Name })
 	return p, nil
+}
+
+// ServerInfo returns the upstream server identity captured during initialize.
+// The key is the operator-configured server name, not the upstream's reported
+// name.
+func (p *Pool) ServerInfo(serverName string) (mcp.ServerInfo, bool) {
+	if p == nil {
+		return mcp.ServerInfo{}, false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	info, ok := p.serverInfo[strings.TrimSpace(serverName)]
+	return info, ok
 }
 
 func namespacedToolFromMCP(serverName string, t mcp.Tool) NamespacedTool {

--- a/internal/mcp/client/pool_test.go
+++ b/internal/mcp/client/pool_test.go
@@ -39,8 +39,9 @@ func newPoolHarnessWithResourceTemplates(t *testing.T, serverTools map[string][]
 	t.Helper()
 	h := &poolHarness{t: t}
 	pool := &Pool{
-		clients: make(map[string]*pooledClient, len(serverTools)),
-		bind:    make(map[string]namespacedToolBinding),
+		clients:    make(map[string]*pooledClient, len(serverTools)),
+		serverInfo: make(map[string]mcp.ServerInfo, len(serverTools)),
+		bind:       make(map[string]namespacedToolBinding),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	t.Cleanup(cancel)
@@ -95,7 +96,8 @@ func newPoolHarnessWithResourceTemplates(t *testing.T, serverTools map[string][]
 		h.stops = append(h.stops, server.stop)
 
 		client := New(transport, mcp.ClientInfo{Name: "hecate-test", Version: "0.0.0"})
-		if _, err := client.Initialize(ctx); err != nil {
+		initRes, err := client.Initialize(ctx)
+		if err != nil {
 			t.Fatalf("server %q initialize: %v", name, err)
 		}
 		serverTools, err := client.ListTools(ctx)
@@ -103,6 +105,7 @@ func newPoolHarnessWithResourceTemplates(t *testing.T, serverTools map[string][]
 			t.Fatalf("server %q list tools: %v", name, err)
 		}
 		pool.clients[name] = &pooledClient{client: client}
+		pool.serverInfo[name] = initRes.ServerInfo
 		for _, tt := range serverTools {
 			nt := namespacedToolFromMCP(name, tt)
 			pool.allTools = append(pool.allTools, nt)
@@ -134,6 +137,26 @@ func sortNamespacedTools(t []NamespacedTool) {
 		for j := i; j > 0 && t[j-1].Name > t[j].Name; j-- {
 			t[j-1], t[j] = t[j], t[j-1]
 		}
+	}
+}
+
+func TestPool_ServerInfoReportsInitializeIdentity(t *testing.T) {
+	h := newPoolHarness(t,
+		map[string][]mcp.Tool{
+			"projects": {{Name: "list", InputSchema: json.RawMessage(`{}`)}},
+		},
+		map[string]map[string]func(json.RawMessage) (mcp.CallToolResult, *mcp.RPCError){},
+	)
+
+	info, ok := h.pool.ServerInfo("projects")
+	if !ok {
+		t.Fatal("ServerInfo ok = false, want true")
+	}
+	if info.Name != "projects" || info.Version != "0.0.0" {
+		t.Fatalf("ServerInfo = %+v, want projects/0.0.0", info)
+	}
+	if _, ok := h.pool.ServerInfo("missing"); ok {
+		t.Fatal("ServerInfo(missing) ok = true, want false")
 	}
 }
 

--- a/internal/orchestrator/mcp_host.go
+++ b/internal/orchestrator/mcp_host.go
@@ -311,7 +311,7 @@ func probeMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher secre
 	}
 	defer func() { _ = pool.Close() }()
 
-	result := mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools())
+	result := mcpProbeResultFromPool(cfg.Name, pool)
 	if includeResourceTemplates {
 		if templates, err := pool.ListResourceTemplates(ctx, cfg.Name); err != nil {
 			result.ResourceTemplateError = err.Error()
@@ -353,7 +353,7 @@ func probeCachedMCPServer(ctx context.Context, cfg types.MCPServerConfig, cipher
 	}
 	defer func() { _ = pool.Close() }()
 
-	result := mcpProbeResultFromPoolTools(cfg.Name, pool.AllTools())
+	result := mcpProbeResultFromPool(cfg.Name, pool)
 	if includeResourceTemplates {
 		if templates, err := pool.ListResourceTemplates(ctx, cfg.Name); err != nil {
 			result.ResourceTemplateError = err.Error()
@@ -448,6 +448,18 @@ func ReadCachedMCPServerResource(ctx context.Context, cfg types.MCPServerConfig,
 		URI:    uri,
 		Result: result,
 	}, nil
+}
+
+func mcpProbeResultFromPool(serverName string, pool *mcpclient.Pool) *MCPProbeResult {
+	if pool == nil {
+		return &MCPProbeResult{}
+	}
+	out := mcpProbeResultFromPoolTools(serverName, pool.AllTools())
+	if info, ok := pool.ServerInfo(serverName); ok {
+		out.ServerName = strings.TrimSpace(info.Name)
+		out.ServerVersion = strings.TrimSpace(info.Version)
+	}
+	return out
 }
 
 func mcpProbeResultFromPoolTools(serverName string, tools []mcpclient.NamespacedTool) *MCPProbeResult {


### PR DESCRIPTION
## Summary
- capture MCP initialize serverInfo in the shared MCP client pool
- surface server_name/server_version on generic MCP probe and Cairnline sidecar probe/connect responses
- add pool and sidecar connector coverage plus runtime/operator docs

## Validation
- go test ./internal/mcp/client ./internal/orchestrator ./internal/api -run 'MCP|CairnlineSidecar'\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./internal/mcp/client ./internal/orchestrator ./internal/api\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...\n- just docs-check\n