### PR TITLE
fix(projects): tolerate nullable work item detail lists

### DIFF
--- a/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.test.tsx
@@ -309,6 +309,36 @@ describe("ProjectWorkItemDetail", () => {
     });
   });
 
+  it("treats null detail lists as empty", () => {
+    renderDetail({
+      assignments: null as unknown as ProjectAssignmentRecord[],
+      artifacts: null as unknown as ProjectCollaborationArtifactRecord[],
+      handoffs: null as unknown as ProjectHandoffRecord[],
+    });
+
+    expect(screen.getByRole("article", { name: "Decompose project UI work item" })).toBeTruthy();
+    expect(screen.getByText("Let Hecate prepare the first step")).toBeTruthy();
+    expect(screen.queryByText("No assignments recorded yet.")).toBeNull();
+  });
+
+  it("treats null closeout lists as empty", () => {
+    renderDetail({
+      closeoutReadiness: {
+        ...closeoutReadiness({
+          ready: false,
+          status: "blocked",
+          title: "Closeout is blocked",
+          blockers: ["1 assignment is still active"],
+        }),
+        review_follow_ups: null as unknown as ProjectWorkItemReadinessRecord["review_follow_ups"],
+        warnings: null as unknown as string[],
+      },
+    });
+
+    expect(screen.getByRole("region", { name: "Work closeout" })).toBeTruthy();
+    expect(screen.getByText("1 assignment is still active")).toBeTruthy();
+  });
+
   it("renders assignment runtime links and delegates row actions", async () => {
     const { handlers, assignment: assign } = renderDetail();
 

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -185,6 +185,9 @@ export function ProjectWorkItemDetail({
   startingAssignmentID,
   workItem,
 }: ProjectWorkItemDetailProps) {
+  const safeAssignments = Array.isArray(assignments) ? assignments : [];
+  const safeArtifacts = Array.isArray(artifacts) ? artifacts : [];
+  const safeHandoffs = Array.isArray(handoffs) ? handoffs : [];
   if (!workItem) {
     return (
       <EmptyBlock
@@ -195,9 +198,9 @@ export function ProjectWorkItemDetail({
   }
   const closeout = closeoutReadiness ?? unavailableCloseoutReadiness(workItem, loading);
   const emptyWorkItem =
-    assignments.length === 0 &&
-    artifacts.length === 0 &&
-    handoffs.length === 0 &&
+    safeAssignments.length === 0 &&
+    safeArtifacts.length === 0 &&
+    safeHandoffs.length === 0 &&
     workItem.status !== "done";
   const reviewFollowUps = closeout.review_follow_ups ?? [];
   const suggestedAssignmentRole = assignmentRoleForWorkItem(workItem, roleByID);
@@ -306,17 +309,17 @@ export function ProjectWorkItemDetail({
             }
           />
         )}
-        {(!emptyWorkItem || assignments.length > 0) && (
+        {(!emptyWorkItem || safeAssignments.length > 0) && (
           <section style={workItemCardSectionStyle}>
             <div style={workItemSectionHeaderStyle}>
               <div style={sectionLabelStyle}>Assignments</div>
-              <span className="badge badge-muted">{assignments.length}</span>
+              <span className="badge badge-muted">{safeAssignments.length}</span>
             </div>
-            {assignments.length === 0 ? (
+            {safeAssignments.length === 0 ? (
               <div style={subtleTextStyle}>No assignments recorded yet.</div>
             ) : (
               <div style={{ display: "grid", gap: 10 }}>
-                {assignments.map((assignment) => {
+                {safeAssignments.map((assignment) => {
                   const activityItem = activityByAssignmentID.get(assignment.id);
                   const reviewRole = reviewerRoleForAssignment(workItem, assignment, roleByID);
                   const reviewAuthorRole = reviewAuthorRoleForAssignment(
@@ -431,17 +434,17 @@ export function ProjectWorkItemDetail({
             )}
           </section>
         )}
-        {(!emptyWorkItem || artifacts.length > 0) && (
+        {(!emptyWorkItem || safeArtifacts.length > 0) && (
           <section style={workItemCardSectionStyle}>
             <div style={workItemSectionHeaderStyle}>
               <div style={sectionLabelStyle}>Collaboration Artifacts</div>
-              <span className="badge badge-muted">{artifacts.length}</span>
+              <span className="badge badge-muted">{safeArtifacts.length}</span>
             </div>
-            {artifacts.length === 0 ? (
+            {safeArtifacts.length === 0 ? (
               <div style={subtleTextStyle}>No collaboration artifacts recorded yet.</div>
             ) : (
               <div style={{ display: "grid", gap: 8 }}>
-                {artifacts.map((artifact) => {
+                {safeArtifacts.map((artifact) => {
                   const artifactActionPending = artifactActionID === artifact.id;
                   return (
                     <div key={artifact.id} style={artifactStyle}>
@@ -510,19 +513,19 @@ export function ProjectWorkItemDetail({
             )}
           </section>
         )}
-        {(!emptyWorkItem || handoffs.length > 0) && (
+        {(!emptyWorkItem || safeHandoffs.length > 0) && (
           <section style={workItemCardSectionStyle}>
             <div style={workItemSectionHeaderStyle}>
               <div style={sectionLabelStyle}>Handoffs</div>
-              <span className="badge badge-muted">{handoffs.length}</span>
+              <span className="badge badge-muted">{safeHandoffs.length}</span>
             </div>
             {handoffError && <InlineError message={handoffError} />}
-            {handoffs.length === 0 ? (
+            {safeHandoffs.length === 0 ? (
               <div style={subtleTextStyle}>No structured handoffs recorded yet.</div>
             ) : (
               <div style={{ display: "grid", gap: 8 }}>
-                {handoffs.map((handoff) => {
-                  const targetAssignment = assignments.find(
+                {safeHandoffs.map((handoff) => {
+                  const targetAssignment = safeAssignments.find(
                     (item) => item.id === handoff.target_assignment_id,
                   );
                   return (
@@ -764,6 +767,8 @@ function WorkItemCloseoutPanel({
 }) {
   const status =
     closeout.status === "ready" || closeout.status === "done" ? "completed" : "blocked";
+  const blockers = Array.isArray(closeout.blockers) ? closeout.blockers : [];
+  const warnings = Array.isArray(closeout.warnings) ? closeout.warnings : [];
   return (
     <section style={workItemCardSectionStyle} aria-label="Work closeout">
       <div style={workItemSectionHeaderStyle}>
@@ -787,16 +792,16 @@ function WorkItemCloseoutPanel({
       </div>
       <div style={titleStyle}>{closeout.title}</div>
       <div style={{ ...subtleTextStyle, marginTop: 4 }}>{closeout.detail}</div>
-      {closeout.blockers.length > 0 && (
+      {blockers.length > 0 && (
         <ul style={closeoutListStyle}>
-          {closeout.blockers.map((blocker) => (
+          {blockers.map((blocker) => (
             <li key={blocker}>{blocker}</li>
           ))}
         </ul>
       )}
-      {closeout.warnings.length > 0 && (
+      {warnings.length > 0 && (
         <div style={{ ...subtleTextStyle, marginTop: 8 }}>
-          {closeout.warnings.map((warning) => (
+          {warnings.map((warning) => (
             <div key={warning}>{warning}</div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- normalize nullable assignment, artifact, and handoff lists before rendering work item detail
- normalize nullable closeout blockers and warnings before rendering closeout state
- add regression coverage for nullable detail/closeout lists discovered during dogfooding

## Dogfood
- created a Hecate dogfood project, role, work item, and external-agent assignment through the local API
- started the assignment with `driver_kind=external_agent`
- verified the linked Codex chat stayed idle with `message_count: 0`
- ran a Playwright UI smoke that opened Projects, rendered the work item, clicked `Open chat`, and confirmed no runtime error

## Tests
- `cd ui && bun run test -- src/features/projects/ProjectWorkItemDetail.test.tsx src/features/projects/ProjectWorkspaceView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run build`
- `cd ui && bun run test`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `just docs-check`
