### PR TITLE
fix(chat): complete image and dictation input flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,16 @@ fail over or follow a same-name replacement. Tools-on turns hydrate images from
 an opaque run input reference immediately before the agent loop starts; task
 conversation artifacts retain an omission marker, never the binary body. Image
 blocks and remote image URLs are not persisted in those artifacts. Same-input
-resume and retry runs rehydrate through the opaque reference. Image drafts never enter the local busy-message queue, and the UI keeps submitted
-in-memory `File` values owned by their turn until it settles.
+resume and retry runs rehydrate through the opaque reference. At the final
+provider-dispatch boundary, Hecate atomically records the exact resolved route
+on the run before provider I/O, so a worker restart cannot Auto-route the image
+elsewhere; the first model may be policy-rewritten, then every later tool turn
+stays on that same route and instance. This private may-disclose fence is
+distinct from the transcript marker, which is set only after a dispatched
+provider call reports its route. A pre-dispatch failure does not mark the
+transcript as having disclosed the image. Image drafts never enter the local busy-message queue, and
+the UI keeps submitted in-memory `File` values owned by their turn until it
+settles.
 
 External Agent chats accept up to four non-empty files of any type, with the
 same 5 MiB per-file and 12 MiB per-message limits. Hecate resolves those inputs

--- a/README.md
+++ b/README.md
@@ -153,17 +153,17 @@ matters.
 
 ## Current Capabilities
 
-| Surface            | What works today                                                                                                                                                                                                                                                                                                                                                                      |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Model gateway**  | OpenAI-compatible Chat Completions, Anthropic-shaped Messages, streaming, vision, model discovery, provider health, failover, retry, usage events, and custom OpenAI-compatible endpoints.                                                                                                                                                                                            |
-| **Connections**    | Cloud presets plus Ollama, LM Studio, LocalAI, llama.cpp-compatible servers, local discovery, health checks, credentials, external-agent readiness, and durable approval grants.                                                                                                                                                                                                      |
-| **Chats**          | Provider-routed dictation, direct model turns with image attachments, External Agent turns with arbitrary file inputs, tools-on task-backed turns with managed-workspace or current-folder execution, queued prompts, task/run/trace links, inline approvals, inline MCP Apps views, context packet snapshots, project-aware history, and workspace changes with rich per-file diffs. |
-| **Projects**       | Cairnline-backed project identity, roots, context and skill metadata, roles, work items, assignments, handoffs, project memory, review artifacts, and memory candidates, presented through Hecate's native operator cockpit and execution links.                                                                                                                                      |
-| **Tasks**          | Native `agent_loop` runs, queue/lease execution, blocking approvals, streamed activity, artifacts, retry/resume, stale-run recovery, MCP tool/App integration, MCP probe, and MCP registry discovery.                                                                                                                                                                                 |
-| **External Agent** | Supervised local ACP sessions for Codex, Claude Code, Cursor Agent, and Grok Build, including file inputs, readiness/version checks, prompt-first approvals, adapter diagnostics, cancellation, and Git diff inspect/revert. External agents keep their own accounts/billing.                                                                                                         |
-| **Observability**  | OpenTelemetry traces/metrics/logs, response trace headers, local trace view, route reports, runtime stats, timing, token usage, and provider-reported cost where available.                                                                                                                                                                                                           |
-| **Desktop app**    | Native bundles run the Hecate runtime as a sidecar. macOS Apple Silicon is launch-tested; Linux and Windows bundles are CI-built but still experimental.                                                                                                                                                                                                                              |
-| **Sandbox policy** | WorkspaceFS boundaries, ProcessRunner/GitRunner seams, env sanitisation, output caps, timeouts, and `bwrap` / `sandbox-exec` wrappers where available. This is not container-level isolation.                                                                                                                                                                                         |
+| Surface            | What works today                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Model gateway**  | OpenAI-compatible Chat Completions, Anthropic-shaped Messages, streaming, vision, model discovery, provider health, failover, retry, usage events, and custom OpenAI-compatible endpoints.                                                                                                                                                                                      |
+| **Connections**    | Cloud presets plus Ollama, LM Studio, LocalAI, llama.cpp-compatible servers, local discovery, health checks, credentials, external-agent readiness, and durable approval grants.                                                                                                                                                                                                |
+| **Chats**          | Provider-routed dictation, Hecate turns with image attachments, External Agent turns with arbitrary file inputs, tools-on task-backed turns with managed-workspace or current-folder execution, queued prompts, task/run/trace links, inline approvals, inline MCP Apps views, context packet snapshots, project-aware history, and workspace changes with rich per-file diffs. |
+| **Projects**       | Cairnline-backed project identity, roots, context and skill metadata, roles, work items, assignments, handoffs, project memory, review artifacts, and memory candidates, presented through Hecate's native operator cockpit and execution links.                                                                                                                                |
+| **Tasks**          | Native `agent_loop` runs, queue/lease execution, blocking approvals, streamed activity, artifacts, retry/resume, stale-run recovery, MCP tool/App integration, MCP probe, and MCP registry discovery.                                                                                                                                                                           |
+| **External Agent** | Supervised local ACP sessions for Codex, Claude Code, Cursor Agent, and Grok Build, including file inputs, readiness/version checks, prompt-first approvals, adapter diagnostics, cancellation, and Git diff inspect/revert. External agents keep their own accounts/billing.                                                                                                   |
+| **Observability**  | OpenTelemetry traces/metrics/logs, response trace headers, local trace view, route reports, runtime stats, timing, token usage, and provider-reported cost where available.                                                                                                                                                                                                     |
+| **Desktop app**    | Native bundles run the Hecate runtime as a sidecar. macOS Apple Silicon is launch-tested; Linux and Windows bundles are CI-built but still experimental.                                                                                                                                                                                                                        |
+| **Sandbox policy** | WorkspaceFS boundaries, ProcessRunner/GitRunner seams, env sanitisation, output caps, timeouts, and `bwrap` / `sandbox-exec` wrappers where available. This is not container-level isolation.                                                                                                                                                                                   |
 
 Design direction that is not yet a runtime contract:
 
@@ -275,15 +275,18 @@ chat cannot silently switch execution boundaries.
 If the selected model cannot call tools, Hecate keeps the chat usable as direct
 model chat and makes the tools-unavailable state visible.
 
-With tools off, image-capable models accept PNG, JPEG, and WebP attachments by
-picker, drag-and-drop, or paste. Hecate stores the image body outside the
+Image-capable models accept PNG, JPEG, and WebP attachments with tools on or
+off, by picker, drag-and-drop, or paste. Hecate stores the image body outside the
 transcript, loads its preview through the normal Hecate-native API path
 (including the runtime-token header when that optional guard is configured),
 and sends it only through an explicitly image-capable provider route.
 Image-bearing requests may retry on that exact provider generation but never
-fail over or follow a same-name replacement. Image drafts never enter the local
-busy-message queue, and the UI keeps submitted in-memory `File` values owned by
-their turn until it settles.
+fail over or follow a same-name replacement. Tools-on turns hydrate images from
+an opaque run input reference immediately before the agent loop starts; task
+conversation artifacts retain an omission marker, never the binary body. Image
+blocks and remote image URLs are not persisted in those artifacts. Same-input
+resume and retry runs rehydrate through the opaque reference. Image drafts never enter the local busy-message queue, and the UI keeps submitted
+in-memory `File` values owned by their turn until it settles.
 
 External Agent chats accept up to four non-empty files of any type, with the
 same 5 MiB per-file and 12 MiB per-message limits. Hecate resolves those inputs
@@ -302,9 +305,11 @@ records for at most two minutes, sends the bounded audio to that route only,
 does not retain the audio, and inserts the returned transcript at the cursor as
 an editable draft. Capture uses standard secure-context browser APIs, with
 native permission integration for the macOS, Windows, and Linux desktop
-webviews; the browser or operating system controls microphone access. Linux and
-Windows desktop capture remain experimental until they have real-machine audio
-smoke coverage. Dictation never sends the chat message automatically.
+webviews; the browser or operating system controls microphone access. The
+transcription route is independent of the selected chat model or External
+Agent, so the editable draft works with Claude and every other target. Linux
+and Windows desktop capture remain experimental until they have real-machine
+audio smoke coverage. Dictation never sends the chat message automatically.
 
 ![Hecate Chat with a selected model that cannot call tools, falling back to direct chat](docs/screenshots/chat-tools-fallback.png)
 

--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -112,7 +112,15 @@ unresolved Auto routing. Carry the generation through catalog, routing, gateway
 metadata, and chat persistence, and revalidate it against the live registry
 immediately before dispatch. Derive durable generations only from non-secret
 control-plane generation/configuration data and never expose them through APIs,
-telemetry, logs, or errors.
+telemetry, logs, or errors. A tools-on task may retain an admitted generation
+only beside its opaque run input reference; at final provider-dispatch
+admission, atomically persist the exact resolved route there before provider
+I/O. Keep that final-dispatch marker separate from admission: its first model
+may be governor-rewritten, while later tool turns, approval continuations, and
+same-input retries must replay the persisted route and instance. Do not treat
+that fence as proof of disclosure. Mark the transcript only after a dispatched
+provider call returns attempted-route metadata. A durability or final-validation
+failure must block provider I/O and leave the transcript marker empty.
 Do not derive provider-native capability provenance from model discovery alone,
 and do not apply Hecate's strict attachment requirement to ordinary
 provider-compatible `/v1` rich-content passthrough. Keep that compatibility

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -753,7 +753,14 @@ attempted provider/model/generation and trace so the durable transcript records
 the disclosure boundary. Do not stamp an attachment-bearing user row with a
 provider generation during admission: only attempted-call metadata may make its
 bytes eligible for later history hydration, and pre-call failures must leave the
-generation empty. Durable attachment claims use the intended user-message id
+user-row generation empty. At the final gateway dispatch boundary, a tools-on task must
+atomically persist the exact resolved provider/model/generation beside its
+opaque `InputRef` before provider I/O. Keep that final-dispatch marker separate
+from admission: its first model may be governor-rewritten, while recovery and
+same-input retries must replay the persisted exact route. This may-disclose
+recovery fence is not transcript disclosure metadata. Preserve it through stale
+state transitions, cancellation, and requeueing, and fail closed when it cannot
+be written. Durable attachment claims use the intended user-message id
 as a fence: exact transcript metadata links,
 absence releases, deleted owners purge, and conflicts remain fail-closed. Do
 the idempotent linked transition again before returning a same-payload keyed

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -361,6 +361,10 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   turns. Put the fallback state in the chat header/status line, not as a noisy
   composer warning. Connections shows observed provider/catalog capability
   metadata, not a global "tools on/off" override editor.
+- Hecate image attachments are independent of the Tools toggle. Keep the
+  PNG/JPEG/WebP and confirmed `image_input` gates in both direct-model and
+  task-backed modes; never reintroduce UI copy that asks operators to disable
+  tools merely to attach an image.
 - Stale selected-model readiness is a composition blocker, not a post-send
   error toast. If the selected model is not in the current model picker for the
   selected route, hide/disable send and show the selected model, provider route,
@@ -605,6 +609,10 @@ these boundaries when changing dictation:
   enabling capture. Keep client capture failures distinct from provider
   readiness failures so “unsupported browser,” “permission denied,” and
   “connect a transcription provider” remain actionable states;
+- explain that speech-to-text routing is independent of the selected chat
+  model or External Agent. A Claude-only setup still needs a transcription
+  route. Permission-denied copy must point browser users to site controls and
+  desktop users to the operating-system microphone privacy settings;
 - show the exact provider and local/cloud kind before recording, and never
   silently select a different route after a failure;
 - cap recording duration and client-side bytes, stop every `MediaStreamTrack`

--- a/docs/contributor/architecture.md
+++ b/docs/contributor/architecture.md
@@ -126,6 +126,7 @@ sequenceDiagram
     participant API as Chat API
     participant Transcript as Chat store
     participant Bodies as Attachment store
+    participant Tasks as Task state
     participant Recovery as Startup reconciler
     participant Gateway as Gateway/router
     participant ACP as External Agent ACP session
@@ -143,6 +144,12 @@ sequenceDiagram
         API->>Gateway: transient text + image blocks + provider generation
         Gateway->>Gateway: revalidate live name + generation
         Gateway-->>API: provider response
+    else Hecate tools-on image turn
+        API->>Tasks: persist opaque chat-message input reference
+        API->>Gateway: hydrate transient image blocks at agent-loop execution
+        Gateway->>Gateway: require image capability + no failover; fence known generation
+        Gateway-->>API: provider response with tools available
+        API->>API: replace image blocks with artifact omission markers
     else External Agent file turn
         API->>ACP: inline image/embedded resource only when live capability allows
         API->>API: otherwise verify retained stage handles + register body-free namespace/redactor

--- a/docs/operator/desktop-app.md
+++ b/docs/operator/desktop-app.md
@@ -63,6 +63,10 @@ What works:
   Browser capture has automated end-to-end coverage; Linux and Windows native
   capture are permission-logic- and bundle-tested but remain experimental until
   exercised with real microphones on those platforms.
+  If access was denied, enable Hecate in the operating system's microphone
+  privacy settings and restart the app. On macOS use **System Settings →
+  Privacy & Security → Microphone**. On Windows use **Settings → Privacy &
+  security → Microphone** and enable desktop-app microphone access.
 - Native Hecate menu with actions to focus the window, open the gateway log,
   open the data directory, and quit.
 - Per-platform writable data dir (`~/Library/Application Support/sh.hecate.app/`,

--- a/docs/operator/providers.md
+++ b/docs/operator/providers.md
@@ -137,6 +137,12 @@ path and default transcription model are configured. Missing credentials,
 disabled providers, and invalid provider configuration remain visible as
 unavailable choices so the operator can repair the intended route.
 
+The dictation choice is independent of the chat target. Claude and other
+External Agents receive the returned text normally, but an Anthropic-only
+connection does not provide speech-to-text; configure OpenAI, Groq, LocalAI, or
+an explicitly compatible transcription endpoint as the separate dictation
+route.
+
 Hecate sends each recording to the explicitly selected provider only. It does
 not use Auto routing or fail over dictation audio to another provider. The
 provider's name and opaque configuration generation are revalidated immediately

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -176,7 +176,9 @@ time. The body exists only in transient request/provider memory: Hecate does not
 write audio to the chat attachment store, transcript rows, usage events,
 traces, metrics, logs, or artifacts.
 
-The operator must select one transcription provider. Hecate captures that
+The operator must select one transcription provider independently of the chat
+model or External Agent that will receive the editable transcript. Anthropic
+chat credentials alone do not configure speech-to-text. Hecate captures that
 provider's opaque generation and revalidates it immediately before the upstream
 call; provider removal, endpoint/account replacement, or capability removal
 fails closed before disclosure. Dictation has no Auto route and no
@@ -285,7 +287,7 @@ route-local 30-second socket deadline. Content delivery is also a counted chat
 lifecycle operation, so chat deletion waits for an admitted lookup and write
 instead of deleting the body while it is being served.
 
-Hecate-owned Tools-off direct-model turns accept PNG, JPEG, and WebP images;
+Hecate-owned turns accept PNG, JPEG, and WebP images with Tools on or off;
 External Agent turns also accept arbitrary files as opaque inputs. Both modes
 accept at most four files per message, with a 5 MiB per-file limit and a 12 MiB
 combined-message limit. Direct-model rasters require MIME/magic-byte agreement,
@@ -307,8 +309,12 @@ digest as proof of secrecy or ownership. Protect session API responses,
 database snapshots, and backups as sensitive metadata even when attachment
 bodies are handled separately. SVG and other arbitrary formats are not
 direct-model image inputs; an External Agent receives them only as files.
-Remote image URLs, filesystem paths supplied by the client, and Tools-on Hecate
-turns remain outside this attachment surface.
+Remote image URLs and filesystem paths supplied by the client remain outside
+this attachment surface. Tools-on task state persists only an opaque chat
+message reference; the runtime hydrates the body under the image-turn gate and
+replaces image blocks (including remote URLs) with an omission marker before
+writing conversation artifacts. Same-input resumes and retries rehydrate from
+the reference instead of persisting the body.
 A fixed two-slot gate per Hecate process bounds concurrent upload body reads and
 image decodes; a saturated upload is rejected with `429` before
 its body is read. Each admitted body must finish reading within 60 seconds;

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -225,7 +225,17 @@ composer reports an unsupported context separately from an unconfigured
 transcription provider, and a denied microphone request leaves the draft and
 the rest of the composer usable.
 
-The built-in transcription routes are OpenAI (`gpt-4o-mini-transcribe`), Groq
+When permission was denied, browser users should open the current site's
+controls in the address bar, change **Microphone** to **Allow**, and reload the
+page. Desktop users should enable Hecate in the operating system's microphone
+privacy settings and restart the app. On macOS that control is **System
+Settings → Privacy & Security → Microphone**; on Windows it is **Settings →
+Privacy & security → Microphone**, including desktop-app access.
+
+The transcription route is independent of the selected chat model or External
+Agent. A Claude/Anthropic chat therefore still needs one configured
+speech-to-text route; the returned text is then an ordinary draft that Claude
+can receive. The built-in routes are OpenAI (`gpt-4o-mini-transcribe`), Groq
 (`whisper-large-v3-turbo`), and LocalAI (`whisper-1`). Operators can also opt an
 env-configured OpenAI-compatible provider into the same typed contract. See
 [Providers](../operator/providers.md#dictation-providers) and the
@@ -233,19 +243,21 @@ env-configured OpenAI-compatible provider into the same typed contract. See
 
 ### File attachments
 
-Chat attachments have two execution-specific admission modes:
+Chat attachments have two ownership-specific admission modes:
 
-- A Hecate-owned direct-model turn requires Tools off, PNG/JPEG/WebP input, and
+- A Hecate-owned turn accepts PNG/JPEG/WebP input with Tools on or off, and
   at least one matching routable provider/model route with effective
   `image_input="supported"`. `unknown`, `none`, and support reported only by a
-  blocked route fail closed.
+  blocked route fail closed. Tools-on agent loops keep only an opaque input
+  reference in task state, hydrate the body immediately before execution, and
+  replace image blocks with a non-sensitive marker in conversation artifacts.
+  Same-input approval resumes and retries rehydrate that marker through the
+  opaque reference; a later chat prompt replaces or clears the reference.
 - An External Agent turn accepts arbitrary non-empty files once its normal
   workspace, adapter, and required launch controls are ready. ACP resource links
   are the baseline. Hecate uses an inline image or embedded resource only when
   the live ACP session reports that capability; otherwise it privately stages
-  the file and sends a resource link. Task-backed Tools-on turns reject
-  attachment ids instead of silently dropping them or changing runtime
-  ownership.
+  the file and sends a resource link.
 
 The direct-model rule is an explicit Hecate Chat runtime requirement;
 provider-compatible `/v1` multimodal requests retain upstream passthrough when
@@ -255,16 +267,16 @@ selected provider instance immediately before dispatch. Their encoded JSON body
 is limited to 32 MiB with a 60-second read deadline.
 
 Both chat modes accept at most four files per message. Each upload is limited to
-5 MiB, and the combined files on one message are limited to 12 MiB. Direct-model
+5 MiB, and the combined files on one message are limited to 12 MiB. Hecate-owned
 images are also limited to 8000 pixels on either axis and 16 megapixels. Hecate
 checks their magic bytes, declared media type, and decoded dimensions, fully
 decodes the bounded image, then records a server-generated id and SHA-256
 digest. External Agent files retain their bounded bytes and declared media type
 without being interpreted as active content by the operator UI. The composer
 supports file selection, drop, and paste. An attachment-bearing draft cannot be
-queued while the chat is busy. Switching from Hecate image mode into an
-External Agent keeps compatible drafts; switching into Tools on or into a
-Hecate route that cannot accept every selected file remains blocked.
+queued while the chat is busy. Switching between Hecate Tools modes or into an
+External Agent keeps compatible drafts; switching into a Hecate route that
+cannot accept every selected file remains blocked.
 Because the browser keeps those local `File` drafts in memory only, it also
 requests confirmation before a page reload or close would discard them. On
 submit, the UI atomically transfers the exact prompt and `File` values out of
@@ -461,15 +473,17 @@ flowchart LR
     Lifecycle -->|"counted binary persistence"| Bodies["Chat attachment store"]
     Destructive["Delete or native close"] -->|"advance generation + drain"| Lifecycle
     Draft -->|"message + attachment ids"| API
-    API -->|"direct-model image"| TurnGate["Image-turn admission"]
+    API -->|"Hecate image"| TurnGate["Image-turn admission"]
     TurnGate -->|"claim drafts"| Bodies
     API -->|"append metadata, then link bodies"| Transcript["Chat transcript metadata"]
-    Transcript --> Hydrate["Direct-model history builder"]
+    Transcript --> Hydrate["Direct-model history or agent-input resolver"]
     Bodies -->|"bounded transient hydration"| Hydrate
     Hydrate -->|"canonical image blocks"| Router["Capability-aware router"]
     Router -->|"name + opaque generation"| Fence["Live provider fence"]
     Fence -->|"exact instance only"| Provider["Selected provider"]
     TurnGate -. "permit held until provider returns" .-> Provider
+    Hydrate -->|"tools-on rich prompt"| AgentLoop["Task-backed agent loop"]
+    AgentLoop -->|"artifact marker; no image body"| TaskArtifacts["Task conversation artifacts"]
     API -->|"External Agent files"| ExternalGate["External file-turn admission"]
     ExternalGate -->|"claim drafts"| Bodies
     Transcript -->|"External Agent turn"| ACP["Live ACP session capabilities"]

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -252,7 +252,10 @@ Chat attachments have two ownership-specific admission modes:
   reference in task state, hydrate the body immediately before execution, and
   replace image blocks with a non-sensitive marker in conversation artifacts.
   Same-input approval resumes and retries rehydrate that marker through the
-  opaque reference; a later chat prompt replaces or clears the reference.
+  opaque reference and stay pinned to the admitted provider generation after
+  first dispatch; a later chat prompt replaces or clears the reference. A
+  failure before dispatch does not make the transcript eligible to rehydrate
+  that image as prior provider context.
 - An External Agent turn accepts arbitrary non-empty files once its normal
   workspace, adapter, and required launch controls are ready. ACP resource links
   are the baseline. Hecate uses an inline image or embedded resource only when
@@ -441,16 +444,28 @@ delete-and-recreate changes it. Legacy transcript rows without a generation and
 runtime-only providers that have been recreated receive an omission marker, as
 do provider switches and unresolved Auto boundaries. The identity contains no
 secret-derived material and is not exposed by the chat or model APIs,
-telemetry, logs, or errors. Once bytes are hydrated, dispatch is pinned to the
-canonical provider and generation resolved during admission. The executor
-rechecks both against the live registry immediately before the provider call.
-A same-name replacement, live alias reassignment, normalized-name takeover, or
-removal therefore fails the turn without disclosing bytes to the replacement.
+telemetry, logs, or errors. For an explicit provider, admission pins that
+provider generation while policy may still rewrite the requested model. The
+executor rechecks the generation against the live registry immediately before
+the provider call. A same-name replacement, live alias reassignment,
+normalized-name takeover, or removal therefore fails the turn without
+disclosing bytes to the replacement.
 Image-bearing requests may retry on the selected provider, but Hecate disables
 cross-provider failover. If an Auto-routed provider receives bytes and then
 fails, the failed transcript still records that attempted provider/model and
 trace correlation. Context compaction keeps original transcript rows but
 replaces the older model-facing window with the normal context summary.
+
+For tools-on Hecate Chat image turns, the task runtime atomically records the
+exact provider/model/generation on the run at the final gateway dispatch
+boundary, immediately before provider I/O. This distinct final-dispatch marker
+allows the first policy-rewritten model while making later recovery and
+same-input retries exact. It is preserved through cancellation and stale-run
+requeueing, so recovery cannot send the image to a different provider. It is
+intentionally not a transcript disclosure marker: Hecate stamps the user row
+only after a dispatched provider call returns attempted-route metadata. A
+final pre-dispatch validation or durability failure leaves the transcript
+marker empty.
 
 A process-wide two-slot image-turn gate bounds the transient memory held by
 attachment claims, historical body hydration, base64 expansion, provider
@@ -483,6 +498,8 @@ flowchart LR
     Fence -->|"exact instance only"| Provider["Selected provider"]
     TurnGate -. "permit held until provider returns" .-> Provider
     Hydrate -->|"tools-on rich prompt"| AgentLoop["Task-backed agent loop"]
+    AgentLoop -->|"atomic final-route record before I/O"| TaskFence["Durable rich-input dispatch fence"]
+    TaskFence -->|"exact route on retry"| Provider
     AgentLoop -->|"artifact marker; no image body"| TaskArtifacts["Task conversation artifacts"]
     API -->|"External Agent files"| ExternalGate["External file-turn admission"]
     ExternalGate -->|"claim drafts"| Bodies

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -4905,12 +4905,16 @@ the user message and assistant output.
   rows.
 - `attachment_ids` — up to four ids returned by the staging endpoint. The ids
   must belong to this session and total no more than 12 MiB. Hecate-owned
-  `tools_enabled=false` turns accept supported raster images only and require a
+  turns accept supported raster images with tools on or off and require a
   currently routable matching route whose effective capability is
-  `image_input="supported"`. External Agent turns accept the staged files;
-  text may be empty when at least one attachment is present. Hecate persists
-  only immutable attachment metadata on the user message and hydrates the
-  binary bodies transiently for the selected provider or ACP session. ACP rich
+  `image_input="supported"`. A tools-on task run persists only an opaque input
+  reference, hydrates the body immediately before agent-loop execution, and
+  replaces image blocks with omission markers in its conversation artifact.
+  Same-input resumes and retries inherit the reference. External Agent
+  turns accept the staged files; text may be empty when at least one attachment
+  is present. Hecate persists only immutable attachment metadata on the user
+  message and hydrates the binary bodies transiently for the selected provider
+  or ACP session. ACP rich
   blocks share a cumulative 768 KiB encoded wire budget below the supported
   adapters' 1 MiB JSON-RPC line limit. Actual serialized prompt text, base64
   expansion, and JSON escaping consume that budget; a file that would overflow

--- a/docs/runtime/telemetry.md
+++ b/docs/runtime/telemetry.md
@@ -340,8 +340,10 @@ even when a later provider recovers the request.
 For Hecate-owned image turns, `provider.call.blocked` records a final
 execution-time provider fence failure before any upstream call. Its
 `hecate.route.skip_reason` is `provider_not_found` or
-`provider_instance_changed`; the event includes the normal provider name/model
-and candidate index, but never the opaque provider generation or image data.
+`provider_instance_changed`. A local rich-input durability or route-fence
+failure instead uses `rich_input_route_fence_failed`; the event includes the
+normal provider name/model and candidate index, but never the opaque provider
+generation or image data.
 
 When `HECATE_TRACE_BODIES=true`, the gateway also records trace events named:
 
@@ -534,6 +536,10 @@ Two operational response classes are worth calling out:
 When rate limiting is enabled, the token-bucket limiter also exposes reset and remaining-quota information through the `X-RateLimit-*` headers above.
 
 The `hecate.error.kind` attribute on error events is clamped to a closed set of known values. Any value outside this set is normalized to `other` to prevent high-cardinality label explosions in metric exporters and trace backends.
+`rich_input_route_fence_failed` distinguishes a local rich-input route or
+durability failure that blocked provider I/O; its accompanying
+`hecate.route.skip_reason` has the same fixed value and does not include a
+provider generation or attachment content.
 
 ## Local Debugging Workflow
 

--- a/internal/api/agent_llm_client.go
+++ b/internal/api/agent_llm_client.go
@@ -18,13 +18,7 @@ func (c gatewayAgentLLMClient) Chat(ctx context.Context, req types.ChatRequest) 
 		return nil, fmt.Errorf("chat service is not configured")
 	}
 	result, err := c.service.HandleChat(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if result == nil {
-		return nil, nil
-	}
-	return result.Response, nil
+	return agentLLMResponse(result), err
 }
 
 func (c gatewayAgentLLMClient) ChatStream(ctx context.Context, req types.ChatRequest, onContentDelta func(string)) (*types.ChatResponse, error) {
@@ -32,10 +26,31 @@ func (c gatewayAgentLLMClient) ChatStream(ctx context.Context, req types.ChatReq
 		return nil, fmt.Errorf("chat service is not configured")
 	}
 	resp, err := c.service.HandleChatStreamCapture(ctx, req, onContentDelta)
-	if err == nil || !isStreamingUnsupported(err) {
+	// A route-only response means the stream entered a provider call. Retrying
+	// through Chat could re-disclose a provider-bound image to a different route.
+	if err == nil || !isStreamingUnsupported(err) || resp != nil {
 		return resp, err
 	}
 	return c.Chat(ctx, req)
+}
+
+func agentLLMResponse(result *gateway.ChatResult) *types.ChatResponse {
+	if result == nil {
+		return nil
+	}
+	if result.Response != nil {
+		return result.Response
+	}
+	return &types.ChatResponse{
+		Model: result.Metadata.Model,
+		Route: types.RouteDecision{
+			Provider:         result.Metadata.Provider,
+			ProviderKind:     result.Metadata.ProviderKind,
+			ProviderInstance: result.Metadata.ProviderInstance,
+			Model:            result.Metadata.Model,
+			Reason:           result.Metadata.RouteReason,
+		},
+	}
 }
 
 func isStreamingUnsupported(err error) bool {

--- a/internal/api/agent_llm_client_test.go
+++ b/internal/api/agent_llm_client_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/catalog"
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/gateway"
+	"github.com/hecatehq/hecate/internal/governor"
+	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/internal/router"
+	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type unsupportedAfterDispatchStreamingProvider struct {
+	fakeProvider
+	streamCalls int
+}
+
+func (p *unsupportedAfterDispatchStreamingProvider) ChatStream(_ context.Context, _ types.ChatRequest, _ io.Writer) error {
+	p.streamCalls++
+	return errors.New("provider does not support streaming after accepting the request")
+}
+
+func TestGatewayAgentLLMClientDoesNotFallbackAfterStreamingDispatch(t *testing.T) {
+	t.Parallel()
+
+	provider := &unsupportedAfterDispatchStreamingProvider{fakeProvider: fakeProvider{
+		name:         "vision",
+		defaultModel: "model-a",
+		capabilities: providers.Capabilities{
+			Name:         "vision",
+			Kind:         providers.KindCloud,
+			DefaultModel: "model-a",
+			Models:       []string{"model-a"},
+			ModelCapabilities: map[string]types.ModelCapabilities{
+				"model-a": {ImageInput: modelcaps.ImageInputSupported, Source: modelcaps.SourceProvider},
+			},
+		},
+		response: &types.ChatResponse{Model: "model-a", Choices: []types.ChatChoice{{
+			Message: types.Message{Role: "assistant", Content: "should not be called"}, FinishReason: "stop",
+		}}},
+	}}
+	registry := providers.NewRegistry(provider)
+	instance, found := registry.GetInstance("vision")
+	if !found {
+		t.Fatal("provider instance not found")
+	}
+	providerCatalog := catalog.NewRegistryCatalog(registry, nil)
+	usageStore := governor.NewMemoryUsageStore()
+	service := gateway.NewService(gateway.Dependencies{
+		Logger:    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Router:    router.NewRuleRouter("model-a", providerCatalog),
+		Catalog:   providerCatalog,
+		Governor:  governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, usageStore, usageStore),
+		Providers: registry,
+		Tracer:    profiler.NewInMemoryTracer(nil),
+		Metrics:   telemetry.NewMetrics(),
+	})
+
+	response, err := (gatewayAgentLLMClient{service: service}).ChatStream(context.Background(), types.ChatRequest{
+		RequestID: "req-stream-after-dispatch",
+		Model:     "model-a",
+		Messages:  []types.Message{{Role: "user", Content: "private image"}},
+		Scope:     types.RequestScope{ProviderHint: "vision"},
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:         true,
+			NoProviderFailover: true,
+			ExactProvider:      true,
+			ProviderInstance:   instance.Identity,
+		},
+	}, nil)
+	if err == nil || response == nil {
+		t.Fatalf("ChatStream() response=%+v err=%v, want attempted-route response and stream failure", response, err)
+	}
+	if response.Route.Provider != "vision" || response.Route.ProviderInstance != instance.Identity {
+		t.Fatalf("attempted route = %+v, want vision/%+v", response.Route, instance.Identity)
+	}
+	if provider.streamCalls != 1 {
+		t.Fatalf("stream calls = %d, want one attempted stream", provider.streamCalls)
+	}
+	if provider.CallCount() != 0 {
+		t.Fatalf("non-stream provider calls = %d, want no fallback after attempted dispatch", provider.CallCount())
+	}
+}

--- a/internal/api/chat_application_http.go
+++ b/internal/api/chat_application_http.go
@@ -62,8 +62,6 @@ func writeChatAdmissionError(w http.ResponseWriter, err error) bool {
 		writeChatExecutionModeInvalid(w)
 	case errors.Is(err, chatapp.ErrExternalCannotRunHecate), errors.Is(err, chatapp.ErrHecateCannotRunExternal):
 		writeAgentChatRuntimeMismatch(w, err.Error())
-	case errors.Is(err, chatapp.ErrAttachmentsDirectOnly):
-		WriteError(w, http.StatusUnprocessableEntity, errCodeAttachmentUnsupported, err.Error())
 	case errors.Is(err, chatapp.ErrTooManyAttachments), errors.Is(err, chatapp.ErrDuplicateAttachmentID), errors.Is(err, chatapp.ErrAttachmentIDRequired):
 		WriteError(w, http.StatusUnprocessableEntity, errCodeAttachmentInvalid, err.Error())
 	default:

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -412,6 +412,7 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 	taskOriginRunGate.SetValidator("chat", h.validateTaskRunOrigin)
 	h.wireAgentChatRunnerHooks(agentChatRunner)
 	runner.SetProjectAssistantDraftTool(h)
+	runner.SetAgentInputResolver(h.resolveHecateAgentInput)
 	h.startAgentChatIdleSweeper()
 	return h
 }

--- a/internal/api/handler_chat_attachments.go
+++ b/internal/api/handler_chat_attachments.go
@@ -525,8 +525,6 @@ func writeChatAttachmentAppError(w http.ResponseWriter, err error, internalFailu
 				"max_message_attachment_bytes": chatapp.MaxMessageAttachmentBytes,
 			},
 		})
-	case errors.Is(err, chatapp.ErrAttachmentsDirectOnly):
-		writeChatAttachmentSurfaceError(w)
 	case errors.Is(err, chatapp.ErrTooManyAttachments), errors.Is(err, chatapp.ErrDuplicateAttachmentID), errors.Is(err, chatapp.ErrAttachmentIDRequired):
 		WriteError(w, http.StatusUnprocessableEntity, errCodeAttachmentInvalid, err.Error())
 	case chatapp.IsValidationError(err):
@@ -534,10 +532,6 @@ func writeChatAttachmentAppError(w http.ResponseWriter, err error, internalFailu
 	default:
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, internalFailureMessage)
 	}
-}
-
-func writeChatAttachmentSurfaceError(w http.ResponseWriter) {
-	WriteError(w, http.StatusUnprocessableEntity, errCodeAttachmentUnsupported, chatapp.ErrAttachmentsDirectOnly.Error())
 }
 
 func formatInt64(value int64) string {

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hecatehq/hecate/internal/agentadapters"
 	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/chatattachments"
 	"github.com/hecatehq/hecate/internal/chatcontext"
 	"github.com/hecatehq/hecate/internal/modelcaps"
 	"github.com/hecatehq/hecate/internal/taskapp"
@@ -60,6 +61,36 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	if model := strings.TrimSpace(req.Model); model != "" {
 		session.Model = model
 		session.Capabilities = types.ModelCapabilities{}
+	}
+	if len(req.AttachmentIDs) > 0 {
+		if strings.TrimSpace(session.Model) == "" {
+			writeAgentChatModelRequired(w, "model")
+			return
+		}
+		requestedProvider := strings.TrimSpace(session.Provider)
+		if strings.EqualFold(requestedProvider, "auto") {
+			requestedProvider = ""
+			session.Provider = ""
+		}
+		if requestedProvider != "" {
+			resolvedRoute, resolveErr := h.modelApplication().ResolveProviderRoute(r.Context(), requestedProvider, session.Model)
+			if resolveErr != nil {
+				writeAgentChatModelResolutionError(w, resolveErr)
+				return
+			}
+			if resolvedRoute.Name != "" {
+				session.Provider = resolvedRoute.Name
+			}
+		}
+		imageCapable, imageErr := h.modelApplication().SupportsImageInput(r.Context(), session.Provider, session.Model)
+		if imageErr != nil {
+			writeAgentChatModelResolutionError(w, imageErr)
+			return
+		}
+		if !imageCapable {
+			writeAgentChatImageCapabilityRequired(w)
+			return
+		}
 	}
 	caps := session.Capabilities
 	if !modelcaps.ToolCapable(caps) {
@@ -119,6 +150,44 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	defer cancel()
 
 	userID := newChatID("msg")
+	claimRef := chatattachments.ClaimRef{
+		SessionID:     session.ID,
+		MessageID:     userID,
+		AttachmentIDs: req.AttachmentIDs,
+	}
+	var resolvedAttachments []chatattachments.StoredAttachment
+	attachmentClaimPending := false
+	appendAttempted := false
+	if len(req.AttachmentIDs) > 0 {
+		resolvedAttachments, err = h.chatApplication().ClaimAttachments(r.Context(), claimRef)
+		if err != nil {
+			writeChatAttachmentAppError(w, err, chatAttachmentClaimFailureMessage)
+			return
+		}
+		claimRef.AttachmentIDs = make([]string, 0, len(resolvedAttachments))
+		for _, attachment := range resolvedAttachments {
+			claimRef.AttachmentIDs = append(claimRef.AttachmentIDs, attachment.ID)
+			if err := validateStoredChatImageAttachment(attachment); err != nil {
+				WriteError(w, http.StatusInternalServerError, errCodeGatewayError, "stored image attachment failed integrity validation")
+				return
+			}
+		}
+		attachmentClaimPending = true
+		defer func() {
+			if !attachmentClaimPending || appendAttempted {
+				return
+			}
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 3*time.Second)
+			defer cleanupCancel()
+			if err := h.chatApplication().ResolveAttachmentClaim(cleanupCtx, claimRef, chatattachments.ClaimReleased); err != nil {
+				h.logger.WarnContext(cleanupCtx, "chat.attachment_claim_release_failed",
+					"session_id", session.ID,
+					"message_id", userID,
+					"error", err,
+				)
+			}
+		}()
+	}
 	forceNewTask := shouldStartNewHecateAgentSegment(session, session.Provider, session.Model) || len(mcpServers) > 0
 	segmentID := hecateAgentSegmentID(session)
 	messageSnapshotSession := session
@@ -131,6 +200,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		messageSnapshotSession.LatestRunID = ""
 	}
 	messageSnapshot := hecateAgentMessageSnapshot(messageSnapshotSession, caps, segmentID)
+	appendAttempted = true
 	updated, err := requestGuard.appendUserMessage(r.Context(), session.ID, chat.Message{
 		ID:            userID,
 		ExecutionMode: messageSnapshot.ExecutionMode,
@@ -146,12 +216,34 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		Capabilities: messageSnapshot.Capabilities,
 		Role:         "user",
 		Content:      content,
+		Attachments:  chatMessageAttachments(resolvedAttachments),
 		CreatedAt:    startedAt,
 	})
 	if err != nil {
+		if attachmentClaimPending {
+			if reconcileErr := h.reconcileChatAttachmentClaim(r.Context(), claimRef, resolvedAttachments); reconcileErr != nil {
+				h.logger.WarnContext(r.Context(), "chat.attachment_claim_reconcile_failed",
+					"session_id", session.ID,
+					"message_id", userID,
+					"error", reconcileErr,
+				)
+			} else {
+				attachmentClaimPending = false
+			}
+		}
 		WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		return
 	}
+	finalizeCtx, finalizeCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 3*time.Second)
+	finalizeErr := h.chatApplication().ResolveAttachmentClaim(finalizeCtx, claimRef, chatattachments.ClaimLinked)
+	finalizeCancel()
+	if finalizeErr != nil {
+		if reconcileErr := h.reconcileChatAttachmentClaim(r.Context(), claimRef, resolvedAttachments); reconcileErr != nil {
+			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, chatAttachmentFinalizeFailureMessage)
+			return
+		}
+	}
+	attachmentClaimPending = false
 	h.agentChatLive.publishSession(updated)
 	trace.Record(telemetry.EventAgentChatRunStarted, hecateAgentChatTraceAttrs(session, "", "", assistantID, map[string]any{
 		telemetry.AttrHecateRunStatus: "running",
@@ -198,9 +290,14 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 	}
 	h.agentChatLive.publishSession(updated)
 
+	inputRef := ""
+	if len(resolvedAttachments) > 0 {
+		inputRef = userID
+	}
 	task, run, err := h.hecateAgentTaskOrchestrator().StartOrContinue(runCtx, hecateAgentTaskRunCommand{
 		Session:       session,
 		Prompt:        content,
+		InputRef:      inputRef,
 		SystemPrompt:  taskSystemPrompt,
 		ForceNewTask:  forceNewTask,
 		MCPServers:    mcpServers,

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -62,6 +62,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		session.Model = model
 		session.Capabilities = types.ModelCapabilities{}
 	}
+	admittedInputProviderInstance := types.ProviderInstanceIdentity{}
 	if len(req.AttachmentIDs) > 0 {
 		if strings.TrimSpace(session.Model) == "" {
 			writeAgentChatModelRequired(w, "model")
@@ -81,6 +82,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 			if resolvedRoute.Name != "" {
 				session.Provider = resolvedRoute.Name
 			}
+			admittedInputProviderInstance = resolvedRoute.Instance
 		}
 		imageCapable, imageErr := h.modelApplication().SupportsImageInput(r.Context(), session.Provider, session.Model)
 		if imageErr != nil {
@@ -295,13 +297,14 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		inputRef = userID
 	}
 	task, run, err := h.hecateAgentTaskOrchestrator().StartOrContinue(runCtx, hecateAgentTaskRunCommand{
-		Session:       session,
-		Prompt:        content,
-		InputRef:      inputRef,
-		SystemPrompt:  taskSystemPrompt,
-		ForceNewTask:  forceNewTask,
-		MCPServers:    mcpServers,
-		ContextPacket: contextPacket,
+		Session:               session,
+		Prompt:                content,
+		InputRef:              inputRef,
+		InputProviderInstance: admittedInputProviderInstance,
+		SystemPrompt:          taskSystemPrompt,
+		ForceNewTask:          forceNewTask,
+		MCPServers:            mcpServers,
+		ContextPacket:         contextPacket,
 	})
 	if err != nil {
 		completedAt := time.Now().UTC()
@@ -518,6 +521,19 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 			WriteError(w, http.StatusInternalServerError, errCodeGatewayError, err.Error())
 		}
 		return
+	}
+	// The watcher snapshots this marker while the run is live, but the terminal
+	// path gets one bounded reconciliation pass as well. A transient transcript
+	// write failure must not make an already-completed provider turn fail, yet
+	// leaving the marker behind forever would conservatively omit a legitimately
+	// disclosed image from later same-route history.
+	if routeErr := h.persistHecateAgentInputRouteWithRetry(terminalCtx, session.ID, finalRun); routeErr != nil {
+		h.logger.WarnContext(terminalCtx, "chat.hecate.input_route_terminal_reconcile_failed",
+			"session_id", session.ID,
+			"message_id", finalRun.InputRef,
+			"run_id", finalRun.ID,
+			"error", routeErr,
+		)
 	}
 	if inc, incErr := h.agentChat.UpdateSession(terminalCtx, session.ID, func(item *chat.Session) {
 		item.TurnsUsed++
@@ -737,6 +753,7 @@ func (h *Handler) waitForHecateAgentRun(ctx context.Context, taskID, runID, sess
 	var lastStatus string
 	var lastActivitySignature string
 	var lastContent string
+	lastInputProviderInstance := types.ProviderInstanceIdentity{}
 	for {
 		run, found, err := h.taskStore.GetRun(ctx, taskID, runID)
 		if err != nil {
@@ -744,6 +761,18 @@ func (h *Handler) waitForHecateAgentRun(ctx context.Context, taskID, runID, sess
 		}
 		if !found {
 			return types.TaskRun{}, fmt.Errorf("task run %q not found", runID)
+		}
+		if run.InputProviderDisclosedInstance.Valid() && run.InputProviderDisclosedInstance != lastInputProviderInstance {
+			if routeErr := h.persistHecateAgentInputRoute(ctx, sessionID, run); routeErr != nil {
+				h.logger.WarnContext(ctx, "chat.hecate.input_route_snapshot_update_failed",
+					"session_id", sessionID,
+					"message_id", run.InputRef,
+					"run_id", run.ID,
+					"error", routeErr,
+				)
+			} else {
+				lastInputProviderInstance = run.InputProviderDisclosedInstance
+			}
 		}
 		taskActivities := []chat.Activity(nil)
 		activitySignature := ""
@@ -792,6 +821,50 @@ func (h *Handler) waitForHecateAgentRun(ctx context.Context, taskID, runID, sess
 		case <-ticker.C:
 		}
 	}
+}
+
+func (h *Handler) persistHecateAgentInputRoute(ctx context.Context, sessionID string, run types.TaskRun) error {
+	inputRef := strings.TrimSpace(run.InputRef)
+	provider := strings.TrimSpace(run.Provider)
+	if inputRef == "" || provider == "" || !run.InputProviderDisclosedInstance.Valid() {
+		return nil
+	}
+	conflict := false
+	_, err := h.agentChat.UpdateMessage(ctx, sessionID, inputRef, func(message *chat.Message) {
+		if (strings.TrimSpace(message.Provider) != "" && strings.TrimSpace(message.Provider) != provider) ||
+			(message.ProviderInstance.Valid() && message.ProviderInstance != run.InputProviderDisclosedInstance) {
+			conflict = true
+			return
+		}
+		message.Provider = provider
+		message.ProviderInstance = run.InputProviderDisclosedInstance
+		message.Model = firstNonEmpty(run.Model, message.Model)
+	})
+	if err != nil {
+		return err
+	}
+	if conflict {
+		return fmt.Errorf("stored rich-input route conflicts with the execution route")
+	}
+	return nil
+}
+
+func (h *Handler) persistHecateAgentInputRouteWithRetry(ctx context.Context, sessionID string, run types.TaskRun) error {
+	const attempts = 3
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		persistCtx, cancel := newAgentChatPersistenceContext(ctx)
+		err := h.persistHecateAgentInputRoute(persistCtx, sessionID, run)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return lastErr
 }
 
 func (h *Handler) finalHecateAgentAnswer(ctx context.Context, taskID, runID string) string {
@@ -923,6 +996,11 @@ func (h *Handler) finishHecateAgentMessage(ctx context.Context, sessionID, messa
 			message.SpanID = firstNonEmpty(run.RootSpanID, message.SpanID)
 			message.CostMode = "hecate"
 			message.Timing = timing
+			message.Provider = firstNonEmpty(run.Provider, message.Provider)
+			if run.InputProviderDisclosedInstance.Valid() {
+				message.ProviderInstance = run.InputProviderDisclosedInstance
+			}
+			message.Model = firstNonEmpty(run.Model, message.Model)
 		}
 		message.Activities = append(message.Activities, newChatActivity(message.Status, message.Status, finalChatActivityTitle(message.Status), errorText))
 	})

--- a/internal/api/handler_chat_hecate_input.go
+++ b/internal/api/handler_chat_hecate_input.go
@@ -52,6 +52,23 @@ func (h *Handler) resolveHecateAgentInput(ctx context.Context, task types.Task, 
 	}
 
 	provider := strings.TrimSpace(run.Provider)
+	messageProvider := strings.TrimSpace(inputMessage.Provider)
+	if provider == "" {
+		provider = messageProvider
+	}
+	if provider != "" && messageProvider != "" && provider != messageProvider {
+		return orchestrator.AgentInput{}, fmt.Errorf("image provider does not match the admitted input route")
+	}
+	providerInstance := run.InputProviderInstance
+	if inputMessage.ProviderInstance.Valid() {
+		if providerInstance.Valid() && providerInstance != inputMessage.ProviderInstance {
+			return orchestrator.AgentInput{}, fmt.Errorf("image provider instance does not match the admitted input route")
+		}
+		providerInstance = inputMessage.ProviderInstance
+	}
+	if provider != "" && !providerInstance.Valid() {
+		return orchestrator.AgentInput{}, fmt.Errorf("image provider instance fence is missing")
+	}
 	model := strings.TrimSpace(run.Model)
 	route, err := h.modelApplication().ResolveProviderRoute(ctx, provider, model)
 	if err != nil {
@@ -59,6 +76,9 @@ func (h *Handler) resolveHecateAgentInput(ctx context.Context, task types.Task, 
 	}
 	if route.Name != "" && route.Name != provider {
 		return orchestrator.AgentInput{}, fmt.Errorf("image provider route changed before execution")
+	}
+	if providerInstance.Valid() && route.Instance != providerInstance {
+		return orchestrator.AgentInput{}, fmt.Errorf("image provider instance changed before execution")
 	}
 	imageCapable, err := h.modelApplication().SupportsImageInput(ctx, provider, model)
 	if err != nil {
@@ -103,7 +123,7 @@ func (h *Handler) resolveHecateAgentInput(ctx context.Context, task types.Task, 
 			ImageInput:         true,
 			NoProviderFailover: true,
 			ExactProvider:      provider != "",
-			ProviderInstance:   route.Instance,
+			ProviderInstance:   providerInstance,
 		},
 		Release: release,
 	}, nil

--- a/internal/api/handler_chat_hecate_input.go
+++ b/internal/api/handler_chat_hecate_input.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/chat"
+	"github.com/hecatehq/hecate/internal/chatapp"
+	"github.com/hecatehq/hecate/internal/chatattachments"
+	"github.com/hecatehq/hecate/internal/orchestrator"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+// resolveHecateAgentInput hydrates a Hecate Chat image at the last responsible
+// moment. Task state carries only run.InputRef; the binary body remains owned
+// by chatattachments and is integrity-checked against immutable transcript
+// metadata before it can cross the provider boundary.
+func (h *Handler) resolveHecateAgentInput(ctx context.Context, task types.Task, run types.TaskRun) (orchestrator.AgentInput, error) {
+	if task.OriginKind != "chat" || strings.TrimSpace(task.OriginID) == "" {
+		return orchestrator.AgentInput{}, fmt.Errorf("rich task input is only available to chat-origin runs")
+	}
+	inputRef := strings.TrimSpace(run.InputRef)
+	if inputRef == "" {
+		return orchestrator.AgentInput{}, fmt.Errorf("rich task input reference is required")
+	}
+	sessionResult, err := h.chatApplication().GetSession(ctx, task.OriginID)
+	if err != nil {
+		return orchestrator.AgentInput{}, fmt.Errorf("load input owner: %w", err)
+	}
+	session := sessionResult.Session
+	if !isHecateChatSession(session) {
+		return orchestrator.AgentInput{}, fmt.Errorf("rich task input owner is not a Hecate chat")
+	}
+	var inputMessage chat.Message
+	found := false
+	for _, message := range session.Messages {
+		if message.ID == inputRef {
+			inputMessage = message
+			found = true
+			break
+		}
+	}
+	if !found || inputMessage.Role != "user" || !inputMessage.ToolsEnabled || inputMessage.ExecutionMode != chat.ExecutionModeHecateTask {
+		return orchestrator.AgentInput{}, fmt.Errorf("rich task input does not reference a tools-on Hecate user message")
+	}
+	if inputMessage.TaskID != "" && inputMessage.TaskID != task.ID {
+		return orchestrator.AgentInput{}, fmt.Errorf("rich task input belongs to a different task")
+	}
+	if len(inputMessage.Attachments) == 0 {
+		return orchestrator.AgentInput{}, fmt.Errorf("rich task input has no attachment metadata")
+	}
+
+	provider := strings.TrimSpace(run.Provider)
+	model := strings.TrimSpace(run.Model)
+	route, err := h.modelApplication().ResolveProviderRoute(ctx, provider, model)
+	if err != nil {
+		return orchestrator.AgentInput{}, fmt.Errorf("resolve image provider: %w", err)
+	}
+	if route.Name != "" && route.Name != provider {
+		return orchestrator.AgentInput{}, fmt.Errorf("image provider route changed before execution")
+	}
+	imageCapable, err := h.modelApplication().SupportsImageInput(ctx, provider, model)
+	if err != nil {
+		return orchestrator.AgentInput{}, fmt.Errorf("resolve image capability: %w", err)
+	}
+	if !imageCapable {
+		return orchestrator.AgentInput{}, fmt.Errorf("selected model route does not declare image-input support")
+	}
+	if h.chatImageTurnAdmission == nil || !h.chatImageTurnAdmission.Acquire(ctx) {
+		return orchestrator.AgentInput{}, fmt.Errorf("image input admission cancelled before execution")
+	}
+	release := h.chatImageTurnAdmission.Release
+	releaseOnError := true
+	defer func() {
+		if releaseOnError {
+			release()
+		}
+	}()
+
+	attachments := make([]chatattachments.StoredAttachment, 0, len(inputMessage.Attachments))
+	for _, metadata := range inputMessage.Attachments {
+		attachment, err := h.chatApplication().GetAttachment(ctx, chatapp.AttachmentCommand{
+			SessionID:    session.ID,
+			AttachmentID: metadata.ID,
+		})
+		if err != nil {
+			return orchestrator.AgentInput{}, fmt.Errorf("load image attachment: %w", err)
+		}
+		if err := validateStoredChatAttachmentTranscript(session.ID, metadata, attachment); err != nil {
+			return orchestrator.AgentInput{}, fmt.Errorf("image attachment metadata mismatch")
+		}
+		if err := validateStoredChatImageAttachment(attachment); err != nil {
+			return orchestrator.AgentInput{}, fmt.Errorf("stored image attachment failed integrity validation")
+		}
+		attachments = append(attachments, attachment)
+	}
+
+	releaseOnError = false
+	return orchestrator.AgentInput{
+		Message: chatModelMessageWithAttachments(inputMessage.Content, attachments, nil),
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:         true,
+			NoProviderFailover: true,
+			ExactProvider:      provider != "",
+			ProviderInstance:   route.Instance,
+		},
+		Release: release,
+	}, nil
+}

--- a/internal/api/handler_chat_hecate_task.go
+++ b/internal/api/handler_chat_hecate_task.go
@@ -33,13 +33,14 @@ type hecateAgentTaskOrchestrator struct {
 }
 
 type hecateAgentTaskRunCommand struct {
-	Session       chat.Session
-	Prompt        string
-	InputRef      string
-	SystemPrompt  string
-	ForceNewTask  bool
-	MCPServers    []types.MCPServerConfig
-	ContextPacket chat.ContextPacket
+	Session               chat.Session
+	Prompt                string
+	InputRef              string
+	InputProviderInstance types.ProviderInstanceIdentity
+	SystemPrompt          string
+	ForceNewTask          bool
+	MCPServers            []types.MCPServerConfig
+	ContextPacket         chat.ContextPacket
 }
 
 func (h *Handler) hecateAgentTaskOrchestrator() hecateAgentTaskOrchestrator {
@@ -127,6 +128,10 @@ func (o hecateAgentTaskOrchestrator) startNewTask(ctx context.Context, cmd hecat
 	}
 	result, err := o.runner.StartTaskWithRunInitializer(ctx, task, o.resourceID, func(run *types.TaskRun) {
 		run.InputRef = strings.TrimSpace(cmd.InputRef)
+		run.InputProviderDispatchRecorded = false
+		if run.InputRef != "" {
+			run.InputProviderInstance = cmd.InputProviderInstance
+		}
 		packet := cmd.ContextPacket
 		packet.Workspace = run.WorkspacePath
 		run.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(packet, chatcontext.MergeRefs(
@@ -157,6 +162,12 @@ func (o hecateAgentTaskOrchestrator) continueTask(ctx context.Context, cmd hecat
 	}
 	result, err := o.runner.ContinueAgentTaskWithRunInitializer(ctx, task, run, cmd.Prompt, o.resourceID, func(nextRun *types.TaskRun) {
 		nextRun.InputRef = strings.TrimSpace(cmd.InputRef)
+		nextRun.InputProviderDispatchRecorded = false
+		if nextRun.InputRef != "" {
+			nextRun.InputProviderInstance = cmd.InputProviderInstance
+		} else {
+			nextRun.InputProviderInstance = types.ProviderInstanceIdentity{}
+		}
 		packet := cmd.ContextPacket
 		packet.Workspace = nextRun.WorkspacePath
 		nextRun.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(packet, chatcontext.MergeRefs(

--- a/internal/api/handler_chat_hecate_task.go
+++ b/internal/api/handler_chat_hecate_task.go
@@ -35,6 +35,7 @@ type hecateAgentTaskOrchestrator struct {
 type hecateAgentTaskRunCommand struct {
 	Session       chat.Session
 	Prompt        string
+	InputRef      string
 	SystemPrompt  string
 	ForceNewTask  bool
 	MCPServers    []types.MCPServerConfig
@@ -125,6 +126,7 @@ func (o hecateAgentTaskOrchestrator) startNewTask(ctx context.Context, cmd hecat
 		return types.Task{}, types.TaskRun{}, err
 	}
 	result, err := o.runner.StartTaskWithRunInitializer(ctx, task, o.resourceID, func(run *types.TaskRun) {
+		run.InputRef = strings.TrimSpace(cmd.InputRef)
 		packet := cmd.ContextPacket
 		packet.Workspace = run.WorkspacePath
 		run.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(packet, chatcontext.MergeRefs(
@@ -154,6 +156,7 @@ func (o hecateAgentTaskOrchestrator) continueTask(ctx context.Context, cmd hecat
 		return types.Task{}, types.TaskRun{}, fmt.Errorf("latest task run %q not found", cmd.Session.LatestRunID)
 	}
 	result, err := o.runner.ContinueAgentTaskWithRunInitializer(ctx, task, run, cmd.Prompt, o.resourceID, func(nextRun *types.TaskRun) {
+		nextRun.InputRef = strings.TrimSpace(cmd.InputRef)
 		packet := cmd.ContextPacket
 		packet.Workspace = nextRun.WorkspacePath
 		nextRun.ContextPacket = chatcontext.Marshal(chatcontext.Normalize(packet, chatcontext.MergeRefs(

--- a/internal/api/handler_chat_image_admission.go
+++ b/internal/api/handler_chat_image_admission.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,6 +19,7 @@ const (
 
 type chatAttachmentTurnAdmission interface {
 	TryAcquire() bool
+	Acquire(context.Context) bool
 	Release()
 }
 
@@ -53,6 +55,15 @@ func (g *fixedChatAttachmentTurnAdmission) TryAcquire() bool {
 	case g.permits <- struct{}{}:
 		return true
 	default:
+		return false
+	}
+}
+
+func (g *fixedChatAttachmentTurnAdmission) Acquire(ctx context.Context) bool {
+	select {
+	case g.permits <- struct{}{}:
+		return true
+	case <-ctx.Done():
 		return false
 	}
 }

--- a/internal/api/handler_chat_image_turn_test.go
+++ b/internal/api/handler_chat_image_turn_test.go
@@ -65,7 +65,7 @@ func TestHecateAgentChatToolsOnHydratesImageWithoutPersistingBodyInTaskArtifacts
 	if len(request.Tools) == 0 {
 		t.Fatal("agent-loop request had no tools")
 	}
-	if !request.Requirements.ImageInput || !request.Requirements.NoProviderFailover || !request.Requirements.ExactProvider || !request.Requirements.ProviderInstance.Valid() {
+	if !request.Requirements.ImageInput || !request.Requirements.ToolCalling || !request.Requirements.NoProviderFailover || !request.Requirements.ExactProvider || !request.Requirements.ProviderInstance.Valid() {
 		t.Fatalf("agent-loop image requirements = %+v, want exact instance-fenced image route", request.Requirements)
 	}
 	modelUser := imageTurnFindUserMessage(t, request.Messages, "Inspect this image with tools available.")
@@ -79,6 +79,15 @@ func TestHecateAgentChatToolsOnHydratesImageWithoutPersistingBodyInTaskArtifacts
 	}
 	if run.InputRef == "" {
 		t.Fatal("task run did not retain the opaque rich-input reference")
+	}
+	if run.InputProviderInstance != request.Requirements.ProviderInstance {
+		t.Fatalf("task run input provider instance = %+v, want dispatched fence %+v", run.InputProviderInstance, request.Requirements.ProviderInstance)
+	}
+	if !run.InputProviderDispatchRecorded {
+		t.Fatal("task run did not retain the final rich-input dispatch fence")
+	}
+	if run.InputProviderDisclosedInstance != request.Requirements.ProviderInstance {
+		t.Fatalf("task run disclosed provider instance = %+v, want dispatched fence %+v", run.InputProviderDisclosedInstance, request.Requirements.ProviderInstance)
 	}
 	artifacts, err := apiHandler.taskStore.ListArtifacts(t.Context(), taskstate.ArtifactFilter{
 		TaskID: response.Data.TaskID,
@@ -109,6 +118,107 @@ func TestHecateAgentChatToolsOnHydratesImageWithoutPersistingBodyInTaskArtifacts
 			t.Fatal("image turn permit was not released after agent-loop execution")
 		}
 		defer apiHandler.chatImageTurnAdmission.Release()
+	}
+}
+
+func TestHecateAgentChatToolsOnReconcilesTransientInputRouteSnapshotFailure(t *testing.T) {
+	provider := imageTurnTestProvider(modelcaps.ImageInputSupported)
+	caps := provider.capabilities.ModelCapabilities["llama-vision"]
+	caps.ToolCalling = modelcaps.ToolCallingParallel
+	provider.capabilities.ModelCapabilities["llama-vision"] = caps
+	apiHandler := imageTurnTestHandler(provider)
+	baseStore := apiHandler.agentChat
+	store := &failFirstUserMessageUpdateStore{Store: baseStore}
+	apiHandler.SetAgentChatStore(store)
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"ollama","model":"llama-vision"}`, t.TempDir()))
+	attachment := imageTurnTestUpload(t, handler, session.Data.ID, "retry-route.png", imageTurnTestPNG(t))
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"ollama","model":"llama-vision","content":"Remember this image route.","attachment_ids":["`+attachment.Data.ID+`"]}`)
+
+	if store.failureCount() != 1 {
+		t.Fatalf("injected user route update failures = %d, want 1", store.failureCount())
+	}
+	persisted, found, err := baseStore.Get(t.Context(), session.Data.ID)
+	if err != nil || !found {
+		t.Fatalf("Get() = found %t err %v", found, err)
+	}
+	user := imageTurnFindStoredUserMessage(t, persisted.Messages, "Remember this image route.")
+	if !user.ProviderInstance.Valid() || user.Provider != "ollama" || user.Model != "llama-vision" {
+		t.Fatalf("user route after terminal reconciliation = %+v, want disclosed ollama image route", user)
+	}
+	if response.Data.Status != "completed" {
+		t.Fatalf("response status = %q, want completed", response.Data.Status)
+	}
+	if provider.CallCount() != 1 {
+		t.Fatalf("provider calls = %d, want one successful image dispatch", provider.CallCount())
+	}
+}
+
+func TestHecateAgentChatToolsOnRejectsSameNameProviderReplacementBeforeHydration(t *testing.T) {
+	original := imageTurnNamedTestProvider("vision-a", modelcaps.ImageInputSupported)
+	originalCaps := original.capabilities.ModelCapabilities["llama-vision"]
+	originalCaps.ToolCalling = modelcaps.ToolCallingParallel
+	original.capabilities.ModelCapabilities["llama-vision"] = originalCaps
+	replacement := imageTurnNamedTestProvider("vision-a", modelcaps.ImageInputSupported)
+	replacementCaps := replacement.capabilities.ModelCapabilities["llama-vision"]
+	replacementCaps.ToolCalling = modelcaps.ToolCallingParallel
+	replacement.capabilities.ModelCapabilities["llama-vision"] = replacementCaps
+	registry := providers.NewMutableRegistry(original)
+	apiHandler := newTestAPIHandlerWithRegistry(
+		imageTurnTestLogger(),
+		registry,
+		[]providers.Provider{original},
+		config.Config{},
+		controlplane.NewMemoryStore(),
+	)
+	apiHandler.SetAgentChatStore(&replaceProviderRegistryOnRunningAssistantStore{
+		Store: apiHandler.agentChat,
+		replace: func() {
+			registry.Replace(replacement)
+		},
+	})
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+	workspace := t.TempDir()
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"vision-a","model":"llama-vision"}`, workspace))
+	attachment := imageTurnTestUpload(t, handler, session.Data.ID, "private.png", imageTurnTestPNG(t))
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"vision-a","model":"llama-vision","content":"Inspect without retargeting.","attachment_ids":["`+attachment.Data.ID+`"]}`)
+
+	if original.CallCount() != 0 || replacement.CallCount() != 0 {
+		t.Fatalf("provider calls original=%d replacement=%d, want fail-closed before image dispatch", original.CallCount(), replacement.CallCount())
+	}
+	var assistant ChatMessageItem
+	for _, message := range response.Data.Messages {
+		if message.Role == "assistant" {
+			assistant = message
+		}
+	}
+	if assistant.Status != "failed" || !strings.Contains(assistant.Error, "provider instance changed before execution") {
+		t.Fatalf("assistant = %+v, want provider-instance replacement failure", assistant)
+	}
+	persisted, ok, err := apiHandler.agentChat.Get(t.Context(), session.Data.ID)
+	if err != nil || !ok || len(persisted.Messages) < 1 {
+		t.Fatalf("Get() = found %v error %v messages %+v", ok, err, persisted.Messages)
+	}
+	user := persisted.Messages[0]
+	if user.ProviderInstance.Valid() {
+		t.Fatalf("pre-dispatch user message instance = %+v, want empty disclosure marker", user.ProviderInstance)
+	}
+	run, found, err := apiHandler.taskStore.GetRun(t.Context(), response.Data.TaskID, response.Data.LatestRunID)
+	if err != nil || !found {
+		t.Fatalf("GetRun() = found %v error %v", found, err)
+	}
+	if run.InputRef != user.ID || !run.InputProviderInstance.Valid() || run.InputProviderDispatchRecorded || run.InputProviderDisclosedInstance.Valid() {
+		t.Fatalf("run input fence = ref %q admitted %+v dispatched=%t disclosed %+v, want admitted-but-undispatched input", run.InputRef, run.InputProviderInstance, run.InputProviderDispatchRecorded, run.InputProviderDisclosedInstance)
 	}
 }
 
@@ -1011,6 +1121,75 @@ func TestHecateChatFailedImageTurnPersistsGovernorRewrittenModel(t *testing.T) {
 		if message.Role == "assistant" && (message.Status != "failed" || message.TraceID == "") {
 			t.Fatalf("failed assistant = status %q trace %q, want correlated rewritten attempt", message.Status, message.TraceID)
 		}
+	}
+}
+
+func TestHecateChatToolsOnImageTurnFencesGovernorRewrittenModelAtDispatch(t *testing.T) {
+	const (
+		requestedModel = "vision-tools-requested"
+		rewrittenModel = "vision-tools-rewritten"
+	)
+	capability := types.ModelCapabilities{
+		ToolCalling: modelcaps.ToolCallingBasic,
+		ImageInput:  modelcaps.ImageInputSupported,
+		Streaming:   true,
+		Source:      modelcaps.SourceProvider,
+	}
+	provider := &fakeProvider{
+		name: "vision-tools",
+		capabilities: providers.Capabilities{
+			Name:         "vision-tools",
+			Kind:         providers.KindCloud,
+			DefaultModel: requestedModel,
+			Models:       []string{requestedModel, rewrittenModel},
+			ModelCapabilities: map[string]types.ModelCapabilities{
+				requestedModel: capability,
+				rewrittenModel: capability,
+			},
+		},
+		response: &types.ChatResponse{
+			ID:        "chatcmpl-rewritten-tools-image",
+			Model:     rewrittenModel,
+			CreatedAt: time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC),
+			Choices: []types.ChatChoice{{
+				Index:        0,
+				Message:      types.Message{Role: "assistant", Content: "I can inspect the image with tools available."},
+				FinishReason: "stop",
+			}},
+		},
+	}
+	apiHandler := newTestAPIHandlerWithSettings(imageTurnTestLogger(), []providers.Provider{provider}, config.Config{
+		Governor: config.GovernorConfig{PolicyRules: []config.PolicyRuleConfig{{
+			ID:             "rewrite-tools-image-model",
+			Action:         "rewrite_model",
+			Models:         []string{requestedModel},
+			RewriteModelTo: rewrittenModel,
+		}}},
+	}, controlplane.NewMemoryStore())
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+	workspace := t.TempDir()
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"vision-tools","model":"%s"}`, workspace, requestedModel))
+	attachment := imageTurnTestUpload(t, handler, session.Data.ID, "rewrite-tools-image.png", imageTurnTestPNG(t))
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"vision-tools","model":"`+requestedModel+`","content":"Inspect this rewritten image with tools.","attachment_ids":["`+attachment.Data.ID+`"]}`)
+
+	if response.Data.Status != "completed" || response.Data.TaskID == "" || response.Data.LatestRunID == "" {
+		t.Fatalf("tools-on rewritten image response = %+v, want completed task-backed turn", response.Data)
+	}
+	request := provider.LastRequest()
+	if request.Model != rewrittenModel || len(request.Tools) == 0 || !request.Requirements.ImageInput || !request.Requirements.ToolCalling {
+		t.Fatalf("provider request = model %q tools=%d requirements=%+v, want rewritten tools-on image dispatch", request.Model, len(request.Tools), request.Requirements)
+	}
+	run, found, err := apiHandler.taskStore.GetRun(t.Context(), response.Data.TaskID, response.Data.LatestRunID)
+	if err != nil || !found {
+		t.Fatalf("GetRun() = found %v, error %v", found, err)
+	}
+	if !run.InputProviderDispatchRecorded || run.Provider != "vision-tools" || run.Model != rewrittenModel || run.InputProviderInstance != request.Requirements.ProviderInstance {
+		t.Fatalf("rewritten rich-input fence = %+v, want provider vision-tools model %q and the dispatched instance", run, rewrittenModel)
 	}
 }
 

--- a/internal/api/handler_chat_image_turn_test.go
+++ b/internal/api/handler_chat_image_turn_test.go
@@ -30,11 +30,86 @@ import (
 	"github.com/hecatehq/hecate/internal/controlplane"
 	"github.com/hecatehq/hecate/internal/modelcaps"
 	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
 type failImageUserAppendStore struct {
 	chat.Store
+}
+
+func TestHecateAgentChatToolsOnHydratesImageWithoutPersistingBodyInTaskArtifacts(t *testing.T) {
+	provider := imageTurnTestProvider(modelcaps.ImageInputSupported)
+	caps := provider.capabilities.ModelCapabilities["llama-vision"]
+	caps.ToolCalling = modelcaps.ToolCallingParallel
+	provider.capabilities.ModelCapabilities["llama-vision"] = caps
+	apiHandler := imageTurnTestHandler(provider)
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+	workspace := t.TempDir()
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"ollama","model":"llama-vision"}`, workspace))
+	imageBytes := imageTurnTestPNG(t)
+	attachment := imageTurnTestUpload(t, handler, session.Data.ID, "tools-on.png", imageBytes)
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"ollama","model":"llama-vision","content":"Inspect this image with tools available.","attachment_ids":["`+attachment.Data.ID+`"]}`)
+
+	if response.Data.Status != "completed" || response.Data.TaskID == "" || response.Data.LatestRunID == "" {
+		t.Fatalf("tools-on image response = %+v, want completed task-backed turn", response.Data)
+	}
+	user := imageTurnFindResponseUserMessage(t, response.Data.Messages, "Inspect this image with tools available.")
+	imageTurnAssertAttachmentMetadata(t, session.Data.ID, attachment.Data, user.Attachments)
+	request := provider.LastRequest()
+	if len(request.Tools) == 0 {
+		t.Fatal("agent-loop request had no tools")
+	}
+	if !request.Requirements.ImageInput || !request.Requirements.NoProviderFailover || !request.Requirements.ExactProvider || !request.Requirements.ProviderInstance.Valid() {
+		t.Fatalf("agent-loop image requirements = %+v, want exact instance-fenced image route", request.Requirements)
+	}
+	modelUser := imageTurnFindUserMessage(t, request.Messages, "Inspect this image with tools available.")
+	if len(modelUser.ContentBlocks) != 2 || modelUser.ContentBlocks[1].Image == nil || !strings.HasPrefix(modelUser.ContentBlocks[1].Image.URL, "data:image/png;base64,") {
+		t.Fatalf("agent-loop user blocks = %+v, want text plus hydrated PNG", modelUser.ContentBlocks)
+	}
+
+	run, found, err := apiHandler.taskStore.GetRun(t.Context(), response.Data.TaskID, response.Data.LatestRunID)
+	if err != nil || !found {
+		t.Fatalf("GetRun() = found %v, error %v", found, err)
+	}
+	if run.InputRef == "" {
+		t.Fatal("task run did not retain the opaque rich-input reference")
+	}
+	artifacts, err := apiHandler.taskStore.ListArtifacts(t.Context(), taskstate.ArtifactFilter{
+		TaskID: response.Data.TaskID,
+		RunID:  response.Data.LatestRunID,
+	})
+	if err != nil {
+		t.Fatalf("ListArtifacts() error = %v", err)
+	}
+	encodedBody := base64.StdEncoding.EncodeToString(imageBytes)
+	foundConversation := false
+	for _, artifact := range artifacts {
+		if artifact.Kind != "agent_conversation" {
+			continue
+		}
+		foundConversation = true
+		if strings.Contains(artifact.ContentText, encodedBody) || strings.Contains(artifact.ContentText, "data:image/") {
+			t.Fatalf("agent conversation retained private image body: %s", artifact.ContentText)
+		}
+		if !strings.Contains(artifact.ContentText, "binary body not retained in task artifacts") {
+			t.Fatalf("agent conversation missing image omission marker: %s", artifact.ContentText)
+		}
+	}
+	if !foundConversation {
+		t.Fatal("agent conversation artifact not found")
+	}
+	for range maxConcurrentChatImageTurns {
+		if !apiHandler.chatImageTurnAdmission.TryAcquire() {
+			t.Fatal("image turn permit was not released after agent-loop execution")
+		}
+		defer apiHandler.chatImageTurnAdmission.Release()
+	}
 }
 
 func (s failImageUserAppendStore) AppendMessage(ctx context.Context, sessionID string, message chat.Message) (chat.Session, error) {
@@ -146,6 +221,14 @@ type observingImageTurnAdmission struct {
 
 func (g *observingImageTurnAdmission) TryAcquire() bool {
 	if !g.delegate.TryAcquire() {
+		return false
+	}
+	g.held.Add(1)
+	return true
+}
+
+func (g *observingImageTurnAdmission) Acquire(ctx context.Context) bool {
+	if !g.delegate.Acquire(ctx) {
 		return false
 	}
 	g.held.Add(1)

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -47,7 +47,6 @@ var (
 	ErrAttachmentSessionCleanup = errors.New("chat attachment session cleanup failed")
 	ErrDuplicateAttachmentID    = errors.New("duplicate attachment id")
 	ErrTooManyAttachments       = errors.New("a chat message supports at most 4 attachments")
-	ErrAttachmentsDirectOnly    = errors.New("attachments are available in External Agent chats or Hecate Chat with Tools Off")
 	ErrClientRequestIDInvalid   = errors.New("client_request_id must be 1-128 ASCII letters, digits, dots, underscores, colons, or hyphens")
 	ErrUserMessageRequired      = errors.New("message role must be user")
 )
@@ -1029,9 +1028,6 @@ func (app *Application) AdmitMessage(cmd AdmitMessageCommand) (*AdmitMessageResu
 	}
 	if cmd.AttachmentCount < 0 || cmd.AttachmentCount > MaxMessageAttachments {
 		return nil, Validation(ErrTooManyAttachments)
-	}
-	if cmd.AttachmentCount > 0 && executionMode == chat.ExecutionModeHecateTask && toolsEnabled {
-		return nil, Validation(ErrAttachmentsDirectOnly)
 	}
 	return &AdmitMessageResult{
 		Content:       content,

--- a/internal/chatapp/application_test.go
+++ b/internal/chatapp/application_test.go
@@ -1285,14 +1285,18 @@ func TestApplication_AdmitMessageAllowsImageOnlyDirectTurns(t *testing.T) {
 	}
 }
 
-func TestApplication_AdmitMessageAllowsExternalAgentAttachmentsAndRejectsHecateToolsOn(t *testing.T) {
+func TestApplication_AdmitMessageAllowsHecateToolsOnAndExternalAgentAttachments(t *testing.T) {
 	t.Parallel()
 
 	toolsOn := true
 	toolsOff := false
 	cmd := AdmitMessageCommand{Session: chat.Session{AgentID: chat.DefaultAgentID}, ToolsEnabled: &toolsOn, AttachmentCount: 1}
-	if _, err := New(Options{}).AdmitMessage(cmd); !errors.Is(err, ErrAttachmentsDirectOnly) || !IsValidationError(err) {
-		t.Fatalf("AdmitMessage(%+v) error = %v, want tools-on validation", cmd, err)
+	hecate, err := New(Options{}).AdmitMessage(cmd)
+	if err != nil {
+		t.Fatalf("AdmitMessage(Hecate tools-on attachment) error = %v", err)
+	}
+	if !hecate.ToolsEnabled || hecate.ExecutionMode != chat.ExecutionModeHecateTask {
+		t.Fatalf("Hecate admission = %+v, want tools-on Hecate task", hecate)
 	}
 	external, err := New(Options{}).AdmitMessage(AdmitMessageCommand{
 		Session:         chat.Session{AgentID: "codex"},

--- a/internal/gateway/executor.go
+++ b/internal/gateway/executor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hecatehq/hecate/internal/policy"
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/providerdispatch"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/router"
 	"github.com/hecatehq/hecate/internal/safetext"
@@ -227,9 +228,10 @@ func (e *ResilientExecutor) Execute(ctx context.Context, trace *profiler.Trace, 
 
 		attemptReq := withResolvedModel(req, candidate.Model)
 		for attempt := 1; attempt <= e.options.MaxAttempts; attempt++ {
-			dispatchProvider := provider
+			dispatchInstance := instance
 			if requiresProviderInstanceFence(req) {
-				dispatchInstance, dispatchErr := providerInstanceForDispatch(e.providers, req, candidate)
+				var dispatchErr error
+				dispatchInstance, dispatchErr = providerInstanceForDispatch(e.providers, req, candidate)
 				if dispatchErr != nil {
 					lastErr = dispatchErr
 					recordProviderCallBlocked(trace, candidate, index, dispatchErr)
@@ -239,7 +241,15 @@ func (e *ResilientExecutor) Execute(ctx context.Context, trace *profiler.Trace, 
 					}
 					return lastAttempt, dispatchErr
 				}
-				dispatchProvider = dispatchInstance.Provider
+			}
+			dispatchProvider := dispatchInstance.Provider
+			dispatchRoute := candidate
+			dispatchRoute.ProviderKind = preflight.ProviderKind
+			dispatchRoute.ProviderInstance = dispatchInstance.Identity
+			if dispatchErr := providerdispatch.RecordAttempt(ctx, dispatchRoute); dispatchErr != nil {
+				lastErr = fmt.Errorf("record provider dispatch: %w", dispatchErr)
+				recordRichInputRouteFenceBlocked(trace, dispatchRoute, index, lastErr)
+				return lastAttempt, lastErr
 			}
 			totalAttempts++
 			lastAttempt = &providerCallResult{

--- a/internal/gateway/executor_test.go
+++ b/internal/gateway/executor_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/governor"
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/providerdispatch"
 	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
@@ -175,6 +177,79 @@ func TestResilientExecutorDoesNotCrossProviderBoundaryWhenFailoverIsDisabledForR
 	}
 	if primary.callCount != 1 || fallback.callCount != 0 {
 		t.Fatalf("provider calls primary=%d fallback=%d, want 1/0", primary.callCount, fallback.callCount)
+	}
+}
+
+func TestResilientExecutorDoesNotDispatchWhenAttemptRecorderFails(t *testing.T) {
+	t.Parallel()
+
+	provider := &sequenceProvider{
+		name:      "vision",
+		kind:      providers.KindCloud,
+		responses: []providerResponse{{response: &types.ChatResponse{Model: "model-a"}}},
+	}
+	registry := providers.NewRegistry(provider)
+	instance, ok := registry.GetInstance("vision")
+	if !ok {
+		t.Fatal("provider instance not found")
+	}
+	store := governor.NewMemoryUsageStore()
+	executor := NewResilientExecutor(
+		staticFallbackRouter{},
+		NewDefaultRoutePreflight(governor.NewStaticGovernor(config.GovernorConfig{}, store, store), registry),
+		registry,
+		nil,
+		nil,
+		nil,
+		ResilienceOptions{MaxAttempts: 1},
+	)
+	trace := profiler.NewTrace("req-attempt-recorder-failed", nil)
+	defer trace.Finalize()
+	var recorded types.RouteDecision
+	ctx := providerdispatch.WithAttemptRecorder(context.Background(), func(route types.RouteDecision) error {
+		recorded = route
+		return errors.New("durable rich-input fence unavailable")
+	})
+	result, err := executor.Execute(ctx, trace, types.ChatRequest{
+		Model: "model-a",
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:         true,
+			NoProviderFailover: true,
+			ProviderInstance:   instance.Identity,
+		},
+		Messages: []types.Message{{Role: "user", Content: "private image"}},
+	}, types.RouteDecision{
+		Provider:         "vision",
+		ProviderInstance: instance.Identity,
+		Model:            "model-a",
+		Reason:           "auto_image",
+	})
+	if err == nil || !strings.Contains(err.Error(), "durable rich-input fence unavailable") {
+		t.Fatalf("Execute() error = %v, want recorder failure", err)
+	}
+	if result != nil {
+		t.Fatalf("Execute() result = %+v, want nil before provider dispatch", result)
+	}
+	if provider.callCount != 0 {
+		t.Fatalf("provider calls = %d, want no dispatch after recorder failure", provider.callCount)
+	}
+	if recorded.Provider != "vision" || recorded.ProviderInstance != instance.Identity || recorded.Model != "model-a" {
+		t.Fatalf("recorded route = %+v, want final vision route", recorded)
+	}
+	var blocked []types.TraceEvent
+	for _, event := range trace.Events() {
+		if event.Name == "provider.call.blocked" {
+			blocked = append(blocked, event)
+		}
+	}
+	if len(blocked) != 1 {
+		t.Fatalf("provider.call.blocked events = %+v, want one", blocked)
+	}
+	if got := blocked[0].Attributes[telemetry.AttrHecateErrorKind]; got != telemetry.ErrorKindRichInputRouteFence {
+		t.Fatalf("blocked error kind = %v, want %q", got, telemetry.ErrorKindRichInputRouteFence)
+	}
+	if got := blocked[0].Attributes[telemetry.AttrHecateRouteSkipReason]; got != richInputRouteFenceSkipReason {
+		t.Fatalf("blocked skip reason = %v, want %q", got, richInputRouteFenceSkipReason)
 	}
 }
 

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/catalog"
@@ -18,6 +19,7 @@ import (
 	"github.com/hecatehq/hecate/internal/models"
 	"github.com/hecatehq/hecate/internal/profiler"
 	"github.com/hecatehq/hecate/internal/prompttokens"
+	"github.com/hecatehq/hecate/internal/providerdispatch"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/retention"
 	"github.com/hecatehq/hecate/internal/router"
@@ -394,13 +396,18 @@ func withResolvedModel(req types.ChatRequest, model string) types.ChatRequest {
 
 // StreamHandle holds everything needed to execute a stream after routing succeeds.
 type StreamHandle struct {
-	Metadata ResponseMetadata
-	stream   func(w io.Writer) error
+	Metadata  ResponseMetadata
+	stream    func(w io.Writer) error
+	attempted *atomic.Bool
 }
 
 // Execute writes the SSE stream to w.
 func (h *StreamHandle) Execute(w io.Writer) error {
 	return h.stream(w)
+}
+
+func (h *StreamHandle) providerCallAttempted() bool {
+	return h != nil && h.attempted != nil && h.attempted.Load()
 }
 
 // StreamedContent holds the text accumulated during a streaming response.
@@ -587,7 +594,10 @@ func (s *Service) HandleChatStreamCapture(ctx context.Context, req types.ChatReq
 	}
 	captured, err := handle.ExecuteAndCaptureDeltas(io.Discard, onContentDelta)
 	if err != nil {
-		return nil, err
+		if !handle.providerCallAttempted() {
+			return nil, err
+		}
+		return streamRouteResponse(handle.Metadata, req.Model), err
 	}
 	model := captured.Model
 	if model == "" {
@@ -622,6 +632,23 @@ func (s *Service) HandleChatStreamCapture(ctx context.Context, req types.ChatReq
 			FinishReason: finishReason,
 		}},
 	}, nil
+}
+
+func streamRouteResponse(metadata ResponseMetadata, fallbackModel string) *types.ChatResponse {
+	model := metadata.Model
+	if model == "" {
+		model = fallbackModel
+	}
+	return &types.ChatResponse{
+		Model: model,
+		Route: types.RouteDecision{
+			Provider:         metadata.Provider,
+			ProviderKind:     metadata.ProviderKind,
+			ProviderInstance: metadata.ProviderInstance,
+			Model:            model,
+			Reason:           metadata.RouteReason,
+		},
+	}
 }
 
 // RouteForStream runs governor/routing checks and returns a StreamHandle ready to
@@ -680,14 +707,18 @@ func (s *Service) RouteForStream(ctx context.Context, req types.ChatRequest) (*S
 		SpanID:           trace.RootSpanID(),
 	}
 
+	attempted := &atomic.Bool{}
 	handle := &StreamHandle{
-		Metadata: meta,
+		Metadata:  meta,
+		attempted: attempted,
 		stream: func(w io.Writer) error {
 			defer trace.Finalize()
 
+			dispatchInstance := instance
 			dispatchStreamer := streamer
 			if requiresProviderInstanceFence(streamReq) {
-				dispatchInstance, err := providerInstanceForDispatch(s.providers, streamReq, plan.Route)
+				var err error
+				dispatchInstance, err = providerInstanceForDispatch(s.providers, streamReq, plan.Route)
 				if err != nil {
 					recordProviderCallBlocked(trace, plan.Route, 0, err)
 					return err
@@ -703,7 +734,16 @@ func (s *Service) RouteForStream(ctx context.Context, req types.ChatRequest) (*S
 				}
 				dispatchStreamer = currentStreamer
 			}
+			dispatchRoute := plan.Route
+			dispatchRoute.ProviderKind = plan.ProviderKind
+			dispatchRoute.ProviderInstance = dispatchInstance.Identity
+			if err := providerdispatch.RecordAttempt(ctx, dispatchRoute); err != nil {
+				err = fmt.Errorf("record provider dispatch: %w", err)
+				recordRichInputRouteFenceBlocked(trace, dispatchRoute, 0, err)
+				return err
+			}
 
+			attempted.Store(true)
 			return dispatchStreamer.ChatStream(ctx, streamReq, w)
 		},
 	}

--- a/internal/gateway/service_stream_capture_test.go
+++ b/internal/gateway/service_stream_capture_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/governor"
 	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/providerdispatch"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -135,8 +136,8 @@ func TestServiceHandleChatStreamCaptureRejectsPartialProviderStream(t *testing.T
 	}, func(delta string) {
 		deltas = append(deltas, delta)
 	})
-	if response != nil {
-		t.Fatalf("HandleChatStreamCapture() response = %+v, want nil for a partial provider stream", response)
+	if response == nil || response.Route.Provider != "fake" || len(response.Choices) != 0 {
+		t.Fatalf("HandleChatStreamCapture() response = %+v, want route-only attempted-provider metadata", response)
 	}
 	var upstreamErr *providers.UpstreamError
 	if !errors.As(err, &upstreamErr) {
@@ -149,6 +150,102 @@ func TestServiceHandleChatStreamCaptureRejectsPartialProviderStream(t *testing.T
 	if strings.Join(deltas, "") != "partial" {
 		t.Fatalf("content deltas = %#v, want already-observed partial delta without a synthesized success", deltas)
 	}
+}
+
+func TestServiceHandleChatStreamCaptureKeepsPreDispatchValidationFailureUndisclosed(t *testing.T) {
+	t.Parallel()
+
+	provider := &validationFailBeforeStreamProvider{
+		streamingSequenceProvider: streamingSequenceProvider{
+			sequenceProvider: sequenceProvider{name: "vision", kind: providers.KindCloud},
+		},
+	}
+	registry := providers.NewRegistry(provider)
+	instance, ok := registry.GetInstance("vision")
+	if !ok {
+		t.Fatal("provider instance not found")
+	}
+	store := governor.NewMemoryUsageStore()
+	service := NewService(Dependencies{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Router: staticFallbackRouter{
+			route: types.RouteDecision{Provider: "vision", ProviderInstance: instance.Identity, Model: "model-a"},
+		},
+		Governor:   governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, store, store),
+		Providers:  registry,
+		Tracer:     profiler.NewInMemoryTracer(nil),
+		Metrics:    telemetry.NewMetrics(),
+		Resilience: ResilienceOptions{MaxAttempts: 1, RetryBackoff: time.Millisecond},
+	})
+
+	response, err := service.HandleChatStreamCapture(context.Background(), types.ChatRequest{
+		RequestID: "req-stream-validation-before-dispatch",
+		Model:     "model-a",
+		Messages:  []types.Message{{Role: "user", Content: "private image"}},
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:         true,
+			NoProviderFailover: true,
+			ProviderInstance:   instance.Identity,
+		},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "stream validator not ready") {
+		t.Fatalf("HandleChatStreamCapture() error = %v, want pre-dispatch validation failure", err)
+	}
+	if response != nil {
+		t.Fatalf("HandleChatStreamCapture() response = %+v, want no attempted-provider metadata before dispatch", response)
+	}
+	if provider.streamCallCount != 0 {
+		t.Fatalf("stream calls = %d, want no provider dispatch", provider.streamCallCount)
+	}
+}
+
+func TestServiceHandleChatStreamCaptureDoesNotDispatchWhenAttemptRecorderFails(t *testing.T) {
+	t.Parallel()
+
+	provider := &streamingSequenceProvider{
+		sequenceProvider: sequenceProvider{name: "vision", kind: providers.KindCloud},
+	}
+	registry := providers.NewRegistry(provider)
+	instance, ok := registry.GetInstance("vision")
+	if !ok {
+		t.Fatal("provider instance not found")
+	}
+	store := governor.NewMemoryUsageStore()
+	tracer := profiler.NewInMemoryTracer(nil)
+	service := NewService(Dependencies{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Router: staticFallbackRouter{
+			route: types.RouteDecision{Provider: "vision", ProviderInstance: instance.Identity, Model: "model-a"},
+		},
+		Governor:   governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, store, store),
+		Providers:  registry,
+		Tracer:     tracer,
+		Metrics:    telemetry.NewMetrics(),
+		Resilience: ResilienceOptions{MaxAttempts: 1, RetryBackoff: time.Millisecond},
+	})
+
+	response, err := service.HandleChatStreamCapture(providerdispatch.WithAttemptRecorder(context.Background(), func(types.RouteDecision) error {
+		return errors.New("durable rich-input fence unavailable")
+	}), types.ChatRequest{
+		RequestID: "req-stream-attempt-recorder-failed",
+		Model:     "model-a",
+		Messages:  []types.Message{{Role: "user", Content: "private image"}},
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:         true,
+			NoProviderFailover: true,
+			ProviderInstance:   instance.Identity,
+		},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "durable rich-input fence unavailable") {
+		t.Fatalf("HandleChatStreamCapture() error = %v, want recorder failure", err)
+	}
+	if response != nil {
+		t.Fatalf("HandleChatStreamCapture() response = %+v, want no attempted-route metadata before dispatch", response)
+	}
+	if provider.streamCallCount != 0 {
+		t.Fatalf("stream calls = %d, want no provider dispatch", provider.streamCallCount)
+	}
+	assertRichInputRouteFenceBlocked(t, tracer, "req-stream-attempt-recorder-failed")
 }
 
 func TestRouteForStreamRejectsProviderReplacementForProviderBoundRequest(t *testing.T) {
@@ -306,6 +403,30 @@ func assertStreamProviderCallBlocked(
 	}
 }
 
+func assertRichInputRouteFenceBlocked(t *testing.T, tracer *profiler.InMemoryTracer, requestID string) {
+	t.Helper()
+	trace, ok := tracer.Get(requestID)
+	if !ok {
+		t.Fatalf("trace %q not found", requestID)
+	}
+	var blocked []types.TraceEvent
+	for _, event := range trace.Events() {
+		if event.Name == "provider.call.blocked" {
+			blocked = append(blocked, event)
+		}
+	}
+	if len(blocked) != 1 {
+		t.Fatalf("provider.call.blocked events = %+v, want exactly one", blocked)
+	}
+	attrs := blocked[0].Attributes
+	if got := attrs[telemetry.AttrHecateErrorKind]; got != telemetry.ErrorKindRichInputRouteFence {
+		t.Fatalf("blocked error kind = %v, want %q", got, telemetry.ErrorKindRichInputRouteFence)
+	}
+	if got := attrs[telemetry.AttrHecateRouteSkipReason]; got != richInputRouteFenceSkipReason {
+		t.Fatalf("blocked skip reason = %v, want %q", got, richInputRouteFenceSkipReason)
+	}
+}
+
 type streamingSequenceProvider struct {
 	sequenceProvider
 	streamCallCount int
@@ -313,6 +434,19 @@ type streamingSequenceProvider struct {
 
 type truncatedStreamingProvider struct {
 	sequenceProvider
+}
+
+type validationFailBeforeStreamProvider struct {
+	streamingSequenceProvider
+	validateCalls int
+}
+
+func (p *validationFailBeforeStreamProvider) Validate() error {
+	p.validateCalls++
+	if p.validateCalls > 1 {
+		return errors.New("stream validator not ready")
+	}
+	return nil
 }
 
 func (p *truncatedStreamingProvider) ChatStream(_ context.Context, _ types.ChatRequest, w io.Writer) error {

--- a/internal/gateway/traceattrs.go
+++ b/internal/gateway/traceattrs.go
@@ -15,15 +15,18 @@ import (
 // constants in the telemetry package. All recording sites in this package use
 // these aliases so that refactoring the constants requires one change here.
 const (
-	errorKindInvalidRequest     = telemetry.ErrorKindInvalidRequest
-	errorKindRequestDenied      = telemetry.ErrorKindRequestDenied
-	errorKindRouterFailed       = telemetry.ErrorKindRouterFailed
-	errorKindRouteDenied        = telemetry.ErrorKindRouteDenied
-	errorKindProviderCallFailed = telemetry.ErrorKindProviderCallFailed
-	errorKindRetryBackoffFailed = telemetry.ErrorKindRetryBackoff
-	errorKindProviderHealth     = telemetry.ErrorKindProviderHealth
-	errorKindUsageRecordFailed  = telemetry.ErrorKindUsageRecord
+	errorKindInvalidRequest      = telemetry.ErrorKindInvalidRequest
+	errorKindRequestDenied       = telemetry.ErrorKindRequestDenied
+	errorKindRouterFailed        = telemetry.ErrorKindRouterFailed
+	errorKindRouteDenied         = telemetry.ErrorKindRouteDenied
+	errorKindProviderCallFailed  = telemetry.ErrorKindProviderCallFailed
+	errorKindRetryBackoffFailed  = telemetry.ErrorKindRetryBackoff
+	errorKindProviderHealth      = telemetry.ErrorKindProviderHealth
+	errorKindUsageRecordFailed   = telemetry.ErrorKindUsageRecord
+	errorKindRichInputRouteFence = telemetry.ErrorKindRichInputRouteFence
 )
+
+const richInputRouteFenceSkipReason = "rich_input_route_fence_failed"
 
 func tracePhaseAttrs(phase string, attrs map[string]any) map[string]any {
 	out := cloneTraceAttrs(attrs)
@@ -78,6 +81,15 @@ func recordProviderCallBlocked(trace *profiler.Trace, decision types.RouteDecisi
 		telemetry.AttrGenAIRequestModel:     decision.Model,
 		telemetry.AttrHecateProviderIndex:   providerIndex,
 		telemetry.AttrHecateRouteSkipReason: reason,
+	})
+}
+
+func recordRichInputRouteFenceBlocked(trace *profiler.Trace, decision types.RouteDecision, providerIndex int, err error) {
+	recordTraceError(trace, "provider.call.blocked", "provider", errorKindRichInputRouteFence, err, map[string]any{
+		telemetry.AttrGenAIProviderName:     decision.Provider,
+		telemetry.AttrGenAIRequestModel:     decision.Model,
+		telemetry.AttrHecateProviderIndex:   providerIndex,
+		telemetry.AttrHecateRouteSkipReason: richInputRouteFenceSkipReason,
 	})
 }
 

--- a/internal/orchestrator/executor.go
+++ b/internal/orchestrator/executor.go
@@ -76,6 +76,10 @@ type ExecutionSpec struct {
 	// ChatRequirements fences every model turn that retains InputMessage in
 	// conversation context (for example, image-capability and provider bounds).
 	ChatRequirements types.ChatRequestRequirements
+	// RecordProviderAttempt durably records the final rich-input route before
+	// gateway I/O. The runner supplies it for task-backed inputs so crash
+	// recovery cannot reroute bytes that may have been disclosed.
+	RecordProviderAttempt func(types.RouteDecision) error
 }
 
 type ResumeCheckpoint struct {
@@ -142,7 +146,11 @@ type ExecutionResult struct {
 	// happened.
 	Provider     string
 	ProviderKind string
-	Model        string
+	// ProviderInstance is the opaque runtime instance that received the
+	// provider-bound input. The runner persists it only for rich-input runs so
+	// later turns and same-input resumes cannot cross a same-name replacement.
+	ProviderInstance types.ProviderInstanceIdentity
+	Model            string
 	// PendingApprovals are approval records the executor produced
 	// during this run that the runner should persist. The agent loop
 	// emits these mid-loop when it pauses on a gated tool call —

--- a/internal/orchestrator/executor.go
+++ b/internal/orchestrator/executor.go
@@ -68,6 +68,14 @@ type ExecutionSpec struct {
 	// typed runtime events.
 	ToolCallID string
 	ToolName   string
+	// InputMessage is a runtime-hydrated replacement for the fresh or appended
+	// user prompt. It can carry rich content such as an image attachment. The
+	// resolver owns its storage boundary; executors must not persist inline
+	// binary bodies in artifacts.
+	InputMessage *types.Message
+	// ChatRequirements fences every model turn that retains InputMessage in
+	// conversation context (for example, image-capability and provider bounds).
+	ChatRequirements types.ChatRequestRequirements
 }
 
 type ResumeCheckpoint struct {

--- a/internal/orchestrator/executor_agent_loop_chat.go
+++ b/internal/orchestrator/executor_agent_loop_chat.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/providerdispatch"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -18,14 +19,16 @@ type agentLoopLLMTurn struct {
 func (e *AgentLoopExecutor) runLLMTurn(ctx context.Context, spec ExecutionSpec, conversation *agentLoopConversation, runState *agentLoopRunState, tools []types.Tool, turn int, startedAt time.Time) (agentLoopLLMTurn, *ExecutionResult, error) {
 	messages := conversation.Messages()
 	req := agentLoopChatRequest(spec, messages, tools)
+	runState.fenceProviderBoundRequest(&req)
 	emitAgentTurnStarted(spec, turn, req)
 
-	resp, err := e.chatTurn(ctx, spec, conversation.ArtifactID(), messages, turn, req)
+	turnCtx := providerdispatch.WithAttemptRecorder(ctx, spec.RecordProviderAttempt)
+	resp, err := e.chatTurn(turnCtx, spec, conversation.ArtifactID(), messages, turn, req)
+	runState.RecordRoute(resp)
 	if err != nil {
 		failed, ferr := e.failedFromError(spec, runState.Steps(), runState.Artifacts(), runState.NextStepIndex(), startedAt, llmTurnErrorMessage(spec, turn, len(tools) > 0, err))
 		return agentLoopLLMTurn{}, runState.attachAccounting(failed), ferr
 	}
-	runState.RecordRoute(resp)
 	if resp == nil || len(resp.Choices) == 0 {
 		failed, ferr := e.failedFromError(spec, runState.Steps(), runState.Artifacts(), runState.NextStepIndex(), startedAt,
 			fmt.Sprintf("LLM returned empty response on turn %d", turn))
@@ -64,12 +67,18 @@ func agentLoopChatRequest(spec ExecutionSpec, messages []types.Message, tools []
 	// operator had only configured a local provider like Ollama.
 	// Empty hint preserves the existing auto-route behavior for
 	// tasks that didn't specify a provider.
+	requirements := spec.ChatRequirements
+	// Rich input needs one candidate that is explicitly capable of both the
+	// image and the tool catalog. Ordinary agent runs retain their established
+	// optimistic behavior for providers whose capability discovery is unknown;
+	// the provider remains the authority for a normal tool-call rejection.
+	requirements.ToolCalling = requirements.ImageInput && len(tools) > 0
 	return types.ChatRequest{
 		RequestID:    spec.RequestID,
 		Model:        spec.Run.Model,
 		Messages:     messages,
 		Tools:        tools,
-		Requirements: spec.ChatRequirements,
+		Requirements: requirements,
 		Scope: types.RequestScope{
 			ProviderHint: spec.Run.Provider,
 		},
@@ -123,10 +132,13 @@ func (e *AgentLoopExecutor) chatTurn(ctx context.Context, spec ExecutionSpec, co
 	})
 	persistPartial(true)
 	if err != nil {
-		return nil, err
+		// Streaming providers can return the route that received an attempted
+		// request alongside a transport error. Preserve it so a rich-input run
+		// records the disclosure fence even though no complete reply exists.
+		return resp, err
 	}
 	if persistErr != nil {
-		return nil, persistErr
+		return resp, persistErr
 	}
 	return resp, nil
 }

--- a/internal/orchestrator/executor_agent_loop_chat.go
+++ b/internal/orchestrator/executor_agent_loop_chat.go
@@ -65,10 +65,11 @@ func agentLoopChatRequest(spec ExecutionSpec, messages []types.Message, tools []
 	// Empty hint preserves the existing auto-route behavior for
 	// tasks that didn't specify a provider.
 	return types.ChatRequest{
-		RequestID: spec.RequestID,
-		Model:     spec.Run.Model,
-		Messages:  messages,
-		Tools:     tools,
+		RequestID:    spec.RequestID,
+		Model:        spec.Run.Model,
+		Messages:     messages,
+		Tools:        tools,
+		Requirements: spec.ChatRequirements,
 		Scope: types.RequestScope{
 			ProviderHint: spec.Run.Provider,
 		},

--- a/internal/orchestrator/executor_agent_loop_conversation.go
+++ b/internal/orchestrator/executor_agent_loop_conversation.go
@@ -149,7 +149,13 @@ func hydrateConversation(spec ExecutionSpec) []types.Message {
 		var saved []types.Message
 		if err := json.Unmarshal(spec.ResumeCheckpoint.AgentConversation, &saved); err == nil && len(saved) > 0 {
 			if prompt := strings.TrimSpace(spec.ResumeCheckpoint.AppendUserPrompt); prompt != "" {
-				saved = append(saved, types.Message{Role: "user", Content: prompt})
+				if spec.InputMessage != nil {
+					saved = append(saved, *spec.InputMessage)
+				} else {
+					saved = append(saved, types.Message{Role: "user", Content: prompt})
+				}
+			} else if spec.InputMessage != nil {
+				restoreArtifactInputMessage(saved, *spec.InputMessage)
 			}
 			return saved
 		}
@@ -173,7 +179,11 @@ func hydrateConversation(spec ExecutionSpec) []types.Message {
 	if strings.TrimSpace(spec.SystemPrompt) != "" {
 		messages = append(messages, types.Message{Role: "system", Content: spec.SystemPrompt})
 	}
-	messages = append(messages, types.Message{Role: "user", Content: spec.Task.Prompt})
+	if spec.InputMessage != nil {
+		messages = append(messages, *spec.InputMessage)
+	} else {
+		messages = append(messages, types.Message{Role: "user", Content: spec.Task.Prompt})
+	}
 	return messages
 }
 
@@ -220,7 +230,7 @@ func upsertConversationArtifact(spec ExecutionSpec, id string, messages []types.
 	if spec.UpsertArtifact == nil {
 		return nil, nil
 	}
-	payload, err := json.Marshal(messages)
+	payload, err := json.Marshal(conversationMessagesForArtifact(messages))
 	if err != nil {
 		// Marshal failures here are fatal — every Message field is
 		// JSON-marshalable by construction; a failure would be a
@@ -247,4 +257,61 @@ func upsertConversationArtifact(spec ExecutionSpec, id string, messages []types.
 		return nil, err
 	}
 	return &art, nil
+}
+
+// conversationMessagesForArtifact removes image blocks before a task
+// conversation snapshot is persisted. This avoids retaining inline bodies or
+// credential-bearing remote URLs. The live executor retains the original
+// blocks for subsequent turns in the same run. Persisted checkpoints carry an
+// explicit marker; same-input resumes can restore that block from the opaque
+// run reference without copying private binary payloads into task artifacts.
+func conversationMessagesForArtifact(messages []types.Message) []types.Message {
+	result := make([]types.Message, len(messages))
+	for i, message := range messages {
+		result[i] = message
+		if len(message.ContentBlocks) == 0 {
+			continue
+		}
+		blocks := make([]types.ContentBlock, 0, len(message.ContentBlocks))
+		for _, block := range message.ContentBlocks {
+			if block.Image == nil {
+				blocks = append(blocks, block)
+				continue
+			}
+			mediaType := strings.TrimSpace(block.Image.MediaType)
+			if mediaType == "" {
+				mediaType = "image"
+			}
+			blocks = append(blocks, types.ContentBlock{
+				Type: "text",
+				Text: artifactImageOmissionText(mediaType),
+			})
+		}
+		result[i].ContentBlocks = blocks
+	}
+	return result
+}
+
+func restoreArtifactInputMessage(messages []types.Message, input types.Message) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		message := messages[i]
+		if message.Role != "user" || strings.TrimSpace(message.Content) != strings.TrimSpace(input.Content) || !hasArtifactImageOmission(message.ContentBlocks) {
+			continue
+		}
+		messages[i] = input
+		return
+	}
+}
+
+func hasArtifactImageOmission(blocks []types.ContentBlock) bool {
+	for _, block := range blocks {
+		if block.Type == "text" && strings.HasSuffix(block.Text, " attachment supplied for this turn; binary body not retained in task artifacts]") {
+			return true
+		}
+	}
+	return false
+}
+
+func artifactImageOmissionText(mediaType string) string {
+	return "[" + mediaType + " attachment supplied for this turn; binary body not retained in task artifacts]"
 }

--- a/internal/orchestrator/executor_agent_loop_conversation_test.go
+++ b/internal/orchestrator/executor_agent_loop_conversation_test.go
@@ -87,6 +87,114 @@ func TestAgentLoopConversation_ResumePendingToolCallsClearAfterToolResult(t *tes
 	}
 }
 
+func TestAgentLoopConversation_ContinuationAppendsRichInputMessage(t *testing.T) {
+	saved := []types.Message{
+		{Role: "user", Content: "first prompt"},
+		{Role: "assistant", Content: "first answer"},
+	}
+	raw, err := json.Marshal(saved)
+	if err != nil {
+		t.Fatalf("marshal saved conversation: %v", err)
+	}
+	richInput := types.Message{
+		Role:    "user",
+		Content: "inspect the new image",
+		ContentBlocks: []types.ContentBlock{
+			{Type: "text", Text: "inspect the new image"},
+			{Type: "image", Image: &types.ContentImage{URL: "data:image/png;base64,cG5n"}},
+		},
+	}
+	spec := newAgentLoopSpec(t)
+	spec.InputMessage = &richInput
+	spec.ResumeCheckpoint = &ResumeCheckpoint{
+		AgentConversation: raw,
+		AppendUserPrompt:  "plain fallback must not be appended",
+	}
+
+	conversation := newAgentLoopConversation(spec)
+	messages := conversation.Messages()
+	if len(messages) != 3 {
+		t.Fatalf("messages = %d, want saved history plus rich input: %+v", len(messages), messages)
+	}
+	got := messages[2]
+	if got.Role != "user" || got.Content != richInput.Content || len(got.ContentBlocks) != 2 || got.ContentBlocks[1].Image == nil {
+		t.Fatalf("appended message = %+v, want rich input message", got)
+	}
+}
+
+func TestAgentLoopConversation_SameRunResumeRestoresRichInputInPlace(t *testing.T) {
+	saved := []types.Message{
+		{
+			Role:    "user",
+			Content: "inspect the image",
+			ContentBlocks: []types.ContentBlock{
+				{Type: "text", Text: "inspect the image"},
+				{Type: "text", Text: artifactImageOmissionText("image/png")},
+			},
+		},
+		{Role: "assistant", ToolCalls: []types.ToolCall{agentLoopToolCall("call-1", "shell_exec", `{"command":"ls"}`)}},
+	}
+	raw, err := json.Marshal(saved)
+	if err != nil {
+		t.Fatalf("marshal saved conversation: %v", err)
+	}
+	richInput := types.Message{
+		Role:    "user",
+		Content: "inspect the image",
+		ContentBlocks: []types.ContentBlock{
+			{Type: "text", Text: "inspect the image"},
+			{Type: "image", Image: &types.ContentImage{URL: "data:image/png;base64,cG5n"}},
+		},
+	}
+	spec := newAgentLoopSpec(t)
+	spec.InputMessage = &richInput
+	spec.ResumeCheckpoint = &ResumeCheckpoint{AgentConversation: raw}
+
+	conversation := newAgentLoopConversation(spec)
+	messages := conversation.Messages()
+	if len(messages) != 2 {
+		t.Fatalf("messages = %d, want restored history without a duplicate user turn: %+v", len(messages), messages)
+	}
+	if image := messages[0].ContentBlocks[1].Image; image == nil || image.URL != richInput.ContentBlocks[1].Image.URL {
+		t.Fatalf("restored user message = %+v, want hydrated image block", messages[0])
+	}
+	pending := conversation.PendingToolCallsForResume()
+	if len(pending) != 1 || pending[0].ID != "call-1" {
+		t.Fatalf("pending tool calls = %+v, want approval-resume call-1", pending)
+	}
+}
+
+func TestAgentLoopConversation_ArtifactSanitizesImageBodiesAndURLs(t *testing.T) {
+	messages := []types.Message{{
+		Role:    "user",
+		Content: "compare images",
+		ContentBlocks: []types.ContentBlock{
+			{Type: "text", Text: "compare images"},
+			{Type: "image_url", Image: &types.ContentImage{URL: "data:image/png;base64,cG5n", MediaType: "image/png"}},
+			{Type: "image", Image: &types.ContentImage{Data: "anBlZw==", MediaType: "image/jpeg"}},
+			{Type: "image_url", Image: &types.ContentImage{URL: "https://example.com/public.png", MediaType: "image/png"}},
+		},
+	}}
+
+	sanitized := conversationMessagesForArtifact(messages)
+	blocks := sanitized[0].ContentBlocks
+	if len(blocks) != 4 {
+		t.Fatalf("sanitized blocks = %d, want 4: %+v", len(blocks), blocks)
+	}
+	if blocks[1].Image != nil || blocks[1].Text != artifactImageOmissionText("image/png") {
+		t.Fatalf("data URL block = %+v, want omission marker", blocks[1])
+	}
+	if blocks[2].Image != nil || blocks[2].Text != artifactImageOmissionText("image/jpeg") {
+		t.Fatalf("inline data block = %+v, want omission marker", blocks[2])
+	}
+	if blocks[3].Image != nil || blocks[3].Text != artifactImageOmissionText("image/png") {
+		t.Fatalf("remote URL block = %+v, want omission marker", blocks[3])
+	}
+	if messages[0].ContentBlocks[1].Image == nil {
+		t.Fatal("sanitizer mutated the live conversation")
+	}
+}
+
 func TestAgentLoopConversation_UpsertArtifactPersistsCurrentMessages(t *testing.T) {
 	spec := newAgentLoopSpec(t)
 	var got types.TaskArtifact

--- a/internal/orchestrator/executor_agent_loop_llm_turn_test.go
+++ b/internal/orchestrator/executor_agent_loop_llm_turn_test.go
@@ -125,6 +125,127 @@ func TestAgentLoopLLMTurn_ErrorPreservesExistingAccounting(t *testing.T) {
 	assertResolvedRoute(t, failed)
 }
 
+func TestAgentLoopLLMTurn_PinsAutoImageRouteAcrossToolTurns(t *testing.T) {
+	instance := types.ProviderInstanceIdentity{ID: "runtime-image-route", Kind: types.ProviderInstanceIdentityRuntime}
+	toolCall := types.ToolCall{
+		ID:   "call-route",
+		Type: "function",
+		Function: types.ToolCallFunction{
+			Name:      "shell_exec",
+			Arguments: `{"command":"pwd"}`,
+		},
+	}
+	first := makeChatResp(makeAssistantMsg("I will inspect.", toolCall))
+	first.Route = types.RouteDecision{
+		Provider:         "vision-a",
+		ProviderKind:     "cloud",
+		ProviderInstance: instance,
+		Model:            "shared-vision",
+	}
+	second := makeChatResp(makeAssistantMsg("Done."))
+	second.Route = first.Route
+	llm := &scriptedLLM{responses: []*types.ChatResponse{first, second}}
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, &stubExecutor{}, &stubExecutor{}, 4, nil, HTTPRequestPolicy{})
+	spec := newAgentLoopSpec(t)
+	spec.Run.Provider = ""
+	spec.Run.ProviderKind = ""
+	// The first Auto route can normalize the requested model. Every later turn
+	// that still retains the image must use the resolved model, not this stale
+	// request value.
+	spec.Run.Model = "requested-vision"
+	spec.ChatRequirements = types.ChatRequestRequirements{
+		ImageInput:         true,
+		NoProviderFailover: true,
+	}
+	conversation := newAgentLoopConversation(spec)
+	runState := newAgentLoopRunState(spec, 4)
+	tools := agentToolDefinitions()
+
+	if _, failed, err := loop.runLLMTurn(context.Background(), spec, &conversation, runState, tools, 1, time.Now().UTC()); err != nil || failed != nil {
+		t.Fatalf("first runLLMTurn = failed %+v, error %v", failed, err)
+	}
+	if _, failed, err := loop.runLLMTurn(context.Background(), spec, &conversation, runState, tools, 2, time.Now().UTC()); err != nil || failed != nil {
+		t.Fatalf("second runLLMTurn = failed %+v, error %v", failed, err)
+	}
+	if len(llm.lastReqs) != 2 {
+		t.Fatalf("LLM requests = %d, want 2", len(llm.lastReqs))
+	}
+	if firstReq := llm.lastReqs[0]; firstReq.Model != "requested-vision" || firstReq.Scope.ProviderHint != "" || firstReq.Requirements.ExactProvider || firstReq.Requirements.ProviderInstance.Valid() || !firstReq.Requirements.ToolCalling {
+		t.Fatalf("first Auto request = %+v, want capability-only route selection", firstReq.Requirements)
+	}
+	secondReq := llm.lastReqs[1]
+	if secondReq.Scope.ProviderHint != "vision-a" || secondReq.Model != "shared-vision" || !secondReq.Requirements.ExactProvider || !secondReq.Requirements.NoProviderFailover || secondReq.Requirements.ProviderInstance != instance || !secondReq.Requirements.ToolCalling {
+		t.Fatalf("second request hint=%q requirements=%+v, want exact first-turn provider instance", secondReq.Scope.ProviderHint, secondReq.Requirements)
+	}
+	result := runState.Result("completed")
+	if result.Provider != "vision-a" || result.ProviderInstance != instance {
+		t.Fatalf("result route = provider %q instance %+v, want vision-a/%+v", result.Provider, result.ProviderInstance, instance)
+	}
+}
+
+func TestAgentLoopChatRequestLeavesUnknownToolCapabilitiesRoutableWithoutRichInput(t *testing.T) {
+	spec := newAgentLoopSpec(t)
+	request := agentLoopChatRequest(spec, nil, agentToolDefinitions())
+	if request.Requirements.ToolCalling {
+		t.Fatalf("ordinary tool request requirements = %+v, want no hard tool-capability requirement", request.Requirements)
+	}
+
+	spec.ChatRequirements.ImageInput = true
+	richRequest := agentLoopChatRequest(spec, nil, agentToolDefinitions())
+	if !richRequest.Requirements.ToolCalling {
+		t.Fatalf("rich tool request requirements = %+v, want hard tool-capability requirement", richRequest.Requirements)
+	}
+}
+
+func TestAgentLoopLLMTurn_ErrorRecordsAttemptedProviderInstance(t *testing.T) {
+	instance := types.ProviderInstanceIdentity{ID: "runtime-failed-route", Kind: types.ProviderInstanceIdentityRuntime}
+	llm := AgentLLMClientFunc(func(context.Context, types.ChatRequest) (*types.ChatResponse, error) {
+		return &types.ChatResponse{Route: types.RouteDecision{
+			Provider:         "vision-a",
+			ProviderKind:     "cloud",
+			ProviderInstance: instance,
+			Model:            "shared-vision",
+		}}, errors.New("upstream rejected request")
+	})
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, &stubExecutor{}, &stubExecutor{}, 4, nil, HTTPRequestPolicy{})
+	spec := newAgentLoopSpec(t)
+	runState := newAgentLoopRunState(spec, 4)
+	conversation := newAgentLoopConversation(spec)
+
+	_, failed, err := loop.runLLMTurn(context.Background(), spec, &conversation, runState, agentToolDefinitions(), 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("runLLMTurn error = %v", err)
+	}
+	if failed == nil || failed.Provider != "vision-a" || failed.ProviderInstance != instance {
+		t.Fatalf("failed result = %+v, want attempted provider instance", failed)
+	}
+}
+
+func TestAgentLoopLLMTurn_StreamingErrorRecordsAttemptedProviderInstance(t *testing.T) {
+	instance := types.ProviderInstanceIdentity{ID: "runtime-stream-failed-route", Kind: types.ProviderInstanceIdentityRuntime}
+	llm := &streamingScriptedLLM{
+		response: &types.ChatResponse{Route: types.RouteDecision{
+			Provider:         "vision-a",
+			ProviderKind:     "cloud",
+			ProviderInstance: instance,
+			Model:            "shared-vision",
+		}},
+		err: errors.New("upstream stream reset"),
+	}
+	loop := NewAgentLoopExecutor(llm, &stubExecutor{}, &stubExecutor{}, &stubExecutor{}, 4, nil, HTTPRequestPolicy{})
+	spec := newAgentLoopSpec(t)
+	runState := newAgentLoopRunState(spec, 4)
+	conversation := newAgentLoopConversation(spec)
+
+	_, failed, err := loop.runLLMTurn(context.Background(), spec, &conversation, runState, agentToolDefinitions(), 1, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("runLLMTurn error = %v", err)
+	}
+	if failed == nil || failed.Provider != "vision-a" || failed.ProviderInstance != instance {
+		t.Fatalf("failed result = %+v, want attempted streaming provider instance", failed)
+	}
+}
+
 func assertEventTypes(t *testing.T, got []string, want ...string) {
 	t.Helper()
 	seen := make(map[string]bool, len(got))

--- a/internal/orchestrator/executor_agent_loop_run_state.go
+++ b/internal/orchestrator/executor_agent_loop_run_state.go
@@ -12,9 +12,10 @@ type agentLoopRunState struct {
 	steps     []types.TaskStep
 	artifacts []types.TaskArtifact
 
-	provider     string
-	providerKind string
-	model        string
+	provider         string
+	providerKind     string
+	providerInstance types.ProviderInstanceIdentity
+	model            string
 
 	costCeiling int64
 	priorCost   int64
@@ -102,6 +103,9 @@ func (s *agentLoopRunState) RecordRoute(resp *types.ChatResponse) {
 	if resp.Route.ProviderKind != "" {
 		s.providerKind = resp.Route.ProviderKind
 	}
+	if resp.Route.ProviderInstance.Valid() {
+		s.providerInstance = resp.Route.ProviderInstance
+	}
 	if resp.Route.Model != "" {
 		s.model = resp.Route.Model
 	} else if resp.Model != "" {
@@ -154,8 +158,23 @@ func (s *agentLoopRunState) attachAccounting(res *ExecutionResult) *ExecutionRes
 	}
 	res.Provider = firstNonEmpty(res.Provider, s.provider)
 	res.ProviderKind = firstNonEmpty(res.ProviderKind, s.providerKind)
+	if !res.ProviderInstance.Valid() {
+		res.ProviderInstance = s.providerInstance
+	}
 	res.Model = firstNonEmpty(res.Model, s.model)
 	res.CostMicrosUSD = s.costSpent
 	res.TurnCosts = s.turnCosts
 	return res
+}
+
+func (s *agentLoopRunState) fenceProviderBoundRequest(req *types.ChatRequest) {
+	if req == nil || !req.Requirements.NoProviderFailover || !s.providerInstance.Valid() || s.provider == "" {
+		return
+	}
+	req.Scope.ProviderHint = s.provider
+	req.Requirements.ExactProvider = true
+	req.Requirements.ProviderInstance = s.providerInstance
+	if s.model != "" {
+		req.Model = s.model
+	}
 }

--- a/internal/orchestrator/executor_agent_loop_run_state_test.go
+++ b/internal/orchestrator/executor_agent_loop_run_state_test.go
@@ -71,13 +71,15 @@ func TestAgentLoopRunState_TrackInitialConversationArtifactOnce(t *testing.T) {
 func TestAgentLoopRunState_RecordRouteAndAttachAccounting(t *testing.T) {
 	spec := newAgentLoopSpec(t)
 	state := newAgentLoopRunState(spec, 4)
+	providerInstance := types.ProviderInstanceIdentity{ID: "runtime-route", Kind: types.ProviderInstanceIdentityRuntime}
 
 	resp := &types.ChatResponse{
 		Model: "fallback-model",
 		Route: types.RouteDecision{
-			Provider:     "ollama",
-			ProviderKind: "local",
-			Model:        "resolved-model",
+			Provider:         "ollama",
+			ProviderKind:     "local",
+			ProviderInstance: providerInstance,
+			Model:            "resolved-model",
 		},
 		Cost: types.CostBreakdown{TotalMicrosUSD: 125},
 	}
@@ -86,7 +88,7 @@ func TestAgentLoopRunState_RecordRouteAndAttachAccounting(t *testing.T) {
 	state.AddTurnCost(2, "step-1", turnCost, 3)
 
 	res := state.Result("completed")
-	if res.Provider != "ollama" || res.ProviderKind != "local" || res.Model != "resolved-model" {
+	if res.Provider != "ollama" || res.ProviderKind != "local" || res.ProviderInstance != providerInstance || res.Model != "resolved-model" {
 		t.Fatalf("route = provider %q kind %q model %q, want resolved ollama/local/resolved-model", res.Provider, res.ProviderKind, res.Model)
 	}
 	if res.CostMicrosUSD != 125 {

--- a/internal/orchestrator/executor_agent_loop_test.go
+++ b/internal/orchestrator/executor_agent_loop_test.go
@@ -75,6 +75,7 @@ func (s *scriptedLLM) Chat(ctx context.Context, req types.ChatRequest) (*types.C
 type streamingScriptedLLM struct {
 	response      *types.ChatResponse
 	chunks        []string
+	err           error
 	chatCalls     atomic.Int32
 	streamCalls   atomic.Int32
 	lastStreamReq types.ChatRequest
@@ -91,7 +92,7 @@ func (s *streamingScriptedLLM) ChatStream(_ context.Context, req types.ChatReque
 	for _, chunk := range s.chunks {
 		onContentDelta(chunk)
 	}
-	return s.response, nil
+	return s.response, s.err
 }
 
 // erroringLLM returns the same canned error on every call. Used by

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -136,21 +136,36 @@ type ShellNetworkPolicy struct {
 // initial message.
 type SystemPromptResolver func(ctx context.Context, tenantID, perTaskPrompt, workspacePath string) string
 
+// AgentInput is rich, execution-time input resolved from an opaque TaskRun
+// reference. Release drops any admission permit or other transient resource
+// held while the executor retains the hydrated body.
+type AgentInput struct {
+	Message      types.Message
+	Requirements types.ChatRequestRequirements
+	Release      func()
+}
+
+// AgentInputResolver keeps application-owned binary storage outside the task
+// runtime. It is invoked only for agent_loop runs with a non-empty InputRef,
+// immediately before execution.
+type AgentInputResolver func(ctx context.Context, task types.Task, run types.TaskRun) (AgentInput, error)
+
 type Runner struct {
-	logger           *slog.Logger
-	store            taskstate.Store
-	tracer           profiler.Tracer
-	exec             Executor
-	shell            Executor
-	file             Executor
-	git              Executor
-	agent            Executor
-	workspaces       *WorkspaceManager
-	config           Config
-	queueCoordinator *runQueueCoordinator
-	policies         map[string]struct{}
-	metrics          *telemetry.OrchestratorMetrics
-	resolveSysPrompt SystemPromptResolver
+	logger            *slog.Logger
+	store             taskstate.Store
+	tracer            profiler.Tracer
+	exec              Executor
+	shell             Executor
+	file              Executor
+	git               Executor
+	agent             Executor
+	workspaces        *WorkspaceManager
+	config            Config
+	queueCoordinator  *runQueueCoordinator
+	policies          map[string]struct{}
+	metrics           *telemetry.OrchestratorMetrics
+	resolveSysPrompt  SystemPromptResolver
+	resolveAgentInput AgentInputResolver
 	// mcpHostFactory is the factory used when building or rebuilding the
 	// agent_loop executor. Stored here so SetAgentLLMClient (which
 	// rebuilds the executor from scratch) can re-bind the same factory
@@ -323,6 +338,12 @@ func (r *Runner) SetGitExecutor(exec Executor) {
 // composition (agent_loop runs with no system prompt).
 func (r *Runner) SetSystemPromptResolver(resolver SystemPromptResolver) {
 	r.resolveSysPrompt = resolver
+}
+
+// SetAgentInputResolver wires application-owned rich prompt hydration. Call it
+// before queue workers start; nil keeps ordinary text-only task behavior.
+func (r *Runner) SetAgentInputResolver(resolver AgentInputResolver) {
+	r.resolveAgentInput = resolver
 }
 
 // SetAgentLLMClient wires the LLM seam into the agent_loop executor.
@@ -763,6 +784,9 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 			run.WorkspacePath = prior.WorkspacePath
 			run.WorkspaceID = firstNonEmpty(prior.WorkspaceID, run.WorkspaceID)
 		}
+		if task.ExecutionKind == "agent_loop" && strings.TrimSpace(options.AppendPrompt) == "" {
+			run.InputRef = strings.TrimSpace(prior.InputRef)
+		}
 		// Inherit cumulative cost from the source run so the per-task
 		// cost ceiling holds across the entire resume chain. Source's
 		// PriorCost (chain so far excluding source) + Total (source's
@@ -1056,6 +1080,23 @@ func (r *Runner) executeRun(ctx context.Context, trace *profiler.Trace, task typ
 		}
 		systemPrompt = r.resolveSysPrompt(ctx, "", task.SystemPrompt, workspacePromptPath)
 	}
+	var agentInput AgentInput
+	if task.ExecutionKind == "agent_loop" && strings.TrimSpace(run.InputRef) != "" {
+		if r.resolveAgentInput == nil {
+			return nil, fmt.Errorf("agent input resolver is not configured for run %q", run.ID)
+		}
+		agentInput, err = r.resolveAgentInput(ctx, task, run)
+		if err != nil {
+			return nil, fmt.Errorf("resolve agent input: %w", err)
+		}
+		if agentInput.Release != nil {
+			defer agentInput.Release()
+		}
+	}
+	var inputMessage *types.Message
+	if task.ExecutionKind == "agent_loop" && strings.TrimSpace(run.InputRef) != "" {
+		inputMessage = &agentInput.Message
+	}
 	execution, err := executor.Execute(ctx, ExecutionSpec{
 		Task:             taskForRun(task, run),
 		Run:              run,
@@ -1077,6 +1118,8 @@ func (r *Runner) executeRun(ctx context.Context, trace *profiler.Trace, task typ
 		SystemPrompt:                systemPrompt,
 		ShellNetworkAllowedHosts:    r.config.ShellNetwork.AllowedHosts,
 		ShellNetworkAllowPrivateIPs: r.config.ShellNetwork.AllowPrivateIPs,
+		InputMessage:                inputMessage,
+		ChatRequirements:            agentInput.Requirements,
 	})
 	if err != nil {
 		recordOrchestratorRunFailed(trace, task.ID, run.ID, "executor_failed", err)

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -786,6 +786,13 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 		}
 		if task.ExecutionKind == "agent_loop" && strings.TrimSpace(options.AppendPrompt) == "" {
 			run.InputRef = strings.TrimSpace(prior.InputRef)
+			if run.InputRef != "" && prior.InputProviderInstance.Valid() {
+				run.InputProviderInstance = prior.InputProviderInstance
+				run.InputProviderDispatchRecorded = prior.InputProviderDispatchRecorded
+				run.Provider = strings.TrimSpace(prior.Provider)
+				run.ProviderKind = strings.TrimSpace(prior.ProviderKind)
+				run.Model = firstNonEmpty(strings.TrimSpace(prior.Model), run.Model)
+			}
 		}
 		// Inherit cumulative cost from the source run so the per-task
 		// cost ceiling holds across the entire resume chain. Source's
@@ -1120,6 +1127,9 @@ func (r *Runner) executeRun(ctx context.Context, trace *profiler.Trace, task typ
 		ShellNetworkAllowPrivateIPs: r.config.ShellNetwork.AllowPrivateIPs,
 		InputMessage:                inputMessage,
 		ChatRequirements:            agentInput.Requirements,
+		RecordProviderAttempt: func(route types.RouteDecision) error {
+			return r.recordAgentInputProviderAttempt(ctx, task, run, route)
+		},
 	})
 	if err != nil {
 		recordOrchestratorRunFailed(trace, task.ID, run.ID, "executor_failed", err)

--- a/internal/orchestrator/runner_agent_input.go
+++ b/internal/orchestrator/runner_agent_input.go
@@ -1,0 +1,45 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/taskstate"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const agentInputRoutePersistenceTimeout = 5 * time.Second
+
+// recordAgentInputProviderAttempt closes the recovery window immediately
+// before gateway dispatch. A worker can disappear after the provider starts
+// receiving a rich input but before it writes a step or artifact, so this
+// narrow state transition must survive independently of finalization.
+func (r *Runner) recordAgentInputProviderAttempt(ctx context.Context, task types.Task, run types.TaskRun, route types.RouteDecision) error {
+	if r == nil || r.store == nil || strings.TrimSpace(run.InputRef) == "" || !route.ProviderInstance.Valid() {
+		return nil
+	}
+	provider := strings.TrimSpace(route.Provider)
+	if provider == "" {
+		return fmt.Errorf("provider attempt route is missing a provider")
+	}
+
+	persistenceCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), agentInputRoutePersistenceTimeout)
+	defer cancel()
+	result, err := r.store.RecordRichInputProviderAttempt(persistenceCtx, taskstate.RichInputProviderAttempt{
+		TaskID:           task.ID,
+		RunID:            run.ID,
+		Provider:         provider,
+		ProviderKind:     strings.TrimSpace(route.ProviderKind),
+		Model:            strings.TrimSpace(route.Model),
+		ProviderInstance: route.ProviderInstance,
+	})
+	if err != nil {
+		return fmt.Errorf("persist provider-attempt route: %w", err)
+	}
+	if result.Applied {
+		return nil
+	}
+	return fmt.Errorf("run status changed to %q before provider dispatch", result.Run.Status)
+}

--- a/internal/orchestrator/runner_lifecycle_test.go
+++ b/internal/orchestrator/runner_lifecycle_test.go
@@ -421,6 +421,7 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 	)
 
 	now := time.Now().UTC()
+	inputProviderInstance := types.ProviderInstanceIdentity{ID: "runtime-resume-input", Kind: types.ProviderInstanceIdentityRuntime}
 	task := types.Task{
 		ID:               "task-resume-context",
 		Title:            "resume context",
@@ -433,13 +434,18 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 		UpdatedAt:        now,
 	}
 	run := types.TaskRun{
-		ID:         "run-resume-source",
-		TaskID:     task.ID,
-		Number:     1,
-		Status:     "completed",
-		StartedAt:  now,
-		FinishedAt: now,
-		InputRef:   "msg_resume_input",
+		ID:                            "run-resume-source",
+		TaskID:                        task.ID,
+		Number:                        1,
+		Status:                        "completed",
+		StartedAt:                     now,
+		FinishedAt:                    now,
+		InputRef:                      "msg_resume_input",
+		Provider:                      "vision-resume",
+		ProviderKind:                  "cloud",
+		Model:                         "resolved-vision-resume",
+		InputProviderInstance:         inputProviderInstance,
+		InputProviderDispatchRecorded: true,
 		ContextPacket: json.RawMessage(`{
 			"id":"ctx_old",
 			"refs":{"session_id":"chat_1","run_id":"run-resume-source"},
@@ -465,6 +471,9 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 	if stored.InputRef != run.InputRef {
 		t.Fatalf("InputRef = %q, want inherited %q", stored.InputRef, run.InputRef)
 	}
+	if stored.Provider != run.Provider || stored.ProviderKind != run.ProviderKind || stored.Model != run.Model || stored.InputProviderInstance != inputProviderInstance || !stored.InputProviderDispatchRecorded {
+		t.Fatalf("inherited input route = provider %q kind %q model %q instance %+v dispatched=%t, want %q/%q/%q/%+v/true", stored.Provider, stored.ProviderKind, stored.Model, stored.InputProviderInstance, stored.InputProviderDispatchRecorded, run.Provider, run.ProviderKind, run.Model, inputProviderInstance)
+	}
 }
 
 func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
@@ -480,6 +489,7 @@ func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
 	)
 
 	now := time.Now().UTC()
+	inputProviderInstance := types.ProviderInstanceIdentity{ID: "runtime-retry-input", Kind: types.ProviderInstanceIdentityRuntime}
 	task := types.Task{
 		ID:               "task-retry-context",
 		Title:            "retry context",
@@ -492,13 +502,18 @@ func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
 		UpdatedAt:        now,
 	}
 	run := types.TaskRun{
-		ID:         "run-retry-source",
-		TaskID:     task.ID,
-		Number:     1,
-		Status:     "completed",
-		StartedAt:  now,
-		FinishedAt: now,
-		InputRef:   "msg_retry_input",
+		ID:                            "run-retry-source",
+		TaskID:                        task.ID,
+		Number:                        1,
+		Status:                        "completed",
+		StartedAt:                     now,
+		FinishedAt:                    now,
+		InputRef:                      "msg_retry_input",
+		Provider:                      "vision-retry",
+		ProviderKind:                  "cloud",
+		Model:                         "resolved-vision-retry",
+		InputProviderInstance:         inputProviderInstance,
+		InputProviderDispatchRecorded: true,
 		ContextPacket: json.RawMessage(`{
 			"id":"ctx_old_retry",
 			"refs":{"session_id":"chat_2","run_id":"run-retry-source"},
@@ -535,6 +550,9 @@ func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
 	assertCopiedRunContextPacket(t, stored.ContextPacket, task.ID, result.Run.ID)
 	if stored.InputRef != run.InputRef {
 		t.Fatalf("InputRef = %q, want inherited %q", stored.InputRef, run.InputRef)
+	}
+	if stored.Provider != run.Provider || stored.ProviderKind != run.ProviderKind || stored.Model != run.Model || stored.InputProviderInstance != inputProviderInstance || !stored.InputProviderDispatchRecorded {
+		t.Fatalf("inherited input route = provider %q kind %q model %q instance %+v dispatched=%t, want %q/%q/%q/%+v/true", stored.Provider, stored.ProviderKind, stored.Model, stored.InputProviderInstance, stored.InputProviderDispatchRecorded, run.Provider, run.ProviderKind, run.Model, inputProviderInstance)
 	}
 }
 

--- a/internal/orchestrator/runner_lifecycle_test.go
+++ b/internal/orchestrator/runner_lifecycle_test.go
@@ -425,7 +425,8 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 		ID:               "task-resume-context",
 		Title:            "resume context",
 		Prompt:           "resume me",
-		ExecutionKind:    "stub",
+		ExecutionKind:    "agent_loop",
+		RequestedModel:   "test-model",
 		WorkingDirectory: t.TempDir(),
 		Status:           "completed",
 		CreatedAt:        now,
@@ -438,6 +439,7 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 		Status:     "completed",
 		StartedAt:  now,
 		FinishedAt: now,
+		InputRef:   "msg_resume_input",
 		ContextPacket: json.RawMessage(`{
 			"id":"ctx_old",
 			"refs":{"session_id":"chat_1","run_id":"run-resume-source"},
@@ -460,6 +462,9 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 		t.Fatalf("GetRun(%q) found=%v err=%v", result.Run.ID, found, err)
 	}
 	assertCopiedRunContextPacket(t, stored.ContextPacket, task.ID, result.Run.ID)
+	if stored.InputRef != run.InputRef {
+		t.Fatalf("InputRef = %q, want inherited %q", stored.InputRef, run.InputRef)
+	}
 }
 
 func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
@@ -479,7 +484,8 @@ func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
 		ID:               "task-retry-context",
 		Title:            "retry context",
 		Prompt:           "retry me",
-		ExecutionKind:    "stub",
+		ExecutionKind:    "agent_loop",
+		RequestedModel:   "test-model",
 		WorkingDirectory: t.TempDir(),
 		Status:           "completed",
 		CreatedAt:        now,
@@ -492,6 +498,7 @@ func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
 		Status:     "completed",
 		StartedAt:  now,
 		FinishedAt: now,
+		InputRef:   "msg_retry_input",
 		ContextPacket: json.RawMessage(`{
 			"id":"ctx_old_retry",
 			"refs":{"session_id":"chat_2","run_id":"run-retry-source"},
@@ -526,6 +533,9 @@ func TestRetryTaskFromTurnCarriesForwardContextPacket(t *testing.T) {
 		t.Fatalf("GetRun(%q) found=%v err=%v", result.Run.ID, found, err)
 	}
 	assertCopiedRunContextPacket(t, stored.ContextPacket, task.ID, result.Run.ID)
+	if stored.InputRef != run.InputRef {
+		t.Fatalf("InputRef = %q, want inherited %q", stored.InputRef, run.InputRef)
+	}
 }
 
 func assertCopiedRunContextPacket(t *testing.T, raw json.RawMessage, taskID, runID string) {

--- a/internal/orchestrator/runner_reconcile_test.go
+++ b/internal/orchestrator/runner_reconcile_test.go
@@ -157,6 +157,71 @@ func TestReconcilePendingRunsRequeuesRecoverableRuns(t *testing.T) {
 	}
 }
 
+func TestRequeueDisconnectedRunPreservesRecordedAutoRichInputRoute(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := taskstate.NewMemoryStore()
+	queue := &recordingQueue{}
+	runner := &Runner{
+		logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store:    store,
+		policies: make(map[string]struct{}),
+	}
+	attachTestQueueCoordinator(runner, queue)
+	now := time.Now().UTC()
+	task := types.Task{ID: "task-auto-rich-recovery", Status: "running", CreatedAt: now, UpdatedAt: now}
+	run := types.TaskRun{
+		ID:        "run-auto-rich-recovery",
+		TaskID:    task.ID,
+		Status:    "running",
+		Model:     "shared-vision",
+		InputRef:  "msg-auto-rich-recovery",
+		StartedAt: now,
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	instance := types.ProviderInstanceIdentity{ID: "runtime-vision-a", Kind: types.ProviderInstanceIdentityRuntime}
+	if err := runner.recordAgentInputProviderAttempt(ctx, task, run, types.RouteDecision{
+		Provider: "vision-a", ProviderKind: "cloud", ProviderInstance: instance, Model: "shared-vision",
+	}); err != nil {
+		t.Fatalf("recordAgentInputProviderAttempt: %v", err)
+	}
+	// This is the stale snapshot a boot reconciler could have loaded before
+	// the first worker crossed the provider-dispatch boundary.
+	if err := runner.requeueDisconnectedRun(ctx, task, run, disconnectedRunRequeueOptions{
+		Reason: "boot_reconcile", RecoveryStrategy: "requeue",
+	}); err != nil {
+		t.Fatalf("requeueDisconnectedRun: %v", err)
+	}
+	stored, found, err := store.GetRun(ctx, task.ID, run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun: found=%t err=%v", found, err)
+	}
+	if stored.Status != "queued" || stored.Provider != "vision-a" || stored.ProviderKind != "cloud" || stored.InputProviderInstance != instance {
+		t.Fatalf("requeued rich-input run = %+v, want queued vision-a route", stored)
+	}
+	if len(queue.enqueued) != 1 {
+		t.Fatalf("enqueued jobs = %+v, want one recovered run", queue.enqueued)
+	}
+	req := agentLoopChatRequest(ExecutionSpec{
+		Run: stored,
+		ChatRequirements: types.ChatRequestRequirements{
+			ImageInput:         true,
+			NoProviderFailover: true,
+			ExactProvider:      true,
+			ProviderInstance:   instance,
+		},
+	}, []types.Message{{Role: "user", Content: "inspect image"}}, nil)
+	if req.Scope.ProviderHint != "vision-a" || req.Requirements.ProviderInstance != instance || !req.Requirements.ExactProvider {
+		t.Fatalf("recovered request = hint %q requirements %+v, want the recorded Auto route", req.Scope.ProviderHint, req.Requirements)
+	}
+}
+
 func TestReconcilePendingRunsPaginatesEveryQueuedRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/runner_terminal_builders.go
+++ b/internal/orchestrator/runner_terminal_builders.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"strings"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/profiler"
@@ -56,6 +57,13 @@ func executionResultTerminalTransition(input executionResultTerminalTransitionIn
 	run.Provider = firstNonEmpty(input.Execution.Provider, run.Provider)
 	run.ProviderKind = firstNonEmpty(input.Execution.ProviderKind, run.ProviderKind)
 	run.Model = firstNonEmpty(input.Execution.Model, run.Model)
+	if strings.TrimSpace(run.InputRef) != "" && input.Execution.ProviderInstance.Valid() {
+		if !run.InputProviderInstance.Valid() {
+			run.InputProviderInstance = input.Execution.ProviderInstance
+		}
+		run.InputProviderDispatchRecorded = true
+		run.InputProviderDisclosedInstance = input.Execution.ProviderInstance
+	}
 	run.Status = firstNonEmpty(input.Execution.Status, "completed")
 	run.StepCount = len(input.PersistedSteps)
 	run.ArtifactCount = len(input.PersistedArtifacts)
@@ -81,16 +89,22 @@ func executionResultTerminalTransition(input executionResultTerminalTransitionIn
 		Now:                    input.FinishedAt,
 		SuppressDuplicateEvent: true,
 		TrustedSupplementalRunMetadata: &taskstate.TerminalRunSupplementalMetadata{
-			Provider:           run.Provider,
-			ProviderKind:       run.ProviderKind,
-			Model:              run.Model,
-			StepCount:          run.StepCount,
-			ArtifactCount:      run.ArtifactCount,
-			TotalCostMicrosUSD: run.TotalCostMicrosUSD,
+			Provider:                       run.Provider,
+			ProviderKind:                   run.ProviderKind,
+			InputProviderInstance:          run.InputProviderInstance,
+			InputProviderDispatchRecorded:  run.InputProviderDispatchRecorded,
+			InputProviderDisclosedInstance: run.InputProviderDisclosedInstance,
+			Model:                          run.Model,
+			StepCount:                      run.StepCount,
+			ArtifactCount:                  run.ArtifactCount,
+			TotalCostMicrosUSD:             run.TotalCostMicrosUSD,
 		},
 		UpdateRun: func(target *types.TaskRun) {
 			target.Provider = run.Provider
 			target.ProviderKind = run.ProviderKind
+			target.InputProviderInstance = run.InputProviderInstance
+			target.InputProviderDispatchRecorded = run.InputProviderDispatchRecorded
+			target.InputProviderDisclosedInstance = run.InputProviderDisclosedInstance
 			target.Model = run.Model
 			target.StepCount = run.StepCount
 			target.ArtifactCount = run.ArtifactCount

--- a/internal/orchestrator/runner_terminal_builders_test.go
+++ b/internal/orchestrator/runner_terminal_builders_test.go
@@ -80,21 +80,25 @@ func TestTerminalRunTransitionBuilders_ExecutionResult(t *testing.T) {
 	trace := profiler.NewInMemoryTracer(nil).Start("request-result-builder")
 	defer trace.Finalize()
 	task := types.Task{ID: "task-result"}
+	inputProviderInstance := types.ProviderInstanceIdentity{ID: "runtime-terminal-input", Kind: types.ProviderInstanceIdentityRuntime}
 	run := types.TaskRun{
-		ID:                 "run-result",
-		TaskID:             task.ID,
-		Provider:           "fallback-provider",
-		ProviderKind:       "fallback-kind",
-		Model:              "fallback-model",
-		TotalCostMicrosUSD: 99,
-		OtelStatusCode:     "old",
-		OtelStatusMessage:  "old message",
-		PriorCostMicrosUSD: 10,
-		WorkspacePath:      "/tmp/workspace",
+		ID:                    "run-result",
+		TaskID:                task.ID,
+		Provider:              "fallback-provider",
+		ProviderKind:          "fallback-kind",
+		Model:                 "fallback-model",
+		TotalCostMicrosUSD:    99,
+		OtelStatusCode:        "old",
+		OtelStatusMessage:     "old message",
+		PriorCostMicrosUSD:    10,
+		WorkspacePath:         "/tmp/workspace",
+		InputRef:              "msg_terminal_input",
+		InputProviderInstance: inputProviderInstance,
 	}
 	execution := &ExecutionResult{
 		Status:            "completed",
 		ProviderKind:      "openai",
+		ProviderInstance:  inputProviderInstance,
 		Model:             "gpt-4.1",
 		CostMicrosUSD:     250,
 		OtelStatusCode:    "ok",
@@ -128,12 +132,18 @@ func TestTerminalRunTransitionBuilders_ExecutionResult(t *testing.T) {
 	}
 	metadata := transition.TrustedSupplementalRunMetadata
 	if metadata == nil || metadata.Provider != transition.Run.Provider || metadata.ProviderKind != transition.Run.ProviderKind ||
+		metadata.InputProviderInstance != transition.Run.InputProviderInstance ||
+		metadata.InputProviderDispatchRecorded != transition.Run.InputProviderDispatchRecorded ||
+		metadata.InputProviderDisclosedInstance != transition.Run.InputProviderDisclosedInstance ||
 		metadata.Model != transition.Run.Model || metadata.StepCount != transition.Run.StepCount ||
 		metadata.ArtifactCount != transition.Run.ArtifactCount || metadata.TotalCostMicrosUSD != transition.Run.TotalCostMicrosUSD {
 		t.Fatalf("trusted supplemental metadata = %+v, want execution-result fields from %+v", metadata, transition.Run)
 	}
 	if transition.Run.Provider != "fallback-provider" || transition.Run.ProviderKind != "openai" || transition.Run.Model != "gpt-4.1" {
 		t.Fatalf("route = provider:%q kind:%q model:%q, want fallback provider + execution kind/model", transition.Run.Provider, transition.Run.ProviderKind, transition.Run.Model)
+	}
+	if transition.Run.InputProviderInstance != inputProviderInstance || !transition.Run.InputProviderDispatchRecorded || transition.Run.InputProviderDisclosedInstance != inputProviderInstance {
+		t.Fatalf("input provider route = admitted %+v dispatched=%t disclosed %+v, want %+v/true/%+v", transition.Run.InputProviderInstance, transition.Run.InputProviderDispatchRecorded, transition.Run.InputProviderDisclosedInstance, inputProviderInstance, inputProviderInstance)
 	}
 	if transition.Run.StepCount != 2 || transition.Run.ArtifactCount != 1 || transition.Run.TotalCostMicrosUSD != 250 {
 		t.Fatalf("counts/cost = steps:%d artifacts:%d cost:%d, want 2/1/250", transition.Run.StepCount, transition.Run.ArtifactCount, transition.Run.TotalCostMicrosUSD)
@@ -144,7 +154,7 @@ func TestTerminalRunTransitionBuilders_ExecutionResult(t *testing.T) {
 
 	targetRun := types.TaskRun{}
 	transition.UpdateRun(&targetRun)
-	if targetRun.Provider != transition.Run.Provider || targetRun.ProviderKind != transition.Run.ProviderKind || targetRun.Model != transition.Run.Model {
+	if targetRun.Provider != transition.Run.Provider || targetRun.ProviderKind != transition.Run.ProviderKind || targetRun.InputProviderInstance != transition.Run.InputProviderInstance || targetRun.InputProviderDispatchRecorded != transition.Run.InputProviderDispatchRecorded || targetRun.InputProviderDisclosedInstance != transition.Run.InputProviderDisclosedInstance || targetRun.Model != transition.Run.Model {
 		t.Fatalf("UpdateRun route = %+v, want route from transition run %+v", targetRun, transition.Run)
 	}
 	if targetRun.StepCount != transition.Run.StepCount || targetRun.ArtifactCount != transition.Run.ArtifactCount || targetRun.TotalCostMicrosUSD != transition.Run.TotalCostMicrosUSD {
@@ -185,5 +195,33 @@ func TestTerminalRunTransitionBuilders_ExecutionResultPreservesExistingTotalCost
 	}
 	if transition.Run.OtelStatusCode != "ok" {
 		t.Fatalf("otel status code = %q, want ok default", transition.Run.OtelStatusCode)
+	}
+}
+
+func TestTerminalRunTransitionBuilders_BackfillsAutoRichInputFenceAfterDispatch(t *testing.T) {
+	t.Parallel()
+
+	trace := profiler.NewInMemoryTracer(nil).Start("request-auto-rich-input")
+	defer trace.Finalize()
+	instance := types.ProviderInstanceIdentity{ID: "runtime-auto-rich-input", Kind: types.ProviderInstanceIdentityRuntime}
+	run := types.TaskRun{
+		ID:       "run-auto-rich-input",
+		TaskID:   "task-auto-rich-input",
+		InputRef: "msg-auto-rich-input",
+	}
+	transition := executionResultTerminalTransition(executionResultTerminalTransitionInput{
+		Task:       types.Task{ID: run.TaskID},
+		Run:        run,
+		Execution:  &ExecutionResult{Status: "completed", Provider: "vision-auto", ProviderInstance: instance},
+		RequestID:  trace.RequestID,
+		Trace:      trace,
+		FinishedAt: time.Now().UTC(),
+	})
+
+	if transition.Run.InputProviderInstance != instance || !transition.Run.InputProviderDispatchRecorded || transition.Run.InputProviderDisclosedInstance != instance {
+		t.Fatalf("Auto rich input route = admitted %+v dispatched=%t disclosed %+v, want %v/true/%v", transition.Run.InputProviderInstance, transition.Run.InputProviderDispatchRecorded, transition.Run.InputProviderDisclosedInstance, instance, instance)
+	}
+	if transition.TrustedSupplementalRunMetadata == nil || transition.TrustedSupplementalRunMetadata.InputProviderInstance != instance || !transition.TrustedSupplementalRunMetadata.InputProviderDispatchRecorded || transition.TrustedSupplementalRunMetadata.InputProviderDisclosedInstance != instance {
+		t.Fatalf("trusted metadata = %+v, want both Auto rich-input instances", transition.TrustedSupplementalRunMetadata)
 	}
 }

--- a/internal/providerdispatch/attempt.go
+++ b/internal/providerdispatch/attempt.go
@@ -1,0 +1,47 @@
+// Package providerdispatch carries the narrow, internal hook that lets a
+// task-backed agent persist its rich-input route immediately before gateway
+// I/O. It deliberately depends only on the shared route contract so the
+// gateway does not depend on the orchestrator.
+package providerdispatch
+
+import (
+	"context"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+// AttemptRecorder persists the concrete route that is about to receive a
+// provider-bound input. Returning an error prevents the gateway from sending
+// the request, which keeps durable recovery state and provider dispatch in
+// lock-step.
+type AttemptRecorder func(types.RouteDecision) error
+
+type attemptRecorderContextKey struct{}
+
+type attemptRecorderState struct {
+	recorder AttemptRecorder
+}
+
+// WithAttemptRecorder attaches an optional recorder to a request context.
+// The hook is internal transport plumbing: ordinary gateway callers do not
+// install one and retain the existing behavior.
+func WithAttemptRecorder(ctx context.Context, recorder AttemptRecorder) context.Context {
+	if recorder == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, attemptRecorderContextKey{}, &attemptRecorderState{recorder: recorder})
+}
+
+// RecordAttempt invokes the task-runtime recorder installed by
+// WithAttemptRecorder. A missing recorder is intentionally a no-op so this
+// remains safe for public gateway and direct-model traffic.
+func RecordAttempt(ctx context.Context, route types.RouteDecision) error {
+	state, _ := ctx.Value(attemptRecorderContextKey{}).(*attemptRecorderState)
+	if state == nil || state.recorder == nil {
+		return nil
+	}
+	if err := state.recorder(route); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -167,7 +167,7 @@ func (r *RuleRouter) routeExplicitProvider(ctx context.Context, req types.ChatRe
 		return types.RouteDecision{}, fmt.Errorf("provider %q configuration changed during image admission", explicitProvider)
 	}
 	if !supportsRequest(entry, routedModel, req) {
-		return types.RouteDecision{}, fmt.Errorf("provider %q model %q does not declare image-input support", explicitProvider, routedModel)
+		return types.RouteDecision{}, fmt.Errorf("provider %q model %q does not satisfy required %s support", explicitProvider, routedModel, requestCapabilityLabel(req.Requirements))
 	}
 
 	return types.RouteDecision{
@@ -273,7 +273,7 @@ func supportsRequest(entry catalog.Entry, model string, req types.ChatRequest) b
 	if req.Requirements.ProviderInstance.Valid() && entry.ProviderInstance != req.Requirements.ProviderInstance {
 		return false
 	}
-	if !req.Requirements.ImageInput {
+	if !req.Requirements.ImageInput && !req.Requirements.ToolCalling {
 		return true
 	}
 	providerCap := types.ModelCapabilities{}
@@ -281,7 +281,21 @@ func supportsRequest(entry catalog.Entry, model string, req types.ChatRequest) b
 		providerCap = entry.ModelCapabilities[model]
 	}
 	capability := modelcaps.ResolveWithProviderCapability(entry.ProviderFamily, string(entry.Kind), model, entry.DiscoverySource, providerCap)
-	return modelcaps.ImageCapable(capability)
+	if req.Requirements.ImageInput && !modelcaps.ImageCapable(capability) {
+		return false
+	}
+	return !req.Requirements.ToolCalling || modelcaps.ToolCapable(capability)
+}
+
+func requestCapabilityLabel(requirements types.ChatRequestRequirements) string {
+	switch {
+	case requirements.ImageInput && requirements.ToolCalling:
+		return "image-input and tool-calling"
+	case requirements.ToolCalling:
+		return "tool-calling"
+	default:
+		return "image-input"
+	}
 }
 
 func (r *RuleRouter) orderedProviders() []catalog.Entry {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -295,6 +295,79 @@ func TestRuleRouterFiltersImageInputCandidatesAndFallbacks(t *testing.T) {
 	}
 }
 
+func TestRuleRouterRequiresImageAndToolCapabilitiesOnSameCandidate(t *testing.T) {
+	t.Parallel()
+
+	capabilities := func(name, imageInput, toolCalling string) providers.Capabilities {
+		return providers.Capabilities{
+			Name:            name,
+			Kind:            providers.KindCloud,
+			DefaultModel:    "shared-model",
+			Models:          []string{"shared-model"},
+			DiscoverySource: "provider",
+			ModelCapabilities: map[string]types.ModelCapabilities{
+				"shared-model": {
+					ImageInput:  imageInput,
+					ToolCalling: toolCalling,
+					Source:      "provider",
+				},
+			},
+		}
+	}
+	newProvider := func(name, imageInput, toolCalling string) *fakeProvider {
+		return &fakeProvider{
+			name:            name,
+			kind:            providers.KindCloud,
+			defaultModel:    "shared-model",
+			supportedModels: []string{"shared-model"},
+			capabilities:    capabilities(name, imageInput, toolCalling),
+		}
+	}
+	req := types.ChatRequest{
+		Model: "shared-model",
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:  true,
+			ToolCalling: true,
+		},
+	}
+
+	t.Run("selects only the capability intersection", func(t *testing.T) {
+		t.Parallel()
+
+		registry := providers.NewRegistry(
+			newProvider("a-tools-only", "none", "parallel"),
+			newProvider("b-image-only", "supported", "none"),
+			newProvider("c-image-tools", "supported", "basic"),
+		)
+		router := NewRuleRouter("shared-model", catalog.NewRegistryCatalog(registry, nil))
+
+		got, err := router.Route(context.Background(), req)
+		if err != nil {
+			t.Fatalf("Route() error = %v", err)
+		}
+		if got.Provider != "c-image-tools" {
+			t.Fatalf("Route() provider = %q, want c-image-tools", got.Provider)
+		}
+		if fallbacks := router.Fallbacks(context.Background(), req, got); len(fallbacks) != 0 {
+			t.Fatalf("Fallbacks() = %+v, want no split-capability candidates", fallbacks)
+		}
+	})
+
+	t.Run("rejects split capabilities across providers", func(t *testing.T) {
+		t.Parallel()
+
+		registry := providers.NewRegistry(
+			newProvider("a-tools-only", "none", "parallel"),
+			newProvider("b-image-only", "supported", "none"),
+		)
+		router := NewRuleRouter("shared-model", catalog.NewRegistryCatalog(registry, nil))
+
+		if _, err := router.Route(context.Background(), req); err == nil {
+			t.Fatal("Route() error = nil, want split capabilities rejected")
+		}
+	})
+}
+
 func TestRuleRouterRejectsExpectedProviderInstanceAfterSameNameReplacement(t *testing.T) {
 	t.Parallel()
 

--- a/internal/taskstate/conformance_test.go
+++ b/internal/taskstate/conformance_test.go
@@ -89,6 +89,22 @@ func RunConformanceTests(t *testing.T, name string, factory StoreFactory) {
 		t.Parallel()
 		runStoreApplyRunStateTransitionResolvesApprovalAtomically(t, factory(t))
 	})
+	t.Run(name+"/RecordRichInputProviderAttempt", func(t *testing.T) {
+		t.Parallel()
+		runStoreRecordRichInputProviderAttempt(t, factory(t))
+	})
+	t.Run(name+"/RecordRichInputProviderAttemptConcurrent", func(t *testing.T) {
+		t.Parallel()
+		runStoreRecordRichInputProviderAttemptConcurrent(t, factory(t))
+	})
+	t.Run(name+"/StateTransitionPreservesRichInputAttempt", func(t *testing.T) {
+		t.Parallel()
+		runStoreStateTransitionPreservesRichInputAttempt(t, factory(t))
+	})
+	t.Run(name+"/TerminalTransitionPreservesRichInputAttempt", func(t *testing.T) {
+		t.Parallel()
+		runStoreTerminalTransitionPreservesRichInputAttempt(t, factory(t))
+	})
 	t.Run(name+"/ApplyRunTerminalTransitionRejectsApprovalAtomically", func(t *testing.T) {
 		t.Parallel()
 		runStoreApplyRunTerminalTransitionRejectsApprovalAtomically(t, factory(t))
@@ -324,6 +340,252 @@ func runStoreApplyRunStateTransitionCompareAndSwap(t *testing.T, store Store) {
 		if event.EventType == "gap.should_not_exist" {
 			t.Fatalf("stale transition appended event: %+v", event)
 		}
+	}
+}
+
+func runStoreRecordRichInputProviderAttempt(t *testing.T, store Store) {
+	t.Helper()
+	ctx := t.Context()
+	now := time.Now().UTC()
+	task, err := store.CreateTask(ctx, types.Task{
+		ID: "task-rich-input-attempt", Status: "running", CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	run := types.TaskRun{
+		ID: "run-rich-input-attempt", TaskID: task.ID, Status: "running", StartedAt: now, InputRef: "msg-rich-input",
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	routed := richInputProviderAttempt(task.ID, "run-rich-input-requested-route", "vision-a", "routed-model", "instance-routed")
+	requested := types.TaskRun{
+		ID:           "run-rich-input-requested-route",
+		TaskID:       task.ID,
+		Status:       "running",
+		StartedAt:    now,
+		InputRef:     "msg-rich-input-requested-route",
+		Provider:     "requested-provider",
+		ProviderKind: "requested-kind",
+		Model:        "requested-model",
+		// An explicit-provider attachment has an admission identity before
+		// policy rewrites the requested model at final dispatch.
+		InputProviderInstance: routed.ProviderInstance,
+	}
+	if _, err := store.CreateRun(ctx, requested); err != nil {
+		t.Fatalf("CreateRun(requested route): %v", err)
+	}
+	if result, err := store.RecordRichInputProviderAttempt(ctx, routed); err != nil || !result.Applied || !result.Run.InputProviderDispatchRecorded || result.Run.Provider != routed.Provider || result.Run.ProviderKind != routed.ProviderKind || result.Run.Model != routed.Model {
+		t.Fatalf("RecordRichInputProviderAttempt(first routed attempt) result=%+v err=%v, want policy-resolved route", result, err)
+	}
+	first := richInputProviderAttempt(task.ID, run.ID, "vision-a", "model-a", "instance-a")
+	result, err := store.RecordRichInputProviderAttempt(ctx, first)
+	if err != nil || !result.Applied {
+		t.Fatalf("RecordRichInputProviderAttempt(first) applied=%t err=%v", result.Applied, err)
+	}
+	if !result.Run.InputProviderDispatchRecorded || result.Run.Provider != first.Provider || result.Run.ProviderKind != first.ProviderKind || result.Run.Model != first.Model || result.Run.InputProviderInstance != first.ProviderInstance {
+		t.Fatalf("recorded rich-input route = %+v, want %+v", result.Run, first)
+	}
+	if result.Run.InputProviderDisclosedInstance.Valid() {
+		t.Fatalf("recorded rich-input attempt disclosed=%+v, want empty before provider I/O", result.Run.InputProviderDisclosedInstance)
+	}
+	if replay, err := store.RecordRichInputProviderAttempt(ctx, first); err != nil || !replay.Applied || !replay.Run.InputProviderDispatchRecorded || replay.Run.InputProviderInstance != first.ProviderInstance {
+		t.Fatalf("RecordRichInputProviderAttempt(replay) result=%+v err=%v", replay, err)
+	}
+	differentModel := first
+	differentModel.Model = "model-b"
+	if _, err := store.RecordRichInputProviderAttempt(ctx, differentModel); !errors.Is(err, ErrRichInputProviderRouteConflict) {
+		t.Fatalf("RecordRichInputProviderAttempt(model conflict) error=%v, want ErrRichInputProviderRouteConflict", err)
+	}
+	differentKind := first
+	differentKind.ProviderKind = "local"
+	if _, err := store.RecordRichInputProviderAttempt(ctx, differentKind); !errors.Is(err, ErrRichInputProviderRouteConflict) {
+		t.Fatalf("RecordRichInputProviderAttempt(kind conflict) error=%v, want ErrRichInputProviderRouteConflict", err)
+	}
+	conflicting := richInputProviderAttempt(task.ID, run.ID, "vision-b", "model-b", "instance-b")
+	if _, err := store.RecordRichInputProviderAttempt(ctx, conflicting); !errors.Is(err, ErrRichInputProviderRouteConflict) {
+		t.Fatalf("RecordRichInputProviderAttempt(conflict) error=%v, want ErrRichInputProviderRouteConflict", err)
+	}
+	stored, found, err := store.GetRun(ctx, task.ID, run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun: found=%v err=%v", found, err)
+	}
+	if !stored.InputProviderDispatchRecorded || stored.Provider != first.Provider || stored.InputProviderInstance != first.ProviderInstance {
+		t.Fatalf("conflicting attempt replaced stored route: %+v", stored)
+	}
+
+	stored.Status = "cancelled"
+	stored.FinishedAt = now.Add(time.Second)
+	if _, err := store.UpdateRun(ctx, stored); err != nil {
+		t.Fatalf("UpdateRun(cancelled): %v", err)
+	}
+	if terminal, err := store.RecordRichInputProviderAttempt(ctx, first); err != nil || terminal.Applied || terminal.Run.Status != "cancelled" {
+		t.Fatalf("RecordRichInputProviderAttempt(terminal) result=%+v err=%v, want unapplied cancelled run", terminal, err)
+	}
+	withoutRef := types.TaskRun{ID: "run-rich-input-missing-ref", TaskID: task.ID, Status: "running", StartedAt: now}
+	if _, err := store.CreateRun(ctx, withoutRef); err != nil {
+		t.Fatalf("CreateRun(missing ref): %v", err)
+	}
+	missingRef := richInputProviderAttempt(task.ID, withoutRef.ID, "vision-a", "model-a", "instance-a")
+	if result, err := store.RecordRichInputProviderAttempt(ctx, missingRef); !errors.Is(err, ErrRichInputProviderRouteConflict) || result.Applied {
+		t.Fatalf("RecordRichInputProviderAttempt(missing ref) result=%+v err=%v, want unapplied route conflict", result, err)
+	}
+}
+
+func runStoreRecordRichInputProviderAttemptConcurrent(t *testing.T, store Store) {
+	t.Helper()
+	ctx := t.Context()
+	now := time.Now().UTC()
+	task, err := store.CreateTask(ctx, types.Task{
+		ID: "task-rich-input-race", Status: "running", CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	run := types.TaskRun{ID: "run-rich-input-race", TaskID: task.ID, Status: "running", StartedAt: now, InputRef: "msg-rich-input"}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	attempts := []RichInputProviderAttempt{
+		richInputProviderAttempt(task.ID, run.ID, "vision-a", "model-a", "instance-a"),
+		richInputProviderAttempt(task.ID, run.ID, "vision-b", "model-b", "instance-b"),
+	}
+	start := make(chan struct{})
+	results := make([]RichInputProviderAttemptResult, len(attempts))
+	errs := make([]error, len(attempts))
+	var wg sync.WaitGroup
+	for index := range attempts {
+		index := index
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			results[index], errs[index] = store.RecordRichInputProviderAttempt(ctx, attempts[index])
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	applied, conflicts := 0, 0
+	for index, err := range errs {
+		switch {
+		case err == nil && results[index].Applied:
+			applied++
+		case errors.Is(err, ErrRichInputProviderRouteConflict):
+			conflicts++
+		default:
+			t.Fatalf("concurrent rich-input result[%d]=%+v err=%v", index, results[index], err)
+		}
+	}
+	if applied != 1 || conflicts != 1 {
+		t.Fatalf("concurrent rich-input results=%+v errors=%v, want one applied and one conflict", results, errs)
+	}
+	stored, found, err := store.GetRun(ctx, task.ID, run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun: found=%v err=%v", found, err)
+	}
+	if stored.Provider != "vision-a" && stored.Provider != "vision-b" {
+		t.Fatalf("stored provider=%q, want one contender", stored.Provider)
+	}
+	if !stored.InputProviderInstance.Valid() {
+		t.Fatalf("stored rich-input instance=%+v, want one contender", stored.InputProviderInstance)
+	}
+}
+
+func runStoreStateTransitionPreservesRichInputAttempt(t *testing.T, store Store) {
+	t.Helper()
+	ctx := t.Context()
+	now := time.Now().UTC()
+	task, err := store.CreateTask(ctx, types.Task{
+		ID: "task-rich-input-state", Status: "running", CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	run := types.TaskRun{ID: "run-rich-input-state", TaskID: task.ID, Status: "running", StartedAt: now, InputRef: "msg-rich-input"}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	// Reconciliation can prepare a running->queued candidate from a snapshot
+	// captured before final dispatch. The atomic transition must merge the
+	// persisted fence instead of erasing it with that stale candidate.
+	staleTask := task
+	staleTask.Status = "queued"
+	staleTask.UpdatedAt = now.Add(time.Second)
+	staleRun := run
+	staleRun.Status = "queued"
+	staleRun.InputProviderDisclosedInstance = types.ProviderInstanceIdentity{ID: "instance-b", Kind: types.ProviderInstanceIdentityRuntime}
+	if _, err := store.RecordRichInputProviderAttempt(ctx, richInputProviderAttempt(task.ID, run.ID, "vision-a", "model-a", "instance-a")); err != nil {
+		t.Fatalf("RecordRichInputProviderAttempt: %v", err)
+	}
+	result, err := store.ApplyRunStateTransition(ctx, RunStateTransition{
+		Task:                staleTask,
+		Run:                 staleRun,
+		ExpectedRunStatuses: []string{"running"},
+	})
+	if err != nil || !result.Applied {
+		t.Fatalf("ApplyRunStateTransition(stale requeue) applied=%t err=%v", result.Applied, err)
+	}
+	if result.Run.Status != "queued" || !result.Run.InputProviderDispatchRecorded || result.Run.Provider != "vision-a" || result.Run.ProviderKind != "cloud" || result.Run.Model != "model-a" || result.Run.InputProviderInstance.ID != "instance-a" || result.Run.InputProviderDisclosedInstance.Valid() {
+		t.Fatalf("state transition lost rich-input route: %+v", result.Run)
+	}
+}
+
+func runStoreTerminalTransitionPreservesRichInputAttempt(t *testing.T, store Store) {
+	t.Helper()
+	ctx := t.Context()
+	now := time.Now().UTC()
+	task, err := store.CreateTask(ctx, types.Task{
+		ID: "task-rich-input-terminal", Status: "running", CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	run := types.TaskRun{ID: "run-rich-input-terminal", TaskID: task.ID, Status: "running", StartedAt: now, InputRef: "msg-rich-input"}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	// Capture the cancellation candidate before the dispatch boundary updates
+	// the stored route. A terminal write must retain that later fence.
+	staleTask := task
+	staleTask.Status = "cancelled"
+	staleTask.FinishedAt = now.Add(time.Second)
+	staleTask.UpdatedAt = staleTask.FinishedAt
+	staleRun := run
+	staleRun.Status = "cancelled"
+	staleRun.FinishedAt = staleTask.FinishedAt
+	if _, err := store.RecordRichInputProviderAttempt(ctx, richInputProviderAttempt(task.ID, run.ID, "vision-a", "model-a", "instance-a")); err != nil {
+		t.Fatalf("RecordRichInputProviderAttempt: %v", err)
+	}
+	if _, err := store.ApplyRunTerminalTransition(ctx, TerminalRunTransition{
+		Task:       staleTask,
+		Run:        staleRun,
+		FinishedAt: staleRun.FinishedAt,
+	}); err != nil {
+		t.Fatalf("ApplyRunTerminalTransition(stale cancellation): %v", err)
+	}
+	stored, found, err := store.GetRun(ctx, task.ID, run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun: found=%v err=%v", found, err)
+	}
+	if stored.Status != "cancelled" || !stored.InputProviderDispatchRecorded || stored.InputProviderInstance.ID != "instance-a" || stored.Provider != "vision-a" || stored.Model != "model-a" {
+		t.Fatalf("terminal run lost rich-input route: %+v", stored)
+	}
+}
+
+func richInputProviderAttempt(taskID, runID, provider, model, instanceID string) RichInputProviderAttempt {
+	return RichInputProviderAttempt{
+		TaskID:       taskID,
+		RunID:        runID,
+		Provider:     provider,
+		ProviderKind: "cloud",
+		Model:        model,
+		ProviderInstance: types.ProviderInstanceIdentity{
+			ID:   instanceID,
+			Kind: types.ProviderInstanceIdentityRuntime,
+		},
 	}
 }
 
@@ -1141,6 +1403,16 @@ func runStoreTaskRunStepRoundTrip(t *testing.T, store Store) {
 		Number:       1,
 		Status:       "running",
 		StartedAt:    time.Now().UTC(),
+		InputRef:     "msg-rich-input",
+		InputProviderInstance: types.ProviderInstanceIdentity{
+			ID:   "runtime-rich-input",
+			Kind: types.ProviderInstanceIdentityRuntime,
+		},
+		InputProviderDispatchRecorded: true,
+		InputProviderDisclosedInstance: types.ProviderInstanceIdentity{
+			ID:   "runtime-rich-input-disclosed",
+			Kind: types.ProviderInstanceIdentityRuntime,
+		},
 	}
 	if _, err := store.CreateRun(ctx, run); err != nil {
 		t.Fatalf("CreateRun: %v", err)
@@ -1154,6 +1426,9 @@ func runStoreTaskRunStepRoundTrip(t *testing.T, store Store) {
 	}
 	if gotRun.ProjectID != "proj-1" || gotRun.WorkItemID != "work-1" || gotRun.AssignmentID != "asgn-1" {
 		t.Fatalf("GetRun linkage = project %q work %q assignment %q, want proj-1/work-1/asgn-1", gotRun.ProjectID, gotRun.WorkItemID, gotRun.AssignmentID)
+	}
+	if gotRun.InputRef != run.InputRef || gotRun.InputProviderInstance != run.InputProviderInstance || gotRun.InputProviderDispatchRecorded != run.InputProviderDispatchRecorded || gotRun.InputProviderDisclosedInstance != run.InputProviderDisclosedInstance {
+		t.Fatalf("GetRun rich-input fence = ref %q admitted %+v dispatched %t disclosed %+v, want %q/%+v/%t/%+v", gotRun.InputRef, gotRun.InputProviderInstance, gotRun.InputProviderDispatchRecorded, gotRun.InputProviderDisclosedInstance, run.InputRef, run.InputProviderInstance, run.InputProviderDispatchRecorded, run.InputProviderDisclosedInstance)
 	}
 
 	for i, status := range []string{"running", "completed"} {

--- a/internal/taskstate/memory.go
+++ b/internal/taskstate/memory.go
@@ -478,7 +478,7 @@ func (s *MemoryStore) ApplyRunTerminalTransition(_ context.Context, tr TerminalR
 
 	finishedAt := terminalTransitionFinishedAt(tr)
 	task := tr.Task
-	run := tr.Run
+	run := mergeStoredRichInputRoute(tr.Run, storedRun)
 	terminalEvent := tr.TerminalEvent
 	taskUpdatedEvent := tr.TaskUpdatedEvent
 	activeStepError := tr.ActiveStepError

--- a/internal/taskstate/rich_input_attempt.go
+++ b/internal/taskstate/rich_input_attempt.go
@@ -1,0 +1,161 @@
+package taskstate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+// RecordRichInputProviderAttempt is the durable boundary immediately before a
+// provider can receive a rich input. It deliberately mutates only the stored
+// route fields: a worker must never replace an authoritative run with its
+// stale copy merely to record a provider attempt.
+func (s *MemoryStore) RecordRichInputProviderAttempt(_ context.Context, attempt RichInputProviderAttempt) (RichInputProviderAttemptResult, error) {
+	if err := validateRichInputProviderAttempt(attempt); err != nil {
+		return RichInputProviderAttemptResult{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	run, found := s.runs[attempt.RunID]
+	if !found || run.TaskID != attempt.TaskID {
+		return RichInputProviderAttemptResult{}, fmt.Errorf("run %q not found", attempt.RunID)
+	}
+	if run.Status != "running" {
+		return RichInputProviderAttemptResult{Run: run}, nil
+	}
+	if strings.TrimSpace(run.InputRef) == "" {
+		return RichInputProviderAttemptResult{Run: run}, fmt.Errorf("%w: rich input reference is missing", ErrRichInputProviderRouteConflict)
+	}
+	updated, err := mergeRichInputProviderAttempt(run, attempt)
+	if err != nil {
+		return RichInputProviderAttemptResult{Run: run}, err
+	}
+	s.runs[updated.ID] = updated
+	s.signalRun(updated.ID)
+	return RichInputProviderAttemptResult{Run: updated, Applied: true}, nil
+}
+
+// RecordRichInputProviderAttempt serializes route admission with every other
+// durable run mutation. SQLite's BEGIN IMMEDIATE setting acquires the writer
+// lock before the read; Postgres adds FOR UPDATE in sqliteGetRunTx.
+func (s *SQLiteStore) RecordRichInputProviderAttempt(ctx context.Context, attempt RichInputProviderAttempt) (RichInputProviderAttemptResult, error) {
+	if err := validateRichInputProviderAttempt(attempt); err != nil {
+		return RichInputProviderAttemptResult{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return RichInputProviderAttemptResult{}, err
+	}
+	defer tx.Rollback()
+
+	run, err := s.sqliteGetRunTx(ctx, tx, attempt.TaskID, attempt.RunID)
+	if err != nil {
+		return RichInputProviderAttemptResult{}, err
+	}
+	if run.Status != "running" {
+		return RichInputProviderAttemptResult{Run: run}, nil
+	}
+	if strings.TrimSpace(run.InputRef) == "" {
+		return RichInputProviderAttemptResult{Run: run}, fmt.Errorf("%w: rich input reference is missing", ErrRichInputProviderRouteConflict)
+	}
+	updated, err := mergeRichInputProviderAttempt(run, attempt)
+	if err != nil {
+		return RichInputProviderAttemptResult{Run: run}, err
+	}
+	payload, err := json.Marshal(updated)
+	if err != nil {
+		return RichInputProviderAttemptResult{}, err
+	}
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET payload = ?
+		WHERE id = ? AND task_id = ? AND status = 'running'
+	`, s.runsTable), string(payload), updated.ID, updated.TaskID)
+	if err != nil {
+		return RichInputProviderAttemptResult{}, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return RichInputProviderAttemptResult{}, err
+	}
+	if affected == 0 {
+		current, err := s.sqliteGetRunTx(ctx, tx, attempt.TaskID, attempt.RunID)
+		if err != nil {
+			return RichInputProviderAttemptResult{}, err
+		}
+		return RichInputProviderAttemptResult{Run: current}, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return RichInputProviderAttemptResult{}, err
+	}
+	s.signalRun(updated.ID)
+	return RichInputProviderAttemptResult{Run: updated, Applied: true}, nil
+}
+
+func validateRichInputProviderAttempt(attempt RichInputProviderAttempt) error {
+	if strings.TrimSpace(attempt.TaskID) == "" {
+		return fmt.Errorf("task id is required")
+	}
+	if strings.TrimSpace(attempt.RunID) == "" {
+		return fmt.Errorf("run id is required")
+	}
+	if strings.TrimSpace(attempt.Provider) == "" {
+		return fmt.Errorf("provider is required")
+	}
+	if !attempt.ProviderInstance.Valid() {
+		return fmt.Errorf("provider instance is required")
+	}
+	return nil
+}
+
+func mergeRichInputProviderAttempt(run types.TaskRun, attempt RichInputProviderAttempt) (types.TaskRun, error) {
+	// InputProviderInstance may be set at admission for an explicit provider,
+	// before the governor rewrites a model and the router resolves the final
+	// route. It still pins the provider generation from that point onward.
+	if run.InputProviderInstance.Valid() && run.InputProviderInstance != attempt.ProviderInstance {
+		return types.TaskRun{}, fmt.Errorf("%w: provider instance changed", ErrRichInputProviderRouteConflict)
+	}
+	if run.InputProviderDisclosedInstance.Valid() && run.InputProviderDisclosedInstance != attempt.ProviderInstance {
+		return types.TaskRun{}, fmt.Errorf("%w: provider disclosure instance changed", ErrRichInputProviderRouteConflict)
+	}
+	provider := strings.TrimSpace(attempt.Provider)
+	// TaskRun's initial provider, kind, and model are request hints, not the
+	// final rich-input route. The separate dispatch marker makes the first
+	// policy-rewritten route admissible while keeping all later attempts exact.
+	hasPriorDispatch := run.InputProviderDispatchRecorded
+	if existing := normalizedRichInputProvider(run.Provider); hasPriorDispatch && existing != "" && existing != provider {
+		return types.TaskRun{}, fmt.Errorf("%w: provider changed from %q to %q", ErrRichInputProviderRouteConflict, existing, provider)
+	}
+	kind := strings.TrimSpace(attempt.ProviderKind)
+	if existing := strings.TrimSpace(run.ProviderKind); hasPriorDispatch && existing != "" && kind != "" && existing != kind {
+		return types.TaskRun{}, fmt.Errorf("%w: provider kind changed from %q to %q", ErrRichInputProviderRouteConflict, existing, kind)
+	}
+	model := strings.TrimSpace(attempt.Model)
+	if existing := strings.TrimSpace(run.Model); hasPriorDispatch && existing != "" && model != "" && existing != model {
+		return types.TaskRun{}, fmt.Errorf("%w: model changed from %q to %q", ErrRichInputProviderRouteConflict, existing, model)
+	}
+
+	updated := run
+	updated.Provider = provider
+	if kind != "" {
+		updated.ProviderKind = kind
+	}
+	if model != "" {
+		updated.Model = model
+	}
+	updated.InputProviderInstance = attempt.ProviderInstance
+	updated.InputProviderDispatchRecorded = true
+	return updated, nil
+}
+
+func normalizedRichInputProvider(provider string) string {
+	provider = strings.TrimSpace(provider)
+	if strings.EqualFold(provider, "auto") {
+		return ""
+	}
+	return provider
+}

--- a/internal/taskstate/run_state_transition.go
+++ b/internal/taskstate/run_state_transition.go
@@ -91,7 +91,7 @@ func (s *MemoryStore) ApplyRunStateTransition(_ context.Context, tr RunStateTran
 	}
 
 	task := cloneTask(tr.Task)
-	run := tr.Run
+	run := mergeStoredRichInputRoute(tr.Run, storedRun)
 	s.tasks[task.ID] = task
 	s.runs[run.ID] = run
 	if tr.ApprovalResolution != nil {
@@ -154,11 +154,12 @@ func (s *SQLiteStore) ApplyRunStateTransition(ctx context.Context, tr RunStateTr
 		}
 	}
 
-	payload, err := json.Marshal(tr.Run)
+	run := mergeStoredRichInputRoute(tr.Run, storedRun)
+	payload, err := json.Marshal(run)
 	if err != nil {
 		return RunStateTransitionResult{}, err
 	}
-	args := []any{tr.Run.Status, tr.Run.StartedAt, string(payload), tr.Run.ID, tr.Task.ID}
+	args := []any{run.Status, run.StartedAt, string(payload), run.ID, tr.Task.ID}
 	for _, status := range tr.ExpectedRunStatuses {
 		args = append(args, status)
 	}
@@ -196,24 +197,24 @@ func (s *SQLiteStore) ApplyRunStateTransition(ctx context.Context, tr RunStateTr
 	var steps []types.TaskStep
 	var artifacts []types.TaskArtifact
 	if tr.ApprovalResolution != nil || runEventSpecsNeedSnapshot(tr.Events) {
-		steps, err = s.sqliteListStepsTx(ctx, tx, tr.Run.ID)
+		steps, err = s.sqliteListStepsTx(ctx, tx, run.ID)
 		if err != nil {
 			return RunStateTransitionResult{}, err
 		}
-		artifacts, err = s.sqliteListArtifactsTx(ctx, tx, ArtifactFilter{TaskID: tr.Task.ID, RunID: tr.Run.ID}, "")
+		artifacts, err = s.sqliteListArtifactsTx(ctx, tx, ArtifactFilter{TaskID: tr.Task.ID, RunID: run.ID}, "")
 		if err != nil {
 			return RunStateTransitionResult{}, err
 		}
 	}
 	events := make([]types.TaskRunEvent, 0, len(tr.Events)+2)
 	if tr.ApprovalResolution != nil {
-		event := approvalResolutionEvent(tr.Task.ID, *tr.ApprovalResolution, resolvedApproval, tr.Run, steps, artifacts)
+		event := approvalResolutionEvent(tr.Task.ID, *tr.ApprovalResolution, resolvedApproval, run, steps, artifacts)
 		inserted, err := s.sqliteInsertRunEventTx(ctx, tx, event)
 		if err != nil {
 			return RunStateTransitionResult{}, err
 		}
 		events = append(events, inserted)
-		queued := approvalRunQueuedEvent(tr.Task.ID, *tr.ApprovalResolution, tr.Run, steps, artifacts)
+		queued := approvalRunQueuedEvent(tr.Task.ID, *tr.ApprovalResolution, run, steps, artifacts)
 		inserted, err = s.sqliteInsertRunEventTx(ctx, tx, queued)
 		if err != nil {
 			return RunStateTransitionResult{}, err
@@ -221,7 +222,7 @@ func (s *SQLiteStore) ApplyRunStateTransition(ctx context.Context, tr RunStateTr
 		events = append(events, inserted)
 	}
 	for _, spec := range tr.Events {
-		event := runStateEventFromSpec(spec, tr.Task.ID, tr.Run, steps, artifacts, time.Now().UTC())
+		event := runStateEventFromSpec(spec, tr.Task.ID, run, steps, artifacts, time.Now().UTC())
 		inserted, err := s.sqliteInsertRunEventTx(ctx, tx, event)
 		if err != nil {
 			return RunStateTransitionResult{}, err
@@ -231,8 +232,8 @@ func (s *SQLiteStore) ApplyRunStateTransition(ctx context.Context, tr RunStateTr
 	if err := tx.Commit(); err != nil {
 		return RunStateTransitionResult{}, err
 	}
-	s.signalRun(tr.Run.ID)
-	return RunStateTransitionResult{Task: tr.Task, Run: tr.Run, Approval: resolvedApproval, Events: events, Applied: true}, nil
+	s.signalRun(run.ID)
+	return RunStateTransitionResult{Task: tr.Task, Run: run, Approval: resolvedApproval, Events: events, Applied: true}, nil
 }
 
 func (s *SQLiteStore) sqliteGetTaskTx(ctx context.Context, tx interface {

--- a/internal/taskstate/sqlite.go
+++ b/internal/taskstate/sqlite.go
@@ -664,7 +664,7 @@ func (s *SQLiteStore) ApplyRunTerminalTransition(ctx context.Context, tr Termina
 
 	finishedAt := terminalTransitionFinishedAt(tr)
 	task := tr.Task
-	run := tr.Run
+	run := mergeStoredRichInputRoute(tr.Run, storedRun)
 	terminalEvent := tr.TerminalEvent
 	taskUpdatedEvent := tr.TaskUpdatedEvent
 	activeStepError := tr.ActiveStepError

--- a/internal/taskstate/store.go
+++ b/internal/taskstate/store.go
@@ -15,6 +15,9 @@ var (
 	// ErrBudgetLower protects the durable per-task ceiling from stale or
 	// concurrent resume requests that would lower it.
 	ErrBudgetLower = errors.New("budget_micros_usd cannot be lower than the current task ceiling")
+	// ErrRichInputProviderRouteConflict prevents a provider-bound rich input
+	// from being sent through a different durable route after admission.
+	ErrRichInputProviderRouteConflict = errors.New("rich input provider route conflicts with the admitted route")
 )
 
 type TaskFilter struct {
@@ -125,16 +128,42 @@ type RunStateTransitionResult struct {
 	Applied  bool
 }
 
+// RichInputProviderAttempt records the concrete provider route immediately
+// before it can receive a provider-bound input. The store owns the
+// empty-or-equal route invariant so concurrent workers cannot overwrite one
+// another's rich-input fence with stale run snapshots.
+type RichInputProviderAttempt struct {
+	TaskID           string
+	RunID            string
+	Provider         string
+	ProviderKind     string
+	Model            string
+	ProviderInstance types.ProviderInstanceIdentity
+}
+
+// RichInputProviderAttemptResult returns the authoritative run. Applied is
+// true only when the run was still eligible for provider dispatch; callers
+// must not send the rich input when it is false.
+type RichInputProviderAttemptResult struct {
+	Run     types.TaskRun
+	Applied bool
+}
+
 // TerminalRunSupplementalMetadata contains executor-observed fields that may
 // safely enrich an already-terminal run without changing its winning status,
-// reason, timestamps, task projection, or events.
+// reason, timestamps, task projection, or events. It is used both at normal
+// execution finalization and when an observed rich-input provider attempt
+// races a terminal transition.
 type TerminalRunSupplementalMetadata struct {
-	Provider           string
-	ProviderKind       string
-	Model              string
-	StepCount          int
-	ArtifactCount      int
-	TotalCostMicrosUSD int64
+	Provider                       string
+	ProviderKind                   string
+	InputProviderInstance          types.ProviderInstanceIdentity
+	InputProviderDispatchRecorded  bool
+	InputProviderDisclosedInstance types.ProviderInstanceIdentity
+	Model                          string
+	StepCount                      int
+	ArtifactCount                  int
+	TotalCostMicrosUSD             int64
 }
 
 // TerminalRunTransition atomically settles a run and its parent projection.
@@ -152,8 +181,8 @@ type TerminalRunTransition struct {
 	// run.cancelled, task.updated, and approval.resolved events. Immutable
 	// approval request provenance comes from the locked stored row.
 	ApprovalResolution *PendingApprovalResolution
-	// TrustedSupplementalRunMetadata may be set only by execution-result
-	// finalization. Operator cancellation and cleanup replays must leave it nil
+	// TrustedSupplementalRunMetadata may be set only by trusted executor
+	// observation. Operator cancellation and cleanup replays must leave it nil
 	// so stale run snapshots cannot replace the actual provider route.
 	TrustedSupplementalRunMetadata *TerminalRunSupplementalMetadata
 	// PreserveTaskProjection applies run-child cleanup without overwriting the
@@ -202,6 +231,7 @@ type Store interface {
 	UpdateRun(ctx context.Context, run types.TaskRun) (types.TaskRun, error)
 	ApplyRunStartTransition(ctx context.Context, transition RunStartTransition) (RunStartTransitionResult, error)
 	ApplyRunStateTransition(ctx context.Context, transition RunStateTransition) (RunStateTransitionResult, error)
+	RecordRichInputProviderAttempt(ctx context.Context, attempt RichInputProviderAttempt) (RichInputProviderAttemptResult, error)
 
 	AppendStep(ctx context.Context, step types.TaskStep) (types.TaskStep, error)
 	GetStep(ctx context.Context, runID, stepID string) (types.TaskStep, bool, error)

--- a/internal/taskstate/terminal.go
+++ b/internal/taskstate/terminal.go
@@ -90,13 +90,22 @@ func terminalTransitionFinishedAt(tr TerminalRunTransition) time.Time {
 func mergeTrustedTerminalRunMetadata(winner types.TaskRun, supplemental *TerminalRunSupplementalMetadata) types.TaskRun {
 	merged := winner
 	if supplemental == nil {
-		return merged
+		return mergeStoredRichInputRoute(merged, winner)
 	}
 	if strings.TrimSpace(supplemental.Provider) != "" {
 		merged.Provider = supplemental.Provider
 	}
 	if strings.TrimSpace(supplemental.ProviderKind) != "" {
 		merged.ProviderKind = supplemental.ProviderKind
+	}
+	if supplemental.InputProviderInstance.Valid() {
+		merged.InputProviderInstance = supplemental.InputProviderInstance
+	}
+	if supplemental.InputProviderDispatchRecorded {
+		merged.InputProviderDispatchRecorded = true
+	}
+	if supplemental.InputProviderDisclosedInstance.Valid() {
+		merged.InputProviderDisclosedInstance = supplemental.InputProviderDisclosedInstance
 	}
 	if strings.TrimSpace(supplemental.Model) != "" {
 		merged.Model = supplemental.Model
@@ -109,6 +118,38 @@ func mergeTrustedTerminalRunMetadata(winner types.TaskRun, supplemental *Termina
 	}
 	if supplemental.TotalCostMicrosUSD > merged.TotalCostMicrosUSD {
 		merged.TotalCostMicrosUSD = supplemental.TotalCostMicrosUSD
+	}
+	return mergeStoredRichInputRoute(merged, winner)
+}
+
+// mergeStoredRichInputRoute keeps the authoritative rich-input fence when a
+// terminal transition was built from an older run snapshot. The dispatch
+// boundary writes this metadata independently of finalization, so cancellation
+// and cleanup paths must never erase it while settling the winning status.
+func mergeStoredRichInputRoute(candidate, stored types.TaskRun) types.TaskRun {
+	if strings.TrimSpace(stored.InputRef) == "" {
+		return candidate
+	}
+	merged := candidate
+	merged.InputRef = stored.InputRef
+	if stored.InputProviderInstance.Valid() {
+		merged.InputProviderInstance = stored.InputProviderInstance
+	}
+	if stored.InputProviderDispatchRecorded {
+		merged.InputProviderDispatchRecorded = true
+		merged.Provider = firstNonEmptyString(stored.Provider, merged.Provider)
+		merged.ProviderKind = firstNonEmptyString(stored.ProviderKind, merged.ProviderKind)
+		merged.Model = firstNonEmptyString(stored.Model, merged.Model)
+	}
+	// A stale terminal or state-transition candidate may have captured an
+	// unrelated disclosure marker before the dispatch fence committed. Keep
+	// the marker empty unless it belongs to the authoritative admitted route;
+	// actual provider-call metadata may fill it below.
+	if stored.InputProviderInstance.Valid() && merged.InputProviderDisclosedInstance.Valid() && merged.InputProviderDisclosedInstance != stored.InputProviderInstance {
+		merged.InputProviderDisclosedInstance = types.ProviderInstanceIdentity{}
+	}
+	if stored.InputProviderDisclosedInstance.Valid() {
+		merged.InputProviderDisclosedInstance = stored.InputProviderDisclosedInstance
 	}
 	return merged
 }

--- a/internal/telemetry/contract.go
+++ b/internal/telemetry/contract.go
@@ -323,20 +323,24 @@ const (
 	ErrorKindRetryBackoff       = "retry_backoff_failed"
 	ErrorKindProviderHealth     = "provider_health_degraded"
 	ErrorKindUsageRecord        = "usage_record_failed"
+	// ErrorKindRichInputRouteFence records a local durability or route-fence
+	// failure that blocks rich-input provider I/O before a provider call starts.
+	ErrorKindRichInputRouteFence = "rich_input_route_fence_failed"
 	// ErrorKindOther is the fallback for any value not in the known set.
 	ErrorKindOther = "other"
 )
 
 var knownErrorKinds = map[string]struct{}{
-	ErrorKindInvalidRequest:     {},
-	ErrorKindRequestDenied:      {},
-	ErrorKindRouterFailed:       {},
-	ErrorKindRouteDenied:        {},
-	ErrorKindProviderCallFailed: {},
-	ErrorKindRetryBackoff:       {},
-	ErrorKindProviderHealth:     {},
-	ErrorKindUsageRecord:        {},
-	ErrorKindOther:              {},
+	ErrorKindInvalidRequest:      {},
+	ErrorKindRequestDenied:       {},
+	ErrorKindRouterFailed:        {},
+	ErrorKindRouteDenied:         {},
+	ErrorKindProviderCallFailed:  {},
+	ErrorKindRetryBackoff:        {},
+	ErrorKindProviderHealth:      {},
+	ErrorKindUsageRecord:         {},
+	ErrorKindRichInputRouteFence: {},
+	ErrorKindOther:               {},
 }
 
 var knownResults = map[string]struct{}{

--- a/internal/telemetry/contract_test.go
+++ b/internal/telemetry/contract_test.go
@@ -25,6 +25,7 @@ func TestNormalizeErrorKindPassesThroughKnownValues(t *testing.T) {
 		ErrorKindRetryBackoff,
 		ErrorKindProviderHealth,
 		ErrorKindUsageRecord,
+		ErrorKindRichInputRouteFence,
 		ErrorKindOther,
 	}
 	for _, kind := range known {
@@ -329,15 +330,16 @@ func TestErrorKindConstantsCoverKnownSet(t *testing.T) {
 
 	// Build the set of all exported error kind constants.
 	exported := map[string]bool{
-		ErrorKindInvalidRequest:     true,
-		ErrorKindRequestDenied:      true,
-		ErrorKindRouterFailed:       true,
-		ErrorKindRouteDenied:        true,
-		ErrorKindProviderCallFailed: true,
-		ErrorKindRetryBackoff:       true,
-		ErrorKindProviderHealth:     true,
-		ErrorKindUsageRecord:        true,
-		ErrorKindOther:              true,
+		ErrorKindInvalidRequest:      true,
+		ErrorKindRequestDenied:       true,
+		ErrorKindRouterFailed:        true,
+		ErrorKindRouteDenied:         true,
+		ErrorKindProviderCallFailed:  true,
+		ErrorKindRetryBackoff:        true,
+		ErrorKindProviderHealth:      true,
+		ErrorKindUsageRecord:         true,
+		ErrorKindRichInputRouteFence: true,
+		ErrorKindOther:               true,
 	}
 
 	// Every value in knownErrorKinds must be reachable via an exported constant.

--- a/pkg/types/chat.go
+++ b/pkg/types/chat.go
@@ -92,6 +92,12 @@ type ChatRequest struct {
 // opting into Hecate's stricter runtime admission policy.
 type ChatRequestRequirements struct {
 	ImageInput bool
+	// ToolCalling requires each route candidate to declare tool-call support.
+	// Rich-input agent turns set this alongside ImageInput so Auto routing cannot
+	// combine image support from one provider with tool support from another.
+	// Ordinary tool turns may leave it false to retain their established
+	// optimistic behavior for providers with unknown capability discovery.
+	ToolCalling bool
 	// NoProviderFailover keeps retries on the selected provider but prevents a
 	// request from crossing into another provider. It also requires the gateway
 	// to revalidate the selected provider instance immediately before every

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -221,6 +221,24 @@ type TaskRun struct {
 	// retry runs inherit it; chat continuations replace or clear it. Public
 	// task-run renderers intentionally omit it.
 	InputRef string
+	// InputProviderInstance is the opaque provider instance admitted for
+	// InputRef. Admission can resolve it before the final gateway route, so it
+	// protects the provider generation while policy and routing resolve the
+	// concrete model. It contains no credential or endpoint data and public
+	// task-run renderers intentionally omit it.
+	InputProviderInstance ProviderInstanceIdentity
+	// InputProviderDispatchRecorded marks the final gateway route as durable
+	// immediately before provider I/O. Unlike InputProviderInstance, it is not
+	// set during admission. Once true, the provider, kind, model, and instance
+	// are immutable for this rich input across recovery and same-input retries.
+	// Public task-run renderers intentionally omit it.
+	InputProviderDispatchRecorded bool
+	// InputProviderDisclosedInstance records the provider instance that actually
+	// received InputRef. It remains empty when admission failed before a
+	// provider dispatch, so transcript history cannot mistake an admission
+	// fence for a disclosure boundary. Public task-run renderers intentionally
+	// omit it.
+	InputProviderDisclosedInstance ProviderInstanceIdentity
 }
 
 type TaskStep struct {

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -215,6 +215,12 @@ type TaskRun struct {
 	OtelStatusCode     string
 	OtelStatusMessage  string
 	ContextPacket      json.RawMessage
+	// InputRef is an opaque, application-owned reference to rich input that
+	// must be hydrated immediately before execution. The task runtime persists
+	// the reference, never the referenced binary body. Same-input resume and
+	// retry runs inherit it; chat continuations replace or clear it. Public
+	// task-run renderers intentionally omit it.
+	InputRef string
 }
 
 type TaskStep struct {

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -1232,14 +1232,6 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
 
   function setChatToolsEnabled(enabled: boolean) {
     if (blockWhileChatOwnershipMutationRuns("changing Tools")) return;
-    if (enabled && hasChatAttachmentTurn()) {
-      params.setNoticeMessage("error", "Wait for the attachment response before turning Tools on.");
-      return;
-    }
-    if (enabled && pendingChatAttachments.length > 0) {
-      params.setNoticeMessage("error", "Remove attached files before turning Tools on.");
-      return;
-    }
     if (activeChatSessionID) {
       setChatToolsEnabledBySessionID((current) => {
         const next = new Map(current);
@@ -1277,9 +1269,6 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
   }
 
   function pendingFilesHecateBlockReason(): string {
-    if (defaultChatToolsEnabled) {
-      return "Remove attached files before switching to Hecate with Tools on.";
-    }
     if (
       pendingChatAttachments.some((attachment) => {
         const mediaType = attachment.file.type.trim().toLowerCase();
@@ -1784,16 +1773,6 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         ),
       );
       settleQueuedLocalFailure();
-      return;
-    }
-    if (attachmentDrafts.length > 0 && !isDirectModelTurn && !isExternalAgent) {
-      setChatErrorState(
-        new ApiError(
-          "Attachments are not available in Hecate Chat with Tools on.",
-          400,
-          "chat.attachments_not_supported",
-        ),
-      );
       return;
     }
     if (

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -1296,6 +1296,7 @@ export function ChatComposer(props: ChatComposerProps) {
               <ChatDictationControl
                 key={activeSessionID || "new-chat"}
                 disabled={composerInputDisabled}
+                onOpenConnections={onNavigate ? () => onNavigate("connections") : undefined}
                 onTranscript={insertDictationTranscript}
               />
               <span aria-hidden="true" style={{ flex: 1 }} />

--- a/ui/src/features/chats/ChatDictationControl.test.tsx
+++ b/ui/src/features/chats/ChatDictationControl.test.tsx
@@ -119,13 +119,38 @@ describe("ChatDictationControl", () => {
 
   it("disables capture with a precise message when browser recording is unsupported", async () => {
     vi.stubGlobal("MediaRecorder", undefined);
-    render(<ChatDictationControl onTranscript={vi.fn()} />);
+    vi.mocked(getDictationOptions).mockResolvedValue({
+      object: "dictation_options",
+      data: [],
+    });
+    render(<ChatDictationControl onOpenConnections={vi.fn()} onTranscript={vi.fn()} />);
 
     const button = await screen.findByRole("button", { name: "Start dictation" });
     expect(button).toBeDisabled();
     expect(button).toHaveAccessibleDescription(
       "This browser or app webview cannot record microphone audio.",
     );
+    expect(screen.queryByRole("button", { name: "Set up dictation provider" })).toBeNull();
+  });
+
+  it("offers a retry instead of provider setup when provider status cannot be loaded", async () => {
+    vi.mocked(getDictationOptions)
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockResolvedValueOnce({
+        object: "dictation_options",
+        data: [localOption],
+      });
+    const user = userEvent.setup();
+    render(<ChatDictationControl onOpenConnections={vi.fn()} onTranscript={vi.fn()} />);
+
+    const button = await screen.findByRole("button", { name: "Start dictation" });
+    expect(button).toBeDisabled();
+    expect(await screen.findByRole("status")).toHaveTextContent("network unavailable");
+    expect(screen.queryByRole("button", { name: "Set up dictation provider" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Retry dictation provider check" }));
+    await waitFor(() => expect(getDictationOptions).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(button).toBeEnabled());
+    expect(screen.getByRole("combobox", { name: "Dictation provider" })).toHaveValue("localai");
   });
 
   it("explains that non-secure web origins cannot request a microphone", async () => {
@@ -160,6 +185,21 @@ describe("ChatDictationControl", () => {
     expect(file.name).toBe("dictation.webm");
     expect(file.type).toBe("audio/webm");
     expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("keeps recording duration out of live status announcements", async () => {
+    installRecorderMocks();
+    const user = userEvent.setup();
+    render(<ChatDictationControl onTranscript={vi.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByRole("combobox", { name: "Dictation provider" })).toHaveValue("localai"),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Start dictation" }));
+
+    expect(screen.getByRole("status")).toHaveTextContent("Recording");
+    expect(screen.getByRole("status")).not.toHaveTextContent("0:00");
+    expect(screen.getByLabelText("Recording duration 0:00")).toHaveAttribute("aria-live", "off");
   });
 
   it("stops the microphone and does not disclose audio after unmount", async () => {

--- a/ui/src/features/chats/ChatDictationControl.test.tsx
+++ b/ui/src/features/chats/ChatDictationControl.test.tsx
@@ -51,6 +51,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   if (originalMediaDevices) {
@@ -81,15 +82,19 @@ describe("ChatDictationControl", () => {
       object: "dictation_options",
       data: [],
     });
-    render(<ChatDictationControl onTranscript={vi.fn()} />);
+    const onOpenConnections = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatDictationControl onOpenConnections={onOpenConnections} onTranscript={vi.fn()} />);
 
     const button = await screen.findByRole("button", { name: "Start dictation" });
     expect(button).toBeDisabled();
     expect(button).toHaveAccessibleDescription(
-      "Connect OpenAI, Groq, or LocalAI in Connections to use dictation.",
+      "Dictation uses a separate speech-to-text provider, independent of the selected chat model or agent. Connect OpenAI, Groq, or LocalAI in Connections.",
     );
     expect(button).toHaveAttribute("title", expect.stringContaining("Connections"));
     expect(screen.queryByRole("combobox", { name: "Dictation provider" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Set up dictation provider" }));
+    expect(onOpenConnections).toHaveBeenCalledOnce();
   });
 
   it("surfaces the configured provider's readiness reason", async () => {
@@ -108,7 +113,7 @@ describe("ChatDictationControl", () => {
     const button = await screen.findByRole("button", { name: "Start dictation" });
     expect(button).toBeDisabled();
     expect(button).toHaveAccessibleDescription(
-      "openai is unavailable: provider credentials are missing. Open Connections to fix it.",
+      "Dictation uses a separate speech-to-text route. openai is unavailable: provider credentials are missing. Open Connections to fix it.",
     );
   });
 
@@ -189,7 +194,29 @@ describe("ChatDictationControl", () => {
 
     await user.click(screen.getByRole("button", { name: "Start dictation" }));
 
-    expect(await screen.findByText(/Microphone access was denied/)).toBeVisible();
+    expect(await screen.findByText(/Open this site's controls in the address bar/)).toBeVisible();
+  });
+
+  it("points desktop users to the operating-system microphone permission", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", { configurable: true, value: {} });
+    vi.spyOn(window.navigator, "platform", "get").mockReturnValue("MacIntel");
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn().mockRejectedValue(new DOMException("denied", "NotAllowedError")),
+      },
+    });
+    const user = userEvent.setup();
+    render(<ChatDictationControl onTranscript={vi.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByRole("combobox", { name: "Dictation provider" })).toHaveValue("localai"),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Start dictation" }));
+
+    expect(
+      await screen.findByText(/System Settings → Privacy & Security → Microphone/),
+    ).toBeVisible();
   });
 });
 

--- a/ui/src/features/chats/ChatDictationControl.tsx
+++ b/ui/src/features/chats/ChatDictationControl.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useRef, useState, type MutableRefObject } from "react
 
 import { ApiError, createDictationTranscription, getDictationOptions } from "../../lib/api";
 import { parseStoredString, usePersistedState } from "../../lib/persistedState";
+import { isTauriRuntime } from "../../lib/tauri";
 import type { DictationProviderOption } from "../../types/dictation";
 import { Icon, Icons } from "../shared/ui";
 
@@ -23,11 +24,13 @@ type DictationCaptureSupport =
 
 export type ChatDictationControlProps = {
   disabled?: boolean;
+  onOpenConnections?: () => void;
   onTranscript: (text: string) => void;
 };
 
 export function ChatDictationControl({
   disabled = false,
+  onOpenConnections,
   onTranscript,
 }: ChatDictationControlProps) {
   const [options, setOptions] = useState<DictationProviderOption[]>([]);
@@ -104,6 +107,7 @@ export function ChatDictationControl({
           ? dictationProviderUnavailableMessage(options)
           : "";
   const unavailable = unavailableMessage !== "";
+  const providerSetupNeeded = optionsPhase === "failed" || noAvailableProvider;
 
   async function startRecording() {
     if (disabled || active || !selectedOption?.available) return;
@@ -305,6 +309,18 @@ export function ChatDictationControl({
             ? unavailableMessage
             : `Audio goes only to ${selectedOption?.provider ?? selectedProvider}; Hecate does not retain it.`)}
       </span>
+      {providerSetupNeeded && onOpenConnections && (
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          aria-label="Set up dictation provider"
+          onClick={onOpenConnections}
+          style={{ padding: "3px 5px", flexShrink: 0 }}
+          title="Open Connections to configure a speech-to-text provider"
+        >
+          Set up
+        </button>
+      )}
     </div>
   );
 }
@@ -327,9 +343,11 @@ function dictationCaptureSupport(): DictationCaptureSupport {
 
 function dictationProviderUnavailableMessage(options: DictationProviderOption[]): string {
   const option = options.find((candidate) => !candidate.available);
-  if (!option) return "Connect OpenAI, Groq, or LocalAI in Connections to use dictation.";
+  if (!option) {
+    return "Dictation uses a separate speech-to-text provider, independent of the selected chat model or agent. Connect OpenAI, Groq, or LocalAI in Connections.";
+  }
   const reason = option.unavailable_reason?.trim().replace(/[.\s]+$/, "");
-  return `${option.provider} is unavailable${reason ? `: ${reason}` : ""}. Open Connections to fix it.`;
+  return `Dictation uses a separate speech-to-text route. ${option.provider} is unavailable${reason ? `: ${reason}` : ""}. Open Connections to fix it.`;
 }
 
 function preferredRecorderMimeType(): string {
@@ -372,7 +390,10 @@ function dictationErrorMessage(cause: unknown, fallback: string): string {
     return [cause.userMessage || cause.message, cause.operatorAction].filter(Boolean).join(" ");
   }
   if (cause instanceof DOMException && cause.name === "NotAllowedError") {
-    return "Microphone access was denied. Allow it for this Hecate site or app in system settings, then try again.";
+    if (isTauriRuntime()) {
+      return desktopMicrophonePermissionMessage();
+    }
+    return "Microphone access is blocked. Open this site's controls in the address bar, set Microphone to Allow, reload Hecate, and try again.";
   }
   if (cause instanceof DOMException && cause.name === "NotFoundError") {
     return "No microphone was found. Connect one and try again.";
@@ -381,6 +402,17 @@ function dictationErrorMessage(cause: unknown, fallback: string): string {
     return "The microphone is unavailable. Close other apps using it and try again.";
   }
   return cause instanceof Error && cause.message ? cause.message : fallback;
+}
+
+function desktopMicrophonePermissionMessage(): string {
+  const platform = navigator.platform.toLowerCase();
+  if (platform.includes("mac")) {
+    return "Microphone access is blocked. Open System Settings → Privacy & Security → Microphone, enable Hecate, then restart Hecate.";
+  }
+  if (platform.includes("win")) {
+    return "Microphone access is blocked. Open Windows Settings → Privacy & security → Microphone, allow microphone access for desktop apps and Hecate, then restart Hecate.";
+  }
+  return "Microphone access is blocked. Allow Hecate microphone access in your system privacy settings, verify the input device is enabled, then restart Hecate.";
 }
 
 function formatElapsed(seconds: number): string {

--- a/ui/src/features/chats/ChatDictationControl.tsx
+++ b/ui/src/features/chats/ChatDictationControl.tsx
@@ -41,6 +41,7 @@ export function ChatDictationControl({
   );
   const [phase, setPhase] = useState<DictationPhase>("idle");
   const [optionsPhase, setOptionsPhase] = useState<DictationOptionsPhase>("loading");
+  const [optionsRefresh, setOptionsRefresh] = useState(0);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [error, setError] = useState("");
   const statusID = useId();
@@ -51,16 +52,23 @@ export function ChatDictationControl({
   const stopTimerRef = useRef<number | null>(null);
   const elapsedTimerRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const selectedProviderRef = useRef(selectedProvider);
+
+  useEffect(() => {
+    selectedProviderRef.current = selectedProvider;
+  }, [selectedProvider]);
 
   useEffect(() => {
     const controller = new AbortController();
+    setOptionsPhase("loading");
+    setError("");
     void getDictationOptions(controller.signal)
       .then((response) => {
         if (!mountedRef.current) return;
         setOptions(response.data);
         setOptionsPhase("ready");
         const selectedAvailable = response.data.some(
-          (option) => option.provider === selectedProvider && option.available,
+          (option) => option.provider === selectedProviderRef.current && option.available,
         );
         if (!selectedAvailable) {
           setSelectedProvider(response.data.find((option) => option.available)?.provider ?? "");
@@ -75,7 +83,7 @@ export function ChatDictationControl({
     return () => controller.abort();
     // Options are a capability snapshot for this mount. Provider changes are
     // re-fenced by the server immediately before audio disclosure.
-  }, []);
+  }, [optionsRefresh, setSelectedProvider]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -107,7 +115,8 @@ export function ChatDictationControl({
           ? dictationProviderUnavailableMessage(options)
           : "";
   const unavailable = unavailableMessage !== "";
-  const providerSetupNeeded = optionsPhase === "failed" || noAvailableProvider;
+  const providerSetupNeeded = captureSupport.available && noAvailableProvider;
+  const providerStatusRetryNeeded = captureSupport.available && optionsPhase === "failed";
 
   async function startRecording() {
     if (disabled || active || !selectedOption?.available) return;
@@ -166,6 +175,12 @@ export function ChatDictationControl({
     }
   }
 
+  function retryOptions() {
+    setError("");
+    setOptionsPhase("loading");
+    setOptionsRefresh((attempt) => attempt + 1);
+  }
+
   async function transcribeRecording(recorder: MediaRecorder) {
     recorderRef.current = null;
     stopStream();
@@ -216,7 +231,7 @@ export function ChatDictationControl({
     phase === "requesting"
       ? "Requesting microphone…"
       : phase === "recording"
-        ? `Recording ${formatElapsed(elapsedSeconds)}`
+        ? "Recording"
         : phase === "transcribing"
           ? "Transcribing…"
           : "";
@@ -309,6 +324,29 @@ export function ChatDictationControl({
             ? unavailableMessage
             : `Audio goes only to ${selectedOption?.provider ?? selectedProvider}; Hecate does not retain it.`)}
       </span>
+      {phase === "recording" && (
+        <span
+          aria-label={`Recording duration ${formatElapsed(elapsedSeconds)}`}
+          aria-live="off"
+          style={{ flexShrink: 0 }}
+          title={`Recording duration ${formatElapsed(elapsedSeconds)}`}
+        >
+          {formatElapsed(elapsedSeconds)}
+        </span>
+      )}
+      {providerStatusRetryNeeded && (
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          aria-label="Retry dictation provider check"
+          disabled={disabled}
+          onClick={retryOptions}
+          style={{ padding: "3px 5px", flexShrink: 0 }}
+          title="Retry loading dictation provider status"
+        >
+          Retry
+        </button>
+      )}
       {providerSetupNeeded && onOpenConnections && (
         <button
           type="button"

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -1341,6 +1341,47 @@ describe("ChatView input", () => {
     expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
   });
 
+  it("accepts pasted images for a confirmed vision model with Hecate tools on", async () => {
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      defaultChatToolsEnabled: true,
+      providerScopedModels: [
+        {
+          id: "gpt-4o-mini",
+          owned_by: "openai",
+          metadata: {
+            provider: "openai",
+            provider_kind: "cloud",
+            capabilities: { tool_calling: "basic", image_input: "supported" },
+          },
+        },
+      ],
+      activeChatSession: {
+        id: "chat_1",
+        title: "Vision agent chat",
+        agent_id: "hecate",
+        status: "idle",
+        provider: "openai",
+        model: "gpt-4o-mini",
+        capabilities: { tool_calling: "basic", image_input: "supported" },
+        tools_enabled: true,
+        workspace: "/tmp/hecate",
+        messages: [],
+      },
+    });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    expect(screen.getByRole("button", { name: "Image" })).toBeEnabled();
+    const file = new File(["image"], "tools-on.png", { type: "image/png" });
+    fireEvent.paste(screen.getByRole("textbox", { name: "Message" }), {
+      clipboardData: { files: [file] },
+    });
+
+    expect(screen.getByRole("button", { name: "Remove tools-on.png" })).toBeVisible();
+    expect(await screen.findByText("tools-on.png added. 1 image ready to attach.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+  });
+
   it("clears a stale image selection error when submission consumes the drafts", async () => {
     const pendingFile = new File(["image"], "map.png", { type: "image/png" });
     const submitChat = vi.fn(async () => undefined);

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -94,7 +94,6 @@ function chatAttachmentsDisabledReason({
   workspaceModePending,
   isExternalAgentChat,
   externalAgentReady,
-  toolsEnabled,
   agentBusy,
   capability,
   model,
@@ -103,7 +102,6 @@ function chatAttachmentsDisabledReason({
   workspaceModePending: boolean;
   isExternalAgentChat: boolean;
   externalAgentReady: boolean;
-  toolsEnabled: boolean;
   agentBusy: boolean;
   capability: ImageInputCapability;
   model: string;
@@ -118,7 +116,6 @@ function chatAttachmentsDisabledReason({
   if (isExternalAgentChat) {
     return externalAgentReady ? "" : "Complete External Agent setup before attaching files.";
   }
-  if (toolsEnabled) return "Turn Tools off to attach images.";
   if (capability === "none") return `${model || "This model"} does not support image input.`;
   if (capability !== "supported") {
     return `Image input has not been confirmed for ${model || "the selected model"}.`;
@@ -712,7 +709,7 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     Boolean(activeWorkspacePath.trim());
   const attachmentModeAllowed = isExternalAgentChat
     ? externalAgentAttachmentsReady
-    : isHecateChat && state.chatTarget === "agent" && !hecateChatToolsEnabled;
+    : isHecateChat && state.chatTarget === "agent";
   const selectedModeAcceptsAttachments =
     isExternalAgentChat || selectedImageInputCapability === "supported";
   const attachmentsEnabled =
@@ -728,7 +725,6 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
     workspaceModePending,
     isExternalAgentChat,
     externalAgentReady: externalAgentAttachmentsReady,
-    toolsEnabled: hecateChatToolsEnabled,
     agentBusy: agentBusy || anotherChatTurnActive || chatCreationPending,
     capability: selectedImageInputCapability,
     model: hecateChatModelValue,

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -239,7 +239,7 @@ describe("useRuntimeConsole", () => {
     expect(result.current.state.chatTarget).toBe("agent");
   });
 
-  it("carries image drafts into External Agent mode but still blocks Tools on", async () => {
+  it("keeps image drafts when enabling Hecate tools or switching to External Agent mode", async () => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
     window.localStorage.setItem("hecate.chatToolsEnabled", "false");
     const { result } = renderRuntimeConsoleHook();
@@ -252,10 +252,9 @@ describe("useRuntimeConsole", () => {
     await waitFor(() => expect(result.current.state.pendingChatAttachments).toHaveLength(1));
 
     act(() => result.current.actions.setChatToolsEnabled(true));
-    expect(result.current.state.defaultChatToolsEnabled).toBe(false);
-    expect(result.current.state.notice?.message).toBe(
-      "Remove attached files before turning Tools on.",
-    );
+    expect(result.current.state.defaultChatToolsEnabled).toBe(true);
+    expect(result.current.state.pendingChatAttachments).toHaveLength(1);
+    expect(result.current.state.notice).toBeNull();
 
     act(() => result.current.actions.setChatTarget("external_agent"));
     expect(result.current.state.chatTarget).toBe("external_agent");


### PR DESCRIPTION
## Summary

- keep image attachments available for Hecate task-backed turns with Tools enabled
- hydrate chat-owned image bodies only at execution time and replace them with omission markers in task artifacts
- record the exact rich-input provider route at the final gateway dispatch boundary, before provider I/O
- keep the first policy-rewritten model valid while pinning provider, model, and generation for recovery, retries, approvals, and later tool turns
- improve dictation setup, retry, permission recovery, and assistive-technology behavior

## Security and privacy

- task state stores an opaque chat-message reference, never attachment bytes or remote image URLs
- a provider call cannot start unless its rich-input dispatch fence has been persisted
- image turns cannot fail over across providers after disclosure eligibility is established
- transcript disclosure remains separate from route admission; pre-dispatch failures leave the user marker empty
- no Projects or Cairnline storage or concepts are added

## Validation

- `go test ./...`
- `just test-race`
- `just test-e2e`
- `go vet ./...`
- `just docs-check`
- `just build`
- UI typecheck, lint, formatting, unit tests, and browser end-to-end tests
- independent final review of dispatch fencing, streaming fallback, terminal persistence, and transcript disclosure
