### PR TITLE
fix(agents): resolve provider CLIs for desktop launches

### DIFF
--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -215,7 +215,12 @@ The Docker runtime image includes the supported agent CLIs and ACP adapters so
 local/self-host Docker deployments can use External Agents without installing
 those binaries into the container at runtime. Bare binary and desktop
 deployments use whatever agent CLIs and Go ACP adapter binaries are installed on
-the operator's machine.
+the operator's machine. Local launches resolve each provider CLI from the
+adapter catalog's direct command and trusted candidate paths. Hecate prepends
+only the resolved executable directory to the adapter's sanitized `PATH`, so a
+desktop launch can use common per-user installations such as `~/.local/bin` or
+`~/.volta/bin` without importing a login shell environment. Remote runtimes keep
+their separate fail-closed credential and process-environment policy.
 
 ## Credential and account boundaries
 

--- a/internal/agentadapters/claude_setup.go
+++ b/internal/agentadapters/claude_setup.go
@@ -1,22 +1,15 @@
 package agentadapters
 
-import (
-	"os/exec"
-)
-
 type SetupCommandStatus struct {
 	Available      bool   `json:"available"`
 	Command        string `json:"command,omitempty"`
 	ExecutablePath string `json:"executable_path,omitempty"`
 }
 
-func DetectClaudeCodeCLI(lookup LookupFunc) SetupCommandStatus {
-	if lookup == nil {
-		lookup = exec.LookPath
+func DetectClaudeCodeCLI(probe VersionProbe, lookup LookupFunc) SetupCommandStatus {
+	path, ok := resolveVersionProbe(probe, lookup)
+	if !ok {
+		return SetupCommandStatus{}
 	}
-	path, err := lookup("claude")
-	if err == nil {
-		return SetupCommandStatus{Available: true, Command: path, ExecutablePath: path}
-	}
-	return SetupCommandStatus{}
+	return SetupCommandStatus{Available: true, Command: path, ExecutablePath: path}
 }

--- a/internal/agentadapters/claude_setup_test.go
+++ b/internal/agentadapters/claude_setup_test.go
@@ -2,11 +2,13 @@ package agentadapters
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestDetectClaudeCodeCLI(t *testing.T) {
-	status := DetectClaudeCodeCLI(func(file string) (string, error) {
+	status := DetectClaudeCodeCLI(VersionProbe{Command: "claude"}, func(file string) (string, error) {
 		if file != "claude" {
 			t.Fatalf("lookup called with %q", file)
 		}
@@ -16,7 +18,7 @@ func TestDetectClaudeCodeCLI(t *testing.T) {
 		t.Fatalf("DetectClaudeCodeCLI() = %+v, want available path", status)
 	}
 
-	status = DetectClaudeCodeCLI(func(string) (string, error) {
+	status = DetectClaudeCodeCLI(VersionProbe{Command: "claude"}, func(string) (string, error) {
 		return "", errors.New("not found")
 	})
 	if status.Available || status.Command != "" || status.ExecutablePath != "" {
@@ -25,7 +27,7 @@ func TestDetectClaudeCodeCLI(t *testing.T) {
 }
 
 func TestDetectClaudeCodeCLI_DoesNotFallbackToNPX(t *testing.T) {
-	status := DetectClaudeCodeCLI(func(file string) (string, error) {
+	status := DetectClaudeCodeCLI(VersionProbe{Command: "claude"}, func(file string) (string, error) {
 		switch file {
 		case "claude":
 			return "", errors.New("not found")
@@ -38,5 +40,30 @@ func TestDetectClaudeCodeCLI_DoesNotFallbackToNPX(t *testing.T) {
 	})
 	if status.Available || status.Command != "" || status.ExecutablePath != "" {
 		t.Fatalf("DetectClaudeCodeCLI() = %+v, want unavailable without npx fallback", status)
+	}
+}
+
+func TestDetectClaudeCodeCLIUsesCandidatePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	want := filepath.Join(home, ".volta", "bin", "claude")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatalf("mkdir candidate directory: %v", err)
+	}
+	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+
+	status := DetectClaudeCodeCLI(VersionProbe{
+		Command:        "claude",
+		CandidatePaths: []string{"${HOME}/.volta/bin/claude"},
+	}, func(file string) (string, error) {
+		if file == want {
+			return file, nil
+		}
+		return "", errors.New("not found")
+	})
+	if !status.Available || status.ExecutablePath != want {
+		t.Fatalf("DetectClaudeCodeCLI() = %+v, want candidate %q", status, want)
 	}
 }

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -742,7 +743,7 @@ func statusForAdapterWithDiagnostics(ctx context.Context, item Adapter, lookup L
 		AuthStatus: AuthStatusUnknown,
 	}
 	if item.ID == "claude_code" {
-		status.ClaudeCodeCLI = DetectClaudeCodeCLI(lookup)
+		status.ClaudeCodeCLI = DetectClaudeCodeCLI(item.AgentVersion, lookup)
 	}
 	if err := ctx.Err(); err != nil {
 		status.Error = err.Error()
@@ -1078,7 +1079,8 @@ func prepareAdapterProcessEnv(ctx context.Context, adapter Adapter, env []string
 		return adapterProcessEnv{}, err
 	}
 	if _, ok := remoteruntime.FromContext(ctx); !ok {
-		return adapterProcessEnv{values: sanitizedEnvForAdapter(adapter.ID, env)}, nil
+		values := sanitizedEnvForAdapter(adapter.ID, env)
+		return adapterProcessEnv{values: prependResolvedAgentRuntimePath(adapter, values, exec.LookPath)}, nil
 	}
 	if mode.ID == CredentialModeLocalLogin {
 		home := remoteRuntimePersistentHome(env)
@@ -1099,6 +1101,52 @@ func prepareAdapterProcessEnv(ctx context.Context, adapter Adapter, env []string
 			_ = os.RemoveAll(home)
 		},
 	}, nil
+}
+
+// prependResolvedAgentRuntimePath keeps local desktop launches independent of
+// the GUI process's often-minimal PATH. The adapter catalog already owns the
+// provider CLI's direct command and trusted candidate paths; resolve that same
+// metadata and expose only the selected executable directory to the adapter.
+// Remote runtime environments intentionally use their separate fail-closed
+// credential and PATH policy above.
+func prependResolvedAgentRuntimePath(adapter Adapter, env []string, lookup LookupFunc) []string {
+	path, ok := resolveVersionProbe(adapter.AgentVersion, lookup)
+	if !ok {
+		return env
+	}
+	dir := filepath.Clean(filepath.Dir(path))
+	if dir == "." || dir == "" {
+		return env
+	}
+	return prependPathEntry(env, dir)
+}
+
+func prependPathEntry(env []string, dir string) []string {
+	for index, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || !strings.EqualFold(name, "PATH") {
+			continue
+		}
+		for _, existing := range filepath.SplitList(value) {
+			if samePathEntry(existing, dir) {
+				return env
+			}
+		}
+		out := append([]string(nil), env...)
+		out[index] = name + "=" + strings.Join(append([]string{dir}, filepath.SplitList(value)...), string(os.PathListSeparator))
+		return out
+	}
+	out := append([]string(nil), env...)
+	return append(out, "PATH="+dir)
+}
+
+func samePathEntry(left, right string) bool {
+	left = filepath.Clean(left)
+	right = filepath.Clean(right)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
 }
 
 func remoteRuntimePersistentHome(env []string) string {

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -742,14 +742,22 @@ func statusForAdapterWithDiagnostics(ctx context.Context, item Adapter, lookup L
 		Status:     StatusMissing,
 		AuthStatus: AuthStatusUnknown,
 	}
+	_, remoteRuntime := remoteruntime.FromContext(ctx)
 	if item.ID == "claude_code" {
-		status.ClaudeCodeCLI = DetectClaudeCodeCLI(item.AgentVersion, lookup)
+		probe := item.AgentVersion
+		if remoteRuntime {
+			// Remote launches intentionally do not inherit local per-user
+			// candidate directories. Keep readiness aligned with the remote
+			// adapter PATH and avoid exposing a runtime-host home path.
+			probe.CandidatePaths = nil
+		}
+		status.ClaudeCodeCLI = DetectClaudeCodeCLI(probe, lookup)
 	}
 	if err := ctx.Err(); err != nil {
 		status.Error = err.Error()
 		return status
 	}
-	if _, ok := remoteruntime.FromContext(ctx); ok {
+	if remoteRuntime {
 		mode, ready, hint := remoteCredentialStatus(item, os.Getenv)
 		status.RemoteCredentialOK = ready
 		status.RemoteCredentialHint = hint
@@ -1122,22 +1130,42 @@ func prependResolvedAgentRuntimePath(adapter Adapter, env []string, lookup Looku
 }
 
 func prependPathEntry(env []string, dir string) []string {
+	out := env
+	found := false
+	copied := false
 	for index, entry := range env {
 		name, value, ok := strings.Cut(entry, "=")
-		if !ok || !strings.EqualFold(name, "PATH") {
+		if !ok || !isPathEnvName(name) {
 			continue
 		}
+		found = true
+		present := false
 		for _, existing := range filepath.SplitList(value) {
 			if samePathEntry(existing, dir) {
-				return env
+				present = true
+				break
 			}
 		}
-		out := append([]string(nil), env...)
+		if present {
+			continue
+		}
+		if !copied {
+			out = append([]string(nil), env...)
+			copied = true
+		}
 		out[index] = name + "=" + strings.Join(append([]string{dir}, filepath.SplitList(value)...), string(os.PathListSeparator))
+	}
+	if found {
 		return out
 	}
-	out := append([]string(nil), env...)
-	return append(out, "PATH="+dir)
+	return append(append([]string(nil), env...), "PATH="+dir)
+}
+
+func isPathEnvName(name string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(name, "PATH")
+	}
+	return name == "PATH"
 }
 
 func samePathEntry(left, right string) bool {

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1074,6 +1075,56 @@ func TestPrependResolvedAgentRuntimePathDoesNotDuplicateDirectory(t *testing.T) 
 	})
 	if value := envValue(got, "PATH"); value != strings.TrimPrefix(input[0], "PATH=") {
 		t.Fatalf("PATH = %q, want existing path unchanged", value)
+	}
+}
+
+func TestPrependPathEntryUsesCaseSensitivePATHNameOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows environment names are case-insensitive")
+	}
+	dir := t.TempDir()
+	input := []string{"Path=/unused", "PATH=/system-bin"}
+
+	got := prependPathEntry(input, dir)
+	if value := envValue(got, "Path"); value != "/unused" {
+		t.Fatalf("Path = %q, want unused mixed-case value unchanged", value)
+	}
+	want := dir + string(os.PathListSeparator) + "/system-bin"
+	if value := envValue(got, "PATH"); value != want {
+		t.Fatalf("PATH = %q, want %q", value, want)
+	}
+}
+
+func TestClaudeStatusDoesNotUseLocalCandidatePathForRemoteRuntime(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "remote-test-key")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	adapter, ok := BuiltInByID("claude_code")
+	if !ok {
+		t.Fatal("missing Claude Code adapter")
+	}
+	localCandidate := filepath.Join(home, ".volta", "bin", "claude")
+
+	status := statusForAdapterWithDiagnostics(
+		remoteIdentityContext(),
+		adapter,
+		func(file string) (string, error) {
+			switch file {
+			case adapter.Command:
+				return filepath.Join(home, "bin", adapter.Command), nil
+			case adapter.AgentVersion.Command:
+				return "", errors.New("not found on remote PATH")
+			case localCandidate:
+				t.Fatalf("remote status probed local candidate %q", file)
+			default:
+				return "", errors.New("not found")
+			}
+			return "", errors.New("unreachable")
+		},
+		statusDiagnosticsCatalog,
+	)
+	if status.ClaudeCodeCLI.Available || status.ClaudeCodeCLI.ExecutablePath != "" {
+		t.Fatalf("ClaudeCodeCLI = %+v, want unavailable without remote PATH command", status.ClaudeCodeCLI)
 	}
 }
 

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -1034,6 +1034,49 @@ func TestSanitizedEnvMapsProviderXAIKeyOnlyForGrokBuild(t *testing.T) {
 	}
 }
 
+func TestPrependResolvedAgentRuntimePathUsesCandidateOutsidePATH(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	runtimePath := filepath.Join(home, ".volta", "bin", "claude")
+	basePath := strings.Join([]string{
+		filepath.Join(home, "system-bin"),
+		filepath.Join(home, "fallback-bin"),
+	}, string(os.PathListSeparator))
+	input := []string{"PATH=" + basePath, "HOME=" + home}
+	adapter := Adapter{AgentVersion: VersionProbe{
+		Command:        "claude",
+		CandidatePaths: []string{"${HOME}/.volta/bin/claude"},
+	}}
+
+	got := prependResolvedAgentRuntimePath(adapter, input, func(file string) (string, error) {
+		if file == runtimePath {
+			return runtimePath, nil
+		}
+		return "", errors.New("not found")
+	})
+	wantPath := filepath.Dir(runtimePath) + string(os.PathListSeparator) + basePath
+	if value := envValue(got, "PATH"); value != wantPath {
+		t.Fatalf("PATH = %q, want %q", value, wantPath)
+	}
+	if input[0] != "PATH="+basePath {
+		t.Fatalf("input mutated to %#v", input)
+	}
+}
+
+func TestPrependResolvedAgentRuntimePathDoesNotDuplicateDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude")
+	input := []string{"PATH=" + dir + string(os.PathListSeparator) + "/usr/bin"}
+	adapter := Adapter{AgentVersion: VersionProbe{Command: "claude"}}
+
+	got := prependResolvedAgentRuntimePath(adapter, input, func(string) (string, error) {
+		return path, nil
+	})
+	if value := envValue(got, "PATH"); value != strings.TrimPrefix(input[0], "PATH=") {
+		t.Fatalf("PATH = %q, want existing path unchanged", value)
+	}
+}
+
 func TestRemoteRuntimeAdapterEnvUsesOnlyRemoteCredentialKeysAndEphemeralHome(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- resolve each local External Agent's upstream provider CLI from its existing typed catalog metadata
- prepend only the resolved executable directory to the adapter's sanitized local `PATH`
- make Claude Code readiness use the same declared candidate paths as launch-time resolution
- keep remote-runtime credential and process-environment policy unchanged

## Root cause and impact

Desktop applications often inherit a minimal environment instead of the operator's login-shell `PATH`. Hecate could find the native Go ACP bridge in `~/.local/bin`, while that bridge could not find the upstream `claude` CLI installed in another per-user binary directory. The uploaded files had already been admitted and stored correctly; the run failed before the provider CLI could process the prompt.

This change does not introduce a package-runner or JavaScript adapter dependency. The native Go bridge remains the ACP integration and continues to invoke the operator-owned provider CLI for its account and runtime behavior.

## Safety and ownership

- candidate paths remain owned by the built-in adapter catalog
- only the selected executable directory is added; no shell startup files or unrelated environment variables are imported
- input environment slices are copied before mutation and duplicate path entries are avoided
- remote-runtime environment construction remains fail-closed and unchanged
- no attachment bodies, credentials, or full environment values are logged

## Validation

- `just go-format-check`
- `go build ./...`
- `go vet ./...`
- `go test -race -count=1 ./internal/agentadapters`
- `go test -race -timeout 10m ./...`
- external-agent runtime documentation format check
- self-review for correctness, security, privacy, cross-platform path handling, and architectural boundaries

## Documentation

The External Agents runtime guide now distinguishes the native Go ACP bridge from the upstream provider CLI and documents local candidate-path resolution. No public API, persisted contract, or diagram changed.
