### PR TITLE
fix(projects): keep setup details within settings layout

### DIFF
--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -2393,12 +2393,31 @@ test("Projects supporting surfaces stay read-first at desktop and narrow widths"
   await page.getByLabel("Purpose").fill("Coordinate research notes and reusable guidance.");
   await page.getByRole("button", { name: "Create project" }).click();
 
-  await page.setViewportSize({ width: 390, height: 844 });
   const onboarding = page.getByRole("region", { name: "Project onboarding" });
   await onboarding.getByText("Setup details").click();
   const onboardingSettings = onboarding.getByRole("button", { name: "Project settings" });
   await onboardingSettings.click();
   let settings = page.getByRole("complementary", { name: "Project settings panel" });
+  await expect(settings).toBeVisible();
+  await expect(settings.getByRole("heading", { level: 1, name: "Project settings" })).toBeFocused();
+  expect(
+    await onboarding.evaluate((element) => {
+      const columns = getComputedStyle(element).gridTemplateColumns.split(" ").filter(Boolean);
+      return columns.length;
+    }),
+  ).toBe(1);
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1,
+    ),
+  ).toBe(true);
+  await settings.getByRole("button", { name: "Back to project" }).click();
+  await expect(settings).toBeHidden();
+  await expect(onboardingSettings).toBeFocused();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await onboardingSettings.click();
+  settings = page.getByRole("complementary", { name: "Project settings panel" });
   await expect(settings).toBeVisible();
   await expect(settings.getByRole("heading", { level: 1, name: "Project settings" })).toBeFocused();
   await expect(settings.getByRole("button", { name: "Back to project" })).toBeVisible();

--- a/ui/src/features/projects/ProjectWorkspaceView.test.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.test.tsx
@@ -465,12 +465,14 @@ describe("ProjectWorkspaceView", () => {
     const onboarding = screen.getByRole("region", {
       name: "Project onboarding",
     });
+    expect(onboarding).toHaveClass("project-workspace-onboarding");
+    expect(onboarding.querySelector(".project-workspace-onboarding-copy")).toBeTruthy();
     expect(within(onboarding).getByRole("button", { name: "Set up project" })).toHaveClass(
       "btn-primary",
     );
-    expect(
-      within(onboarding).getByText("Setup details").closest("summary")?.closest("details"),
-    ).not.toHaveAttribute("open");
+    const setupDetails = within(onboarding).getByText("Setup details").closest("details");
+    expect(setupDetails).toHaveClass("project-workspace-onboarding-details");
+    expect(setupDetails).not.toHaveAttribute("open");
     await userEvent.click(within(onboarding).getByRole("button", { name: "Set up project" }));
 
     await userEvent.click(within(onboarding).getByText("Setup details"));

--- a/ui/src/features/projects/ProjectWorkspaceView.tsx
+++ b/ui/src/features/projects/ProjectWorkspaceView.tsx
@@ -1110,9 +1110,10 @@ function ProjectOnboardingPanel({
     <section
       aria-busy={bootstrapPending}
       aria-label="Project onboarding"
+      className="project-workspace-onboarding"
       style={projectOnboardingStyle}
     >
-      <div style={projectOnboardingCopyStyle}>
+      <div className="project-workspace-onboarding-copy" style={projectOnboardingCopyStyle}>
         <div>
           <div style={sectionLabelStyle}>Guided start</div>
           <h1 style={{ ...projectOnboardingTitleStyle, margin: "8px 0 0" }}>
@@ -1177,7 +1178,10 @@ function ProjectOnboardingPanel({
           )}
         </div>
       )}
-      <details style={projectOnboardingDetailsStyle}>
+      <details
+        className="project-workspace-onboarding-details"
+        style={projectOnboardingDetailsStyle}
+      >
         <summary style={projectOnboardingSummaryStyle}>
           <span>Setup details</span>
           <span className="badge badge-muted">

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -345,6 +345,20 @@ textarea {
   }
 }
 
+.projects-cockpit-main-body--settings .project-workspace-onboarding {
+  grid-template-columns: minmax(0, 1fr) !important;
+  min-height: auto !important;
+}
+
+.projects-cockpit-main-body--settings .project-workspace-onboarding-copy {
+  align-content: start !important;
+  min-height: 0 !important;
+}
+
+.projects-cockpit-main-body--settings .project-workspace-onboarding-details {
+  align-self: start !important;
+}
+
 @media (max-width: 720px) {
   .projects-cockpit-shell {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- scope Projects onboarding compaction to the settings-open layout so Setup details no longer drifts under the inspector
- keep the normal onboarding card layout unchanged outside the settings inspector
- extend the Projects browser test to cover desktop onboarding plus Project settings and page overflow

## Verification
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test -- ProjectWorkspaceView.test.tsx
- cd ui && bun run test
- cd ui && bun run test:e2e -- e2e/projects.spec.ts -g "Projects supporting surfaces stay read-first at desktop and narrow widths"

## Review
- layout review: CLEAN after fixing scoped-layout feedback
- test review: CLEAN after removing brittle inline-style assertions