### PR TITLE
feat(projects): add Cairnline next-action env bundle

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -718,9 +718,10 @@ diagnostic list into
 `orchestrator_capabilities`, and `migration_blockers`, so durable
 coordination-state switchpoint work is separated from Hecate-owned
 runtime/workspace capabilities and final cutover work. Settings shows the same
-backend-status summary, shows copyable next-action configuration hints, turns
-the next action's probes into a run-in-order checklist, keeps replacement gates
-and migration rehearsal evidence as supporting proof, and lists
+backend-status summary, shows copyable next-action configuration hints and a
+full env block when multiple settings are required, turns the next action's
+probes into a run-in-order checklist, keeps replacement gates and migration
+rehearsal evidence as supporting proof, and lists
 write-switchpoint authority/state rows under Project coordination for local
 operator inspection. The reported replacement
 target is embedded Cairnline first: Hecate should make the embedded Cairnline

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -69,10 +69,10 @@ also shows a compact **Project coordination** strip above the workspace. It is
 read-only status from `GET /hecate/v1/projects/backend-status`; use it to
 confirm whether portable project coordination is still Hecate-native, in
 Cairnline dogfood, or reporting Cairnline authoritative. The strip previews the
-server-recommended next replacement action, target, probe count, and copyable
-environment hints when backend status provides them. Use **Backend settings** to
-jump to the global Settings workspace for full gates, ordered probe checklists,
-and migration evidence.
+server-recommended next replacement action, target, probe count, copyable
+environment hints, and a full env block when more than one setting is required.
+Use **Backend settings** to jump to the global Settings workspace for full
+gates, ordered probe checklists, and migration evidence.
 
 The Work Coordination tab starts with Project Operations when the server finds
 actionable project state: missing launch defaults, pending approvals, blocked

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -480,6 +480,11 @@ describe("ProjectWorkspaceView", () => {
               value: "project-skills",
               detail: "Enable skill metadata writes.",
             },
+            {
+              env: "HECATE_PROJECTS_CAIRNLINE_CONNECTOR",
+              value: "embedded",
+              detail: "Use embedded Cairnline for write-authority dogfood.",
+            },
           ],
           probes: [{ method: "GET", url: "/hecate/v1/projects/{id}/cairnline/read-model" }],
         },
@@ -499,7 +504,10 @@ describe("ProjectWorkspaceView", () => {
     expect(
       within(strip).getByText("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills"),
     ).toBeTruthy();
-    expect(within(strip).getByRole("button", { name: "copy" })).toBeTruthy();
+    expect(within(strip).getByText("HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded")).toBeTruthy();
+    expect(within(strip).getByText("env bundle")).toBeTruthy();
+    expect(within(strip).getByRole("button", { name: "copy all" })).toBeTruthy();
+    expect(within(strip).getAllByRole("button", { name: "copy" }).length).toBe(2);
 
     await userEvent.click(within(strip).getByRole("button", { name: "Backend settings" }));
     expect(handlers.onOpenSystemSettings).toHaveBeenCalledTimes(1);

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -23,6 +23,10 @@ import type {
   ProjectWorkRoleRecord,
   UpdateProjectSkillPayload,
 } from "../../types/project";
+import {
+  projectCoordinationConfigAssignment,
+  projectCoordinationConfigBlock,
+} from "../../lib/project-coordination-backend";
 import { Badge, CopyBtn, Icon, Icons, InlineError } from "../shared/ui";
 import { ProjectAssistantPanel } from "./ProjectAssistantPanel";
 import { ProjectMemoryPanel } from "./ProjectMemoryPanel";
@@ -534,6 +538,7 @@ function ProjectCoordinationStatusStrip({
   const nextAction = status.next_replacement_action;
   const detail = nextAction?.detail || status.detail;
   const configHints = nextAction?.config_hints ?? [];
+  const configBlock = projectCoordinationConfigBlock(configHints);
   const probeCount = nextAction
     ? (nextAction.probes?.length ?? nextAction.probe_urls?.length ?? 0)
     : 0;
@@ -560,8 +565,14 @@ function ProjectCoordinationStatusStrip({
                 {probeCount} probe{probeCount === 1 ? "" : "s"}
               </span>
             )}
+            {configBlock && configHints.length > 1 && (
+              <span style={projectCoordinationHintStyle}>
+                <code style={projectCoordinationHintCodeStyle}>env bundle</code>
+                <CopyBtn label="copy all" text={configBlock} />
+              </span>
+            )}
             {configHints.map((hint) => {
-              const assignment = `${hint.env}=${hint.value}`;
+              const assignment = projectCoordinationConfigAssignment(hint);
               return (
                 <span key={assignment} style={projectCoordinationHintStyle}>
                   <code style={projectCoordinationHintCodeStyle}>{assignment}</code>

--- a/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
+++ b/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
@@ -2,6 +2,10 @@ import type {
   ProjectCoordinationBackendProbeRecord,
   ProjectCoordinationBackendStatusRecord,
 } from "../../types/project";
+import {
+  projectCoordinationConfigAssignment,
+  projectCoordinationConfigBlock,
+} from "../../lib/project-coordination-backend";
 import { Badge, CopyBtn, Icon, Icons, InlineError } from "../shared/ui";
 import { SettingsSectionHeader as SectionHeader } from "./SettingsSectionHeader";
 
@@ -516,6 +520,7 @@ function ProjectBackendConfigHints({
     NonNullable<ProjectCoordinationBackendStatusRecord["next_replacement_action"]>["config_hints"]
   >;
 }) {
+  const configBlock = projectCoordinationConfigBlock(hints);
   return (
     <div style={{ display: "grid", gap: 4 }}>
       <div
@@ -528,9 +533,41 @@ function ProjectBackendConfigHints({
       >
         Configuration hints
       </div>
+      {configBlock && hints.length > 1 && (
+        <div
+          style={{
+            alignItems: "center",
+            background: "var(--bg3)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm)",
+            display: "grid",
+            gap: 7,
+            gridTemplateColumns: "minmax(0, 1fr) auto",
+            padding: "7px 9px",
+          }}
+        >
+          <div style={{ display: "grid", gap: 3, minWidth: 0 }}>
+            <span style={{ color: "var(--t1)", fontSize: 12, fontWeight: 650 }}>
+              Full env block
+            </span>
+            <code
+              style={{
+                color: "var(--t2)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                overflowWrap: "anywhere",
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {configBlock}
+            </code>
+          </div>
+          <CopyBtn label="copy all" text={configBlock} />
+        </div>
+      )}
       <div style={{ display: "grid", gap: 4 }}>
         {hints.map((hint) => {
-          const assignment = `${hint.env}=${hint.value}`;
+          const assignment = projectCoordinationConfigAssignment(hint);
           return (
             <div
               key={assignment}

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -179,6 +179,11 @@ describe("SettingsView", () => {
               value: "project-skills",
               detail: "Enable the skill switchpoint before moving skill metadata writes.",
             },
+            {
+              env: "HECATE_PROJECTS_CAIRNLINE_CONNECTOR",
+              value: "embedded",
+              detail: "Use the embedded connector for write-authority dogfood.",
+            },
           ],
           probe_urls: ["/hecate/v1/projects/{id}/cairnline/read-model"],
         },
@@ -269,6 +274,9 @@ describe("SettingsView", () => {
     expect(
       screen.getByText("HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-skills"),
     ).toBeTruthy();
+    expect(screen.getByText("HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded")).toBeTruthy();
+    expect(screen.getByText("Full env block")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "copy all" })).toBeTruthy();
     expect(screen.getByText("Configuration hints")).toBeTruthy();
     expect(
       screen.getByText("Enable the skill switchpoint before moving skill metadata writes."),

--- a/ui/src/features/shared/Atoms.tsx
+++ b/ui/src/features/shared/Atoms.tsx
@@ -102,7 +102,7 @@ export function Toggle({
 
 // ─── CopyBtn ─────────────────────────────────────────────────────────────────
 
-export function CopyBtn({ text }: { text: string }) {
+export function CopyBtn({ label = "copy", text }: { label?: string; text: string }) {
   const [copied, setCopied] = useState(false);
   const resetTimerRef = useRef<number | null>(null);
 
@@ -124,7 +124,7 @@ export function CopyBtn({ text }: { text: string }) {
   return (
     <button className="btn btn-ghost btn-sm" onClick={copy} style={{ gap: 4, padding: "3px 6px" }}>
       <Icon d={copied ? Icons.check : Icons.copy} size={12} />
-      {copied ? "copied" : "copy"}
+      {copied ? "copied" : label}
     </button>
   );
 }

--- a/ui/src/lib/project-coordination-backend.test.ts
+++ b/ui/src/lib/project-coordination-backend.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  projectCoordinationConfigAssignment,
+  projectCoordinationConfigBlock,
+} from "./project-coordination-backend";
+
+describe("project coordination backend helpers", () => {
+  it("builds shell-style config assignments and env blocks from hints", () => {
+    expect(
+      projectCoordinationConfigAssignment({
+        env: "HECATE_PROJECTS_COORDINATION_BACKEND",
+        value: "cairnline",
+      }),
+    ).toBe("HECATE_PROJECTS_COORDINATION_BACKEND=cairnline");
+
+    expect(
+      projectCoordinationConfigBlock([
+        {
+          env: "HECATE_PROJECTS_COORDINATION_BACKEND",
+          value: "cairnline",
+        },
+        {
+          env: "HECATE_PROJECTS_CAIRNLINE_CONNECTOR",
+          value: "embedded",
+        },
+      ]),
+    ).toBe(
+      "HECATE_PROJECTS_COORDINATION_BACKEND=cairnline\nHECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded",
+    );
+  });
+
+  it("returns an empty block without hints", () => {
+    expect(projectCoordinationConfigBlock(undefined)).toBe("");
+    expect(projectCoordinationConfigBlock([])).toBe("");
+  });
+});

--- a/ui/src/lib/project-coordination-backend.ts
+++ b/ui/src/lib/project-coordination-backend.ts
@@ -1,0 +1,13 @@
+import type { ProjectCoordinationBackendNextActionRecord } from "../types/project";
+
+type ConfigHint = NonNullable<ProjectCoordinationBackendNextActionRecord["config_hints"]>[number];
+
+export function projectCoordinationConfigAssignment(hint: ConfigHint): string {
+  return `${hint.env}=${hint.value}`;
+}
+
+export function projectCoordinationConfigBlock(
+  hints: ProjectCoordinationBackendNextActionRecord["config_hints"],
+): string {
+  return (hints ?? []).map(projectCoordinationConfigAssignment).filter(Boolean).join("\n");
+}


### PR DESCRIPTION
## Summary
- add a shared UI helper for Cairnline next-action env assignments and env blocks
- show copyable full env bundles in the Projects coordination strip and Settings backend panel when multiple hints are required
- update operator docs for the full env-block affordance

## Tests
- cd ui && bun run test -- src/lib/project-coordination-backend.test.ts src/features/projects/ProjectWorkspaceView.test.tsx src/features/settings/SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- just docs-check