### PR TITLE
test(projects): clarify cairnline sidecar checklist

### DIFF
--- a/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
+++ b/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
@@ -791,14 +791,15 @@ function projectBackendProbePlan(url: string, method: string): { label: string; 
   if (url.includes("/sidecar-connect")) {
     return {
       label: "Connect sidecar client",
-      detail: "Start or reuse the local Cairnline MCP sidecar client before sidecar read checks.",
+      detail:
+        "Start or reuse the local Cairnline MCP sidecar client and capture its typed coordination capability self-description when available.",
     };
   }
   if (url.includes("/sidecar-probe")) {
     return {
       label: "Probe sidecar contract",
       detail:
-        "Confirm the standalone Cairnline MCP server exposes the expected tools and resource templates.",
+        "Confirm the standalone Cairnline MCP server exposes the required tools, resource templates, and coordination capabilities tool.",
     };
   }
   if (url.includes("/sidecar-")) {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -363,6 +363,10 @@ describe("SettingsView", () => {
               method: "POST",
               url: "/hecate/v1/projects/cairnline/sidecar-probe",
             },
+            {
+              method: "POST",
+              url: "/hecate/v1/projects/cairnline/sidecar-connect",
+            },
           ],
         },
       },
@@ -372,8 +376,12 @@ describe("SettingsView", () => {
 
     expect(await screen.findByText("Probe standalone sidecar")).toBeTruthy();
     expect(screen.getByText("Probe sidecar contract")).toBeTruthy();
-    expect(screen.getByText(/expected tools and resource templates/i)).toBeTruthy();
+    expect(screen.getByText(/required tools, resource templates/i)).toBeTruthy();
+    expect(screen.getByText(/coordination capabilities tool/i)).toBeTruthy();
+    expect(screen.getByText("Connect sidecar client")).toBeTruthy();
+    expect(screen.getByText(/typed coordination capability self-description/i)).toBeTruthy();
     expect(screen.getByText("/hecate/v1/projects/cairnline/sidecar-probe")).toBeTruthy();
+    expect(screen.getByText("/hecate/v1/projects/cairnline/sidecar-connect")).toBeTruthy();
   });
 
   it("shows strict embedded smoke probe routes in the next project backend action", async () => {


### PR DESCRIPTION
## Summary
- clarify the Settings sidecar probe checklist to name the required coordination capabilities tool
- clarify sidecar-connect as the step that captures Cairnline typed coordination capability metadata when available
- extend the Settings test fixture to cover probe + connect checklist rows

## Tests
- `cd ui && bun run test -- src/features/settings/SettingsView.test.tsx`
- `just ui-format-check`
- `just docs-check`