### PR TITLE
Adapt shell chrome for mobile

### DIFF
--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -573,6 +573,8 @@ export async function mockGatewayAPIs(
     r.fulfill(ok({ object: "agent_adapters", data: MOCK_AGENT_ADAPTERS })),
   );
 
+  await page.route("/hecate/v1/plugins*", (r) => r.fulfill(ok({ object: "plugins", data: [] })));
+
   await page.route(/\/hecate\/v1\/chat\/sessions(?:\/.*)?(?:\?.*)?$/, async (route) => {
     const request = route.request();
     const method = request.method();

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -2169,13 +2169,17 @@ test("Projects attention is keyboard-operable and contained at 320px", async ({ 
   await expect(narrowAttention).toBeVisible();
   const contentBox = await page.locator(".hecate-content").boundingBox();
   const statusBarBox = await page.locator(".hecate-statusbar").boundingBox();
+  const activityBarBox = await page.locator(".hecate-activitybar").boundingBox();
   const attentionBox = await narrowAttention.boundingBox();
   expect(attentionBox?.x ?? 0).toBeGreaterThanOrEqual(contentBox?.x ?? 0);
   expect((attentionBox?.x ?? 0) + (attentionBox?.width ?? 0)).toBeLessThanOrEqual(
     (contentBox?.x ?? 0) + (contentBox?.width ?? 0) + 1,
   );
+  expect(attentionBox?.y ?? 0).toBeGreaterThanOrEqual(
+    (statusBarBox?.y ?? 0) + (statusBarBox?.height ?? 0) - 1,
+  );
   expect((attentionBox?.y ?? 0) + (attentionBox?.height ?? 0)).toBeLessThanOrEqual(
-    (statusBarBox?.y ?? 0) + 1,
+    (activityBarBox?.y ?? 0) + 1,
   );
   expect(
     await narrowAttention.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),

--- a/ui/e2e/shell.spec.ts
+++ b/ui/e2e/shell.spec.ts
@@ -28,6 +28,30 @@ test("status bar shows configured provider count and model count", async ({ page
   await expect(bar).toContainText("models");
 });
 
+test("adapts shell chrome for a phone viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  const statusbar = page.locator(".hecate-statusbar");
+  const content = page.locator(".hecate-content");
+  const nav = page.locator(".hecate-activitybar");
+
+  await expect(nav).toHaveCSS("flex-direction", "row");
+  await expect(statusbar.locator(".hecate-statusbar__brand")).toBeVisible();
+  await expect(statusbar.locator(".hecate-statusbar__providers")).toBeHidden();
+  await expect(statusbar.locator(".hecate-statusbar__models")).toBeHidden();
+
+  const statusBox = await statusbar.boundingBox();
+  const contentBox = await content.boundingBox();
+  const navBox = await nav.boundingBox();
+  expect(statusBox).not.toBeNull();
+  expect(contentBox).not.toBeNull();
+  expect(navBox).not.toBeNull();
+  expect(statusBox!.y).toBeLessThan(contentBox!.y);
+  expect(navBox!.y).toBeGreaterThan(contentBox!.y);
+});
+
 test("clicking a nav button switches the active workspace", async ({ page }) => {
   await page.locator(".hecate-activitybar [aria-label^='Observability']").click();
   await expect(page.locator(".hecate-activitybar [aria-current='page']")).toHaveAttribute(

--- a/ui/e2e/shell.spec.ts
+++ b/ui/e2e/shell.spec.ts
@@ -36,6 +36,8 @@ test("adapts shell chrome for a phone viewport", async ({ page }) => {
   const statusbar = page.locator(".hecate-statusbar");
   const content = page.locator(".hecate-content");
   const nav = page.locator(".hecate-activitybar");
+  const chatSidebar = page.locator(".chat-sidebar");
+  const chatMainBody = page.locator(".chat-main-body");
 
   await expect(nav).toHaveCSS("flex-direction", "row");
   await expect(statusbar.locator(".hecate-statusbar__brand")).toBeVisible();
@@ -50,6 +52,34 @@ test("adapts shell chrome for a phone viewport", async ({ page }) => {
   expect(navBox).not.toBeNull();
   expect(statusBox!.y).toBeLessThan(contentBox!.y);
   expect(navBox!.y).toBeGreaterThan(contentBox!.y);
+
+  const sidebarBox = await chatSidebar.boundingBox();
+  const mainBodyBox = await chatMainBody.boundingBox();
+  expect(sidebarBox).not.toBeNull();
+  expect(mainBodyBox).not.toBeNull();
+  expect(sidebarBox!.width).toBeGreaterThan(330);
+  expect(mainBodyBox!.width).toBeGreaterThan(330);
+  expect(mainBodyBox!.y).toBeGreaterThan(sidebarBox!.y);
+});
+
+test("stacks settings maintenance controls for a phone viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  await page.locator(".hecate-activitybar [aria-label^='Settings']").click();
+
+  const controls = page.locator(".retention-controls");
+  const cleanupButton = page.locator(".retention-cleanup-button");
+  await expect(controls).toHaveCSS("flex-direction", "column");
+  await expect(cleanupButton).toBeVisible();
+
+  const controlsBox = await controls.boundingBox();
+  const buttonBox = await cleanupButton.boundingBox();
+  expect(controlsBox).not.toBeNull();
+  expect(buttonBox).not.toBeNull();
+  expect(buttonBox!.width).toBeGreaterThan(280);
+  expect(buttonBox!.y).toBeGreaterThan(controlsBox!.y + 40);
 });
 
 test("clicking a nav button switches the active workspace", async ({ page }) => {

--- a/ui/src/app/App.css
+++ b/ui/src/app/App.css
@@ -199,6 +199,119 @@ html[data-tauri-os="macos"] .hecate-shell {
   white-space: nowrap;
 }
 
+@media (max-width: 640px) {
+  .hecate-shell {
+    height: 100dvh;
+  }
+
+  html[data-tauri-os="macos"] .hecate-shell {
+    padding-top: 0;
+  }
+
+  .hecate-titlebar {
+    display: none;
+  }
+
+  .hecate-workarea {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) auto;
+  }
+
+  .hecate-content {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .console-content {
+    padding: 12px;
+  }
+
+  .console-content--bare {
+    padding: 0;
+  }
+
+  .hecate-activitybar {
+    grid-column: 1;
+    grid-row: 2;
+    align-items: center;
+    background: color-mix(in oklch, var(--bg1) 94%, transparent);
+    border-right: 0;
+    border-top: 1px solid var(--border);
+    flex-direction: row;
+    gap: 4px;
+    justify-content: space-around;
+    min-height: calc(52px + env(safe-area-inset-bottom, 0px));
+    overflow-x: auto;
+    padding: 4px max(8px, env(safe-area-inset-left, 0px)) max(4px, env(safe-area-inset-bottom, 0px))
+      max(8px, env(safe-area-inset-right, 0px));
+    scrollbar-width: none;
+  }
+
+  .hecate-activitybar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .hecate-activitybar > span {
+    display: none !important;
+  }
+
+  .hecate-activitybtn {
+    border-radius: 8px;
+    flex: 0 0 44px;
+    height: 44px;
+    min-width: 44px;
+    touch-action: manipulation;
+  }
+
+  .hecate-statusbar {
+    order: -1;
+    background: var(--bg1);
+    border-bottom: 1px solid var(--border);
+    color: var(--t2);
+    gap: 8px;
+    min-height: calc(28px + env(safe-area-inset-top, 0px));
+    overflow-x: auto;
+    padding: env(safe-area-inset-top, 0px) max(10px, env(safe-area-inset-right, 0px)) 0
+      max(10px, env(safe-area-inset-left, 0px));
+    scrollbar-width: none;
+  }
+
+  .hecate-statusbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .hecate-statusbar__brand {
+    color: var(--teal);
+  }
+
+  .hecate-statusbar__sep,
+  .hecate-statusbar__providers,
+  .hecate-statusbar__models {
+    display: none;
+  }
+
+  .hecate-statusbar__runtime,
+  .hecate-statusbar__session {
+    flex: 0 0 auto;
+  }
+
+  .hecate-statusbar__path {
+    flex: 1 1 auto;
+    max-width: 42vw;
+  }
+}
+
+@media (max-width: 430px) {
+  .hecate-statusbar__branch,
+  .hecate-statusbar__usage {
+    display: none;
+  }
+
+  .hecate-statusbar__path {
+    max-width: 36vw;
+  }
+}
+
 /* Persistent error banner (fatal/connection errors only) */
 .page-banner {
   display: flex;

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -535,13 +535,15 @@ function AuthenticatedShell({
         <span className="hecate-statusbar__brand">hecate</span>
         {runtimeVersion && (
           <>
-            <span className="hecate-statusbar__sep">|</span>
-            <span style={{ fontFamily: "var(--font-mono)" }}>{runtimeVersion}</span>
+            <span className="hecate-statusbar__sep hecate-statusbar__sep--runtime">|</span>
+            <span className="hecate-statusbar__runtime" style={{ fontFamily: "var(--font-mono)" }}>
+              {runtimeVersion}
+            </span>
           </>
         )}
-        <span className="hecate-statusbar__sep">|</span>
-        <span>{session.label}</span>
-        <span className="hecate-statusbar__sep">|</span>
+        <span className="hecate-statusbar__sep hecate-statusbar__sep--session">|</span>
+        <span className="hecate-statusbar__session">{session.label}</span>
+        <span className="hecate-statusbar__sep hecate-statusbar__sep--providers">|</span>
         {/* "configured" = providers in the CP store (operator-added).
             "models" is intersected with the configured set so the count
             reflects models the operator can actually route to from the
@@ -560,30 +562,38 @@ function AuthenticatedShell({
             : providersAndModels.state.models.length;
           return (
             <>
-              <span>{configuredCount} configured</span>
-              <span className="hecate-statusbar__sep">|</span>
-              <span>{modelCount} models</span>
+              <span className="hecate-statusbar__providers">{configuredCount} configured</span>
+              <span className="hecate-statusbar__sep hecate-statusbar__sep--models">|</span>
+              <span className="hecate-statusbar__models">{modelCount} models</span>
             </>
           );
         })()}
         {activeWorkspace === "chats" && agentWorkspace && (
           <>
-            <span className="hecate-statusbar__sep">|</span>
+            <span className="hecate-statusbar__sep hecate-statusbar__sep--workspace">|</span>
             <span className="hecate-statusbar__path" title={agentWorkspace}>
               {agentWorkspace}
             </span>
             {agentWorkspaceBranch && (
               <>
-                <span className="hecate-statusbar__sep">|</span>
-                <span title={`git branch: ${agentWorkspaceBranch}`}>
+                <span className="hecate-statusbar__sep hecate-statusbar__sep--branch">|</span>
+                <span
+                  className="hecate-statusbar__branch"
+                  title={`git branch: ${agentWorkspaceBranch}`}
+                >
                   git:{agentWorkspaceBranch}
                 </span>
               </>
             )}
             {agentUsageLabel && (
               <>
-                <span className="hecate-statusbar__sep">|</span>
-                <span title={formatAgentUsageTitle(agentUsage!)}>{agentUsageLabel}</span>
+                <span className="hecate-statusbar__sep hecate-statusbar__sep--usage">|</span>
+                <span
+                  className="hecate-statusbar__usage"
+                  title={formatAgentUsageTitle(agentUsage!)}
+                >
+                  {agentUsageLabel}
+                </span>
               </>
             )}
           </>

--- a/ui/src/features/chats/ChatEmptyState.tsx
+++ b/ui/src/features/chats/ChatEmptyState.tsx
@@ -660,7 +660,7 @@ function QuickLocalProviderAdd({
           </div>
         </div>
         {loading && (
-          <span style={{ fontSize: 11, color: "var(--t3)", paddingTop: 2 }}>Checking...</span>
+          <span style={{ fontSize: 11, color: "var(--t3)", paddingTop: 2 }}>Checking…</span>
         )}
         <button
           className="btn btn-ghost btn-sm"
@@ -811,7 +811,7 @@ function QuickLocalProviderAdd({
                 type="button"
                 style={{ display: "flex", alignItems: "center" }}
               >
-                {adding ? "Adding..." : "Add selected"}
+                {adding ? "Adding…" : "Add selected"}
               </button>
               <button
                 className="btn btn-ghost btn-sm"

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -231,13 +231,17 @@ export function ChatSidebar({
   return (
     <>
       <div
+        className="chat-sidebar"
         style={{
-          width: 220,
-          borderRight: "1px solid var(--border)",
+          width: "var(--chat-sidebar-width, 220px)",
+          borderRight: "var(--chat-sidebar-border-right, 1px solid var(--border))",
+          borderBottom: "var(--chat-sidebar-border-bottom, 0)",
           display: "flex",
           flexDirection: "column",
           flexShrink: 0,
+          maxHeight: "var(--chat-sidebar-max-height, none)",
           background: "var(--bg1)",
+          overflow: "hidden",
         }}
       >
         <ProjectScopePanel

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1081,7 +1081,14 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
   }
 
   return (
-    <div style={{ display: "flex", height: "100%", overflow: "hidden" }}>
+    <div
+      className="chat-view"
+      style={{
+        display: "flex",
+        height: "100%",
+        overflow: "hidden",
+      }}
+    >
       {sidebarOpen && (
         <ChatSidebar
           isAgentChat={isAgentChat}
@@ -1154,7 +1161,10 @@ export function ChatView({ onNavigate, onOpenTask, onOpenTrace }: Props) {
           />
         )}
 
-        <div style={{ flex: 1, display: "flex", minHeight: 0, overflow: "hidden" }}>
+        <div
+          className="chat-main-body"
+          style={{ flex: 1, display: "flex", minHeight: 0, overflow: "hidden" }}
+        >
           <div
             style={{
               flex: 1,

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -628,7 +628,13 @@ function RetentionSettings({
 
       {/* Controls */}
       <div className="card" style={{ padding: "14px 16px", marginBottom: 16 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+        <div
+          className="retention-controls"
+          style={{
+            display: "flex",
+            marginBottom: 12,
+          }}
+        >
           <div style={{ minWidth: 0 }}>
             <div style={{ fontSize: 13, fontWeight: 500, color: "var(--t0)", marginBottom: 3 }}>
               Run cleanup
@@ -638,17 +644,17 @@ function RetentionSettings({
             </div>
           </div>
           <span
+            className="retention-summary"
             style={{
               fontSize: 11,
               color: "var(--t3)",
               fontFamily: "var(--font-mono)",
-              marginLeft: "auto",
             }}
           >
             {selectedSet.size === 0 ? "full cleanup" : `${selectedSet.size} selected`}
           </span>
           <button
-            className="btn btn-primary btn-sm"
+            className="btn btn-primary btn-sm retention-cleanup-button"
             disabled={state.loading}
             onClick={() => void runRetention()}
           >

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -339,6 +339,20 @@ textarea {
   color: var(--t0);
 }
 
+.chat-view {
+  flex-direction: row;
+}
+
+.retention-controls {
+  align-items: center;
+  flex-direction: row;
+  gap: 10px;
+}
+
+.retention-summary {
+  margin-left: auto;
+}
+
 @media (max-width: 1180px) {
   .project-work-coordination-grid {
     grid-template-columns: minmax(0, 1fr);
@@ -346,6 +360,37 @@ textarea {
 }
 
 @media (max-width: 720px) {
+  .chat-view {
+    --chat-sidebar-border-bottom: 1px solid var(--border);
+    --chat-sidebar-border-right: 0;
+    --chat-sidebar-max-height: 260px;
+    --chat-sidebar-width: 100%;
+    flex-direction: column;
+  }
+
+  .chat-main-body {
+    min-height: 0;
+  }
+
+  .chat-right-panel-resize-handle {
+    display: none;
+  }
+
+  .retention-controls {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .retention-summary {
+    margin-left: 0;
+  }
+
+  .retention-cleanup-button {
+    justify-content: center;
+    width: 100%;
+  }
+
   .projects-cockpit-shell {
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary

- move the activity bar to a bottom tab strip on narrow screens
- move the status bar to a quieter top strip on phone viewports
- hide provider/model counts from the mobile status strip while preserving desktop status details
- add a Playwright shell test for the phone viewport layout

## Verification

- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test src/app/AppShell.test.tsx
- cd ui && bun run test:e2e e2e/shell.spec.ts
- cd ui && bun run test
- git diff --check