### PR TITLE
fix(projects): open Cairnline projects after create

### DIFF
--- a/internal/api/handler_projects.go
+++ b/internal/api/handler_projects.go
@@ -214,6 +214,19 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if h.config.ProjectsUseCairnlineOnly() && projectUpdateOnlyTouchesLastOpenedAt(req) {
+		project, err := h.renderProject(r.Context(), r.PathValue("id"))
+		if err != nil {
+			writeProjectReadRenderError(w, err)
+			return
+		}
+		if project == nil {
+			WriteError(w, http.StatusNotFound, errCodeNotFound, "project not found")
+			return
+		}
+		WriteJSON(w, http.StatusOK, ProjectResponse{Object: "project", Data: *project})
+		return
+	}
 	usesCairnlineMetadataDefaultsAuthority := h.projectMetadataDefaultsWritesUseCairnlineAuthority() && projectUpdateCanUseCairnlineMetadataDefaultsAuthority(req)
 	if req.DefaultRootID != nil && !usesCairnlineMetadataDefaultsAuthority {
 		defaultRootID := strings.TrimSpace(*req.DefaultRootID)
@@ -347,6 +360,22 @@ func (h *Handler) HandleUpdateProject(w http.ResponseWriter, r *http.Request) {
 
 func projectUpdateTouchesPortableMetadata(req updateProjectRequest) bool {
 	return req.Name != nil || req.Description != nil
+}
+
+func projectUpdateOnlyTouchesLastOpenedAt(req updateProjectRequest) bool {
+	return req.LastOpenedAt != nil &&
+		req.Name == nil &&
+		req.Description == nil &&
+		req.Roots == nil &&
+		req.ContextSources == nil &&
+		req.DefaultRootID == nil &&
+		req.DefaultProvider == nil &&
+		req.DefaultModel == nil &&
+		req.DefaultAgentProfile == nil &&
+		req.DefaultToolsEnabled == nil &&
+		req.DefaultWorkspaceMode == nil &&
+		req.DefaultSystemPrompt == nil &&
+		req.DefaultCompactToolOutput == nil
 }
 
 func projectUpdateTouchesPortableDefaults(req updateProjectRequest) bool {

--- a/internal/api/handler_projects_test.go
+++ b/internal/api/handler_projects_test.go
@@ -805,6 +805,33 @@ func TestProjectsAPI_CairnlineReplacementModeCreatesCairnlineOnlyIdentity(t *tes
 	}
 }
 
+func TestProjectsAPI_CairnlineReplacementModeIgnoresLastOpenedAtPatch(t *testing.T) {
+	t.Parallel()
+	handler, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)
+	client := newAPITestClient(t, server)
+
+	created := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", `{
+		"name":"Replacement Auto Open"
+	}`)
+	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after replacement create, want no native identity row", ok, err)
+	}
+
+	openedAt := time.Date(2026, 7, 19, 9, 30, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	opened := mustRequestJSONStatus[ProjectResponse](client, http.StatusOK, http.MethodPatch, "/hecate/v1/projects/"+created.Data.ID, fmt.Sprintf(`{
+		"last_opened_at":%q
+	}`, openedAt))
+	if opened.Data.ID != created.Data.ID || opened.Data.Name != "Replacement Auto Open" || opened.Data.ReadBackend != "cairnline" {
+		t.Fatalf("last-opened response = %+v, want Cairnline-backed created project", opened.Data)
+	}
+	if opened.Data.LastOpenedAt != "" {
+		t.Fatalf("last_opened_at = %q, want omitted without native Hecate project state", opened.Data.LastOpenedAt)
+	}
+	if _, ok, err := handler.projects.Get(t.Context(), created.Data.ID); err != nil || ok {
+		t.Fatalf("Hecate project store ok=%v err=%v after last-opened patch, want no native identity row", ok, err)
+	}
+}
+
 func TestProjectsAPI_CairnlineReplacementModeRejectsDuplicateNameAndRootPath(t *testing.T) {
 	t.Parallel()
 	_, server := newProjectsCairnlineReplacementIdentityAuthorityTestServer(t)

--- a/ui/src/features/projects/ProjectScopePanel.test.tsx
+++ b/ui/src/features/projects/ProjectScopePanel.test.tsx
@@ -372,6 +372,42 @@ describe("ProjectScopePanel catalog recovery", () => {
     expect(screen.getByText("Projects could not be loaded.")).toBeTruthy();
   });
 
+  it("opens a newly created Cairnline project without leaving a server error", async () => {
+    const createdProject = {
+      ...project,
+      id: "proj_created",
+      name: "Created project",
+    } satisfies ProjectRecord;
+    vi.mocked(createProject).mockResolvedValue({
+      object: "project",
+      data: createdProject,
+    });
+    vi.mocked(updateProject).mockResolvedValue({
+      object: "project",
+      data: createdProject,
+    });
+    const user = userEvent.setup();
+    renderPanel({ projects: [], loaded: true });
+
+    await user.click(screen.getByRole("button", { name: "Add project" }));
+    await user.type(screen.getByLabelText("Name"), "Created project");
+    await user.click(screen.getByRole("button", { name: "Create project" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Create project" })).toBeNull(),
+    );
+    expect(updateProject).toHaveBeenCalledWith("proj_created", {
+      last_opened_at: expect.any(String),
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Project Created project" })).toHaveAttribute(
+        "aria-current",
+        "true",
+      ),
+    );
+  });
+
   it("submits create once and keeps its pending result in the dialog", async () => {
     let rejectCreate!: (reason: Error) => void;
     vi.mocked(createProject).mockReturnValue(


### PR DESCRIPTION
## Summary
- allow Cairnline-only project open timestamp updates to read back the authoritative project without writing native Hecate project state
- cover the create-then-open journey so a successful project create does not leave the sidebar server-error alert visible

## Verification
Local:
- go test ./internal/api
- go vet ./internal/api
- cd ui && bun run test -- ProjectScopePanel.test.tsx

CI:
- babysitting PR checks to completion

## Review
- Independent HEAD review: CLEAN