### PR TITLE
chore(deps): bump cairnline and wire exported error codes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/cairnline v0.1.0-alpha.5.0.20260709011843-08cabfe23570
+	github.com/hecatehq/cairnline v0.1.0-alpha.6
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/cairnline v0.1.0-alpha.5.0.20260709011843-08cabfe23570 h1:IZwJ8JgsNBTuHZLNDAGuQCPGHiI9LMYmbzBwEUN4Lsw=
-github.com/hecatehq/cairnline v0.1.0-alpha.5.0.20260709011843-08cabfe23570/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.1.0-alpha.6 h1:Nm/DN0rWxIkpSmv5i9fGOBvud9+LlopJQM+ZMPn1LlM=
+github.com/hecatehq/cairnline v0.1.0-alpha.6/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/handler_project_cairnline_sidecar_reads.go
+++ b/internal/api/handler_project_cairnline_sidecar_reads.go
@@ -585,13 +585,6 @@ func projectCairnlineSidecarStructuredSkills(raw json.RawMessage) ([]ProjectCair
 	return skills, true, nil
 }
 
-// cairnlineToolErrorCodeNotFound mirrors the machine-readable error code
-// Cairnline emits in structuredContent on a failed tool call. Kept as a local
-// wire constant so this classification change stays decoupled from the cairnline
-// module pin; once the error-code contract is tagged and the ExecutionRef bump
-// lands, this can be swapped for the exported cairnline.ErrorCodeNotFound.
-const cairnlineToolErrorCodeNotFound = "not_found"
-
 // projectCairnlineSidecarToolErrorCode returns the machine-readable error code
 // Cairnline emits in structuredContent on a failed tool call, or "" when the
 // sidecar did not provide one (pre-contract builds). The code is one of the
@@ -624,7 +617,7 @@ func projectCairnlineSidecarToolErrorCode(result *orchestrator.CachedMCPToolCall
 // not-found still maps to 404 during rollout.
 func projectCairnlineSidecarToolErrorIsNotFound(result *orchestrator.CachedMCPToolCallResult) bool {
 	if code := projectCairnlineSidecarToolErrorCode(result); code != "" {
-		return code == cairnlineToolErrorCodeNotFound
+		return code == cairnline.ErrorCodeNotFound
 	}
 	if result == nil {
 		return false


### PR DESCRIPTION
## Summary

Completes the follow-up flagged in #834: bump the cairnline module and swap the transitional local wire constant for the now-exported error-code constant.

### Pin choice

Bumped `github.com/hecatehq/cairnline` to the tag **`v0.1.0-alpha.6`** (not a pseudo-version). The tag exists and resolves to cairnline commit `dde0c49` (PR #79's squash-merge), which carries the structured error-code contract and the B1 protocol surface, so no re-pin is needed later.

- Before: `v0.1.0-alpha.5.0.20260709011843-08cabfe23570` (pseudo-version)
- After: `v0.1.0-alpha.6`

### Constant swap

`internal/api/handler_project_cairnline_sidecar_reads.go` previously defined a local wire constant to stay decoupled from the module pin while #834 shipped standalone:

```go
const cairnlineToolErrorCodeNotFound = "not_found"
```

That constant is removed and its single use in `projectCairnlineSidecarToolErrorIsNotFound` now compares against the exported `cairnline.ErrorCodeNotFound` from the bumped module, so the not-found classification tracks cairnline's canonical constant instead of a duplicated string literal.

- Before: `return code == cairnlineToolErrorCodeNotFound`
- After: `return code == cairnline.ErrorCodeNotFound`

The `cairnline` package was already imported in this file, so no import churn. HTTP mappings are unchanged (`not_found` → 404; other codes / read failures → 502), and the transitional prose fallback is untouched.

## Verification

- `go build ./...` — clean
- `go test ./internal/cairnlinebridge/... ./internal/api/... ./internal/projectskills/...` — ok
- `go vet ./internal/api/... ./internal/cairnlinebridge/...` — clean
- `GOCACHE="$(pwd)/.gocache" go test -race -timeout 10m ./...` — green except the 3 pre-existing container-noise failures in `internal/sandbox` (x2) and `internal/workspace` (x1) caused by `nvm` stdout pollution, unrelated to this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WvKeANpeoRWga5Wy5fSFcJ)_