### PR TITLE
feat(agents): preserve live ACP command catalogs

### DIFF
--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -331,6 +331,17 @@ External Agent has two live/persistence layers:
    parallel implementation-metadata shape.
 2. `internal/agentadapters` owns the live ACP/process session manager.
 
+ACP `available_commands_update` is a complete provider-owned replacement
+snapshot, not a Hecate-maintained command list. Retain updates received during
+`session/new` until the exact live peer is installed, then republish the latest
+snapshot through the manager's identity fence. A live update (including an
+explicit empty list) is authoritative over older prepare, prompt-result, and
+config-result snapshots; persist that authority with the session so a full
+record update cannot restore stale commands. Reset the authority and catalog
+when the native session is replaced or closed. Do not turn provider skills or
+other non-command metadata into slash commands without a provider-defined,
+side-effect-free invocation contract.
+
 Native-session recovery crosses both layers and must remain fail-closed.
 Provider-specific adapters may classify an exact prompt failure as
 `native_session_missing`, but they must not retry or replace the id. Hecate may

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -512,12 +512,16 @@ flowchart LR
 ```
 
 External Agent sessions may expose ACP-advertised `available_commands` on the
-session snapshot. These are agent-native slash command hints, not Hecate
-project commands; selecting one still sends ordinary prompt text to the
-external agent. The operator UI may show these hints while the composer starts
-with `/`; choosing a hint only inserts the slash command text. Hecate-owned
-chat commands are separate local shortcuts and must still route through
-Hecate's proposal, validation, and operator-apply boundaries.
+session snapshot. This is the latest complete, provider-owned replacement
+snapshot, not a Hecate command registry: it can contain aliases or
+workspace-provided commands, and an explicit empty list clears older hints. A
+live ACP notification takes precedence over an older session-create,
+prompt-result, or config-result snapshot. These are agent-native slash command
+hints, not Hecate project commands; selecting one still sends ordinary prompt
+text to the external agent. The operator UI may show these hints while the
+composer starts with `/`; choosing a hint only inserts the slash command text.
+Hecate-owned chat commands are separate local shortcuts and must still route
+through Hecate's proposal, validation, and operator-apply boundaries.
 The composer picker labels command provenance as **External Agent** for
 ACP-advertised external commands, **Project** for Hecate-owned project proposal
 shortcuts, and **Hecate** for local navigation/runtime shortcuts.

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -149,12 +149,13 @@ its first stable release, and documents draft ACP RFD work as non-blocking
 future work.
 Claude Code adapter `v0.1.0-alpha.11` adds command-backed stdio/HTTP MCP server
 config propagation into Claude `--mcp-config`, and `v0.1.0-alpha.12` adds
-Claude-native `--session-id` reload after adapter restarts. Claude Code adapter
-`v0.1.0-alpha.13` advertises `/init` through the normal `claude --print` prompt
-path so operators can ask Claude Code to inspect the workspace and create or
-update `CLAUDE.md` from Hecate. Claude Code adapter `v0.1.0-alpha.14` also
-advertises `/review`, `/code-review`, and `/security-review` as normal prompt
-commands backed by Claude Code's native slash-command handling.
+Claude-native `--session-id` reload after adapter restarts. Early alpha releases
+also supplied a small adapter-maintained set of prompt suggestions. Claude Code
+adapter `v0.3.0` replaces that fixed list with a live Claude CLI command
+catalog: the adapter discovers a provider-owned bare/minimal inventory and
+publishes it as an ACP replacement snapshot. Hecate therefore does not promise
+that a particular slash command, alias, workspace skill, or plugin command is
+available; it renders only what the installed provider actually advertises.
 Claude Code adapter `v0.1.0-alpha.15` exposes Claude Code's
 `bypassPermissions` permission mode as an ACP session config option for
 operators who intentionally want the full-access Claude Code boundary.
@@ -420,18 +421,22 @@ controls before the session is created. Session-level MCP config is fixed at
 ACP session start; existing chats show the configured servers in Chat settings.
 
 ACP agents may also advertise **available slash commands** with
-`available_commands_update`. Hecate stores the latest advertised command
-metadata on the chat session as `available_commands` so clients can render
-agent-native command hints. Commands are still submitted as normal
-`session/prompt` text such as `/web agent client protocol`; ACP does not define
-a separate execute-command RPC. The operator UI can surface the advertised list
-when the composer starts with `/`, but choosing an item only inserts the command
-text. These are external-agent-native commands, not Hecate-owned project
-mutations. Hecate Chat shortcuts such as `/proposal` are separate local UI
-commands, not ACP commands. Project-shaping shortcuts such as `/plan`, `/work`,
-`/handoff`, and `/review` should remain intent hints that go through the usual
-proposal, validation, and operator-apply boundaries instead of directly
-mutating project records.
+`available_commands_update`. Each update is a complete provider-owned
+replacement snapshot, including an explicit empty snapshot when the provider
+no longer offers any commands. Hecate persists the latest live snapshot as
+`available_commands`; it never merges it with an adapter-maintained allowlist
+or assumes a command exists for every external agent. A later asynchronous ACP
+update wins over an older session-create, prompt-result, or config-result
+snapshot, so aliases and workspace-provided commands remain provider-defined.
+Commands are still submitted as normal `session/prompt` text such as `/web
+agent client protocol`; ACP does not define a separate execute-command RPC. The
+operator UI can surface the advertised list when the composer starts with `/`,
+but choosing an item only inserts the command text. These are
+external-agent-native commands, not Hecate-owned project mutations. Hecate Chat
+shortcuts such as `/proposal` are separate local UI commands, not ACP commands.
+Project-shaping shortcuts such as `/plan`, `/work`, `/handoff`, and `/review`
+should remain intent hints that go through the usual proposal, validation, and
+operator-apply boundaries instead of directly mutating project records.
 The composer picker labels ACP-advertised commands as **External Agent**.
 Hecate-owned local shortcuts use **Project** for proposal-oriented project
 commands and **Hecate** for local navigation/runtime commands.

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -4374,10 +4374,12 @@ adapter and upstream agent. Hecate-owned chats do not accept session-level
 `mcp_servers`; pass them on `POST /hecate/v1/chat/sessions/{id}/messages` so
 the backing task segment records the exact server set for that run.
 If an ACP agent advertises native slash commands with
-`available_commands_update`, Hecate stores the latest command metadata on the
-session as `available_commands`. Clients send those commands back as ordinary
-prompt text, for example `/web agent client protocol`; there is no separate ACP
-execute-command RPC.
+`available_commands_update`, Hecate stores the latest complete provider-owned
+replacement snapshot on the session as `available_commands`. An explicit empty
+snapshot clears previous hints, and a live notification takes precedence over
+an older create, prompt, or configuration result. Clients send those commands
+back as ordinary prompt text, for example `/web agent client protocol`; there
+is no separate ACP execute-command RPC.
 
 ```json
 POST /hecate/v1/chat/sessions
@@ -4542,10 +4544,12 @@ include `model`, `mode`, and `thought_level`, but clients must handle missing
 or custom categories.
 
 External Agent sessions may also include `available_commands`, the latest ACP
-available slash command list advertised by the agent. Each item has `name`,
-optional `description`, and optional `input_hint`. The `name` is agent-owned;
-clients should render it as a slash command hint but submit the chosen command
-as normal prompt text.
+available slash command replacement snapshot advertised by the agent. Each
+item has `name`, optional `description`, and optional `input_hint`. The `name`
+is agent-owned; clients should render it as a slash command hint but submit the
+chosen command as normal prompt text. Clients must not treat the field as a
+Hecate-maintained catalog: provider updates may replace it with aliases,
+workspace-provided commands, or an explicit empty list.
 
 External Agent sessions and assistant messages may include `agent_info`, the
 adapter-reported ACP implementation metadata from `initialize.agentInfo`.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717112436-e42875248155
+	github.com/hecatehq/acp-adapter-kit v0.3.0
 	github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8
 	github.com/hecatehq/claude-code-acp-adapter v0.1.1-0.20260717112639-78e0df63c0bb
 	github.com/hecatehq/codex-acp-adapter v0.1.1-0.20260717083804-e28b0459660e

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717112436-e42875248155 h1:1ulRRFdVg4C1Tx/YERaAVdEECdt7lnin4Qmz0rDBNa0=
-github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717112436-e42875248155/go.mod h1:tqRmkI7UfnabJsmhj6GrQdTdX2GwtYcCobiSPZl8ERo=
 github.com/hecatehq/acp-adapter-kit v0.3.0 h1:6gi3A5DTYsqcLccUlPYIe3UXfyf9vT+0jokgqPPvdzQ=
 github.com/hecatehq/acp-adapter-kit v0.3.0/go.mod h1:tqRmkI7UfnabJsmhj6GrQdTdX2GwtYcCobiSPZl8ERo=
 github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8 h1:Wycv8NJYHwTmOQDz7Nsoqc2onBsavTRY86dX49hat1w=

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717112436-e42875248155 h1:1ulRRFdVg4C1Tx/YERaAVdEECdt7lnin4Qmz0rDBNa0=
 github.com/hecatehq/acp-adapter-kit v0.1.1-0.20260717112436-e42875248155/go.mod h1:tqRmkI7UfnabJsmhj6GrQdTdX2GwtYcCobiSPZl8ERo=
+github.com/hecatehq/acp-adapter-kit v0.3.0 h1:6gi3A5DTYsqcLccUlPYIe3UXfyf9vT+0jokgqPPvdzQ=
+github.com/hecatehq/acp-adapter-kit v0.3.0/go.mod h1:tqRmkI7UfnabJsmhj6GrQdTdX2GwtYcCobiSPZl8ERo=
 github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8 h1:Wycv8NJYHwTmOQDz7Nsoqc2onBsavTRY86dX49hat1w=
 github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/hecatehq/claude-code-acp-adapter v0.1.1-0.20260717112639-78e0df63c0bb h1:ZyXCB9D5J9FfNZa9GjNXYWWdft8cY0GV924uRpyJ3cw=

--- a/internal/agentadapters/acp_session_lifecycle.go
+++ b/internal/agentadapters/acp_session_lifecycle.go
@@ -50,10 +50,17 @@ type acpSession struct {
 	configOptions []agentcontrols.ConfigOption
 	managedConfig map[string]struct{}
 
-	commandMu              sync.Mutex
-	availableCommands      []agentcontrols.Command
-	availableCommandsKnown bool
-	commandUpdate          chan struct{}
+	commandMu                 sync.Mutex
+	commandPublishMu          sync.Mutex
+	availableCommands         []agentcontrols.Command
+	availableCommandsKnown    bool
+	availableCommandsRevision uint64
+	// availableCommandsPublishing stays false until SessionManager has installed
+	// this exact session. ACP peers may notify during session/new; retaining the
+	// snapshot here avoids both dropping that update and publishing it through a
+	// stale session identity.
+	availableCommandsPublishing bool
+	commandUpdate               chan struct{}
 
 	turnMu sync.Mutex
 
@@ -69,7 +76,7 @@ type acpSession struct {
 	verifyPromptStage  func(*acpPromptStage) error
 }
 
-func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace, previousNativeSessionID string, selectedOptions []agentcontrols.ConfigOption, mcpServers []types.MCPServerConfig, logger *slog.Logger, coordinator *ApprovalCoordinator, metrics *telemetry.AgentAdapterMetrics, onAvailableCommands func(AvailableCommandsUpdate), workspaceCoordinator *workspacecoord.Registry, terminalSupport bool) (*acpSession, bool, string, error) {
+func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace, previousNativeSessionID string, selectedOptions []agentcontrols.ConfigOption, mcpServers []types.MCPServerConfig, logger *slog.Logger, coordinator *ApprovalCoordinator, metrics *telemetry.AgentAdapterMetrics, workspaceCoordinator *workspacecoord.Registry, terminalSupport bool) (*acpSession, bool, string, error) {
 	if terminalSupport && workspaceCoordinator == nil {
 		return nil, false, "", fmt.Errorf("workspace coordination is required when ACP terminal support is enabled")
 	}
@@ -123,16 +130,15 @@ func startACPSession(ctx context.Context, adapter Adapter, sessionID, workspace,
 	}
 	client.terminalsEnabled = terminalSupport
 	session := &acpSession{
-		sessionID:           sessionID,
-		adapter:             adapter,
-		workspace:           workspace,
-		mcpServers:          cloneMCPServerConfigs(mcpServers),
-		peer:                peer,
-		client:              client,
-		logger:              sessionLogger,
-		onAvailableCommands: onAvailableCommands,
-		commandUpdate:       make(chan struct{}),
-		promptStageOwner:    processACPPromptStageCleanupOwner,
+		sessionID:        sessionID,
+		adapter:          adapter,
+		workspace:        workspace,
+		mcpServers:       cloneMCPServerConfigs(mcpServers),
+		peer:             peer,
+		client:           client,
+		logger:           sessionLogger,
+		commandUpdate:    make(chan struct{}),
+		promptStageOwner: processACPPromptStageCleanupOwner,
 	}
 	client.onAvailableCommands = session.setAvailableCommands
 	client.onConfigOptions = session.applyConfigOptionsUpdate
@@ -677,18 +683,68 @@ func (s *acpSession) setAvailableCommands(commands []agentcontrols.Command) {
 	s.commandMu.Lock()
 	s.availableCommands = commands
 	s.availableCommandsKnown = true
+	s.availableCommandsRevision++
 	if s.commandUpdate != nil {
 		close(s.commandUpdate)
 	}
 	s.commandUpdate = make(chan struct{})
+	publish := s.availableCommandsPublishing && s.onAvailableCommands != nil
+	callback := s.onAvailableCommands
+	update := AvailableCommandsUpdate{
+		SessionID: s.sessionID,
+		AdapterID: s.adapter.ID,
+		Commands:  cloneCommands(commands),
+		revision:  s.availableCommandsRevision,
+	}
 	s.commandMu.Unlock()
 
-	if s.onAvailableCommands != nil {
-		s.onAvailableCommands(AvailableCommandsUpdate{
-			SessionID: s.sessionID,
-			AdapterID: s.adapter.ID,
-			Commands:  cloneCommands(commands),
-		})
+	if publish {
+		callback(update)
+	}
+}
+
+// activateAvailableCommands opens publication only after SessionManager has
+// associated the peer with its durable Hecate session. It republishes the
+// latest retained snapshot so an ACP notification received during session/new
+// cannot be lost before the manager installs this session.
+func (s *acpSession) activateAvailableCommands(callback func(AvailableCommandsUpdate)) {
+	if s == nil {
+		return
+	}
+	s.commandMu.Lock()
+	s.onAvailableCommands = callback
+	s.availableCommandsPublishing = true
+	publish := s.availableCommandsKnown && callback != nil
+	update := AvailableCommandsUpdate{
+		SessionID: s.sessionID,
+		AdapterID: s.adapter.ID,
+		Commands:  cloneCommands(s.availableCommands),
+		revision:  s.availableCommandsRevision,
+	}
+	s.commandMu.Unlock()
+	if publish {
+		callback(update)
+	}
+}
+
+// publishAvailableCommands serializes persistence of this peer's replacement
+// snapshots. A new notification may arrive after activation snapshots a
+// retained catalog but before that catalog reaches SessionManager; rechecking
+// the revision under this gate drops the older publication. The gate remains
+// held through callback so a newer snapshot is persisted immediately after,
+// never before, the snapshot it supersedes.
+func (s *acpSession) publishAvailableCommands(update AvailableCommandsUpdate, callback func(AvailableCommandsUpdate)) {
+	if s == nil || callback == nil {
+		return
+	}
+	s.commandPublishMu.Lock()
+	defer s.commandPublishMu.Unlock()
+
+	s.commandMu.Lock()
+	current := s.availableCommandsKnown && update.revision == s.availableCommandsRevision
+	s.commandMu.Unlock()
+	if current {
+		callback(update)
 	}
 }
 

--- a/internal/agentadapters/acp_session_test.go
+++ b/internal/agentadapters/acp_session_test.go
@@ -763,6 +763,31 @@ func TestACPChatClientCapturesAvailableCommandsWithoutActiveTurn(t *testing.T) {
 	}
 }
 
+func TestACPChatClientPreservesExplicitEmptyAvailableCommandsUpdate(t *testing.T) {
+	var got []agentcontrols.Command
+	client := &acpChatClient{
+		onAvailableCommands: func(commands []agentcontrols.Command) {
+			got = commands
+		},
+	}
+
+	err := client.SessionUpdate(context.Background(), acp.SessionNotification{
+		SessionId: acp.SessionId("native_session"),
+		Update: acp.SessionUpdate{
+			AvailableCommandsUpdate: &acp.SessionAvailableCommandsUpdate{
+				SessionUpdate:     "available_commands_update",
+				AvailableCommands: []acp.AvailableCommand{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SessionUpdate: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("available commands = %#v, want explicit empty snapshot", got)
+	}
+}
+
 func TestACPChatClientCapturesConfigOptionsWithoutActiveTurn(t *testing.T) {
 	var got []agentcontrols.ConfigOption
 	client := &acpChatClient{
@@ -882,6 +907,250 @@ func TestSessionManagerPrepareWaitsForInitialAvailableCommands(t *testing.T) {
 	}
 	if got := result.AvailableCommands; len(got) != 2 || got[0].Name != "web" || got[1].Name != "plan" {
 		t.Fatalf("available commands = %#v, want web and plan", got)
+	}
+}
+
+func TestSessionManagerPublishesCommandSnapshotRetainedBeforeInstall(t *testing.T) {
+	manager := NewSessionManager()
+	updates := make(chan AvailableCommandsUpdate, 1)
+	manager.SetAvailableCommandsUpdateHook(func(update AvailableCommandsUpdate) {
+		updates <- update
+	})
+	session := testCommandCatalogSession("chat_retained_commands", "claude_code")
+
+	// ACP can notify during session/new, before the manager has a current peer
+	// to associate with the durable chat session. Retain it without publishing.
+	session.setAvailableCommands([]agentcontrols.Command{{Name: "goal"}})
+	assertNoAvailableCommandsUpdate(t, updates)
+
+	manager.mu.Lock()
+	manager.sessions[session.sessionID] = session
+	manager.mu.Unlock()
+	manager.activateSessionAvailableCommands(session)
+
+	update := waitForAvailableCommandsUpdate(t, updates)
+	if update.SessionID != session.sessionID || update.AdapterID != "claude_code" || len(update.Commands) != 1 || update.Commands[0].Name != "goal" {
+		t.Fatalf("retained update = %#v, want published goal catalog", update)
+	}
+}
+
+func TestSessionManagerReplaysCatalogWhenHookIsInstalledLate(t *testing.T) {
+	manager := NewSessionManager()
+	session := testCommandCatalogSession("chat_late_catalog_hook", "claude_code")
+	manager.mu.Lock()
+	manager.sessions[session.sessionID] = session
+	manager.mu.Unlock()
+	manager.activateSessionAvailableCommands(session)
+	session.setAvailableCommands([]agentcontrols.Command{{Name: "goal"}})
+
+	updates := make(chan AvailableCommandsUpdate, 1)
+	manager.SetAvailableCommandsUpdateHook(func(update AvailableCommandsUpdate) {
+		updates <- update
+	})
+	update := waitForAvailableCommandsUpdate(t, updates)
+	if update.SessionID != session.sessionID || len(update.Commands) != 1 || update.Commands[0].Name != "goal" {
+		t.Fatalf("replayed update = %#v, want goal catalog", update)
+	}
+}
+
+func TestSessionManagerDropsStaleRetainedCatalogDuringActivation(t *testing.T) {
+	manager := NewSessionManager()
+	updates := make(chan AvailableCommandsUpdate, 2)
+	manager.SetAvailableCommandsUpdateHook(func(update AvailableCommandsUpdate) {
+		updates <- update
+	})
+	session := testCommandCatalogSession("chat_activation_catalog", "claude_code")
+
+	// The first snapshot arrives during session/new and is retained before the
+	// manager can identify the peer.
+	session.setAvailableCommands([]agentcontrols.Command{{Name: "retained"}})
+
+	// Block activation in SessionManager after it has retained that first
+	// snapshot. A second ACP notification can then update the session before
+	// either callback is allowed to persist.
+	manager.mu.Lock()
+	manager.sessions[session.sessionID] = session
+	activated := make(chan struct{})
+	go func() {
+		manager.activateSessionAvailableCommands(session)
+		close(activated)
+	}()
+	waitForCommandCatalogPublishing(t, session)
+
+	updated := make(chan struct{})
+	go func() {
+		session.setAvailableCommands([]agentcontrols.Command{{Name: "current"}})
+		close(updated)
+	}()
+	waitForCommandCatalog(t, session, "current")
+	manager.mu.Unlock()
+
+	select {
+	case <-activated:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retained catalog activation")
+	}
+	select {
+	case <-updated:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for current catalog update")
+	}
+
+	update := waitForAvailableCommandsUpdate(t, updates)
+	if len(update.Commands) != 1 || update.Commands[0].Name != "current" {
+		t.Fatalf("published update = %#v, want only current catalog", update)
+	}
+	assertNoAvailableCommandsUpdate(t, updates)
+}
+
+func TestSessionManagerRejectsCommandsFromReplacedOrClosedPeer(t *testing.T) {
+	manager := NewSessionManager()
+	updates := make(chan AvailableCommandsUpdate, 4)
+	manager.SetAvailableCommandsUpdateHook(func(update AvailableCommandsUpdate) {
+		updates <- update
+	})
+	old := testCommandCatalogSession("chat_replaced_commands", "claude_code")
+	current := testCommandCatalogSession("chat_replaced_commands", "claude_code")
+
+	manager.mu.Lock()
+	manager.sessions[old.sessionID] = old
+	manager.mu.Unlock()
+	manager.activateSessionAvailableCommands(old)
+
+	manager.mu.Lock()
+	manager.sessions[old.sessionID] = current
+	manager.mu.Unlock()
+	manager.activateSessionAvailableCommands(current)
+
+	old.setAvailableCommands([]agentcontrols.Command{{Name: "stale"}})
+	assertNoAvailableCommandsUpdate(t, updates)
+
+	current.setAvailableCommands([]agentcontrols.Command{{Name: "goal"}})
+	update := waitForAvailableCommandsUpdate(t, updates)
+	if len(update.Commands) != 1 || update.Commands[0].Name != "goal" {
+		t.Fatalf("current update = %#v, want goal catalog", update)
+	}
+
+	manager.mu.Lock()
+	delete(manager.sessions, current.sessionID)
+	manager.mu.Unlock()
+	current.setAvailableCommands([]agentcontrols.Command{{Name: "after-close"}})
+	assertNoAvailableCommandsUpdate(t, updates)
+}
+
+func TestSessionManagerSerializesCommandPublicationWithReplacement(t *testing.T) {
+	manager := NewSessionManager()
+	publishStarted := make(chan struct{})
+	releasePublish := make(chan struct{})
+	manager.SetAvailableCommandsUpdateHook(func(AvailableCommandsUpdate) {
+		close(publishStarted)
+		<-releasePublish
+	})
+	old := testCommandCatalogSession("chat_serialized_commands", "claude_code")
+	current := testCommandCatalogSession("chat_serialized_commands", "claude_code")
+	manager.mu.Lock()
+	manager.sessions[old.sessionID] = old
+	manager.mu.Unlock()
+	manager.activateSessionAvailableCommands(old)
+
+	published := make(chan struct{})
+	go func() {
+		old.setAvailableCommands([]agentcontrols.Command{{Name: "goal"}})
+		close(published)
+	}()
+	select {
+	case <-publishStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for command publication")
+	}
+
+	replaced := make(chan struct{})
+	go func() {
+		manager.mu.Lock()
+		manager.sessions[old.sessionID] = current
+		manager.mu.Unlock()
+		close(replaced)
+	}()
+	select {
+	case <-replaced:
+		t.Fatal("replacement completed while the old peer publication was active")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(releasePublish)
+	select {
+	case <-published:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for command publication to finish")
+	}
+	select {
+	case <-replaced:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement")
+	}
+}
+
+func testCommandCatalogSession(sessionID, adapterID string) *acpSession {
+	return &acpSession{
+		sessionID:     sessionID,
+		adapter:       Adapter{ID: adapterID},
+		commandUpdate: make(chan struct{}),
+	}
+}
+
+func waitForCommandCatalogPublishing(t testing.TB, session *acpSession) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		session.commandMu.Lock()
+		publishing := session.availableCommandsPublishing
+		session.commandMu.Unlock()
+		if publishing {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for command catalog publication activation")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func waitForCommandCatalog(t testing.TB, session *acpSession, wantName string) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		commands, known := session.availableCommandsSnapshot()
+		if known && len(commands) == 1 && commands[0].Name == wantName {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for command catalog %q; got %#v (known=%t)", wantName, commands, known)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func waitForAvailableCommandsUpdate(t testing.TB, updates <-chan AvailableCommandsUpdate) AvailableCommandsUpdate {
+	t.Helper()
+	select {
+	case update := <-updates:
+		return update
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for available-commands update")
+		return AvailableCommandsUpdate{}
+	}
+}
+
+func assertNoAvailableCommandsUpdate(t testing.TB, updates <-chan AvailableCommandsUpdate) {
+	t.Helper()
+	select {
+	case update := <-updates:
+		t.Fatalf("unexpected available-commands update: %#v", update)
+	case <-time.After(25 * time.Millisecond):
 	}
 }
 

--- a/internal/agentadapters/embedded_server.go
+++ b/internal/agentadapters/embedded_server.go
@@ -44,7 +44,22 @@ func (r providerProcessRunner) RunStream(ctx context.Context, spec adapterproces
 	return r.runner.RunStream(ctx, r.bindCommand(spec), onStdout)
 }
 
+// Start lets embedded adapters run short-lived discovery exchanges through the
+// same resolved provider binary and constrained base environment as prompts.
+// It is intentionally separate from Run because discovery needs stdin/stdout
+// pipes while retaining the host's executable binding.
+func (r providerProcessRunner) Start(ctx context.Context, spec adapterprocess.StartSpec) (*adapterprocess.Child, error) {
+	return r.runner.Start(ctx, r.bindStartCommand(spec))
+}
+
 func (r providerProcessRunner) bindCommand(spec adapterprocess.Spec) adapterprocess.Spec {
+	if strings.TrimSpace(spec.Command) == r.command && r.path != "" {
+		spec.Command = r.path
+	}
+	return spec
+}
+
+func (r providerProcessRunner) bindStartCommand(spec adapterprocess.StartSpec) adapterprocess.StartSpec {
 	if strings.TrimSpace(spec.Command) == r.command && r.path != "" {
 		spec.Command = r.path
 	}

--- a/internal/agentadapters/embedded_server_test.go
+++ b/internal/agentadapters/embedded_server_test.go
@@ -1,0 +1,53 @@
+package agentadapters
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	adapterprocess "github.com/hecatehq/acp-adapter-kit/process"
+)
+
+func TestProviderProcessRunnerStartBindsProviderPathAndEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is Unix-only")
+	}
+	providerPath := filepath.Join(t.TempDir(), "provider")
+	if err := os.WriteFile(providerPath, []byte("#!/bin/sh\nprintf 'bound=%s dropped=%s arg=%s\\n' \"${HECATE_BOUND-}\" \"${HECATE_DROPPED-}\" \"$1\"\n"), 0o755); err != nil {
+		t.Fatalf("write provider fixture: %v", err)
+	}
+	runner := newProviderProcessRunner("provider", providerPath, []string{
+		"HECATE_BOUND=bound-value",
+		"HECATE_DROPPED=must-not-reach-provider",
+	})
+
+	child, err := runner.Start(context.Background(), adapterprocess.StartSpec{
+		Command: "provider",
+		Args:    []string{"--discover"},
+		Dir:     t.TempDir(),
+		Env: adapterprocess.EnvPolicy{
+			Inherit: []string{"HECATE_BOUND"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = child.Kill() }()
+	if err := child.Stdin.Close(); err != nil {
+		t.Fatalf("close stdin: %v", err)
+	}
+	output, err := io.ReadAll(child.Stdout)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := child.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if got := strings.TrimSpace(string(output)); got != "bound=bound-value dropped= arg=--discover" {
+		t.Fatalf("provider output = %q, want bound executable and constrained environment", got)
+	}
+}

--- a/internal/agentadapters/registry.go
+++ b/internal/agentadapters/registry.go
@@ -293,6 +293,11 @@ type AvailableCommandsUpdate struct {
 	SessionID string
 	AdapterID string
 	Commands  []agentcontrols.Command
+
+	// revision is an internal per-peer ordering fence. ACP command catalogs are
+	// replacement snapshots, so a delayed retained snapshot must never overwrite
+	// a newer notification from the same peer.
+	revision uint64
 }
 
 type SetSessionConfigOptionRequest struct {

--- a/internal/agentadapters/session_manager.go
+++ b/internal/agentadapters/session_manager.go
@@ -81,8 +81,53 @@ func (m *SessionManager) SetAdapterMetrics(metrics *telemetry.AgentAdapterMetric
 
 func (m *SessionManager) SetAvailableCommandsUpdateHook(hook func(AvailableCommandsUpdate)) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.onAvailableCommands = hook
+	sessions := make([]*acpSession, 0, len(m.sessions))
+	if hook != nil && !m.closed {
+		for _, session := range m.sessions {
+			sessions = append(sessions, session)
+		}
+	}
+	m.mu.Unlock()
+
+	// Handler construction normally installs this hook before sessions start,
+	// but the public setter also supports dynamic runner wiring. Replaying the
+	// current snapshots ensures a catalog learned before the hook existed is
+	// not silently lost. activateSessionAvailableCommands rechecks peer
+	// identity before persistence, so sessions replaced after the copy are safe.
+	for _, session := range sessions {
+		m.activateSessionAvailableCommands(session)
+	}
+}
+
+// activateSessionAvailableCommands releases a session's retained ACP command
+// snapshot only after the manager has installed that exact peer. The callback
+// checks identity while holding m.mu, which serializes publication with every
+// detach, replacement, and shutdown path below.
+func (m *SessionManager) activateSessionAvailableCommands(session *acpSession) {
+	if m == nil || session == nil {
+		return
+	}
+	session.activateAvailableCommands(func(update AvailableCommandsUpdate) {
+		m.publishAvailableCommands(session, update)
+	})
+}
+
+func (m *SessionManager) publishAvailableCommands(session *acpSession, update AvailableCommandsUpdate) {
+	if m == nil || session == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed || update.SessionID != session.sessionID || m.sessions[update.SessionID] != session {
+		return
+	}
+	if hook := m.onAvailableCommands; hook != nil {
+		// This hook is Hecate's persistence boundary. Keep m.mu through the call
+		// so a previous peer cannot pass the identity check and then write after
+		// a replacement or close removes it from m.sessions.
+		session.publishAvailableCommands(update, hook)
+	}
 }
 
 // SetTerminalSupportEnabled controls whether ACP sessions advertise and honor
@@ -416,11 +461,10 @@ func (m *SessionManager) completeNativeSessionReplacement(adapter Adapter, req R
 	logger := m.logger
 	coordinator := m.coordinator
 	metrics := m.metrics
-	onAvailableCommands := m.onAvailableCommands
 	workspaceCoordinator := m.workspaceCoordinator
 	terminalSupport := m.terminalSupport
 	m.mu.Unlock()
-	fresh, _, _, err := startACPSession(start.ctx, adapter, req.SessionID, req.Workspace, "", req.ConfigOptions, req.MCPServers, logger, coordinator, metrics, onAvailableCommands, workspaceCoordinator, terminalSupport)
+	fresh, _, _, err := startACPSession(start.ctx, adapter, req.SessionID, req.Workspace, "", req.ConfigOptions, req.MCPServers, logger, coordinator, metrics, workspaceCoordinator, terminalSupport)
 	if err != nil {
 		start.cancel()
 		m.abortNativeSessionReplacement(req.SessionID, start, stale)
@@ -467,6 +511,7 @@ func (m *SessionManager) completeNativeSessionReplacement(adapter Adapter, req R
 	}
 	m.sessions[req.SessionID] = fresh
 	m.mu.Unlock()
+	m.activateSessionAvailableCommands(fresh)
 	closeACPSessionBounded(stale)
 	m.mu.Lock()
 	if m.starts[req.SessionID] == start {
@@ -480,13 +525,18 @@ func (m *SessionManager) completeNativeSessionReplacement(adapter Adapter, req R
 func (m *SessionManager) abortNativeSessionReplacement(sessionID string, start *sessionStart, stale *acpSession) {
 	m.mu.Lock()
 	closed := m.closed
+	restored := false
 	if m.starts[sessionID] == start {
 		delete(m.starts, sessionID)
 		if !closed {
 			m.sessions[sessionID] = stale
+			restored = true
 		}
 	}
 	m.mu.Unlock()
+	if restored {
+		m.activateSessionAvailableCommands(stale)
+	}
 	if closed {
 		closeACPSessionBounded(stale)
 	}
@@ -530,12 +580,11 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 		logger := m.logger
 		coordinator := m.coordinator
 		metrics := m.metrics
-		onAvailableCommands := m.onAvailableCommands
 		workspaceCoordinator := m.workspaceCoordinator
 		terminalSupport := m.terminalSupport
 		m.mu.Unlock()
 
-		started, resumed, recovery, err := startACPSession(startCtx, adapter, req.SessionID, req.Workspace, req.PreviousNativeSessionID, req.ConfigOptions, req.MCPServers, logger, coordinator, metrics, onAvailableCommands, workspaceCoordinator, terminalSupport)
+		started, resumed, recovery, err := startACPSession(startCtx, adapter, req.SessionID, req.Workspace, req.PreviousNativeSessionID, req.ConfigOptions, req.MCPServers, logger, coordinator, metrics, workspaceCoordinator, terminalSupport)
 		committedReplacement := false
 		if err == nil && recovery != "" {
 			replacement := NativeSessionReplacement{
@@ -602,6 +651,7 @@ func (m *SessionManager) session(ctx context.Context, adapter Adapter, req RunRe
 		m.sessions[req.SessionID] = started
 		delete(m.starts, req.SessionID)
 		m.mu.Unlock()
+		m.activateSessionAvailableCommands(started)
 
 		if previous != nil {
 			closeACPSessionBounded(previous)

--- a/internal/agentcontrols/config_options.go
+++ b/internal/agentcontrols/config_options.go
@@ -88,10 +88,12 @@ func FromACPOptions(options []acp.SessionConfigOption) []ConfigOption {
 }
 
 // FromACPCommands converts ACP available commands to Hecate's stable wire
-// shape. Commands with empty names are ignored because the name is the prompt
-// token the operator sends back to the agent, usually as /name.
+// shape. A non-nil but empty input remains an explicit empty output so an ACP
+// replacement snapshot can clear prior command hints. Commands with empty names
+// are ignored because the name is the prompt token the operator sends back to
+// the agent, usually as /name.
 func FromACPCommands(commands []acp.AvailableCommand) []Command {
-	if len(commands) == 0 {
+	if commands == nil {
 		return nil
 	}
 	out := make([]Command, 0, len(commands))
@@ -110,9 +112,6 @@ func FromACPCommands(commands []acp.AvailableCommand) []Command {
 			Description: trimString(command.Description),
 			InputHint:   acpCommandInputHint(command.Input),
 		})
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }

--- a/internal/agentcontrols/config_options_test.go
+++ b/internal/agentcontrols/config_options_test.go
@@ -116,6 +116,18 @@ func TestFromACPCommands_NormalizesAvailableCommands(t *testing.T) {
 	}
 }
 
+func TestFromACPCommands_PreservesExplicitEmptyCatalog(t *testing.T) {
+	if got := FromACPCommands(nil); got != nil {
+		t.Fatalf("FromACPCommands(nil) = %#v, want nil", got)
+	}
+	if got := FromACPCommands([]acp.AvailableCommand{}); got == nil || len(got) != 0 {
+		t.Fatalf("FromACPCommands(empty) = %#v, want explicit empty catalog", got)
+	}
+	if got := FromACPCommands([]acp.AvailableCommand{{Name: " "}}); got == nil || len(got) != 0 {
+		t.Fatalf("FromACPCommands(invalid) = %#v, want explicit empty catalog", got)
+	}
+}
+
 func TestFromACPImplementation_TrimsAndOmitsEmptyValues(t *testing.T) {
 	if got := FromACPImplementation(nil); got != nil {
 		t.Fatalf("FromACPImplementation(nil) = %#v, want nil", got)

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -267,11 +267,11 @@ func (h *Handler) handleAgentChatAvailableCommandsUpdate(update agentadapters.Av
 	if update.AdapterID != "" && session.AgentID != update.AdapterID {
 		return
 	}
-	if slices.Equal(session.AvailableCommands, commands) {
+	if session.AvailableCommandsAuthoritative && slices.Equal(session.AvailableCommands, commands) {
 		return
 	}
 	updated, err := h.agentChat.UpdateSession(ctx, sessionID, func(item *chat.Session) {
-		item.AvailableCommands = commands
+		chat.ApplyAvailableCommandsLive(item, commands)
 	})
 	if err != nil {
 		telemetry.Warn(h.logger, ctx, "agent chat available commands update failed", slog.String("session_id", sessionID), slog.Any("error", err))
@@ -1428,9 +1428,7 @@ func (h *Handler) handleCreateExternalAgentChatMessage(w http.ResponseWriter, r 
 			if result.ConfigOptions != nil {
 				item.ConfigOptions = result.ConfigOptions
 			}
-			if result.AvailableCommandsKnown {
-				item.AvailableCommands = result.AvailableCommands
-			}
+			chat.ApplyAvailableCommandsBootstrap(item, result.AvailableCommands, result.AvailableCommandsKnown)
 		})
 		if err != nil {
 			if r.Context().Err() == nil {

--- a/internal/api/handler_project_assignment_launch.go
+++ b/internal/api/handler_project_assignment_launch.go
@@ -1374,9 +1374,7 @@ func (h *Handler) startStrictEmbeddedCairnlineExternalAgentAssignment(
 		item.NativeSessionID = prepared.NativeSessionID
 		item.AgentInfo = prepared.AgentInfo
 		item.ConfigOptions = prepared.ConfigOptions
-		if prepared.AvailableCommandsKnown {
-			item.AvailableCommands = prepared.AvailableCommands
-		}
+		chat.ApplyAvailableCommandsBootstrap(item, prepared.AvailableCommands, prepared.AvailableCommandsKnown)
 	})
 	if err != nil {
 		h.cleanupStrictEmbeddedExternalAgentSession(session.ID)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -3417,6 +3417,9 @@ func TestAgentChatAvailableCommandsUpdateHookPersistsAndPublishes(t *testing.T) 
 	if got := got.AvailableCommands; len(got) != 2 || got[0].Name != "web" || got[1].Name != "plan" {
 		t.Fatalf("stored commands = %#v, want web and plan", got)
 	}
+	if !got.AvailableCommandsAuthoritative {
+		t.Fatal("stored command snapshot is not authoritative")
+	}
 	select {
 	case event := <-updates:
 		if event.Type != AgentChatLiveEventSessionUpdate || event.SessionUpdate == nil {
@@ -3427,6 +3430,36 @@ func TestAgentChatAvailableCommandsUpdateHookPersistsAndPublishes(t *testing.T) 
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for session update")
+	}
+}
+
+func TestAgentChatAvailableCommandsUpdateHookMakesEmptyCatalogAuthoritative(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	apiHandler := newTestAPIHandlerWithSettings(logger, []providers.Provider{&fakeProvider{}}, config.Config{}, nil)
+	session, err := apiHandler.agentChat.Create(context.Background(), chat.Session{
+		ID:                "chat_commands_empty",
+		Title:             "Claude chat",
+		AgentID:           "claude_code",
+		DriverKind:        agentadapters.DriverKindACP,
+		Workspace:         t.TempDir(),
+		AvailableCommands: []agentcontrols.Command{{Name: "stale"}},
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	apiHandler.handleAgentChatAvailableCommandsUpdate(agentadapters.AvailableCommandsUpdate{
+		SessionID: session.ID,
+		AdapterID: "claude_code",
+		Commands:  []agentcontrols.Command{},
+	})
+
+	got, ok, err := apiHandler.agentChat.Get(context.Background(), session.ID)
+	if err != nil || !ok {
+		t.Fatalf("get session: ok=%v err=%v", ok, err)
+	}
+	if !got.AvailableCommandsAuthoritative || got.AvailableCommands == nil || len(got.AvailableCommands) != 0 {
+		t.Fatalf("stored commands = %#v authoritative=%v, want authoritative empty catalog", got.AvailableCommands, got.AvailableCommandsAuthoritative)
 	}
 }
 

--- a/internal/chat/conformance_test.go
+++ b/internal/chat/conformance_test.go
@@ -41,6 +41,10 @@ func RunConformanceTests(t *testing.T, name string, factory StoreFactory) {
 		t.Parallel()
 		runStoreAvailableCommandsRoundTrip(t, factory(t))
 	})
+	t.Run(name+"/AvailableCommandsAuthorityRoundTrip", func(t *testing.T) {
+		t.Parallel()
+		runStoreAvailableCommandsAuthorityRoundTrip(t, factory(t))
+	})
 	t.Run(name+"/AgentInfoRoundTrip", func(t *testing.T) {
 		t.Parallel()
 		runStoreAgentInfoRoundTrip(t, factory(t))

--- a/internal/chat/sqlite.go
+++ b/internal/chat/sqlite.go
@@ -94,9 +94,9 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 		fmt.Sprintf(
 			`INSERT INTO %s (
 				id, title, project_id, agent_id, driver_kind, native_session_id, agent_info, workspace, workspace_mode, workspace_branch,
-				status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, mcp_servers, rtk_enabled, turns_used, context_summary, created_at, updated_at
+				status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, available_commands_authoritative, mcp_servers, rtk_enabled, turns_used, context_summary, created_at, updated_at
 			 )
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(id) DO UPDATE SET
 			   title = excluded.title,
 			   project_id = excluded.project_id,
@@ -115,6 +115,7 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 			   capabilities = excluded.capabilities,
 			   config_options = excluded.config_options,
 			   available_commands = excluded.available_commands,
+			   available_commands_authoritative = excluded.available_commands_authoritative,
 			   mcp_servers = excluded.mcp_servers,
 			   rtk_enabled = excluded.rtk_enabled,
 			   context_summary = excluded.context_summary,
@@ -139,6 +140,7 @@ func (s *SQLiteStore) Create(ctx context.Context, session Session) (Session, err
 		marshalModelCapabilities(session.Capabilities),
 		marshalConfigOptions(session.ConfigOptions),
 		marshalCommands(session.AvailableCommands),
+		boolToSQLiteInt(session.AvailableCommandsAuthoritative),
 		marshalMCPServers(session.MCPServers),
 		boolToSQLiteInt(session.RTKEnabled),
 		session.TurnsUsed,
@@ -168,12 +170,12 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		ctx,
 		fmt.Sprintf(
 			`SELECT s.id, s.title, s.project_id, s.agent_id, s.driver_kind, s.native_session_id, s.agent_info, s.workspace, s.workspace_mode, s.workspace_branch,
-			        s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.mcp_servers, s.rtk_enabled, s.turns_used, s.context_summary, s.created_at, s.updated_at,
+			        s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.available_commands_authoritative, s.mcp_servers, s.rtk_enabled, s.turns_used, s.context_summary, s.created_at, s.updated_at,
 			        COUNT(m.id) AS message_count
 			 FROM %s AS s
 			 LEFT JOIN %s AS m ON m.session_id = s.id
 			 GROUP BY s.id, s.title, s.project_id, s.agent_id, s.driver_kind, s.native_session_id, s.agent_info, s.workspace, s.workspace_mode, s.workspace_branch,
-			          s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.mcp_servers, s.rtk_enabled, s.turns_used, s.context_summary, s.created_at, s.updated_at
+			          s.status, s.task_id, s.latest_run_id, s.provider, s.model, s.capabilities, s.config_options, s.available_commands, s.available_commands_authoritative, s.mcp_servers, s.rtk_enabled, s.turns_used, s.context_summary, s.created_at, s.updated_at
 			 ORDER BY s.updated_at DESC, s.created_at DESC`,
 			s.sessionsTable,
 			s.messagesTable,
@@ -191,6 +193,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		var capabilities string
 		var configOptions string
 		var availableCommands string
+		var availableCommandsAuthoritative int
 		var agentInfo string
 		var mcpServers string
 		var contextSummary string
@@ -214,6 +217,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 			&capabilities,
 			&configOptions,
 			&availableCommands,
+			&availableCommandsAuthoritative,
 			&mcpServers,
 			&rtkEnabled,
 			&session.TurnsUsed,
@@ -227,6 +231,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Session, error) {
 		session.Capabilities = unmarshalModelCapabilities(capabilities)
 		session.ConfigOptions = unmarshalConfigOptions(configOptions)
 		session.AvailableCommands = unmarshalCommands(availableCommands)
+		session.AvailableCommandsAuthoritative = availableCommandsAuthoritative != 0
 		session.AgentInfo = unmarshalImplementationInfo(agentInfo)
 		session.MCPServers = unmarshalMCPServers(mcpServers)
 		session.ContextSummary = unmarshalContextSummary(contextSummary)
@@ -357,7 +362,7 @@ func (s *SQLiteStore) updateSessionRecord(ctx context.Context, runner execRunner
 		fmt.Sprintf(
 			`UPDATE %s SET
 			   title = ?, project_id = ?, agent_id = ?, driver_kind = ?, native_session_id = ?, agent_info = ?, workspace = ?, workspace_mode = ?, workspace_branch = ?,
-			   status = ?, task_id = ?, latest_run_id = ?, provider = ?, model = ?, capabilities = ?, config_options = ?, available_commands = ?, mcp_servers = ?, rtk_enabled = ?, turns_used = ?, context_summary = ?, updated_at = ?
+			   status = ?, task_id = ?, latest_run_id = ?, provider = ?, model = ?, capabilities = ?, config_options = ?, available_commands = ?, available_commands_authoritative = ?, mcp_servers = ?, rtk_enabled = ?, turns_used = ?, context_summary = ?, updated_at = ?
 			 WHERE id = ?`,
 			s.sessionsTable,
 		),
@@ -378,6 +383,7 @@ func (s *SQLiteStore) updateSessionRecord(ctx context.Context, runner execRunner
 		marshalModelCapabilities(session.Capabilities),
 		marshalConfigOptions(session.ConfigOptions),
 		marshalCommands(session.AvailableCommands),
+		boolToSQLiteInt(session.AvailableCommandsAuthoritative),
 		marshalMCPServers(session.MCPServers),
 		boolToSQLiteInt(session.RTKEnabled),
 		session.TurnsUsed,
@@ -665,6 +671,7 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 				capabilities TEXT NOT NULL DEFAULT '{}',
 				config_options TEXT NOT NULL DEFAULT '[]',
 				available_commands TEXT NOT NULL DEFAULT '[]',
+				available_commands_authoritative INTEGER NOT NULL DEFAULT 0,
 				mcp_servers TEXT NOT NULL DEFAULT '[]',
 				context_summary TEXT NOT NULL DEFAULT '{}',
 				rtk_enabled INTEGER NOT NULL DEFAULT 0,
@@ -780,6 +787,7 @@ func (s *SQLiteStore) migrate(ctx context.Context) error {
 		{name: "capabilities", definition: "TEXT NOT NULL DEFAULT '{}'"},
 		{name: "config_options", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "available_commands", definition: "TEXT NOT NULL DEFAULT '[]'"},
+		{name: "available_commands_authoritative", definition: "INTEGER NOT NULL DEFAULT 0"},
 		{name: "mcp_servers", definition: "TEXT NOT NULL DEFAULT '[]'"},
 		{name: "context_summary", definition: "TEXT NOT NULL DEFAULT '{}'"},
 		{name: "rtk_enabled", definition: "INTEGER NOT NULL DEFAULT 0"},
@@ -852,6 +860,7 @@ func (s *SQLiteStore) loadSessionFrom(ctx context.Context, runner queryRunner, i
 	var capabilities string
 	var configOptions string
 	var availableCommands string
+	var availableCommandsAuthoritative int
 	var agentInfo string
 	var mcpServers string
 	var contextSummary string
@@ -860,7 +869,7 @@ func (s *SQLiteStore) loadSessionFrom(ctx context.Context, runner queryRunner, i
 		ctx,
 		fmt.Sprintf(
 			`SELECT id, title, project_id, agent_id, driver_kind, native_session_id, agent_info, workspace, workspace_mode, workspace_branch,
-			        status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, mcp_servers, rtk_enabled, turns_used, context_summary, created_at, updated_at
+			        status, task_id, latest_run_id, provider, model, capabilities, config_options, available_commands, available_commands_authoritative, mcp_servers, rtk_enabled, turns_used, context_summary, created_at, updated_at
 			 FROM %s WHERE id = ?`,
 			s.sessionsTable,
 		),
@@ -884,6 +893,7 @@ func (s *SQLiteStore) loadSessionFrom(ctx context.Context, runner queryRunner, i
 		&capabilities,
 		&configOptions,
 		&availableCommands,
+		&availableCommandsAuthoritative,
 		&mcpServers,
 		&rtkEnabled,
 		&session.TurnsUsed,
@@ -903,6 +913,7 @@ func (s *SQLiteStore) loadSessionFrom(ctx context.Context, runner queryRunner, i
 	session.Capabilities = unmarshalModelCapabilities(capabilities)
 	session.ConfigOptions = unmarshalConfigOptions(configOptions)
 	session.AvailableCommands = unmarshalCommands(availableCommands)
+	session.AvailableCommandsAuthoritative = availableCommandsAuthoritative != 0
 	session.AgentInfo = unmarshalImplementationInfo(agentInfo)
 	session.MCPServers = unmarshalMCPServers(mcpServers)
 	session.ContextSummary = unmarshalContextSummary(contextSummary)

--- a/internal/chat/sqlite_test.go
+++ b/internal/chat/sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hecatehq/hecate/internal/agentcontrols"
 	"github.com/hecatehq/hecate/internal/storage"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -72,6 +73,44 @@ func TestSQLiteStoreMigratesProviderInstanceColumn(t *testing.T) {
 	}
 	if len(got.Messages) != 1 || got.Messages[0].Content != "preserve me" || got.Messages[0].ProviderInstance.Valid() {
 		t.Fatalf("legacy message after migration = %+v, want preserved row with empty provider instance", got.Messages)
+	}
+}
+
+func TestSQLiteStoreMigratesAvailableCommandsAuthorityColumn(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLiteTestStore(t)
+	if _, err := store.Create(context.Background(), Session{
+		ID:                "chat_legacy_commands",
+		Title:             "Legacy commands",
+		AgentID:           "claude_code",
+		Workspace:         "/tmp/hecate",
+		AvailableCommands: []agentcontrols.Command{{Name: "goal"}},
+	}); err != nil {
+		t.Fatalf("Create legacy session: %v", err)
+	}
+	if _, err := store.client.DB().ExecContext(context.Background(), "ALTER TABLE "+store.sessionsTable+" DROP COLUMN available_commands_authoritative"); err != nil {
+		t.Fatalf("drop available_commands_authoritative test column: %v", err)
+	}
+	exists, err := store.columnExists(context.Background(), store.sessionsTable, "available_commands_authoritative")
+	if err != nil || exists {
+		t.Fatalf("column before migration exists=%v err=%v, want absent", exists, err)
+	}
+
+	migrated, err := newSQLStore(context.Background(), store.client)
+	if err != nil {
+		t.Fatalf("newSQLStore migration: %v", err)
+	}
+	exists, err = migrated.columnExists(context.Background(), migrated.sessionsTable, "available_commands_authoritative")
+	if err != nil || !exists {
+		t.Fatalf("column after migration exists=%v err=%v, want present", exists, err)
+	}
+	got, ok, err := migrated.Get(context.Background(), "chat_legacy_commands")
+	if err != nil || !ok {
+		t.Fatalf("Get legacy session after migration: found=%v err=%v", ok, err)
+	}
+	if got.AvailableCommandsAuthoritative || len(got.AvailableCommands) != 1 || got.AvailableCommands[0].Name != "goal" {
+		t.Fatalf("legacy session after migration = %#v, want commands preserved with non-authoritative default", got)
 	}
 }
 

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -37,9 +37,14 @@ type Session struct {
 	Capabilities      types.ModelCapabilities
 	ConfigOptions     []agentcontrols.ConfigOption
 	AvailableCommands []agentcontrols.Command
-	AgentInfo         *agentcontrols.ImplementationInfo
-	MCPServers        []types.MCPServerConfig
-	RTKEnabled        bool
+	// AvailableCommandsAuthoritative records that an ACP peer has published a
+	// live replacement catalog. It is deliberately internal state: API clients
+	// receive the catalog itself, not the ordering fence that protects it from
+	// an older prepare/run/config snapshot.
+	AvailableCommandsAuthoritative bool
+	AgentInfo                      *agentcontrols.ImplementationInfo
+	MCPServers                     []types.MCPServerConfig
+	RTKEnabled                     bool
 	// TurnsUsed counts how many user→assistant round-trips have completed
 	// (successfully or with failure) in this session. Used to enforce the
 	// HECATE_CHAT_MAX_TURNS_PER_SESSION ceiling.
@@ -676,6 +681,39 @@ func cloneCommands(commands []agentcontrols.Command) []agentcontrols.Command {
 	out := make([]agentcontrols.Command, len(commands))
 	copy(out, commands)
 	return out
+}
+
+// ApplyAvailableCommandsBootstrap accepts a synchronous session snapshot only
+// until an ACP peer has supplied an authoritative live replacement. This keeps
+// an older prepare/run/config result from erasing a newer notification that
+// arrived concurrently.
+func ApplyAvailableCommandsBootstrap(session *Session, commands []agentcontrols.Command, known bool) {
+	if session == nil || !known || session.AvailableCommandsAuthoritative {
+		return
+	}
+	session.AvailableCommands = cloneCommands(commands)
+}
+
+// ApplyAvailableCommandsLive records the complete command snapshot last
+// advertised by an ACP peer. An explicit empty list is authoritative too: it
+// tells Hecate to clear commands the peer no longer offers.
+func ApplyAvailableCommandsLive(session *Session, commands []agentcontrols.Command) {
+	if session == nil {
+		return
+	}
+	session.AvailableCommands = cloneCommands(commands)
+	session.AvailableCommandsAuthoritative = true
+}
+
+// ResetAvailableCommandsAuthority discards a catalog bound to a prior native
+// session. The next bootstrap snapshot or live peer notification may populate
+// it for the replacement session.
+func ResetAvailableCommandsAuthority(session *Session) {
+	if session == nil {
+		return
+	}
+	session.AvailableCommands = nil
+	session.AvailableCommandsAuthoritative = false
 }
 
 const (

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -818,6 +818,52 @@ func runStoreAvailableCommandsRoundTrip(t *testing.T, store Store) {
 	}
 }
 
+func runStoreAvailableCommandsAuthorityRoundTrip(t *testing.T, store Store) {
+	t.Helper()
+	ctx := context.Background()
+	created, err := store.Create(ctx, Session{
+		ID:                             "chat_commands_authoritative",
+		Title:                          "Commands authority",
+		AgentID:                        "claude_code",
+		Workspace:                      "/tmp/hecate",
+		AvailableCommands:              []agentcontrols.Command{},
+		AvailableCommandsAuthoritative: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !created.AvailableCommandsAuthoritative || created.AvailableCommands == nil {
+		t.Fatalf("created session = %#v, want authoritative explicit empty catalog", created)
+	}
+	updated, err := store.UpdateSession(ctx, created.ID, func(item *Session) {
+		ResetAvailableCommandsAuthority(item)
+	})
+	if err != nil {
+		t.Fatalf("UpdateSession: %v", err)
+	}
+	if updated.AvailableCommandsAuthoritative || len(updated.AvailableCommands) != 0 {
+		t.Fatalf("updated session = %#v, want reset authority and empty catalog", updated)
+	}
+	updated, err = store.UpdateSession(ctx, created.ID, func(item *Session) {
+		ApplyAvailableCommandsLive(item, []agentcontrols.Command{{Name: "goal"}})
+	})
+	if err != nil {
+		t.Fatalf("UpdateSession live catalog: %v", err)
+	}
+	if !updated.AvailableCommandsAuthoritative || len(updated.AvailableCommands) != 1 || updated.AvailableCommands[0].Name != "goal" {
+		t.Fatalf("updated session = %#v, want authoritative goal catalog", updated)
+	}
+	updated, err = store.UpdateSession(ctx, created.ID, func(item *Session) {
+		ApplyAvailableCommandsBootstrap(item, []agentcontrols.Command{{Name: "stale"}}, true)
+	})
+	if err != nil {
+		t.Fatalf("UpdateSession bootstrap catalog: %v", err)
+	}
+	if !updated.AvailableCommandsAuthoritative || len(updated.AvailableCommands) != 1 || updated.AvailableCommands[0].Name != "goal" {
+		t.Fatalf("updated session = %#v, want live goal catalog to win over bootstrap", updated)
+	}
+}
+
 func runStoreAgentInfoRoundTrip(t *testing.T, store Store) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/chatapp/application.go
+++ b/internal/chatapp/application.go
@@ -464,6 +464,7 @@ func (app *Application) ReplaceNativeSession(ctx context.Context, cmd ReplaceNat
 			return
 		}
 		item.NativeSessionID = nativeID
+		chat.ResetAvailableCommandsAuthority(item)
 	})
 	if err != nil {
 		return nil, err
@@ -564,9 +565,7 @@ func (app *Application) CreateSession(ctx context.Context, cmd CreateSessionComm
 		item.NativeSessionID = prepared.NativeSessionID
 		item.AgentInfo = prepared.AgentInfo
 		item.ConfigOptions = prepared.ConfigOptions
-		if prepared.AvailableCommandsKnown {
-			item.AvailableCommands = prepared.AvailableCommands
-		}
+		chat.ApplyAvailableCommandsBootstrap(item, prepared.AvailableCommands, prepared.AvailableCommandsKnown)
 	})
 	if err != nil {
 		app.cleanupExternalSession(sessionID)
@@ -857,6 +856,7 @@ func (app *Application) CloseNativeSession(ctx context.Context, cmd CloseNativeS
 		item.DriverKind = ""
 		item.NativeSessionID = ""
 		item.AgentInfo = nil
+		chat.ResetAvailableCommandsAuthority(item)
 	})
 	if err != nil {
 		return nil, err
@@ -907,9 +907,7 @@ func (app *Application) SetConfigOption(ctx context.Context, cmd SetConfigOption
 	}
 	session, err := app.store.UpdateSession(ctx, cmd.Session.ID, func(item *chat.Session) {
 		item.ConfigOptions = result.ConfigOptions
-		if result.AvailableCommandsKnown {
-			item.AvailableCommands = result.AvailableCommands
-		}
+		chat.ApplyAvailableCommandsBootstrap(item, result.AvailableCommands, result.AvailableCommandsKnown)
 	})
 	if err != nil {
 		return nil, err

--- a/internal/chatapp/application_test.go
+++ b/internal/chatapp/application_test.go
@@ -17,17 +17,19 @@ import (
 )
 
 type recordingAgentRunner struct {
-	prepareCalls    int
-	closeCalls      int
-	deleteCalls     int
-	prepareErr      error
-	setCalls        int
-	setErr          error
-	prepareReq      agentadapters.PrepareSessionRequest
-	setReq          agentadapters.SetSessionConfigOptionRequest
-	closedSessions  []string
-	deletedSessions []string
-	configOptions   []agentcontrols.ConfigOption
+	prepareCalls           int
+	closeCalls             int
+	deleteCalls            int
+	prepareErr             error
+	setCalls               int
+	setErr                 error
+	prepareReq             agentadapters.PrepareSessionRequest
+	setReq                 agentadapters.SetSessionConfigOptionRequest
+	closedSessions         []string
+	deletedSessions        []string
+	configOptions          []agentcontrols.ConfigOption
+	availableCommands      []agentcontrols.Command
+	availableCommandsKnown bool
 }
 
 type blockingAttachmentCreateStore struct {
@@ -152,7 +154,9 @@ func (r *recordingAgentRunner) PrepareSession(_ context.Context, req agentadapte
 			Title:   "Codex ACP Adapter",
 			Version: "0.1.0-alpha.28",
 		},
-		ConfigOptions: r.configOptions,
+		ConfigOptions:          r.configOptions,
+		AvailableCommands:      r.availableCommands,
+		AvailableCommandsKnown: r.availableCommandsKnown,
 	}, nil
 }
 
@@ -162,7 +166,11 @@ func (r *recordingAgentRunner) SetSessionConfigOption(_ context.Context, req age
 	if r.setErr != nil {
 		return agentadapters.SetSessionConfigOptionResult{}, r.setErr
 	}
-	return agentadapters.SetSessionConfigOptionResult{ConfigOptions: r.configOptions}, nil
+	return agentadapters.SetSessionConfigOptionResult{
+		ConfigOptions:          r.configOptions,
+		AvailableCommands:      r.availableCommands,
+		AvailableCommandsKnown: r.availableCommandsKnown,
+	}, nil
 }
 
 func (r *recordingAgentRunner) CloseSession(_ context.Context, sessionID string) error {
@@ -365,6 +373,8 @@ func TestApplication_CreateSessionPreparesExternalSession(t *testing.T) {
 			Name:         "Model",
 			CurrentValue: "sonnet",
 		}},
+		availableCommands:      []agentcontrols.Command{{Name: "review"}},
+		availableCommandsKnown: true,
 	}
 	app := New(Options{Store: store, Runner: runner, PrepareTimeout: time.Second})
 
@@ -408,6 +418,9 @@ func TestApplication_CreateSessionPreparesExternalSession(t *testing.T) {
 	if len(result.Session.ConfigOptions) != 1 || result.Session.ConfigOptions[0].CurrentValue != "sonnet" {
 		t.Fatalf("config options = %+v, want prepared options", result.Session.ConfigOptions)
 	}
+	if result.Session.AvailableCommandsAuthoritative || len(result.Session.AvailableCommands) != 1 || result.Session.AvailableCommands[0].Name != "review" {
+		t.Fatalf("available commands = %#v authoritative=%v, want bootstrap review catalog", result.Session.AvailableCommands, result.Session.AvailableCommandsAuthoritative)
+	}
 }
 
 func TestApplication_ReplaceNativeSessionPersistsWithCompareAndSwap(t *testing.T) {
@@ -415,7 +428,12 @@ func TestApplication_ReplaceNativeSessionPersistsWithCompareAndSwap(t *testing.T
 
 	ctx := context.Background()
 	store := chat.NewMemoryStore()
-	if _, err := store.Create(ctx, chat.Session{ID: "chat_ext", NativeSessionID: "native_stale"}); err != nil {
+	if _, err := store.Create(ctx, chat.Session{
+		ID:                             "chat_ext",
+		NativeSessionID:                "native_stale",
+		AvailableCommands:              []agentcontrols.Command{{Name: "goal"}},
+		AvailableCommandsAuthoritative: true,
+	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	app := New(Options{Store: store})
@@ -427,8 +445,8 @@ func TestApplication_ReplaceNativeSessionPersistsWithCompareAndSwap(t *testing.T
 	if err != nil {
 		t.Fatalf("ReplaceNativeSession: %v", err)
 	}
-	if result.Session.NativeSessionID != "native_fresh" {
-		t.Fatalf("native session = %q, want native_fresh", result.Session.NativeSessionID)
+	if result.Session.NativeSessionID != "native_fresh" || result.Session.AvailableCommandsAuthoritative || len(result.Session.AvailableCommands) != 0 {
+		t.Fatalf("replaced session = %#v, want fresh native id and reset command authority", result.Session)
 	}
 	_, err = app.ReplaceNativeSession(ctx, ReplaceNativeSessionCommand{
 		SessionID:               "chat_ext",
@@ -560,11 +578,13 @@ func TestApplication_DeleteSessionDeletesNativeSessionWhenRequested(t *testing.T
 	runner := &recordingAgentRunner{}
 	app := New(Options{Store: store, Runner: runner})
 	session, err := store.Create(ctx, chat.Session{
-		ID:              "chat_ext",
-		AgentID:         "codex",
-		DriverKind:      agentadapters.DriverKindACP,
-		NativeSessionID: "native_chat_ext",
-		AgentInfo:       &agentcontrols.ImplementationInfo{Name: "codex-acp-adapter"},
+		ID:                             "chat_ext",
+		AgentID:                        "codex",
+		DriverKind:                     agentadapters.DriverKindACP,
+		NativeSessionID:                "native_chat_ext",
+		AvailableCommands:              []agentcontrols.Command{{Name: "goal"}},
+		AvailableCommandsAuthoritative: true,
+		AgentInfo:                      &agentcontrols.ImplementationInfo{Name: "codex-acp-adapter"},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -1007,10 +1027,12 @@ func TestApplication_CloseNativeSessionClearsRuntimeHandles(t *testing.T) {
 	runner := &recordingAgentRunner{}
 	app := New(Options{Store: store, Runner: runner})
 	session, err := store.Create(ctx, chat.Session{
-		ID:              "chat_ext",
-		AgentID:         "codex",
-		DriverKind:      agentadapters.DriverKindACP,
-		NativeSessionID: "native_chat_ext",
+		ID:                             "chat_ext",
+		AgentID:                        "codex",
+		DriverKind:                     agentadapters.DriverKindACP,
+		NativeSessionID:                "native_chat_ext",
+		AvailableCommands:              []agentcontrols.Command{{Name: "goal"}},
+		AvailableCommandsAuthoritative: true,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -1023,7 +1045,7 @@ func TestApplication_CloseNativeSessionClearsRuntimeHandles(t *testing.T) {
 	if runner.closeCalls != 1 || runner.closedSessions[0] != "chat_ext" {
 		t.Fatalf("closed sessions = %+v closeCalls=%d, want chat_ext closed once", runner.closedSessions, runner.closeCalls)
 	}
-	if result.Session.DriverKind != "" || result.Session.NativeSessionID != "" || result.Session.AgentInfo != nil {
+	if result.Session.DriverKind != "" || result.Session.NativeSessionID != "" || result.Session.AgentInfo != nil || result.Session.AvailableCommandsAuthoritative || len(result.Session.AvailableCommands) != 0 {
 		t.Fatalf("session runtime handles = %q/%q/%#v, want cleared", result.Session.DriverKind, result.Session.NativeSessionID, result.Session.AgentInfo)
 	}
 }
@@ -1052,9 +1074,16 @@ func TestApplication_SetConfigOptionPersistsRunnerOptions(t *testing.T) {
 			Type:         agentcontrols.ConfigOptionTypeSelect,
 			CurrentValue: "sonnet",
 		}},
+		availableCommands:      []agentcontrols.Command{{Name: "stale"}},
+		availableCommandsKnown: true,
 	}
 	app := New(Options{Store: store, Runner: runner, ConfigOptionTimeout: time.Second})
-	session, err := store.Create(ctx, chat.Session{ID: "chat_ext", AgentID: "codex"})
+	session, err := store.Create(ctx, chat.Session{
+		ID:                             "chat_ext",
+		AgentID:                        "codex",
+		AvailableCommands:              []agentcontrols.Command{{Name: "goal"}},
+		AvailableCommandsAuthoritative: true,
+	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -1072,6 +1101,9 @@ func TestApplication_SetConfigOptionPersistsRunnerOptions(t *testing.T) {
 	}
 	if len(result.Session.ConfigOptions) != 1 || result.Session.ConfigOptions[0].CurrentValue != "sonnet" {
 		t.Fatalf("config options = %+v, want runner options persisted", result.Session.ConfigOptions)
+	}
+	if !result.Session.AvailableCommandsAuthoritative || len(result.Session.AvailableCommands) != 1 || result.Session.AvailableCommands[0].Name != "goal" {
+		t.Fatalf("available commands = %#v authoritative=%v, want live goal catalog preserved", result.Session.AvailableCommands, result.Session.AvailableCommandsAuthoritative)
 	}
 }
 

--- a/internal/projectworkapp/application.go
+++ b/internal/projectworkapp/application.go
@@ -789,9 +789,7 @@ func (app *Application) StartExternalAgentAssignment(ctx context.Context, cmd St
 		item.NativeSessionID = prepared.NativeSessionID
 		item.AgentInfo = prepared.AgentInfo
 		item.ConfigOptions = prepared.ConfigOptions
-		if prepared.AvailableCommandsKnown {
-			item.AvailableCommands = prepared.AvailableCommands
-		}
+		chat.ApplyAvailableCommandsBootstrap(item, prepared.AvailableCommands, prepared.AvailableCommandsKnown)
 	})
 	if err != nil {
 		app.cleanupExternalSession(session.ID)


### PR DESCRIPTION
## Summary

- Retain every provider-owned ACP `available_commands_update` snapshot, including an explicit empty catalog, and persist it with the chat session.
- Make a live catalog authoritative over older prepare, run, and configuration snapshots; reset that authority when its native session is replaced or closed.
- Bind embedded adapter discovery to Hecate’s resolved provider executable and sanitized environment through released adapter-kit v0.3.0.
- Add storage migration, application/API, embedded-process, lifecycle, and deterministic concurrency coverage.
- Document the provider-owned dynamic inventory contract and the no-static-allowlist boundary.

## Dependency

This remains a draft until [claude-code-acp-adapter#57](https://github.com/hecatehq/claude-code-acp-adapter/pull/57) is merged and released as a stable module tag. The current provider pin intentionally remains unchanged, so this PR cannot make the new live catalog visible by itself.

## Validation

- `go vet ./...`
- `go test -count=1 -timeout 10m ./...`
- `go test -race -count=1 -timeout 10m ./...`
- `go build ./...`
- Independent concurrency, storage, security, and boundary review; both actionable findings were fixed and re-reviewed.