### PR TITLE
docs: clarify Hecate positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,44 @@
 <h1 align="center">
-  <img src="docs/assets/brand/hecate-lockup-horizontal-dark-2x.png" alt="Hecate - Agent Operations Console" width="720">
+  <img src="docs/assets/brand/hecate-lockup-horizontal-dark-2x.png" alt="Hecate - AI Workspace and Runtime" width="720">
 </h1>
 
-[![Latest release](https://img.shields.io/github/v/release/hecatehq/hecate?include_prereleases)](https://github.com/hecatehq/hecate/releases)
-[![Container](https://img.shields.io/badge/Container-ghcr.io-2496ED?logo=docker&logoColor=white)](docs/operator/deployment.md#image-pinning)
-[![Test](https://github.com/hecatehq/hecate/actions/workflows/test.yml/badge.svg)](https://github.com/hecatehq/hecate/actions/workflows/test.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hecatehq/hecate)](https://goreportcard.com/report/github.com/hecatehq/hecate)
-[![Go version](https://img.shields.io/github/go-mod/go-version/hecatehq/hecate)](go.mod)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-enabled-f5a800?logo=opentelemetry&logoColor=white)](https://opentelemetry.io/)
-
 <p align="center">
-  <strong>Agent operations console and local runtime control plane.</strong><br>
-  Run Hecate between operators, AI clients, agent runtimes, model providers,
-  and local workspaces so agent work can be routed, supervised, approved,
-  traced, and reviewable.
+  <a href="https://github.com/hecatehq/hecate/releases">
+    <img alt="Latest release" src="https://img.shields.io/github/v/release/hecatehq/hecate?include_prereleases">
+  </a>
+  <a href="docs/operator/deployment.md#image-pinning">
+    <img alt="Container image" src="https://img.shields.io/badge/container-ghcr.io-2496ED?logo=docker&logoColor=white">
+  </a>
+  <a href="https://github.com/hecatehq/hecate/actions/workflows/test.yml">
+    <img alt="Test workflow" src="https://github.com/hecatehq/hecate/actions/workflows/test.yml/badge.svg?branch=master">
+  </a>
+  <a href="https://goreportcard.com/report/github.com/hecatehq/hecate">
+    <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/hecatehq/hecate">
+  </a>
+  <a href="go.mod">
+    <img alt="Go version" src="https://img.shields.io/github/go-mod/go-version/hecatehq/hecate">
+  </a>
+  <a href="LICENSE">
+    <img alt="MIT license" src="https://img.shields.io/badge/license-MIT-yellow.svg">
+  </a>
+  <a href="https://opentelemetry.io/">
+    <img alt="OpenTelemetry enabled" src="https://img.shields.io/badge/OpenTelemetry-enabled-f5a800?logo=opentelemetry&logoColor=white">
+  </a>
 </p>
 
-> **Status: public alpha.** Hecate is useful today for model-provider routing,
-> Hecate Chat, External Agent sessions, project-scoped work, approvals,
-> artifacts, usage, and observability. It is not production-stable
-> infrastructure yet: workflow runbooks, richer Agent Presets, browser QA, and
-> sandbox hardening are still design or early-alpha work. Read
+<p align="center">
+  <strong>AI workspace and runtime for projects, chats, providers, and supervised agents.</strong><br>
+  Run Hecate on your machine as the personal control plane for agent work:
+  create projects, chat with models, supervise external agents, approve risky
+  actions, inspect diffs, and trace what happened.
+</p>
+
+> **Status: public alpha.** Hecate is useful today as an AI workspace for
+> model-provider routing, Hecate Chat, External Agent sessions,
+> project-scoped work, approvals, artifacts, usage, and observability. It is not
+> production-stable infrastructure yet: workflow runbooks, richer Agent
+> Presets, browser QA, and sandbox hardening are still design or early-alpha
+> work. Read
 > [known limitations](docs/operator/known-limitations.md) before depending on it.
 
 ## Contents
@@ -40,15 +57,16 @@
 
 ## What Hecate Is
 
-Hecate is the operator-facing runtime layer for AI work. It gives you one local
-place to talk to models, run Hecate-native agent tasks, supervise external agent
-CLIs, inspect project context, approve risky actions, collect evidence, and see
-what happened after the run.
+Hecate is an AI workspace and runtime for people who want one place for
+projects, chats, model providers, memory, approvals, and supervised agent work.
+It gives you a product surface to talk to models, run Hecate-native agent tasks,
+supervise external agent CLIs, inspect project context, approve risky actions,
+collect evidence, and see what happened after the run.
 
-Hecate is local-first in the operational sense: the runtime and UI run on your
-machine, Hecate-owned state is stored locally, and the gateway binds to loopback
-by default. It is not local-only: you can route to cloud providers and supervise
-external coding-agent CLIs that use their own accounts.
+The open-source runtime can run as a desktop app, from source, in Docker, or
+behind an access layer for personal remote use. In the default desktop/source
+setup, Hecate-owned state is stored locally and the gateway binds to loopback;
+hosted deployments provide their own access-control and storage boundary.
 
 Hecate is not trying to be the only agent framework in your stack. It is the
 place where agents, agent frameworks, model calls, local tools, and project
@@ -72,9 +90,9 @@ The short version:
 - **Evidence:** traces, route reports, task artifacts, diffs, logs, screenshots
   where available, and final run output close to the decision that produced it.
 
-The product goal is not just to make model calls. It is to give the operator a
-single place to coordinate project-scoped agent work and understand what is
-happening, what context it used, what it changed, what it cost, what needs
+The product goal is not just to make model calls. It is to give you a single
+place to coordinate personal and project-scoped agent work and understand what
+is happening, what context it used, what it changed, what it cost, what needs
 approval, and where the evidence lives.
 
 ## Positioning
@@ -84,11 +102,13 @@ them.
 
 | Question                                 | Hecate answer                                                                                                                                             |
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Is Hecate a personal assistant?**      | It can be the runtime and memory base for one, but it stays grounded in visible chats, projects, tools, approvals, and evidence rather than a hidden bot. |
 | **Is Hecate an agent?**                  | It includes a native task agent loop, but Hecate itself is the operator console and runtime boundary around agent work, not a single autonomous persona.  |
 | **Is Hecate an orchestrator?**           | Yes, when it coordinates projects, assignments, native tasks, external-agent sessions, approvals, handoffs, and reviews. The operator remains in control. |
 | **Is Hecate an agent framework?**        | Not primarily. Hecate exposes APIs and runtime contracts, but it does not require teams to rewrite their agents into a Hecate SDK.                        |
 | **Is Hecate a model gateway?**           | Yes, but the gateway is one subsystem. It exists so chats, tasks, external tools, and compatible clients share routing, policy, usage, and observability. |
 | **Is Hecate a project-management tool?** | No. Projects are a coordination graph for AI work: context, assignments, evidence, memory candidates, reviews, handoffs, and runtime links.               |
+| **Is this Hecate Cloud?**                | No. This repo is the open-source Hecate runtime and app. Hecate Cloud is the separate hosted deployment and remote-access product at hecatehq.com.        |
 
 The practical model is:
 
@@ -178,11 +198,12 @@ Design direction that is not yet a runtime contract:
 
 Choose the path that matches how you want to run Hecate.
 
-| Path                        | Best for                                                                                                                                         |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Desktop app](#desktop-app) | macOS personal use on your laptop with optional embedded workspace terminal support. No Docker required. Linux/Windows bundles are experimental. |
-| [Docker](#docker)           | Local container, scripted local deploys, and the safer Linux/Windows alpha path today.                                                           |
-| [From source](#from-source) | Contributors and local development.                                                                                                              |
+| Path                                 | Best for                                                                                                                   |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| [Desktop app](#desktop-app)          | Personal Hecate on your laptop. No Docker required. macOS is the most-tested path; Linux/Windows bundles are experimental. |
+| [Docker](#docker)                    | Local container, scripted local deploys, and Linux/Windows alpha use today.                                                |
+| [From source](#from-source)          | Contributors and local development.                                                                                        |
+| [Hecate Cloud](https://hecatehq.com) | Optional hosted deployment and browser access when you do not want to keep a local machine online.                         |
 
 ### Desktop app
 
@@ -435,7 +456,7 @@ Operator guides:
 
 - [Providers](docs/operator/providers.md) - provider presets, custom endpoints,
   credentials, model discovery, health, and circuit breaking.
-- [Security](docs/operator/security.md) - local-first threat model, workspace
+- [Security](docs/operator/security.md) - runtime threat model, workspace
   safety, approvals, secrets, and advisory handling.
 - [Known limitations](docs/operator/known-limitations.md) - the plain-language
   alpha boundary.

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -34,7 +34,7 @@ async function startHecateChat(page: Page) {
   await expect(
     page
       .getByText(
-        /Ready when you are|Choose a workspace|No routable model|No models discovered|Nothing runnable yet/,
+        /Ready when you are|Choose a workspace|No routable model|No models discovered|Connect a model or agent/,
       )
       .first(),
   ).toBeVisible();
@@ -240,7 +240,7 @@ test("empty Hecate Chat points operators to Connections before send", async ({ p
 
   // Brand-new users land directly on the chat empty state with the
   // onboarding panel — no "click New Hecate chat to get started" detour.
-  await expect(page.getByText("Nothing runnable yet")).toBeVisible();
+  await expect(page.getByText("Connect a model or agent")).toBeVisible();
   await page.getByRole("button", { name: "Open Connections" }).click();
   await expect(page.locator(".hecate-activitybar [aria-current='page']")).toHaveAttribute(
     "aria-label",
@@ -1331,11 +1331,9 @@ test("empty model chat can add all detected local providers in one click", async
   await expect
     .poll(() => created.map((body) => String(body.preset_id)).sort((a, b) => a.localeCompare(b)))
     .toEqual(["lmstudio", "ollama"]);
-  await expect(page.getByText("Nothing runnable yet")).toBeVisible();
+  await expect(page.getByText("Connect a model or agent")).toBeVisible();
   await expect(
-    page.getByText(
-      /Add a model provider or install a supported coding-agent CLI before sending a message/,
-    ),
+    page.getByText(/Add a model provider in Connections or set up a supported external agent/),
   ).toBeVisible();
   await expect(page.getByRole("button", { name: /Add selected/i })).toHaveCount(0);
 });
@@ -1367,7 +1365,7 @@ test("empty Hecate Agent chat can add all detected local providers in one click"
   await expect
     .poll(() => created.map((body) => String(body.preset_id)).sort((a, b) => a.localeCompare(b)))
     .toEqual(["lmstudio", "ollama"]);
-  await expect(page.getByText("Nothing runnable yet")).toBeVisible();
+  await expect(page.getByText("Connect a model or agent")).toBeVisible();
   await expect(page.getByRole("button", { name: /Add selected/i })).toHaveCount(0);
 });
 
@@ -2941,11 +2939,9 @@ test("configured provider with no models shows troubleshooting, not detected-pro
   await page.waitForSelector(".hecate-activitybar");
   await switchToModel(page, false);
 
-  await expect(page.getByText("Nothing runnable yet")).toBeVisible();
+  await expect(page.getByText("Connect a model or agent")).toBeVisible();
   await expect(
-    page.getByText(
-      /Add a model provider or install a supported coding-agent CLI before sending a message/,
-    ),
+    page.getByText(/Add a model provider in Connections or set up a supported external agent/),
   ).toBeVisible();
   await expect(page.getByText("Detected locally")).toHaveCount(0);
   await expect(page.getByRole("button", { name: /Add selected/i })).toHaveCount(0);

--- a/ui/e2e/provider-lifecycle.spec.ts
+++ b/ui/e2e/provider-lifecycle.spec.ts
@@ -21,7 +21,9 @@ test("adding and deleting a provider keeps chat available", async ({ page }) => 
   // Default fixture starts empty. Chats should stay useful by showing the
   // provider onboarding surface after the operator starts a chat.
   await page.getByRole("button", { name: "New Hecate chat", exact: true }).click();
-  await expect(page.getByText(/Nothing runnable yet|No model provider configured/)).toBeVisible();
+  await expect(
+    page.getByText(/Connect a model or agent|No model provider configured/),
+  ).toBeVisible();
   await expect(page.getByRole("button", { name: /Open Connections/i })).toBeVisible();
   await expectComposerNotRunnable(page);
 
@@ -43,7 +45,7 @@ test("adding and deleting a provider keeps chat available", async ({ page }) => 
   // are routable yet.
   await page.locator(".hecate-activitybar [aria-label^='Chats']").click();
   await page.getByRole("button", { name: "New Hecate chat", exact: true }).click();
-  await expect(page.getByText(/Nothing runnable yet|No routable model/)).toBeVisible();
+  await expect(page.getByText(/Connect a model or agent|No routable model/)).toBeVisible();
   await expectComposerNotRunnable(page);
 
   // Back to Connections, delete the row.
@@ -61,7 +63,9 @@ test("adding and deleting a provider keeps chat available", async ({ page }) => 
   // returning to the same first-run setup surface.
   await page.locator(".hecate-activitybar [aria-label^='Chats']").click();
   await page.getByRole("button", { name: "New Hecate chat", exact: true }).click();
-  await expect(page.getByText(/Nothing runnable yet|No model provider configured/)).toBeVisible();
+  await expect(
+    page.getByText(/Connect a model or agent|No model provider configured/),
+  ).toBeVisible();
   await expect(page.getByRole("button", { name: /Open Connections/i })).toBeVisible();
   await expectComposerNotRunnable(page);
 });

--- a/ui/e2e/shell.spec.ts
+++ b/ui/e2e/shell.spec.ts
@@ -41,7 +41,7 @@ test("workspace navigation keeps the current view visible while the next chunk l
 }) => {
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
-  await expect(page.getByText("Nothing runnable yet")).toBeVisible();
+  await expect(page.getByText("Connect a model or agent")).toBeVisible();
 
   let releaseUsageChunk: (() => void) | null = null;
   const usageChunkRequested = new Promise<void>((resolve) => {
@@ -57,7 +57,7 @@ test("workspace navigation keeps the current view visible while the next chunk l
   await page.locator(".hecate-activitybar [aria-label^='Usage']").click();
   await usageChunkRequested;
 
-  await expect(page.getByText("Nothing runnable yet")).toBeVisible();
+  await expect(page.getByText("Connect a model or agent")).toBeVisible();
   await expect(page.getByText("Loading workspace…")).toHaveCount(0);
 
   releaseUsageChunk?.();

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -478,7 +478,7 @@ describe("ConsoleShell navigation", () => {
     // still be queried synchronously.
     expect(screen.getByRole("link", { name: "Chats" })).toHaveAttribute("href", "/chats");
     expect(
-      await screen.findByText(/Nothing runnable yet/i, undefined, { timeout: 30_000 }),
+      await screen.findByText(/Connect a model or agent/i, undefined, { timeout: 30_000 }),
     ).toBeInTheDocument();
     expect(screen.queryByText(/No model providers configured/i)).toBeNull();
     expect(screen.getByRole("button", { name: /Open Connections/i })).toBeInTheDocument();

--- a/ui/src/features/chats/ChatEmptyState.tsx
+++ b/ui/src/features/chats/ChatEmptyState.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { type CSSProperties, useEffect, useState } from "react";
 
 import { type ChatSetupRepairState } from "../../lib/chat-setup-readiness";
 import type { SelectedModelIssue } from "../../lib/provider-issues";
@@ -98,7 +98,7 @@ export function ChatEmptyState({
       : isExternalAgentChat && agentRouteUnavailable
         ? "No available coding agent"
         : nothingRunnable
-          ? "Nothing runnable yet"
+          ? "Connect a model or agent"
           : selectedModelIssue
             ? selectedModelIssue.title
             : setupRepair
@@ -112,7 +112,7 @@ export function ChatEmptyState({
       : isExternalAgentChat && agentRouteUnavailable
         ? "Hecate did not find any supported coding-agent CLI in the known operator locations."
         : nothingRunnable
-          ? "Add a model provider or install a supported coding-agent CLI before sending a message."
+          ? "Add a model provider in Connections or set up a supported external agent. Hecate will keep chats, approvals, files, and traces together once something can run."
           : selectedModelIssue
             ? selectedModelIssue.message
             : setupRepair
@@ -121,6 +121,14 @@ export function ChatEmptyState({
                 ? "Add a provider with discovered models before sending through Hecate."
                 : readyDetail;
   const emptyRepairAction = setupRepair;
+  const startGuideItems = buildStartGuideItems({
+    agentAdapters,
+    hasConfiguredProviders,
+    isRemoteRuntime,
+    modelRouteUnavailable,
+    selectedModelIssue,
+    setupRepair: emptyRepairAction,
+  });
 
   function runEmptyRepairAction() {
     if (!emptyRepairAction) return;
@@ -141,23 +149,15 @@ export function ChatEmptyState({
   }
 
   return (
-    <div
-      style={{ padding: "28px 16px 18px", maxWidth: 820, margin: "0 auto", textAlign: "center" }}
-    >
-      <div style={{ fontSize: 13, fontWeight: 600, color: "var(--t1)", marginBottom: 5 }}>
-        {title}
+    <div style={emptyStateShellStyle}>
+      <div style={emptyStateHeaderStyle}>
+        <div style={emptyStateKickerStyle}>
+          {isExternalAgentChat ? "External agent" : "Hecate chat"}
+        </div>
+        <div style={emptyStateTitleStyle}>{title}</div>
+        <div style={emptyStateDetailStyle}>{detail}</div>
       </div>
-      <div
-        style={{
-          fontSize: 12,
-          color: "var(--t3)",
-          lineHeight: 1.5,
-          maxWidth: 430,
-          margin: "0 auto",
-        }}
-      >
-        {detail}
-      </div>
+      <StartGuide items={startGuideItems} />
       {isAgentChat && (agentRouteUnavailable || selectedAgentUnavailable) && (
         <AgentSetupHints adapters={agentAdapters} selectedID={selectedAgent?.id} />
       )}
@@ -252,6 +252,120 @@ export function ChatEmptyState({
         ))}
     </div>
   );
+}
+
+type StartGuideTone = "ready" | "needed" | "setup" | "optional";
+
+type StartGuideItem = {
+  detail: string;
+  icon: string | string[];
+  label: string;
+  status: string;
+  tone: StartGuideTone;
+};
+
+function StartGuide({ items }: { items: StartGuideItem[] }) {
+  return (
+    <div aria-label="Start checklist" style={startGuideStyle}>
+      {items.map((item, index) => (
+        <div
+          key={item.label}
+          style={{
+            ...startGuideRowStyle,
+            borderTop: index === 0 ? undefined : "1px solid var(--border)",
+          }}
+        >
+          <span style={startGuideIconStyle}>
+            <Icon d={item.icon} size={15} />
+          </span>
+          <span style={{ minWidth: 0 }}>
+            <span style={startGuideLabelStyle}>{item.label}</span>
+            <span style={startGuideDetailStyle}>{item.detail}</span>
+          </span>
+          <span style={{ ...startGuideStatusStyle, ...startGuideToneStyle(item.tone) }}>
+            {item.status}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function buildStartGuideItems({
+  agentAdapters,
+  hasConfiguredProviders,
+  isRemoteRuntime,
+  modelRouteUnavailable,
+  selectedModelIssue,
+  setupRepair,
+}: {
+  agentAdapters: AgentAdapterRecord[];
+  hasConfiguredProviders: boolean;
+  isRemoteRuntime: boolean;
+  modelRouteUnavailable: boolean;
+  selectedModelIssue: SelectedModelIssue | null;
+  setupRepair: ChatSetupRepairState | null;
+}): StartGuideItem[] {
+  const modelNeedsAttention =
+    !hasConfiguredProviders || modelRouteUnavailable || Boolean(selectedModelIssue);
+  const agentReady = agentAdapters.some((adapter) => adapter.available);
+  const workspaceNeedsAttention = setupRepair?.action === "choose_workspace";
+  return [
+    {
+      detail: isRemoteRuntime
+        ? "Add an API-key provider in Connections."
+        : "Add a provider, or use detected local model apps.",
+      icon: Icons.model,
+      label: "Models",
+      status: modelNeedsAttention ? "Needed" : "Ready",
+      tone: modelNeedsAttention ? "needed" : "ready",
+    },
+    {
+      detail: "Choose a folder when chats need files, diffs, tasks, or project context.",
+      icon: Icons.folder,
+      label: "Workspace",
+      status: workspaceNeedsAttention ? "Needed" : "Optional",
+      tone: workspaceNeedsAttention ? "needed" : "optional",
+    },
+    {
+      detail: isRemoteRuntime
+        ? "Use supported external agents after API-key setup."
+        : "Use Codex, Claude Code, Cursor, or Grok Build once ready.",
+      icon: Icons.terminal,
+      label: "Agents",
+      status: agentReady ? "Ready" : agentAdapters.length > 0 ? "Setup" : "Unavailable",
+      tone: agentReady ? "ready" : agentAdapters.length > 0 ? "setup" : "optional",
+    },
+  ];
+}
+
+function startGuideToneStyle(tone: StartGuideTone): CSSProperties {
+  switch (tone) {
+    case "ready":
+      return {
+        background: "var(--green-bg)",
+        borderColor: "var(--green-border)",
+        color: "var(--green)",
+      };
+    case "needed":
+      return {
+        background: "var(--amber-bg)",
+        borderColor: "var(--amber-border)",
+        color: "var(--amber)",
+      };
+    case "setup":
+      return {
+        background: "var(--teal-bg)",
+        borderColor: "var(--teal-border)",
+        color: "var(--teal)",
+      };
+    case "optional":
+      return {
+        background: "var(--bg2)",
+        borderColor: "var(--border)",
+        color: "var(--t3)",
+      };
+  }
 }
 
 function AgentSetupHints({
@@ -860,3 +974,94 @@ function localProviderReadiness(discovery: LocalProviderDiscoveryRecord): {
     border: "var(--amber-border)",
   };
 }
+
+const emptyStateShellStyle: CSSProperties = {
+  margin: "0 auto",
+  maxWidth: 760,
+  padding: "clamp(28px, 6vw, 52px) 16px 18px",
+  textAlign: "left",
+};
+
+const emptyStateHeaderStyle: CSSProperties = {
+  margin: "0 auto",
+  maxWidth: 620,
+  textAlign: "center",
+};
+
+const emptyStateKickerStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  fontWeight: 650,
+  letterSpacing: "0.06em",
+  marginBottom: 7,
+  textTransform: "uppercase",
+};
+
+const emptyStateTitleStyle: CSSProperties = {
+  color: "var(--t0)",
+  fontSize: "clamp(18px, 2.4vw, 24px)",
+  fontWeight: 720,
+  lineHeight: 1.18,
+};
+
+const emptyStateDetailStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 12,
+  lineHeight: 1.55,
+  margin: "8px auto 0",
+  maxWidth: 520,
+};
+
+const startGuideStyle: CSSProperties = {
+  borderBottom: "1px solid var(--border)",
+  borderTop: "1px solid var(--border)",
+  margin: "20px auto 0",
+  maxWidth: 640,
+};
+
+const startGuideRowStyle: CSSProperties = {
+  alignItems: "center",
+  display: "grid",
+  gap: 11,
+  gridTemplateColumns: "26px minmax(0, 1fr) auto",
+  minHeight: 60,
+  padding: "11px 0",
+};
+
+const startGuideIconStyle: CSSProperties = {
+  alignItems: "center",
+  border: "1px solid var(--border)",
+  borderRadius: 999,
+  color: "var(--t2)",
+  display: "inline-flex",
+  height: 26,
+  justifyContent: "center",
+  width: 26,
+};
+
+const startGuideLabelStyle: CSSProperties = {
+  color: "var(--t1)",
+  display: "block",
+  fontSize: 12,
+  fontWeight: 650,
+  lineHeight: 1.25,
+};
+
+const startGuideDetailStyle: CSSProperties = {
+  color: "var(--t3)",
+  display: "block",
+  fontSize: 11,
+  lineHeight: 1.45,
+  marginTop: 2,
+};
+
+const startGuideStatusStyle: CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: 999,
+  fontSize: 10,
+  fontWeight: 650,
+  lineHeight: "18px",
+  padding: "0 7px",
+  whiteSpace: "nowrap",
+};

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -2435,7 +2435,11 @@ describe("ChatView input", () => {
       ],
     });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
-    expect(screen.getByText("Nothing runnable yet")).toBeTruthy();
+    expect(screen.getByText("Connect a model or agent")).toBeTruthy();
+    expect(screen.getByLabelText("Start checklist")).toBeTruthy();
+    expect(screen.getByText("Models")).toBeTruthy();
+    expect(screen.getByText("Workspace")).toBeTruthy();
+    expect(screen.getByText("Agents")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Open Connections/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: "New Hecate chat" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Choose agent for new chat" })).toBeTruthy();
@@ -7297,7 +7301,7 @@ describe("ChatView error display", () => {
     });
     render(withRuntimeConsole(<ChatView />, { state, actions }));
 
-    expect(await screen.findByText("Nothing runnable yet")).toBeTruthy();
+    expect(await screen.findByText("Connect a model or agent")).toBeTruthy();
     expect(screen.getByRole("button", { name: /Open Connections/i })).toBeTruthy();
     expect(screen.queryByText("Selected model is unavailable")).toBeNull();
     expect(screen.queryByText("422 · model_not_configured")).toBeNull();

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -70,20 +70,20 @@ try {
 
 const capabilityRows = [
   [
-    "Model gateway",
-    "Route OpenAI-compatible and Anthropic-shaped requests across cloud and local providers with health, failover, and usage visibility.",
+    "Chats and routing",
+    "Talk to models through OpenAI-compatible and Anthropic-shaped APIs with health, failover, and usage visibility.",
   ],
   [
-    "Project orchestration",
-    "Coordinate durable projects, workspace roots, assignments, handoffs, context snapshots, and operator-approved memory.",
+    "Projects and memory",
+    "Keep work areas, workspace roots, assignments, context snapshots, evidence, and approved memory together.",
   ],
   [
-    "External agents",
-    "Supervise local Codex, Claude Code, Cursor, and Grok Build sessions while their CLIs keep their own accounts and runtimes.",
+    "Supervised agents",
+    "Run Codex, Claude Code, Cursor, and Grok Build from Hecate while their CLIs keep their own accounts and runtime behavior.",
   ],
   [
-    "Evidence",
-    "Keep traces, route reports, task artifacts, diffs, logs, usage, and final output close to the decision that produced them.",
+    "Observable work",
+    "Keep approvals, traces, route reports, artifacts, diffs, logs, usage, and final output close to the decision that produced them.",
   ],
 ];
 
@@ -101,10 +101,10 @@ const downloadRows = [
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Hecate is a local AI operations console for supervised agent work across AI clients, model providers, coding agents, workspace tools, projects, approvals, artifacts, and traces."
+      content="Hecate is an AI workspace and runtime for projects, chats, providers, memory, approvals, traces, and supervised external agents."
     />
     <link rel="icon" href="/brand/png/mark-trivium-black-64.png" sizes="64x64" />
-    <title>Hecate - Local AI Operations Console</title>
+    <title>Hecate - AI Workspace and Runtime</title>
   </head>
   <body>
     <header class="site-nav" aria-label="Primary navigation">
@@ -126,12 +126,12 @@ const downloadRows = [
           <img src="/product/chat-workspace-diff.png" alt="" />
         </div>
         <div class="hero__copy">
-          <p class="eyebrow">local AI operations console</p>
+          <p class="eyebrow">AI workspace and runtime</p>
           <h1 id="hero-title">hecate</h1>
           <p class="lede">
-            Run Hecate on your machine between AI clients, model providers,
-            coding agents, and workspace tools so project work can be coordinated,
-            routed, approved, traced, and reviewable.
+            Run Hecate on your machine as the personal control plane for AI work:
+            projects, chats, model providers, memory, approvals, diffs, traces,
+            and supervised external agents in one UI.
           </p>
 
           <div class="hero__actions" aria-label="Primary actions">
@@ -164,6 +164,10 @@ const downloadRows = [
         <div class="section-heading">
           <p class="eyebrow">public alpha</p>
           <h2 id="download-title">Install the local console.</h2>
+          <p>
+            Start with the desktop app, Docker image, or source checkout. Hecate
+            runs locally by default and keeps the runtime boundary visible.
+          </p>
         </div>
 
         <div class="download-table" aria-label="Download options">
@@ -180,11 +184,11 @@ const downloadRows = [
       <section class="workflow" id="workflow" aria-labelledby="workflow-title">
         <div class="workflow__copy">
           <p class="eyebrow">project workflow</p>
-          <h2 id="workflow-title">Project work gets a durable local identity.</h2>
+          <h2 id="workflow-title">One workspace for personal and project agents.</h2>
           <p>
             Start with a project, attach workspace roots when files matter, and
-            keep chats, tasks, external-agent sessions, context, memory, and evidence
-            connected to the same work.
+            keep chats, tasks, external-agent sessions, context, memory, and
+            evidence connected to the same work.
           </p>
         </div>
 
@@ -228,12 +232,13 @@ const downloadRows = [
 
       <section class="cloud-bridge" aria-labelledby="cloud-title">
         <div>
-          <p class="eyebrow">hosted direction</p>
-          <h2 id="cloud-title">Open source first. Hosted runtimes stay separate.</h2>
+          <p class="eyebrow">remote option</p>
+          <h2 id="cloud-title">Use Hecate away from your desk.</h2>
         </div>
         <p>
-          hecate.sh stays focused on the open-source local console. Hecate Cloud
-          will live separately at hecatehq.com, with the console at console.hecatehq.com.
+          hecate.sh is the open-source Hecate runtime and app. Hecate Cloud is
+          the separate hosted deployment and access layer for opening that same
+          Hecate UI from a browser.
         </p>
         <a class="button button--ghost" href="https://hecatehq.com">Hecate Cloud</a>
       </section>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -309,6 +309,13 @@ h2 {
   max-width: 44rem;
 }
 
+.section-heading p:not(.eyebrow) {
+  margin: 1.1rem 0 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 1.6vw, 1.2rem);
+  line-height: 1.55;
+}
+
 .download-table {
   display: grid;
   align-content: start;


### PR DESCRIPTION
## Summary
- Reposition README around Hecate as an AI workspace/runtime for projects, chats, providers, memory, approvals, and supervised agents
- Update hecate.sh copy and metadata to match the open-source runtime/app positioning
- Improve the Hecate chat start screen with a clearer setup checklist for models, workspace, and external agents
- Keep Hecate Cloud framed as the separate hosted deployment and browser-access layer

## Verification
- cd website && bun run format
- cd website && bun run lint
- cd website && bun run format:check
- ./ui/node_modules/.bin/oxfmt --check README.md
- cd website && bun run build
- cd ui && bun run test -- ChatView.test.tsx AppShell.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test:e2e -- e2e/chat.spec.ts e2e/shell.spec.ts e2e/provider-lifecycle.spec.ts
- Visual check with Playwright screenshots at 1440x1000 and 390x844

## Metadata
- Updated GitHub repo description to: AI workspace and runtime for projects, chats, providers, memory, approvals, and supervised agents.