### PR TITLE
feat(projects): open external-agent assignment chats with drafts

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -553,8 +553,10 @@ Project assignments can also prepare External Agent sessions. Starting a
 linked External Agent chat session, records assignment/profile/workspace context,
 stores the ACP adapter metadata, advertised command list, and session link on
 the assignment-linked chat. It does not append a visible chat message, create a
-`message_id`, or send the assignment prompt automatically; the operator stays in
-control of the first turn from the linked chat. Project assignment and activity
+`message_id`, or send the assignment prompt automatically. After a successful
+prepare from the Projects cockpit, the UI opens the linked chat with an editable
+launch-context draft so the operator can review or change the first turn before
+sending it. Project assignment and activity
 rows project the linked chat's latest assistant-message status, session status,
 adapter identity, and missing-session diagnostics so the Projects cockpit can
 show follow-through state without embedding the full chat transcript. When the

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -846,13 +846,14 @@ describe("ConsoleShell navigation", () => {
     expect(onSelectWorkspace).toHaveBeenCalledWith("chats");
   });
 
-  it("selects linked External Agent chats when opening a started project assignment", async () => {
+  async function openLinkedExternalAgentChat(selected: boolean) {
     const createChatSession = vi.fn<RuntimeConsoleFixtureActions["createChatSession"]>(
       async () => undefined,
     );
     const selectChatSession = vi.fn<RuntimeConsoleFixtureActions["selectChatSession"]>(
-      async () => undefined,
+      async () => selected,
     );
+    const setMessage = vi.fn<RuntimeConsoleFixtureActions["setMessage"]>(() => undefined);
     const onSelectWorkspace = vi.fn();
     const project = {
       id: "proj_1",
@@ -920,7 +921,12 @@ describe("ConsoleShell navigation", () => {
         <ConsoleShell activeWorkspace="projects" onSelectWorkspace={onSelectWorkspace} />,
         {
           state,
-          actions: { ...createRuntimeConsoleActions(), createChatSession, selectChatSession },
+          actions: {
+            ...createRuntimeConsoleActions(),
+            createChatSession,
+            selectChatSession,
+            setMessage,
+          },
         },
       ),
     );
@@ -930,11 +936,28 @@ describe("ConsoleShell navigation", () => {
     expect(selectChatSession).toHaveBeenCalledWith("chat_external_1");
     expect(createChatSession).not.toHaveBeenCalled();
     expect(onSelectWorkspace).toHaveBeenCalledWith("chats");
+    return { selectChatSession, setMessage };
+  }
+
+  it("selects linked External Agent chats and seeds the draft after a successful selection", async () => {
+    const { setMessage } = await openLinkedExternalAgentChat(true);
+
+    await waitFor(() =>
+      expect(setMessage).toHaveBeenCalledWith(expect.stringContaining("Launch context")),
+    );
+    expect(setMessage.mock.calls[0]?.[0]).toContain("- Driver: external_agent");
+  });
+
+  it("selects linked External Agent chats without seeding a draft when selection fails", async () => {
+    const { selectChatSession, setMessage } = await openLinkedExternalAgentChat(false);
+
+    await waitFor(() => expect(selectChatSession).toHaveBeenCalledTimes(1));
+    expect(setMessage).not.toHaveBeenCalled();
   });
 
   it("moves the active chat when selecting a different project", () => {
     const selectProject = vi.fn(async () => undefined);
-    const selectChatSession = vi.fn(async () => undefined);
+    const selectChatSession = vi.fn(async () => true);
     const state = createRuntimeConsoleFixture({
       projects: [
         {

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -324,7 +324,11 @@ function AuthenticatedShell({
       void projects.actions.selectProject(request.projectID);
     }
     if (request.chatSessionID) {
-      void chatActions.selectChatSession(request.chatSessionID);
+      void chatActions.selectChatSession(request.chatSessionID).then((selected) => {
+        if (selected && request.draft) {
+          runtime.actions.setMessage(request.draft);
+        }
+      });
       onSelectWorkspace("chats");
       return;
     }

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -292,7 +292,7 @@ type ChatActionsReturn = {
   updateToolResult: (index: number, result: string) => void;
   submitToolResults: () => Promise<void>;
   createChatSession: (options?: CreateChatSessionOptions) => Promise<void>;
-  selectChatSession: (id: string) => Promise<void>;
+  selectChatSession: (id: string) => Promise<boolean>;
   startNewChat: () => void;
   deleteChatSession: (id: string) => Promise<void>;
   renameChatSession: (id: string, title: string) => Promise<void>;
@@ -1100,11 +1100,11 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     }
   }
 
-  async function selectChatSession(id: string) {
+  async function selectChatSession(id: string): Promise<boolean> {
     setActiveChatSessionID(id);
     if (!id) {
       setActiveChatSession(null);
-      return;
+      return true;
     }
     try {
       const payload = await getChatSession(id);
@@ -1121,6 +1121,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       }
       setAgentWorkspace(payload.data.workspace ?? "");
       setAgentWorkspaceBranch(payload.data.workspace_branch ?? "");
+      return true;
     } catch (error) {
       const msg = error instanceof Error ? error.message : "failed to load agent chat";
       setActiveChatSessionID("");
@@ -1128,6 +1129,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       setAgentWorkspaceBranch("");
       setChatErrorState(error, "failed to load agent chat");
       params.setNoticeMessage("error", msg);
+      return false;
     }
   }
 

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -312,7 +312,7 @@ describe("ChatView input", () => {
 
   it("creates a Grok Build chat before the launch model is selected", async () => {
     const createChatSession = vi.fn(async () => undefined);
-    const selectChatSession = vi.fn(async () => undefined);
+    const selectChatSession = vi.fn(async () => true);
     const { state, actions } = setup(
       {
         chatTarget: "external_agent",
@@ -4133,7 +4133,7 @@ describe("ChatView chats sidebar", () => {
   });
 
   it("calls selectChatSession when clicking a chat row", async () => {
-    const selectChatSession = vi.fn(async () => undefined);
+    const selectChatSession = vi.fn(async () => true);
     const { state, actions } = setup(
       {
         chatTarget: "agent",
@@ -4151,7 +4151,7 @@ describe("ChatView chats sidebar", () => {
   });
 
   it("calls selectChatSession when pressing Enter or Space on a focused chat row", async () => {
-    const selectChatSession = vi.fn(async () => undefined);
+    const selectChatSession = vi.fn(async () => true);
     const { state, actions } = setup(
       {
         chatTarget: "agent",
@@ -6615,7 +6615,7 @@ describe("ChatView session focus", () => {
     // effect deliberately does NOT focus, because data-load (chats
     // arriving from the API) also drives that transition and stealing
     // focus on load would hijack normal page navigation.
-    const selectChatSession = vi.fn(async () => undefined);
+    const selectChatSession = vi.fn(async () => true);
     const { state, actions } = setup(
       {
         chatTarget: "agent",

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -343,18 +343,22 @@ export function ProjectWorkItemDetail({
                           ? () => {
                               const executionRef =
                                 toProjectAssignmentExecutionViewModel(assignment);
+                              const chatRequest = buildProjectAssignmentChatLaunchRequest({
+                                project,
+                                workItem,
+                                assignment,
+                                role: roleByID.get(assignment.role_id) ?? null,
+                              });
+                              const linkedChatRequest = {
+                                projectID: project.id,
+                                chatSessionID: executionRef.chatSessionID,
+                                ...(assignment.driver_kind === "external_agent" &&
+                                !executionRef.messageID
+                                  ? chatRequest
+                                  : {}),
+                              };
                               onOpenChat?.(
-                                executionRef.chatSessionID
-                                  ? {
-                                      projectID: project.id,
-                                      chatSessionID: executionRef.chatSessionID,
-                                    }
-                                  : buildProjectAssignmentChatLaunchRequest({
-                                      project,
-                                      workItem,
-                                      assignment,
-                                      role: roleByID.get(assignment.role_id) ?? null,
-                                    }),
+                                executionRef.chatSessionID ? linkedChatRequest : chatRequest,
                               );
                             }
                           : undefined

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -3165,11 +3165,17 @@ describe("ProjectsView cockpit", () => {
       }),
     );
     window.localStorage.setItem("hecate.project", project.id);
+    const onOpenChat = vi.fn();
     const state = createRuntimeConsoleFixture({
       projects: [project],
       activeProjectID: project.id,
     });
-    render(withRuntimeConsole(<ProjectsView />, { state, actions: createRuntimeConsoleActions() }));
+    render(
+      withRuntimeConsole(<ProjectsView onOpenChat={onOpenChat} />, {
+        state,
+        actions: createRuntimeConsoleActions(),
+      }),
+    );
 
     await userEvent.click(
       await screen.findByRole("button", { name: "Open work item Build cockpit UI" }),
@@ -3197,22 +3203,31 @@ describe("ProjectsView cockpit", () => {
       "external_agent",
     );
     expect(startProjectAssignment).toHaveBeenCalledTimes(1);
-    resolveStartAssignment({
-      object: "project_assignment",
-      data: {
-        ...externalAssignment,
-        status: "running",
-        execution_ref: {
-          kind: "chat_session",
-          chat_session_id: "chat_external_1",
-          context_snapshot_id: "ctx_external_1",
+    await act(async () => {
+      resolveStartAssignment({
+        object: "project_assignment",
+        data: {
+          ...externalAssignment,
           status: "running",
+          execution_ref: {
+            kind: "chat_session",
+            chat_session_id: "chat_external_1",
+            context_snapshot_id: "ctx_external_1",
+            status: "running",
+          },
         },
-      },
+      });
     });
-    await waitFor(() => {
-      expect(prepareButton).not.toBeDisabled();
-    });
+    await waitFor(() =>
+      expect(onOpenChat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectID: project.id,
+          chatSessionID: "chat_external_1",
+          draft: expect.stringContaining("Launch context"),
+        }),
+      ),
+    );
+    expect(onOpenChat.mock.calls[0]?.[0].draft).toContain("- Driver: external_agent");
   });
 
   it("opens linked external-agent assignment chat sessions directly", async () => {
@@ -3256,10 +3271,14 @@ describe("ProjectsView cockpit", () => {
     const detail = await screen.findByRole("region", { name: "Selected work item" });
     await userEvent.click(within(detail).getByRole("button", { name: "Open chat" }));
 
-    expect(onOpenChat).toHaveBeenCalledWith({
-      projectID: project.id,
-      chatSessionID: "chat_external_1",
-    });
+    expect(onOpenChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectID: project.id,
+        chatSessionID: "chat_external_1",
+        draft: expect.stringContaining("Launch context"),
+      }),
+    );
+    expect(onOpenChat.mock.calls[0]?.[0].draft).toContain("- Driver: external_agent");
   });
 
   it("prefills handoffs from linked external-agent assignment context", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -77,7 +77,10 @@ import {
 } from "./projectActionRouting";
 import { ProjectMemoryModal, ProjectSourceModal, type MemoryForm } from "./ProjectMemoryPanel";
 import { ProjectReviewArtifactModal } from "./ProjectReviewArtifactModal";
-import { type ProjectAssignmentChatLaunchRequest } from "./ProjectWorkItemDetail";
+import {
+  buildProjectAssignmentChatLaunchRequest,
+  type ProjectAssignmentChatLaunchRequest,
+} from "./ProjectWorkItemDetail";
 import {
   ProjectEmptyBlock,
   ProjectWorkspaceView,
@@ -1588,6 +1591,7 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenSettings, on
         assignment.driver_kind || "hecate_task",
       );
       setAssignments((current) => upsertAssignment(current, res.data));
+      openPreparedExternalAgentChat(res.data, workItemID);
       await loadWorkForProject(selectedProjectID, workItemID);
       await loadWorkItemDetail(selectedProjectID, workItemID);
     } catch (error) {
@@ -1603,6 +1607,37 @@ export function ProjectsView({ onOpenChat, onOpenConnections, onOpenSettings, on
       startingAssignmentIDsRef.current.delete(assignment.id);
       setStartingAssignmentID("");
     }
+  }
+
+  function openPreparedExternalAgentChat(assignment: ProjectAssignmentRecord, workItemID: string) {
+    if (!onOpenChat || assignment.driver_kind !== "external_agent") return;
+    const project =
+      selectedProject?.id === selectedProjectID
+        ? selectedProject
+        : projects.state.projects.find((item) => item.id === selectedProjectID);
+    if (!project) return;
+    const chatSessionID = assignment.execution_ref?.chat_session_id?.trim();
+    if (!chatSessionID) return;
+    const workItem = (selectedWorkItem?.id === workItemID ? selectedWorkItem : null) ??
+      workItems.find((item) => item.id === workItemID) ?? {
+        id: workItemID,
+        project_id: project.id,
+        title: workItemID,
+        status: "",
+        priority: "",
+        created_at: "",
+        updated_at: "",
+      };
+    const request = buildProjectAssignmentChatLaunchRequest({
+      project,
+      workItem,
+      assignment,
+      role: roleByID.get(assignment.role_id) ?? null,
+    });
+    onOpenChat({
+      ...request,
+      chatSessionID,
+    });
   }
 
   const hasWorkItemDetail =

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -2889,7 +2889,7 @@ describe("useRuntimeConsole", () => {
       });
 
       expect(result.current.state.queuedChatMessages).toHaveLength(1);
-      let selectPromise!: Promise<void>;
+      let selectPromise!: Promise<boolean>;
       act(() => {
         selectPromise = result.current.actions.selectChatSession("a2");
       });
@@ -3001,7 +3001,7 @@ describe("useRuntimeConsole", () => {
       });
       await waitFor(() => expect(result.current.state.activeChatSession?.id).toBe("a1"));
 
-      let selectA2Promise!: Promise<void>;
+      let selectA2Promise!: Promise<boolean>;
       act(() => {
         selectA2Promise = result.current.actions.selectChatSession("a2");
       });

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -233,7 +233,7 @@ export type RuntimeConsoleFixtureActions = {
   submitChat: (event: unknown) => Promise<void>;
   submitToolResults: () => Promise<void>;
   runRetention: () => Promise<void>;
-  selectChatSession: (id: string) => Promise<void>;
+  selectChatSession: (id: string) => Promise<boolean>;
   startNewChat: () => void;
   upsertPolicyRule: (payload: unknown) => Promise<void>;
   updateToolResult: (index: number, result: string) => void;
@@ -312,7 +312,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
     submitChat: async () => undefined,
     submitToolResults: async () => undefined,
     runRetention: async () => undefined,
-    selectChatSession: async () => undefined,
+    selectChatSession: async () => true,
     startNewChat: () => undefined,
     upsertPolicyRule: async () => undefined,
     updateToolResult: () => undefined,


### PR DESCRIPTION
## Summary
- open the prepared External Agent assignment chat after a successful Projects prepare action
- seed linked External Agent chats with the editable launch-context draft when no assistant message exists yet
- document that Projects opens an editable draft but still does not auto-send the first turn

## Verification
- cd ui && bun run typecheck
- cd ui && bun run test
- just docs-check