### PR TITLE
feat(projects): expose backend next-action config block

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -677,7 +677,9 @@ parsing warning prose. The next action keeps the blocker list separate from the
 recommended dogfood order, so metadata-only context-source and skill authority
 can be suggested before broader project identity cutover. Write-authority
 `config_hints` preserve already-enabled switchpoints in the suggested env value,
-so operators can copy the whole value without dropping prior dogfood authority.
+and `config_block` joins the hints into a newline-delimited env block so
+operators can copy all required settings without dropping prior dogfood
+authority.
 Gates and next actions include method-aware `probes` alongside compatibility
 `probe_urls`, so Settings can turn the next action into an ordered, copyable
 probe checklist and distinguish POST smoke/rehearsal routes from GET read

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2568,9 +2568,11 @@ than the raw `portable_write_gaps` order so operators can dogfood narrower setup
 metadata surfaces such as context sources and skills before broad project
 identity cutover. It can include `config_hints`, which are environment setting
 suggestions such as a specific `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY`
-value; write-authority hint values preserve already-enabled switchpoints so
-they can be presented as whole copyable env values. Clients must treat them as
-operator guidance, not as mutations to apply automatically. `replacement_gates`
+value, and `config_block`, a newline-delimited `ENV=value` block built from the
+same hints for copy-to-shell or `.env` use. Write-authority hint values preserve
+already-enabled switchpoints so they can be presented as whole copyable env
+values. Clients must treat them as operator guidance, not as mutations to apply
+automatically. `replacement_gates`
 reports those high-level gates as structured checklist items so clients do not
 need to parse warning prose. Each gate and next action may include `probes`, a
 method-aware list of route templates that produce supporting evidence, plus the
@@ -2965,7 +2967,8 @@ Example response, with `write_switchpoints` shortened for readability:
           "value": "project-identity,project-metadata-defaults",
           "detail": "Add these comma-separated values to HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY; this gap requires the switchpoints together."
         }
-      ]
+      ],
+      "config_block": "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-identity,project-metadata-defaults"
     },
     "replacement_gates": [
       {

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -491,6 +491,24 @@ func projectCairnlineHydrateProbeMetadata(response *ProjectCoordinationBackendSt
 	if response.NextReplacementAction != nil && len(response.NextReplacementAction.Probes) == 0 {
 		response.NextReplacementAction.Probes = projectCairnlineProbesForURLs(response.NextReplacementAction.ProbeURLs)
 	}
+	if response.NextReplacementAction != nil && strings.TrimSpace(response.NextReplacementAction.ConfigBlock) == "" {
+		response.NextReplacementAction.ConfigBlock = projectCairnlineConfigBlock(response.NextReplacementAction.ConfigHints)
+	}
+}
+
+func projectCairnlineConfigBlock(hints []ProjectCoordinationBackendActionConfigHint) string {
+	if len(hints) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(hints))
+	for _, hint := range hints {
+		env := strings.TrimSpace(hint.Env)
+		if env == "" {
+			continue
+		}
+		lines = append(lines, env+"="+hint.Value)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func projectCairnlineProbesForURLs(urls []string) []ProjectCoordinationBackendProbe {

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -1379,6 +1379,19 @@ func TestProjectCoordinationBackendStatus_NextActionReplacementModeHints(t *test
 	}
 }
 
+func TestProjectCoordinationBackendStatus_ConfigBlock(t *testing.T) {
+	block := projectCairnlineConfigBlock([]ProjectCoordinationBackendActionConfigHint{
+		{Env: " HECATE_PROJECTS_COORDINATION_BACKEND ", Value: "cairnline"},
+		{Env: "", Value: "ignored"},
+		{Env: "HECATE_PROJECTS_CAIRNLINE_CONNECTOR", Value: "embedded"},
+	})
+
+	want := "HECATE_PROJECTS_COORDINATION_BACKEND=cairnline\nHECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded"
+	if block != want {
+		t.Fatalf("config block = %q, want %q", block, want)
+	}
+}
+
 func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	cfg := config.Config{
@@ -1426,6 +1439,9 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 	}
 	if findConfigHint(response.Data.NextReplacementAction.ConfigHints, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY") == nil {
 		t.Fatalf("response next action config hints = %+v, want write authority hint", response.Data.NextReplacementAction.ConfigHints)
+	}
+	if !strings.Contains(response.Data.NextReplacementAction.ConfigBlock, "HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=") {
+		t.Fatalf("response next action config block = %q, want write-authority env assignment", response.Data.NextReplacementAction.ConfigBlock)
 	}
 	migrationSwitchpoint := findWriteSwitchpoint(response.Data.WriteSwitchpoints, "migration-cutover")
 	if migrationSwitchpoint == nil || migrationSwitchpoint.CairnlineState != "snapshot_import_rehearsal_available" || !containsString(migrationSwitchpoint.Seams, "sync-rehearsal") {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -605,6 +605,7 @@ type ProjectCoordinationBackendNextAction struct {
 	Detail      string                                       `json:"detail"`
 	Target      string                                       `json:"target,omitempty"`
 	ConfigHints []ProjectCoordinationBackendActionConfigHint `json:"config_hints,omitempty"`
+	ConfigBlock string                                       `json:"config_block,omitempty"`
 	Probes      []ProjectCoordinationBackendProbe            `json:"probes,omitempty"`
 	ProbeURLs   []string                                     `json:"probe_urls,omitempty"`
 }

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -25,7 +25,7 @@ import type {
 } from "../../types/project";
 import {
   projectCoordinationConfigAssignment,
-  projectCoordinationConfigBlock,
+  projectCoordinationNextActionConfigBlock,
 } from "../../lib/project-coordination-backend";
 import { Badge, CopyBtn, Icon, Icons, InlineError } from "../shared/ui";
 import { ProjectAssistantPanel } from "./ProjectAssistantPanel";
@@ -538,7 +538,7 @@ function ProjectCoordinationStatusStrip({
   const nextAction = status.next_replacement_action;
   const detail = nextAction?.detail || status.detail;
   const configHints = nextAction?.config_hints ?? [];
-  const configBlock = projectCoordinationConfigBlock(configHints);
+  const configBlock = nextAction ? projectCoordinationNextActionConfigBlock(nextAction) : "";
   const probeCount = nextAction
     ? (nextAction.probes?.length ?? nextAction.probe_urls?.length ?? 0)
     : 0;

--- a/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
+++ b/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
@@ -4,7 +4,7 @@ import type {
 } from "../../types/project";
 import {
   projectCoordinationConfigAssignment,
-  projectCoordinationConfigBlock,
+  projectCoordinationNextActionConfigBlock,
 } from "../../lib/project-coordination-backend";
 import { Badge, CopyBtn, Icon, Icons, InlineError } from "../shared/ui";
 import { SettingsSectionHeader as SectionHeader } from "./SettingsSectionHeader";
@@ -471,6 +471,7 @@ function ProjectBackendNextAction({
 }) {
   const probes = projectBackendProbes(action.probes, action.probe_urls);
   const configHints = action.config_hints ?? [];
+  const configBlock = projectCoordinationNextActionConfigBlock(action);
   return (
     <div
       style={{
@@ -508,19 +509,22 @@ function ProjectBackendNextAction({
       <div style={{ color: "var(--t0)", fontSize: 13, fontWeight: 650 }}>{action.label}</div>
       <div style={{ color: "var(--t2)", fontSize: 12, lineHeight: 1.45 }}>{action.detail}</div>
       {probes.length > 0 && <ProjectBackendProbeList probes={probes} checklist />}
-      {configHints.length > 0 && <ProjectBackendConfigHints hints={configHints} />}
+      {configHints.length > 0 && (
+        <ProjectBackendConfigHints configBlock={configBlock} hints={configHints} />
+      )}
     </div>
   );
 }
 
 function ProjectBackendConfigHints({
+  configBlock,
   hints,
 }: {
+  configBlock: string;
   hints: NonNullable<
     NonNullable<ProjectCoordinationBackendStatusRecord["next_replacement_action"]>["config_hints"]
   >;
 }) {
-  const configBlock = projectCoordinationConfigBlock(hints);
   return (
     <div style={{ display: "grid", gap: 4 }}>
       <div

--- a/ui/src/lib/project-coordination-backend.test.ts
+++ b/ui/src/lib/project-coordination-backend.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   projectCoordinationConfigAssignment,
   projectCoordinationConfigBlock,
+  projectCoordinationNextActionConfigBlock,
 } from "./project-coordination-backend";
 
 describe("project coordination backend helpers", () => {
@@ -33,5 +34,36 @@ describe("project coordination backend helpers", () => {
   it("returns an empty block without hints", () => {
     expect(projectCoordinationConfigBlock(undefined)).toBe("");
     expect(projectCoordinationConfigBlock([])).toBe("");
+  });
+
+  it("prefers a backend-provided config block and falls back to hints", () => {
+    expect(
+      projectCoordinationNextActionConfigBlock({
+        id: "enable-cairnline-dogfood",
+        label: "Enable Cairnline dogfood",
+        detail: "Configure the runtime.",
+        config_block: "HECATE_PROJECTS_COORDINATION_BACKEND=cairnline",
+        config_hints: [
+          {
+            env: "HECATE_PROJECTS_CAIRNLINE_CONNECTOR",
+            value: "embedded",
+          },
+        ],
+      }),
+    ).toBe("HECATE_PROJECTS_COORDINATION_BACKEND=cairnline");
+
+    expect(
+      projectCoordinationNextActionConfigBlock({
+        id: "enable-cairnline-dogfood",
+        label: "Enable Cairnline dogfood",
+        detail: "Configure the runtime.",
+        config_hints: [
+          {
+            env: "HECATE_PROJECTS_CAIRNLINE_CONNECTOR",
+            value: "embedded",
+          },
+        ],
+      }),
+    ).toBe("HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded");
   });
 });

--- a/ui/src/lib/project-coordination-backend.ts
+++ b/ui/src/lib/project-coordination-backend.ts
@@ -11,3 +11,9 @@ export function projectCoordinationConfigBlock(
 ): string {
   return (hints ?? []).map(projectCoordinationConfigAssignment).filter(Boolean).join("\n");
 }
+
+export function projectCoordinationNextActionConfigBlock(
+  action: ProjectCoordinationBackendNextActionRecord,
+): string {
+  return action.config_block?.trim() || projectCoordinationConfigBlock(action.config_hints);
+}

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -106,6 +106,7 @@ export type ProjectCoordinationBackendNextActionRecord = {
     value: string;
     detail?: string;
   }>;
+  config_block?: string;
   probes?: ProjectCoordinationBackendProbeRecord[];
   probe_urls?: string[];
 };


### PR DESCRIPTION
## Summary
- add `config_block` to project backend-status next actions
- hydrate the block from `config_hints` so clients can copy a whole env bundle
- update the UI to prefer server-provided blocks with hint fallback
- document the runtime API and operator behavior

## Tests
- go test ./internal/api -run 'TestProjectCoordinationBackendStatus'\n- cd ui && bun run test -- src/lib/project-coordination-backend.test.ts src/features/projects/ProjectWorkspaceView.test.tsx src/features/settings/SettingsView.test.tsx\n- cd ui && bun run typecheck\n- cd ui && bun run lint\n- cd ui && bun run format:check\n- just docs-check\n- GOCACHE="$(pwd)/.gocache" go test -race -timeout 20m ./...\n\nNote: `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...` timed out in `TestProjectRootsDiscovery_MirrorsRootsWithoutReplacingCairnlineState`; the isolated test passed in normal and race mode, and the full race suite passed with a 20m package timeout.