### PR TITLE
docs(cairnline): reflect shipped embedding and replacement mode

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -44,8 +44,13 @@ Read these in order:
 The invariant: projects provide identity, context assembly decides what enters
 a model or adapter call, memory is operator-approved durable context, and window
 management fits an already-labelled context packet into a model limit.
-Cairnline is a future extraction path for the project coordination substrate,
-not current Hecate runtime behavior.
+Cairnline is the portable extraction path for the project coordination
+substrate. Hecate now embeds the Cairnline Go package and, when the coordination
+backend is configured, uses it for live project read routes, opt-in
+write-authority switchpoints, and an armed embedded replacement mode. It stays
+opt-in and non-default: Hecate-native stores remain authoritative until an
+operator configures the Cairnline backend, and Hecate keeps execution,
+approvals, supervision, traces, and migration cutover on its own runtime.
 
 ### Workflow Runbooks
 

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -1,6 +1,11 @@
 # Cairnline: Portable Project Coordination
 
-> **Status:** proposed.
+> **Status:** proposed (extraction design). The embedded integration has
+> shipped as an opt-in, non-default path: Hecate pins the Cairnline Go package,
+> serves configured project read routes from it, exposes opt-in write-authority
+> switchpoints, and has an armed embedded replacement mode. This document keeps
+> the long-term extraction boundaries and product shape; the accepted Projects
+> design and Runtime API docs remain the source of truth for current behavior.
 > **Current source of truth:** [Projects](../accepted/projects.md),
 > [Runtime API](../../runtime/runtime-api.md),
 > [MCP](../../runtime/mcp.md), [External Agents](../../runtime/external-agents.md),
@@ -91,6 +96,23 @@ only when backend status reports `replacement_ready=true` and
 - Hecate's Projects UI can consume Cairnline state without losing current
   onboarding, attention, context-inspection, review, handoff, or closeout
   behavior.
+
+The first end-to-end embedded replacement dogfood (evidence recorded in
+[hecatehq/hecate#831](https://github.com/hecatehq/hecate/pull/831)) showed that
+backend status could report `replacement_ready=true` while three fidelity gaps
+still lost portable detail: the assignment execution ref collapsed Hecate's
+structured task/run/chat/context refs into a single string, Cairnline-projected
+context packets omitted project memory, and `awaiting_approval` assignments were
+reported as `running`. The portable-model fixes for these landed in
+[hecatehq/cairnline#76](https://github.com/hecatehq/cairnline/pull/76) (merged);
+the Hecate-side wiring that consumes them — a structured execution ref, a
+first-class `awaiting_approval` assignment status, project memory in context
+packets, and additional replacement gates so the fidelity checks block
+`replacement_ready` — is in flight in
+[hecatehq/hecate#832](https://github.com/hecatehq/hecate/pull/832). Until that
+wiring merges, treat `replacement_ready` as necessary but not sufficient and
+review the fidelity of execution refs, context memory, and approval status by
+hand.
 
 The intended order is therefore:
 

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -98,7 +98,8 @@ only when backend status reports `replacement_ready=true` and
   behavior.
 
 The first end-to-end embedded replacement dogfood (evidence recorded in
-[hecatehq/hecate#831](https://github.com/hecatehq/hecate/pull/831)) showed that
+[`evidence/cairnline-replacement-dogfood-2026-07-08.md`](evidence/cairnline-replacement-dogfood-2026-07-08.md))
+showed that
 backend status could report `replacement_ready=true` while three fidelity gaps
 still lost portable detail: the assignment execution ref collapsed Hecate's
 structured task/run/chat/context refs into a single string, Cairnline-projected

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -155,6 +155,73 @@ Worktree creation is an explicit operator action. In V1, Hecate creates
 worktrees under the selected root's `.worktrees/` directory and does not create
 sibling workspaces outside the registered project root.
 
+## Cairnline Coordination Backend
+
+Hecate embeds the [Cairnline](https://github.com/hecatehq/cairnline) portable
+coordination package and can serve project coordination state from it. This is
+opt-in and non-default: with no configuration, Hecate-native stores stay
+authoritative and none of the switches below have any effect. All of these gates
+are alpha and their contracts are not yet stable; back up your data before
+enabling them and use `GET /hecate/v1/projects/backend-status` to inspect the
+effective state, replacement gates, and remaining write switchpoints.
+
+Five environment gates control the path, from off to fully armed:
+
+- `HECATE_PROJECTS_COORDINATION_BACKEND` — `hecate` (default) or `cairnline`.
+  `cairnline` turns on the live Cairnline read routes (22 project read families)
+  and enables the opt-in write-authority switchpoints below. Hecate-native
+  stores remain authoritative for every mutation family whose switchpoint is not
+  enabled.
+- `HECATE_PROJECTS_CAIRNLINE_CONNECTOR` — `embedded` (default) or `sidecar`.
+  `embedded` uses the in-process Cairnline Go package and is the only connector
+  that can make live write routes and write-authority switchpoints use Cairnline.
+  `sidecar` runs a standalone Cairnline MCP process for contract/read smokes only;
+  write-authority switchpoints are ignored in sidecar connector mode. The sidecar
+  process is configured through `HECATE_PROJECTS_CAIRNLINE_SIDECAR_COMMAND`
+  (default `cairnline`), `_SIDECAR_ARGS`, `_SIDECAR_DB`, and
+  `_SIDECAR_PROBE_TIMEOUT` (default `10s`).
+- `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE` — `auto` (default), `snapshot`,
+  `embedded`, or `sidecar`. `auto` prefers the embedded mirror database when it
+  already contains the requested project and otherwise uses the snapshot-seeded
+  bridge; `snapshot` forces the bridge; `embedded` requires a populated embedded
+  mirror and fails loudly when it is missing or stale, which is what strict
+  cutover rehearsal wants; `sidecar` routes the read families through the
+  standalone MCP client and requires `_CONNECTOR=sidecar`.
+- `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY` — `none` (default) or a
+  comma-separated list of portable write-authority switchpoints (or the
+  `all-portable` shorthand). Each enabled switchpoint makes that family commit to
+  Cairnline first and then best-effort shadow the record back into Hecate-native
+  stores. The twelve portable families are `project-identity`,
+  `project-metadata-defaults`, `project-roots`, `project-context-sources`,
+  `project-skills`, `project-roles`, `project-work-items`, `project-assignments`,
+  `project-collaboration`, `project-memory`, `memory-candidates` (requires
+  `project-memory`), and `project-assistant-proposals`. Enabling write authority
+  does not move Hecate-owned runtime side effects (root scans, Git worktree
+  creation, assignment-start dispatch, task/External Agent supervision,
+  approvals, traces) or migration cutover.
+- `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE` — `disabled` (default) or
+  `embedded`. `embedded` is the explicit cutover arm and is accepted only with
+  `_COORDINATION_BACKEND=cairnline`, `_CONNECTOR=embedded`, and
+  `_READ_SOURCE=embedded`. It implies all portable write authority and lets
+  strict embedded reads serve project state directly from Cairnline. Backend
+  status still reports the remaining strict-embedded-read-smoke,
+  migration-and-rollback, and replacement-mode gates, so operators can tell
+  "portable writes are Cairnline-first" apart from "every replacement proof is
+  complete."
+
+Two declared boundaries remain even with replacement mode armed: **assignment
+start dispatch** stays Hecate-owned (Hecate can claim and progress a Cairnline
+assignment record and mirror runtime refs, but it does not launch tasks or
+External Agents from Cairnline), and there is **no one-way migration cutover**.
+`POST /hecate/v1/projects/cairnline/sync` runs a full-refresh
+delete-and-reseed rehearsal into the embedded mirror, and snapshot import is
+additive-only, so the mirror can drift after that full-refresh rehearsal; that
+staleness risk applies to the sync rehearsal path, not to the live authoritative
+write switchpoints, which delete through Cairnline directly. For local dogfood,
+`just dev-cairnline-projects --reset` starts a clean runtime with the embedded
+dogfood posture applied and `just test-projects-dogfood` runs the focused API
+check.
+
 ## What Projects V1 Does Not Do
 
 - It does not replace issue trackers or team project-management systems.

--- a/docs/runtime/project-assistant.md
+++ b/docs/runtime/project-assistant.md
@@ -201,8 +201,15 @@ The adapter preserves Hecate-owned projection details such as native snapshot
 timestamps and Hecate-only metadata while using Cairnline as the portable graph
 source, so ordering-sensitive context such as recent activity stays compatible
 with the Hecate-native path during replacement-readiness testing.
-Proposal ledger writes and proposal apply remain Hecate-owned until the
-Cairnline write adapter is authoritative.
+Proposal ledger writes are Hecate-owned by default and best-effort mirrored into
+Cairnline, but the opt-in `project-assistant-proposals` write-authority
+switchpoint makes draft/propose/apply-attempt ledger records Cairnline-first.
+Confirmed apply routes its project create, project metadata/default, root, role,
+work-item, assignment, handoff, and memory-candidate side effects through the
+matching opt-in Cairnline authority switchpoints when they are enabled; the
+remaining chat and runtime side effects stay Hecate-owned orchestrator
+capabilities and are mirrored into Cairnline only as replacement-readiness
+evidence.
 
 The v0 context packet is item-limited and body-budgeted. It includes project
 defaults, roots, context-source metadata, the selected work item when present,

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -461,10 +461,13 @@ sequenceDiagram
   events, and settings.
 - `HECATE_PROJECTS_COORDINATION_BACKEND=hecate|cairnline` records the intended
   Projects coordination authority. The default is `hecate`. `cairnline` is an
-  opt-in replacement-readiness setting only: Hecate-native stores remain
-  authoritative until the feature-flagged Cairnline read/write adapter and
-  migration path land. Use
-  `GET /hecate/v1/projects/backend-status` to inspect the effective state.
+  opt-in setting: it turns on the live Cairnline read routes and opt-in
+  write-authority switchpoints, but Hecate-native stores stay authoritative for
+  any mutation family whose switchpoint is not enabled, and full delegation
+  additionally requires the armed embedded replacement mode plus the outstanding
+  migration/rollback cutover. Use
+  `GET /hecate/v1/projects/backend-status` to inspect the effective state,
+  replacement gates, and remaining write switchpoints.
 - `HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded|sidecar` chooses the Cairnline
   connector mode while `HECATE_PROJECTS_COORDINATION_BACKEND=cairnline`.
   `embedded` is the current replacement-readiness path: Hecate uses the
@@ -2396,8 +2399,11 @@ The response reports the scoped records Hecate cleaned up:
 
 Local-only endpoint that reports the configured Projects coordination backend
 and the backend that is actually authoritative for live project reads/writes.
-It exists to make the Cairnline replacement switch explicit while the adapter is
-being built.
+It exists to make the Cairnline replacement switch explicit: read routes and
+opt-in write-authority switchpoints are live, and the endpoint reports which
+replacement gates remain (strict embedded read smoke, outstanding portable write
+switchpoints, and the migration/rollback cutover) before it will report
+Cairnline as authoritative.
 
 `configured_backend` reflects `HECATE_PROJECTS_COORDINATION_BACKEND`.
 `cairnline_connector` reflects `HECATE_PROJECTS_CAIRNLINE_CONNECTOR`.

--- a/internal/cairnlinebridge/bridge.go
+++ b/internal/cairnlinebridge/bridge.go
@@ -1,9 +1,16 @@
 // Package cairnlinebridge maps Hecate Projects records into Cairnline's
 // portable coordination model.
 //
-// This package is an integration proof, not a runtime backend switch. Hecate
-// remains the execution/orchestration authority; Cairnline receives durable
-// coordination records that can later back MCP pull or migration experiments.
+// The mapping now backs live behavior, not just an integration proof: the
+// configured Cairnline read routes serve project reads, opt-in write-authority
+// switchpoints commit portable coordination state to Cairnline first, live
+// mirrors shadow the remaining families into the embedded Cairnline database,
+// and an armed embedded replacement mode can report Cairnline as authoritative
+// for portable coordination state. Hecate stays the execution/orchestration
+// authority: task/chat/External Agent dispatch, approvals, traces, root
+// discovery, Git worktree creation, and assignment-start remain Hecate-owned
+// runtime/workspace side effects, and migration cutover is still a rehearsal
+// rather than a one-way storage switch.
 package cairnlinebridge
 
 import (


### PR DESCRIPTION
## Before

Several docs still framed Cairnline as a future-only, design-first extraction path or as behavior gated behind an unlanded read/write adapter:

- `docs/design/README.md` called Cairnline "a future extraction path ... not current Hecate runtime behavior."
- `docs/runtime/runtime-api.md` said Hecate-native stores stay authoritative "until the feature-flagged Cairnline read/write adapter and migration path land," and described the backend-status endpoint as existing "while the adapter is being built."
- `docs/runtime/project-assistant.md` said proposal ledger writes and apply "remain Hecate-owned until the Cairnline write adapter is authoritative."
- `internal/cairnlinebridge/bridge.go` described the package as "an integration proof, not a runtime backend switch."
- `docs/operator/projects.md` had no operator-facing documentation of the coordination-backend config gates.

In reality Hecate already embeds the Cairnline Go package (`go.mod` pins `v0.1.0-alpha.5`), serves the configured project read routes from it, exposes opt-in write-authority switchpoints that commit portable coordination state to Cairnline first, live-mirrors the remaining families, and has an armed embedded replacement mode.

## After

- `design/README.md`, `runtime-api.md`, and `project-assistant.md` describe the shipped, opt-in, non-default state and name the boundaries that remain (assignment-start dispatch and migration cutover stay Hecate-owned).
- `docs/operator/projects.md` gains a **Cairnline Coordination Backend** section documenting the five config gates (`HECATE_PROJECTS_COORDINATION_BACKEND`, `_CAIRNLINE_CONNECTOR`, `_CAIRNLINE_READ_SOURCE`, `_CAIRNLINE_WRITE_AUTHORITY`, `_CAIRNLINE_REPLACEMENT_MODE`) with their real defaults and accepted values, plus the sidecar sub-vars and the two declared boundaries.
- The Cairnline proposal doc records the fidelity gaps the first embedded dogfood surfaced — a lossy execution ref, context packets missing project memory, and `awaiting_approval` reported as `running` — with the portable-model fix (cairnline#76, merged) and the in-flight Hecate-side wiring (hecate#832).
- The `cairnlinebridge` package comment now describes the live behavior instead of an integration proof (comment-only; `go build`/`go vet` pass).

## How

Every claim was verified against the code before writing it: the config gates and their defaults/accepted values in `internal/config/config.go`, the 22 read-route and 12 portable write-authority family lists and the replacement-gate logic in `internal/api/handler_project_coordination_backend.go`, and the current bridge mapping in `internal/cairnlinebridge/bridge.go`. The three fidelity gaps are presented as in-flight because on this base branch the bridge still collapses the structured execution ref to one string and still clamps `awaiting_approval` to `running`; the follow-up wiring lands in hecate#832. The dogfood evidence is cited by PR reference (hecate#831) rather than a relative link because that file is not on this branch. Alpha / unstable-contract caveats are kept intact.

Docs-only plus one comment-only code change. No behavior change.