### PR TITLE
feat(projects): surface Cairnline shadow-mirror failures in backend status

### DIFF
--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -424,6 +424,13 @@ launch agents. Those remain explicit operator or orchestrator actions.
   tracked without parsing warning prose. These fields are diagnostic only:
   `replacement_ready=false` until read parity, strict embedded mirror probes,
   authoritative write switchpoints, and migration/rollback gates are ready.
+- Backend status and mirror-parity output include `mirror_write_health`:
+  process-local per-write-family shadow-mirror failure counters (failure count,
+  last error, last failure/success timestamps) plus a derived
+  `drifting_families` list of families whose most recent mirror write failed.
+  The `mirror-write-health` replacement gate keeps `replacement_ready=false`
+  while any family is drifting, so swallowed best-effort mirror errors cannot
+  silently coexist with a replacement-ready verdict.
 - `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY=project-memory` enables Hecate's
   accepted-memory Cairnline write-authority switchpoint: accepted project
   memory entry create/update/delete commits to embedded Cairnline first and then

--- a/docs/design/proposals/evidence/cairnline-replacement-dogfood-2026-07-08.md
+++ b/docs/design/proposals/evidence/cairnline-replacement-dogfood-2026-07-08.md
@@ -46,21 +46,21 @@ representability.
 
 ## Setup
 
-| Setting | Full-mode run | Observability run |
-| --- | --- | --- |
-| `HECATE_ADDRESS` | `127.0.0.1:8899` | `127.0.0.1:8899` |
-| `HECATE_BACKEND` | `sqlite` | `sqlite` |
-| `HECATE_PROJECTS_COORDINATION_BACKEND` | `cairnline` | `cairnline` |
-| `HECATE_PROJECTS_CAIRNLINE_CONNECTOR` | `embedded` | `embedded` |
-| `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE` | `embedded` | `auto` |
-| `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE` | `embedded` (armed) | `disabled` |
-| `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY` | `all-portable` | `project-roles,project-memory,project-collaboration` (partial) |
-| Model provider | stub OpenAI-compatible server (`mock-model`) for start flows | none |
+| Setting                                      | Full-mode run                                                | Observability run                                              |
+| -------------------------------------------- | ------------------------------------------------------------ | -------------------------------------------------------------- |
+| `HECATE_ADDRESS`                             | `127.0.0.1:8899`                                             | `127.0.0.1:8899`                                               |
+| `HECATE_BACKEND`                             | `sqlite`                                                     | `sqlite`                                                       |
+| `HECATE_PROJECTS_COORDINATION_BACKEND`       | `cairnline`                                                  | `cairnline`                                                    |
+| `HECATE_PROJECTS_CAIRNLINE_CONNECTOR`        | `embedded`                                                   | `embedded`                                                     |
+| `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE`      | `embedded`                                                   | `auto`                                                         |
+| `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE` | `embedded` (armed)                                           | `disabled`                                                     |
+| `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY`  | `all-portable`                                               | `project-roles,project-memory,project-collaboration` (partial) |
+| Model provider                               | stub OpenAI-compatible server (`mock-model`) for start flows | none                                                           |
 
 Env-gate source of truth: `internal/config/config.go:576-585` and validation at
-`:669-691`. Armed embedded replacement mode requires the four gates in lockstep:
-`COORDINATION_BACKEND=cairnline` + `CONNECTOR=embedded` + `READ_SOURCE=embedded`
-+ `REPLACEMENT_MODE=embedded`, which implies all portable write-authority
+`:669-691`. Armed embedded replacement mode requires the four gates in lockstep
+(`COORDINATION_BACKEND=cairnline`, `CONNECTOR=embedded`, `READ_SOURCE=embedded`,
+`REPLACEMENT_MODE=embedded`), which implies all portable write-authority
 switchpoints (`config.go:293-312`).
 
 The observability run uses **partial** write authority on purpose: see
@@ -74,17 +74,17 @@ mode. "Mirrored OK" = the record is present and correct in the embedded
 Cairnline SQLite DB. "Read parity" = the record reads back correctly through the
 strict embedded read routes.
 
-| Family | Create | Update | Delete | Mirrored OK | Read parity | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| projects | ✅ 201 | ✅ 200 (desc + rename) | ✅ 200 (victim) | ✅ | ✅ | `read_backend: cairnline` |
-| roots | ✅ 201 | — | — | ✅ | ✅ | Hecate still owns Git/workspace scan |
-| roles | ✅ 201 (×3) | ✅ 200 | ✅ 204 (temp) | ✅ | ✅ | built-in roles listable/immutable |
-| work-items | ✅ 201 | ✅ 200 (status transitions) | ✅ 204 (stale) | ✅ | ✅ | statuses backlog/ready/running/review/blocked exercised |
-| assignments | ✅ 201 | ✅ 200 (status) | ✅ 204 | ✅ (partial) | ✅ | execution-ref lossy — see Probe 1 |
-| artifacts | ✅ 201 (decision_note, evidence_link, review) | n/a (immutable) | n/a | ✅ | ✅ | update/delete absent by design |
-| handoffs | ✅ 201 | ✅ 200 (status→accepted) | — | ✅ | ✅ | |
-| memory | ✅ 201 | ✅ 200 | ✅ 204 | ✅ | ✅ | |
-| memory-candidates | ✅ 201 | promote ✅ / reject ✅ | — | ✅ | ✅ | promotion creates durable memory |
+| Family            | Create                                        | Update                      | Delete          | Mirrored OK  | Read parity | Notes                                                   |
+| ----------------- | --------------------------------------------- | --------------------------- | --------------- | ------------ | ----------- | ------------------------------------------------------- |
+| projects          | ✅ 201                                        | ✅ 200 (desc + rename)      | ✅ 200 (victim) | ✅           | ✅          | `read_backend: cairnline`                               |
+| roots             | ✅ 201                                        | —                           | —               | ✅           | ✅          | Hecate still owns Git/workspace scan                    |
+| roles             | ✅ 201 (×3)                                   | ✅ 200                      | ✅ 204 (temp)   | ✅           | ✅          | built-in roles listable/immutable                       |
+| work-items        | ✅ 201                                        | ✅ 200 (status transitions) | ✅ 204 (stale)  | ✅           | ✅          | statuses backlog/ready/running/review/blocked exercised |
+| assignments       | ✅ 201                                        | ✅ 200 (status)             | ✅ 204          | ✅ (partial) | ✅          | execution-ref lossy — see Probe 1                       |
+| artifacts         | ✅ 201 (decision_note, evidence_link, review) | n/a (immutable)             | n/a             | ✅           | ✅          | update/delete absent by design                          |
+| handoffs          | ✅ 201                                        | ✅ 200 (status→accepted)    | —               | ✅           | ✅          |                                                         |
+| memory            | ✅ 201                                        | ✅ 200                      | ✅ 204          | ✅           | ✅          |                                                         |
+| memory-candidates | ✅ 201                                        | promote ✅ / reject ✅      | —               | ✅           | ✅          | promotion creates durable memory                        |
 
 Assignment-start flows: `hecate_task` native start succeeded through the task
 runtime (produced `task_id`/`run_id`/`trace_id`, model `mock-model`).
@@ -198,7 +198,7 @@ subsequently-diverged Cairnline target would only reconcile on a full re-sync.
 ## Observability evidence
 
 **Why full all-portable authority cannot exercise `mirror_write_health`.** With
-a family's write authority enabled, the mutation is an *authoritative* Cairnline
+a family's write authority enabled, the mutation is an _authoritative_ Cairnline
 write: if it fails, the request fails (`500 gateway_error`) and never reaches the
 best-effort shadow-mirror hook that the health tracker instruments. Confirmed by
 making the embedded DB immutable (`chattr +i`) under full mode:
@@ -223,16 +223,20 @@ it:
 ```json
 // GET /hecate/v1/projects/backend-status  → data.mirror_write_health
 {
- "total_failure_count": 2,
- "drifting_families": ["work-items"],
- "families": [
-  {"family":"projects","failure_count":0,"drifting":false,"last_success_at":"…"},
-  {"family":"work-items","failure_count":2,
-   "last_error":"migrate sqlite: attempt to write a readonly database (8)",
-   "last_failed_operation":"project_work_item_create",
-   "last_failure_at":"2026-07-08T12:10:50Z","last_success_at":"2026-07-08T12:10:35Z",
-   "drifting":true}
- ]
+  "total_failure_count": 2,
+  "drifting_families": ["work-items"],
+  "families": [
+    { "family": "projects", "failure_count": 0, "drifting": false, "last_success_at": "…" },
+    {
+      "family": "work-items",
+      "failure_count": 2,
+      "last_error": "migrate sqlite: attempt to write a readonly database (8)",
+      "last_failed_operation": "project_work_item_create",
+      "last_failure_at": "2026-07-08T12:10:50Z",
+      "last_success_at": "2026-07-08T12:10:35Z",
+      "drifting": true
+    }
+  ]
 }
 ```
 
@@ -271,14 +275,14 @@ model on the project:
   "replacement_ready": true,
   "mirror_write_health": { "total_failure_count": 0 },
   "replacement_gates": [
-    {"id":"read-routes","ready":true,"status":"ready"},
-    {"id":"strict-embedded-read-smoke","ready":true,"status":"verified"},
-    {"id":"write-authority-switchpoints","ready":true,"status":"ready"},
-    {"id":"mirror-write-health","ready":true,"status":"healthy"},
-    {"id":"migration-and-rollback","ready":true,"status":"ready"},
-    {"id":"embedded-replacement-mode","ready":true,"status":"armed"}
+    { "id": "read-routes", "ready": true, "status": "ready" },
+    { "id": "strict-embedded-read-smoke", "ready": true, "status": "verified" },
+    { "id": "write-authority-switchpoints", "ready": true, "status": "ready" },
+    { "id": "mirror-write-health", "ready": true, "status": "healthy" },
+    { "id": "migration-and-rollback", "ready": true, "status": "ready" },
+    { "id": "embedded-replacement-mode", "ready": true, "status": "armed" }
   ],
-  "migration_rehearsal": { "status":"verified", "cutover_ready": true, "authoritative": true }
+  "migration_rehearsal": { "status": "verified", "cutover_ready": true, "authoritative": true }
 }
 ```
 

--- a/docs/design/proposals/evidence/cairnline-replacement-dogfood-2026-07-08.md
+++ b/docs/design/proposals/evidence/cairnline-replacement-dogfood-2026-07-08.md
@@ -1,0 +1,323 @@
+# Cairnline Replacement Dogfood Rehearsal — 2026-07-08
+
+Evidence for [`cairnline-portable-project-coordination.md`](../cairnline-portable-project-coordination.md).
+Branch `feat/cairnline-mirror-observability` (commit `3c668c6`). All flows were
+driven through the HTTP API against a locally built `cmd/hecate` gateway. This
+rehearsal exercises armed embedded replacement mode (Cairnline authoritative for
+all portable project-coordination families) and uses the new
+`mirror_write_health` observability as evidence.
+
+## Summary verdict
+
+**What works.** Armed embedded replacement mode is functional end to end. Every
+portable write family (projects, roots, roles, work-items, assignments,
+artifacts, handoffs, memory, memory-candidates) creates, updates, and — in live
+authoritative mode — deletes/renames correctly through the Cairnline-first write
+path, with responses labelled `read_backend: "cairnline"`. Strict embedded reads
+serve the portable read model. Assignment status transitions, launch readiness,
+preflight context packets, and native `hecate_task` assignment start all work
+once a default model is configured. With a default model set,
+`replacement_ready` reaches **`true`** with `cutover_ready: true` and all six
+gates ready. The new `mirror_write_health` observability was demonstrated
+catching, blocking on, and recovering from a real induced mirror failure.
+
+**What breaks / is lossy.** Four fidelity gaps are proven below:
+
+1. **Lossy execution-ref mapping** — Cairnline's `assignments` schema collapses
+   the execution ref to `run_id` + `context_snapshot_id`; `task_id` and `kind`
+   are dropped from the portable row and survive only in Hecate's
+   `hecate_project_assignment_runtime` overlay. A true cutover that drops the
+   overlay loses `task_id`.
+2. **Context packets are not portable through the Cairnline read path** — the
+   Cairnline read-model launch packet for an assignment omits project memory;
+   only Hecate's native `hecate_task` preflight packet injects memory.
+3. **`awaiting_approval` is not representable** — the bridge clamps
+   `awaiting_approval` to Cairnline's `running`; the portable status vocabulary
+   has no awaiting-approval state.
+4. **Additive-only is a property of the sync-rehearsal path, not live writes** —
+   in live authoritative mode deletes/renames DID propagate correctly (no stale
+   rows). The additive/refresh limitation applies to the standalone snapshot
+   `POST /cairnline/sync` path.
+
+**Also proven:** the readiness gates are necessary but **not sufficient** —
+`replacement_ready: true` was reached while fidelity gaps 1–3 remain, because no
+gate inspects execution-ref fidelity, context-packet portability, or status-enum
+representability.
+
+## Setup
+
+| Setting | Full-mode run | Observability run |
+| --- | --- | --- |
+| `HECATE_ADDRESS` | `127.0.0.1:8899` | `127.0.0.1:8899` |
+| `HECATE_BACKEND` | `sqlite` | `sqlite` |
+| `HECATE_PROJECTS_COORDINATION_BACKEND` | `cairnline` | `cairnline` |
+| `HECATE_PROJECTS_CAIRNLINE_CONNECTOR` | `embedded` | `embedded` |
+| `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE` | `embedded` | `auto` |
+| `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE` | `embedded` (armed) | `disabled` |
+| `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY` | `all-portable` | `project-roles,project-memory,project-collaboration` (partial) |
+| Model provider | stub OpenAI-compatible server (`mock-model`) for start flows | none |
+
+Env-gate source of truth: `internal/config/config.go:576-585` and validation at
+`:669-691`. Armed embedded replacement mode requires the four gates in lockstep:
+`COORDINATION_BACKEND=cairnline` + `CONNECTOR=embedded` + `READ_SOURCE=embedded`
++ `REPLACEMENT_MODE=embedded`, which implies all portable write-authority
+switchpoints (`config.go:293-312`).
+
+The observability run uses **partial** write authority on purpose: see
+"Observability evidence" for why full all-portable authority cannot exercise the
+`mirror_write_health` shadow-mirror path.
+
+## Per-family results
+
+Driven against project `Atlas Gateway Hardening` (`proj_e961…`) in full armed
+mode. "Mirrored OK" = the record is present and correct in the embedded
+Cairnline SQLite DB. "Read parity" = the record reads back correctly through the
+strict embedded read routes.
+
+| Family | Create | Update | Delete | Mirrored OK | Read parity | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| projects | ✅ 201 | ✅ 200 (desc + rename) | ✅ 200 (victim) | ✅ | ✅ | `read_backend: cairnline` |
+| roots | ✅ 201 | — | — | ✅ | ✅ | Hecate still owns Git/workspace scan |
+| roles | ✅ 201 (×3) | ✅ 200 | ✅ 204 (temp) | ✅ | ✅ | built-in roles listable/immutable |
+| work-items | ✅ 201 | ✅ 200 (status transitions) | ✅ 204 (stale) | ✅ | ✅ | statuses backlog/ready/running/review/blocked exercised |
+| assignments | ✅ 201 | ✅ 200 (status) | ✅ 204 | ✅ (partial) | ✅ | execution-ref lossy — see Probe 1 |
+| artifacts | ✅ 201 (decision_note, evidence_link, review) | n/a (immutable) | n/a | ✅ | ✅ | update/delete absent by design |
+| handoffs | ✅ 201 | ✅ 200 (status→accepted) | — | ✅ | ✅ | |
+| memory | ✅ 201 | ✅ 200 | ✅ 204 | ✅ | ✅ | |
+| memory-candidates | ✅ 201 | promote ✅ / reject ✅ | — | ✅ | ✅ | promotion creates durable memory |
+
+Assignment-start flows: `hecate_task` native start succeeded through the task
+runtime (produced `task_id`/`run_id`/`trace_id`, model `mock-model`).
+`external_agent` assignment start requires an agent preset with
+`external_agent_kind`; without a configured external adapter it stops at
+preflight (`external-agent assignment requires an agent preset with
+external_agent_kind`). A real `awaiting_approval` run could not be forced: the
+sandbox reports `os_isolation: none` (no `bwrap`) and no approval policy is
+configured, so the stubbed shell tool auto-completed. The `awaiting_approval`
+mapping gap is instead proven at the persistence layer (Probe 3).
+
+## Weak-spot probes
+
+### Probe 1 — Lossy execution-ref mapping
+
+Assignment `asgn_1bd3…` was created with a full ref
+`{kind: task_run, task_id, run_id, context_snapshot_id}`. The raw Cairnline row
+keeps only `run_id` and `context_snapshot_id`; `task_id` and `kind` are dropped
+from the portable schema:
+
+```
+# Cairnline assignments row (execution_ref, context_snapshot_id):
+('run_dogfood_0001', 'ctx_dogfood_0001')
+
+# task_id survives ONLY in Hecate overlay hecate_project_assignment_runtime:
+{"kind":"task_run","task_id":"task_dogfood_0001","run_id":"run_dogfood_0001","context_snapshot_id":"ctx_dogfood_0001"}
+
+# API response reassembles the full ref from the overlay (looks complete):
+{"kind":"task_run","task_id":"task_dogfood_0001","run_id":"run_dogfood_0001","context_snapshot_id":"ctx_dogfood_0001","status":"queued","missing":true}
+```
+
+Cairnline `assignments` schema has a single `execution_ref TEXT` column plus
+`context_snapshot_id TEXT` — there is no `task_id` column. Fidelity is currently
+preserved only because Hecate keeps a parallel runtime overlay row. A migration
+that retires the overlay loses `task_id` and `kind`. The `"missing":true` flag
+also shows the projected task/run does not exist (synthetic ids), which is
+correct behavior, not the gap.
+
+### Probe 2 — Dropped context packets (project memory not portable)
+
+Two project memory entries exist (`Timeout invariant`, `Retry ceiling`). The
+assignment context packet served through the Cairnline read path
+(`GET …/assignments/{id}/context`) contains no memory items:
+
+```
+item kinds: project, work_item, assignment, project_root, role, cairnline_assignment_context(included=false)
+mentions "Timeout invariant": False   mentions "Retry ceiling": False
+```
+
+By contrast the native Hecate `hecate_task` preflight packet
+(`GET …/assignments/{id}/preflight`, which runs Hecate's own launch composer)
+DOES inject both memory entries:
+
+```
+item kinds: …, memory, memory, launch_readiness, cairnline_launch_packet, …
+mentions "Timeout invariant": True   mentions "Retry ceiling": True
+```
+
+The Cairnline read-model launch packet marks its assignment-context row
+`included: false` ("Read-model preview only … no task/chat execution snapshot").
+Project memory bodies flow into a runnable prompt only via Hecate's native
+launch path, not the portable Cairnline context read.
+
+### Probe 3 — `awaiting_approval` status mapping
+
+`PATCH` an assignment to `status: awaiting_approval`, then read it back — it is
+`running`:
+
+```
+PATCH status=awaiting_approval  →  readback status = "running"
+```
+
+Root cause, `internal/cairnlinebridge/bridge.go:401-413`:
+
+```go
+func AssignmentStatus(status string) string {
+    switch strings.TrimSpace(status) {
+    case projectwork.AssignmentStatusRunning, projectwork.AssignmentStatusAwaitingApproval:
+        return cairnline.AssignmentRunning        // awaiting_approval collapses into running
+    ...
+```
+
+Cairnline's status vocabulary (`cairnline/internal/core/types.go`) has no
+awaiting-approval state (it exposes `awaiting_review`). An assignment blocked on
+a Hecate approval is indistinguishable from a running one in the portable store.
+The Activity Inbox `blocking_signal=awaiting_approval` and pending-approval
+counts are Hecate-runtime projections layered on top; the portable row cannot
+carry that state on its own.
+
+### Probe 4 — Additive-only snapshot import vs live deletes
+
+In **live armed replacement mode** deletes and renames propagate correctly — no
+stale rows:
+
+```
+DELETE victim project     → cairnline projects row count for victim = 0
+DELETE work item (stale)  → cairnline work_items row count = 0
+DELETE role (temp)        → cairnline roles row count = 0
+PATCH  project rename      → cairnline projects.name = "Atlas Gateway Hardening (renamed)"
+```
+
+So the weak spot as literally stated ("deleting/renaming leaves a stale row") is
+**not reproduced** on the live authoritative write path — that path issues real
+Cairnline deletes/updates. The additive/refresh concern is a property of the
+standalone snapshot rehearsal path `POST /hecate/v1/projects/cairnline/sync`,
+which "replaces the same embedded sync database after the Hecate snapshots have
+been loaded" (runtime-api.md) — i.e. a full refresh keyed off the current Hecate
+graph rather than an incremental import. A Hecate-authoritative source with a
+subsequently-diverged Cairnline target would only reconcile on a full re-sync.
+
+## Observability evidence
+
+**Why full all-portable authority cannot exercise `mirror_write_health`.** With
+a family's write authority enabled, the mutation is an *authoritative* Cairnline
+write: if it fails, the request fails (`500 gateway_error`) and never reaches the
+best-effort shadow-mirror hook that the health tracker instruments. Confirmed by
+making the embedded DB immutable (`chattr +i`) under full mode:
+
+```
+create work-item (all-portable authority) → 500 gateway_error
+  "migrate sqlite: attempt to write a readonly database (8)"
+```
+
+The `mirror_write_health` tracker only records on the `mirrorProject*ToCairnline`
+best-effort path (`handler_project_cairnline_mirror_health.go`), which runs when
+a family is Hecate-authoritative and Cairnline is a compatibility shadow — i.e.
+the transitional dual-write posture, not full replacement.
+
+**Induced failure under partial authority.** Second run: authority for
+roles/memory/collaboration only, so `work-items` is a best-effort shadow family.
+A healthy write records success; then the embedded DB was made immutable and two
+`work-items` creates were issued — both returned **201** (Hecate authoritative
+succeeded) while the Cairnline mirror silently failed. The observability caught
+it:
+
+```json
+// GET /hecate/v1/projects/backend-status  → data.mirror_write_health
+{
+ "total_failure_count": 2,
+ "drifting_families": ["work-items"],
+ "families": [
+  {"family":"projects","failure_count":0,"drifting":false,"last_success_at":"…"},
+  {"family":"work-items","failure_count":2,
+   "last_error":"migrate sqlite: attempt to write a readonly database (8)",
+   "last_failed_operation":"project_work_item_create",
+   "last_failure_at":"2026-07-08T12:10:50Z","last_success_at":"2026-07-08T12:10:35Z",
+   "drifting":true}
+ ]
+}
+```
+
+The `mirror-write-health` replacement gate flipped to block:
+
+```
+mirror-write-health gate: ready=false status=drifting
+  "Cairnline shadow-mirror writes recorded 2 failure(s) … these write families
+   have not mirrored successfully since their last failure: work-items."
+```
+
+**Recovery.** After clearing immutability, a single successful `work-items`
+mirror write cleared the drift while retaining the cumulative failure count:
+
+```
+work-items now: drifting=false failure_count=2 last_success_at=2026-07-08T12:11:11Z
+mirror-write-health gate: ready=true status=recovered
+```
+
+This is exactly the before/after the observability change targets: previously
+these two failures were only `slog.Warn` lines; now operators see per-family
+failure counts, last error/operation, drifting families, and a gate that blocks
+`replacement_ready` while drift is outstanding.
+
+## Final `replacement_ready` verdict
+
+Captured in full armed embedded replacement mode after configuring a default
+model on the project:
+
+```json
+{
+  "configured_backend": "cairnline",
+  "authoritative_backend": "cairnline",
+  "replacement_mode": "embedded",
+  "replacement_mode_armed": true,
+  "replacement_ready": true,
+  "mirror_write_health": { "total_failure_count": 0 },
+  "replacement_gates": [
+    {"id":"read-routes","ready":true,"status":"ready"},
+    {"id":"strict-embedded-read-smoke","ready":true,"status":"verified"},
+    {"id":"write-authority-switchpoints","ready":true,"status":"ready"},
+    {"id":"mirror-write-health","ready":true,"status":"healthy"},
+    {"id":"migration-and-rollback","ready":true,"status":"ready"},
+    {"id":"embedded-replacement-mode","ready":true,"status":"armed"}
+  ],
+  "migration_rehearsal": { "status":"verified", "cutover_ready": true, "authoritative": true }
+}
+```
+
+Note: before a default model was configured, `strict-embedded-read-smoke`
+reported `failed` ("project assignment start requires a default model") because
+the smoke's assignment-preflight check needs a resolvable model
+(`internal/projectworkapp/launch_plan.go:164-166`, model resolved from
+role/project defaults then `Router.DefaultModel`). This makes
+`replacement_ready` for embedded assignment-bearing projects contingent on a
+routable default model, not just on portable-state fidelity.
+
+## Gaps proven by this rehearsal (do NOT build here — follow-ups)
+
+- **One-way migration-cutover path.** `write_adapter_gaps` and
+  `migration_blockers` both still list `migration-cutover`; Probe 1 shows
+  `task_id`/`kind` live only in a Hecate overlay, and Probe 4 shows the sync
+  path is a full refresh. A durable, overlay-independent cutover that preserves
+  the full execution ref and reconciles deletes incrementally is needed but out
+  of scope. Evidence: `differences`/`id_differences` in mirror-parity show
+  `hecate: 0` for every family in replacement mode (authoritative rows have
+  moved to Cairnline; the snapshot-parity comparator has no Hecate side to
+  diff), so parity as currently computed is not a cutover-fidelity signal.
+- **MCP error codes.** The sidecar/MCP contract paths (`sidecar-*` smokes) were
+  not exercised (no standalone Cairnline MCP process). The proposal's Future
+  Test Plan calls for MCP contract tests incl. conflict/claim races; typed
+  sidecar error-code coverage is needed but out of scope here.
+- **Approvals-enum change.** Probe 3 proves the portable status vocabulary
+  cannot represent `awaiting_approval` (clamped to `running`). Faithful
+  supervised-approval semantics in the portable store would require an
+  approvals/status enum extension in Cairnline — needed but out of scope.
+- **Context-packet portability.** Probe 2 shows project memory does not flow
+  through the Cairnline read-model launch packet. Making the portable launch
+  packet carry memory/context bodies (or a documented decision that it never
+  will, keeping Hecate's native composer authoritative for runnable prompts) is
+  a follow-up.
+
+## Artifacts
+
+Raw request/response captures live in the session scratchpad
+(`…/scratchpad/evidence/`), including `30-backend-status-final-fullmode.json`
+(final verdict), `33-backend-status-fault.json` / `34-backend-status-recovered.json`
+(observability lifecycle), and per-family create/update/delete responses.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2605,7 +2605,23 @@ items, missing rollback steps, or non-passing embedded smoke as
 `write-authority-switchpoints` gate can be `blocked`, `partial`, or `ready`;
 it is driven by `portable_write_gaps` and ignores Hecate-owned orchestrator
 capabilities and the separate `migration-cutover` gap because those are reported
-by their own status fields/gates. The `migration-and-rollback` gate reports
+by their own status fields/gates.
+`mirror_write_health` surfaces live shadow-mirror write outcomes so mirror
+failures are operator-visible instead of log-only warnings. It reports
+`total_failure_count` (failures recorded since the runtime started),
+`drifting_families` (write families whose most recent mirror write failed), and
+per-family `families` entries carrying `family`, `failure_count`, `last_error`,
+`last_failed_operation`, `last_failure_at`, `last_success_at`, and `drifting`.
+Family names reuse the portable write-gap vocabulary (`projects`, `roots`,
+`context-sources`, `skills`, `roles`, `work-items`, `assignments`, `artifacts`,
+`handoffs`, `memory`, `memory-candidates`, `project-assistant-proposals`). The
+counters are process-local runtime observability, not persisted state: they
+reset on restart together with the mirror hooks they observe. The matching
+`mirror-write-health` replacement gate is `healthy` when no failures have been
+recorded, `recovered` (still ready) when every affected family has mirrored
+successfully since its last failure, and `drifting` (not ready) while any
+family has outstanding failures — so `replacement_ready` cannot report `true`
+while shadow-mirror failure evidence is outstanding. The `migration-and-rollback` gate reports
 `waiting_for_read_smoke` until strict embedded read-smoke evidence is verified.
 In pre-cutover rehearsal it then reports `cutover_switch_missing` until Hecate
 has an explicit authoritative Cairnline storage cutover and rollback switch. In
@@ -4779,7 +4795,12 @@ The response shape matches the sync response, except `object` is
 `project_cairnline_mirror_parity`, `database_exists` may be `false`, and
 `migration_rehearsal.status` is `verified` for an exact existing mirror,
 `drift_detected` for a mismatched existing mirror, or `not_run` when no mirror
-database exists.
+database exists. Mirror-parity output additionally attaches
+`mirror_write_health`, the same live shadow-mirror failure evidence reported by
+backend status (`total_failure_count`, `drifting_families`, and per-family
+failure/success detail), so a structurally matching database can still be
+flagged when recent mirror writes have failed. Sync and export rehearsals do
+not attach it because they rebuild their target database.
 
 ### `POST /hecate/v1/projects/cairnline/sync`
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -88,6 +88,12 @@ type Handler struct {
 	// servers.
 	projectCairnlineSidecarMu    sync.Mutex
 	projectCairnlineSidecarCache *mcpclient.SharedClientCache
+	// cairnlineMirrorHealth tracks shadow-mirror write outcomes per portable
+	// write family so backend-status and mirror-parity surface failures
+	// instead of leaving them as log-only warnings. In-memory on purpose:
+	// this is runtime observability for the current process, not persisted
+	// coordination state.
+	cairnlineMirrorHealth cairnlineMirrorHealth
 	// orchestratorMetrics is shared between the runner and the MCP
 	// client cache observer. Built once in NewHandler so a second
 	// NewOrchestratorMetrics() can't register duplicate instruments;

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -1441,9 +1441,7 @@ func (h *Handler) mirrorProjectAssignmentStartResultToCairnline(ctx context.Cont
 	if strings.TrimSpace(assignment.ID) == "" {
 		return
 	}
-	if err := h.writeProjectAssignmentToCairnline(ctx, assignment); err != nil {
-		h.logCairnlineMirrorError(ctx, "project_assignment_start_result", assignment.ProjectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyAssignments, "project_assignment_start_result", assignment.ProjectID, h.writeProjectAssignmentToCairnline(ctx, assignment))
 }
 
 func decodeOptionalProjectWorkAssignmentStartRequest(w http.ResponseWriter, r *http.Request) (startProjectWorkAssignmentRequest, bool) {

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -82,7 +82,7 @@ func (h *Handler) projectCairnlineMirrorParity(ctx context.Context) (ProjectCair
 		if !os.IsNotExist(err) {
 			return ProjectCairnlineSyncResponseItem{}, err
 		}
-		return projectCairnlineMissingMirrorParity(dbPath, snapshots), nil
+		return h.withProjectCairnlineMirrorWriteHealth(projectCairnlineMissingMirrorParity(dbPath, snapshots)), nil
 	}
 	service, store, err := cairnline.NewSQLiteService(ctx, dbPath)
 	if err != nil {
@@ -94,7 +94,20 @@ func (h *Handler) projectCairnlineMirrorParity(ctx context.Context) (ProjectCair
 	if err != nil {
 		return ProjectCairnlineSyncResponseItem{}, err
 	}
-	return item, nil
+	return h.withProjectCairnlineMirrorWriteHealth(item), nil
+}
+
+// withProjectCairnlineMirrorWriteHealth attaches live shadow-mirror failure
+// evidence to parity output so drift caused by failed mirror writes is
+// visible next to the structural parity verdict, even when the current
+// database contents happen to hash equal.
+func (h *Handler) withProjectCairnlineMirrorWriteHealth(item ProjectCairnlineSyncResponseItem) ProjectCairnlineSyncResponseItem {
+	if h == nil {
+		return item
+	}
+	health := h.cairnlineMirrorHealth.snapshot()
+	item.MirrorWriteHealth = &health
+	return item
 }
 
 func (h *Handler) HandleExportProjectToCairnline(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_project_cairnline_mirror.go
+++ b/internal/api/handler_project_cairnline_mirror.go
@@ -18,33 +18,23 @@ import (
 )
 
 func (h *Handler) mirrorProjectIdentityToCairnline(ctx context.Context, operation string, project projects.Project) {
-	if err := h.writeProjectIdentityToCairnline(ctx, project); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyProjects, operation, project.ID, h.writeProjectIdentityToCairnline(ctx, project))
 }
 
 func (h *Handler) mirrorProjectDefaultsToCairnline(ctx context.Context, operation string, project projects.Project) {
-	if err := h.writeProjectDefaultsToCairnline(ctx, project); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyProjects, operation, project.ID, h.writeProjectDefaultsToCairnline(ctx, project))
 }
 
 func (h *Handler) mirrorProjectMetadataToCairnline(ctx context.Context, operation string, project projects.Project) {
-	if err := h.writeProjectMetadataToCairnline(ctx, project); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyProjects, operation, project.ID, h.writeProjectMetadataToCairnline(ctx, project))
 }
 
 func (h *Handler) mirrorProjectDeleteToCairnline(ctx context.Context, operation string, project projects.Project) {
-	if err := h.deleteProjectIdentityFromCairnline(ctx, project); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyProjects, operation, project.ID, h.deleteProjectIdentityFromCairnline(ctx, project))
 }
 
 func (h *Handler) mirrorProjectRootToCairnline(ctx context.Context, operation string, project projects.Project, root projects.Root) {
-	if err := h.writeProjectRootToCairnline(ctx, project, root); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyRoots, operation, project.ID, h.writeProjectRootToCairnline(ctx, project, root))
 }
 
 func (h *Handler) mirrorProjectRootsToCairnline(ctx context.Context, operation string, project projects.Project, roots []projects.Root) {
@@ -54,21 +44,15 @@ func (h *Handler) mirrorProjectRootsToCairnline(ctx context.Context, operation s
 }
 
 func (h *Handler) mirrorProjectRootListReplaceToCairnline(ctx context.Context, operation string, project projects.Project, roots []projects.Root) {
-	if err := h.replaceProjectRootsInCairnline(ctx, project, roots); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyRoots, operation, project.ID, h.replaceProjectRootsInCairnline(ctx, project, roots))
 }
 
 func (h *Handler) mirrorProjectRootDeleteToCairnline(ctx context.Context, operation, projectID, rootID string) {
-	if err := h.deleteProjectRootFromCairnline(ctx, projectID, rootID); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, projectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyRoots, operation, projectID, h.deleteProjectRootFromCairnline(ctx, projectID, rootID))
 }
 
 func (h *Handler) mirrorProjectContextSourceToCairnline(ctx context.Context, operation string, project projects.Project, source projects.ContextSource) {
-	if err := h.writeProjectContextSourceToCairnline(ctx, project, source); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyContextSources, operation, project.ID, h.writeProjectContextSourceToCairnline(ctx, project, source))
 }
 
 func (h *Handler) mirrorProjectContextSourcesToCairnline(ctx context.Context, operation string, project projects.Project, sources []projects.ContextSource) {
@@ -78,27 +62,19 @@ func (h *Handler) mirrorProjectContextSourcesToCairnline(ctx context.Context, op
 }
 
 func (h *Handler) mirrorProjectContextSourceListReplaceToCairnline(ctx context.Context, operation string, project projects.Project, sources []projects.ContextSource) {
-	if err := h.replaceProjectContextSourcesInCairnline(ctx, project, sources); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyContextSources, operation, project.ID, h.replaceProjectContextSourcesInCairnline(ctx, project, sources))
 }
 
 func (h *Handler) mirrorProjectContextSourceDeleteToCairnline(ctx context.Context, operation, projectID, sourceID string) {
-	if err := h.deleteProjectContextSourceFromCairnline(ctx, projectID, sourceID); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, projectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyContextSources, operation, projectID, h.deleteProjectContextSourceFromCairnline(ctx, projectID, sourceID))
 }
 
 func (h *Handler) mirrorProjectSkillsToCairnline(ctx context.Context, operation string, project projects.Project, skills []projectskills.Skill) {
-	if err := h.writeProjectSkillsToCairnline(ctx, project, skills); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilySkills, operation, project.ID, h.writeProjectSkillsToCairnline(ctx, project, skills))
 }
 
 func (h *Handler) mirrorProjectRoleToCairnline(ctx context.Context, operation string, project projects.Project, role projectwork.AgentRoleProfile) {
-	if err := h.writeProjectRoleToCairnline(ctx, project, role); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyRoles, operation, project.ID, h.writeProjectRoleToCairnline(ctx, project, role))
 }
 
 func (h *Handler) mirrorProjectRoleByIDToCairnline(ctx context.Context, operation, projectID string, role projectwork.AgentRoleProfile) {
@@ -110,15 +86,11 @@ func (h *Handler) mirrorProjectRoleByIDToCairnline(ctx context.Context, operatio
 }
 
 func (h *Handler) mirrorProjectRoleDeleteToCairnline(ctx context.Context, operation string, role projectwork.AgentRoleProfile) {
-	if err := h.deleteProjectRoleFromCairnline(ctx, role); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, role.ProjectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyRoles, operation, role.ProjectID, h.deleteProjectRoleFromCairnline(ctx, role))
 }
 
 func (h *Handler) mirrorProjectWorkItemToCairnline(ctx context.Context, operation string, project projects.Project, item projectwork.WorkItem) {
-	if err := h.writeProjectWorkItemToCairnline(ctx, project, item); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, project.ID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyWorkItems, operation, project.ID, h.writeProjectWorkItemToCairnline(ctx, project, item))
 }
 
 func (h *Handler) mirrorProjectWorkItemByIDToCairnline(ctx context.Context, operation, projectID string, item projectwork.WorkItem) {
@@ -130,63 +102,45 @@ func (h *Handler) mirrorProjectWorkItemByIDToCairnline(ctx context.Context, oper
 }
 
 func (h *Handler) mirrorProjectWorkItemDeleteToCairnline(ctx context.Context, operation, projectID, workItemID string) {
-	if err := h.deleteProjectWorkItemFromCairnline(ctx, projectID, workItemID); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, projectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyWorkItems, operation, projectID, h.deleteProjectWorkItemFromCairnline(ctx, projectID, workItemID))
 }
 
 func (h *Handler) mirrorProjectAssignmentToCairnline(ctx context.Context, operation string, assignment projectwork.Assignment) {
-	if err := h.writeProjectAssignmentToCairnline(ctx, assignment); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, assignment.ProjectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyAssignments, operation, assignment.ProjectID, h.writeProjectAssignmentToCairnline(ctx, assignment))
 }
 
 func (h *Handler) mirrorProjectAssignmentDeleteToCairnline(ctx context.Context, operation, projectID, assignmentID string) {
-	if err := h.deleteProjectAssignmentFromCairnline(ctx, projectID, assignmentID); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, projectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyAssignments, operation, projectID, h.deleteProjectAssignmentFromCairnline(ctx, projectID, assignmentID))
 }
 
 func (h *Handler) mirrorProjectArtifactToCairnline(ctx context.Context, operation string, artifact projectwork.CollaborationArtifact) {
-	if err := h.writeProjectArtifactToCairnline(ctx, artifact); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, artifact.ProjectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyArtifacts, operation, artifact.ProjectID, h.writeProjectArtifactToCairnline(ctx, artifact))
 }
 
 func (h *Handler) mirrorProjectHandoffToCairnline(ctx context.Context, operation string, handoff projectwork.Handoff) {
-	if err := h.writeProjectHandoffToCairnline(ctx, handoff); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, handoff.ProjectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyHandoffs, operation, handoff.ProjectID, h.writeProjectHandoffToCairnline(ctx, handoff))
 }
 
 func (h *Handler) mirrorProjectHandoffDeleteToCairnline(ctx context.Context, operation, projectID, workItemID, handoffID string) {
-	if err := h.deleteProjectHandoffFromCairnline(ctx, projectID, workItemID, handoffID); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, projectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyHandoffs, operation, projectID, h.deleteProjectHandoffFromCairnline(ctx, projectID, workItemID, handoffID))
 }
 
 func (h *Handler) mirrorProjectMemoryEntryToCairnline(ctx context.Context, operation string, entry memory.Entry) {
-	if err := h.writeProjectMemoryEntryToCairnline(ctx, entry); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, entry.ProjectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyMemory, operation, entry.ProjectID, h.writeProjectMemoryEntryToCairnline(ctx, entry))
 }
 
 func (h *Handler) mirrorProjectMemoryEntryDeleteToCairnline(ctx context.Context, operation, projectID, memoryID string) {
-	if err := h.deleteProjectMemoryEntryFromCairnline(ctx, projectID, memoryID); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, projectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyMemory, operation, projectID, h.deleteProjectMemoryEntryFromCairnline(ctx, projectID, memoryID))
 }
 
 func (h *Handler) mirrorProjectMemoryCandidateToCairnline(ctx context.Context, operation string, candidate memory.Candidate) {
-	if err := h.writeProjectMemoryCandidateToCairnline(ctx, candidate); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, candidate.ProjectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyMemoryCandidates, operation, candidate.ProjectID, h.writeProjectMemoryCandidateToCairnline(ctx, candidate))
 }
 
 func (h *Handler) mirrorProjectAssistantProposalByIDToCairnline(ctx context.Context, operation, proposalID string) {
 	record, ok, err := h.loadProjectAssistantProposalForCairnlineMirror(ctx, proposalID)
 	if err != nil {
-		h.logCairnlineMirrorError(ctx, operation, "", err)
+		h.recordCairnlineMirrorFailure(ctx, cairnlineMirrorFamilyAssistantProposals, operation, "", err)
 		return
 	}
 	if !ok {
@@ -196,9 +150,7 @@ func (h *Handler) mirrorProjectAssistantProposalByIDToCairnline(ctx context.Cont
 }
 
 func (h *Handler) mirrorProjectAssistantProposalRecordToCairnline(ctx context.Context, operation string, record projectassistant.ProposalRecord) {
-	if err := h.writeProjectAssistantProposalRecordToCairnline(ctx, record); err != nil {
-		h.logCairnlineMirrorError(ctx, operation, record.ProjectID, err)
-	}
+	h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyAssistantProposals, operation, record.ProjectID, h.writeProjectAssistantProposalRecordToCairnline(ctx, record))
 }
 
 func (h *Handler) mirrorProjectAssistantApplyResultToCairnline(ctx context.Context, operation string, result projectassistant.ApplyResult) {
@@ -206,9 +158,7 @@ func (h *Handler) mirrorProjectAssistantApplyResultToCairnline(ctx context.Conte
 		return
 	}
 	for _, action := range result.Actions {
-		if err := h.writeProjectAssistantActionResultToCairnline(ctx, action); err != nil {
-			h.logCairnlineMirrorError(ctx, operation, projectAssistantActionResultProjectID(action), err)
-		}
+		h.recordCairnlineMirrorResult(ctx, cairnlineMirrorFamilyAssistantProposals, operation, projectAssistantActionResultProjectID(action), h.writeProjectAssistantActionResultToCairnline(ctx, action))
 	}
 }
 

--- a/internal/api/handler_project_cairnline_mirror_health.go
+++ b/internal/api/handler_project_cairnline_mirror_health.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Portable write family names tracked by the shadow-mirror health monitor.
+// They reuse the family vocabulary of the coordination backend gap and
+// switchpoint reporting so operators can correlate mirror drift with the
+// portable write authority it endangers.
+const (
+	cairnlineMirrorFamilyProjects           = "projects"
+	cairnlineMirrorFamilyRoots              = "roots"
+	cairnlineMirrorFamilyContextSources     = "context-sources"
+	cairnlineMirrorFamilySkills             = "skills"
+	cairnlineMirrorFamilyRoles              = "roles"
+	cairnlineMirrorFamilyWorkItems          = "work-items"
+	cairnlineMirrorFamilyAssignments        = "assignments"
+	cairnlineMirrorFamilyArtifacts          = "artifacts"
+	cairnlineMirrorFamilyHandoffs           = "handoffs"
+	cairnlineMirrorFamilyMemory             = "memory"
+	cairnlineMirrorFamilyMemoryCandidates   = "memory-candidates"
+	cairnlineMirrorFamilyAssistantProposals = "project-assistant-proposals"
+)
+
+// cairnlineMirrorHealth aggregates shadow-mirror write outcomes per portable
+// write family. It is intentionally in-memory: the counters are process-local
+// runtime observability for the best-effort mirror hooks, not persisted
+// coordination state, and they reset on restart together with the mirror
+// process they observe. The zero value is usable so handler construction
+// paths (including test fixtures) need no extra wiring.
+type cairnlineMirrorHealth struct {
+	mu       sync.Mutex
+	families map[string]*cairnlineMirrorFamilyState
+	// now is a test seam for deterministic drift ordering; nil falls back
+	// to time.Now.
+	now func() time.Time
+}
+
+type cairnlineMirrorFamilyState struct {
+	failureCount        int64
+	lastFailedOperation string
+	lastError           string
+	lastFailureAt       time.Time
+	lastSuccessAt       time.Time
+}
+
+func (m *cairnlineMirrorHealth) timestamp() time.Time {
+	if m.now != nil {
+		return m.now()
+	}
+	return time.Now()
+}
+
+func (m *cairnlineMirrorHealth) familyState(family string) *cairnlineMirrorFamilyState {
+	if m.families == nil {
+		m.families = make(map[string]*cairnlineMirrorFamilyState)
+	}
+	state, ok := m.families[family]
+	if !ok {
+		state = &cairnlineMirrorFamilyState{}
+		m.families[family] = state
+	}
+	return state
+}
+
+func (m *cairnlineMirrorHealth) recordFailure(family, operation string, err error) {
+	family = strings.TrimSpace(family)
+	if m == nil || family == "" {
+		return
+	}
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	state := m.familyState(family)
+	state.failureCount++
+	state.lastFailedOperation = operation
+	state.lastError = message
+	state.lastFailureAt = m.timestamp()
+}
+
+func (m *cairnlineMirrorHealth) recordSuccess(family string) {
+	family = strings.TrimSpace(family)
+	if m == nil || family == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.familyState(family).lastSuccessAt = m.timestamp()
+}
+
+// snapshot projects the tracker into the API shape. A family is drifting when
+// its most recent mirror write failed: until a later write for that family
+// succeeds (or the operator resyncs the mirror), the embedded Cairnline copy
+// cannot be assumed to match Hecate's authoritative stores.
+func (m *cairnlineMirrorHealth) snapshot() ProjectCairnlineMirrorWriteHealth {
+	out := ProjectCairnlineMirrorWriteHealth{}
+	if m == nil {
+		return out
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	names := make([]string, 0, len(m.families))
+	for name := range m.families {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		state := m.families[name]
+		item := ProjectCairnlineMirrorWriteFamilyHealth{
+			Family:              name,
+			FailureCount:        state.failureCount,
+			LastError:           state.lastError,
+			LastFailedOperation: state.lastFailedOperation,
+		}
+		if !state.lastFailureAt.IsZero() {
+			item.LastFailureAt = state.lastFailureAt.UTC().Format(time.RFC3339Nano)
+		}
+		if !state.lastSuccessAt.IsZero() {
+			item.LastSuccessAt = state.lastSuccessAt.UTC().Format(time.RFC3339Nano)
+		}
+		// A same-instant failure/success tie counts as drifting on purpose:
+		// when ordering is ambiguous the safe read is that the mirror may be
+		// behind.
+		item.Drifting = state.failureCount > 0 &&
+			(state.lastSuccessAt.IsZero() || !state.lastFailureAt.Before(state.lastSuccessAt))
+		out.TotalFailureCount += state.failureCount
+		if item.Drifting {
+			out.DriftingFamilies = append(out.DriftingFamilies, name)
+		}
+		out.Families = append(out.Families, item)
+	}
+	return out
+}
+
+// recordCairnlineMirrorFailure keeps the existing operator log signal and
+// additionally records the failure against its write family so backend-status
+// and mirror-parity output can surface the evidence.
+func (h *Handler) recordCairnlineMirrorFailure(ctx context.Context, family, operation, projectID string, err error) {
+	h.logCairnlineMirrorError(ctx, operation, projectID, err)
+	if h != nil {
+		h.cairnlineMirrorHealth.recordFailure(family, operation, err)
+	}
+}
+
+// recordCairnlineMirrorResult funnels every shadow-mirror write outcome into
+// the health tracker. Successes matter as much as failures: the drifting
+// classification depends on whether a family has mirrored successfully since
+// its last failure.
+func (h *Handler) recordCairnlineMirrorResult(ctx context.Context, family, operation, projectID string, err error) {
+	if err != nil {
+		h.recordCairnlineMirrorFailure(ctx, family, operation, projectID, err)
+		return
+	}
+	// A disabled embedded connector returns nil without attempting the
+	// write; recording success there would fabricate mirror freshness.
+	if h == nil || !h.projectCairnlineEmbeddedConnectorEnabled() {
+		return
+	}
+	h.cairnlineMirrorHealth.recordSuccess(family)
+}

--- a/internal/api/handler_project_cairnline_mirror_health_test.go
+++ b/internal/api/handler_project_cairnline_mirror_health_test.go
@@ -1,0 +1,269 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+func newCairnlineMirrorHealthClock(start time.Time) (*cairnlineMirrorHealth, func(time.Duration)) {
+	current := start
+	tracker := &cairnlineMirrorHealth{}
+	tracker.now = func() time.Time { return current }
+	advance := func(d time.Duration) { current = current.Add(d) }
+	return tracker, advance
+}
+
+func TestCairnlineMirrorHealth_RecordsPerFamilyFailures(t *testing.T) {
+	tracker, advance := newCairnlineMirrorHealthClock(time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC))
+
+	tracker.recordFailure(cairnlineMirrorFamilySkills, "project_skill_update", errors.New("disk full"))
+	advance(time.Second)
+	tracker.recordFailure(cairnlineMirrorFamilySkills, "project_skills_discover", errors.New("still failing"))
+	advance(time.Second)
+	tracker.recordFailure(cairnlineMirrorFamilyRoots, "project_root_mutation", errors.New("locked"))
+	tracker.recordFailure("", "ignored", errors.New("no family"))
+
+	health := tracker.snapshot()
+	if health.TotalFailureCount != 3 {
+		t.Fatalf("total failure count = %d, want 3", health.TotalFailureCount)
+	}
+	if len(health.Families) != 2 {
+		t.Fatalf("families = %+v, want skills and roots aggregates only", health.Families)
+	}
+	skills := findMirrorWriteFamilyHealth(health.Families, cairnlineMirrorFamilySkills)
+	if skills == nil || skills.FailureCount != 2 || skills.LastError != "still failing" || skills.LastFailedOperation != "project_skills_discover" {
+		t.Fatalf("skills health = %+v, want two aggregated failures with latest error and operation", skills)
+	}
+	if skills.LastFailureAt != "2026-07-08T12:00:01Z" || skills.LastSuccessAt != "" {
+		t.Fatalf("skills timestamps = %q / %q, want latest failure timestamp and no success", skills.LastFailureAt, skills.LastSuccessAt)
+	}
+	roots := findMirrorWriteFamilyHealth(health.Families, cairnlineMirrorFamilyRoots)
+	if roots == nil || roots.FailureCount != 1 || roots.LastError != "locked" {
+		t.Fatalf("roots health = %+v, want single recorded failure", roots)
+	}
+	if !containsString(health.DriftingFamilies, cairnlineMirrorFamilyRoots) || !containsString(health.DriftingFamilies, cairnlineMirrorFamilySkills) {
+		t.Fatalf("drifting families = %+v, want both failing families", health.DriftingFamilies)
+	}
+}
+
+func TestCairnlineMirrorHealth_DriftClearsAfterLaterSuccess(t *testing.T) {
+	tracker, advance := newCairnlineMirrorHealthClock(time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC))
+
+	tracker.recordFailure(cairnlineMirrorFamilyAssignments, "project_assignment_update", errors.New("boom"))
+	advance(time.Second)
+	tracker.recordSuccess(cairnlineMirrorFamilyAssignments)
+	advance(time.Second)
+	tracker.recordSuccess(cairnlineMirrorFamilyMemory)
+	advance(time.Second)
+	tracker.recordFailure(cairnlineMirrorFamilyMemory, "project_memory_update", errors.New("late failure"))
+
+	health := tracker.snapshot()
+	assignments := findMirrorWriteFamilyHealth(health.Families, cairnlineMirrorFamilyAssignments)
+	if assignments == nil || assignments.Drifting || assignments.FailureCount != 1 || assignments.LastSuccessAt == "" {
+		t.Fatalf("assignments health = %+v, want recovered non-drifting family with retained failure evidence", assignments)
+	}
+	memoryFamily := findMirrorWriteFamilyHealth(health.Families, cairnlineMirrorFamilyMemory)
+	if memoryFamily == nil || !memoryFamily.Drifting {
+		t.Fatalf("memory health = %+v, want drifting family after failure that followed a success", memoryFamily)
+	}
+	if len(health.DriftingFamilies) != 1 || health.DriftingFamilies[0] != cairnlineMirrorFamilyMemory {
+		t.Fatalf("drifting families = %+v, want only memory", health.DriftingFamilies)
+	}
+	if health.TotalFailureCount != 2 {
+		t.Fatalf("total failure count = %d, want 2", health.TotalFailureCount)
+	}
+}
+
+func TestCairnlineMirrorHealth_ConcurrentRecordingIsSafe(t *testing.T) {
+	tracker := &cairnlineMirrorHealth{}
+	families := []string{
+		cairnlineMirrorFamilyProjects,
+		cairnlineMirrorFamilyRoots,
+		cairnlineMirrorFamilySkills,
+		cairnlineMirrorFamilyAssignments,
+	}
+
+	var wg sync.WaitGroup
+	for _, family := range families {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				tracker.recordFailure(family, "op", errors.New("boom"))
+				tracker.recordSuccess(family)
+				_ = tracker.snapshot()
+			}
+		}()
+	}
+	wg.Wait()
+
+	health := tracker.snapshot()
+	if health.TotalFailureCount != int64(len(families)*50) {
+		t.Fatalf("total failure count = %d, want %d", health.TotalFailureCount, len(families)*50)
+	}
+	if len(health.Families) != len(families) {
+		t.Fatalf("families = %+v, want one aggregate per recorded family", health.Families)
+	}
+}
+
+func TestCairnlineMirrorHealth_MirrorHookFailureIsRecorded(t *testing.T) {
+	// A regular file where the mirror expects its data directory forces the
+	// embedded mirror write itself to fail, exercising the wrapper-level
+	// recording path rather than the tracker directly.
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: blocked},
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CoordinationBackend: "cairnline",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+
+	handler.mirrorProjectIdentityToCairnline(t.Context(), "project_create", projects.Project{ID: "proj_mirror_fail"})
+
+	health := handler.cairnlineMirrorHealth.snapshot()
+	family := findMirrorWriteFamilyHealth(health.Families, cairnlineMirrorFamilyProjects)
+	if health.TotalFailureCount != 1 || family == nil || family.FailureCount != 1 || family.LastFailedOperation != "project_create" || family.LastError == "" || !family.Drifting {
+		t.Fatalf("mirror health = %+v, want projects family failure recorded by the mirror hook", health)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_MirrorWriteFailuresSurfaceInStatusPayload(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Projects: config.ProjectsConfig{
+			Backend:             "sqlite",
+			CoordinationBackend: "cairnline",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.cairnlineMirrorHealth.recordFailure(cairnlineMirrorFamilySkills, "project_skill_update", errors.New("mirror write exploded"))
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	response := mustRequestJSONStatus[ProjectCoordinationBackendStatusEnvelope](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/backend-status", "")
+	if response.Object != "project_coordination_backend_status" {
+		t.Fatalf("object = %q, want project_coordination_backend_status", response.Object)
+	}
+	health := response.Data.MirrorWriteHealth
+	if health.TotalFailureCount != 1 || len(health.DriftingFamilies) != 1 || health.DriftingFamilies[0] != cairnlineMirrorFamilySkills {
+		t.Fatalf("mirror write health = %+v, want one drifting skills failure", health)
+	}
+	family := findMirrorWriteFamilyHealth(health.Families, cairnlineMirrorFamilySkills)
+	if family == nil || !family.Drifting || family.FailureCount != 1 || family.LastError != "mirror write exploded" || family.LastFailedOperation != "project_skill_update" || family.LastFailureAt == "" {
+		t.Fatalf("skills family health = %+v, want failure evidence in backend-status payload", family)
+	}
+	gate := findReplacementGate(response.Data.ReplacementGates, "mirror-write-health")
+	if gate == nil || gate.Ready || gate.Status != "drifting" {
+		t.Fatalf("mirror write health gate = %+v, want drifting non-ready gate", gate)
+	}
+	if !containsString(gate.ProbeURLs, projectCoordinationBackendStatusURL) || !containsString(gate.ProbeURLs, projectCoordinationBackendMirrorParityURL) {
+		t.Fatalf("mirror write health gate probes = %+v, want status and mirror-parity probes", gate.ProbeURLs)
+	}
+}
+
+func TestProjectCoordinationBackendStatus_MirrorDriftBlocksReplacementReady(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			Backend:                  "sqlite",
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineReplacementMode: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name":             "Mirror Drift Blocks Replacement",
+		"default_provider": "anthropic",
+		"default_model":    "claude-sonnet-4",
+	}))
+
+	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
+	if !status.ReplacementReady {
+		t.Fatalf("status = %+v, want replacement ready before any mirror failure is recorded", status)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "mirror-write-health"); gate == nil || !gate.Ready || gate.Status != "healthy" {
+		t.Fatalf("mirror write health gate = %+v, want healthy ready gate without failures", gate)
+	}
+
+	handler.cairnlineMirrorHealth.recordFailure(cairnlineMirrorFamilyAssignments, "project_assignment_update", errors.New("mirror down"))
+	status = handler.projectCoordinationBackendStatusWithContext(t.Context())
+	if status.ReplacementReady || status.AuthoritativeBackend != "hecate" || status.CairnlineAuthoritative {
+		t.Fatalf("status = %+v, want outstanding mirror drift to block replacement readiness", status)
+	}
+	gate := findReplacementGate(status.ReplacementGates, "mirror-write-health")
+	if gate == nil || gate.Ready || gate.Status != "drifting" {
+		t.Fatalf("mirror write health gate = %+v, want drifting gate blocking replacement", gate)
+	}
+
+	handler.cairnlineMirrorHealth.recordSuccess(cairnlineMirrorFamilyAssignments)
+	status = handler.projectCoordinationBackendStatusWithContext(t.Context())
+	if !status.ReplacementReady {
+		t.Fatalf("status = %+v, want replacement ready again after the failing family recovered", status)
+	}
+	if gate := findReplacementGate(status.ReplacementGates, "mirror-write-health"); gate == nil || !gate.Ready || gate.Status != "recovered" {
+		t.Fatalf("mirror write health gate = %+v, want ready recovered gate after later success", gate)
+	}
+}
+
+func TestProjectCairnlineMirrorParityAPI_IncludesMirrorWriteHealth(t *testing.T) {
+	handler := NewHandler(config.Config{
+		Server:   config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{CoordinationBackend: "cairnline"},
+	}, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	handler.cairnlineMirrorHealth.recordFailure(cairnlineMirrorFamilyHandoffs, "project_handoff_update", errors.New("mirror rejected handoff"))
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+
+	mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name": "Mirror Parity Health",
+	}))
+	response := mustRequestJSONStatus[ProjectCairnlineSyncResponse](client, http.StatusOK, http.MethodGet, "/hecate/v1/projects/cairnline/mirror-parity", "")
+	health := response.Data.MirrorWriteHealth
+	if health == nil || health.TotalFailureCount != 1 {
+		t.Fatalf("mirror write health = %+v, want recorded failure in parity output", health)
+	}
+	if len(health.DriftingFamilies) != 1 || health.DriftingFamilies[0] != cairnlineMirrorFamilyHandoffs {
+		t.Fatalf("drifting families = %+v, want handoffs", health.DriftingFamilies)
+	}
+	family := findMirrorWriteFamilyHealth(health.Families, cairnlineMirrorFamilyHandoffs)
+	if family == nil || !family.Drifting || family.LastError != "mirror rejected handoff" {
+		t.Fatalf("handoffs family health = %+v, want drifting failure evidence in parity output", family)
+	}
+}
+
+func findMirrorWriteFamilyHealth(items []ProjectCairnlineMirrorWriteFamilyHealth, family string) *ProjectCairnlineMirrorWriteFamilyHealth {
+	for idx := range items {
+		if items[idx].Family == family {
+			return &items[idx]
+		}
+	}
+	return nil
+}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -332,12 +332,14 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 	readSource := "auto"
 	connector := "embedded"
 	replacementMode := "disabled"
+	var mirrorWriteHealth ProjectCairnlineMirrorWriteHealth
 	if h != nil {
 		configured = h.config.ProjectsCoordinationBackend()
 		storageBackend = h.config.Projects.Backend
 		readSource = h.config.ProjectsCairnlineReadSource()
 		connector = h.config.ProjectsCairnlineConnector()
 		replacementMode = h.config.ProjectsCairnlineReplacementMode()
+		mirrorWriteHealth = h.cairnlineMirrorHealth.snapshot()
 	}
 	connectorReady := projectCairnlineConnectorReady(connector)
 	response := ProjectCoordinationBackendStatusResponse{
@@ -376,6 +378,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 		EmbeddedParityReportURL:              projectCoordinationBackendEmbeddedParityReportURL,
 		SyncReadinessURL:                     projectCoordinationBackendSyncReadinessURL,
 		MirrorParityURL:                      projectCoordinationBackendMirrorParityURL,
+		MirrorWriteHealth:                    mirrorWriteHealth,
 	}
 	switch configured {
 	case "cairnline":
@@ -397,13 +400,13 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 		nativeShadowSkipArmed := replacementMode == "embedded" && len(response.PortableWriteGaps) == 0
 		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority, nativeShadowSkipArmed, migrationCutoverArmed)
 		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps, migrationCutoverArmed)
-		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed)
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth)
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
 				response.Detail = "Cairnline sidecar is configured as the project read source, so " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " routes read through the persistent standalone Cairnline MCP client. Project writes and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
-				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed)
+				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth)
 				response.Warnings = []string{
 					"Only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " use the Cairnline sidecar MCP client in this mode.",
 					projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
@@ -413,7 +416,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
-			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed)
+			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
 				projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
@@ -838,7 +841,7 @@ func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
 	}
 }
 
-func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool) []ProjectCoordinationBackendReplacementGate {
+func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool, mirrorWriteHealth ProjectCairnlineMirrorWriteHealth) []ProjectCoordinationBackendReplacementGate {
 	if strings.TrimSpace(strictEmbeddedReadGate.ID) == "" {
 		strictEmbeddedReadGate = projectCairnlineStrictEmbeddedReadSmokeDefaultGate()
 	}
@@ -853,9 +856,36 @@ func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []
 		},
 		strictEmbeddedReadGate,
 		writeGate,
+		projectCairnlineMirrorWriteHealthGate(mirrorWriteHealth),
 		projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed),
 		projectCairnlineReplacementModeGate(replacementMode),
 	}
+}
+
+// projectCairnlineMirrorWriteHealthGate turns live shadow-mirror failure
+// evidence into a replacement gate. A backend whose portable write families
+// have failed to mirror since their last success is demonstrably behind
+// Hecate's stores, so replacement readiness must not be reported while that
+// evidence is outstanding.
+func projectCairnlineMirrorWriteHealthGate(health ProjectCairnlineMirrorWriteHealth) ProjectCoordinationBackendReplacementGate {
+	gate := ProjectCoordinationBackendReplacementGate{
+		ID:        "mirror-write-health",
+		Ready:     true,
+		Status:    "healthy",
+		Detail:    "No Cairnline shadow-mirror write failures have been recorded in this runtime.",
+		ProbeURLs: []string{projectCoordinationBackendStatusURL, projectCoordinationBackendMirrorParityURL},
+	}
+	if len(health.DriftingFamilies) > 0 {
+		gate.Ready = false
+		gate.Status = "drifting"
+		gate.Detail = fmt.Sprintf("Cairnline shadow-mirror writes recorded %d failure(s) in this runtime, and these write families have not mirrored successfully since their last failure: %s. Resolve the mirror errors or resync before treating the mirror as replacement evidence.", health.TotalFailureCount, strings.Join(health.DriftingFamilies, ", "))
+		return gate
+	}
+	if health.TotalFailureCount > 0 {
+		gate.Status = "recovered"
+		gate.Detail = fmt.Sprintf("Cairnline shadow-mirror writes recorded %d failure(s) in this runtime, but every affected write family has mirrored successfully since its last failure.", health.TotalFailureCount)
+	}
+	return gate
 }
 
 func projectCairnlineStrictEmbeddedReadSmokeDefaultGate() ProjectCoordinationBackendReplacementGate {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -330,6 +330,26 @@ type ProjectCairnlineSyncResponseItem struct {
 	Cairnline          ProjectCairnlineSyncCounts          `json:"cairnline"`
 	Authoritative      bool                                `json:"authoritative"`
 	MigrationRehearsal ProjectCairnlineMigrationRehearsal  `json:"migration_rehearsal"`
+	// MirrorWriteHealth carries live shadow-mirror failure evidence next to
+	// the structural parity verdict; only the mirror-parity probe attaches
+	// it because sync/export rehearsals rebuild their target database.
+	MirrorWriteHealth *ProjectCairnlineMirrorWriteHealth `json:"mirror_write_health,omitempty"`
+}
+
+type ProjectCairnlineMirrorWriteHealth struct {
+	TotalFailureCount int64                                     `json:"total_failure_count"`
+	DriftingFamilies  []string                                  `json:"drifting_families,omitempty"`
+	Families          []ProjectCairnlineMirrorWriteFamilyHealth `json:"families,omitempty"`
+}
+
+type ProjectCairnlineMirrorWriteFamilyHealth struct {
+	Family              string `json:"family"`
+	FailureCount        int64  `json:"failure_count"`
+	LastError           string `json:"last_error,omitempty"`
+	LastFailedOperation string `json:"last_failed_operation,omitempty"`
+	LastFailureAt       string `json:"last_failure_at,omitempty"`
+	LastSuccessAt       string `json:"last_success_at,omitempty"`
+	Drifting            bool   `json:"drifting"`
 }
 
 type ProjectCairnlineMigrationRehearsal struct {
@@ -597,6 +617,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	EmbeddedParityReportURL              string                                       `json:"embedded_parity_report_url,omitempty"`
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
 	MirrorParityURL                      string                                       `json:"mirror_parity_url,omitempty"`
+	MirrorWriteHealth                    ProjectCairnlineMirrorWriteHealth            `json:"mirror_write_health"`
 }
 
 type ProjectCoordinationBackendNextAction struct {


### PR DESCRIPTION
## Before / After

**Before:** when Hecate shadow-mirrored a portable project-coordination write to the embedded Cairnline database and that mirror write failed, the error was swallowed — the only signal was a `slog.Warn` log line. A drifting embedded Cairnline mirror was invisible to operators and to the replacement-readiness verdict, so `replacement_ready` could report healthy while a write family had silently stopped mirroring.

**After:** operators see the drift directly. `GET /hecate/v1/projects/backend-status` and `GET /hecate/v1/projects/cairnline/mirror-parity` now carry a `mirror_write_health` payload with per-write-family failure counts, last error, last failed operation, last failure/success timestamps, and the list of currently drifting families. A new `mirror-write-health` gate in `data.replacement_gates` blocks `replacement_ready` while any write family is drifting (its most recent mirror write failed and has not since succeeded), and clears once a later mirror write for that family succeeds.

## How

A new in-memory, mutex-guarded health tracker owned by the mirror layer records the outcome of every shadow-mirror write, keyed by the existing portable write-family vocabulary (projects, roots, context-sources, skills, roles, work-items, assignments, artifacts, handoffs, memory, memory-candidates, project-assistant-proposals). Every `mirrorProject*ToCairnline` wrapper now funnels its result through the tracker via `recordCairnlineMirrorResult`. A family is classified as drifting when its most recent write failed; a same-instant failure/success tie counts as drifting (the safe read). Successes are only recorded when the embedded connector is actually enabled, so a disabled connector cannot fabricate mirror freshness. The counters are process-local runtime observability by design — not persisted coordination state — and reset on restart with the mirror process they observe. The tracker snapshot is projected into the API shape and attached to backend-status and mirror-parity output, and drives the new replacement gate.

## Verification / dogfood evidence

Added `docs/design/proposals/evidence/cairnline-replacement-dogfood-2026-07-08.md`: a full armed embedded replacement-mode rehearsal driven through the project-coordination HTTP API. It exercises every portable write family (create/update/delete), records the four known fidelity probes (lossy execution-ref mapping, non-portable context packets, `awaiting_approval` status clamp, additive-only sync path), and demonstrates the new observability catching an induced shadow-mirror failure end to end:

- Under partial write authority, two `work-items` mirror writes failed against an immutable embedded DB while the requests still returned `201` (Hecate authoritative). `mirror_write_health` recorded `total_failure_count: 2`, `drifting_families: ["work-items"]`, the last error, and the `mirror-write-health` gate flipped to `ready: false status: drifting`, blocking `replacement_ready`.
- After the DB recovered, one successful mirror write cleared the drift (`drifting: false`) and the gate returned to `ready: true status: recovered`, retaining the cumulative failure count.
- The rehearsal also documents that in **full** all-portable authority the shadow-mirror path is not exercised (authoritative-write failures fail the request outright), so the gate is meaningful in the transitional dual-write posture.

## Notes

- `mirror_write_health` counters are intentionally not persisted; they are runtime observability for best-effort mirror hooks.
- Docs updated: `docs/runtime/runtime-api.md` (backend-status and mirror-parity payloads) and the proposal.
- Tests: `internal/api/handler_project_cairnline_mirror_health_test.go`.