### PR TITLE
chore(projects): build cairnline sidecar for dev

### DIFF
--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -152,10 +152,13 @@ This starts Hecate with `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=sidecar` and
 `.data/cairnline/sidecar/projects.db` unless `.env` overrides
 `HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB`. The recipe prints the detected
 Cairnline version before launch, so binaries that do not support the version
-probe fail before Hecate starts. It is an MCP interoperability/dev surface:
-Hecate still keeps authoritative Projects writes on the native or embedded
-replacement path, and sidecar mode should not be treated as the final Cairnline
-cutover.
+probe fail before Hecate starts. In the multi-repo workspace, if `cairnline` is
+not installed and `../cairnline` exists, the recipe builds a local dev binary at
+`.data/cairnline/bin/cairnline-dev`; set
+`HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND` to force a release binary or any
+other command path. It is an MCP interoperability/dev surface: Hecate still
+keeps authoritative Projects writes on the native or embedded replacement path,
+and sidecar mode should not be treated as the final Cairnline cutover.
 
 ## UI hot reload
 

--- a/just/go.just
+++ b/just/go.just
@@ -158,11 +158,17 @@ dev-cairnline-sidecar-projects *args: _go-cache
 	set -a; \
 	[ -f ./.env ] && . ./.env; \
 	set +a; \
-	sidecar_cmd="${HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND:-cairnline}"; \
+	configured_sidecar_cmd="${HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND:-}"; \
+	sidecar_cmd="${configured_sidecar_cmd:-cairnline}"; \
 	if ! command -v "$sidecar_cmd" >/dev/null 2>&1; then \
-	  echo "cairnline sidecar command not found: $sidecar_cmd"; \
-	  echo "Install Cairnline from https://github.com/hecatehq/cairnline/releases or set HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND."; \
-	  exit 1; \
+	  if [ -z "$configured_sidecar_cmd" ] && [ -d ../cairnline/cmd/cairnline ]; then \
+	    just build-cairnline-sidecar; \
+	    sidecar_cmd="$PWD/.data/cairnline/bin/cairnline-dev"; \
+	  else \
+	    echo "cairnline sidecar command not found: $sidecar_cmd"; \
+	    echo "Install Cairnline from https://github.com/hecatehq/cairnline/releases or set HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND."; \
+	    exit 1; \
+	  fi; \
 	fi; \
 	if ! "$sidecar_cmd" -version; then \
 	  echo "could not read Cairnline sidecar version from: $sidecar_cmd"; \
@@ -179,6 +185,27 @@ dev-cairnline-sidecar-projects *args: _go-cache
 	HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND="$sidecar_cmd" \
 	HECATE_PROJECTS_CAIRNLINE_SIDECAR_DB="$sidecar_db" \
 	{{go_env}} go run ./cmd/hecate serve
+
+# Build the sibling Cairnline repository into Hecate's local .data tree for
+# sidecar dogfood. This is a contributor convenience for the multi-repo
+# workspace; release binaries or HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND still
+# remain the explicit operator path.
+# Build local Cairnline sidecar binary from ../cairnline.
+build-cairnline-sidecar: _go-cache
+	if [ ! -d ../cairnline/cmd/cairnline ]; then \
+	  echo "sibling Cairnline repo not found at ../cairnline"; \
+	  echo "Install Cairnline from https://github.com/hecatehq/cairnline/releases or set HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND."; \
+	  exit 1; \
+	fi; \
+	out="$PWD/.data/cairnline/bin/cairnline-dev"; \
+	cache="$PWD/.gocache"; \
+	mkdir -p "$(dirname "$out")"; \
+	echo "building sibling Cairnline sidecar: $out"; \
+	if ! (cd ../cairnline && GOCACHE="$cache" go build -o "$out" ./cmd/cairnline); then \
+	  echo "failed to build sibling Cairnline sidecar from ../cairnline"; \
+	  exit 1; \
+	fi; \
+	"$out" -version
 
 # Run the focused API tests that prove Projects can be dogfooded through the
 # Hecate-native flow and the embedded Cairnline replacement flow.


### PR DESCRIPTION
## Summary
- add `just build-cairnline-sidecar` to build the sibling Cairnline repo into `.data/cairnline/bin/cairnline-dev`
- let `just dev-cairnline-sidecar-projects` fall back to that sibling build when no explicit sidecar command is configured and `cairnline` is not on PATH
- document the multi-repo workspace fallback while keeping release binaries / `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND` as the explicit override path

## Tests
- just build-cairnline-sidecar
- just dev-cairnline-sidecar-projects (started successfully with sibling fallback, then interrupted after gateway startup)
- just test-projects-sidecar
- just docs-check