### PR TITLE
fix(chat): preview attached images in app

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -2232,8 +2232,18 @@ test("Hecate Chat stages and renders an image through the browser attachment flo
       ),
     )
     .toBe(true);
-  await expect(page.getByRole("link", { name: "Open browser-vision.png" })).toBeVisible();
+  const previewButton = page.getByRole("button", { name: "Open browser-vision.png" });
+  await expect(previewButton).toBeVisible();
   await expect(page.getByRole("img", { name: "browser-vision.png" })).toBeVisible();
+  await previewButton.click();
+  const previewDialog = page.getByRole("dialog", {
+    name: "Image preview: browser-vision.png",
+  });
+  await expect(previewDialog).toBeVisible();
+  await expect(previewDialog.getByRole("img", { name: "browser-vision.png" })).toBeVisible();
+  await previewDialog.getByRole("button", { name: "Close" }).click();
+  await expect(previewDialog).toHaveCount(0);
+  await expect(previewButton).toBeFocused();
   await expect(page.locator("body")).toContainText("Direct response to: Describe this image");
 });
 

--- a/ui/src/features/chats/ChatImageAttachments.test.tsx
+++ b/ui/src/features/chats/ChatImageAttachments.test.tsx
@@ -517,6 +517,28 @@ describe("stored chat image attachments", () => {
   });
 
   it("opens an accessible in-app preview and returns focus when dismissed", async () => {
+    let notify: IntersectionObserverCallback = () => {};
+    class MockIntersectionObserver implements IntersectionObserver {
+      readonly root = null;
+      readonly rootMargin = "240px 0px";
+      readonly scrollMargin = "0px";
+      readonly thresholds = [0];
+
+      constructor(callback: IntersectionObserverCallback) {
+        notify = callback;
+      }
+
+      observe() {}
+      disconnect() {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+      unobserve() {}
+    }
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      value: MockIntersectionObserver,
+    });
     defineURLMethod(
       "createObjectURL",
       vi.fn(() => "blob:preview"),
@@ -529,6 +551,12 @@ describe("stored chat image attachments", () => {
 
     render(<ChatImageAttachmentGallery attachments={[storedAttachment()]} />);
 
+    act(() => {
+      notify(
+        [{ isIntersecting: true, intersectionRatio: 1 } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
     const trigger = await screen.findByRole("button", { name: "Open map.png" });
     await user.click(trigger);
 
@@ -540,6 +568,13 @@ describe("stored chat image attachments", () => {
     );
     expect(within(dialog).getByRole("button", { name: "Close" })).toHaveFocus();
     expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    act(() => {
+      notify(
+        [{ isIntersecting: false, intersectionRatio: 0 } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
 
     await user.keyboard("{Escape}");
 

--- a/ui/src/features/chats/ChatImageAttachments.test.tsx
+++ b/ui/src/features/chats/ChatImageAttachments.test.tsx
@@ -543,7 +543,8 @@ describe("stored chat image attachments", () => {
       "createObjectURL",
       vi.fn(() => "blob:preview"),
     );
-    defineURLMethod("revokeObjectURL", vi.fn());
+    const revokeObjectURL = vi.fn();
+    defineURLMethod("revokeObjectURL", revokeObjectURL);
     vi.mocked(getChatAttachmentContentBlob).mockResolvedValue(
       new Blob(["image"], { type: "image/png" }),
     );
@@ -579,8 +580,9 @@ describe("stored chat image attachments", () => {
     await user.keyboard("{Escape}");
 
     expect(screen.queryByRole("dialog", { name: "Image preview: map.png" })).toBeNull();
-    expect(trigger).toHaveFocus();
-    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Load map.png" })).toHaveFocus());
+    expect(screen.queryByRole("img", { name: "map.png" })).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview");
   });
 
   it("lets the operator load a deferred image before it intersects the viewport", async () => {

--- a/ui/src/features/chats/ChatImageAttachments.test.tsx
+++ b/ui/src/features/chats/ChatImageAttachments.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -429,10 +429,12 @@ describe("stored chat image attachments", () => {
         expect.any(AbortSignal),
       ),
     );
-    await waitFor(() => expect(screen.getByRole("img", { name: "map.png" })).toBeVisible());
-    expect(screen.getByRole("link", { name: "Open map.png" })).toHaveAttribute(
-      "href",
-      "blob:stored-1",
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: "map.png" })).toHaveAttribute("src", "blob:stored-1"),
+    );
+    expect(screen.getByRole("button", { name: "Open map.png" })).toHaveAttribute(
+      "aria-haspopup",
+      "dialog",
     );
     expect(disconnect).not.toHaveBeenCalled();
 
@@ -453,10 +455,7 @@ describe("stored chat image attachments", () => {
     });
     await waitFor(() => expect(getChatAttachmentContentBlob).toHaveBeenCalledTimes(2));
     await waitFor(() =>
-      expect(screen.getByRole("link", { name: "Open map.png" })).toHaveAttribute(
-        "href",
-        "blob:stored-2",
-      ),
+      expect(screen.getByRole("img", { name: "map.png" })).toHaveAttribute("src", "blob:stored-2"),
     );
 
     unmount();
@@ -481,10 +480,7 @@ describe("stored chat image attachments", () => {
       "att-1",
       expect.any(AbortSignal),
     );
-    expect(screen.getByRole("link", { name: "Open map.png" })).toHaveAttribute(
-      "href",
-      "blob:stored",
-    );
+    expect(screen.getByRole("img", { name: "map.png" })).toHaveAttribute("src", "blob:stored");
 
     unmount();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:stored");
@@ -514,10 +510,42 @@ describe("stored chat image attachments", () => {
     expect(image).toHaveAttribute("width", "132");
     expect(image).toHaveAttribute("height", "96");
     expect(image).toHaveStyle({ width: "100%", height: "100%" });
-    expect(screen.getByRole("link", { name: "Open map.png" })).toHaveStyle({
+    expect(screen.getByRole("button", { name: "Open map.png" })).toHaveStyle({
       width: "132px",
       height: "96px",
     });
+  });
+
+  it("opens an accessible in-app preview and returns focus when dismissed", async () => {
+    defineURLMethod(
+      "createObjectURL",
+      vi.fn(() => "blob:preview"),
+    );
+    defineURLMethod("revokeObjectURL", vi.fn());
+    vi.mocked(getChatAttachmentContentBlob).mockResolvedValue(
+      new Blob(["image"], { type: "image/png" }),
+    );
+    const user = userEvent.setup();
+
+    render(<ChatImageAttachmentGallery attachments={[storedAttachment()]} />);
+
+    const trigger = await screen.findByRole("button", { name: "Open map.png" });
+    await user.click(trigger);
+
+    const dialog = screen.getByRole("dialog", { name: "Image preview: map.png" });
+    expect(dialog).toBeVisible();
+    expect(within(dialog).getByRole("img", { name: "map.png" })).toHaveAttribute(
+      "src",
+      "blob:preview",
+    );
+    expect(within(dialog).getByRole("button", { name: "Close" })).toHaveFocus();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog", { name: "Image preview: map.png" })).toBeNull();
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
 
   it("lets the operator load a deferred image before it intersects the viewport", async () => {
@@ -562,7 +590,7 @@ describe("stored chat image attachments", () => {
     expect(screen.getByRole("status", { name: "Loading map.png" })).toHaveFocus();
     act(() => resolveBlob?.(new Blob(["image"], { type: "image/png" })));
     expect(await screen.findByRole("img", { name: "map.png" })).toBeVisible();
-    await waitFor(() => expect(screen.getByRole("link", { name: "Open map.png" })).toHaveFocus());
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open map.png" })).toHaveFocus());
   });
 
   it("does not reclaim focus when the operator leaves a manually loading preview", async () => {
@@ -608,7 +636,7 @@ describe("stored chat image attachments", () => {
     await user.click(screen.getByRole("button", { name: "Elsewhere" }));
 
     act(() => resolveBlob?.(new Blob(["image"], { type: "image/png" })));
-    expect(await screen.findByRole("link", { name: "Open map.png" })).toBeVisible();
+    expect(await screen.findByRole("button", { name: "Open map.png" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Elsewhere" })).toHaveFocus();
   });
 
@@ -759,7 +787,7 @@ describe("stored chat image attachments", () => {
     expect(screen.getByRole("status", { name: "Loading map.png" })).toHaveFocus();
     act(() => resolveRetry?.(new Blob(["image"], { type: "image/png" })));
     expect(await screen.findByRole("img", { name: "map.png" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "Open map.png" })).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Open map.png" })).toHaveFocus();
   });
 });
 

--- a/ui/src/features/chats/ChatImageAttachments.tsx
+++ b/ui/src/features/chats/ChatImageAttachments.tsx
@@ -11,7 +11,7 @@ import {
 import { getChatAttachmentContentBlob } from "../../lib/api";
 import type { PendingChatAttachment } from "../../app/state/_shared";
 import type { ChatAttachmentRecord } from "../../types/chat";
-import { Icon, Icons } from "../shared/ui";
+import { Icon, Icons, Modal } from "../shared/ui";
 
 export const MAX_CHAT_IMAGE_ATTACHMENTS = 4;
 export const MAX_CHAT_IMAGE_BYTES = 5 * 1024 * 1024;
@@ -559,11 +559,12 @@ function StoredImagePreview({ attachment }: { attachment: ChatAttachmentRecord }
   const loadButtonRef = useRef<HTMLButtonElement>(null);
   const loadingStatusRef = useRef<HTMLDivElement>(null);
   const retryButtonRef = useRef<HTMLButtonElement>(null);
-  const imageLinkRef = useRef<HTMLAnchorElement>(null);
+  const imageButtonRef = useRef<HTMLButtonElement>(null);
   const focusTransferSourceRef = useRef<HTMLElement | null>(null);
   const nearViewport = useNearViewport(viewportRef);
   const [loadRequested, setLoadRequested] = useState(false);
-  const shouldLoad = nearViewport || loadRequested;
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const shouldLoad = nearViewport || loadRequested || previewOpen;
   const [src, setSrc] = useState("");
   const [failed, setFailed] = useState(false);
   const [loadAttempt, setLoadAttempt] = useState(0);
@@ -617,7 +618,7 @@ function StoredImagePreview({ attachment }: { attachment: ChatAttachmentRecord }
       return;
     }
     const target = src
-      ? imageLinkRef.current
+      ? imageButtonRef.current
       : failed
         ? retryButtonRef.current
         : !shouldLoad
@@ -743,19 +744,23 @@ function StoredImagePreview({ attachment }: { attachment: ChatAttachmentRecord }
     );
   } else {
     preview = (
-      <a
-        ref={imageLinkRef}
-        href={src}
-        target="_blank"
-        rel="noreferrer"
+      <button
+        ref={imageButtonRef}
+        type="button"
         aria-label={`Open ${attachment.filename}`}
+        aria-haspopup="dialog"
+        aria-expanded={previewOpen}
         title={`${attachment.filename} · ${formatBytes(attachment.size_bytes)}`}
+        onClick={() => setPreviewOpen(true)}
         onFocus={(event) => rememberFocusSource(event.currentTarget)}
         onBlur={releaseFocusSource}
         style={{
           ...STORED_IMAGE_PREVIEW_FRAME_STYLE,
           display: "block",
           overflow: "hidden",
+          padding: 0,
+          color: "inherit",
+          cursor: "zoom-in",
         }}
       >
         <img
@@ -771,21 +776,65 @@ function StoredImagePreview({ attachment }: { attachment: ChatAttachmentRecord }
             objectFit: "contain",
           }}
         />
-      </a>
+      </button>
     );
   }
 
   return (
-    <div
-      ref={viewportRef}
-      style={{
-        width: STORED_IMAGE_PREVIEW_WIDTH,
-        height: STORED_IMAGE_PREVIEW_HEIGHT,
-        maxWidth: "100%",
-      }}
-    >
-      {preview}
-    </div>
+    <>
+      <div
+        ref={viewportRef}
+        style={{
+          width: STORED_IMAGE_PREVIEW_WIDTH,
+          height: STORED_IMAGE_PREVIEW_HEIGHT,
+          maxWidth: "100%",
+        }}
+      >
+        {preview}
+      </div>
+      {previewOpen && src && (
+        <Modal
+          title={attachment.filename}
+          ariaLabel={`Image preview: ${attachment.filename}`}
+          width={960}
+          returnFocusRef={imageButtonRef}
+          onClose={() => setPreviewOpen(false)}
+          footer={
+            <span
+              style={{
+                color: "var(--t3)",
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+              }}
+            >
+              {formatBytes(attachment.size_bytes)} · {attachment.media_type || "unknown type"}
+            </span>
+          }
+        >
+          <div
+            style={{
+              display: "grid",
+              placeItems: "center",
+              minHeight: 160,
+              background: "var(--bg0)",
+              borderRadius: "var(--radius-sm)",
+              overflow: "hidden",
+            }}
+          >
+            <img
+              src={src}
+              alt={attachment.filename}
+              style={{
+                display: "block",
+                maxWidth: "100%",
+                maxHeight: "calc(80dvh - 150px)",
+                objectFit: "contain",
+              }}
+            />
+          </div>
+        </Modal>
+      )}
+    </>
   );
 }
 

--- a/ui/src/features/chats/ChatImageAttachments.tsx
+++ b/ui/src/features/chats/ChatImageAttachments.tsx
@@ -653,13 +653,6 @@ function StoredImagePreview({ attachment }: { attachment: ChatAttachmentRecord }
     setLoadAttempt((current) => current + 1);
   }
 
-  function closePreview() {
-    // Keep the opener mounted long enough for the dialog to restore focus when
-    // its thumbnail moved outside the observer range while the preview was open.
-    if (!nearViewport) setLoadRequested(true);
-    setPreviewOpen(false);
-  }
-
   let preview;
   if (!shouldLoad) {
     preview = (
@@ -804,8 +797,8 @@ function StoredImagePreview({ attachment }: { attachment: ChatAttachmentRecord }
           title={attachment.filename}
           ariaLabel={`Image preview: ${attachment.filename}`}
           width={960}
-          returnFocusRef={imageButtonRef}
-          onClose={closePreview}
+          returnFocusRef={loadButtonRef}
+          onClose={() => setPreviewOpen(false)}
           footer={
             <span
               style={{

--- a/ui/src/features/chats/ChatImageAttachments.tsx
+++ b/ui/src/features/chats/ChatImageAttachments.tsx
@@ -653,6 +653,13 @@ function StoredImagePreview({ attachment }: { attachment: ChatAttachmentRecord }
     setLoadAttempt((current) => current + 1);
   }
 
+  function closePreview() {
+    // Keep the opener mounted long enough for the dialog to restore focus when
+    // its thumbnail moved outside the observer range while the preview was open.
+    if (!nearViewport) setLoadRequested(true);
+    setPreviewOpen(false);
+  }
+
   let preview;
   if (!shouldLoad) {
     preview = (
@@ -798,7 +805,7 @@ function StoredImagePreview({ attachment }: { attachment: ChatAttachmentRecord }
           ariaLabel={`Image preview: ${attachment.filename}`}
           width={960}
           returnFocusRef={imageButtonRef}
-          onClose={() => setPreviewOpen(false)}
+          onClose={closePreview}
           footer={
             <span
               style={{


### PR DESCRIPTION
## Summary

- open sent image attachments in an accessible in-app preview
- preserve deferred loading and guarded object URL cleanup
- support Escape, backdrop, and close-button dismissal with focus restoration

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test` (104 files, 2,297 tests)
- focused Chromium attachment-preview journey

## Documentation

No changes. This is an intuitive UI-only interaction with no API or configuration changes.