### PR TITLE
test(projects): lock empty cairnline replacement guidance

### DIFF
--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -110,7 +110,12 @@ authority enabled, and embedded replacement mode armed. Use `--reset` for a
 clean local dogfood store; omit it only when intentionally checking an existing
 `.data/` directory. Then open `http://127.0.0.1:8765`, create or inspect a
 project, and confirm **Settings → Project coordination** reports Cairnline as
-authoritative before trusting the run.
+authoritative before trusting the run. On a freshly reset store, the status may
+first ask for live portable project state; create or import a project, then
+refresh Settings so backend status can smoke the embedded Cairnline database
+instead of an empty store. Adding a small work item and assignment gives the
+smoke more route coverage, but the first requirement is simply non-empty
+Cairnline project state.
 
 For automated confidence before or after manual dogfood, run:
 

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -747,7 +747,10 @@ backend status includes that env var as a copyable next-action config hint.
 Once replacement mode is
 armed, `run-strict-embedded-read-smoke` points at backend status itself because
 the proof is live embedded Cairnline state, not a Hecate-store mirror-parity
-rehearsal. That status cutover does not
+rehearsal. On a newly reset replacement-mode runtime, that proof remains
+`not_run` until the embedded Cairnline database has live portable project state
+to inspect; create or import a project, then refresh backend status. That status
+cutover does not
 move Hecate-owned runtime/workspace capabilities such as assignment dispatch or
 Project Assistant apply side effects into Cairnline core. `GET
 /hecate/v1/projects/cairnline/mirror-parity` compares the existing embedded

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2617,6 +2617,10 @@ replacement mode,
 Cairnline-authoritative project identity create returns the Cairnline record
 with `read_backend: "cairnline"` and without creating a native Hecate project
 identity row; strict embedded read routes serve the new project from Cairnline.
+If replacement mode is armed before any embedded Cairnline project exists,
+`strict-embedded-read-smoke` reports `not_run` and points at backend status
+itself; create or import portable project state before expecting
+`replacement_ready=true`.
 That identity-shadow behavior is a write-path switch, not the full readiness
 verdict: clients should use `replacement_ready` and `replacement_gates` to tell
 whether the relevant strict read smoke, migration, and rollback evidence is

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -1194,6 +1194,37 @@ func TestProjectCoordinationBackendStatus_CairnlineEmbeddedReplacementModeArmed(
 	}
 }
 
+func TestProjectCoordinationBackendStatus_EmbeddedReplacementModeWithoutStateUsesLiveStatusProbe(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			Backend:                  "sqlite",
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineReplacementMode: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
+	gate := findReplacementGate(status.ReplacementGates, "strict-embedded-read-smoke")
+	if gate == nil || gate.Ready || gate.Status != "not_run" {
+		t.Fatalf("strict embedded gate = %+v, want missing live replacement state", gate)
+	}
+	if !containsString(gate.ProbeURLs, projectCoordinationBackendStatusURL) || containsString(gate.ProbeURLs, projectCoordinationBackendSyncReadinessURL) || containsString(gate.ProbeURLs, projectCoordinationBackendMirrorParityURL) {
+		t.Fatalf("strict embedded gate probes = %+v, want live backend-status probe without Hecate mirror sync/parity", gate.ProbeURLs)
+	}
+	if status.MigrationRehearsal == nil || status.MigrationRehearsal.Operation != "embedded_replacement_smoke" || status.MigrationRehearsal.Authoritative {
+		t.Fatalf("migration rehearsal = %+v, want embedded replacement smoke evidence for missing live state", status.MigrationRehearsal)
+	}
+	if status.NextReplacementAction == nil || status.NextReplacementAction.ID != "run-strict-embedded-read-smoke" || !containsString(status.NextReplacementAction.ProbeURLs, projectCoordinationBackendStatusURL) {
+		t.Fatalf("next action = %+v, want live backend-status smoke action", status.NextReplacementAction)
+	}
+	if containsString(status.NextReplacementAction.ProbeURLs, projectCoordinationBackendMirrorParityURL) {
+		t.Fatalf("next action probes = %+v, want no Hecate mirror-parity probe after replacement mode is armed", status.NextReplacementAction.ProbeURLs)
+	}
+}
+
 func TestProjectCoordinationBackendStatus_WriteAuthorityGateUsesPortableGaps(t *testing.T) {
 	gate := projectCairnlineWriteAuthorityReplacementGate(nil)
 	if !gate.Ready || gate.Status != "ready" || !strings.Contains(gate.Detail, "orchestrator capabilities") {


### PR DESCRIPTION
## Summary
- add backend-status coverage for armed embedded replacement mode with no live Cairnline project state
- document that reset dogfood stores need live portable project state before replacement readiness can pass
- clarify backend-status remains the live smoke probe after replacement mode is armed

## Tests
- go test ./internal/api -run 'TestProjectCoordinationBackendStatus_(CairnlineEmbeddedReplacementModeArmed|EmbeddedReplacementModeWithoutStateUsesLiveStatusProbe|EmbeddedReplacementModeReportsCairnlineAuthoritativeAfterVerifiedCutover)$'\n- go test ./internal/api\n- just docs-check