### PR TITLE
feat(settings): add Cairnline migration controls

### DIFF
--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -228,6 +228,16 @@ rehearsal above: `sync` refreshes the live mirror in place, while migrate stages
 a rebuild, verifies it, backs up the live database, and only then swaps it into
 place.
 
+Use **Settings -> Project coordination -> Migration cutover** for the operator
+flow. The panel appears when the Cairnline backend advertises the migration
+contract, shows whether a verified migration is recorded, and requires typing
+`MIGRATE` before it calls the migration endpoint. After a migration with a
+recorded pre-migration database, the same panel exposes **Restore backup** and
+requires typing `ROLLBACK`. Both actions refresh backend status. A migration
+whose verification report fails is shown as failed and leaves the live
+Cairnline database unchanged. Migration and rollback do not edit environment
+configuration or arm/disarm replacement mode.
+
 - `POST /hecate/v1/projects/cairnline/migrate` executes the cutover as a staged
   **rebuild -> verify -> backup -> atomic swap**. It rebuilds the migration
   target in a `projects.db.migrating` staging file, verifies it against the

--- a/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
+++ b/ui/src/features/settings/ProjectCoordinationBackendSettings.tsx
@@ -12,12 +12,20 @@ import { SettingsSectionHeader as SectionHeader } from "./SettingsSectionHeader"
 export function ProjectCoordinationBackendSettings({
   error,
   loading,
+  migrationError,
+  migrationPending,
+  onMigrate,
   onRefresh,
+  onRollback,
   status,
 }: {
   error: string;
   loading: boolean;
+  migrationError: string;
+  migrationPending: "migrate" | "rollback" | null;
+  onMigrate: () => void;
   onRefresh: () => void;
+  onRollback: () => void;
   status: ProjectCoordinationBackendStatusRecord | null;
 }) {
   const readRoutes = status?.read_routes ?? [];
@@ -114,6 +122,13 @@ export function ProjectCoordinationBackendSettings({
             </div>
           </div>
           {nextAction && <ProjectBackendNextAction action={nextAction} />}
+          <ProjectBackendMigrationCutover
+            error={migrationError}
+            pending={migrationPending}
+            status={status}
+            onMigrate={onMigrate}
+            onRollback={onRollback}
+          />
           {replacementGates.length > 0 && <ProjectBackendGateList gates={replacementGates} />}
           {migrationRehearsal && (
             <ProjectBackendMigrationRehearsal rehearsal={migrationRehearsal} />
@@ -149,6 +164,118 @@ export function ProjectCoordinationBackendSettings({
         </article>
       )}
     </section>
+  );
+}
+
+function ProjectBackendMigrationCutover({
+  error,
+  onMigrate,
+  onRollback,
+  pending,
+  status,
+}: {
+  error: string;
+  onMigrate: () => void;
+  onRollback: () => void;
+  pending: "migrate" | "rollback" | null;
+  status: ProjectCoordinationBackendStatusRecord;
+}) {
+  const cutover = status.migration_cutover;
+  if (!cutover) return null;
+
+  const canMigrate = !status.cairnline_authoritative;
+  const canRollback = cutover.migrated && Boolean(cutover.rollback_backup_path);
+  return (
+    <div style={{ display: "grid", gap: 8, marginTop: 14 }}>
+      <div
+        style={{
+          color: "var(--t3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        Migration cutover
+      </div>
+      <div
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius-sm)",
+          display: "grid",
+          gap: 9,
+          padding: "10px 12px",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 7, flexWrap: "wrap" }}>
+          <span
+            className={
+              cutover.migrated && cutover.verified && cutover.parity_match
+                ? "badge badge-green"
+                : "badge badge-muted"
+            }
+            style={{ textTransform: "none" }}
+          >
+            {projectBackendDisplayLabel(cutover.status)}
+          </span>
+          <span style={{ color: "var(--t0)", fontSize: 12, fontWeight: 650 }}>
+            {cutover.migrated ? "Migration recorded" : "Native Projects ready to migrate"}
+          </span>
+          {cutover.migrated_at && (
+            <span className="badge badge-muted" style={{ textTransform: "none" }}>
+              {new Date(cutover.migrated_at).toLocaleString()}
+            </span>
+          )}
+        </div>
+        <div style={{ color: "var(--t2)", fontSize: 11, lineHeight: 1.45 }}>
+          {cutover.migrated
+            ? "The embedded Cairnline database was rebuilt from Hecate's native project stores and passed migration verification."
+            : "Build and verify a staged Cairnline database, preserve the current live database when present, then atomically replace it only after every parity check passes."}
+        </div>
+        {(cutover.source_authority?.length ?? 0) > 0 && (
+          <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
+            {cutover.source_authority?.map((source) => (
+              <span key={source} className="badge badge-muted" style={{ textTransform: "none" }}>
+                {projectBackendDisplayLabel(source)}
+              </span>
+            ))}
+          </div>
+        )}
+        {cutover.migrated && !cutover.rollback_backup_path && (
+          <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.45 }}>
+            No pre-migration Cairnline database existed, so there is no database backup to restore.
+            Hecate's native project stores remain the recovery source until replacement mode is
+            armed.
+          </div>
+        )}
+        {error && <InlineError message={error} />}
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {canMigrate && (
+            <button
+              className="btn btn-primary btn-sm"
+              disabled={pending !== null}
+              onClick={onMigrate}
+            >
+              <Icon d={Icons.refresh} size={13} />
+              {pending === "migrate"
+                ? "Migrating…"
+                : cutover.migrated
+                  ? "Re-run migration"
+                  : "Migrate to Cairnline"}
+            </button>
+          )}
+          {canRollback && (
+            <button
+              className="btn btn-danger btn-sm"
+              disabled={pending !== null}
+              onClick={onRollback}
+            >
+              <Icon d={Icons.revert} size={13} />
+              {pending === "rollback" ? "Restoring…" : "Restore backup"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -2,7 +2,13 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getPlugins, getProjectCoordinationBackendStatus, resetSystemData } from "../../lib/api";
+import {
+  getPlugins,
+  getProjectCoordinationBackendStatus,
+  migrateProjectsToCairnline,
+  resetSystemData,
+  rollbackProjectsCairnlineMigration,
+} from "../../lib/api";
 import { ConnectionsPanel } from "../connections/ConnectionsPanel";
 import { SettingsView } from "./SettingsView";
 import {
@@ -15,7 +21,9 @@ vi.mock("../../lib/api", async (importOriginal) => ({
   ...((await importOriginal()) as Record<string, unknown>),
   getPlugins: vi.fn(),
   getProjectCoordinationBackendStatus: vi.fn(),
+  migrateProjectsToCairnline: vi.fn(),
   resetSystemData: vi.fn(),
+  rollbackProjectsCairnlineMigration: vi.fn(),
 }));
 
 function setup(stateOverrides = {}, actionOverrides = {}) {
@@ -31,6 +39,44 @@ function capability(id: string, name: string, status = "supported") {
     name,
     status,
     description: `${name} support`,
+  };
+}
+
+function migrationBackendStatus(migrationCutover: {
+  status: string;
+  endpoint: string;
+  rollback_endpoint: string;
+  migrated: boolean;
+  verified: boolean;
+  parity_match: boolean;
+  migrated_at?: string;
+  rollback_backup_path?: string;
+  source_authority?: string[];
+}) {
+  return {
+    object: "project_coordination_backend_status",
+    data: {
+      configured_backend: "cairnline",
+      authoritative_backend: "hecate",
+      storage_backend: "sqlite",
+      cairnline_connector: "embedded",
+      cairnline_connector_ready: true,
+      cairnline_read_source: "embedded",
+      cairnline_bridge_ready: true,
+      cairnline_authoritative: false,
+      read_model_switch_ready: true,
+      write_adapter_ready: true,
+      replacement_ready: false,
+      replacement_mode: "disabled",
+      replacement_mode_armed: false,
+      read_routes: ["project-list"],
+      portable_write_gaps: [],
+      orchestrator_capabilities: ["assignment-start"],
+      migration_blockers: ["migration-cutover"],
+      migration_cutover: migrationCutover,
+      status: "cairnline_read_routes_ready",
+      detail: "Cairnline migration is ready for operator review.",
+    },
   };
 }
 
@@ -65,6 +111,8 @@ beforeEach(() => {
       },
     },
   });
+  vi.mocked(migrateProjectsToCairnline).mockReset();
+  vi.mocked(rollbackProjectsCairnlineMigration).mockReset();
   vi.mocked(resetSystemData).mockReset();
   sessionStorage.removeItem("hecate.settingsFocus");
   sessionStorage.removeItem("hecate.connectionsFocus");
@@ -537,6 +585,121 @@ describe("SettingsView", () => {
     expect(screen.getByText(/Hecate still owns runtime\/workspace side effects/i)).toBeTruthy();
     expect(screen.getByText(/Remaining Hecate-owned orchestrator capabilities/i)).toBeTruthy();
     expect(screen.getByText("Monitor Cairnline backend")).toBeTruthy();
+  });
+
+  it("migrates and restores the embedded Cairnline database with typed confirmation", async () => {
+    const notMigrated = migrationBackendStatus({
+      status: "not_migrated",
+      endpoint: "/hecate/v1/projects/cairnline/migrate",
+      rollback_endpoint: "/hecate/v1/projects/cairnline/migrate/rollback",
+      migrated: false,
+      verified: false,
+      parity_match: false,
+    });
+    const migrated = migrationBackendStatus({
+      status: "migrated_verified",
+      endpoint: "/hecate/v1/projects/cairnline/migrate",
+      rollback_endpoint: "/hecate/v1/projects/cairnline/migrate/rollback",
+      migrated: true,
+      verified: true,
+      parity_match: true,
+      migrated_at: "2026-07-09T12:00:00Z",
+      rollback_backup_path: "/tmp/projects.db.pre-migration.bak",
+      source_authority: ["hecate_native_stores"],
+    });
+    vi.mocked(getProjectCoordinationBackendStatus).mockReset();
+    vi.mocked(getProjectCoordinationBackendStatus)
+      .mockResolvedValueOnce(notMigrated)
+      .mockResolvedValueOnce(migrated)
+      .mockResolvedValueOnce(notMigrated);
+    vi.mocked(migrateProjectsToCairnline).mockResolvedValue({
+      object: "project_cairnline_migration",
+      data: {
+        object: "project_cairnline_migration_report",
+        migrated_at: "2026-07-09T12:00:00Z",
+        verified: true,
+        parity_match: true,
+        target: "/tmp/projects.db",
+        source_authority: ["hecate_native_stores"],
+        rollback_backup_path: "/tmp/projects.db.pre-migration.bak",
+        project_count: 2,
+        checklist: [],
+        rollback: [],
+        parity: {},
+      },
+    });
+    vi.mocked(rollbackProjectsCairnlineMigration).mockResolvedValue({
+      object: "project_cairnline_migration_rollback",
+      data: {
+        restored: true,
+        restored_from: "/tmp/projects.db.pre-migration.bak",
+        target: "/tmp/projects.db",
+      },
+    });
+    const { state, actions, user } = setup();
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
+
+    await user.click(await screen.findByRole("button", { name: "Migrate to Cairnline" }));
+    const migrateConfirm = screen.getByRole("button", { name: "Migrate and verify" });
+    expect(migrateConfirm).toBeDisabled();
+    await user.type(screen.getByLabelText("Type MIGRATE to continue"), "MIGRATE");
+    await user.click(migrateConfirm);
+
+    await waitFor(() => expect(migrateProjectsToCairnline).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("Migration recorded")).toBeTruthy();
+    expect(getProjectCoordinationBackendStatus).toHaveBeenCalledTimes(2);
+
+    await user.click(screen.getByRole("button", { name: "Restore backup" }));
+    const rollbackConfirm = within(screen.getByRole("dialog")).getByRole("button", {
+      name: "Restore backup",
+    });
+    expect(rollbackConfirm).toBeDisabled();
+    await user.type(screen.getByLabelText("Type ROLLBACK to continue"), "ROLLBACK");
+    await user.click(rollbackConfirm);
+
+    await waitFor(() => expect(rollbackProjectsCairnlineMigration).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("Native Projects ready to migrate")).toBeTruthy();
+    expect(getProjectCoordinationBackendStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports a migration verification failure without claiming success", async () => {
+    const status = migrationBackendStatus({
+      status: "not_migrated",
+      endpoint: "/hecate/v1/projects/cairnline/migrate",
+      rollback_endpoint: "/hecate/v1/projects/cairnline/migrate/rollback",
+      migrated: false,
+      verified: false,
+      parity_match: false,
+    });
+    vi.mocked(getProjectCoordinationBackendStatus).mockReset();
+    vi.mocked(getProjectCoordinationBackendStatus).mockResolvedValue(status);
+    vi.mocked(migrateProjectsToCairnline).mockResolvedValue({
+      object: "project_cairnline_migration",
+      data: {
+        object: "project_cairnline_migration_report",
+        migrated_at: "2026-07-09T12:00:00Z",
+        verified: false,
+        parity_match: false,
+        target: "/tmp/projects.db",
+        source_authority: ["hecate_native_stores"],
+        project_count: 2,
+        checklist: [],
+        rollback: [],
+        parity: {},
+      },
+    });
+    const { state, actions, user } = setup();
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
+
+    await user.click(await screen.findByRole("button", { name: "Migrate to Cairnline" }));
+    await user.type(screen.getByLabelText("Type MIGRATE to continue"), "MIGRATE");
+    await user.click(screen.getByRole("button", { name: "Migrate and verify" }));
+
+    await waitFor(() => expect(migrateProjectsToCairnline).toHaveBeenCalledTimes(1));
+    expect(
+      (await screen.findAllByText(/live Cairnline database was left unchanged/i)).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("Migration recorded")).toBeNull();
   });
 
   it("shows project backend load failures without hiding maintenance", async () => {

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -3,7 +3,13 @@ import { useRetention, type RetentionState } from "../../app/state/retention";
 import { useRetentionActions } from "../../app/state/coordinators/retention";
 import { useWiredDashboardActions } from "../../app/state/coordinators/wired";
 import { useSettings } from "../../app/state/settings";
-import { getPlugins, getProjectCoordinationBackendStatus, resetSystemData } from "../../lib/api";
+import {
+  getPlugins,
+  getProjectCoordinationBackendStatus,
+  migrateProjectsToCairnline,
+  resetSystemData,
+  rollbackProjectsCairnlineMigration,
+} from "../../lib/api";
 import type { PluginRecord } from "../../types/plugin";
 import type { ProjectCoordinationBackendStatusRecord } from "../../types/project";
 import { Badge, ConfirmModal, Icon, Icons, InlineError } from "../shared/ui";
@@ -31,6 +37,14 @@ export function SettingsView() {
     useState<ProjectCoordinationBackendStatusRecord | null>(null);
   const [projectBackendLoading, setProjectBackendLoading] = useState(false);
   const [projectBackendError, setProjectBackendError] = useState("");
+  const [projectMigrationAction, setProjectMigrationAction] = useState<
+    "migrate" | "rollback" | null
+  >(null);
+  const [projectMigrationConfirmation, setProjectMigrationConfirmation] = useState("");
+  const [projectMigrationPending, setProjectMigrationPending] = useState<
+    "migrate" | "rollback" | null
+  >(null);
+  const [projectMigrationError, setProjectMigrationError] = useState("");
   // Retention runs aren't in the boot-time dashboard snapshot —
   // fetch on first SettingsView mount so the user doesn't see a
   // permanently empty list. `loadRuns` is a stable useCallback, so
@@ -76,6 +90,65 @@ export function SettingsView() {
     }
   }
 
+  function openProjectMigrationAction(action: "migrate" | "rollback") {
+    setProjectMigrationAction(action);
+    setProjectMigrationConfirmation("");
+    setProjectMigrationError("");
+  }
+
+  async function handleProjectMigrationAction() {
+    const action = projectMigrationAction;
+    if (!action) return;
+    const confirmation = action === "migrate" ? "MIGRATE" : "ROLLBACK";
+    if (projectMigrationConfirmation !== confirmation) return;
+
+    setProjectMigrationPending(action);
+    setProjectMigrationError("");
+    settings.actions.setNotice(null);
+    try {
+      if (action === "migrate") {
+        const response = await migrateProjectsToCairnline();
+        if (!response.data.verified || !response.data.parity_match) {
+          const message =
+            "Cairnline migration verification did not pass. The live Cairnline database was left unchanged.";
+          setProjectMigrationError(message);
+          settings.actions.setNotice({ kind: "error", message });
+        } else {
+          settings.actions.setNotice({
+            kind: "success",
+            message: `Migrated ${response.data.project_count} project${response.data.project_count === 1 ? "" : "s"} to the verified Cairnline database.`,
+          });
+        }
+      } else {
+        const response = await rollbackProjectsCairnlineMigration();
+        if (!response.data.restored) {
+          const message =
+            response.data.reason === "no_backup"
+              ? "No recorded pre-migration Cairnline backup is available to restore."
+              : "The pre-migration Cairnline backup was not restored.";
+          setProjectMigrationError(message);
+          settings.actions.setNotice({ kind: "error", message });
+        } else {
+          settings.actions.setNotice({
+            kind: "success",
+            message:
+              "Restored the pre-migration Cairnline database. Runtime configuration was not changed.",
+          });
+        }
+      }
+      setProjectMigrationAction(null);
+      setProjectMigrationConfirmation("");
+      await loadProjectBackendStatus();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : `Failed to ${action} the Cairnline project database.`;
+      setProjectMigrationError(message);
+      settings.actions.setNotice({ kind: "error", message });
+    } finally {
+      setProjectMigrationPending(null);
+    }
+  }
+
   async function handleResetData() {
     if (resetConfirmation !== "RESET") return;
     setResetPending(true);
@@ -105,8 +178,12 @@ export function SettingsView() {
         <ProjectCoordinationBackendSettings
           error={projectBackendError}
           loading={projectBackendLoading}
+          migrationError={projectMigrationError}
+          migrationPending={projectMigrationPending}
           status={projectBackendStatus}
+          onMigrate={() => openProjectMigrationAction("migrate")}
           onRefresh={() => void loadProjectBackendStatus()}
+          onRollback={() => openProjectMigrationAction("rollback")}
         />
         <PluginRegistrySettings
           error={pluginsError}
@@ -163,6 +240,56 @@ export function SettingsView() {
                 />
               </label>
               {resetError && <InlineError message={resetError} />}
+            </div>
+          }
+        />
+      )}
+      {projectMigrationAction && (
+        <ConfirmModal
+          title={
+            projectMigrationAction === "migrate"
+              ? "Migrate Projects to Cairnline"
+              : "Restore Cairnline backup"
+          }
+          danger={projectMigrationAction === "rollback"}
+          pending={projectMigrationPending === projectMigrationAction}
+          confirmDisabled={
+            projectMigrationConfirmation !==
+            (projectMigrationAction === "migrate" ? "MIGRATE" : "ROLLBACK")
+          }
+          confirmLabel={
+            projectMigrationAction === "migrate" ? "Migrate and verify" : "Restore backup"
+          }
+          onClose={() => {
+            if (!projectMigrationPending) {
+              setProjectMigrationAction(null);
+              setProjectMigrationConfirmation("");
+            }
+          }}
+          onConfirm={handleProjectMigrationAction}
+          message={
+            <div style={{ display: "grid", gap: 12 }}>
+              <div>
+                {projectMigrationAction === "migrate"
+                  ? "Hecate will rebuild a staged Cairnline database from native project stores, verify parity, preserve the current Cairnline database when present, and replace it only after every check passes. This does not change runtime configuration."
+                  : "Hecate will replace the live Cairnline database with the backup recorded by the latest migration and remove that migration record. This does not switch runtime configuration back to Hecate."}
+              </div>
+              <label
+                htmlFor="project-migration-confirmation"
+                style={{ display: "grid", gap: 6, color: "var(--t2)" }}
+              >
+                Type {projectMigrationAction === "migrate" ? "MIGRATE" : "ROLLBACK"} to continue
+                <input
+                  id="project-migration-confirmation"
+                  className="input"
+                  autoComplete="off"
+                  autoFocus
+                  disabled={projectMigrationPending !== null}
+                  value={projectMigrationConfirmation}
+                  onChange={(event) => setProjectMigrationConfirmation(event.target.value)}
+                />
+              </label>
+              {projectMigrationError && <InlineError message={projectMigrationError} />}
             </div>
           }
         />

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -59,6 +59,7 @@ import {
   listChatGrants,
   listChatMessageFiles,
   logoutAgentAdapter,
+  migrateProjectsToCairnline,
   openWorkspaceTargetViaAPI,
   probeAgentAdapter,
   promoteProjectMemoryCandidate,
@@ -66,6 +67,7 @@ import {
   revertChatMessageFiles,
   revertChatWorkspaceFiles,
   resolveChatApproval,
+  rollbackProjectsCairnlineMigration,
   setChatSettings,
   setProviderAPIKey,
   setProviderBaseURL,
@@ -129,6 +131,34 @@ describe("api client", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "/hecate/v1/usage/events?limit=7",
       expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("runs project migration and rollback through local operator routes", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          object: "project_cairnline_migration",
+          data: { verified: true, parity_match: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          object: "project_cairnline_migration_rollback",
+          data: { restored: true },
+        }),
+      );
+
+    await migrateProjectsToCairnline();
+    await rollbackProjectsCairnlineMigration();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/cairnline/migrate",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hecate/v1/projects/cairnline/migrate/rollback",
+      expect.objectContaining({ method: "POST" }),
     );
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -93,6 +93,8 @@ import type {
   ProjectCollaborationArtifactResponse,
   ProjectCollaborationArtifactsResponse,
   ProjectCoordinationBackendStatusResponse,
+  ProjectCairnlineMigrationResponse,
+  ProjectCairnlineMigrationRollbackResponse,
   ProjectContextSourcePayload,
   ProjectDeleteResponse,
   ProjectHandoffResponse,
@@ -530,6 +532,19 @@ export async function deleteProject(id: string): Promise<ProjectDeleteResponse> 
 export async function getProjectCoordinationBackendStatus(): Promise<ProjectCoordinationBackendStatusResponse> {
   return fetchJSON<ProjectCoordinationBackendStatusResponse>(
     `${HECATE_API}/projects/backend-status`,
+  );
+}
+
+export async function migrateProjectsToCairnline(): Promise<ProjectCairnlineMigrationResponse> {
+  return fetchJSON<ProjectCairnlineMigrationResponse>(`${HECATE_API}/projects/cairnline/migrate`, {
+    method: "POST",
+  });
+}
+
+export async function rollbackProjectsCairnlineMigration(): Promise<ProjectCairnlineMigrationRollbackResponse> {
+  return fetchJSON<ProjectCairnlineMigrationRollbackResponse>(
+    `${HECATE_API}/projects/cairnline/migrate/rollback`,
+    { method: "POST" },
   );
 }
 

--- a/ui/src/types/project.ts
+++ b/ui/src/types/project.ts
@@ -145,6 +145,52 @@ export type ProjectCairnlineMigrationRehearsalRecord = {
   };
 };
 
+export type ProjectCairnlineMigrationCutoverRecord = {
+  status: string;
+  endpoint: string;
+  rollback_endpoint: string;
+  migrated: boolean;
+  verified: boolean;
+  parity_match: boolean;
+  migrated_at?: string;
+  rollback_backup_path?: string;
+  source_authority?: string[];
+};
+
+export type ProjectCairnlineMigrationReport = {
+  object: string;
+  migrated_at: string;
+  verified: boolean;
+  parity_match: boolean;
+  target: string;
+  source_authority: string[];
+  rollback_backup_path?: string;
+  project_count: number;
+  checklist: Array<{
+    id: string;
+    status: string;
+    detail: string;
+  }>;
+  rollback: string[];
+  verification_notes?: string[];
+  parity: Record<string, unknown>;
+};
+
+export type ProjectCairnlineMigrationResponse = {
+  object: string;
+  data: ProjectCairnlineMigrationReport;
+};
+
+export type ProjectCairnlineMigrationRollbackResponse = {
+  object: string;
+  data: {
+    restored: boolean;
+    reason?: string;
+    restored_from?: string;
+    target: string;
+  };
+};
+
 export type ProjectCoordinationBackendStatusRecord = {
   configured_backend: string;
   authoritative_backend: string;
@@ -172,6 +218,7 @@ export type ProjectCoordinationBackendStatusRecord = {
   side_effect_blockers?: string[];
   migration_blockers?: string[];
   migration_rehearsal?: ProjectCairnlineMigrationRehearsalRecord;
+  migration_cutover?: ProjectCairnlineMigrationCutoverRecord;
   next_replacement_action?: ProjectCoordinationBackendNextActionRecord;
   replacement_gates?: ProjectCoordinationBackendReplacementGateRecord[];
   write_switchpoints?: ProjectCoordinationBackendWriteSwitchpointRecord[];


### PR DESCRIPTION
## Summary

- add an operator-facing Cairnline migration cutover panel in Settings
- require typed confirmation for verified migration and recorded-backup restore
- refresh backend status after each action and preserve verification failures as visible evidence
- add typed API contracts, focused workflow tests, and operator documentation

## Why

The one-way migration and rollback endpoints are implemented, but operators otherwise have to invoke them manually. This exposes the crash-safe backend workflow through Hecate without changing runtime configuration or silently arming replacement mode.

## Validation

- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- src/features/settings/SettingsView.test.tsx src/lib/api.test.ts
- cd ui && bun run test (91 files, 1577 tests)
- just agent-docs-check
- just format-check
- git diff --check

The change is UI, API-client typing, tests, and documentation only; no Go runtime behavior changed.