### PR TITLE
feat(cairnline): one-way migration cutover for Hecate → Cairnline coordination

### DIFF
--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -84,8 +84,8 @@ only when backend status reports `replacement_ready=true` and
   Cairnline assignment coordination records, while execution itself remains
   Hecate-owned.
 - Hecate can migrate, import/export, and verify existing local project state
-  through embedded sync, mirror parity, strict embedded read smoke, and rollback
-  evidence.
+  through embedded sync, mirror parity, strict embedded read smoke, the
+  authoritative one-way migration cutover, and rollback evidence.
 - Workspace root, worktree, evidence-link, and source-locator boundaries keep a
   documented security boundary in the Cairnline API. The current Cairnline
   package documents that boundary and tests unsafe guidance-path rejection for
@@ -571,6 +571,34 @@ launch agents. Those remain explicit operator or orchestrator actions.
   configured-route smoke tests after sync and live-mirror parity to prove normal
   project, setup, health, skill, memory, role, work, collaboration, assistant
   context, activity, and operations reads can run from the embedded database.
+- The authoritative one-way migration cutover is now implemented as
+  `POST /hecate/v1/projects/cairnline/migrate` with a
+  `POST /hecate/v1/projects/cairnline/migrate/rollback` companion. The migrate
+  path is a staged **rebuild -> verify -> backup -> atomic swap**: it rebuilds
+  the migration target in a `projects.db.migrating` staging file, verifies it
+  (a parity report over every family plus a strict embedded read smoke that
+  reads from the staged database), backs up any existing live `projects.db` to
+  `projects.db.pre-migration.bak`, then atomically swaps the verified staging
+  database into the live path. The live embedded database is never mutated until
+  the staged rebuild passes full verification; on verification failure the
+  endpoint still returns 200 with the parity diffs so the operator can diagnose
+  the mismatch. The migration is **deletion-faithful by reconstruction**: the
+  target is rebuilt purely from the current native snapshot, so any natively
+  deleted (absent) row is never written. Reconstruction rather than incremental
+  per-record delete is the chosen strategy precisely because five write families
+  (skills, generic artifacts, evidence, reviews, and assistant proposals) are
+  recorded as immutable and expose no delete API, so there is no per-record
+  delete path to drive; rebuilding from the snapshot makes absence in the source
+  become absence in the target for every family. The cutover is idempotent —
+  re-running backs up the current live database and swaps a freshly rebuilt
+  staging database, converging to the same verified state. A durable
+  `migration.json` record next to the embedded database is written as evidence
+  that a verified authoritative migration was executed; backend status reads it
+  into the `migration_cutover` field, the `migration-cutover` write-adapter gap
+  clears once a verified migration is executed, and the `migration-and-rollback`
+  replacement gate surfaces the executed, verified migration together with its
+  rollback backup path. Rollback restores the pre-migration backup over the live
+  database and deletes the record.
 - Hecate should keep the embedded portable core as its first Projects backend
   replacement target. Talking to the MCP server as a separate local coordination
   process remains the later standalone/interoperability boundary.

--- a/docs/design/proposals/cairnline-portable-project-coordination.md
+++ b/docs/design/proposals/cairnline-portable-project-coordination.md
@@ -577,28 +577,40 @@ launch agents. Those remain explicit operator or orchestrator actions.
   path is a staged **rebuild -> verify -> backup -> atomic swap**: it rebuilds
   the migration target in a `projects.db.migrating` staging file, verifies it
   (a parity report over every family plus a strict embedded read smoke that
-  reads from the staged database), backs up any existing live `projects.db` to
-  `projects.db.pre-migration.bak`, then atomically swaps the verified staging
-  database into the live path. The live embedded database is never mutated until
-  the staged rebuild passes full verification; on verification failure the
-  endpoint still returns 200 with the parity diffs so the operator can diagnose
-  the mismatch. The migration is **deletion-faithful by reconstruction**: the
-  target is rebuilt purely from the current native snapshot, so any natively
-  deleted (absent) row is never written. Reconstruction rather than incremental
-  per-record delete is the chosen strategy precisely because five write families
-  (skills, generic artifacts, evidence, reviews, and assistant proposals) are
-  recorded as immutable and expose no delete API, so there is no per-record
-  delete path to drive; rebuilding from the snapshot makes absence in the source
-  become absence in the target for every family. The cutover is idempotent —
-  re-running backs up the current live database and swaps a freshly rebuilt
-  staging database, converging to the same verified state. A durable
-  `migration.json` record next to the embedded database is written as evidence
-  that a verified authoritative migration was executed; backend status reads it
-  into the `migration_cutover` field, the `migration-cutover` write-adapter gap
-  clears once a verified migration is executed, and the `migration-and-rollback`
-  replacement gate surfaces the executed, verified migration together with its
-  rollback backup path. Rollback restores the pre-migration backup over the live
-  database and deletes the record.
+  reads from the staged database), **copies** any existing live `projects.db` to
+  a timestamped backup generation `projects.db.pre-migration-<utc-timestamp>.bak`
+  (leaving the live file in place), then replaces the live path with the verified
+  staging database via a **single atomic rename**. The swap copies the backup
+  rather than moving the live file so the live path is never absent at any
+  instant: a crash between steps can only leave the live path holding the
+  original bytes or the migrated bytes, never nothing. The live embedded database
+  is never mutated until the staged rebuild passes full verification; on
+  verification failure the endpoint still returns 200 with the parity diffs so
+  the operator can diagnose the mismatch. Parity is verified across all twelve
+  portable write families by count, record-ID set, and content digest; the
+  content-digest comparison excludes timestamp fields and compares only the
+  record-ID intersection, with additions and deletions covered by the
+  record-ID-set layer (the report's `verification_notes` array records this). The
+  migration is **deletion-faithful by reconstruction**: the target is rebuilt
+  purely from the current native snapshot, so any natively deleted (absent) row
+  is never written. Reconstruction rather than incremental per-record delete is
+  the chosen strategy precisely because five of the fourteen Cairnline record
+  types (skills, generic artifacts, evidence, reviews, and assistant proposals —
+  the fourteen come from project collaboration splitting into artifacts,
+  evidence, and reviews) are recorded as immutable and expose no delete API, so
+  there is no per-record delete path to drive; rebuilding from the snapshot makes
+  absence in the source become absence in the target for every family. The
+  cutover is idempotent — re-running copies the current live database to a new
+  timestamped backup generation and swaps a freshly rebuilt staging database,
+  converging to the same verified state without clobbering earlier backup
+  generations. A durable `migration.json` record next to the embedded database is
+  written as evidence that a verified authoritative migration was executed;
+  backend status reads it into the `migration_cutover` field, the
+  `migration-cutover` write-adapter gap clears once a verified migration is
+  executed, and the `migration-and-rollback` replacement gate surfaces the
+  executed, verified migration together with its rollback backup path. Rollback
+  restores the latest recorded backup generation over the live database (copying
+  it so older generations survive for manual recovery) and deletes the record.
 - Hecate should keep the embedded portable core as its first Projects backend
   replacement target. Talking to the MCP server as a separate local coordination
   process remains the later standalone/interoperability boundary.

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -209,18 +209,62 @@ Five environment gates control the path, from off to fully armed:
   "portable writes are Cairnline-first" apart from "every replacement proof is
   complete."
 
-Two declared boundaries remain even with replacement mode armed: **assignment
-start dispatch** stays Hecate-owned (Hecate can claim and progress a Cairnline
+One declared boundary remains even with replacement mode armed: **assignment
+start dispatch** stays Hecate-owned. Hecate can claim and progress a Cairnline
 assignment record and mirror runtime refs, but it does not launch tasks or
-External Agents from Cairnline), and there is **no one-way migration cutover**.
-`POST /hecate/v1/projects/cairnline/sync` runs a full-refresh
-delete-and-reseed rehearsal into the embedded mirror, and snapshot import is
-additive-only, so the mirror can drift after that full-refresh rehearsal; that
-staleness risk applies to the sync rehearsal path, not to the live authoritative
-write switchpoints, which delete through Cairnline directly. For local dogfood,
+External Agents from Cairnline. `POST /hecate/v1/projects/cairnline/sync`
+remains a full-refresh delete-and-reseed *rehearsal* into the embedded mirror; it
+never becomes authoritative, so treat its output as replacement evidence rather
+than a source of truth. For local dogfood,
 `just dev-cairnline-projects --reset` starts a clean runtime with the embedded
 dogfood posture applied and `just test-projects-dogfood` runs the focused API
 check.
+
+### Migration cutover
+
+The authoritative one-way migration from Hecate-native project stores into the
+embedded Cairnline database has shipped. It is distinct from the `sync`
+rehearsal above: `sync` refreshes the live mirror in place, while migrate stages
+a rebuild, verifies it, backs up the live database, and only then swaps it into
+place.
+
+- `POST /hecate/v1/projects/cairnline/migrate` executes the cutover as a staged
+  **rebuild -> verify -> backup -> atomic swap**. It rebuilds the migration
+  target in a `projects.db.migrating` staging file, verifies it against the
+  current native snapshot (full parity over every family plus a strict embedded
+  read smoke), backs up any existing live `projects.db` to
+  `projects.db.pre-migration.bak`, then atomically swaps the verified staging
+  database into place and writes a durable `migration.json` record next to the
+  embedded database. The endpoint always returns 200: on verification failure the
+  live database is left untouched, the staging files are removed, and the parity
+  diffs are returned in the report so you can diagnose the mismatch.
+- The migration is **deletion-faithful by reconstruction**. The target is rebuilt
+  purely from the current native snapshot, so any row that was deleted natively
+  (and is therefore absent from the snapshot) is never written into the rebuilt
+  database. Deletions propagate for all twelve portable write families, including
+  the immutable ones (skills, artifacts, evidence, reviews, assistant proposals)
+  that have no delete API. Hecate keeps no tombstones — absence in the source is
+  absence in the target — and the migration is idempotent, so re-running
+  converges to the same verified state.
+- `GET /hecate/v1/projects/backend-status` reports the result under
+  `migration_cutover` (`status` is `not_migrated`, `migrated_verified`, or
+  `migrated_unverified`, alongside the migrate/rollback endpoints, the
+  `migrated`/`verified`/`parity_match` flags, `migrated_at`,
+  `rollback_backup_path`, and `source_authority`). Once a verified migration is
+  executed, the `migration-cutover` write-adapter gap clears and the
+  `migration-and-rollback` replacement gate surfaces the executed, verified
+  migration and its rollback backup path.
+
+To roll back or disarm the cutover, the native stores stay the untouched source
+of truth until you flip authority away from them:
+
+- Unset `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE` (and/or
+  `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY`) to return reads and writes to the
+  native stores with no data loss, and/or
+- `POST /hecate/v1/projects/cairnline/migrate/rollback` to restore the
+  `projects.db.pre-migration.bak` backup over the live embedded database and
+  delete the migration record. It is a no-op (`restored: false`,
+  `reason: "no_backup"`) when no backup exists.
 
 ## What Projects V1 Does Not Do
 

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -232,18 +232,33 @@ place.
   **rebuild -> verify -> backup -> atomic swap**. It rebuilds the migration
   target in a `projects.db.migrating` staging file, verifies it against the
   current native snapshot (full parity over every family plus a strict embedded
-  read smoke), backs up any existing live `projects.db` to
-  `projects.db.pre-migration.bak`, then atomically swaps the verified staging
-  database into place and writes a durable `migration.json` record next to the
-  embedded database. The endpoint always returns 200: on verification failure the
+  read smoke), **copies** any existing live `projects.db` to a timestamped backup
+  generation `projects.db.pre-migration-<utc-timestamp>.bak` (leaving the live
+  file in place), then replaces the live database with the verified staging file
+  via a **single atomic rename** and writes a durable `migration.json` record
+  next to the embedded database. The swap copies the backup rather than moving
+  the live file so the live path is never absent at any instant: a crash can only
+  leave the live path holding either the original bytes or the migrated bytes,
+  never nothing. The endpoint always returns 200: on verification failure the
   live database is left untouched, the staging files are removed, and the parity
   diffs are returned in the report so you can diagnose the mismatch.
+- Parity is verified across all twelve portable write families by count,
+  record-ID set, and content digest. The content-digest comparison deliberately
+  excludes timestamp fields and compares only the record-ID intersection;
+  additions and deletions are covered by the record-ID-set layer, so stripping
+  timestamps does not weaken the check.
+- Each migration writes a distinct timestamped backup generation, so re-running
+  never clobbers an earlier original. Older generations are left on disk for
+  manual recovery; `rollback` restores the latest generation recorded in
+  `migration.json`.
 - The migration is **deletion-faithful by reconstruction**. The target is rebuilt
   purely from the current native snapshot, so any row that was deleted natively
   (and is therefore absent from the snapshot) is never written into the rebuilt
   database. Deletions propagate for all twelve portable write families, including
-  the immutable ones (skills, artifacts, evidence, reviews, assistant proposals)
-  that have no delete API. Hecate keeps no tombstones — absence in the source is
+  the immutable record types: five of the fourteen Cairnline record types
+  (skills, artifacts, evidence, reviews, assistant proposals) have no delete API,
+  so reconstruction — not per-record deletes — is what makes them
+  deletion-faithful. Hecate keeps no tombstones — absence in the source is
   absence in the target — and the migration is idempotent, so re-running
   converges to the same verified state.
 - `GET /hecate/v1/projects/backend-status` reports the result under
@@ -261,10 +276,13 @@ of truth until you flip authority away from them:
 - Unset `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE` (and/or
   `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY`) to return reads and writes to the
   native stores with no data loss, and/or
-- `POST /hecate/v1/projects/cairnline/migrate/rollback` to restore the
-  `projects.db.pre-migration.bak` backup over the live embedded database and
-  delete the migration record. It is a no-op (`restored: false`,
-  `reason: "no_backup"`) when no backup exists.
+- `POST /hecate/v1/projects/cairnline/migrate/rollback` to restore the latest
+  `projects.db.pre-migration-<utc-timestamp>.bak` generation recorded in
+  `migration.json` over the live embedded database and delete the migration
+  record. The backup generation is copied (not moved) so it is preserved for
+  further manual recovery. It is a no-op (`restored: false`, `reason:
+"no_backup"`) when the record has no backup path or the recorded backup is
+  missing.
 
 ## What Projects V1 Does Not Do
 

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -213,7 +213,7 @@ One declared boundary remains even with replacement mode armed: **assignment
 start dispatch** stays Hecate-owned. Hecate can claim and progress a Cairnline
 assignment record and mirror runtime refs, but it does not launch tasks or
 External Agents from Cairnline. `POST /hecate/v1/projects/cairnline/sync`
-remains a full-refresh delete-and-reseed *rehearsal* into the embedded mirror; it
+remains a full-refresh delete-and-reseed _rehearsal_ into the embedded mirror; it
 never becomes authoritative, so treat its output as replacement evidence rather
 than a source of truth. For local dogfood,
 `just dev-cairnline-projects --reset` starts a clean runtime with the embedded

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -2574,7 +2574,14 @@ runtime/workspace behavior such as root discovery or worktree creation,
 assignment dispatch, and Project Assistant chat/runtime effects. Those
 capabilities are intentionally outside Cairnline core and do not block
 Cairnline owning portable project coordination state. `migration_blockers`
-lists remaining cutover/rollback work. The groups are explanatory and not
+lists remaining cutover/rollback work. `migration_cutover` reports the
+authoritative one-way migration state read from the durable `migration.json`
+record next to the embedded database: `status` (`not_migrated`,
+`migrated_verified`, or `migrated_unverified`), the `endpoint` and
+`rollback_endpoint` (the migrate and rollback routes), the
+`migrated`/`verified`/`parity_match` flags, and, once a migration has run,
+`migrated_at`, `rollback_backup_path`, and `source_authority`. Once a verified
+migration is executed the `migration-cutover` write-adapter gap clears. The groups are explanatory and not
 guaranteed to be exclusive: for example, `roots` can appear in
 `portable_write_gaps` until root metadata writes are Cairnline-authoritative and
 can remain in `orchestrator_capabilities` while Hecate still owns discovery
@@ -2658,8 +2665,12 @@ successfully since its last failure, and `drifting` (not ready) while any
 family has outstanding failures — so `replacement_ready` cannot report `true`
 while shadow-mirror failure evidence is outstanding. The `migration-and-rollback` gate reports
 `waiting_for_read_smoke` until strict embedded read-smoke evidence is verified.
-In pre-cutover rehearsal it then reports `cutover_switch_missing` until Hecate
-has an explicit authoritative Cairnline storage cutover and rollback switch. In
+The authoritative Cairnline storage cutover and rollback switch now exists as
+`POST /hecate/v1/projects/cairnline/migrate` and
+`POST /hecate/v1/projects/cairnline/migrate/rollback`; when a verified migration
+has been executed the gate detail is enriched with that executed-migration
+evidence and its rollback backup path, and the separate `migration_cutover`
+status field reports `migrated_verified`. In
 armed replacement mode, successful live embedded smoke plus rollback evidence
 makes the gate `ready`: `migration_blockers` is empty, the
 `migration-and-rollback` gate is `ready`, and `authoritative_backend` reports
@@ -2714,9 +2725,12 @@ include `HECATE_PROJECTS_CAIRNLINE_READ_SOURCE=embedded` so the suggested
 configuration matches the embedded probe set.
 `write_switchpoints` maps each live mutation family to the current authority,
 the Cairnline state (`live_mirror_non_authoritative`, `result_mirror_only`,
-`snapshot_import_rehearsal_available`, `authoritative_opt_in` for enabled
+`authoritative_migration_available`, `authoritative_opt_in` for enabled
 alpha write-authority switchpoints, or `partial_authoritative_opt_in` when only
-some routes in a family have moved). When strict embedded smoke and replacement
+some routes in a family have moved). The `migration-cutover` switchpoint
+baseline is `authoritative_migration_available` because an authoritative
+migration endpoint exists; it advances to `migrated_verified` once a verified
+migration has been executed. When strict embedded smoke and replacement
 evidence are verified and `replacement_mode=embedded`, the
 `migration-cutover` switchpoint reports
 `embedded_cutover_armed` and no longer blocks authority. Each switchpoint also
@@ -3127,14 +3141,22 @@ Example response, with `write_switchpoints` shortened for readability:
       {
         "name": "migration-cutover",
         "current_authority": "hecate",
-        "cairnline_state": "snapshot_import_rehearsal_available",
+        "cairnline_state": "authoritative_migration_available",
         "live_mirror": false,
         "blocks_authority": true,
         "seams": ["sync-rehearsal"],
         "gap": "migration-cutover",
-        "detail": "Snapshot import/export rehearsal and rollback notes exist, but no authoritative Cairnline storage cutover switch exists yet."
+        "detail": "An authoritative one-way migration cutover is available at POST /hecate/v1/projects/cairnline/migrate (with rollback at POST /hecate/v1/projects/cairnline/migrate/rollback); no verified migration has been executed yet."
       }
     ],
+    "migration_cutover": {
+      "status": "not_migrated",
+      "endpoint": "/hecate/v1/projects/cairnline/migrate",
+      "rollback_endpoint": "/hecate/v1/projects/cairnline/migrate/rollback",
+      "migrated": false,
+      "verified": false,
+      "parity_match": false
+    },
     "status": "cairnline_read_routes_ready",
     "detail": "Cairnline is configured as the future Projects coordination backend, and the project-list, project-detail, setup-readiness, health, skills, memory, memory-candidate, roles, work-item, assignment-list, assignment-context, launch-readiness, assignment-preflight, artifact-list, handoff-list, project-assistant-context, project-assistant-proposal, project-chat-prelude, project-chat-context, activity, closeout-readiness, and operations brief read routes are served from the Cairnline read model. Configured read routes prefer the embedded mirror database when it already contains the requested project or proposal record; otherwise they fall back to the snapshot-seeded in-memory bridge projection. Hecate stores remain authoritative until the remaining portable writes and migration are ready.",
     "warnings": [
@@ -5017,6 +5039,94 @@ Example response:
   }
 }
 ```
+
+### `POST /hecate/v1/projects/cairnline/migrate`
+
+Local-only endpoint. This is the authoritative one-way migration cutover from
+Hecate's native Projects stores into the embedded Cairnline database. Unlike
+`sync`, which refreshes the live mirror in place, migrate is a staged **rebuild
+-> verify -> backup -> atomic swap** that never mutates the live embedded
+database until a staged rebuild passes full verification.
+
+It rebuilds the migration target from scratch in a `projects.db.migrating`
+staging file, verifies it against the current native snapshot (a parity report
+over every family plus a strict embedded read smoke run against the staged
+database), backs up any existing live `projects.db` to
+`projects.db.pre-migration.bak`, then atomically swaps the verified staging
+database into the live path and writes a durable `migration.json` record next to
+the embedded database. The rebuild-from-snapshot design is deletion-faithful:
+any row deleted natively is absent from the snapshot and is therefore never
+written, so deletions propagate for every family including the immutable ones
+(skills, artifacts, evidence, reviews, assistant proposals) that expose no
+delete API. The migration is idempotent.
+
+The endpoint always returns 200 so the parity diff payload reaches the operator.
+`verified` is `true` only when the parity report matches and the strict read
+smoke passes; on `verified: false` the live database is left untouched, the
+staging files are removed, and `parity` carries the diffs (the backup, swap, and
+record checklist steps are `skipped`).
+
+Example response:
+
+```json
+{
+  "object": "project_cairnline_migration",
+  "data": {
+    "object": "project_cairnline_migration_report",
+    "migrated_at": "2026-07-09T13:18:18Z",
+    "verified": true,
+    "parity_match": true,
+    "target": "/Users/alice/.hecate/cairnline/embedded/projects.db",
+    "source_authority": ["sqlite"],
+    "rollback_backup_path": "/Users/alice/.hecate/cairnline/embedded/projects.db.pre-migration.bak",
+    "project_count": 2,
+    "checklist": [
+      { "id": "load-hecate-stores", "status": "complete", "detail": "..." },
+      { "id": "staged-rebuild", "status": "complete", "detail": "..." },
+      { "id": "parity-verify", "status": "complete", "detail": "..." },
+      { "id": "backup-live-store", "status": "complete", "detail": "..." },
+      { "id": "atomic-swap", "status": "complete", "detail": "..." },
+      { "id": "migration-record-written", "status": "complete", "detail": "..." }
+    ],
+    "rollback": [
+      "Native Hecate stores remain the untouched source of truth; migration only writes the embedded Cairnline database.",
+      "To discard the migrated embedded store, POST /hecate/v1/projects/cairnline/migrate/rollback (restores the pre-migration backup).",
+      "To return authority to Hecate, unset HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE (and/or HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY); reads and writes fall back to the native stores with no data loss."
+    ],
+    "parity": { "...": "same shape as the sync response item" }
+  }
+}
+```
+
+`source_authority` reports the native storage tier backing the sources
+(`memory`, `sqlite`, or `postgres`). `rollback_backup_path` is `""` when no
+prior live database existed. When `verified` is `false`, `parity` carries the
+`differences`, `id_differences`, and `content_differences` that explain the
+mismatch.
+
+### `POST /hecate/v1/projects/cairnline/migrate/rollback`
+
+Local-only endpoint. It restores the `projects.db.pre-migration.bak` backup over
+the live embedded database and deletes the `migration.json` record, returning the
+operator to the pre-migration embedded state. It is a no-op when no backup
+exists.
+
+Example response:
+
+```json
+{
+  "object": "project_cairnline_migration_rollback",
+  "data": {
+    "restored": true,
+    "reason": "",
+    "restored_from": "/Users/alice/.hecate/cairnline/embedded/projects.db.pre-migration.bak",
+    "target": "/Users/alice/.hecate/cairnline/embedded/projects.db"
+  }
+}
+```
+
+When no backup is present the endpoint still returns 200 with `restored: false`,
+`reason: "no_backup"`, and the live database untouched.
 
 ### `POST /hecate/v1/projects/{id}/cairnline/export`
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -5051,14 +5051,27 @@ database until a staged rebuild passes full verification.
 It rebuilds the migration target from scratch in a `projects.db.migrating`
 staging file, verifies it against the current native snapshot (a parity report
 over every family plus a strict embedded read smoke run against the staged
-database), backs up any existing live `projects.db` to
-`projects.db.pre-migration.bak`, then atomically swaps the verified staging
-database into the live path and writes a durable `migration.json` record next to
-the embedded database. The rebuild-from-snapshot design is deletion-faithful:
-any row deleted natively is absent from the snapshot and is therefore never
-written, so deletions propagate for every family including the immutable ones
-(skills, artifacts, evidence, reviews, assistant proposals) that expose no
-delete API. The migration is idempotent.
+database), **copies** any existing live `projects.db` to a timestamped backup
+generation `projects.db.pre-migration-<utc-timestamp>.bak` (leaving the live file
+in place), then replaces the live path with the verified staging database via a
+**single atomic rename** and writes a durable `migration.json` record next to the
+embedded database. The swap copies the backup rather than moving the live file so
+the live path is never absent: a crash between steps can only leave the live path
+holding the original bytes or the migrated bytes, never nothing. The
+rebuild-from-snapshot design is deletion-faithful: any row deleted natively is
+absent from the snapshot and is therefore never written, so deletions propagate
+for every family including the immutable ones (skills, artifacts, evidence,
+reviews, assistant proposals) that expose no delete API. The migration is
+idempotent, and each run writes a distinct timestamped backup generation so
+re-running never clobbers an earlier original.
+
+Parity is verified across all twelve portable write families by count, record-ID
+set, and content digest. The content-digest comparison excludes timestamp fields
+and compares only the record-ID intersection; additions and deletions are covered
+by the record-ID-set layer, and the `verification_notes` array in the report
+records this. The digest layer covers fourteen Cairnline record types (project
+collaboration splits into artifacts, evidence, and reviews) plus a derived
+`launch_packets` view.
 
 The endpoint always returns 200 so the parity diff payload reaches the operator.
 `verified` is `true` only when the parity report matches and the strict read
@@ -5078,7 +5091,7 @@ Example response:
     "parity_match": true,
     "target": "/Users/alice/.hecate/cairnline/embedded/projects.db",
     "source_authority": ["sqlite"],
-    "rollback_backup_path": "/Users/alice/.hecate/cairnline/embedded/projects.db.pre-migration.bak",
+    "rollback_backup_path": "/Users/alice/.hecate/cairnline/embedded/projects.db.pre-migration-20260709T131818.123456789Z.bak",
     "project_count": 2,
     "checklist": [
       { "id": "load-hecate-stores", "status": "complete", "detail": "..." },
@@ -5093,6 +5106,10 @@ Example response:
       "To discard the migrated embedded store, POST /hecate/v1/projects/cairnline/migrate/rollback (restores the pre-migration backup).",
       "To return authority to Hecate, unset HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE (and/or HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY); reads and writes fall back to the native stores with no data loss."
     ],
+    "verification_notes": [
+      "Parity verified across all 12 portable write families by count, record-ID set, and content digest.",
+      "Content-digest comparison excludes timestamp fields (created_at, updated_at, discovered_at, applied_at) and compares the record-ID intersection; additions and deletions are covered by the record-ID-set layer."
+    ],
     "parity": { "...": "same shape as the sync response item" }
   }
 }
@@ -5106,10 +5123,13 @@ mismatch.
 
 ### `POST /hecate/v1/projects/cairnline/migrate/rollback`
 
-Local-only endpoint. It restores the `projects.db.pre-migration.bak` backup over
-the live embedded database and deletes the `migration.json` record, returning the
-operator to the pre-migration embedded state. It is a no-op when no backup
-exists.
+Local-only endpoint. It restores the latest timestamped
+`projects.db.pre-migration-<utc-timestamp>.bak` generation recorded in
+`migration.json` over the live embedded database and deletes the record,
+returning the operator to the pre-migration embedded state. The backup is copied
+(not moved) so the generation survives for further manual recovery, and older
+generations are left on disk. It is a no-op when the record has no backup path or
+the recorded backup is missing.
 
 Example response:
 
@@ -5119,7 +5139,7 @@ Example response:
   "data": {
     "restored": true,
     "reason": "",
-    "restored_from": "/Users/alice/.hecate/cairnline/embedded/projects.db.pre-migration.bak",
+    "restored_from": "/Users/alice/.hecate/cairnline/embedded/projects.db.pre-migration-20260709T131818.123456789Z.bak",
     "target": "/Users/alice/.hecate/cairnline/embedded/projects.db"
   }
 }

--- a/e2e/cairnline_migration_test.go
+++ b/e2e/cairnline_migration_test.go
@@ -1,0 +1,222 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestE2E_CairnlineMigrationCutover drives the full one-way migration cutover
+// against the real hecate binary: seed native project/work/memory state through
+// the public API, migrate into the embedded Cairnline database, verify parity +
+// the backend-status cutover gate, prove idempotency and deletion-faithfulness,
+// then roll the migration back and confirm the cutover record is cleared.
+func TestE2E_CairnlineMigrationCutover(t *testing.T) {
+	// Coordination backend must be cairnline so backend-status populates the
+	// migration_cutover gate; the embedded connector routes the migration into a
+	// local projects.db. Read source is left at the default (auto) and write
+	// authority at the default (none) so seeding writes land in the native
+	// Hecate stores that the migration reconstructs from.
+	baseURL := gatewayServer(t,
+		"HECATE_BACKEND=sqlite",
+		"HECATE_PROJECTS_COORDINATION_BACKEND=cairnline",
+		"HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded",
+	)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	// 1. Seed native state across several families so parity is meaningful.
+	project := postJSONDecodeStatus[e2eMigrationProjectResponse](t, baseURL+"/hecate/v1/projects", fmt.Sprintf(`{
+		"name": "cairnline migration e2e %s"
+	}`, suffix), http.StatusCreated)
+	projectID := project.Data.ID
+	if projectID == "" {
+		t.Fatal("created project id is empty")
+	}
+
+	postJSONDecodeStatus[e2eProjectWorkRoleResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/roles", `{
+		"id": "role_migrate",
+		"name": "Migration reviewer"
+	}`, http.StatusCreated)
+	postJSONDecodeStatus[e2eProjectWorkItemResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/work-items", `{
+		"id": "work_migrate",
+		"title": "Migrate projects to Cairnline",
+		"owner_role_id": "role_migrate"
+	}`, http.StatusCreated)
+	postJSONDecodeStatus[e2eProjectWorkAssignmentResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/work-items/work_migrate/assignments", `{
+		"id": "asgn_migrate",
+		"role_id": "role_migrate"
+	}`, http.StatusCreated)
+	memory := postJSONDecodeStatus[e2eProjectMemoryResponse](t, baseURL+"/hecate/v1/projects/"+projectID+"/memory", `{
+		"title": "Migration replacement gate",
+		"body": "Migration should preserve accepted project memory.",
+		"trust_label": "operator-memory",
+		"source_kind": "operator"
+	}`, http.StatusCreated)
+	memoryID := memory.Data.ID
+	if memoryID == "" {
+		t.Fatal("created memory entry id is empty")
+	}
+
+	// 2. Migrate: reconstruct the embedded DB from the native snapshot and swap.
+	migrate := postJSONDecode[e2eMigrationResponse](t, baseURL+"/hecate/v1/projects/cairnline/migrate", "")
+	if migrate.Object != "project_cairnline_migration" || migrate.Data.Object != "project_cairnline_migration_report" {
+		t.Fatalf("migrate envelope = %+v, want project_cairnline_migration report", migrate)
+	}
+	if !migrate.Data.Verified || !migrate.Data.ParityMatch {
+		t.Fatalf("migrate report = %+v, want verified parity match", migrate.Data)
+	}
+	if migrate.Data.ProjectCount < 1 {
+		t.Fatalf("migrate project count = %d, want >= 1", migrate.Data.ProjectCount)
+	}
+	if len(migrate.Data.Rollback) == 0 {
+		t.Fatalf("migrate rollback plan = %+v, want operator rollback steps", migrate.Data.Rollback)
+	}
+
+	// 3. Backend status must report the verified cutover and clear the gates.
+	assertMigratedVerifiedStatus(t, baseURL)
+
+	// 4. Idempotency: a second migration converges to the same verified state.
+	second := postJSONDecode[e2eMigrationResponse](t, baseURL+"/hecate/v1/projects/cairnline/migrate", "")
+	if !second.Data.Verified || !second.Data.ParityMatch {
+		t.Fatalf("second migrate = %+v, want still verified parity match", second.Data)
+	}
+	assertMigratedVerifiedStatus(t, baseURL)
+
+	// 5. Deletion-faithfulness: dropping a native record then re-migrating must
+	// still verify, proving the reconstructed embedded store drops the absent row.
+	deleteJSONExpectStatus(t, baseURL+"/hecate/v1/projects/"+projectID+"/memory/"+memoryID, http.StatusNoContent)
+	afterDelete := postJSONDecode[e2eMigrationResponse](t, baseURL+"/hecate/v1/projects/cairnline/migrate", "")
+	if !afterDelete.Data.Verified || !afterDelete.Data.ParityMatch {
+		t.Fatalf("post-delete migrate = %+v, want verified parity match against the new native snapshot", afterDelete.Data)
+	}
+
+	// 6. Rollback: a backup exists after the repeated migrations, so restore it
+	// and confirm the cutover record is cleared back to not_migrated.
+	rollback := postJSONDecode[e2eMigrationRollbackResponse](t, baseURL+"/hecate/v1/projects/cairnline/migrate/rollback", "")
+	if rollback.Object != "project_cairnline_migration_rollback" {
+		t.Fatalf("rollback envelope = %+v, want project_cairnline_migration_rollback", rollback)
+	}
+	if !rollback.Data.Restored || rollback.Data.RestoredFrom == "" {
+		t.Fatalf("rollback = %+v, want restored from a backup path", rollback.Data)
+	}
+
+	status := getJSON[e2eBackendStatusResponse](t, baseURL+"/hecate/v1/projects/backend-status")
+	if status.Data.MigrationCutover == nil || status.Data.MigrationCutover.Status != "not_migrated" {
+		t.Fatalf("post-rollback migration cutover = %+v, want not_migrated", status.Data.MigrationCutover)
+	}
+}
+
+func assertMigratedVerifiedStatus(t *testing.T, baseURL string) {
+	t.Helper()
+	status := getJSON[e2eBackendStatusResponse](t, baseURL+"/hecate/v1/projects/backend-status")
+	cutover := status.Data.MigrationCutover
+	if cutover == nil || cutover.Status != "migrated_verified" || !cutover.Migrated || !cutover.Verified || !cutover.ParityMatch {
+		t.Fatalf("migration cutover = %+v, want migrated_verified", cutover)
+	}
+	if containsE2EString(status.Data.WriteAdapterGaps, "migration-cutover") {
+		t.Fatalf("write adapter gaps = %+v, want migration-cutover cleared after verified migration", status.Data.WriteAdapterGaps)
+	}
+	if containsE2EString(status.Data.MigrationBlockers, "migration-cutover") {
+		t.Fatalf("migration blockers = %+v, want migration-cutover cleared after verified migration", status.Data.MigrationBlockers)
+	}
+	point := findE2EWriteSwitchpoint(status.Data.WriteSwitchpoints, "migration-cutover")
+	if point == nil || point.CairnlineState != "migrated_verified" {
+		t.Fatalf("migration switchpoint = %+v, want migrated_verified cairnline state", point)
+	}
+}
+
+func deleteJSONExpectStatus(t *testing.T, url string, status int) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("new DELETE request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != status {
+		t.Fatalf("DELETE %s: HTTP %d, want %d -- body: %s", url, resp.StatusCode, status, readBody(t, resp))
+	}
+}
+
+func containsE2EString(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func findE2EWriteSwitchpoint(points []e2eWriteSwitchpoint, name string) *e2eWriteSwitchpoint {
+	for i := range points {
+		if points[i].Name == name {
+			return &points[i]
+		}
+	}
+	return nil
+}
+
+type e2eMigrationProjectResponse struct {
+	Object string `json:"object"`
+	Data   struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+type e2eProjectMemoryResponse struct {
+	Object string `json:"object"`
+	Data   struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+type e2eMigrationResponse struct {
+	Object string `json:"object"`
+	Data   struct {
+		Object          string   `json:"object"`
+		Verified        bool     `json:"verified"`
+		ParityMatch     bool     `json:"parity_match"`
+		Target          string   `json:"target"`
+		SourceAuthority []string `json:"source_authority"`
+		ProjectCount    int      `json:"project_count"`
+		Rollback        []string `json:"rollback"`
+	} `json:"data"`
+}
+
+type e2eMigrationRollbackResponse struct {
+	Object string `json:"object"`
+	Data   struct {
+		Restored     bool   `json:"restored"`
+		Reason       string `json:"reason"`
+		RestoredFrom string `json:"restored_from"`
+		Target       string `json:"target"`
+	} `json:"data"`
+}
+
+type e2eWriteSwitchpoint struct {
+	Name           string `json:"name"`
+	CairnlineState string `json:"cairnline_state"`
+	LiveMirror     bool   `json:"live_mirror"`
+}
+
+type e2eBackendStatusResponse struct {
+	Object string `json:"object"`
+	Data   struct {
+		WriteAdapterGaps  []string              `json:"write_adapter_gaps"`
+		MigrationBlockers []string              `json:"migration_blockers"`
+		WriteSwitchpoints []e2eWriteSwitchpoint `json:"write_switchpoints"`
+		MigrationCutover  *struct {
+			Status      string `json:"status"`
+			Migrated    bool   `json:"migrated"`
+			Verified    bool   `json:"verified"`
+			ParityMatch bool   `json:"parity_match"`
+		} `json:"migration_cutover"`
+	} `json:"data"`
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -94,6 +94,11 @@ type Handler struct {
 	// this is runtime observability for the current process, not persisted
 	// coordination state.
 	cairnlineMirrorHealth cairnlineMirrorHealth
+	// cairnlineEmbeddedPathOverride redirects embedded Cairnline reads to a
+	// specific database file. Empty in production; the migration cutover sets it
+	// on a probe-handler clone so the strict read smoke can verify a staged
+	// database before it is swapped into the live embedded path.
+	cairnlineEmbeddedPathOverride string
 	// orchestratorMetrics is shared between the runner and the MCP
 	// client cache observer. Built once in NewHandler so a second
 	// NewOrchestratorMetrics() can't register duplicate instruments;

--- a/internal/api/handler_project_cairnline.go
+++ b/internal/api/handler_project_cairnline.go
@@ -920,39 +920,40 @@ func (h *Handler) projectCairnlineStrictEmbeddedProbeHandler() *Handler {
 		return nil
 	}
 	return &Handler{
-		config:                    h.config,
-		logger:                    h.logger,
-		service:                   h.service,
-		controlPlane:              h.controlPlane,
-		providerRuntime:           h.providerRuntime,
-		taskStore:                 h.taskStore,
-		taskRunner:                h.taskRunner,
-		tracer:                    h.tracer,
-		agentChat:                 h.agentChat,
-		projects:                  h.projects,
-		memory:                    h.memory,
-		memoryCandidates:          h.memoryCandidates,
-		projectWork:               h.projectWork,
-		projectSkills:             h.projectSkills,
-		projectAssistantProposals: h.projectAssistantProposals,
-		pluginRegistry:            h.pluginRegistry,
-		projectAssistant:          h.projectAssistant,
-		agentProfiles:             h.agentProfiles,
-		agentChatRunner:           h.agentChatRunner,
-		agentChatLive:             h.agentChatLive,
-		agentChatIdleSweepCancel:  h.agentChatIdleSweepCancel,
-		operatorTerminals:         h.operatorTerminals,
-		rateLimiter:               h.rateLimiter,
-		secretCipher:              h.secretCipher,
-		mcpClientCache:            h.mcpClientCache,
-		orchestratorMetrics:       h.orchestratorMetrics,
-		agentChatMetrics:          h.agentChatMetrics,
-		approvalConfig:            h.approvalConfig,
-		agentAdapterProbe:         h.agentAdapterProbe,
-		agentAdapterLogout:        h.agentAdapterLogout,
-		agentAdapterAuthenticate:  h.agentAdapterAuthenticate,
-		stateCleaner:              h.stateCleaner,
-		quitFunc:                  h.quitFunc,
+		config:                        h.config,
+		cairnlineEmbeddedPathOverride: h.cairnlineEmbeddedPathOverride,
+		logger:                        h.logger,
+		service:                       h.service,
+		controlPlane:                  h.controlPlane,
+		providerRuntime:               h.providerRuntime,
+		taskStore:                     h.taskStore,
+		taskRunner:                    h.taskRunner,
+		tracer:                        h.tracer,
+		agentChat:                     h.agentChat,
+		projects:                      h.projects,
+		memory:                        h.memory,
+		memoryCandidates:              h.memoryCandidates,
+		projectWork:                   h.projectWork,
+		projectSkills:                 h.projectSkills,
+		projectAssistantProposals:     h.projectAssistantProposals,
+		pluginRegistry:                h.pluginRegistry,
+		projectAssistant:              h.projectAssistant,
+		agentProfiles:                 h.agentProfiles,
+		agentChatRunner:               h.agentChatRunner,
+		agentChatLive:                 h.agentChatLive,
+		agentChatIdleSweepCancel:      h.agentChatIdleSweepCancel,
+		operatorTerminals:             h.operatorTerminals,
+		rateLimiter:                   h.rateLimiter,
+		secretCipher:                  h.secretCipher,
+		mcpClientCache:                h.mcpClientCache,
+		orchestratorMetrics:           h.orchestratorMetrics,
+		agentChatMetrics:              h.agentChatMetrics,
+		approvalConfig:                h.approvalConfig,
+		agentAdapterProbe:             h.agentAdapterProbe,
+		agentAdapterLogout:            h.agentAdapterLogout,
+		agentAdapterAuthenticate:      h.agentAdapterAuthenticate,
+		stateCleaner:                  h.stateCleaner,
+		quitFunc:                      h.quitFunc,
 	}
 }
 
@@ -2136,6 +2137,9 @@ func (h *Handler) cairnlineExportPath(projectID string) (string, error) {
 }
 
 func (h *Handler) cairnlineEmbeddedDatabasePath() string {
+	if override := strings.TrimSpace(h.cairnlineEmbeddedPathOverride); override != "" {
+		return override
+	}
 	dataDir := strings.TrimSpace(h.config.Server.DataDir)
 	if dataDir == "" {
 		dataDir = ".data"

--- a/internal/api/handler_project_cairnline_migrate.go
+++ b/internal/api/handler_project_cairnline_migrate.go
@@ -3,11 +3,14 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/cairnlinebridge"
@@ -37,40 +40,155 @@ func cairnlineMigrationStagingPath(dbPath string) string {
 	return dbPath + ".migrating"
 }
 
-func cairnlineMigrationBackupPath(dbPath string) string {
-	return dbPath + ".pre-migration.bak"
+// cairnlineMigrationBackupPath builds a timestamped, colon-free backup filename
+// so repeated migrations keep distinct backup generations instead of clobbering
+// the true pre-migration original. Colons are avoided so the name is safe on
+// Windows and macOS filesystems. migratedAt is the same timestamp recorded in
+// migration.json, so the backup name and the durable record always agree.
+func cairnlineMigrationBackupPath(dbPath string, migratedAt time.Time) string {
+	ts := migratedAt.UTC().Format("20060102T150405.000000000Z")
+	return dbPath + ".pre-migration-" + ts + ".bak"
 }
 
 func cairnlineMigrationRecordPath(dbPath string) string {
 	return filepath.Join(filepath.Dir(dbPath), "migration.json")
 }
 
-// renameCairnlineSQLiteFiles atomically moves an SQLite database triplet
-// (main + optional -wal/-shm sidecars) from src to dst within the same
-// directory. The main file rename is required when src exists so the swap
-// cannot silently drop the database; the -wal/-shm sidecars may legitimately
-// be absent after a clean close, so their missing rename is not an error.
-func renameCairnlineSQLiteFiles(src, dst string) error {
-	// Clear any stale destination triplet first so rename cannot collide with
-	// leftover files from a previous swap.
-	if err := removeCairnlineSQLiteFiles(dst); err != nil {
+// copyFileSync copies src to dst and fsyncs the written file so the copy is
+// durable before a caller relies on it (e.g. as a pre-migration backup a crash
+// must not lose).
+func copyFileSync(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(src); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
 		return err
 	}
-	if err := os.Rename(src, dst); err != nil {
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// copyCairnlineSQLiteFiles copies an SQLite database (main file plus any present
+// -wal/-shm sidecars) from src to dst, fsyncing each written file. The main file
+// must exist; sidecars are legitimately absent after a clean close, so a missing
+// sidecar is not an error but any stale destination sidecar is cleared so the
+// destination triplet matches the source.
+func copyCairnlineSQLiteFiles(src, dst string) error {
+	if err := copyFileSync(src, dst); err != nil {
 		return err
 	}
 	for _, suffix := range []string{"-wal", "-shm"} {
-		if err := os.Rename(src+suffix, dst+suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := copyFileSync(src+suffix, dst+suffix); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// Source has no such sidecar; drop any stale destination one so the
+				// backup/restore triplet is exactly what the source holds.
+				if rmErr := os.Remove(dst + suffix); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+					return rmErr
+				}
+				continue
+			}
 			return err
 		}
 	}
 	return nil
+}
+
+// fsyncDir flushes a directory's metadata so a freshly created or renamed entry
+// survives a crash. On Linux a rename/create is not durable until the containing
+// directory is fsynced; on platforms where this is a no-op the call is harmless.
+func fsyncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// swapCairnlineMigrationStore replaces the live embedded database at dbPath with
+// the freshly rebuilt staging database at stagingPath without ever leaving
+// dbPath absent. The previous swap did two renames (live->backup, then
+// staging->dbPath); a crash between them removed dbPath entirely, so the
+// embedded reader silently recreated a fresh empty store and the real data
+// survived only in the .bak. This copy-then-single-rename sequence closes that
+// window: dbPath always resolves to either the original bytes or the migrated
+// bytes, never nothing.
+//
+// backupPath is "" when there is no live database to back up. beforeRename is an
+// optional crash-injection hook (nil in production) that a test uses to simulate
+// a crash AFTER the backup copy but BEFORE the atomic rename.
+func swapCairnlineMigrationStore(dbPath, stagingPath, backupPath string, beforeRename func() error) error {
+	liveExists := false
+	if _, err := os.Stat(dbPath); err == nil {
+		liveExists = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	// 1. COPY (not move) the live database and any sidecars to the backup so
+	// dbPath stays in place; on any failure below dbPath is still the original.
+	if liveExists && backupPath != "" {
+		if err := copyCairnlineSQLiteFiles(dbPath, backupPath); err != nil {
+			return err
+		}
+		// 2. Durability: the copy helper fsyncs each written file; fsync the
+		// directory so the new backup dir entries survive a crash too.
+		if err := fsyncDir(filepath.Dir(backupPath)); err != nil {
+			return err
+		}
+	}
+
+	// 3. Test crash-injection point: return before the rename so dbPath is left
+	// as the intact original with no swap performed.
+	if beforeRename != nil {
+		if err := beforeRename(); err != nil {
+			return err
+		}
+	}
+
+	// 4. Single atomic replace of the destination. The staging store was cleanly
+	// closed as a single file, so one os.Rename swaps the whole database in place
+	// with no instant where dbPath is absent.
+	if err := os.Rename(stagingPath, dbPath); err != nil {
+		return err
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		stagingSidecar := stagingPath + suffix
+		liveSidecar := dbPath + suffix
+		if _, err := os.Stat(stagingSidecar); err == nil {
+			// Unusual after a clean Close, but if staging still has a sidecar move
+			// it over the old one so the swapped database is complete.
+			if err := os.Rename(stagingSidecar, liveSidecar); err != nil {
+				return err
+			}
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		// Staging had no sidecar (the expected clean-close case). Remove any stale
+		// -wal/-shm left from the OLD database: those sidecars describe different
+		// bytes and would corrupt the freshly swapped main file if SQLite replayed
+		// them.
+		if err := os.Remove(liveSidecar); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+
+	// 5. fsync the directory again so the rename is durable.
+	return fsyncDir(filepath.Dir(dbPath))
 }
 
 func writeCairnlineMigrationRecord(dbPath string, rec cairnlineMigrationRecord) error {
@@ -144,8 +262,18 @@ func cairnlineMigrationRollbackPlan() []string {
 	}
 }
 
+func cairnlineMigrationVerificationNotes() []string {
+	// Documents what the parity oracle does and does not compare so operators do
+	// not read the timestamp-stripped content digest as a weaker check than it is.
+	return []string{
+		"Parity verified across all 12 portable write families by count, record-ID set, and content digest.",
+		"Content-digest comparison excludes timestamp fields (created_at, updated_at, discovered_at, applied_at) and compares the record-ID intersection; additions and deletions are covered by the record-ID-set layer.",
+	}
+}
+
 func (h *Handler) HandleMigrateProjectsToCairnline(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+	ctx, span := httpServerTracer.Start(r.Context(), "hecate.projects.cairnline.migrate")
+	defer span.End()
 	dbPath := h.cairnlineEmbeddedDatabasePath()
 	stagingPath := cairnlineMigrationStagingPath(dbPath)
 
@@ -203,6 +331,11 @@ func (h *Handler) HandleMigrateProjectsToCairnline(w http.ResponseWriter, r *htt
 		return
 	}
 	verified := item.Match && smoke != nil && smoke.Status == "passed"
+	span.SetAttributes(
+		attribute.Bool("hecate.cairnline.migration.verified", verified),
+		attribute.Bool("hecate.cairnline.migration.parity_match", item.Match),
+		attribute.Int("hecate.cairnline.migration.project_count", len(snapshots)),
+	)
 
 	sourceAuthority := h.cairnlineMigrationSourceAuthority()
 	migratedAt := time.Now().UTC()
@@ -215,6 +348,10 @@ func (h *Handler) HandleMigrateProjectsToCairnline(w http.ResponseWriter, r *htt
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
 		}
+		// The parity item was computed against the staging file, which is deleted
+		// below; re-point it at the intended live target so the returned report
+		// never references a path that no longer exists.
+		item.DatabasePath = dbPath
 		if err := removeCairnlineSQLiteFiles(stagingPath); err != nil {
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 			return
@@ -245,8 +382,6 @@ func (h *Handler) HandleMigrateProjectsToCairnline(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
-	backupPath := cairnlineMigrationBackupPath(dbPath)
-	rollbackBackupPath := ""
 	liveExists := false
 	if _, statErr := os.Stat(dbPath); statErr == nil {
 		liveExists = true
@@ -254,19 +389,17 @@ func (h *Handler) HandleMigrateProjectsToCairnline(w http.ResponseWriter, r *htt
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, statErr.Error())
 		return
 	}
+	// Timestamped backup generation named from the same migratedAt recorded below
+	// so the backup file and migration.json agree; empty when no live DB exists.
+	rollbackBackupPath := ""
 	if liveExists {
-		if err := renameCairnlineSQLiteFiles(dbPath, backupPath); err != nil {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
-		rollbackBackupPath = backupPath
+		rollbackBackupPath = cairnlineMigrationBackupPath(dbPath, migratedAt)
 	}
-	if err := renameCairnlineSQLiteFiles(stagingPath, dbPath); err != nil {
-		// Best-effort restore of the backup so the live database is not lost when
-		// the swap fails after the backup rename.
-		if rollbackBackupPath != "" {
-			_ = renameCairnlineSQLiteFiles(backupPath, dbPath)
-		}
+	// Crash-safe swap: copy the live DB to the backup (leaving dbPath in place)
+	// then a single atomic rename replaces dbPath. On failure dbPath is still the
+	// original because the copy did not move it, so no restore dance is needed.
+	if err := swapCairnlineMigrationStore(dbPath, stagingPath, rollbackBackupPath, nil); err != nil {
+		_ = removeCairnlineSQLiteFiles(stagingPath)
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
@@ -300,6 +433,7 @@ func (h *Handler) HandleMigrateProjectsToCairnline(w http.ResponseWriter, r *htt
 		ProjectCount:       len(snapshots),
 		Checklist:          cairnlineMigrationChecklist(item.Match, true, liveExists, true),
 		Rollback:           cairnlineMigrationRollbackPlan(),
+		VerificationNotes:  cairnlineMigrationVerificationNotes(),
 		Parity:             item,
 	}
 	WriteJSON(w, http.StatusOK, ProjectCairnlineMigrationResponse{
@@ -309,14 +443,12 @@ func (h *Handler) HandleMigrateProjectsToCairnline(w http.ResponseWriter, r *htt
 }
 
 func (h *Handler) HandleRollbackProjectsCairnlineMigration(w http.ResponseWriter, r *http.Request) {
+	_, span := httpServerTracer.Start(r.Context(), "hecate.projects.cairnline.migrate.rollback")
+	defer span.End()
 	dbPath := h.cairnlineEmbeddedDatabasePath()
-	backupPath := cairnlineMigrationBackupPath(dbPath)
 
-	if _, err := os.Stat(backupPath); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
-			return
-		}
+	noBackup := func() {
+		span.SetAttributes(attribute.Bool("hecate.cairnline.migration.restored", false))
 		WriteJSON(w, http.StatusOK, ProjectCairnlineMigrationRollbackResponse{
 			Object: "project_cairnline_migration_rollback",
 			Data: ProjectCairnlineMigrationRollbackResult{
@@ -325,20 +457,51 @@ func (h *Handler) HandleRollbackProjectsCairnlineMigration(w http.ResponseWriter
 				Target:   dbPath,
 			},
 		})
+	}
+
+	// Roll back to the backup generation recorded in the CURRENT migration.json
+	// rather than a fixed path, so timestamped generations restore the latest one.
+	rec, ok, err := readCairnlineMigrationRecord(dbPath)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	backupPath := ""
+	if ok && rec != nil {
+		backupPath = strings.TrimSpace(rec.RollbackBackupPath)
+	}
+	if backupPath == "" {
+		noBackup()
+		return
+	}
+	if _, err := os.Stat(backupPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		noBackup()
 		return
 	}
 
-	if err := renameCairnlineSQLiteFiles(backupPath, dbPath); err != nil {
+	// Restore by COPY (not rename) so the backup generation is preserved after
+	// rollback for manual recovery. Older backup generations are intentionally
+	// left on disk for the same reason.
+	if err := copyCairnlineSQLiteFiles(backupPath, dbPath); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if err := fsyncDir(filepath.Dir(dbPath)); err != nil {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
 	// The authoritative migration was rolled back, so the operator is back to the
 	// pre-migration embedded state; delete the migration record rather than
-	// leaving stale evidence pointing at a database that no longer exists.
+	// leaving stale evidence pointing at the superseded migrated database.
 	if err := os.Remove(cairnlineMigrationRecordPath(dbPath)); err != nil && !errors.Is(err, os.ErrNotExist) {
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	span.SetAttributes(attribute.Bool("hecate.cairnline.migration.restored", true))
 	WriteJSON(w, http.StatusOK, ProjectCairnlineMigrationRollbackResponse{
 		Object: "project_cairnline_migration_rollback",
 		Data: ProjectCairnlineMigrationRollbackResult{
@@ -369,12 +532,12 @@ func cairnlineMigrationChecklist(parityMatch, verified, backedUp, swapped bool) 
 		{
 			ID:     "backup-live-store",
 			Status: cairnlineMigrationStepStatus(verified, backedUp),
-			Detail: "Renamed the existing live embedded database to a pre-migration backup before the swap; skipped when no prior live database existed.",
+			Detail: "Copied the existing live embedded database to a timestamped pre-migration backup generation, leaving the live file in place; skipped when no prior live database existed.",
 		},
 		{
 			ID:     "atomic-swap",
 			Status: cairnlineMigrationStepStatus(verified, swapped),
-			Detail: "Atomically renamed the verified staged database into the live embedded path.",
+			Detail: "Replaced the live embedded path with the verified staged database via a single atomic rename over the copied backup, so the live path is never absent.",
 		},
 		{
 			ID:     "migration-record-written",

--- a/internal/api/handler_project_cairnline_migrate.go
+++ b/internal/api/handler_project_cairnline_migrate.go
@@ -1,0 +1,420 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/cairnlinebridge"
+)
+
+const projectCairnlineMigrateURL = "/hecate/v1/projects/cairnline/migrate"
+const projectCairnlineMigrateRollbackURL = "/hecate/v1/projects/cairnline/migrate/rollback"
+
+// cairnlineMigrationRecord is durable evidence that an authoritative one-way
+// migration into the embedded Cairnline database has been executed and
+// verified. It is written as a sidecar JSON file next to the embedded
+// projects.db. This is embedded-runtime-local operational metadata, consistent
+// with the embedded projects.db itself being a local, non-tiered file; it is
+// NOT Hecate app data, so it deliberately does not flow through the
+// memory/sqlite/postgres storage tiers.
+type cairnlineMigrationRecord struct {
+	MigratedAt         time.Time `json:"migrated_at"`
+	Verified           bool      `json:"verified"`
+	ParityMatch        bool      `json:"parity_match"`
+	Target             string    `json:"target"`
+	SourceAuthority    []string  `json:"source_authority"`
+	RollbackBackupPath string    `json:"rollback_backup_path"`
+	ProjectCount       int       `json:"project_count"`
+}
+
+func cairnlineMigrationStagingPath(dbPath string) string {
+	return dbPath + ".migrating"
+}
+
+func cairnlineMigrationBackupPath(dbPath string) string {
+	return dbPath + ".pre-migration.bak"
+}
+
+func cairnlineMigrationRecordPath(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "migration.json")
+}
+
+// renameCairnlineSQLiteFiles atomically moves an SQLite database triplet
+// (main + optional -wal/-shm sidecars) from src to dst within the same
+// directory. The main file rename is required when src exists so the swap
+// cannot silently drop the database; the -wal/-shm sidecars may legitimately
+// be absent after a clean close, so their missing rename is not an error.
+func renameCairnlineSQLiteFiles(src, dst string) error {
+	// Clear any stale destination triplet first so rename cannot collide with
+	// leftover files from a previous swap.
+	if err := removeCairnlineSQLiteFiles(dst); err != nil {
+		return err
+	}
+	if _, err := os.Stat(src); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if err := os.Rename(src, dst); err != nil {
+		return err
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Rename(src+suffix, dst+suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeCairnlineMigrationRecord(dbPath string, rec cairnlineMigrationRecord) error {
+	rec.MigratedAt = rec.MigratedAt.UTC()
+	payload, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return err
+	}
+	recordPath := cairnlineMigrationRecordPath(dbPath)
+	// Write to a temp file in the same directory then rename so a reader never
+	// observes a partially written record.
+	tmp, err := os.CreateTemp(filepath.Dir(recordPath), "migration-*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, recordPath); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+func readCairnlineMigrationRecord(dbPath string) (*cairnlineMigrationRecord, bool, error) {
+	payload, err := os.ReadFile(cairnlineMigrationRecordPath(dbPath))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	var rec cairnlineMigrationRecord
+	if err := json.Unmarshal(payload, &rec); err != nil {
+		return nil, false, err
+	}
+	return &rec, true, nil
+}
+
+func (h *Handler) cairnlineMigrationSourceAuthority() []string {
+	tier := ""
+	if h != nil {
+		tier = strings.TrimSpace(h.config.Projects.Backend)
+	}
+	if tier == "" {
+		tier = "memory"
+	}
+	return []string{tier}
+}
+
+// cairnlineMigrationRollbackPlan is the operator-facing rollback plan shared by
+// the migration report and the migration-and-rollback replacement gate.
+func cairnlineMigrationRollbackPlan() []string {
+	return []string{
+		"Native Hecate stores remain the untouched source of truth; migration only writes the embedded Cairnline database.",
+		"To discard the migrated embedded store, POST " + projectCairnlineMigrateRollbackURL + " (restores the pre-migration backup).",
+		"To return authority to Hecate, unset HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE (and/or HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY); reads and writes fall back to the native stores with no data loss.",
+	}
+}
+
+func (h *Handler) HandleMigrateProjectsToCairnline(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	stagingPath := cairnlineMigrationStagingPath(dbPath)
+
+	snapshots, err := cairnlinebridge.LoadSnapshots(ctx, h.cairnlineSnapshotSources())
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+
+	// Build the migration target in a staging file so the live embedded database
+	// is never mutated until a staged rebuild passes full parity verification.
+	// Reconstructing purely from the current native snapshot makes the migration
+	// deletion-faithful: any natively-absent row is never written, so deletions
+	// propagate for every family even though Cairnline's import path only upserts.
+	if err := removeCairnlineSQLiteFiles(stagingPath); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	service, store, err := cairnline.NewSQLiteService(ctx, stagingPath)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	// The staging store must be closed before any swap rename so SQLite releases
+	// its file handles; guard the defer so the explicit close is not doubled.
+	storeClosed := false
+	closeStore := func() error {
+		if storeClosed {
+			return nil
+		}
+		storeClosed = true
+		return store.Close()
+	}
+	defer func() { _ = closeStore() }()
+
+	if err := cairnlinebridge.SeedSnapshots(ctx, service, snapshots); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+
+	// Verify the staged database before touching the live store. The strict read
+	// smoke opens the embedded database through the handler's embedded path, so
+	// it is pointed at the staging file while the staged store stays open (a
+	// second read connection observes the just-imported rows).
+	smokeHandler := h.projectCairnlineStrictEmbeddedProbeHandler()
+	smokeHandler.cairnlineEmbeddedPathOverride = stagingPath
+	smoke := smokeHandler.projectCairnlineStrictEmbeddedSmoke(ctx, snapshots)
+	item, err := projectCairnlineServiceParity(ctx, stagingPath, true, "authoritative_migration", snapshots, service, smoke)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	verified := item.Match && smoke != nil && smoke.Status == "passed"
+
+	sourceAuthority := h.cairnlineMigrationSourceAuthority()
+	migratedAt := time.Now().UTC()
+
+	if !verified {
+		// The staged rebuild failed verification, so the live database is left
+		// untouched. Respond 200 with verified=false rather than an error status
+		// so the parity diff payload still reaches the operator for diagnosis.
+		if err := closeStore(); err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		if err := removeCairnlineSQLiteFiles(stagingPath); err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		report := ProjectCairnlineMigrationReport{
+			Object:          "project_cairnline_migration_report",
+			MigratedAt:      migratedAt,
+			Verified:        false,
+			ParityMatch:     item.Match,
+			Target:          dbPath,
+			SourceAuthority: sourceAuthority,
+			ProjectCount:    len(snapshots),
+			Checklist:       cairnlineMigrationChecklist(item.Match, verified, false, false),
+			Rollback:        cairnlineMigrationRollbackPlan(),
+			Parity:          item,
+		}
+		WriteJSON(w, http.StatusOK, ProjectCairnlineMigrationResponse{
+			Object: "project_cairnline_migration",
+			Data:   report,
+		})
+		return
+	}
+
+	// Verified: close the staging store before renaming so SQLite handles are
+	// released, then back up any existing live database and atomically swap the
+	// staged database into place.
+	if err := closeStore(); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	backupPath := cairnlineMigrationBackupPath(dbPath)
+	rollbackBackupPath := ""
+	liveExists := false
+	if _, statErr := os.Stat(dbPath); statErr == nil {
+		liveExists = true
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, statErr.Error())
+		return
+	}
+	if liveExists {
+		if err := renameCairnlineSQLiteFiles(dbPath, backupPath); err != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		rollbackBackupPath = backupPath
+	}
+	if err := renameCairnlineSQLiteFiles(stagingPath, dbPath); err != nil {
+		// Best-effort restore of the backup so the live database is not lost when
+		// the swap fails after the backup rename.
+		if rollbackBackupPath != "" {
+			_ = renameCairnlineSQLiteFiles(backupPath, dbPath)
+		}
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+
+	rec := cairnlineMigrationRecord{
+		MigratedAt:         migratedAt,
+		Verified:           true,
+		ParityMatch:        item.Match,
+		Target:             dbPath,
+		SourceAuthority:    sourceAuthority,
+		RollbackBackupPath: rollbackBackupPath,
+		ProjectCount:       len(snapshots),
+	}
+	if err := writeCairnlineMigrationRecord(dbPath, rec); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+
+	// The staged parity item was computed against the exact bytes now living at
+	// dbPath, so it is reused as the live report's parity evidence; re-point it
+	// at the live path.
+	item.DatabasePath = dbPath
+	report := ProjectCairnlineMigrationReport{
+		Object:             "project_cairnline_migration_report",
+		MigratedAt:         migratedAt,
+		Verified:           true,
+		ParityMatch:        item.Match,
+		Target:             dbPath,
+		SourceAuthority:    sourceAuthority,
+		RollbackBackupPath: rollbackBackupPath,
+		ProjectCount:       len(snapshots),
+		Checklist:          cairnlineMigrationChecklist(item.Match, true, liveExists, true),
+		Rollback:           cairnlineMigrationRollbackPlan(),
+		Parity:             item,
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineMigrationResponse{
+		Object: "project_cairnline_migration",
+		Data:   report,
+	})
+}
+
+func (h *Handler) HandleRollbackProjectsCairnlineMigration(w http.ResponseWriter, r *http.Request) {
+	dbPath := h.cairnlineEmbeddedDatabasePath()
+	backupPath := cairnlineMigrationBackupPath(dbPath)
+
+	if _, err := os.Stat(backupPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectCairnlineMigrationRollbackResponse{
+			Object: "project_cairnline_migration_rollback",
+			Data: ProjectCairnlineMigrationRollbackResult{
+				Restored: false,
+				Reason:   "no_backup",
+				Target:   dbPath,
+			},
+		})
+		return
+	}
+
+	if err := renameCairnlineSQLiteFiles(backupPath, dbPath); err != nil {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	// The authoritative migration was rolled back, so the operator is back to the
+	// pre-migration embedded state; delete the migration record rather than
+	// leaving stale evidence pointing at a database that no longer exists.
+	if err := os.Remove(cairnlineMigrationRecordPath(dbPath)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
+		return
+	}
+	WriteJSON(w, http.StatusOK, ProjectCairnlineMigrationRollbackResponse{
+		Object: "project_cairnline_migration_rollback",
+		Data: ProjectCairnlineMigrationRollbackResult{
+			Restored:     true,
+			RestoredFrom: backupPath,
+			Target:       dbPath,
+		},
+	})
+}
+
+func cairnlineMigrationChecklist(parityMatch, verified, backedUp, swapped bool) []ProjectCairnlineMigrationRehearsalCheck {
+	return []ProjectCairnlineMigrationRehearsalCheck{
+		{
+			ID:     "load-hecate-stores",
+			Status: "complete",
+			Detail: "Loaded Hecate's authoritative project, work, skill, memory, and assistant stores.",
+		},
+		{
+			ID:     "staged-rebuild",
+			Status: "complete",
+			Detail: "Rebuilt the migration target from scratch in a staging database so absent native rows are never written, making the migration deletion-faithful by reconstruction.",
+		},
+		{
+			ID:     "parity-verify",
+			Status: projectCairnlineMigrationParityStatus(true, parityMatch),
+			Detail: "Compared counts, IDs, launch packets, and content digests plus the strict embedded read smoke against the staged database before touching the live store.",
+		},
+		{
+			ID:     "backup-live-store",
+			Status: cairnlineMigrationStepStatus(verified, backedUp),
+			Detail: "Renamed the existing live embedded database to a pre-migration backup before the swap; skipped when no prior live database existed.",
+		},
+		{
+			ID:     "atomic-swap",
+			Status: cairnlineMigrationStepStatus(verified, swapped),
+			Detail: "Atomically renamed the verified staged database into the live embedded path.",
+		},
+		{
+			ID:     "migration-record-written",
+			Status: cairnlineMigrationStepStatus(verified, swapped),
+			Detail: "Persisted the durable migration record next to the embedded database.",
+		},
+	}
+}
+
+func cairnlineMigrationStepStatus(verified, executed bool) string {
+	if !verified {
+		return "skipped"
+	}
+	if executed {
+		return "complete"
+	}
+	return "skipped"
+}
+
+func (h *Handler) projectCairnlineMigrationCutoverStatus(dbPath string) *ProjectCairnlineMigrationCutoverStatus {
+	status := &ProjectCairnlineMigrationCutoverStatus{
+		Status:           "not_migrated",
+		Endpoint:         projectCairnlineMigrateURL,
+		RollbackEndpoint: projectCairnlineMigrateRollbackURL,
+	}
+	rec, ok, err := readCairnlineMigrationRecord(dbPath)
+	if err != nil || !ok || rec == nil {
+		return status
+	}
+	migratedAt := rec.MigratedAt
+	status.Migrated = true
+	status.Verified = rec.Verified
+	status.ParityMatch = rec.ParityMatch
+	status.MigratedAt = &migratedAt
+	status.RollbackBackupPath = rec.RollbackBackupPath
+	status.SourceAuthority = append([]string(nil), rec.SourceAuthority...)
+	if rec.Verified && rec.ParityMatch {
+		status.Status = "migrated_verified"
+	} else {
+		status.Status = "migrated_unverified"
+	}
+	return status
+}

--- a/internal/api/handler_project_cairnline_migrate_test.go
+++ b/internal/api/handler_project_cairnline_migrate_test.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentprofiles"
@@ -204,11 +207,12 @@ func TestHandler_MigrateProjectsToCairnline_IdempotentAndBacksUpPriorLiveStore(t
 	if !second.Data.Verified || !second.Data.ParityMatch {
 		t.Fatalf("second migrate = %+v, want still verified parity match", second.Data)
 	}
-	// The second run had a prior live database, so it must back it up.
+	// The second run had a prior live database, so it must back it up to a
+	// timestamped generation recorded in the report.
 	dbPath := handler.cairnlineEmbeddedDatabasePath()
-	backupPath := cairnlineMigrationBackupPath(dbPath)
-	if second.Data.RollbackBackupPath != backupPath {
-		t.Fatalf("second rollback backup = %q, want %q", second.Data.RollbackBackupPath, backupPath)
+	backupPath := second.Data.RollbackBackupPath
+	if backupPath == "" || !strings.Contains(backupPath, ".pre-migration-") || !strings.HasPrefix(backupPath, dbPath+".pre-migration-") {
+		t.Fatalf("second rollback backup = %q, want timestamped pre-migration backup for %q", backupPath, dbPath)
 	}
 	if _, err := os.Stat(backupPath); err != nil {
 		t.Fatalf("stat backup after idempotent rerun: %v", err)
@@ -277,10 +281,13 @@ func TestHandler_RollbackProjectsCairnlineMigration_RestoresBackupAndClearsRecor
 
 	// Two migrations so a pre-migration backup exists to roll back to.
 	mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
-	mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	second := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
 
 	dbPath := handler.cairnlineEmbeddedDatabasePath()
-	backupPath := cairnlineMigrationBackupPath(dbPath)
+	backupPath := second.Data.RollbackBackupPath
+	if backupPath == "" {
+		t.Fatalf("second migrate = %+v, want recorded rollback backup path", second.Data)
+	}
 	if _, err := os.Stat(backupPath); err != nil {
 		t.Fatalf("expected backup before rollback: %v", err)
 	}
@@ -346,4 +353,155 @@ func TestHandler_MigrateProjectsToCairnline_BackendStatusReportsMigratedVerified
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CairnlineState != "migrated_verified" || !point.LiveMirror {
 		t.Fatalf("migration switchpoint = %+v, want migrated_verified live-mirror state", point)
 	}
+}
+
+// buildCairnlineStoreWithProject writes a real Cairnline SQLite store at dbPath
+// containing a single named project so swap assertions are content-meaningful.
+func buildCairnlineStoreWithProject(t *testing.T, dbPath, projectID, projectName string) {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteService(%q): %v", dbPath, err)
+	}
+	if _, err := service.CreateProject(t.Context(), cairnline.Project{ID: projectID, Name: projectName}); err != nil {
+		_ = store.Close()
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close store: %v", err)
+	}
+}
+
+// cairnlineStoreHasProject opens a Cairnline store read-only-ish and reports
+// whether the given project id is present, so swap tests can prove which bytes
+// survived a crash.
+func cairnlineStoreHasProject(t *testing.T, dbPath, projectID string) bool {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("open store %q: %v", dbPath, err)
+	}
+	defer func() { _ = store.Close() }()
+	if _, err := service.GetProject(t.Context(), projectID); err != nil {
+		return false
+	}
+	return true
+}
+
+// TestCairnlineSwapMigrationStore_CrashBeforeRenameKeepsOriginal proves the
+// crash-safe swap: a crash injected AFTER the backup copy but BEFORE the atomic
+// rename must leave the live database intact with its original content, and the
+// backup must hold that same original. A successful swap then replaces the live
+// content while the backup preserves the original.
+func TestCairnlineSwapMigrationStore_CrashBeforeRenameKeepsOriginal(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := dir + "/projects.db"
+	stagingPath := cairnlineMigrationStagingPath(dbPath)
+	migratedAt := timeParseUTC(t, "2026-07-09T13:18:18.123456789Z")
+	backupPath := cairnlineMigrationBackupPath(dbPath, migratedAt)
+
+	buildCairnlineStoreWithProject(t, dbPath, "proj_original", "Original")
+	buildCairnlineStoreWithProject(t, stagingPath, "proj_staging", "Staging")
+
+	injected := errors.New("simulated crash before rename")
+	if err := swapCairnlineMigrationStore(dbPath, stagingPath, backupPath, func() error { return injected }); !errors.Is(err, injected) {
+		t.Fatalf("swap with crash hook err = %v, want injected error", err)
+	}
+	// dbPath must still exist and still hold the ORIGINAL content: the swap must
+	// never leave the live path absent or empty.
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("live db missing after injected crash: %v", err)
+	}
+	if !cairnlineStoreHasProject(t, dbPath, "proj_original") {
+		t.Fatal("live db lost original content after injected crash")
+	}
+	if cairnlineStoreHasProject(t, dbPath, "proj_staging") {
+		t.Fatal("live db unexpectedly holds staging content after injected crash")
+	}
+	if !cairnlineStoreHasProject(t, backupPath, "proj_original") {
+		t.Fatal("backup missing original content after injected crash")
+	}
+
+	// A clean swap (no crash hook) now completes: live holds staging content,
+	// backup still holds the original.
+	if err := swapCairnlineMigrationStore(dbPath, stagingPath, backupPath, nil); err != nil {
+		t.Fatalf("clean swap: %v", err)
+	}
+	if !cairnlineStoreHasProject(t, dbPath, "proj_staging") {
+		t.Fatal("live db missing staging content after clean swap")
+	}
+	if !cairnlineStoreHasProject(t, backupPath, "proj_original") {
+		t.Fatal("backup lost original content after clean swap")
+	}
+	if _, err := os.Stat(stagingPath); !os.IsNotExist(err) {
+		t.Fatalf("staging stat err = %v, want removed after clean swap", err)
+	}
+}
+
+// TestHandler_MigrateProjectsToCairnline_TimestampedBackupsAndRollbackLatest
+// proves repeated migrations produce distinct timestamped backup generations and
+// that rollback restores the generation recorded in the current migration.json.
+func TestHandler_MigrateProjectsToCairnline_TimestampedBackupsAndRollbackLatest(t *testing.T) {
+	handler, client := newCairnlineMigrationHandler(t, config.Config{Server: config.ServerConfig{DataDir: t.TempDir()}})
+	seed := seedCairnlineMigrationProject(t, handler, client)
+
+	// First migration: no prior live DB, so no backup generation is created.
+	first := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if !first.Data.Verified || first.Data.RollbackBackupPath != "" {
+		t.Fatalf("first migrate = %+v, want verified with no backup", first.Data)
+	}
+	// Second migration: backs up the first live DB to a timestamped generation.
+	second := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if second.Data.RollbackBackupPath == "" {
+		t.Fatalf("second migrate = %+v, want a recorded backup generation", second.Data)
+	}
+	// Third migration: a distinct generation, leaving the second's intact.
+	third := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if third.Data.RollbackBackupPath == "" {
+		t.Fatalf("third migrate = %+v, want a recorded backup generation", third.Data)
+	}
+	if second.Data.RollbackBackupPath == third.Data.RollbackBackupPath {
+		t.Fatalf("backup generations not distinct: %q", third.Data.RollbackBackupPath)
+	}
+	for _, p := range []string{second.Data.RollbackBackupPath, third.Data.RollbackBackupPath} {
+		if !strings.Contains(p, ".pre-migration-") {
+			t.Fatalf("backup path %q, want timestamped .pre-migration- generation", p)
+		}
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("stat backup generation %q: %v", p, err)
+		}
+	}
+
+	dbPath := handler.cairnlineEmbeddedDatabasePath()
+	rec, ok, err := readCairnlineMigrationRecord(dbPath)
+	if err != nil || !ok || rec == nil {
+		t.Fatalf("migration record ok=%v err=%v, want durable record", ok, err)
+	}
+	if rec.RollbackBackupPath != third.Data.RollbackBackupPath {
+		t.Fatalf("record backup = %q, want latest generation %q", rec.RollbackBackupPath, third.Data.RollbackBackupPath)
+	}
+
+	// Rollback restores the latest recorded generation and leaves it on disk.
+	rollback := mustRequestJSON[ProjectCairnlineMigrationRollbackResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate/rollback", "")
+	if !rollback.Data.Restored || rollback.Data.RestoredFrom != third.Data.RollbackBackupPath {
+		t.Fatalf("rollback = %+v, want restored from latest generation %q", rollback.Data, third.Data.RollbackBackupPath)
+	}
+	// The older generation is intentionally left on disk for manual recovery.
+	if _, err := os.Stat(second.Data.RollbackBackupPath); err != nil {
+		t.Fatalf("older backup generation removed: %v", err)
+	}
+	// The restored live database still resolves the seeded project content.
+	service := openMigratedCairnlineService(t, dbPath)
+	if _, err := service.GetProject(t.Context(), seed.projectID); err != nil {
+		t.Fatalf("GetProject from restored DB: %v", err)
+	}
+}
+
+func timeParseUTC(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", value, err)
+	}
+	return parsed.UTC()
 }

--- a/internal/api/handler_project_cairnline_migrate_test.go
+++ b/internal/api/handler_project_cairnline_migrate_test.go
@@ -1,0 +1,349 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hecatehq/cairnline"
+	"github.com/hecatehq/hecate/internal/agentprofiles"
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/memory"
+	"github.com/hecatehq/hecate/internal/projectassistant"
+	"github.com/hecatehq/hecate/internal/projects"
+	"github.com/hecatehq/hecate/internal/projectskills"
+	"github.com/hecatehq/hecate/internal/projectwork"
+)
+
+// migrationSeed captures the identifiers a seeded project exposes so migration
+// tests can assert against reconstructed embedded state.
+type migrationSeed struct {
+	projectID    string
+	rootID       string
+	assignmentID string
+	memoryID     string
+}
+
+func newCairnlineMigrationHandler(t *testing.T, cfg config.Config) (*Handler, apiTestClient) {
+	t.Helper()
+	handler := NewHandler(cfg, quietLogger(), nil, nil, nil, nil)
+	handler.SetProjectStore(projects.NewMemoryStore())
+	handler.SetProjectWorkStore(projectwork.NewMemoryStore())
+	handler.SetProjectSkillStore(projectskills.NewMemoryStore())
+	handler.SetMemoryStore(memory.NewMemoryStore())
+	handler.SetProjectAssistantProposalStore(projectassistant.NewMemoryProposalStore())
+	handler.SetAgentProfileStore(agentprofiles.NewMemoryStore())
+	server := NewServer(quietLogger(), handler)
+	client := newAPITestClient(t, server)
+	return handler, client
+}
+
+func seedCairnlineMigrationProject(t *testing.T, handler *Handler, client apiTestClient) migrationSeed {
+	t.Helper()
+	root := t.TempDir()
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name":           "Cairnline Migration",
+		"workspace_path": root,
+		"workspace_kind": "git",
+	}))
+	projectID := project.Data.ID
+	rootID := project.Data.Roots[0].ID
+	if _, err := handler.agentProfiles.Create(t.Context(), agentprofiles.Profile{
+		ID:                  "migrate_profile",
+		Name:                "Migrate profile",
+		Surface:             agentprofiles.SurfaceHecateTask,
+		ProjectMemoryPolicy: agentprofiles.MemoryInclude,
+		ContextSourcePolicy: agentprofiles.ContextIncludeEnabled,
+		ProviderHint:        "openai",
+		ModelHint:           "gpt-5",
+	}); err != nil {
+		t.Fatalf("Create profile: %v", err)
+	}
+	if _, err := handler.projectSkills.UpsertDiscovered(t.Context(), projectID, []projectskills.Skill{{
+		ID:          "backend",
+		ProjectID:   projectID,
+		Title:       "Backend",
+		Path:        "docs-ai/skills/backend/SKILL.md",
+		RootID:      rootID,
+		Format:      projectskills.FormatSkillMD,
+		Enabled:     true,
+		Status:      projectskills.StatusAvailable,
+		TrustLabel:  projectskills.TrustWorkspaceSkill,
+		Description: "Backend guidance.",
+	}}); err != nil {
+		t.Fatalf("Upsert skills: %v", err)
+	}
+	role := mustRequestJSONStatus[ProjectWorkRoleEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/roles", projectJourneyJSON(t, map[string]any{
+		"id":                    "migrate_developer",
+		"name":                  "Migrate Developer",
+		"default_agent_profile": "migrate_profile",
+		"default_driver_kind":   projectwork.AssignmentDriverHecateTask,
+		"skill_ids":             []string{"backend"},
+	}))
+	work := mustRequestJSONStatus[ProjectWorkItemEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items", projectJourneyJSON(t, map[string]any{
+		"id":            "work_migrate",
+		"title":         "Migrate Projects to Cairnline",
+		"brief":         "Prove Hecate can migrate a durable all-project Cairnline DB.",
+		"owner_role_id": role.Data.ID,
+		"root_id":       rootID,
+	}))
+	assignment := mustRequestJSONStatus[ProjectWorkAssignmentEnvelope](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects/"+projectID+"/work-items/"+work.Data.ID+"/assignments", projectJourneyJSON(t, map[string]any{
+		"id":          "asgn_migrate",
+		"role_id":     role.Data.ID,
+		"driver_kind": projectwork.AssignmentDriverHecateTask,
+		"root_id":     rootID,
+	}))
+	if _, err := handler.memory.Create(t.Context(), memory.Entry{
+		ID:         "mem_migrate",
+		Scope:      memory.ScopeProject,
+		ProjectID:  projectID,
+		Title:      "Migration replacement gate",
+		Body:       "Migration should preserve accepted project memory.",
+		TrustLabel: memory.TrustLabelOperatorMemory,
+		SourceKind: memory.SourceKindOperator,
+		SourceID:   assignment.Data.ID,
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Create memory: %v", err)
+	}
+	return migrationSeed{
+		projectID:    projectID,
+		rootID:       rootID,
+		assignmentID: assignment.Data.ID,
+		memoryID:     "mem_migrate",
+	}
+}
+
+func openMigratedCairnlineService(t *testing.T, dbPath string) *cairnline.Service {
+	t.Helper()
+	service, store, err := cairnline.NewSQLiteService(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("Open migrated Cairnline DB %q: %v", dbPath, err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return service
+}
+
+func TestHandler_MigrateProjectsToCairnline_HappyPathVerifiesAndSwaps(t *testing.T) {
+	handler, client := newCairnlineMigrationHandler(t, config.Config{Server: config.ServerConfig{DataDir: t.TempDir()}})
+	seed := seedCairnlineMigrationProject(t, handler, client)
+
+	resp := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if resp.Object != "project_cairnline_migration" || resp.Data.Object != "project_cairnline_migration_report" {
+		t.Fatalf("migrate envelope = %+v, want project_cairnline_migration report", resp)
+	}
+	if !resp.Data.Verified || !resp.Data.ParityMatch {
+		t.Fatalf("migrate report = %+v, want verified parity match", resp.Data)
+	}
+	if !resp.Data.Parity.Match || len(resp.Data.Parity.Differences) != 0 || len(resp.Data.Parity.IDDifferences) != 0 || len(resp.Data.Parity.ContentDifferences) != 0 {
+		t.Fatalf("migrate parity = %+v, want exact match", resp.Data.Parity)
+	}
+	if resp.Data.ProjectCount != 1 || len(resp.Data.SourceAuthority) == 0 || resp.Data.SourceAuthority[0] != "memory" {
+		t.Fatalf("migrate report = %+v, want single project migrated from memory tier", resp.Data)
+	}
+	// No prior live database existed, so no backup is recorded on the first run.
+	if resp.Data.RollbackBackupPath != "" {
+		t.Fatalf("rollback backup path = %q, want empty on first migration", resp.Data.RollbackBackupPath)
+	}
+	if len(resp.Data.Rollback) == 0 {
+		t.Fatalf("rollback plan = %+v, want operator rollback steps", resp.Data.Rollback)
+	}
+	for _, id := range []string{"load-hecate-stores", "staged-rebuild", "parity-verify", "backup-live-store", "atomic-swap", "migration-record-written"} {
+		found := false
+		for _, check := range resp.Data.Checklist {
+			if check.ID == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("checklist = %+v, want step %q", resp.Data.Checklist, id)
+		}
+	}
+
+	dbPath := handler.cairnlineEmbeddedDatabasePath()
+	if resp.Data.Target != dbPath {
+		t.Fatalf("target = %q, want embedded db path %q", resp.Data.Target, dbPath)
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("stat live db: %v", err)
+	}
+	if _, err := os.Stat(cairnlineMigrationStagingPath(dbPath)); !os.IsNotExist(err) {
+		t.Fatalf("staging db stat err = %v, want removed after swap", err)
+	}
+	rec, ok, err := readCairnlineMigrationRecord(dbPath)
+	if err != nil || !ok || rec == nil {
+		t.Fatalf("migration record ok=%v err=%v rec=%+v, want durable record", ok, err, rec)
+	}
+	if !rec.Verified || !rec.ParityMatch || rec.Target != dbPath || rec.ProjectCount != 1 {
+		t.Fatalf("migration record = %+v, want verified record for one project", rec)
+	}
+
+	service := openMigratedCairnlineService(t, dbPath)
+	if _, err := service.GetProject(t.Context(), seed.projectID); err != nil {
+		t.Fatalf("GetProject from migrated DB: %v", err)
+	}
+	entries, err := service.ListMemoryEntries(t.Context(), seed.projectID, true)
+	if err != nil {
+		t.Fatalf("ListMemoryEntries from migrated DB: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ID != seed.memoryID {
+		t.Fatalf("migrated memory = %+v, want seeded entry", entries)
+	}
+}
+
+func TestHandler_MigrateProjectsToCairnline_IdempotentAndBacksUpPriorLiveStore(t *testing.T) {
+	handler, client := newCairnlineMigrationHandler(t, config.Config{Server: config.ServerConfig{DataDir: t.TempDir()}})
+	seedCairnlineMigrationProject(t, handler, client)
+
+	first := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if !first.Data.Verified || !first.Data.ParityMatch || first.Data.RollbackBackupPath != "" {
+		t.Fatalf("first migrate = %+v, want verified with no backup", first.Data)
+	}
+	second := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if !second.Data.Verified || !second.Data.ParityMatch {
+		t.Fatalf("second migrate = %+v, want still verified parity match", second.Data)
+	}
+	// The second run had a prior live database, so it must back it up.
+	dbPath := handler.cairnlineEmbeddedDatabasePath()
+	backupPath := cairnlineMigrationBackupPath(dbPath)
+	if second.Data.RollbackBackupPath != backupPath {
+		t.Fatalf("second rollback backup = %q, want %q", second.Data.RollbackBackupPath, backupPath)
+	}
+	if _, err := os.Stat(backupPath); err != nil {
+		t.Fatalf("stat backup after idempotent rerun: %v", err)
+	}
+}
+
+func TestHandler_MigrateProjectsToCairnline_DeletionFaithfulByReconstruction(t *testing.T) {
+	handler, client := newCairnlineMigrationHandler(t, config.Config{Server: config.ServerConfig{DataDir: t.TempDir()}})
+	seed := seedCairnlineMigrationProject(t, handler, client)
+
+	first := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if !first.Data.Verified {
+		t.Fatalf("first migrate = %+v, want verified", first.Data)
+	}
+	dbPath := handler.cairnlineEmbeddedDatabasePath()
+	before := openMigratedCairnlineService(t, dbPath)
+	entriesBefore, err := before.ListMemoryEntries(t.Context(), seed.projectID, true)
+	if err != nil || len(entriesBefore) != 1 {
+		t.Fatalf("pre-delete migrated memory = %+v err=%v, want seeded entry", entriesBefore, err)
+	}
+
+	// Delete a native record; Hecate stores keep no tombstone, so the absence
+	// must propagate through a rebuild-from-source migration.
+	if err := handler.memory.Delete(t.Context(), seed.projectID, seed.memoryID); err != nil {
+		t.Fatalf("Delete native memory: %v", err)
+	}
+
+	second := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if !second.Data.Verified || !second.Data.ParityMatch {
+		t.Fatalf("second migrate = %+v, want verified parity match against the new native snapshot", second.Data)
+	}
+	after := openMigratedCairnlineService(t, dbPath)
+	entriesAfter, err := after.ListMemoryEntries(t.Context(), seed.projectID, true)
+	if err != nil {
+		t.Fatalf("post-delete ListMemoryEntries: %v", err)
+	}
+	if len(entriesAfter) != 0 {
+		t.Fatalf("migrated memory = %+v, want deleted native entry absent after reconstruction", entriesAfter)
+	}
+}
+
+func TestHandler_MigrateProjectsToCairnline_EmptySourcesVerifyAndSwap(t *testing.T) {
+	handler, client := newCairnlineMigrationHandler(t, config.Config{Server: config.ServerConfig{DataDir: t.TempDir()}})
+
+	resp := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if !resp.Data.Verified || !resp.Data.ParityMatch || resp.Data.ProjectCount != 0 {
+		t.Fatalf("empty migrate = %+v, want verified empty parity match", resp.Data)
+	}
+	dbPath := handler.cairnlineEmbeddedDatabasePath()
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("stat live db after empty migrate: %v", err)
+	}
+	service := openMigratedCairnlineService(t, dbPath)
+	projectsList, err := service.ListProjects(t.Context())
+	if err != nil {
+		t.Fatalf("ListProjects from empty migrated DB: %v", err)
+	}
+	if len(projectsList) != 0 {
+		t.Fatalf("migrated projects = %+v, want empty", projectsList)
+	}
+}
+
+func TestHandler_RollbackProjectsCairnlineMigration_RestoresBackupAndClearsRecord(t *testing.T) {
+	handler, client := newCairnlineMigrationHandler(t, config.Config{Server: config.ServerConfig{DataDir: t.TempDir()}})
+	seed := seedCairnlineMigrationProject(t, handler, client)
+
+	// Two migrations so a pre-migration backup exists to roll back to.
+	mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+
+	dbPath := handler.cairnlineEmbeddedDatabasePath()
+	backupPath := cairnlineMigrationBackupPath(dbPath)
+	if _, err := os.Stat(backupPath); err != nil {
+		t.Fatalf("expected backup before rollback: %v", err)
+	}
+
+	resp := mustRequestJSON[ProjectCairnlineMigrationRollbackResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate/rollback", "")
+	if resp.Object != "project_cairnline_migration_rollback" || !resp.Data.Restored || resp.Data.RestoredFrom != backupPath || resp.Data.Target != dbPath {
+		t.Fatalf("rollback = %+v, want restored from backup", resp)
+	}
+	if _, err := os.Stat(cairnlineMigrationRecordPath(dbPath)); !os.IsNotExist(err) {
+		t.Fatalf("migration record stat err = %v, want removed after rollback", err)
+	}
+	// The restored live database still contains the pre-migration content.
+	service := openMigratedCairnlineService(t, dbPath)
+	entries, err := service.ListMemoryEntries(t.Context(), seed.projectID, true)
+	if err != nil {
+		t.Fatalf("ListMemoryEntries from restored DB: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ID != seed.memoryID {
+		t.Fatalf("restored memory = %+v, want pre-migration content", entries)
+	}
+}
+
+func TestHandler_RollbackProjectsCairnlineMigration_NoBackupReportsNoOp(t *testing.T) {
+	handler, client := newCairnlineMigrationHandler(t, config.Config{Server: config.ServerConfig{DataDir: t.TempDir()}})
+	_ = handler
+
+	resp := mustRequestJSON[ProjectCairnlineMigrationRollbackResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate/rollback", "")
+	if resp.Data.Restored || resp.Data.Reason != "no_backup" {
+		t.Fatalf("rollback = %+v, want no-op with no_backup reason", resp.Data)
+	}
+}
+
+func TestHandler_MigrateProjectsToCairnline_BackendStatusReportsMigratedVerified(t *testing.T) {
+	handler, client := newCairnlineMigrationHandler(t, config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			Backend:             "memory",
+			CoordinationBackend: "cairnline",
+			CairnlineConnector:  "embedded",
+			CairnlineReadSource: "embedded",
+		},
+	})
+	seedCairnlineMigrationProject(t, handler, client)
+
+	migrate := mustRequestJSON[ProjectCairnlineMigrationResponse](client, http.MethodPost, "/hecate/v1/projects/cairnline/migrate", "")
+	if !migrate.Data.Verified {
+		t.Fatalf("migrate = %+v, want verified before checking backend status", migrate.Data)
+	}
+
+	status := handler.projectCoordinationBackendStatusWithContext(t.Context())
+	if status.MigrationCutover == nil || status.MigrationCutover.Status != "migrated_verified" || !status.MigrationCutover.Migrated || !status.MigrationCutover.Verified || !status.MigrationCutover.ParityMatch {
+		t.Fatalf("migration cutover = %+v, want migrated_verified", status.MigrationCutover)
+	}
+	if status.MigrationCutover.Endpoint != projectCairnlineMigrateURL || status.MigrationCutover.RollbackEndpoint != projectCairnlineMigrateRollbackURL {
+		t.Fatalf("migration cutover endpoints = %+v, want migrate + rollback urls", status.MigrationCutover)
+	}
+	if containsString(status.WriteAdapterGaps, "migration-cutover") {
+		t.Fatalf("write adapter gaps = %+v, want migration-cutover cleared after verified migration", status.WriteAdapterGaps)
+	}
+	if len(status.MigrationBlockers) != 0 {
+		t.Fatalf("migration blockers = %+v, want none after verified migration", status.MigrationBlockers)
+	}
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CairnlineState != "migrated_verified" || !point.LiveMirror {
+		t.Fatalf("migration switchpoint = %+v, want migrated_verified live-mirror state", point)
+	}
+}

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -307,11 +307,11 @@ var projectCairnlineWriteSwitchpoints = []ProjectCoordinationBackendWriteSwitchp
 	{
 		Name:             "migration-cutover",
 		CurrentAuthority: "hecate",
-		CairnlineState:   "snapshot_import_rehearsal_available",
+		CairnlineState:   "authoritative_migration_available",
 		BlocksAuthority:  true,
 		Seams:            []string{"sync-rehearsal"},
 		Gap:              "migration-cutover",
-		Detail:           "Snapshot import/export rehearsal and rollback notes exist, but no authoritative Cairnline storage cutover switch exists yet.",
+		Detail:           "One-way migration endpoint POST /hecate/v1/projects/cairnline/migrate rebuilds and verifies the embedded Cairnline store from native sources; run it to arm cutover.",
 	},
 }
 
@@ -396,17 +396,23 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 		response.OrchestratorCapabilities = projectCairnlineOrchestratorCapabilitiesSnapshot(writeAdapterGaps)
 		response.WriteAdapterReady = len(response.PortableWriteGaps) == 0
 		migrationCutoverArmed := replacementMode == "embedded" && strictEmbeddedReadGate.Ready && projectCairnlineMigrationRollbackEvidenceReady(migrationRehearsal) && len(response.PortableWriteGaps) == 0
-		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsAfterMigrationCutover(writeAdapterGaps, migrationCutoverArmed)
+		// A durable migration record moves migration-cutover from a declared gap
+		// to an implemented, evidenced capability independent of the armed
+		// replacement-mode heuristic.
+		migrationCutover := h.projectCairnlineMigrationCutoverStatus(h.cairnlineEmbeddedDatabasePath())
+		response.MigrationCutover = migrationCutover
+		migrationExecutedVerified := migrationCutover != nil && migrationCutover.Status == "migrated_verified"
+		response.WriteAdapterGaps = projectCairnlineWriteAdapterGapsAfterMigrationCutover(writeAdapterGaps, migrationCutoverArmed, migrationExecutedVerified)
 		nativeShadowSkipArmed := replacementMode == "embedded" && len(response.PortableWriteGaps) == 0
-		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority, nativeShadowSkipArmed, migrationCutoverArmed)
-		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps, migrationCutoverArmed)
-		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth)
+		response.WriteSwitchpoints = projectCairnlineWriteSwitchpointsSnapshot(effectiveWriteAuthority, nativeShadowSkipArmed, migrationCutoverArmed, migrationCutover)
+		response.MigrationBlockers = projectCairnlineMigrationBlockersSnapshot(response.WriteAdapterGaps, migrationCutoverArmed, migrationExecutedVerified)
+		response.ReplacementGates = projectCairnlineReplacementGates(readReady, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth, migrationCutover)
 		if !connectorReady {
 			if h.projectCairnlineSidecarReadRoutesEnabled() {
 				response.Status = "cairnline_sidecar_read_routes_ready"
 				response.Detail = "Cairnline sidecar is configured as the project read source, so " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " routes read through the persistent standalone Cairnline MCP client. Project writes and migration remain on Hecate-native stores or existing embedded dogfood paths."
 				response.ReadRoutes = append([]string(nil), projectCairnlineSidecarReadRouteNames...)
-				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth)
+				response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth, migrationCutover)
 				response.Warnings = []string{
 					"Only " + projectCairnlineReadRouteList(projectCairnlineSidecarReadRouteNames) + " use the Cairnline sidecar MCP client in this mode.",
 					projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
@@ -416,7 +422,7 @@ func (h *Handler) projectCoordinationBackendStatusWithContext(ctx context.Contex
 			}
 			response.Status = "cairnline_connector_not_ready"
 			response.Detail = projectCairnlineConnectorDetail(connector) + " Hecate keeps Projects reads and writes on Hecate-native stores in this mode; use HECATE_PROJECTS_CAIRNLINE_CONNECTOR=embedded for the current replacement-readiness dogfood path."
-			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth)
+			response.ReplacementGates = projectCairnlineReplacementGates(false, response.PortableWriteGaps, replacementMode, strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, mirrorWriteHealth, migrationCutover)
 			response.Warnings = []string{
 				projectCairnlineConnectorWarning(connector),
 				projectCairnlineSidecarWriteAuthorityWarning(writeAuthority),
@@ -841,7 +847,7 @@ func projectCairnlineWriteAuthorityValuesForGap(gap string) []string {
 	}
 }
 
-func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool, mirrorWriteHealth ProjectCairnlineMirrorWriteHealth) []ProjectCoordinationBackendReplacementGate {
+func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []string, replacementMode string, strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool, mirrorWriteHealth ProjectCairnlineMirrorWriteHealth, migrationCutover *ProjectCairnlineMigrationCutoverStatus) []ProjectCoordinationBackendReplacementGate {
 	if strings.TrimSpace(strictEmbeddedReadGate.ID) == "" {
 		strictEmbeddedReadGate = projectCairnlineStrictEmbeddedReadSmokeDefaultGate()
 	}
@@ -857,7 +863,7 @@ func projectCairnlineReplacementGates(readRoutesReady bool, portableWriteGaps []
 		strictEmbeddedReadGate,
 		writeGate,
 		projectCairnlineMirrorWriteHealthGate(mirrorWriteHealth),
-		projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed),
+		projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate, migrationRehearsal, migrationCutoverArmed, migrationCutover),
 		projectCairnlineReplacementModeGate(replacementMode),
 	}
 }
@@ -1039,8 +1045,23 @@ func projectCairnlineEmbeddedReplacementModeRehearsal(dbPath string, databaseExi
 	}
 }
 
-func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool) ProjectCoordinationBackendReplacementGate {
-	gate := ProjectCoordinationBackendReplacementGate{
+func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate ProjectCoordinationBackendReplacementGate, migrationRehearsal *ProjectCairnlineMigrationRehearsal, migrationCutoverArmed bool, migrationCutover *ProjectCairnlineMigrationCutoverStatus) (gate ProjectCoordinationBackendReplacementGate) {
+	migrationExecutedVerified := migrationCutover != nil && migrationCutover.Status == "migrated_verified"
+	// A verified authoritative migration is durable, executed evidence, so it
+	// enriches the gate detail at every exit without weakening the armed-mode
+	// readiness semantics.
+	if migrationExecutedVerified {
+		defer func() {
+			backup := strings.TrimSpace(migrationCutover.RollbackBackupPath)
+			note := " An authoritative one-way migration has been executed and verified with parity matched"
+			if backup != "" {
+				note += " and a rollback backup at " + backup
+			}
+			note += "."
+			gate.Detail = strings.TrimRight(gate.Detail, " ") + note
+		}()
+	}
+	gate = ProjectCoordinationBackendReplacementGate{
 		ID:        "migration-and-rollback",
 		Ready:     false,
 		Status:    "waiting_for_read_smoke",
@@ -1307,8 +1328,8 @@ func projectCairnlineOrchestratorCapabilitiesSnapshot(writeGaps []string) []stri
 	return out
 }
 
-func projectCairnlineMigrationBlockersSnapshot(writeGaps []string, migrationCutoverArmed bool) []string {
-	if migrationCutoverArmed {
+func projectCairnlineMigrationBlockersSnapshot(writeGaps []string, migrationCutoverArmed, migrationExecutedVerified bool) []string {
+	if migrationCutoverArmed || migrationExecutedVerified {
 		return nil
 	}
 	out := make([]string, 0, 1)
@@ -1320,8 +1341,8 @@ func projectCairnlineMigrationBlockersSnapshot(writeGaps []string, migrationCuto
 	return out
 }
 
-func projectCairnlineWriteAdapterGapsAfterMigrationCutover(writeGaps []string, migrationCutoverArmed bool) []string {
-	if !migrationCutoverArmed {
+func projectCairnlineWriteAdapterGapsAfterMigrationCutover(writeGaps []string, migrationCutoverArmed, migrationExecutedVerified bool) []string {
+	if !migrationCutoverArmed && !migrationExecutedVerified {
 		return append([]string(nil), writeGaps...)
 	}
 	out := make([]string, 0, len(writeGaps))
@@ -1334,8 +1355,10 @@ func projectCairnlineWriteAdapterGapsAfterMigrationCutover(writeGaps []string, m
 	return out
 }
 
-func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeShadowSkipArmed, migrationCutoverArmed bool) []ProjectCoordinationBackendWriteSwitchpoint {
+func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeShadowSkipArmed, migrationCutoverArmed bool, migrationCutover *ProjectCairnlineMigrationCutoverStatus) []ProjectCoordinationBackendWriteSwitchpoint {
 	out := make([]ProjectCoordinationBackendWriteSwitchpoint, 0, len(projectCairnlineWriteSwitchpoints))
+	migrationExecuted := migrationCutover != nil && migrationCutover.Migrated
+	migrationExecutedVerified := migrationCutover != nil && migrationCutover.Status == "migrated_verified"
 	projectMemoryAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, "project-memory")
 	memoryCandidatesAuthoritative := projectMemoryAuthoritative && projectCairnlineWriteAuthorityEnabled(writeAuthority, "memory-candidates")
 	projectCollaborationAuthoritative := projectCairnlineWriteAuthorityEnabled(writeAuthority, projectCairnlineWriteAuthorityProjectCollaboration)
@@ -1497,6 +1520,21 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			item.BlocksAuthority = false
 			item.Gap = ""
 			item.Detail = "Project memory-candidate create, promote, and reject mutations commit to the embedded Cairnline database first, validating project identity from Cairnline when no Hecate-native project row exists, then best-effort shadow review state and promoted-memory references back into Hecate-native stores for compatibility."
+		}
+		if item.Name == "migration-cutover" {
+			// The one-way migration endpoint exists, so the baseline reports the
+			// capability as available; a durable migration record upgrades the
+			// per-request state to reflect what has actually been executed. The
+			// armed-mode override below still wins when embedded replacement mode
+			// is armed.
+			item.Detail = "One-way migration endpoint POST /hecate/v1/projects/cairnline/migrate rebuilds and verifies the embedded Cairnline store from native sources; run it to arm cutover."
+			if migrationExecuted {
+				item.LiveMirror = true
+				item.Detail += " A verified authoritative migration has been executed with a rollback backup."
+			}
+			if migrationExecutedVerified {
+				item.CairnlineState = "migrated_verified"
+			}
 		}
 		if migrationCutoverArmed && item.Name == "migration-cutover" {
 			item.CurrentAuthority = "cairnline"

--- a/internal/api/handler_project_coordination_backend.go
+++ b/internal/api/handler_project_coordination_backend.go
@@ -1055,9 +1055,11 @@ func projectCairnlineMigrationRollbackReplacementGate(strictEmbeddedReadGate Pro
 			backup := strings.TrimSpace(migrationCutover.RollbackBackupPath)
 			note := " An authoritative one-way migration has been executed and verified with parity matched"
 			if backup != "" {
-				note += " and a rollback backup at " + backup
+				note += " and a rollback backup at " + backup + "."
+			} else {
+				// First migration with no prior embedded database: nothing was backed up.
+				note += "; no prior embedded store existed, so no rollback backup was created."
 			}
-			note += "."
 			gate.Detail = strings.TrimRight(gate.Detail, " ") + note
 		}()
 	}
@@ -1530,7 +1532,12 @@ func projectCairnlineWriteSwitchpointsSnapshot(writeAuthority []string, nativeSh
 			item.Detail = "One-way migration endpoint POST /hecate/v1/projects/cairnline/migrate rebuilds and verifies the embedded Cairnline store from native sources; run it to arm cutover."
 			if migrationExecuted {
 				item.LiveMirror = true
-				item.Detail += " A verified authoritative migration has been executed with a rollback backup."
+				if strings.TrimSpace(migrationCutover.RollbackBackupPath) != "" {
+					item.Detail += " A verified authoritative migration has been executed with a rollback backup."
+				} else {
+					// First migration with no prior embedded database: nothing was backed up.
+					item.Detail += " A verified authoritative migration has been executed; no prior embedded store existed, so no rollback backup was created."
+				}
 			}
 			if migrationExecutedVerified {
 				item.CairnlineState = "migrated_verified"

--- a/internal/api/handler_project_coordination_backend_test.go
+++ b/internal/api/handler_project_coordination_backend_test.go
@@ -388,8 +388,8 @@ func TestProjectCoordinationBackendStatus_CairnlineConfiguredReadRoutesReady(t *
 	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "memory-candidates"); point == nil || !strings.Contains(point.Detail, "create/promote/reject still commits") || strings.Contains(point.Detail, "delete") {
 		t.Fatalf("memory-candidates switchpoint = %+v, want live Hecate API surface limited to create/promote/reject", point)
 	}
-	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "snapshot_import_rehearsal_available" || point.LiveMirror || !point.BlocksAuthority || point.Gap != "migration-cutover" || !containsString(point.Seams, "sync-rehearsal") {
-		t.Fatalf("migration switchpoint = %+v, want snapshot-import rehearsal blocker", point)
+	if point := findWriteSwitchpoint(status.WriteSwitchpoints, "migration-cutover"); point == nil || point.CurrentAuthority != "hecate" || point.CairnlineState != "authoritative_migration_available" || point.LiveMirror || !point.BlocksAuthority || point.Gap != "migration-cutover" || !containsString(point.Seams, "sync-rehearsal") {
+		t.Fatalf("migration switchpoint = %+v, want authoritative migration available blocker", point)
 	}
 	if status.SyncReadinessURL != projectCoordinationBackendSyncReadinessURL {
 		t.Fatalf("sync readiness URL = %q, want %q", status.SyncReadinessURL, projectCoordinationBackendSyncReadinessURL)
@@ -1238,13 +1238,13 @@ func TestProjectCoordinationBackendStatus_WriteAuthorityGateUsesPortableGaps(t *
 
 func TestProjectCoordinationBackendStatus_MigrationRollbackGateRequiresRehearsalEvidence(t *testing.T) {
 	strictGate := ProjectCoordinationBackendReplacementGate{ID: "strict-embedded-read-smoke", Ready: true, Status: "verified"}
-	gate := projectCairnlineMigrationRollbackReplacementGate(strictGate, nil, false)
+	gate := projectCairnlineMigrationRollbackReplacementGate(strictGate, nil, false, nil)
 	if gate.Ready || gate.Status != "rehearsal_incomplete" || !strings.Contains(gate.Detail, "does not include migration or replacement smoke") {
 		t.Fatalf("migration gate = %+v, want missing rehearsal evidence blocker", gate)
 	}
 
 	rehearsal := projectCairnlineMigrationRehearsal("mirror_parity", true, true, nil)
-	gate = projectCairnlineMigrationRollbackReplacementGate(strictGate, &rehearsal, true)
+	gate = projectCairnlineMigrationRollbackReplacementGate(strictGate, &rehearsal, true, nil)
 	if gate.Ready || gate.Status != "rehearsal_incomplete" || !strings.Contains(gate.Detail, "strict-embedded-read-smoke") {
 		t.Fatalf("migration gate = %+v, want incomplete smoke evidence to block even when replacement mode is armed", gate)
 	}
@@ -1475,8 +1475,8 @@ func TestProjectCoordinationBackendStatusRoute(t *testing.T) {
 		t.Fatalf("response next action config block = %q, want write-authority env assignment", response.Data.NextReplacementAction.ConfigBlock)
 	}
 	migrationSwitchpoint := findWriteSwitchpoint(response.Data.WriteSwitchpoints, "migration-cutover")
-	if migrationSwitchpoint == nil || migrationSwitchpoint.CairnlineState != "snapshot_import_rehearsal_available" || !containsString(migrationSwitchpoint.Seams, "sync-rehearsal") {
-		t.Fatalf("response migration switchpoint = %+v, want snapshot-import rehearsal blocker", migrationSwitchpoint)
+	if migrationSwitchpoint == nil || migrationSwitchpoint.CairnlineState != "authoritative_migration_available" || !containsString(migrationSwitchpoint.Seams, "sync-rehearsal") {
+		t.Fatalf("response migration switchpoint = %+v, want authoritative migration available blocker", migrationSwitchpoint)
 	}
 	if findReplacementGate(response.Data.ReplacementGates, "write-authority-switchpoints") == nil || findWriteSwitchpoint(response.Data.WriteSwitchpoints, "project-assistant-proposal-ledger") == nil || findWriteSwitchpoint(response.Data.WriteSwitchpoints, "project-assistant-apply-side-effects") == nil {
 		t.Fatalf("response gates/switchpoints = %+v / %+v, want structured replacement blockers", response.Data.ReplacementGates, response.Data.WriteSwitchpoints)

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hecatehq/cairnline"
 	"github.com/hecatehq/hecate/internal/agentcontrols"
@@ -618,6 +619,7 @@ type ProjectCoordinationBackendStatusResponse struct {
 	SyncReadinessURL                     string                                       `json:"sync_readiness_url,omitempty"`
 	MirrorParityURL                      string                                       `json:"mirror_parity_url,omitempty"`
 	MirrorWriteHealth                    ProjectCairnlineMirrorWriteHealth            `json:"mirror_write_health"`
+	MigrationCutover                     *ProjectCairnlineMigrationCutoverStatus      `json:"migration_cutover,omitempty"`
 }
 
 type ProjectCoordinationBackendNextAction struct {
@@ -660,6 +662,49 @@ type ProjectCoordinationBackendWriteSwitchpoint struct {
 	Seams            []string `json:"seams,omitempty"`
 	Gap              string   `json:"gap,omitempty"`
 	Detail           string   `json:"detail"`
+}
+
+type ProjectCairnlineMigrationResponse struct {
+	Object string                          `json:"object"`
+	Data   ProjectCairnlineMigrationReport `json:"data"`
+}
+
+type ProjectCairnlineMigrationReport struct {
+	Object             string                                    `json:"object"`
+	MigratedAt         time.Time                                 `json:"migrated_at"`
+	Verified           bool                                      `json:"verified"`
+	ParityMatch        bool                                      `json:"parity_match"`
+	Target             string                                    `json:"target"`
+	SourceAuthority    []string                                  `json:"source_authority"`
+	RollbackBackupPath string                                    `json:"rollback_backup_path,omitempty"`
+	ProjectCount       int                                       `json:"project_count"`
+	Checklist          []ProjectCairnlineMigrationRehearsalCheck `json:"checklist"`
+	Rollback           []string                                  `json:"rollback"`
+	Parity             ProjectCairnlineSyncResponseItem          `json:"parity"`
+}
+
+type ProjectCairnlineMigrationRollbackResponse struct {
+	Object string                                  `json:"object"`
+	Data   ProjectCairnlineMigrationRollbackResult `json:"data"`
+}
+
+type ProjectCairnlineMigrationRollbackResult struct {
+	Restored     bool   `json:"restored"`
+	Reason       string `json:"reason,omitempty"`
+	RestoredFrom string `json:"restored_from,omitempty"`
+	Target       string `json:"target"`
+}
+
+type ProjectCairnlineMigrationCutoverStatus struct {
+	Status             string     `json:"status"`
+	Endpoint           string     `json:"endpoint"`
+	RollbackEndpoint   string     `json:"rollback_endpoint"`
+	Migrated           bool       `json:"migrated"`
+	Verified           bool       `json:"verified"`
+	ParityMatch        bool       `json:"parity_match"`
+	MigratedAt         *time.Time `json:"migrated_at,omitempty"`
+	RollbackBackupPath string     `json:"rollback_backup_path,omitempty"`
+	SourceAuthority    []string   `json:"source_authority,omitempty"`
 }
 
 type AgentPresetResponse struct {

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -680,6 +680,7 @@ type ProjectCairnlineMigrationReport struct {
 	ProjectCount       int                                       `json:"project_count"`
 	Checklist          []ProjectCairnlineMigrationRehearsalCheck `json:"checklist"`
 	Rollback           []string                                  `json:"rollback"`
+	VerificationNotes  []string                                  `json:"verification_notes,omitempty"`
 	Parity             ProjectCairnlineSyncResponseItem          `json:"parity"`
 }
 

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -39,6 +39,8 @@ var remoteRuntimeLocalOnlyRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-write-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sidecar-work-smoke"},
 	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/sync"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/migrate"},
+	{method: http.MethodPost, path: "/hecate/v1/projects/cairnline/migrate/rollback"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/parity-report"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/read-model"},
 	{method: http.MethodGet, path: "/hecate/v1/projects/{id}/cairnline/embedded-read-model"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -99,6 +99,8 @@ func registerHecateProjectRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-work-smoke", handler.HandleProjectCairnlineSidecarWorkSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sidecar-collaboration-smoke", handler.HandleProjectCairnlineSidecarCollaborationSmoke)
 	mux.HandleFunc("POST /hecate/v1/projects/cairnline/sync", handler.HandleSyncProjectsToCairnline)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/migrate", handler.HandleMigrateProjectsToCairnline)
+	mux.HandleFunc("POST /hecate/v1/projects/cairnline/migrate/rollback", handler.HandleRollbackProjectsCairnlineMigration)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/parity-report", handler.HandleProjectCairnlineParityReport)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/read-model", handler.HandleProjectCairnlineReadModel)
 	mux.HandleFunc("GET /hecate/v1/projects/{id}/cairnline/embedded-read-model", handler.HandleProjectCairnlineEmbeddedReadModel)


### PR DESCRIPTION
## Summary

**Before:** arming Cairnline replacement mode had no production-grade way to move existing Hecate-native project history into an authoritative Cairnline store. The only path was `POST /hecate/v1/projects/cairnline/sync`, a full-refresh delete-and-reseed rehearsal that wipes the live embedded DB in place and imports additively, so deletions never propagate. `migration-cutover` was a declared gap in the coordination backend.

**After:** operators can run an authoritative one-way migration that rebuilds the embedded Cairnline store from native sources, verifies parity across every write family *before* touching the live DB, backs it up, then atomically swaps it in. `migration-cutover` moves from declared-gap to implemented and is surfaced in backend status.

New surface:
- `POST /hecate/v1/projects/cairnline/migrate` — staged rebuild -> verify (count + record-ID set + content-digest parity + strict embedded read smoke) -> back up the live embedded DB -> atomic swap. Always returns 200; a `verified:false` report carries the parity diffs and leaves the live DB untouched.
- `POST /hecate/v1/projects/cairnline/migrate/rollback` — restores the most recent pre-migration backup (path recorded in the migration record) and clears the record.
- `GET /hecate/v1/projects/backend-status` now includes a `migration_cutover` object.

## Deletion-faithful by reconstruction

Cairnline's embedded store only upserts on import, and 5 of the 14 Cairnline record types have no delete API (skills, artifacts, evidence, reviews, assistant-proposals — the 14 come from collaboration splitting into artifacts, evidence, and reviews; artifacts/evidence/reviews are contractually immutable). So an incremental per-record delete-reconcile can't be fully faithful. Instead the target is rebuilt purely from the current native snapshot: anything deleted natively — an absent row, since Hecate keeps no tombstones — is simply never written, so deletions propagate across all 12 portable write families. Re-running converges to the same verified state (idempotent).

Verification covers every family by count, record-ID set, and content digest, plus a strict embedded read smoke. The content-digest comparison excludes timestamp fields and compares the record-ID intersection; additions and deletions are covered by the record-ID-set layer. These exclusions are stated in the report's `verification_notes`.

## Crash-safe swap

The live embedded DB is never left absent during cutover. The swap copies the live DB (and any WAL/SHM sidecars) to a timestamped backup while leaving the live file in place, fsyncs the backup and directory, then performs a single atomic `rename(staging, live)` that replaces the destination in one syscall, followed by a directory fsync. A crash at any point leaves either the original or the fully-swapped store on disk — never an empty or half-written one. Backups are timestamped generations (`projects.db.pre-migration-<utc>.bak`), so re-migrating never clobbers an earlier backup; older generations remain on disk for manual recovery.

## How

- `internal/api/handler_project_cairnline_migrate.go`: the two handlers, the crash-safe copy/fsync/atomic-rename swap helper (factored so a test can inject a pre-rename crash), timestamped backups, and a durable `migration.json` record written beside the embedded DB. That record is embedded-runtime-local operational metadata (like the embedded `projects.db` itself) and is deliberately not routed through the memory/sqlite/postgres tiers. Verification reuses the existing `projectCairnlineServiceParity` oracle; seeding reuses `cairnlinebridge.SeedSnapshots`.
- `internal/api/handler_project_coordination_backend.go`: reads the migration record into a `MigrationCutover` status; the `migration-cutover` write-adapter gap clears once a verified migration is executed (not only when armed); the `migration-cutover` switchpoint and the `migration-and-rollback` replacement gate reflect the executed+verified migration, mentioning the rollback backup only when one was created.
- Routes registered in `server.go`, classified local-only in `remote_runtime_policy.go` (they mutate the local embedded store and filesystem), and traced with OTel spans.
- Runtime invariants preserved: native stores stay the untouched source of truth until the operator flips authority; structured execution_ref / awaiting_approval fidelity flows through the existing bridge mappers; timestamps stored UTC.

## Rollback / disarm

Native stores remain authoritative until authority is flipped, so returning is lossless: unset `HECATE_PROJECTS_CAIRNLINE_REPLACEMENT_MODE` (and/or `HECATE_PROJECTS_CAIRNLINE_WRITE_AUTHORITY`) to fall reads/writes back to native, and/or POST the rollback endpoint to restore the most recent pre-migration backup and discard the migrated embedded store.

## Tests

- Unit/handler (`handler_project_cairnline_migrate_test.go`): happy path, idempotency, deletion-faithfulness, crash-safety (injected failure before rename leaves the original store intact), timestamped-backup generations with latest-generation rollback, and backend-status reflecting the migrated/verified state.
- E2E (`e2e/cairnline_migration_test.go`, `TestE2E_CairnlineMigrationCutover`): seed native stores -> migrate -> parity-verify -> idempotency -> deletion-faithfulness -> rollback, against the real binary. Passes.
- `go vet ./...` clean; `go test -race ./...` green apart from the 3 known container-noise sandbox/workspace failures.

## Docs

Updated `docs/operator/projects.md` (cutover + rollback procedure, timestamped backups, parity exclusions), the design proposal `docs/design/proposals/cairnline-portable-project-coordination.md` (cutover now implemented, crash-safe swap), and `docs/runtime/runtime-api.md` (the two new endpoints + `migration_cutover` field).