### PR TITLE
fix(agents): isolate remote version probes

### DIFF
--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -737,21 +737,21 @@ const (
 )
 
 func statusForAdapterWithDiagnostics(ctx context.Context, item Adapter, lookup LookupFunc, diagnostics statusDiagnosticsMode) Status {
+	_, remoteRuntime := remoteruntime.FromContext(ctx)
+	diagnosticItem := item
+	if remoteRuntime {
+		// Remote launches intentionally do not inherit local per-user provider
+		// directories. Apply the same boundary to every status probe, including
+		// the full version diagnostics used after an explicit adapter probe.
+		diagnosticItem.AgentVersion.CandidatePaths = nil
+	}
 	status := Status{
 		Adapter:    item,
 		Status:     StatusMissing,
 		AuthStatus: AuthStatusUnknown,
 	}
-	_, remoteRuntime := remoteruntime.FromContext(ctx)
 	if item.ID == "claude_code" {
-		probe := item.AgentVersion
-		if remoteRuntime {
-			// Remote launches intentionally do not inherit local per-user
-			// candidate directories. Keep readiness aligned with the remote
-			// adapter PATH and avoid exposing a runtime-host home path.
-			probe.CandidatePaths = nil
-		}
-		status.ClaudeCodeCLI = DetectClaudeCodeCLI(probe, lookup)
+		status.ClaudeCodeCLI = DetectClaudeCodeCLI(diagnosticItem.AgentVersion, lookup)
 	}
 	if err := ctx.Err(); err != nil {
 		status.Error = err.Error()
@@ -785,7 +785,7 @@ func statusForAdapterWithDiagnostics(ctx context.Context, item Adapter, lookup L
 	status.Status = StatusAvailable
 	status.Path = path
 	if diagnostics == statusDiagnosticsFull {
-		status.AdapterVersion, status.AgentVersion = detectAdapterAndAgentVersionsForStatus(ctx, item, path, lookup)
+		status.AdapterVersion, status.AgentVersion = detectAdapterAndAgentVersionsForStatus(ctx, diagnosticItem, path, lookup)
 		status.VersionOutsideRange = !satisfiesRange(firstNonEmptyVersion(status.AdapterVersion, status.AgentVersion), item.SupportedRange)
 		status.AuthStatus, status.AuthError = DetectAuthStatus(item)
 	}

--- a/internal/agentadapters/registry_test.go
+++ b/internal/agentadapters/registry_test.go
@@ -1128,6 +1128,45 @@ func TestClaudeStatusDoesNotUseLocalCandidatePathForRemoteRuntime(t *testing.T) 
 	}
 }
 
+func TestExplicitRemoteClaudeStatusDoesNotUseLocalAgentCandidatePath(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "remote-test-key")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	adapter, ok := BuiltInByID("claude_code")
+	if !ok {
+		t.Fatal("missing Claude Code adapter")
+	}
+	adapterBinary := writeFakeBinary(t, t.TempDir(), adapter.Command, "adapter 1.2.3")
+	localCandidate := filepath.Join(home, ".volta", "bin", "claude")
+
+	status, ok := StatusForAdapterAfterExplicitProbe(
+		remoteIdentityContext(),
+		adapter.ID,
+		func(file string) (string, error) {
+			switch file {
+			case adapter.Command:
+				return adapterBinary, nil
+			case adapter.AgentVersion.Command:
+				return "", errors.New("not found on remote PATH")
+			case localCandidate:
+				t.Fatalf("explicit remote status probed local candidate %q", file)
+			default:
+				return "", errors.New("not found")
+			}
+			return "", errors.New("unreachable")
+		},
+	)
+	if !ok {
+		t.Fatal("StatusForAdapterAfterExplicitProbe(claude_code) ok = false")
+	}
+	if status.AgentVersion != "" {
+		t.Fatalf("AgentVersion = %q, want unavailable without remote PATH command", status.AgentVersion)
+	}
+	if status.ClaudeCodeCLI.Available || status.ClaudeCodeCLI.ExecutablePath != "" {
+		t.Fatalf("ClaudeCodeCLI = %+v, want unavailable without remote PATH command", status.ClaudeCodeCLI)
+	}
+}
+
 func TestRemoteRuntimeAdapterEnvUsesOnlyRemoteCredentialKeysAndEphemeralHome(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- apply the remote-runtime provider-path boundary to full version diagnostics as well as catalog readiness
- keep local desktop candidate-path discovery unchanged
- add a regression test for the exact explicit remote adapter-probe path

## Root cause and impact

The catalog status path removed local provider CLI candidates in remote-runtime mode, but the full diagnostics run after an explicit Connections probe reused the unsanitized version probe. That path could inspect a runtime-host user candidate such as `~/.volta/bin/claude` and report a provider version that was not available through the remote runtime PATH.

The fix uses a copy of the typed adapter metadata with provider candidate paths removed for every remote status diagnostic. It does not mutate the catalog or change local launches.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -race -count=1 ./internal/agentadapters`
- `go test -race -timeout 10m ./...`
- `git diff --check`

This is a release blocker discovered while reviewing the `v0.4.0-alpha.2` privacy notes. The release will rerun its complete gate on the final merged head.
