### PR TITLE
fix(projects): tolerate empty operations brief items

### DIFF
--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -8,6 +8,7 @@ import type {
   ProjectAssignmentRecord,
   ProjectCoordinationBackendStatusRecord,
   ProjectMemoryCandidateRecord,
+  ProjectOperationsBriefItem,
   ProjectRecord,
   ProjectSetupReadiness,
   ProjectWorkItemRecord,
@@ -761,6 +762,27 @@ describe("ProjectWorkspaceView", () => {
     });
 
     expect(screen.queryByRole("region", { name: "Project next action" })).toBeNull();
+    expect(screen.queryByRole("region", { name: "Project operations" })).toBeNull();
+    expect(screen.getByRole("region", { name: "Project resume" })).toBeTruthy();
+  });
+
+  it("treats a null operations brief item list as empty", () => {
+    renderWorkspace({
+      operationsBrief: {
+        project_id: "proj_1",
+        generated_at: "2026-06-13T00:00:00Z",
+        summary: {
+          item_count: 0,
+          high_count: 0,
+          medium_count: 0,
+          low_count: 0,
+          pending_memory_candidate_count: 0,
+          pending_handoff_count: 0,
+        },
+        items: null as unknown as ProjectOperationsBriefItem[],
+      },
+    });
+
     expect(screen.queryByRole("region", { name: "Project operations" })).toBeNull();
     expect(screen.getByRole("region", { name: "Project resume" })).toBeTruthy();
   });

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -793,11 +793,11 @@ function ProjectOperationsBriefPanel({
   loading: boolean;
   onAction: (item: ProjectOperationsBriefItem) => void;
 }) {
-  if ((!brief || brief.items.length === 0) && !loading) {
+  const items = Array.isArray(brief?.items) ? brief.items : [];
+  if ((!brief || items.length === 0) && !loading) {
     return error ? <InlineError message={error} /> : null;
   }
 
-  const items = brief?.items ?? [];
   const primary = items[0] ?? null;
   const secondary = items.slice(1, 4);
   const shownItemCount = (primary ? 1 : 0) + secondary.length;
@@ -864,7 +864,8 @@ function projectOperationsLimitDetail(
   shownItemCount: number,
 ) {
   if (!brief || shownItemCount === 0) return "";
-  const returnedItemCount = Math.max(brief.summary.item_count ?? 0, brief.items.length);
+  const items = Array.isArray(brief.items) ? brief.items : [];
+  const returnedItemCount = Math.max(brief.summary.item_count ?? 0, items.length);
   const availableItemCount = Math.max(
     brief.summary.available_item_count ?? returnedItemCount,
     returnedItemCount,


### PR DESCRIPTION
## Summary
- harden the Project Operations strip against non-array/null operation item payloads
- add a regression test for a null operations brief item list so Projects falls back to the resume view instead of crashing

## Dogfood note
While dogfooding the merged external-agent assignment draft flow, I created a temporary in-memory Hecate project, prepared a Codex external-agent assignment, then opened Projects in the embedded UI. Projects hit the error boundary with `Cannot read properties of null (reading 'length')`; this PR fixes the null-safety gap in that render path.

## Tests
- `cd ui && bun run test -- src/features/projects/ProjectWorkspaceView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `cd ui && bun run test`
- `cd ui && bun run build`
- `just docs-check`