### PR TITLE
feat(cairnline): classify sidecar tool errors by structured code

### DIFF
--- a/internal/api/handler_project_assistant.go
+++ b/internal/api/handler_project_assistant.go
@@ -298,7 +298,7 @@ func (h *Handler) cairnlineSidecarProjectAssistantProposal(ctx context.Context, 
 		return projectassistant.ProposalRecord{}, false, err
 	}
 	if result.IsError {
-		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
+		if projectCairnlineSidecarToolErrorIsNotFound(result) {
 			return projectassistant.ProposalRecord{}, false, nil
 		}
 		return projectassistant.ProposalRecord{}, false, projectCairnlineSidecarReadFailure("assistant.proposals.get returned a tool-level error: " + strings.TrimSpace(result.Text))

--- a/internal/api/handler_project_cairnline_sidecar_error_code_test.go
+++ b/internal/api/handler_project_cairnline_sidecar_error_code_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/mcp"
+	"github.com/hecatehq/hecate/internal/orchestrator"
+)
+
+// sidecarToolErrorResult builds a failed CachedMCPToolCallResult with the given
+// prose text and raw structuredContent, mirroring what the sidecar client sees
+// from a Cairnline tool-level error.
+func sidecarToolErrorResult(text string, structured json.RawMessage) *orchestrator.CachedMCPToolCallResult {
+	return &orchestrator.CachedMCPToolCallResult{
+		Text:    text,
+		IsError: true,
+		Result: mcp.CallToolResult{
+			Content:           mcp.TextContent(text),
+			StructuredContent: structured,
+			IsError:           true,
+		},
+	}
+}
+
+func TestProjectCairnlineSidecarToolErrorCode(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *orchestrator.CachedMCPToolCallResult
+		want   string
+	}{
+		{
+			name:   "nil result",
+			result: nil,
+			want:   "",
+		},
+		{
+			name:   "empty structured content",
+			result: sidecarToolErrorResult("boom", nil),
+			want:   "",
+		},
+		{
+			name:   "json null structured content",
+			result: sidecarToolErrorResult("boom", json.RawMessage("null")),
+			want:   "",
+		},
+		{
+			name:   "valid not_found code",
+			result: sidecarToolErrorResult(`root "x" not found`, json.RawMessage(`{"error":{"code":"not_found","message":"root \"x\" not found"}}`)),
+			want:   "not_found",
+		},
+		{
+			name:   "valid conflict code",
+			result: sidecarToolErrorResult("state conflict", json.RawMessage(`{"error":{"code":"conflict","message":"state conflict"}}`)),
+			want:   "conflict",
+		},
+		{
+			name:   "malformed json",
+			result: sidecarToolErrorResult("boom", json.RawMessage(`{"error":`)),
+			want:   "",
+		},
+		{
+			name:   "error object without code",
+			result: sidecarToolErrorResult("boom", json.RawMessage(`{"error":{"message":"boom"}}`)),
+			want:   "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := projectCairnlineSidecarToolErrorCode(tc.result); got != tc.want {
+				t.Fatalf("projectCairnlineSidecarToolErrorCode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProjectCairnlineSidecarToolErrorIsNotFound covers the classification the
+// four sidecar read sites rely on: a structured not_found code (and the legacy
+// prose fallback for pre-contract sidecars) resolves to the not-found path
+// (ok=false -> HTTP 404), while any other code or prose resolves to the
+// read-failure path (HTTP 502).
+func TestProjectCairnlineSidecarToolErrorIsNotFound(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *orchestrator.CachedMCPToolCallResult
+		want   bool
+	}{
+		{
+			name:   "structured not_found maps to not-found",
+			result: sidecarToolErrorResult("unrelated prose", json.RawMessage(`{"error":{"code":"not_found","message":"gone"}}`)),
+			want:   true,
+		},
+		{
+			name:   "structured conflict is not not-found",
+			result: sidecarToolErrorResult("gone not found", json.RawMessage(`{"error":{"code":"conflict","message":"state conflict"}}`)),
+			want:   false,
+		},
+		{
+			name:   "structured internal is not not-found",
+			result: sidecarToolErrorResult("gone not found", json.RawMessage(`{"error":{"code":"internal","message":"boom"}}`)),
+			want:   false,
+		},
+		{
+			name:   "empty structured falls back to prose not found",
+			result: sidecarToolErrorResult("projects.get: root not found", nil),
+			want:   true,
+		},
+		{
+			name:   "empty structured with unrelated prose is read-failure",
+			result: sidecarToolErrorResult("projects.get: internal error", nil),
+			want:   false,
+		},
+		{
+			name:   "nil result is not not-found",
+			result: nil,
+			want:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := projectCairnlineSidecarToolErrorIsNotFound(tc.result); got != tc.want {
+				t.Fatalf("projectCairnlineSidecarToolErrorIsNotFound = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -102,7 +102,7 @@ func (h *Handler) cairnlineSidecarProject(ctx context.Context, projectID string)
 		return ProjectCairnlineSidecarProjectItem{}, false, err
 	}
 	if result.IsError {
-		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
+		if projectCairnlineSidecarToolErrorIsNotFound(result) {
 			return ProjectCairnlineSidecarProjectItem{}, false, nil
 		}
 		return ProjectCairnlineSidecarProjectItem{}, false, projectCairnlineSidecarReadFailure("projects.get returned a tool-level error: " + strings.TrimSpace(result.Text))
@@ -202,7 +202,7 @@ func (h *Handler) cairnlineSidecarAssignmentLaunchPacket(ctx context.Context, pr
 		return cairnline.AssignmentLaunchPacket{}, false, err
 	}
 	if result.IsError {
-		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
+		if projectCairnlineSidecarToolErrorIsNotFound(result) {
 			return cairnline.AssignmentLaunchPacket{}, false, nil
 		}
 		return cairnline.AssignmentLaunchPacket{}, false, projectCairnlineSidecarReadFailure("assignments.launch_packet returned a tool-level error: " + strings.TrimSpace(result.Text))
@@ -231,7 +231,7 @@ func (h *Handler) cairnlineSidecarAssignmentContext(ctx context.Context, project
 		return cairnline.AssignmentContext{}, false, err
 	}
 	if result.IsError {
-		if projectCairnlineSidecarToolErrorIsNotFound(result.Text) {
+		if projectCairnlineSidecarToolErrorIsNotFound(result) {
 			return cairnline.AssignmentContext{}, false, nil
 		}
 		return cairnline.AssignmentContext{}, false, projectCairnlineSidecarReadFailure("assignments.context returned a tool-level error: " + strings.TrimSpace(result.Text))
@@ -579,7 +579,58 @@ func projectCairnlineSidecarStructuredSkills(raw json.RawMessage) ([]ProjectCair
 	return skills, true, nil
 }
 
-func projectCairnlineSidecarToolErrorIsNotFound(text string) bool {
+// cairnlineToolErrorCodeNotFound mirrors the machine-readable error code
+// Cairnline emits in structuredContent on a failed tool call. Kept as a local
+// wire constant so this classification change stays decoupled from the cairnline
+// module pin; once the error-code contract is tagged and the ExecutionRef bump
+// lands, this can be swapped for the exported cairnline.ErrorCodeNotFound.
+const cairnlineToolErrorCodeNotFound = "not_found"
+
+// projectCairnlineSidecarToolErrorCode returns the machine-readable error code
+// Cairnline emits in structuredContent on a failed tool call, or "" when the
+// sidecar did not provide one (pre-contract builds). The code is one of the
+// Cairnline wire error-code values (not_found, invalid, already_exists,
+// conflict, internal).
+func projectCairnlineSidecarToolErrorCode(result *orchestrator.CachedMCPToolCallResult) string {
+	if result == nil {
+		return ""
+	}
+	raw := bytes.TrimSpace(result.Result.StructuredContent)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Error.Code)
+}
+
+// projectCairnlineSidecarToolErrorIsNotFound reports whether a failed sidecar
+// tool call represents a not-found condition. It prefers the machine-readable
+// structured error code Cairnline now emits; when the sidecar predates that
+// contract and returns no code, it falls back to the legacy prose match so a
+// not-found still maps to 404 during rollout.
+func projectCairnlineSidecarToolErrorIsNotFound(result *orchestrator.CachedMCPToolCallResult) bool {
+	if code := projectCairnlineSidecarToolErrorCode(result); code != "" {
+		return code == cairnlineToolErrorCodeNotFound
+	}
+	if result == nil {
+		return false
+	}
+	return projectCairnlineSidecarToolErrorTextIsNotFound(result.Text)
+}
+
+// projectCairnlineSidecarToolErrorTextIsNotFound is the transitional prose
+// fallback: it matches Cairnline's not-found message by substring. It is used
+// only when the sidecar returned no structured error code, and should be
+// removed once every sidecar build emits structuredContent error codes.
+func projectCairnlineSidecarToolErrorTextIsNotFound(text string) bool {
 	return strings.Contains(strings.ToLower(strings.TrimSpace(text)), "not found")
 }
 


### PR DESCRIPTION
## Summary

The Hecate Cairnline sidecar client previously detected a not-found tool-level error by substring-matching Cairnline's prose (`"not found"`). This change makes it read the machine-readable `structuredContent.error.code` that Cairnline now emits on a failed MCP tool call, and demotes the prose match to a transitional fallback used only when the sidecar returns no structured code (pre-contract builds).

### Before / After

- **Before:** `projectCairnlineSidecarToolErrorIsNotFound(result.Text)` — substring match on prose.
- **After:** `projectCairnlineSidecarToolErrorIsNotFound(result)` — reads `result.Result.StructuredContent` → `{error:{code,message}}` as the primary signal (`code == not_found`), falling back to the legacy prose match only when no structured code is present.

**HTTP mappings unchanged:** `not_found` → `ok=false` → 404; every other code (or read failure) → 502.

### What changed

- New `projectCairnlineSidecarToolErrorCode` extractor decodes `structuredContent` into `{error:{code,message}}`, guarding nil/empty/`null`/malformed JSON (returns `""`).
- `projectCairnlineSidecarToolErrorIsNotFound` now takes the full result and prefers the structured code.
- Legacy substring match kept as `projectCairnlineSidecarToolErrorTextIsNotFound`, clearly commented as a transitional fallback.
- All 4 call sites converted (`projects.get`, `assignments.launch_packet`, `assignments.context`, `assistant.proposals.get`).
- Added table-driven regression tests for the extractor and the classifier (structured `not_found` → 404, other codes → 502, empty-structured + prose "not found" fallback → 404, empty + unrelated prose → 502).

## Notes

- **Standalone — does NOT bump the cairnline module pin.** It reads the structured `structuredContent.error.code` contract added in hecatehq/cairnline#79 via a **local wire constant** (`cairnlineToolErrorCodeNotFound = "not_found"`), deliberately avoiding a pin bump: bumping cairnline past `alpha.5` pulls in the unrelated `Assignment.ExecutionRef` string→struct refactor (cairnline#76) whose Hecate-side adaptation is owned by the in-flight #832. **Follow-up:** once #79 is tagged and #832's ExecutionRef adaptation lands, bump the pin and swap the local constant for `cairnline.ErrorCodeNotFound`.
- **Localized** to the error-classification helpers + 4 call sites; touches no bridge mapping functions, so it rebases cleanly over #832.
- **Caveat:** cairnline `assistant.apply` signals partial-failure via its result body status fields, not `structuredContent.error.code`. Hecate's sidecar reads don't use `apply`, so there is no impact here.

## Verification

- `go build ./...` — clean
- `go vet ./internal/api/... ./internal/orchestrator/...` — clean
- `go test ./internal/api/...` — ok
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./internal/api/... ./internal/orchestrator/...` — ok


---
_Generated by [Claude Code](https://claude.ai/code/session_01WcR7hFVrLnwsdbrNXFNknd)_