### PR TITLE
fix(chat): classify durable operator cancellations

### DIFF
--- a/internal/api/handler_chat_cancel_metrics_test.go
+++ b/internal/api/handler_chat_cancel_metrics_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/hecatehq/hecate/internal/controlplane"
 	"github.com/hecatehq/hecate/internal/modelcaps"
 	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/pkg/types"
 	"go.opentelemetry.io/otel/attribute"
@@ -18,13 +20,91 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
+func TestHecateAgentChatCancellationReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		run        types.TaskRun
+		liveReason string
+		want       string
+	}{
+		{
+			name: "durable operator cancellation wins before live wake",
+			run: types.TaskRun{
+				Status:    "cancelled",
+				LastError: "run cancelled: operator",
+			},
+			want: "operator",
+		},
+		{
+			name: "live cancellation covers non task turn",
+			run: types.TaskRun{
+				Status:    "cancelled",
+				LastError: "cancelled",
+			},
+			liveReason: "operator",
+			want:       "operator",
+		},
+		{
+			name: "request context remains fallback",
+			run: types.TaskRun{
+				Status:    "cancelled",
+				LastError: "cancelled",
+			},
+			want: "request_cancelled",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hecateAgentChatCancellationReason(tt.run, tt.liveReason); got != tt.want {
+				t.Fatalf("hecateAgentChatCancellationReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+type blockingOperatorCancelTerminalStore struct {
+	taskstate.Store
+	durableCommitted chan struct{}
+	release          <-chan struct{}
+	once             sync.Once
+}
+
+func (s *blockingOperatorCancelTerminalStore) ApplyRunTerminalTransition(ctx context.Context, transition taskstate.TerminalRunTransition) (taskstate.TerminalRunTransitionResult, error) {
+	result, err := s.Store.ApplyRunTerminalTransition(ctx, transition)
+	if err != nil || result.Run.Status != "cancelled" || result.Run.LastError != "run cancelled: operator" {
+		return result, err
+	}
+	s.once.Do(func() {
+		close(s.durableCommitted)
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+		}
+	})
+	return result, err
+}
+
 func TestHecateChatOperatorCancelRecordsOperatorMetricWithDetachedWatcher(t *testing.T) {
 	provider := &cancelBlockingProvider{
 		fakeProvider: &fakeProvider{name: "openai"},
 		started:      make(chan struct{}),
 		cancelled:    make(chan error, 1),
 	}
-	handler := newTestAPIHandlerWithSettings(quietLogger(), []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore())
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	store := &blockingOperatorCancelTerminalStore{
+		Store:            taskstate.NewMemoryStore(),
+		durableCommitted: make(chan struct{}),
+		release:          release,
+	}
+	handler := newTestAPIHandlerWithSettingsAndTaskStore(quietLogger(), []providers.Provider{provider}, config.Config{}, controlplane.NewMemoryStore(), store)
 	reader := sdkmetric.NewManualReader()
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	metrics, err := telemetry.NewAgentChatMetricsWithMeterProvider(meterProvider)
@@ -57,9 +137,15 @@ func TestHecateChatOperatorCancelRecordsOperatorMetricWithDetachedWatcher(t *tes
 		t.Fatal("backing provider did not start")
 	}
 	waitForChatTaskLink(t, handler.agentChat, sessionID)
-	cancelResponse := performRequest(t, server, http.MethodPost, "/hecate/v1/chat/sessions/"+sessionID+"/cancel", `{}`)
-	if cancelResponse.Code != http.StatusAccepted {
-		t.Fatalf("cancel status = %d, want 202; body=%s", cancelResponse.Code, cancelResponse.Body.String())
+	cancelDone := make(chan *chatMessageHTTPResult, 1)
+	go func() {
+		recorder := performRequest(t, server, http.MethodPost, "/hecate/v1/chat/sessions/"+sessionID+"/cancel", `{}`)
+		cancelDone <- &chatMessageHTTPResult{status: recorder.Code, body: recorder.Body.Bytes()}
+	}()
+	select {
+	case <-store.durableCommitted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("operator cancellation did not persist its terminal task outcome")
 	}
 	select {
 	case result := <-messageDone:
@@ -67,7 +153,7 @@ func TestHecateChatOperatorCancelRecordsOperatorMetricWithDetachedWatcher(t *tes
 			t.Fatalf("message status = %d, want 200; body=%s", result.status, result.body)
 		}
 	case <-time.After(3 * time.Second):
-		t.Fatal("message handler did not finalize after operator cancel")
+		t.Fatal("detached watcher did not finalize from the durable operator cancellation")
 	}
 
 	var collected metricdata.ResourceMetrics
@@ -98,6 +184,16 @@ func TestHecateChatOperatorCancelRecordsOperatorMetricWithDetachedWatcher(t *tes
 	}
 	if !foundOperator {
 		t.Fatalf("missing hecate/operator cancellation metric: %+v", collected)
+	}
+	close(release)
+	released = true
+	select {
+	case result := <-cancelDone:
+		if result.status != http.StatusAccepted {
+			t.Fatalf("cancel status = %d, want 202; body=%s", result.status, result.body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("cancel handler did not finish after terminal transition release")
 	}
 }
 

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -500,10 +500,7 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		Timing:     agentChatRunTimingMetrics(timing),
 	})
 	if status == "cancelled" {
-		reason := h.agentChatLive.cancelReasonFor(session.ID)
-		if reason == "" {
-			reason = "request_cancelled"
-		}
+		reason := hecateAgentChatCancellationReason(finalRun, h.agentChatLive.cancelReasonFor(session.ID))
 		h.agentChatMetrics.RecordChatCancelled(traceCtx, telemetry.AgentChatCancelledRecord{
 			AdapterID: "hecate",
 			Reason:    reason,
@@ -558,6 +555,19 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		Data:           renderChatSession(updated, h.agentChatSnapshotConfig()),
 		MessageRequest: requestGuard.responseMetadata(false, ""),
 	})
+}
+
+// hecateAgentChatCancellationReason prefers the runner's durable operator
+// outcome because CancelRun persists it before it can wake the detached chat
+// watcher. The live reason remains the authority for non-task chat cancels.
+func hecateAgentChatCancellationReason(run types.TaskRun, liveReason string) string {
+	if run.LastError == "run cancelled: operator" {
+		return "operator"
+	}
+	if liveReason != "" {
+		return liveReason
+	}
+	return "request_cancelled"
 }
 
 func (h *Handler) linkHecateTaskRun(

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/hecatehq/hecate/internal/ratelimit"
 	"github.com/hecatehq/hecate/internal/retention"
 	"github.com/hecatehq/hecate/internal/router"
+	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
 	"github.com/hecatehq/hecate/internal/workspacefs"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -7626,11 +7627,19 @@ func newTestHTTPHandlerWithSettings(logger *slog.Logger, items []providers.Provi
 }
 
 func newTestAPIHandlerWithSettings(logger *slog.Logger, items []providers.Provider, cfg config.Config, cpStore controlplane.Store) *Handler {
+	return newTestAPIHandlerWithSettingsAndTaskStore(logger, items, cfg, cpStore, nil)
+}
+
+func newTestAPIHandlerWithSettingsAndTaskStore(logger *slog.Logger, items []providers.Provider, cfg config.Config, cpStore controlplane.Store, taskStore taskstate.Store) *Handler {
 	registry := providers.NewRegistry(items...)
-	return newTestAPIHandlerWithRegistry(logger, registry, items, cfg, cpStore)
+	return newTestAPIHandlerWithRegistryAndTaskStore(logger, registry, items, cfg, cpStore, taskStore)
 }
 
 func newTestAPIHandlerWithRegistry(logger *slog.Logger, registry providers.Registry, items []providers.Provider, cfg config.Config, cpStore controlplane.Store) *Handler {
+	return newTestAPIHandlerWithRegistryAndTaskStore(logger, registry, items, cfg, cpStore, nil)
+}
+
+func newTestAPIHandlerWithRegistryAndTaskStore(logger *slog.Logger, registry providers.Registry, items []providers.Provider, cfg config.Config, cpStore controlplane.Store, taskStore taskstate.Store) *Handler {
 	providerHistoryStore := providers.NewMemoryHealthHistoryStore()
 	healthTracker := providers.NewMemoryHealthTrackerWithHistory(
 		cfg.Provider.HealthThreshold,
@@ -7687,7 +7696,7 @@ func newTestAPIHandlerWithRegistry(logger *slog.Logger, registry providers.Regis
 	})
 
 	cfg.Governor = governorCfg
-	handler := NewHandler(cfg, logger, service, cpStore, nil, nil)
+	handler := NewHandler(cfg, logger, service, cpStore, taskStore, nil)
 	return handler
 }
 


### PR DESCRIPTION
## Summary

- Classify task-backed Hecate Chat operator cancellations from the durable task outcome.
- Preserve live cancellation reasons for non-task turns.
- Add a deterministic regression test that holds the cancel endpoint after terminal persistence and confirms the detached watcher records operator.

## Why

The runner makes the terminal task row visible before the cancel endpoint wakes the detached watcher. In that small window, the watcher previously recorded request_cancelled even when an operator initiated cancellation.

## Scope

No public API or documentation change: the established telemetry cancellation reasons are already documented.

## Validation

- go test -count=1 -timeout 10m ./...
- go test -race -count=1 -timeout 10m ./...
- go test -tags e2e -count=1 -timeout 3m ./e2e/...
- go vet ./...
- go build ./...
- go mod tidy -diff
- go mod verify
- just docs-check
