### PR TITLE
fix(release): preserve Markdown tag headings

### DIFF
--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -45,7 +45,10 @@ The release helper creates an annotated tag whose message is only the version,
 so ordinary releases use GoReleaser's generated changelog. For a substantive
 release, create an annotated tag manually from a reviewed Markdown file. The
 release workflow detects that non-version annotation and passes it to
-GoReleaser as the public GitHub Release body.
+GoReleaser as the public GitHub Release body. Create that tag with
+`git tag -a --cleanup=verbatim vX.Y.Z -F /tmp/release-notes.md`; without
+`--cleanup=verbatim`, Git treats Markdown headings as comments and silently
+strips them from the annotation.
 
 ## Tauri desktop app
 

--- a/docs/contributor/release.md
+++ b/docs/contributor/release.md
@@ -184,13 +184,15 @@ TAURI_VERSION=X.Y.Z bun scripts/stamp-version.ts
 git add tauri/src-tauri/Cargo.toml tauri/src-tauri/Cargo.lock \
         tauri/src-tauri/tauri.conf.json tauri/package.json
 git commit -m "chore(tauri): stamp version X.Y.Z"
-git tag -a vX.Y.Z -F /tmp/release-notes.md
+git tag -a --cleanup=verbatim vX.Y.Z -F /tmp/release-notes.md
 git push origin HEAD:master vX.Y.Z
 ```
 
 The annotation remains visible through `git show vX.Y.Z`; the same content is
 published on GitHub. A version-only annotation continues to use the generated
-commit changelog.
+commit changelog. Keep `--cleanup=verbatim` on Markdown annotations: Git's
+default cleanup treats lines beginning with `#` as comments and would silently
+strip the release title and section headings.
 
 The version stamp commit stays on `master`. This keeps the visible Tauri
 metadata (`tauri/package.json`, `Cargo.toml`, `tauri.conf.json`) aligned with


### PR DESCRIPTION
## Summary

- add `--cleanup=verbatim` to the substantive release tag command
- explain why Git default cleanup silently strips Markdown headings
- align maintainer and agent release guidance with the verified v0.4.0-alpha.1 process

## Verification

- `./ui/node_modules/.bin/oxfmt --check docs/contributor/release.md docs-ai/tasks/release.md`
- `git diff --check`