### PR TITLE
feat(projects): expose cairnline capability diagnostics

### DIFF
--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -507,7 +507,9 @@ self-description tool, plus the portable Projects `resources/templates/list`
 contract and reports the sidecar's MCP initialize `serverInfo` as
 `server_name` / `server_version`.
 `sidecar-connect` keeps the process warm in Hecate's
-Cairnline-specific MCP client cache. `sidecar-read-smoke`,
+Cairnline-specific MCP client cache and best-effort calls
+`coordination.capabilities` to expose Cairnline's own host/runtime boundary
+metadata in `coordination_capabilities`. `sidecar-read-smoke`,
 `sidecar-detail-smoke`, `sidecar-resource-smoke`,
 `sidecar-coordination-smoke`, `sidecar-assignment-context-smoke`, and
 `sidecar-launch-packet-smoke` use that cached client to call read-only

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -3448,6 +3448,14 @@ Projects routing. Add
 read families through the standalone MCP client; write-authority switchpoints
 still require the embedded Cairnline connector.
 
+When the sidecar exposes `coordination.capabilities`, `sidecar-connect`
+best-effort calls it and returns `coordination_capabilities` with Cairnline's
+portable coordination contract, execution modes, skill metadata paths,
+recommended MCP-pull flow, and host-owned runtime responsibilities. A missing
+or text-only structured payload is reported as a warning; it does not make the
+sidecar connection fail after the required tool/resource-template contract has
+already passed.
+
 The response uses the same fields as `sidecar-probe` plus cache metadata:
 
 - `persistent_client=true` means the operation used the cached sidecar client.
@@ -3455,6 +3463,9 @@ The response uses the same fields as `sidecar-probe` plus cache metadata:
   cache.
 - `client_cache_entries`, `client_cache_in_use`, and `client_cache_idle`
   report the cache occupancy after the connect attempt.
+- `coordination_capabilities`, when present, is Cairnline's typed
+  self-description of what it coordinates and what the consuming agent host
+  still owns.
 
 Example response, shortened:
 
@@ -3479,6 +3490,23 @@ Example response, shortened:
     "tool_count": 82,
     "required_tools": ["coordination.capabilities", "projects.list", "projects.get"],
     "missing_tools": [],
+    "coordination_capabilities": {
+      "server_name": "cairnline",
+      "server_version": "v0.1.0-alpha.5",
+      "product": "local-first project coordination server for operators and AI agents",
+      "core_rule": "Assignment is coordination. Execution is capability-dependent.",
+      "execution_modes": ["manual", "mcp_pull", "external_adapter", "orchestrated"],
+      "skill_metadata_paths": [".agents/skills", ".cairnline/skills", ".claude/skills"],
+      "agent_host_owns": ["agent launch and supervision", "provider and model selection"],
+      "recommended_mcp_pull_flow": [
+        "assignments.next",
+        "assignments.claim",
+        "assignments.context",
+        "assignments.launch_packet",
+        "evidence.record",
+        "assignments.complete"
+      ]
+    },
     "tools": [{ "name": "projects.list" }],
     "warnings": []
   }

--- a/internal/api/cairnline_sidecar_fixture_test.go
+++ b/internal/api/cairnline_sidecar_fixture_test.go
@@ -223,6 +223,66 @@ func cairnlineSidecarFixtureReadResource(mode string, state *cairnlineSidecarFix
 
 func cairnlineSidecarFixtureCallTool(mode string, state *cairnlineSidecarFixtureState, params mcp.CallToolParams) (mcp.CallToolResult, *mcp.RPCError) {
 	switch params.Name {
+	case "coordination.capabilities":
+		if cairnlineSidecarFixtureModeHas(mode, "coordination-capabilities-tool-error") {
+			return mcp.CallToolResult{
+				Content: mcp.TextContent("fixture coordination.capabilities failed"),
+				IsError: true,
+			}, nil
+		}
+		result := mcp.CallToolResult{Content: mcp.TextContent("Cairnline coordinates project work; it does not launch or authorize agents.")}
+		if !cairnlineSidecarFixtureTextOnly(mode, "coordination.capabilities") {
+			result.StructuredContent = mustRawJSON(ProjectCairnlineCoordinationCapabilities{
+				ServerName:    "cairnline",
+				ServerVersion: "fixture",
+				Product:       "local-first project coordination server for operators and AI agents",
+				CoreRule:      "Assignment is coordination. Execution is capability-dependent.",
+				ExecutionModes: []string{
+					"manual",
+					"mcp_pull",
+					"external_adapter",
+					"orchestrated",
+				},
+				AssignmentStatuses: []string{
+					"queued",
+					"claimed",
+					"running",
+					"awaiting_review",
+					"completed",
+					"failed",
+					"cancelled",
+				},
+				DesiredAgentKindHints: []string{
+					"any",
+					"human",
+					"claude",
+					"cursor",
+					"hecate",
+				},
+				SkillMetadataPaths: []string{
+					".agents/skills",
+					".cairnline/skills",
+					".claude/skills",
+					".gemini/skills",
+					".hecate/skills",
+				},
+				AgentHostOwns: []string{
+					"agent launch and supervision",
+					"provider and model selection",
+					"tool, write, network, and sandbox permissions",
+					"mapping desired_agent hints to host-specific agents or presets",
+				},
+				RecommendedMCPPullFlow: []string{
+					"assignments.next",
+					"assignments.claim",
+					"assignments.context",
+					"assignments.launch_packet",
+					"evidence.record",
+					"assignments.complete",
+				},
+			})
+		}
+		return result, nil
 	case "projects.list":
 		if cairnlineSidecarFixtureModeHas(mode, "tool-error") {
 			return mcp.CallToolResult{

--- a/internal/api/handler_project_cairnline_connector.go
+++ b/internal/api/handler_project_cairnline_connector.go
@@ -492,10 +492,41 @@ func (h *Handler) projectCairnlineSidecarConnect(ctx context.Context) ProjectCai
 		response.Detail = "Cairnline sidecar MCP client connected, but it does not expose every resource template Hecate expects for portable Projects diagnostics."
 		return response
 	}
+	h.appendProjectCairnlineSidecarCoordinationCapabilities(connectCtx, cfg, cache, &response)
+	response.setSidecarCacheStats(cache.Stats())
 	response.Ready = true
 	response.Status = "sidecar_client_ready"
 	response.Detail = "Cairnline sidecar MCP client connected and exposes the required portable Projects tool and resource-template contract. " + projectCairnlineSidecarLiveReadDetail()
 	return response
+}
+
+func (h *Handler) appendProjectCairnlineSidecarCoordinationCapabilities(ctx context.Context, cfg types.MCPServerConfig, cache *mcpclient.SharedClientCache, response *ProjectCairnlineSidecarProbeResponse) {
+	if h == nil || response == nil {
+		return
+	}
+	result, err := orchestrator.CallCachedMCPServerTool(ctx, cfg, h.secretCipher, cache, "coordination.capabilities", json.RawMessage(`{}`))
+	if err != nil {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar coordination.capabilities call failed: "+err.Error())
+		return
+	}
+	if result.IsError {
+		detail := strings.TrimSpace(result.Text)
+		if detail == "" {
+			detail = "tool-level error"
+		}
+		response.Warnings = append(response.Warnings, "Cairnline sidecar coordination.capabilities returned a tool-level error: "+detail)
+		return
+	}
+	capabilities, structuredReady, structuredErr := projectCairnlineSidecarStructuredCoordinationCapabilities(result.Result.StructuredContent)
+	if structuredErr != nil {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar coordination.capabilities returned structuredContent that Hecate could not parse.")
+		return
+	}
+	if !structuredReady {
+		response.Warnings = append(response.Warnings, "Cairnline sidecar coordination.capabilities did not return structuredContent; Hecate verified the tool exists but not its typed self-description.")
+		return
+	}
+	response.CoordinationCapabilities = &capabilities
 }
 
 func (h *Handler) projectCairnlineSidecarReadSmoke(ctx context.Context) ProjectCairnlineSidecarReadResponse {
@@ -3612,6 +3643,21 @@ func projectCairnlineSidecarStructuredProjects(raw json.RawMessage) ([]ProjectCa
 		projects = []ProjectCairnlineSidecarProjectItem{}
 	}
 	return projects, true, nil
+}
+
+func projectCairnlineSidecarStructuredCoordinationCapabilities(raw json.RawMessage) (ProjectCairnlineCoordinationCapabilities, bool, error) {
+	if len(raw) == 0 {
+		return ProjectCairnlineCoordinationCapabilities{}, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ProjectCairnlineCoordinationCapabilities{}, false, nil
+	}
+	var capabilities ProjectCairnlineCoordinationCapabilities
+	if err := json.Unmarshal(trimmed, &capabilities); err != nil {
+		return ProjectCairnlineCoordinationCapabilities{}, false, err
+	}
+	return capabilities, true, nil
 }
 
 func projectCairnlineSidecarProjectByName(projects []ProjectCairnlineSidecarProjectItem, name string) (ProjectCairnlineSidecarProjectItem, bool) {

--- a/internal/api/handler_project_cairnline_connector_test.go
+++ b/internal/api/handler_project_cairnline_connector_test.go
@@ -227,11 +227,43 @@ func TestProjectCairnlineSidecarConnect_ReadyUsesPersistentClientCache(t *testin
 	if got.ResourceTemplateCount != len(projectCairnlineSidecarRequiredResourceTemplates) || len(got.MissingResourceTemplates) != 0 {
 		t.Fatalf("resource template count=%d missing=%+v, want full contract", got.ResourceTemplateCount, got.MissingResourceTemplates)
 	}
+	if got.CoordinationCapabilities == nil {
+		t.Fatalf("coordination capabilities = nil, want Cairnline self-description")
+	}
+	if got.CoordinationCapabilities.CoreRule != "Assignment is coordination. Execution is capability-dependent." ||
+		!containsString(got.CoordinationCapabilities.ExecutionModes, "mcp_pull") ||
+		!containsString(got.CoordinationCapabilities.AgentHostOwns, "agent launch and supervision") ||
+		!containsString(got.CoordinationCapabilities.RecommendedMCPPullFlow, "assignments.claim") {
+		t.Fatalf("coordination capabilities = %+v, want portable boundary metadata", got.CoordinationCapabilities)
+	}
 	assertSidecarLiveReadDetail(t, got.Detail)
 	for _, name := range []string{"coordination.capabilities", "projects.activity", "skills.discover", "work_items.closeout_readiness", "artifacts.create", "handoffs.update_status", "memory_candidates.promote"} {
 		if !containsString(got.RequiredTools, name) {
 			t.Fatalf("required tools = %+v, want %q", got.RequiredTools, name)
 		}
+	}
+}
+
+func TestProjectCairnlineSidecarConnect_CoordinationCapabilitiesAreBestEffort(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			CairnlineConnector:           "sidecar",
+			CairnlineSidecarCommand:      os.Args[0],
+			CairnlineSidecarArgs:         []string{cairnlineSidecarFixtureArgPrefix + "coordination.capabilities-text-only"},
+			CairnlineSidecarProbeTimeout: 5 * time.Second,
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	t.Cleanup(func() { _ = handler.Shutdown(context.Background()) })
+
+	got := handler.projectCairnlineSidecarConnect(t.Context())
+	if !got.Ready || got.Status != "sidecar_client_ready" {
+		t.Fatalf("connect = %+v, want ready despite missing typed capabilities", got)
+	}
+	if got.CoordinationCapabilities != nil {
+		t.Fatalf("coordination capabilities = %+v, want nil when structuredContent is missing", got.CoordinationCapabilities)
+	}
+	if !containsString(got.Warnings, "Cairnline sidecar coordination.capabilities did not return structuredContent; Hecate verified the tool exists but not its typed self-description.") {
+		t.Fatalf("warnings = %+v, want typed self-description warning", got.Warnings)
 	}
 }
 

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -1852,30 +1852,44 @@ type ProjectCairnlineSidecarAssistantRequest struct {
 }
 
 type ProjectCairnlineSidecarProbeResponse struct {
-	Ready                     bool                                 `json:"ready"`
-	Status                    string                               `json:"status"`
-	Detail                    string                               `json:"detail"`
-	Command                   string                               `json:"command"`
-	Args                      []string                             `json:"args,omitempty"`
-	DatabasePath              string                               `json:"database_path,omitempty"`
-	ProbeTimeoutMS            int64                                `json:"probe_timeout_ms"`
-	ServerName                string                               `json:"server_name,omitempty"`
-	ServerVersion             string                               `json:"server_version,omitempty"`
-	PersistentClient          bool                                 `json:"persistent_client,omitempty"`
-	ClientCacheConfigured     bool                                 `json:"client_cache_configured,omitempty"`
-	ClientCacheEntries        int                                  `json:"client_cache_entries,omitempty"`
-	ClientCacheInUse          int                                  `json:"client_cache_in_use,omitempty"`
-	ClientCacheIdle           int                                  `json:"client_cache_idle,omitempty"`
-	ToolCount                 int                                  `json:"tool_count"`
-	RequiredTools             []string                             `json:"required_tools"`
-	MissingTools              []string                             `json:"missing_tools,omitempty"`
-	Tools                     []MCPProbeToolDescriptor             `json:"tools,omitempty"`
-	ResourceTemplateCount     int                                  `json:"resource_template_count"`
-	RequiredResourceTemplates []string                             `json:"required_resource_templates"`
-	MissingResourceTemplates  []string                             `json:"missing_resource_templates,omitempty"`
-	ResourceTemplateError     string                               `json:"resource_template_error,omitempty"`
-	ResourceTemplates         []MCPProbeResourceTemplateDescriptor `json:"resource_templates,omitempty"`
-	Warnings                  []string                             `json:"warnings,omitempty"`
+	Ready                     bool                                      `json:"ready"`
+	Status                    string                                    `json:"status"`
+	Detail                    string                                    `json:"detail"`
+	Command                   string                                    `json:"command"`
+	Args                      []string                                  `json:"args,omitempty"`
+	DatabasePath              string                                    `json:"database_path,omitempty"`
+	ProbeTimeoutMS            int64                                     `json:"probe_timeout_ms"`
+	ServerName                string                                    `json:"server_name,omitempty"`
+	ServerVersion             string                                    `json:"server_version,omitempty"`
+	PersistentClient          bool                                      `json:"persistent_client,omitempty"`
+	ClientCacheConfigured     bool                                      `json:"client_cache_configured,omitempty"`
+	ClientCacheEntries        int                                       `json:"client_cache_entries,omitempty"`
+	ClientCacheInUse          int                                       `json:"client_cache_in_use,omitempty"`
+	ClientCacheIdle           int                                       `json:"client_cache_idle,omitempty"`
+	ToolCount                 int                                       `json:"tool_count"`
+	RequiredTools             []string                                  `json:"required_tools"`
+	MissingTools              []string                                  `json:"missing_tools,omitempty"`
+	Tools                     []MCPProbeToolDescriptor                  `json:"tools,omitempty"`
+	ResourceTemplateCount     int                                       `json:"resource_template_count"`
+	RequiredResourceTemplates []string                                  `json:"required_resource_templates"`
+	MissingResourceTemplates  []string                                  `json:"missing_resource_templates,omitempty"`
+	ResourceTemplateError     string                                    `json:"resource_template_error,omitempty"`
+	ResourceTemplates         []MCPProbeResourceTemplateDescriptor      `json:"resource_templates,omitempty"`
+	CoordinationCapabilities  *ProjectCairnlineCoordinationCapabilities `json:"coordination_capabilities,omitempty"`
+	Warnings                  []string                                  `json:"warnings,omitempty"`
+}
+
+type ProjectCairnlineCoordinationCapabilities struct {
+	ServerName             string   `json:"server_name,omitempty"`
+	ServerVersion          string   `json:"server_version,omitempty"`
+	Product                string   `json:"product,omitempty"`
+	CoreRule               string   `json:"core_rule,omitempty"`
+	ExecutionModes         []string `json:"execution_modes,omitempty"`
+	AssignmentStatuses     []string `json:"assignment_statuses,omitempty"`
+	DesiredAgentKindHints  []string `json:"desired_agent_kind_hints,omitempty"`
+	SkillMetadataPaths     []string `json:"skill_metadata_paths,omitempty"`
+	AgentHostOwns          []string `json:"agent_host_owns,omitempty"`
+	RecommendedMCPPullFlow []string `json:"recommended_mcp_pull_flow,omitempty"`
 }
 
 type ProjectCairnlineSidecarReadResponse struct {


### PR DESCRIPTION
## Summary
- call Cairnline `coordination.capabilities` during Projects sidecar connect after the required tool/resource-template contract passes
- expose structured coordination capability metadata in the sidecar connect response
- treat missing or malformed capability metadata as a warning so compatible older/partial servers can still connect
- document the new `coordination_capabilities` response field and deployment diagnostics

## Tests
- `go test ./internal/api -run 'TestProjectCairnlineSidecar(Probe|Connect)'`\n- `just test-projects-sidecar`\n- `just docs-check`\n- `GOCACHE="$PWD/.gocache" go test -race -count=1 -timeout 2m ./internal/api -run 'TestProjectCairnlineSidecar(Probe|Connect)' -v`\n- `just test-race`