### PR TITLE
fix(agent): secure External Agent file delivery

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -568,7 +568,9 @@ implemented by the probe client against its temporary workspace rather than
 returning "not supported" during `session/new`.
 Use opt-in real CLI smokes for both embedded and direct runtimes when a change
 needs verification against authenticated vendor CLIs. Keep real
-provider prompts minimal, workspace-local, and outside the default test ladder.
+provider prompts minimal and outside the default test ladder. Preserve the
+shared smoke's privately staged text-file turn so every supported adapter proves
+that Hecate's file-input boundary works against the authenticated vendor CLI.
 
 Chat session lifecycle orchestration starts in `internal/chatapp.Application`.
 Session create, external-agent prepare, native session metadata persistence,

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -338,10 +338,12 @@ just test-acp-real-embedded
 ```
 
 That opt-in smoke runs Hecate's built-in adapter, probe, session preparation,
-and prompt path against the installed `codex` and `claude` CLIs. It uses local
-vendor authentication, may consume provider quota, and is intentionally outside
-the normal unit-test ladder. Hermetic integration coverage uses strict fake
-vendor CLIs and includes private image/file links and environment isolation.
+and prompt path against the installed `codex` and `claude` CLIs. It sends a
+minimal text turn followed by a privately staged text-file turn on the same
+native session. It uses local vendor authentication, may consume provider
+quota, and is intentionally outside the normal unit-test ladder. Hermetic
+integration coverage uses strict fake vendor CLIs and includes private
+image/file links and environment isolation.
 
 Cursor and Grok expose ACP directly from their vendor CLIs. To verify Hecate's
 live probe, session creation, prompt, and prepared-session reuse against both
@@ -352,9 +354,10 @@ just test-acp-real-direct
 ```
 
 Pass `cursor_agent` or `grok_build` as the optional argument to select one.
-This smoke uses the operator's local CLI authentication and sends one small real
-prompt per selected adapter, so it may consume provider quota and remains
-outside the default verification ladder.
+This smoke uses the operator's local CLI authentication and sends a minimal text
+turn followed by a privately staged text-file turn on the same native session
+for each selected adapter, so it may consume provider quota and remains outside
+the default verification ladder.
 
 There is also a narrower discovery-only fixture env var,
 `HECATE_AGENT_ADAPTER_DISCOVERY_OVERRIDES`, used by backend tests that only

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -503,14 +503,16 @@ in the standalone adapter repositories.
 
 For the built-in adapters, operators can run `just test-acp-real-embedded` (or
 pass one adapter id as its argument). The opt-in smoke uses the installed,
-authenticated vendor CLI and may consume provider quota.
+authenticated vendor CLI, verifies a minimal text turn, then verifies that the
+same prepared native session can read a privately staged text-file input. It may
+consume provider quota.
 
 For the direct ACP implementations bundled with Cursor and Grok, operators can
 run `just test-acp-real-direct` (or pass one adapter id as its argument). The
 opt-in smoke starts the installed vendor CLI, checks Hecate's live probe and
-session preparation, sends one minimal prompt, and verifies that the prepared
-native session handled the turn. It uses local vendor authentication and may
-consume provider quota.
+session preparation, sends a minimal text turn, then verifies that the same
+prepared native session can read a privately staged text-file input. It uses
+local vendor authentication and may consume provider quota.
 
 ## Setup checks
 

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.26.5
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717083303-8510f612270d
+	github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717112436-e42875248155
 	github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8
-	github.com/hecatehq/claude-code-acp-adapter v0.1.1-0.20260717083804-bffeb0bf0ee6
+	github.com/hecatehq/claude-code-acp-adapter v0.1.1-0.20260717112639-78e0df63c0bb
 	github.com/hecatehq/codex-acp-adapter v0.1.1-0.20260717083804-e28b0459660e
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ncruces/zenity v0.10.14

--- a/go.sum
+++ b/go.sum
@@ -33,12 +33,12 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717083303-8510f612270d h1:cDHoW7nujGNHTujpynDUcFM8j0cCLuArSJWvONT6mKo=
-github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717083303-8510f612270d/go.mod h1:tqRmkI7UfnabJsmhj6GrQdTdX2GwtYcCobiSPZl8ERo=
+github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717112436-e42875248155 h1:1ulRRFdVg4C1Tx/YERaAVdEECdt7lnin4Qmz0rDBNa0=
+github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717112436-e42875248155/go.mod h1:tqRmkI7UfnabJsmhj6GrQdTdX2GwtYcCobiSPZl8ERo=
 github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8 h1:Wycv8NJYHwTmOQDz7Nsoqc2onBsavTRY86dX49hat1w=
 github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
-github.com/hecatehq/claude-code-acp-adapter v0.1.1-0.20260717083804-bffeb0bf0ee6 h1:9jq0hdGPbjGvONNy4ehysB7HAKURJwYsjbqAeZLKcyU=
-github.com/hecatehq/claude-code-acp-adapter v0.1.1-0.20260717083804-bffeb0bf0ee6/go.mod h1:x9lCc2cmxBM4S8l0kHrcFAyDQMWoS9jkoqs1DpD85Ek=
+github.com/hecatehq/claude-code-acp-adapter v0.1.1-0.20260717112639-78e0df63c0bb h1:ZyXCB9D5J9FfNZa9GjNXYWWdft8cY0GV924uRpyJ3cw=
+github.com/hecatehq/claude-code-acp-adapter v0.1.1-0.20260717112639-78e0df63c0bb/go.mod h1:Uc1pFyNoBv3pmWwMKtHARLLhlJpsLmc5ytxCaxuPfv4=
 github.com/hecatehq/codex-acp-adapter v0.1.1-0.20260717083804-e28b0459660e h1:e0XT2wHRGStazUJg/aQ/7URy+D7goFYHxF9E77+MDcM=
 github.com/hecatehq/codex-acp-adapter v0.1.1-0.20260717083804-e28b0459660e/go.mod h1:un5aXdOYQdbdocF3FzplLhCpj39QvqXOgUI0tpQ/w0U=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/agentadapters/embedded_adapter_integration_test.go
+++ b/internal/agentadapters/embedded_adapter_integration_test.go
@@ -1,16 +1,34 @@
-//go:build !windows
-
 package agentadapters
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
+
+const fakeEmbeddedProviderConfigSuffix = ".hecate-provider.json"
+
+type fakeEmbeddedProviderConfig struct {
+	Command       string            `json:"command"`
+	Capture       string            `json:"capture"`
+	Output        string            `json:"output"`
+	ExpectedFiles map[string]string `json:"expectedFiles"`
+}
+
+func TestMain(m *testing.M) {
+	configPath := os.Args[0] + fakeEmbeddedProviderConfigSuffix
+	if _, err := os.Stat(configPath); err == nil {
+		os.Exit(runFakeEmbeddedProviderCLI(configPath, os.Args[1:]))
+	}
+	os.Exit(m.Run())
+}
 
 func TestEmbeddedAdaptersRunProviderCLIsWithPrivateFileLinks(t *testing.T) {
 	t.Setenv(adapterTestProcessOverridesEnv, "")
@@ -90,19 +108,33 @@ func TestEmbeddedAdaptersRunProviderCLIsWithPrivateFileLinks(t *testing.T) {
 				t.Fatalf("read captured provider prompt: %v", err)
 			}
 			promptText := string(prompt)
-			for _, want := range []string{"screen.png", "image/png", "notes.txt", "text/plain", "file://"} {
+			for _, want := range []string{"screen.png", "image/png", "notes.txt", "text/plain"} {
 				if !strings.Contains(promptText, want) {
 					t.Fatalf("provider prompt = %q, want %q", promptText, want)
 				}
 			}
+			if strings.Contains(promptText, "file://") {
+				t.Fatalf("provider prompt leaked source resource URI: %q", promptText)
+			}
+			var stagedPaths []string
 			for _, line := range strings.Split(promptText, "\n") {
-				if !strings.HasPrefix(line, "file://") {
+				var manifest struct {
+					Kind string `json:"kind"`
+					Path string `json:"path"`
+				}
+				if err := json.Unmarshal([]byte(line), &manifest); err != nil || manifest.Kind != "resource_link" || manifest.Path == "" {
 					continue
 				}
-				path := strings.TrimPrefix(line, "file://")
-				if _, err := os.Stat(path); !os.IsNotExist(err) {
-					t.Fatalf("private prompt stage %q still exists after provider command: %v", path, err)
+				if !filepath.IsAbs(manifest.Path) {
+					t.Fatalf("provider prompt private path = %q, want absolute path", manifest.Path)
 				}
+				stagedPaths = append(stagedPaths, manifest.Path)
+				if _, err := os.Stat(manifest.Path); !os.IsNotExist(err) {
+					t.Fatalf("private prompt stage input %q still exists after provider command: %v", manifest.Path, err)
+				}
+			}
+			if len(stagedPaths) != 2 {
+				t.Fatalf("provider prompt staged paths = %#v, want two private inputs", stagedPaths)
 			}
 
 			followUp, err := manager.Run(context.Background(), RunRequest{
@@ -127,9 +159,19 @@ func TestEmbeddedAdaptersRunProviderCLIsWithPrivateFileLinks(t *testing.T) {
 			if strings.Contains(followUpText, "file://") {
 				t.Fatalf("follow-up provider prompt replayed ephemeral resource link: %q", followUpText)
 			}
-			for _, want := range []string{"screen.png", "image/png", "notes.txt", "text/plain", "Summarize what you found."} {
+			for _, stagedPath := range stagedPaths {
+				if strings.Contains(followUpText, stagedPath) {
+					t.Fatalf("follow-up provider prompt replayed private stage path %q", stagedPath)
+				}
+			}
+			for _, want := range []string{"Inspect both attached inputs.", tt.output, "Summarize what you found."} {
 				if !strings.Contains(followUpText, want) {
-					t.Fatalf("follow-up provider prompt = %q, want retained metadata %q", followUpText, want)
+					t.Fatalf("follow-up provider prompt = %q, want transcript text %q", followUpText, want)
+				}
+			}
+			for _, privateMetadata := range []string{"screen.png", "image/png", "notes.txt", "text/plain", "acp-commandbridge-private-"} {
+				if strings.Contains(followUpText, privateMetadata) {
+					t.Fatalf("follow-up provider prompt retained private resource metadata %q", privateMetadata)
 				}
 			}
 		})
@@ -142,42 +184,133 @@ func installFakeEmbeddedProviderCLI(t *testing.T, command, capture, output strin
 	if err := os.Mkdir(bin, 0o755); err != nil {
 		t.Fatalf("mkdir provider bin: %v", err)
 	}
-	executable := filepath.Join(bin, command)
-	providerOutput := ""
-	if command == "codex" {
-		providerOutput = fmt.Sprintf("printf '%%s\\n' %q\nprintf '%%s\\n' %q\n", `{"method":"item/completed","params":{"item":{"type":"agent_message","id":"msg-1","text":"`+output+`"}}}`, `{"method":"turn/completed","params":{"usage":{"input_tokens":2,"output_tokens":3,"context_window":128}}}`)
-	} else {
-		providerOutput = fmt.Sprintf("printf '%%s\\n' %q\nprintf '%%s\\n' %q\n", `{"type":"assistant","message":{"content":[{"type":"text","text":"`+output+`"}]}}`, `{"type":"result","subtype":"success","usage":{"input_tokens":2,"output_tokens":3,"context_window":128}}`)
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
 	}
-	script := fmt.Sprintf(`#!/bin/sh
-if [ -n "$HECATE_EMBEDDED_TEST_SECRET" ]; then
-  echo "unexpected inherited environment" >&2
-  exit 90
-fi
-if [ "$1" = "--version" ]; then
-  echo "%s 1.2.3"
-  exit 0
-fi
-case "$*" in
-  "login"|"logout"|"/login"|"auth logout") exit 0 ;;
-esac
-prompt=""
-for arg in "$@"; do prompt="$arg"; done
-printf '%%s' "$prompt" > %q
-while IFS= read -r line; do
-  case "$line" in
-    file://*)
-      path=${line#file://}
-      [ -r "$path" ] || exit 91
-      ;;
-  esac
-done <<HECATE_PROMPT
-$prompt
-HECATE_PROMPT
-%s`, command, capture, providerOutput)
-	if err := os.WriteFile(executable, []byte(script), 0o755); err != nil {
-		t.Fatalf("write provider CLI: %v", err)
+	executable := filepath.Join(bin, command+suffix)
+	copyExecutable(t, executable)
+	config := fakeEmbeddedProviderConfig{
+		Command: command,
+		Capture: capture,
+		Output:  output,
+		ExpectedFiles: map[string]string{
+			"screen.png": "private-image-bytes",
+			"notes.txt":  "private notes",
+		},
+	}
+	rawConfig, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal provider config: %v", err)
+	}
+	if err := os.WriteFile(executable+fakeEmbeddedProviderConfigSuffix, rawConfig, 0o600); err != nil {
+		t.Fatalf("write provider config: %v", err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return executable
+}
+
+func copyExecutable(t *testing.T, destination string) {
+	t.Helper()
+	sourcePath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatalf("open test executable: %v", err)
+	}
+	defer source.Close()
+	destinationFile, err := os.OpenFile(destination, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o700)
+	if err != nil {
+		t.Fatalf("create provider executable: %v", err)
+	}
+	if _, err := io.Copy(destinationFile, source); err != nil {
+		_ = destinationFile.Close()
+		t.Fatalf("copy provider executable: %v", err)
+	}
+	if err := destinationFile.Close(); err != nil {
+		t.Fatalf("close provider executable: %v", err)
+	}
+	if err := os.Chmod(destination, 0o700); err != nil {
+		t.Fatalf("make provider executable: %v", err)
+	}
+}
+
+func runFakeEmbeddedProviderCLI(configPath string, args []string) int {
+	rawConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		return 92
+	}
+	var config fakeEmbeddedProviderConfig
+	if err := json.Unmarshal(rawConfig, &config); err != nil {
+		return 92
+	}
+	if os.Getenv("HECATE_EMBEDDED_TEST_SECRET") != "" {
+		_, _ = fmt.Fprintln(os.Stderr, "unexpected inherited environment")
+		return 90
+	}
+	if len(args) == 1 && args[0] == "--version" {
+		_, _ = fmt.Fprintf(os.Stdout, "%s 1.2.3\n", config.Command)
+		return 0
+	}
+	switch strings.Join(args, " ") {
+	case "login", "logout", "/login", "auth logout":
+		return 0
+	}
+	prompt := ""
+	if len(args) > 0 {
+		prompt = args[len(args)-1]
+	}
+	if err := os.WriteFile(config.Capture, []byte(prompt), 0o600); err != nil {
+		return 92
+	}
+	for _, line := range strings.Split(prompt, "\n") {
+		var manifest struct {
+			Kind string `json:"kind"`
+			Path string `json:"path"`
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal([]byte(line), &manifest); err != nil || manifest.Kind != "resource_link" || manifest.Path == "" {
+			continue
+		}
+		data, err := os.ReadFile(manifest.Path)
+		expected, known := config.ExpectedFiles[manifest.Name]
+		if err != nil || !known || string(data) != expected {
+			return 91
+		}
+	}
+	if config.Command == "codex" {
+		writeFakeProviderJSON(map[string]any{
+			"method": "item/completed",
+			"params": map[string]any{"item": map[string]any{
+				"type": "agent_message", "id": "msg-1", "text": config.Output,
+			}},
+		})
+		writeFakeProviderJSON(map[string]any{
+			"method": "turn/completed",
+			"params": map[string]any{"usage": map[string]any{
+				"input_tokens": 2, "output_tokens": 3, "context_window": 128,
+			}},
+		})
+		return 0
+	}
+	writeFakeProviderJSON(map[string]any{
+		"type": "assistant",
+		"message": map[string]any{"content": []map[string]any{{
+			"type": "text", "text": config.Output,
+		}}},
+	})
+	writeFakeProviderJSON(map[string]any{
+		"type": "result", "subtype": "success",
+		"usage": map[string]any{"input_tokens": 2, "output_tokens": 3, "context_window": 128},
+	})
+	return 0
+}
+
+func writeFakeProviderJSON(value any) {
+	raw, err := json.Marshal(value)
+	if err == nil {
+		_, _ = fmt.Fprintln(os.Stdout, string(raw))
+	}
 }

--- a/internal/agentadapters/real_direct_cli_smoke_test.go
+++ b/internal/agentadapters/real_direct_cli_smoke_test.go
@@ -19,12 +19,13 @@ func TestRealACPCLIsSmoke(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		token string
+		token     string
+		fileToken string
 	}{
-		"codex":        {token: "HECATE_CODEX_EMBEDDED_OK"},
-		"claude_code":  {token: "HECATE_CLAUDE_EMBEDDED_OK"},
-		"cursor_agent": {token: "HECATE_CURSOR_ACP_OK"},
-		"grok_build":   {token: "HECATE_GROK_ACP_OK"},
+		"codex":        {token: "HECATE_CODEX_EMBEDDED_OK", fileToken: "HECATE_CODEX_FILE_OK"},
+		"claude_code":  {token: "HECATE_CLAUDE_EMBEDDED_OK", fileToken: "HECATE_CLAUDE_FILE_OK"},
+		"cursor_agent": {token: "HECATE_CURSOR_ACP_OK", fileToken: "HECATE_CURSOR_FILE_OK"},
+		"grok_build":   {token: "HECATE_GROK_ACP_OK", fileToken: "HECATE_GROK_FILE_OK"},
 	}
 	requested := strings.TrimSpace(os.Getenv("HECATE_ACP_REAL_ADAPTERS"))
 	if requested == "" {
@@ -100,6 +101,31 @@ func TestRealACPCLIsSmoke(t *testing.T) {
 			}
 			if strings.TrimSpace(result.Output) != testCase.token {
 				t.Fatalf("Run(%s) returned unexpected output", adapterID)
+			}
+
+			fileRunCtx, cancelFileRun := context.WithTimeout(t.Context(), 4*time.Minute)
+			fileResult, err := manager.Run(fileRunCtx, RunRequest{
+				SessionID: sessionID,
+				AdapterID: adapterID,
+				Workspace: workspace,
+				Prompt: PromptInput{
+					Text: "Read the attached input.txt file. Reply with exactly the token it contains and nothing else.",
+					Files: []PromptFile{
+						promptTestFile("input.txt", "text/plain", []byte(testCase.fileToken+"\n")),
+					},
+				},
+				Timeout:        3 * time.Minute,
+				MaxOutputBytes: 64 * 1024,
+			})
+			cancelFileRun()
+			if err != nil {
+				t.Fatalf("Run(%s) with file failed", adapterID)
+			}
+			if fileResult.DriverKind != DriverKindACP || fileResult.SessionStarted || fileResult.NativeSessionID != prepared.NativeSessionID {
+				t.Fatalf("Run(%s) with file did not reuse the prepared ACP session", adapterID)
+			}
+			if strings.TrimSpace(fileResult.Output) != testCase.fileToken {
+				t.Fatalf("Run(%s) with file returned %q, want %q", adapterID, strings.TrimSpace(fileResult.Output), testCase.fileToken)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- pin Hecate to the shared private ACP prompt-resource staging boundary
- pin the Claude adapter fix that grants only the prompt-scoped private stage
- verify that provider prompts receive private staged paths, cleanup completes after each turn, and later transcript turns retain no file paths or metadata
- extend the authenticated live smoke to exercise text and staged-file turns on the same native session for all four supported adapters
- document the release-level External Agent file verification path

## Why

Hecate already staged External Agent attachments, but the embedded command bridge did not privately materialize local resource links before launching providers. Claude also needs the resulting private stage passed through its existing additional-directory mechanism. Without both boundaries, a file could appear in the chat while the provider could not read it.

## Dependencies

- hecatehq/acp-adapter-kit#26
- hecatehq/claude-code-acp-adapter#55

## Verification

- `just verify`
- `just verify-desktop`
- `go test -race -timeout 10m ./internal/agentadapters`
- authenticated live text-and-file turns through all four supported adapters
- `git diff --check`
