### PR TITLE
fix(docs): satisfy release formatting gate

### DIFF
--- a/docs/design/implemented/external-agent-approval-loop-v1.md
+++ b/docs/design/implemented/external-agent-approval-loop-v1.md
@@ -238,7 +238,7 @@ oldest pending first.
       "adapter_id": "codex",
       "status": "pending",
       "tool_kind": "file_write",
-      "acp_payload": {/* verbatim RequestPermissionRequest */},
+      "acp_payload": {},
       "acp_options": [
         { "option_id": "allow_once", "kind": "allow_once", "name": "Allow once" },
         {
@@ -257,6 +257,9 @@ oldest pending first.
   ]
 }
 ```
+
+`acp_payload` contains the verbatim `RequestPermissionRequest`; the empty object
+above keeps the example compact.
 
 ### Single approval
 


### PR DESCRIPTION
## Summary

- replace a platform-dependent JSON block-comment layout with a stable empty object
- preserve the design meaning in adjacent prose
- unblock the required release verification gate on macOS and Linux

## Verification

- `./ui/node_modules/.bin/oxfmt --check docs/design/implemented/external-agent-approval-loop-v1.md`
- pinned Oxfmt 0.58.0 check in an isolated Linux container
- `just verify`