### PR TITLE
fix(settings): report reset agent presets

### DIFF
--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -821,7 +821,7 @@ Tool names come back un-namespaced — the operator wants to see what the upstre
     "project_work_rows_deleted": 3,
     "project_runtime_rows_deleted": 1,
     "plugins_deleted": 1,
-    "agent_profiles_deleted": 1,
+    "agent_presets_deleted": 1,
     "chat_sessions_deleted": 2,
     "tasks_deleted": 1,
     "providers_deleted": 1,

--- a/internal/api/handler_system_reset.go
+++ b/internal/api/handler_system_reset.go
@@ -83,7 +83,7 @@ func (h *Handler) resetSystemData(ctx context.Context) (SystemResetDataResponseI
 	if err != nil {
 		return stats, err
 	}
-	stats.AgentProfilesDeleted = agentProfilesDeleted
+	stats.AgentPresetsDeleted = agentProfilesDeleted
 
 	tasksDeleted, err := h.resetTasks(ctx)
 	if err != nil {

--- a/internal/api/handler_system_reset_test.go
+++ b/internal/api/handler_system_reset_test.go
@@ -104,7 +104,7 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 		t.Fatalf("create task: %v", err)
 	}
 	if _, err := handler.agentProfiles.Create(ctx, agentprofiles.Profile{ID: "prof_reset", Name: "Reset profile"}); err != nil {
-		t.Fatalf("create agent profile: %v", err)
+		t.Fatalf("create agent preset: %v", err)
 	}
 	if _, err := handler.pluginRegistry.Upsert(ctx, pluginregistry.Plugin{
 		ID:                    "github",
@@ -146,8 +146,8 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	if err := json.Unmarshal(rec.Body.Bytes(), &reset); err != nil {
 		t.Fatalf("decode reset response: %v", err)
 	}
-	if reset.Data.ProjectsDeleted != 1 || reset.Data.ProjectWorkRowsDeleted != 2 || reset.Data.ProjectRuntimeRowsDeleted != 1 || reset.Data.PluginsDeleted != 1 || reset.Data.AgentProfilesDeleted != 1 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
-		t.Fatalf("reset stats = %+v, want one project, one runtime row, one plugin, one profile, two project-work rows, one task, provider, rule and two chats", reset.Data)
+	if reset.Data.ProjectsDeleted != 1 || reset.Data.ProjectWorkRowsDeleted != 2 || reset.Data.ProjectRuntimeRowsDeleted != 1 || reset.Data.PluginsDeleted != 1 || reset.Data.AgentPresetsDeleted != 1 || reset.Data.ChatSessionsDeleted != 2 || reset.Data.TasksDeleted != 1 || reset.Data.ProvidersDeleted != 1 || reset.Data.PolicyRulesDeleted != 1 {
+		t.Fatalf("reset stats = %+v, want one project, one runtime row, one plugin, one preset, two project-work rows, one task, provider, rule and two chats", reset.Data)
 	}
 	if len(runner.deletedSessions) != 2 {
 		t.Fatalf("deleted sessions = %#v, want two external chats deleted", runner.deletedSessions)
@@ -172,10 +172,10 @@ func TestSystemResetDataMemoryBackendDeletesStateAndClosesAgentSessions(t *testi
 	}
 	profiles, err := handler.agentProfiles.List(ctx)
 	if err != nil {
-		t.Fatalf("list agent profiles: %v", err)
+		t.Fatalf("list agent presets: %v", err)
 	}
 	if !agentProfileListIsBuiltInOnly(profiles) {
-		t.Fatalf("agent profiles after reset = %#v, want only built-ins", profiles)
+		t.Fatalf("agent presets after reset = %#v, want only built-ins", profiles)
 	}
 	workItems, err := handler.projectWork.ListWorkItems(ctx, project.Data.ID)
 	if err != nil {
@@ -367,7 +367,7 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 		t.Fatalf("create task: %v", err)
 	}
 	if _, err := agentProfileStore.Create(ctx, agentprofiles.Profile{ID: "prof_sqlite_reset", Name: "SQLite profile"}); err != nil {
-		t.Fatalf("create agent profile: %v", err)
+		t.Fatalf("create agent preset: %v", err)
 	}
 	if _, err := pluginStore.Upsert(ctx, pluginregistry.Plugin{
 		ID:                    "linear",
@@ -407,8 +407,8 @@ func TestSystemResetDataSQLiteBackendClearsRemainingRows(t *testing.T) {
 	if reset.Data.ProjectWorkRowsDeleted != 1 {
 		t.Fatalf("project work rows deleted = %d, want 1", reset.Data.ProjectWorkRowsDeleted)
 	}
-	if reset.Data.AgentProfilesDeleted != 1 {
-		t.Fatalf("agent profiles deleted = %d, want 1", reset.Data.AgentProfilesDeleted)
+	if reset.Data.AgentPresetsDeleted != 1 {
+		t.Fatalf("agent presets deleted = %d, want 1", reset.Data.AgentPresetsDeleted)
 	}
 	if reset.Data.PluginsDeleted != 1 {
 		t.Fatalf("plugins deleted = %d, want 1", reset.Data.PluginsDeleted)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -2700,7 +2700,7 @@ type SystemResetDataResponseItem struct {
 	ProjectRuntimeRowsDeleted        int `json:"project_runtime_rows_deleted"`
 	ProjectAssistantProposalsDeleted int `json:"project_assistant_proposals_deleted"`
 	PluginsDeleted                   int `json:"plugins_deleted"`
-	AgentProfilesDeleted             int `json:"agent_profiles_deleted"`
+	AgentPresetsDeleted              int `json:"agent_presets_deleted"`
 	ChatSessionsDeleted              int `json:"chat_sessions_deleted"`
 	TasksDeleted                     int `json:"tasks_deleted"`
 	ProvidersDeleted                 int `json:"providers_deleted"`

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -707,7 +707,7 @@ describe("SettingsView maintenance cleanup", () => {
         project_work_rows_deleted: 2,
         project_assistant_proposals_deleted: 1,
         plugins_deleted: 1,
-        agent_profiles_deleted: 1,
+        agent_presets_deleted: 1,
         chat_sessions_deleted: 2,
         tasks_deleted: 1,
         providers_deleted: 1,

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -177,7 +177,7 @@ function resetSummary(data: {
   project_work_rows_deleted?: number;
   project_assistant_proposals_deleted?: number;
   plugins_deleted?: number;
-  agent_profiles_deleted?: number;
+  agent_presets_deleted?: number;
   chat_sessions_deleted: number;
   tasks_deleted: number;
   providers_deleted: number;
@@ -192,7 +192,7 @@ function resetSummary(data: {
     (data.project_work_rows_deleted ?? 0) +
     (data.project_assistant_proposals_deleted ?? 0) +
     (data.plugins_deleted ?? 0) +
-    (data.agent_profiles_deleted ?? 0) +
+    (data.agent_presets_deleted ?? 0) +
     data.chat_sessions_deleted +
     data.tasks_deleted +
     data.providers_deleted +

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -112,7 +112,7 @@ export type SystemResetDataResponse = {
     project_work_rows_deleted?: number;
     project_assistant_proposals_deleted?: number;
     plugins_deleted?: number;
-    agent_profiles_deleted?: number;
+    agent_presets_deleted?: number;
     chat_sessions_deleted: number;
     tasks_deleted: number;
     providers_deleted: number;


### PR DESCRIPTION
## Summary
- rename the system reset deleted-count field from `agent_profiles_deleted` to `agent_presets_deleted`
- update backend reset tests, settings UI types/tests, and runtime API docs to match the Agent Preset public wording

## Validation
- `go test ./internal/api -run 'TestSystemReset'`
- `cd ui && bun run test -- src/features/settings/SettingsView.test.tsx`
- `cd ui && bun run typecheck`
- `just docs-check`
