### PR TITLE
fix(ui): hide local-only plugins remotely

### DIFF
--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getPlugins } from "../../lib/api";
+import { ApiError, getPlugins } from "../../lib/api";
 import { ConnectionsPanel } from "../connections/ConnectionsPanel";
 import { SettingsView } from "./SettingsView";
 import {
@@ -146,6 +146,44 @@ describe("SettingsView", () => {
       screen.getByText(/MCP github · stdio: npx -y @modelcontextprotocol\/server-github/i),
     ).toBeTruthy();
     expect(screen.getByText(/Unresolved auth: github_token/i)).toBeTruthy();
+  });
+
+  it("does not probe local-only plugin registry in remote runtime mode", async () => {
+    const { state, actions } = setup({
+      sessionInfo: {
+        role: "operator",
+        remote_identity: {
+          actor_id: "actor_1",
+          org_id: "org_1",
+          project_id: "proj_1",
+          runtime_id: "rt_1",
+        },
+      },
+    });
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
+
+    expect(
+      screen.getByText(/Plugin registry inspection is available only from a local Hecate runtime/i),
+    ).toBeTruthy();
+    await waitFor(() => expect(getPlugins).not.toHaveBeenCalled());
+    expect(screen.queryByText(/The request was blocked/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /Refresh/i })).toBeNull();
+  });
+
+  it("treats a forbidden plugin registry probe as local-only", async () => {
+    vi.mocked(getPlugins).mockRejectedValueOnce(
+      new ApiError("The request was blocked.", 403, "forbidden"),
+    );
+    const { state, actions } = setup();
+    render(withRuntimeConsole(<SettingsView />, { state, actions }));
+
+    expect(
+      await screen.findByText(
+        /Plugin registry inspection is available only from a local Hecate runtime/i,
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/The request was blocked/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /Refresh/i })).toBeNull();
   });
 
   it("shows desktop cloud connection controls inside the native app", async () => {

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRetention, type RetentionState } from "../../app/state/retention";
 import { useRetentionActions } from "../../app/state/coordinators/retention";
+import { useRuntime } from "../../app/state/runtime";
 import { useSettings } from "../../app/state/settings";
 import {
   canUseDesktopCloudConnection,
@@ -9,7 +10,8 @@ import {
   stopDesktopCloudConnection,
   type DesktopCloudConnectionStatus,
 } from "../../lib/cloud-connection";
-import { getPlugins } from "../../lib/api";
+import { ApiError, getPlugins } from "../../lib/api";
+import { isRemoteRuntimeSession } from "../../lib/runtime-utils";
 import type { PluginRecord } from "../../types/plugin";
 import { Badge, Icon, Icons, InlineError } from "../shared/ui";
 import { SettingsSectionHeader as SectionHeader } from "./SettingsSectionHeader";
@@ -19,12 +21,15 @@ export function SettingsView() {
   // useRetentionActions takes setNotice — the same setter the
   // shim used to wire success/failure banner toggles through.
   const settings = useSettings();
+  const runtime = useRuntime();
   const { runRetention } = useRetentionActions({ setNotice: settings.actions.setNotice });
   const loadRetentionRuns = retention.actions.loadRuns;
   const storageBackend = settings.state.config?.backend ?? "memory";
+  const remoteRuntime = isRemoteRuntimeSession(runtime.state.sessionInfo);
   const [plugins, setPlugins] = useState<PluginRecord[]>([]);
   const [pluginsLoading, setPluginsLoading] = useState(false);
   const [pluginsError, setPluginsError] = useState("");
+  const [pluginsLocalOnly, setPluginsLocalOnly] = useState(false);
   // Retention runs aren't in the boot-time dashboard snapshot —
   // fetch on first SettingsView mount so the user doesn't see a
   // permanently empty list. `loadRuns` is a stable useCallback, so
@@ -38,16 +43,30 @@ export function SettingsView() {
   }, [loadRetentionRuns]);
 
   useEffect(() => {
+    if (remoteRuntime) {
+      setPlugins([]);
+      setPluginsError("");
+      setPluginsLoading(false);
+      setPluginsLocalOnly(false);
+      return;
+    }
     void loadPlugins();
-  }, []);
+  }, [remoteRuntime]);
 
   async function loadPlugins() {
     setPluginsLoading(true);
     setPluginsError("");
+    setPluginsLocalOnly(false);
     try {
       const response = await getPlugins();
       setPlugins(response.data ?? []);
     } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        setPlugins([]);
+        setPluginsLocalOnly(true);
+        setPluginsError("");
+        return;
+      }
       const message = err instanceof Error ? err.message : "Failed to load plugins.";
       setPluginsError(message);
     } finally {
@@ -63,6 +82,7 @@ export function SettingsView() {
           error={pluginsError}
           loading={pluginsLoading}
           plugins={plugins}
+          localOnly={remoteRuntime || pluginsLocalOnly}
           onRefresh={() => void loadPlugins()}
         />
         <RetentionSettings
@@ -380,11 +400,13 @@ function PluginRegistrySettings({
   loading,
   onRefresh,
   plugins,
+  localOnly,
 }: {
   error: string;
   loading: boolean;
   onRefresh: () => void;
   plugins: PluginRecord[];
+  localOnly: boolean;
 }) {
   const capabilityCount = plugins.reduce(
     (sum, plugin) => sum + (plugin.capabilities?.length ?? 0),
@@ -395,15 +417,26 @@ function PluginRegistrySettings({
       <SectionHeader
         title="Plugins"
         description="Installed plugin manifests and requested capabilities. Registry entries do not run code or mount tools yet."
-        meta={`${plugins.length} plugin${plugins.length === 1 ? "" : "s"} · ${capabilityCount} cap${capabilityCount === 1 ? "" : "s"}`}
+        meta={
+          localOnly
+            ? "local-only"
+            : `${plugins.length} plugin${plugins.length === 1 ? "" : "s"} · ${capabilityCount} cap${capabilityCount === 1 ? "" : "s"}`
+        }
         actions={
-          <button className="btn btn-ghost btn-sm" disabled={loading} onClick={onRefresh}>
-            <Icon d={Icons.refresh} size={13} /> {loading ? "Loading…" : "Refresh"}
-          </button>
+          localOnly ? null : (
+            <button className="btn btn-ghost btn-sm" disabled={loading} onClick={onRefresh}>
+              <Icon d={Icons.refresh} size={13} /> {loading ? "Loading…" : "Refresh"}
+            </button>
+          )
         }
       />
+      {localOnly && (
+        <div className="card" style={{ padding: "14px 16px", color: "var(--t3)", fontSize: 12 }}>
+          Plugin registry inspection is available only from a local Hecate runtime.
+        </div>
+      )}
       {error && <InlineError message={error} />}
-      {!error && plugins.length === 0 && !loading && (
+      {!localOnly && !error && plugins.length === 0 && !loading && (
         <div className="card" style={{ padding: "14px 16px", color: "var(--t3)", fontSize: 12 }}>
           No plugins installed.
         </div>


### PR DESCRIPTION
## Summary
- skip the local-only plugin registry request when Hecate is opened through a remote runtime
- render a clear local-only Plugins state instead of surfacing the generic blocked-request error
- treat a 403 plugin registry response as the same local-only state for defensive compatibility

## Verification
- cd ui && bun run test SettingsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run build