### PR TITLE
fix(projects): clarify memory suggestion review

### DIFF
--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -298,6 +298,34 @@ test("Projects guided start stays on Overview at desktop and narrow widths", asy
   await expect(page.getByRole("button", { name: "Apply setup" })).toBeFocused();
   const proposalDetails = page.locator("details").filter({ hasText: "Review proposed changes" });
   await expect(proposalDetails).not.toHaveAttribute("open", "");
+  await page.getByText("Review proposed changes").click();
+  const memorySuggestion = page.getByRole("article", {
+    name: "Memory suggestion Guidance from AGENTS.md",
+  });
+  await expect(memorySuggestion).toBeVisible();
+  await expect(
+    memorySuggestion.getByText("Discovered project guidance source.").first(),
+  ).toBeVisible();
+  await expect(memorySuggestion.getByText("Workspace guidance").first()).toBeVisible();
+  await expect(memorySuggestion.getByText("Pending promotion")).toBeVisible();
+  await expect(memorySuggestion.getByText("Show payload details")).toBeVisible();
+  const memoryTechnicalDetails = memorySuggestion.locator("details").filter({
+    hasText: "Show payload details",
+  });
+  await expect(memoryTechnicalDetails).not.toHaveAttribute("open", "");
+  await expect(memorySuggestion.locator("dt", { hasText: "suggested_kind" }).first()).toBeHidden();
+  expect(
+    await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1),
+  ).toBe(true);
+  await memorySuggestion.getByText("Show payload details").click();
+  await expect(memoryTechnicalDetails).toHaveAttribute("open", "");
+  await expect(memorySuggestion.locator("dt", { hasText: "suggested_kind" }).first()).toBeVisible();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(memorySuggestion).toBeVisible();
+  expect(
+    await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1),
+  ).toBe(true);
+  await page.setViewportSize({ width: 1280, height: 720 });
   await page.getByRole("button", { name: "Dismiss setup" }).click();
   await expect(onboarding.getByRole("button", { name: "Set up project" })).toBeFocused();
   await onboarding.getByRole("button", { name: "Set up project" }).click();
@@ -3737,7 +3765,26 @@ function bootstrapProposal(project?: ProjectRecord) {
       "Create reviewable memory candidates from discovered guidance metadata and suggest project roles from local skill files.",
     requires_confirmation: true,
     actions: [
-      { kind: "create_memory_candidate", target: { project_id: project?.id || "" } },
+      {
+        kind: "create_memory_candidate",
+        target: { project_id: project?.id || "" },
+        patch: {
+          project_id: project?.id || "",
+          title: "Guidance source: AGENTS.md",
+          body: "Discovered project guidance source.\nReview the source file before promoting it.",
+          suggested_kind: "workspace_guidance",
+          suggested_trust_label: "workspace_guidance",
+          suggested_source_kind: "context_source",
+          suggested_source_id: "ctxsrc_agents",
+          source_refs: [
+            {
+              kind: "file",
+              id: "AGENTS.md",
+              title: "AGENTS.md",
+            },
+          ],
+        },
+      },
       {
         kind: "create_role",
         patch: { id: "skill_implementation", name: "Implementation" },

--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -271,6 +271,78 @@ describe("ProjectAssistantPanel", () => {
     expect(handlers.onApply).toHaveBeenCalledTimes(1);
   });
 
+  it("summarizes memory suggestions before technical payload details", async () => {
+    const user = userEvent.setup();
+    renderAssistantPanel({
+      proposal: {
+        id: "pa_setup_memory",
+        title: "Set up Hecate guidance",
+        summary: "Record host-specific guidance as reviewable project memory.",
+        requires_confirmation: true,
+        trace_id: "trace_setup_memory",
+        actions: [
+          {
+            kind: "create_memory_candidate",
+            target: { project_id: "proj_1" },
+            patch: {
+              project_id: "proj_1",
+              title: "Guidance source: .github/copilot-instructions.md",
+              body: "Discovered project guidance source.\nReview the source file before promoting it.",
+              suggested_kind: "workspace_guidance",
+              suggested_trust_label: "workspace_guidance",
+              suggested_source_kind: "context_source",
+              suggested_source_id: "ctxsrc_1",
+              source_refs: [
+                {
+                  kind: "file",
+                  id: ".github/copilot-instructions.md",
+                  title: ".github/copilot-instructions.md",
+                },
+              ],
+            },
+            reason: "Record host-specific guidance as reviewable metadata.",
+          },
+        ],
+      },
+      setupFirst: true,
+    });
+
+    const assistant = screen.getByRole("region", { name: "Project Assistant" });
+    await user.click(
+      within(assistant).getByText("Review proposed changes", { selector: "summary" }),
+    );
+
+    const suggestion = within(assistant).getByRole("article", {
+      name: "Memory suggestion Guidance from .github/copilot-instructions.md",
+    });
+    expect(within(suggestion).getByText("Save for review")).toBeTruthy();
+    expect(
+      within(suggestion).getByRole("heading", {
+        name: "Guidance from .github/copilot-instructions.md",
+      }),
+    ).toBeTruthy();
+    expect(
+      within(suggestion).getAllByText(/Review the source file before promoting it\./).length,
+    ).toBeTruthy();
+    expect(within(suggestion).getAllByText(".github/copilot-instructions.md").length).toBe(2);
+    expect(within(suggestion).getAllByText("Workspace guidance").length).toBeGreaterThan(0);
+    expect(within(suggestion).getByText("Pending promotion")).toBeTruthy();
+    expect(
+      within(suggestion).getByText(
+        "Applying saves a pending suggestion only. It does not change durable project memory until you review and promote it.",
+      ),
+    ).toBeTruthy();
+    const technicalDetails = within(suggestion)
+      .getByText("Show payload details", { selector: "summary" })
+      .closest("details");
+    expect(technicalDetails).not.toHaveAttribute("open");
+
+    await user.click(within(suggestion).getByText("Show payload details", { selector: "summary" }));
+    expect(technicalDetails).toHaveAttribute("open");
+    expect(within(suggestion).getByText("suggested_kind")).toBeTruthy();
+    expect(within(suggestion).getAllByText("workspace_guidance").length).toBeGreaterThan(0);
+  });
+
   it("focuses a new work proposal heading before its apply action", () => {
     renderAssistantPanel({
       proposal: {

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -762,6 +762,10 @@ function ProjectAssistantActionRow({
 }: {
   action: ProjectAssistantProposal["actions"][number];
 }) {
+  if (action.kind === "create_memory_candidate") {
+    return <ProjectAssistantMemorySuggestionAction action={action} />;
+  }
+
   const targetEntries = Object.entries(action.target ?? {});
   const patchEntries = Object.entries(action.patch ?? {});
   return (
@@ -778,6 +782,101 @@ function ProjectAssistantActionRow({
           <ProjectAssistantFieldGroup title="Patch" entries={patchEntries} />
         )}
       </div>
+    </div>
+  );
+}
+
+function ProjectAssistantMemorySuggestionAction({
+  action,
+}: {
+  action: ProjectAssistantProposal["actions"][number];
+}) {
+  const targetEntries = Object.entries(action.target ?? {});
+  const patchEntries = Object.entries(action.patch ?? {});
+  const title = assistantStringField(action.patch, "title") || "Memory suggestion";
+  const body = assistantStringField(action.patch, "body");
+  const kind = assistantHumanLabel(assistantStringField(action.patch, "suggested_kind"));
+  const trustLabel = assistantHumanLabel(
+    assistantStringField(action.patch, "suggested_trust_label"),
+  );
+  const sourceID = assistantStringField(action.patch, "suggested_source_id");
+  const sourceRefs = assistantSourceRefs(action.patch?.source_refs);
+  const sourceLabel =
+    sourceRefs[0]?.title ||
+    sourceRefs[0]?.id ||
+    sourceID ||
+    assistantStringField(action.target, "project_id") ||
+    "Project";
+  const evidenceItems = sourceRefs.length > 0 ? sourceRefs : sourceID ? [{ id: sourceID }] : [];
+  const displayTitle = assistantMemorySuggestionTitle(title, sourceLabel);
+  const bodyPreview = assistantMemoryBodyPreview(body);
+
+  return (
+    <article style={assistantMemoryActionStyle} aria-label={`Memory suggestion ${displayTitle}`}>
+      <div style={assistantMemoryHeaderStyle}>
+        <span className="badge badge-muted">Save for review</span>
+        <div style={assistantMemoryTitleWrapStyle}>
+          <div style={sectionLabelStyle}>Memory suggestion</div>
+          <h4 style={assistantMemoryTitleStyle}>{displayTitle}</h4>
+          <div style={assistantMemoryReasonStyle}>
+            {action.reason || "Store guidance as a suggestion you can review before promotion."}
+          </div>
+        </div>
+      </div>
+      <figure style={assistantMemoryBodyStyle}>
+        <blockquote style={assistantMemoryQuoteStyle}>
+          {bodyPreview || "No memory text supplied. Review the technical details before applying."}
+        </blockquote>
+        {body && bodyPreview !== body && (
+          <figcaption style={assistantMemoryCaptionStyle}>
+            Preview only. Open technical details for the full proposed text.
+          </figcaption>
+        )}
+      </figure>
+      <div style={assistantMemoryMetaGridStyle} aria-label="Memory suggestion summary">
+        <ProjectAssistantMemoryMeta label="Source" value={sourceLabel} />
+        <ProjectAssistantMemoryMeta label="Review path" value="Pending promotion" />
+        <ProjectAssistantMemoryMeta label="Type" value={kind || "Project guidance"} />
+        <ProjectAssistantMemoryMeta label="Trust" value={trustLabel || "Review first"} />
+      </div>
+      {evidenceItems.length > 0 && (
+        <div style={assistantMemoryEvidenceStyle} aria-label="Memory suggestion evidence">
+          <span style={fieldLabelStyle}>Evidence</span>
+          <ul style={assistantMemoryEvidenceListStyle}>
+            {evidenceItems.map((item) => (
+              <li key={`${item.title ?? ""}-${item.id}`} style={assistantMemoryEvidenceItemStyle}>
+                {item.title || item.id}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div style={assistantMemorySafetyStyle}>
+        Applying saves a pending suggestion only. It does not change durable project memory until
+        you review and promote it.
+      </div>
+      {(targetEntries.length > 0 || patchEntries.length > 0) && (
+        <details style={assistantTechnicalDetailsStyle}>
+          <summary style={assistantTechnicalSummaryStyle}>Show payload details</summary>
+          <div style={assistantPatchGridStyle}>
+            {targetEntries.length > 0 && (
+              <ProjectAssistantFieldGroup title="Target" entries={targetEntries} />
+            )}
+            {patchEntries.length > 0 && (
+              <ProjectAssistantFieldGroup title="Patch" entries={patchEntries} />
+            )}
+          </div>
+        </details>
+      )}
+    </article>
+  );
+}
+
+function ProjectAssistantMemoryMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={assistantMemoryMetaStyle}>
+      <span style={fieldLabelStyle}>{label}</span>
+      <span style={assistantMemoryMetaValueStyle}>{value}</span>
     </div>
   );
 }
@@ -1010,6 +1109,52 @@ function formatAssistantValue(value: unknown): string {
     }
   }
   return String(value);
+}
+
+function assistantStringField(
+  record: Record<string, unknown> | Record<string, string> | undefined,
+  key: string,
+): string {
+  const value = record?.[key];
+  return typeof value === "string" ? value : "";
+}
+
+function assistantHumanLabel(value: string): string {
+  if (!value) return "";
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^\w/, (letter) => letter.toUpperCase());
+}
+
+function assistantMemorySuggestionTitle(title: string, sourceLabel: string): string {
+  const trimmedTitle = title.trim();
+  const guidancePrefix = "Guidance source:";
+  if (trimmedTitle.toLowerCase().startsWith(guidancePrefix.toLowerCase())) {
+    const source = trimmedTitle.slice(guidancePrefix.length).trim() || sourceLabel;
+    return `Guidance from ${source}`;
+  }
+  return trimmedTitle || "Project guidance suggestion";
+}
+
+function assistantMemoryBodyPreview(body: string): string {
+  const trimmedBody = body.trim();
+  if (trimmedBody.length <= 420) return trimmedBody;
+  return `${trimmedBody.slice(0, 417).trimEnd()}…`;
+}
+
+function assistantSourceRefs(value: unknown): Array<{ id: string; title?: string }> {
+  if (!Array.isArray(value)) return [];
+  const refs: Array<{ id: string; title?: string }> = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const source = item as Record<string, unknown>;
+    const id = typeof source.id === "string" ? source.id : "";
+    const title = typeof source.title === "string" ? source.title : "";
+    if (id || title) refs.push(title ? { id, title } : { id });
+  }
+  return refs;
 }
 
 const assistantPanelStyle: CSSProperties = {
@@ -1371,6 +1516,140 @@ const assistantFieldValueStyle: CSSProperties = {
   margin: 0,
   minWidth: 0,
   overflowWrap: "anywhere",
+};
+
+const assistantMemoryActionStyle: CSSProperties = {
+  background: "var(--bg1)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 10,
+  minWidth: 0,
+  padding: 10,
+};
+
+const assistantMemoryHeaderStyle: CSSProperties = {
+  alignItems: "flex-start",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 9,
+  minWidth: 0,
+};
+
+const assistantMemoryTitleWrapStyle: CSSProperties = {
+  display: "grid",
+  flex: "1 1 220px",
+  gap: 3,
+  minWidth: 0,
+};
+
+const assistantMemoryTitleStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 13,
+  lineHeight: 1.35,
+  margin: 0,
+  overflowWrap: "anywhere",
+};
+
+const assistantMemoryReasonStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontSize: 12,
+  lineHeight: 1.4,
+  overflowWrap: "anywhere",
+};
+
+const assistantMemoryBodyStyle: CSSProperties = {
+  background: "var(--bg0)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--t1)",
+  fontSize: 12,
+  lineHeight: 1.45,
+  margin: 0,
+  minWidth: 0,
+  overflowWrap: "anywhere",
+  padding: "8px 9px",
+};
+
+const assistantMemoryQuoteStyle: CSSProperties = {
+  margin: 0,
+  whiteSpace: "pre-wrap",
+};
+
+const assistantMemoryCaptionStyle: CSSProperties = {
+  color: "var(--t3)",
+  fontSize: 11,
+  marginTop: 6,
+};
+
+const assistantMemoryMetaGridStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 140px), 1fr))",
+  minWidth: 0,
+};
+
+const assistantMemoryMetaStyle: CSSProperties = {
+  background: "var(--bg0)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 3,
+  minWidth: 0,
+  padding: "7px 8px",
+};
+
+const assistantMemoryMetaValueStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 12,
+  minWidth: 0,
+  overflowWrap: "anywhere",
+};
+
+const assistantMemoryEvidenceStyle: CSSProperties = {
+  display: "grid",
+  gap: 5,
+  minWidth: 0,
+};
+
+const assistantMemoryEvidenceListStyle: CSSProperties = {
+  color: "var(--t2)",
+  display: "grid",
+  gap: 3,
+  listStyle: "none",
+  margin: 0,
+  minWidth: 0,
+  padding: 0,
+};
+
+const assistantMemoryEvidenceItemStyle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  minWidth: 0,
+  overflowWrap: "anywhere",
+};
+
+const assistantMemorySafetyStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontSize: 12,
+  lineHeight: 1.45,
+};
+
+const assistantTechnicalDetailsStyle: CSSProperties = {
+  borderTop: "1px solid var(--border)",
+  display: "grid",
+  gap: 8,
+  minWidth: 0,
+  paddingTop: 8,
+};
+
+const assistantTechnicalSummaryStyle: CSSProperties = {
+  color: "var(--t2)",
+  cursor: "pointer",
+  fontSize: 12,
+  fontWeight: 600,
+  lineHeight: 1.4,
+  listStylePosition: "inside",
 };
 
 const assistantProposalActionsStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -3785,7 +3785,7 @@ describe("ProjectsView cockpit", () => {
 
     const assistant = await openProjectAssistant();
     await user.click(within(assistant).getByRole("button", { name: "Draft proposal" }));
-    await within(assistant).findByText("Create memory candidate");
+    await within(assistant).findByRole("article", { name: "Memory suggestion Decision" });
     await user.click(within(assistant).getByRole("button", { name: "Apply proposal" }));
 
     expect(


### PR DESCRIPTION
## Summary
- render Project Assistant memory suggestions as operator-facing review cards instead of raw target/patch payloads
- keep payload fields available behind a collapsed details disclosure
- cover the guided-start memory suggestion card at desktop and narrow widths

## Review
- Fast contract review: CLEAN
- Visual review: CLEAN after source/evidence wrapping check

## Verification
- bun run test -- ProjectAssistantPanel.test.tsx
- bun run test -- ProjectsView.test.tsx
- bun run test
- bun run test:e2e -- e2e/projects.spec.ts -g "Projects guided start stays on Overview at desktop and narrow widths"
- bun run typecheck
- bun run lint
- bun run format:check
- git diff --check