### PR TITLE
fix(release): preserve published release notes

### DIFF
--- a/.github/workflows/_tauri-shared.yml
+++ b/.github/workflows/_tauri-shared.yml
@@ -140,6 +140,26 @@ jobs:
       - name: Stamp Tauri version
         run: bun scripts/stamp-version.ts
 
+      # GoReleaser owns the GitHub Release entry and its release notes.
+      # tauri-action v1 updates an existing release's name and body whenever it
+      # resolves that release from tagName; with no releaseBody input, that
+      # clears GoReleaser's notes. Resolve the already-created release once per
+      # matrix leg and pass its immutable id so this job only uploads assets.
+      - name: Resolve existing GitHub release
+        id: release
+        if: inputs.tagName != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tagName }}
+        run: |
+          set -euo pipefail
+          release_id=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" --jq '.id')
+          if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+            echo "invalid release id for ${TAG}: ${release_id:-missing}" >&2
+            exit 1
+          fi
+          echo "id=$release_id" >> "$GITHUB_OUTPUT"
+
       # Keep PR builds and release builds as separate steps. Setting signing
       # variables to an empty string is not the same as omitting them: Tauri's
       # bundler still treats some present-but-empty vars as "signing requested"
@@ -163,8 +183,9 @@ jobs:
             --bundles ${{ matrix.os == 'macos-latest' && inputs.unsignedMacosBundles || matrix.bundles }}
             --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
-      # Tagged release build. Uploads bundles to the existing GitHub Release and
-      # signs/notarizes when the corresponding secrets are configured.
+      # Tagged release build. Uploads bundles to the existing GitHub Release by
+      # id, preserving GoReleaser's name and notes, and signs/notarizes when
+      # the corresponding secrets are configured.
       - name: Build Tauri bundles (signed release)
         if: inputs.tagName != ''
         uses: tauri-apps/tauri-action@v1
@@ -210,7 +231,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_UPDATER_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: tauri
-          tagName: ${{ inputs.tagName }}
+          releaseId: ${{ steps.release.outputs.id }}
           args: --bundles ${{ matrix.bundles }}
 
       # Upload updater payloads (.tar.gz / .zip + .sig) to the GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: release
 
-# Fires on tag pushes that look like a semver release. Manual dispatch
-# stays available for re-runs without re-tagging.
+# Fires on tag pushes that look like a semver release. Manual dispatch stays
+# available for re-runs when the workflow ref selector is set to an existing
+# v* release tag; branch dispatches fail before checkout or build work.
 on:
   push:
     tags:
@@ -22,7 +23,20 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    outputs:
+      release_body_sha256: ${{ steps.release-body.outputs.sha256 }}
     steps:
+      - name: Validate release ref
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_TYPE" != "tag" || "$REF_NAME" != v* ]]; then
+            echo "Release workflow requires a v* tag ref; got ${REF_TYPE} ${REF_NAME}." >&2
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -59,13 +73,61 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The release helper's ordinary tags contain only the version and should
+      # keep GoReleaser's generated changelog. A maintainer may instead create
+      # an annotated tag with substantive Markdown notes; preserve that public
+      # release contract by passing the annotation to GoReleaser explicitly.
+      - name: Prepare release notes
+        id: release-notes
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          tag_ref="refs/tags/${TAG}"
+          tag_type=$(git cat-file -t "$tag_ref")
+          if [[ "$tag_type" == "commit" ]]; then
+            echo "args=release --clean" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$tag_type" != "tag" ]]; then
+            echo "Release ref ${TAG} points to unsupported object type ${tag_type}." >&2
+            exit 1
+          fi
+          tag_notes=$(git for-each-ref --format='%(contents)' "$tag_ref")
+          if [[ "$tag_notes" == "$TAG" ]]; then
+            echo "args=release --clean" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${tag_notes//[[:space:]]/}" ]]; then
+            echo "Release tag ${TAG} has an empty annotation." >&2
+            exit 1
+          fi
+          notes_path="$RUNNER_TEMP/release-notes.md"
+          printf '%s\n' "$tag_notes" > "$notes_path"
+          echo "args=release --clean --release-notes=$notes_path" >> "$GITHUB_OUTPUT"
+
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --clean
+          args: ${{ steps.release-notes.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Record published release body
+        id: release-body
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          body_path="$RUNNER_TEMP/published-release-body.md"
+          gh release view "$TAG" --repo "${{ github.repository }}" --json body --jq '.body' > "$body_path"
+          if ! grep -q '[^[:space:]]' "$body_path"; then
+            echo "GitHub Release ${TAG} has no release notes after GoReleaser." >&2
+            exit 1
+          fi
+          echo "sha256=$(sha256sum "$body_path" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
   # Native desktop bundles. All matrix steps live in _tauri-shared.yml.
   tauri:
@@ -84,10 +146,9 @@ jobs:
 
   update-release-docs:
     name: Update release docs
-    needs: tauri
+    needs: [goreleaser, tauri]
     runs-on: ubuntu-latest
-    # Only tag-triggered releases publish assets. Manual workflow_dispatch runs
-    # may point at a branch, where github.ref_name is not a release tag.
+    # The goreleaser job rejects non-tag refs before release work begins.
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout master
@@ -100,6 +161,31 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
+
+      - name: Verify release body was preserved
+        env:
+          EXPECTED_SHA256: ${{ needs.goreleaser.outputs.release_body_sha256 }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          body_path="$RUNNER_TEMP/final-release-body.md"
+          gh release view "$TAG" --repo "${{ github.repository }}" --json body --jq '.body' > "$body_path"
+          if ! grep -q '[^[:space:]]' "$body_path"; then
+            echo "GitHub Release ${TAG} has no release notes after desktop packaging." >&2
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "GoReleaser did not report a valid release-body digest." >&2
+            exit 1
+          fi
+          actual_sha256=$(sha256sum "$body_path" | awk '{print $1}')
+          if [[ "$actual_sha256" != "$EXPECTED_SHA256" ]]; then
+            echo "GitHub Release ${TAG} body changed during desktop packaging." >&2
+            echo "expected sha256: $EXPECTED_SHA256" >&2
+            echo "actual sha256:   $actual_sha256" >&2
+            exit 1
+          fi
 
       - name: Regenerate release docs
         run: bun scripts/update-release-links.ts "${{ github.ref_name }}"

--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -41,7 +41,11 @@ To skip the snapshot dry-run (e.g. already ran it manually):
 just release v0.2.0 --skip-snapshot
 ```
 
-The annotated tag message becomes the canonical release notes — it's what `git show vX.Y.Z` and the GitHub Releases page surface. Write it before tagging; the script prompts for confirmation but doesn't prompt for the message (pass it as the annotation when the script creates the tag, or edit via `git tag -a -f` before pushing if needed).
+The release helper creates an annotated tag whose message is only the version,
+so ordinary releases use GoReleaser's generated changelog. For a substantive
+release, create an annotated tag manually from a reviewed Markdown file. The
+release workflow detects that non-version annotation and passes it to
+GoReleaser as the public GitHub Release body.
 
 ## Tauri desktop app
 
@@ -60,7 +64,11 @@ End state of a successful tag: the GitHub Release page has goreleaser tarballs +
 
 `just release` / `bun scripts/release.ts` handles the stamp automatically: after confirmation it calls `scripts/stamp-version.ts` with `TAURI_VERSION=<semver>`, commits the changed files (`Cargo.toml`, `package.json`, `tauri.conf.json`), then creates the annotated tag on that commit. CI re-runs the stamp from the tag name as a belt-and-suspenders measure (`stamp-version.ts` is idempotent).
 
-**The stamp commit lives only on the tag, not on master.** The script pushes the tag, not the branch, then resets the local release branch back to the pre-stamp commit. Meanwhile the release CI's `publish updater manifest` + `docs: update release references` jobs push their own commits to `master` on top of that same pre-tag commit. Once CI completes, run `git pull --ff-only origin master` to pick up those post-release commits. Branches cut after that should not inherit a phantom Tauri version bump.
+The stamp commit remains on the release branch. The script pushes both that
+branch and the annotated tag, keeping visible Tauri version metadata aligned
+with the latest release. Release CI may then add updater-manifest and release
+reference commits to `master`; after CI completes, run
+`git pull --ff-only origin master` to pick up those post-release commits.
 
 The Tauri matrix doesn't need any local action — pushing the tag fires the workflow.
 
@@ -98,7 +106,7 @@ Outputs land in `tauri/src-tauri/target/release/bundle/`. Use this for iterating
 
 - **Don't build manually then expect CI artifacts to match.** The CI matrix produces bundles signed differently (or unsigned) from a local build. Local artifacts are for debugging, not distribution.
 - **`0.1.0-alpha.N` is valid semver for Tauri**, but macOS `CFBundleShortVersionString` strips the pre-release suffix in the About dialog. That's expected — Tauri handles it internally.
-- **macOS bundles are signed + notarized only on release-workflow runs; PR-validation builds are unsigned by design.** "Release-workflow run" = any invocation of `release.yml` (tag push OR `workflow_dispatch`), both of which pass a non-empty `tagName` to the reusable workflow. Two protections in series:
+- **macOS bundles are signed + notarized only on release-workflow runs; PR-validation builds are unsigned by design.** "Release-workflow run" = a tag push or a `workflow_dispatch` whose selected ref is an existing `v*` tag. Branch-based manual dispatches fail before build work, so every accepted invocation passes a release tag to the reusable workflow. Two protections in series:
   - **Caller-side (load-bearing):** PR validation in `test.yml` and manual `tauri-build.yml` runs do NOT use `secrets: inherit` when calling the reusable workflow. The called workflow's `secrets.APPLE_*` references therefore resolve to empty unconditionally during PR/manual validation — the secret values are not in the calling job's context, so even a same-repo PR that rewrites the called workflow can't read them. `release.yml` does inherit (it needs the credentials to actually sign).
   - **Called-side (defense in depth):** the env block in `_tauri-shared.yml` gates each Apple secret on `matrix.os == 'macos-latest' && inputs.tagName != ''`. Belt-and-suspenders against future misconfiguration where some new caller might inherit secrets unintentionally.
   - The shared workflow uses `${{ github.token }}` instead of `${{ secrets.GITHUB_TOKEN }}` so it works in both modes — `github.token` is the per-job-run token, available in every workflow run without needing secrets-inherit.
@@ -125,7 +133,11 @@ Total wall-clock: ~20–35 min (the website publish + verification adds 2–5 mi
 Acceptance:
 
 - Both workflow jobs are green.
-- GitHub Releases page has the entry, marked **Pre-release** for `-alpha.N` tags.
+- GitHub Releases page has the entry, is marked **Pre-release** for `-alpha.N`
+  tags, and has non-empty notes from either a substantive tag annotation or
+  GoReleaser's generated changelog. The Tauri matrix must attach bundles through
+  `releaseId`; passing only `tagName` to tauri-action v1 rewrites the existing
+  release body.
 - Goreleaser-side artifacts attached: tarballs for each `goos/goarch`, source tarball, checksums. Each binary tarball contains `hecate`.
 - Tauri-side artifacts attached: one `.dmg`, one `.deb`, one `.AppImage`, one `.msi`. If any is missing, the matrix leg silently skipped upload — open the run, find the leg, see what failed.
 - `latest.json` is attached as a release asset (the auto-updater manifest, GitHub Release copy). Missing means the `publish-updater-manifest` job failed — most likely on its `missing updater signature(s)` check. Look there first; common causes are `bundle.createUpdaterArtifacts` being unset in `tauri.conf.json` (bundler produced no sigs) or the `TAURI_UPDATER_*` secrets having been removed from repo settings.

--- a/docs/contributor/release.md
+++ b/docs/contributor/release.md
@@ -92,6 +92,10 @@ Acceptance after the run:
 
 - All release jobs green.
 - Release entry marked **Pre-release** for `-alpha.N` tags.
+- Release entry has non-empty notes: the annotated tag's Markdown for a
+  substantive release, otherwise GoReleaser's generated changelog. The desktop
+  matrix uploads by release id so it cannot replace those notes while attaching
+  bundles.
 - Goreleaser-side artifacts attached: tarballs for each goos/goarch + checksums.
   Each tarball contains `hecate`.
 - Tauri-side bundles attached: 1 `.dmg`, 1 `.deb`, 1 `.AppImage`, 1 `.msi`.
@@ -170,19 +174,23 @@ and verification gate have passed:
 bun scripts/release.ts vX.Y.Z --skip-snapshot --yes
 ```
 
-The script's annotated tag message is just the version string. For
-substantive release notes, tag manually instead so the message becomes
-the canonical release notes (what `git show vX.Y.Z` and the GitHub
-Releases page surface):
+The script's annotated tag message is just the version string, so GoReleaser
+publishes its generated changelog for ordinary releases. For a substantive
+release, tag manually with reviewed Markdown. The release workflow detects a
+non-version annotation and passes it to GoReleaser as the GitHub Release body:
 
 ```bash
 TAURI_VERSION=X.Y.Z bun scripts/stamp-version.ts
 git add tauri/src-tauri/Cargo.toml tauri/src-tauri/Cargo.lock \
         tauri/src-tauri/tauri.conf.json tauri/package.json
 git commit -m "chore(tauri): stamp version X.Y.Z"
-git tag -a vX.Y.Z -F /tmp/release-notes.txt    # message from a file
+git tag -a vX.Y.Z -F /tmp/release-notes.md
 git push origin HEAD:master vX.Y.Z
 ```
+
+The annotation remains visible through `git show vX.Y.Z`; the same content is
+published on GitHub. A version-only annotation continues to use the generated
+commit changelog.
 
 The version stamp commit stays on `master`. This keeps the visible Tauri
 metadata (`tauri/package.json`, `Cargo.toml`, `tauri.conf.json`) aligned with


### PR DESCRIPTION
## Summary

- publish substantive annotated-tag Markdown through GoReleaser while keeping generated changelogs for version-only and lightweight tags
- resolve the existing GitHub release ID before Tauri packaging so tauri-action v1 only uploads assets and cannot replace release metadata
- compare the release-body digest before and after desktop packaging
- reject branch-based manual dispatches before checkout or build work
- align contributor and AI release guidance with the enforced notes and version-stamp contracts

## Root cause

tauri-action v1 updates the name and body of an existing release when it resolves that release from tagName. Hecate supplied no release body, so every desktop matrix leg replaced the GoReleaser notes with an empty body.

## Operator impact

The published v0.3.0-alpha.1 notes have been restored from the existing annotated tag. Future desktop release jobs preserve either curated notes or the generated changelog and fail if the body changes.

## Validation

- just verify
- actionlint .github/workflows/_tauri-shared.yml .github/workflows/release.yml
- docs release checks and formatting
- behavioral checks for curated, version-only, and historical lightweight tags
- release-body digest preservation check against v0.3.0-alpha.1
