### PR TITLE
fix(projects): polish memory suggestion review

### DIFF
--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -103,11 +103,14 @@ test("Projects journey: setup, first work, assignment, evidence, closeout", asyn
   });
   await expect(setupMemorySuggestion).toBeVisible();
   await expect(setupMemorySuggestion.getByText("Needs review")).toBeVisible();
-  await expect(setupMemorySuggestion.getByText("Why suggested")).toBeVisible();
-  await expect(setupMemorySuggestion.getByText("Evidence")).toBeVisible();
-  await expect(setupMemorySuggestion.getByText("Review and edit")).toBeVisible();
+  await expect(setupMemorySuggestion.getByText("Type")).toBeVisible();
+  await expect(setupMemorySuggestion.getByText("Why Hecate suggested it")).toBeVisible();
+  await expect(setupMemorySuggestion.getByText("Evidence", { exact: true })).toBeVisible();
+  await expect(setupMemorySuggestion.getByText("Review to save")).toBeVisible();
   await setupMemorySuggestion
-    .getByRole("button", { name: "Review memory suggestion Guidance source: AGENTS.md" })
+    .getByRole("button", {
+      name: "Review memory suggestion Guidance source: AGENTS.md before saving",
+    })
     .click();
   const memoryReviewDialog = page.getByRole("dialog", { name: "Review memory suggestion" });
   await expect(memoryReviewDialog).toBeVisible();

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -98,7 +98,30 @@ test("Projects journey: setup, first work, assignment, evidence, closeout", asyn
   await expect(page.getByRole("region", { name: "Project Assistant" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Set up project" })).toHaveCount(0);
   await page.getByRole("tab", { name: /Memory/ }).click();
-  await expect(page.getByText("Guidance source: AGENTS.md")).toBeVisible();
+  const setupMemorySuggestion = page.getByRole("article", {
+    name: "Memory suggestion Guidance source: AGENTS.md",
+  });
+  await expect(setupMemorySuggestion).toBeVisible();
+  await expect(setupMemorySuggestion.getByText("Needs review")).toBeVisible();
+  await expect(setupMemorySuggestion.getByText("Why suggested")).toBeVisible();
+  await expect(setupMemorySuggestion.getByText("Evidence")).toBeVisible();
+  await expect(setupMemorySuggestion.getByText("Review and edit")).toBeVisible();
+  await setupMemorySuggestion
+    .getByRole("button", { name: "Review memory suggestion Guidance source: AGENTS.md" })
+    .click();
+  const memoryReviewDialog = page.getByRole("dialog", { name: "Review memory suggestion" });
+  await expect(memoryReviewDialog).toBeVisible();
+  await expect(memoryReviewDialog.getByText("Suggested memory")).toBeVisible();
+  await expect(memoryReviewDialog.getByText("Pending promotion")).toBeVisible();
+  await expect(
+    memoryReviewDialog.getByRole("button", { name: "Save to project memory" }),
+  ).toBeVisible();
+  await page.setViewportSize({ width: 390, height: 844 });
+  expect(
+    await memoryReviewDialog.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+  ).toBe(true);
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await memoryReviewDialog.getByRole("button", { name: "Close" }).click();
   await page
     .getByRole("button", { name: "Dismiss memory suggestion Guidance source: AGENTS.md" })
     .click();

--- a/ui/src/features/projects/ProjectMemoryPanel.test.tsx
+++ b/ui/src/features/projects/ProjectMemoryPanel.test.tsx
@@ -142,11 +142,16 @@ describe("ProjectMemoryPanel", () => {
     });
     expect(within(suggestion).getAllByText("Generated summary").length).toBeGreaterThan(0);
     expect(within(suggestion).getByText("Needs review")).toBeTruthy();
-    expect(within(suggestion).getByText("Why suggested")).toBeTruthy();
+    expect(within(suggestion).getByText("Suggested memory")).toBeTruthy();
+    expect(within(suggestion).getByText("Type")).toBeTruthy();
+    expect(within(suggestion).getByText("Why Hecate suggested it")).toBeTruthy();
     expect(within(suggestion).getByText("Evidence")).toBeTruthy();
-    expect(within(suggestion).getByText("Review and edit")).toBeTruthy();
+    expect(within(suggestion).getByText("Found in task_run Implementation run")).toBeTruthy();
+    expect(within(suggestion).getByText("Review to save")).toBeTruthy();
 
-    await userEvent.click(within(suggestion).getByText("Source details", { selector: "summary" }));
+    await userEvent.click(
+      within(suggestion).getByText("Evidence and payload details", { selector: "summary" }),
+    );
     expect(screen.getByText("Source refs: task_run Implementation run")).toBeTruthy();
 
     await userEvent.click(screen.getByRole("button", { name: "Refresh project memory" }));
@@ -162,7 +167,9 @@ describe("ProjectMemoryPanel", () => {
     await userEvent.click(screen.getByRole("button", { name: "Edit memory Commit style" }));
     await userEvent.click(screen.getByRole("button", { name: "Delete memory Commit style" }));
     await userEvent.click(
-      screen.getByRole("button", { name: "Review memory suggestion Generated summary" }),
+      screen.getByRole("button", {
+        name: "Review memory suggestion Generated summary before saving",
+      }),
     );
     await userEvent.click(
       screen.getByRole("button", { name: "Dismiss memory suggestion Generated summary" }),
@@ -298,9 +305,18 @@ describe("ProjectMemoryPanel", () => {
 
     const dialog = screen.getByRole("dialog", { name: "Review memory suggestion" });
     expect(within(dialog).getByText("Suggested memory")).toBeTruthy();
+    expect(within(dialog).getByText("Needs review")).toBeTruthy();
+    expect(
+      within(dialog).getByText(
+        "Hecate found this in task_run Implementation run. Save it only if it should become durable project guidance; edit the title or body first if the wording is too broad.",
+      ),
+    ).toBeTruthy();
     expect(within(dialog).getByText("Pending promotion")).toBeTruthy();
     expect(within(dialog).getByText("Evidence")).toBeTruthy();
-    await userEvent.click(within(dialog).getByText("Source details", { selector: "summary" }));
+    expect(within(dialog).getByText("Why Hecate suggested it")).toBeTruthy();
+    await userEvent.click(
+      within(dialog).getByText("Evidence and payload details", { selector: "summary" }),
+    );
     expect(within(dialog).getByText("Source refs: task_run Implementation run")).toBeTruthy();
     await userEvent.click(screen.getByText("Advanced memory details", { selector: "summary" }));
     fireEvent.change(screen.getByLabelText("Trust label"), {
@@ -395,7 +411,9 @@ describe("ProjectMemoryPanel", () => {
 
     expect(screen.getByRole("button", { name: "Review first suggestion" })).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: "Review memory suggestion Generated summary" }),
+      screen.getByRole("button", {
+        name: "Review memory suggestion Generated summary before saving",
+      }),
     ).toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Dismiss memory suggestion Generated summary" }),

--- a/ui/src/features/projects/ProjectMemoryPanel.test.tsx
+++ b/ui/src/features/projects/ProjectMemoryPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -137,9 +137,16 @@ describe("ProjectMemoryPanel", () => {
     expect(screen.getByText("1 saved · 1 enabled · 1 to review · 1 source enabled")).toBeTruthy();
     expect(screen.getAllByText("AGENTS.md").length).toBeGreaterThan(0);
     expect(screen.getByText("Commit style")).toBeTruthy();
-    expect(screen.getByText("Generated summary")).toBeTruthy();
+    const suggestion = screen.getByRole("article", {
+      name: "Memory suggestion Generated summary",
+    });
+    expect(within(suggestion).getAllByText("Generated summary").length).toBeGreaterThan(0);
+    expect(within(suggestion).getByText("Needs review")).toBeTruthy();
+    expect(within(suggestion).getByText("Why suggested")).toBeTruthy();
+    expect(within(suggestion).getByText("Evidence")).toBeTruthy();
+    expect(within(suggestion).getByText("Review and edit")).toBeTruthy();
 
-    await userEvent.click(screen.getByText("Suggestion source", { selector: "summary" }));
+    await userEvent.click(within(suggestion).getByText("Source details", { selector: "summary" }));
     expect(screen.getByText("Source refs: task_run Implementation run")).toBeTruthy();
 
     await userEvent.click(screen.getByRole("button", { name: "Refresh project memory" }));
@@ -289,13 +296,17 @@ describe("ProjectMemoryPanel", () => {
       />,
     );
 
-    expect(screen.getByText("Suggestion source", { selector: "div" })).toBeTruthy();
-    expect(screen.getByText("Source refs: task_run Implementation run")).toBeTruthy();
+    const dialog = screen.getByRole("dialog", { name: "Review memory suggestion" });
+    expect(within(dialog).getByText("Suggested memory")).toBeTruthy();
+    expect(within(dialog).getByText("Pending promotion")).toBeTruthy();
+    expect(within(dialog).getByText("Evidence")).toBeTruthy();
+    await userEvent.click(within(dialog).getByText("Source details", { selector: "summary" }));
+    expect(within(dialog).getByText("Source refs: task_run Implementation run")).toBeTruthy();
     await userEvent.click(screen.getByText("Advanced memory details", { selector: "summary" }));
     fireEvent.change(screen.getByLabelText("Trust label"), {
       target: { value: "operator_memory" },
     });
-    await userEvent.click(screen.getByRole("button", { name: "Save to memory" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save to project memory" }));
 
     expect(onSave).toHaveBeenCalledWith({
       title: "Generated summary",
@@ -382,7 +393,7 @@ describe("ProjectMemoryPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Review suggestion" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Review first suggestion" })).toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Review memory suggestion Generated summary" }),
     ).toBeDisabled();
@@ -417,7 +428,11 @@ describe("ProjectMemoryPanel", () => {
     expect(screen.queryByRole("heading", { name: "Suggestions to review" })).toBeNull();
     expect(screen.getByText("1 saved · 1 enabled · 0 to review · 1 source enabled")).toBeTruthy();
     await userEvent.click(screen.getByText("Reviewed suggestions", { selector: "span" }));
-    expect(screen.getByText("Generated summary")).toBeTruthy();
+    expect(
+      within(
+        screen.getByRole("article", { name: "Memory suggestion Generated summary" }),
+      ).getAllByText("Generated summary").length,
+    ).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /Review memory suggestion/ })).toBeNull();
   });
 });

--- a/ui/src/features/projects/ProjectMemoryPanel.tsx
+++ b/ui/src/features/projects/ProjectMemoryPanel.tsx
@@ -476,6 +476,9 @@ export function ProjectMemoryModal({
   const valid = form.title.trim().length > 0 && form.body.trim().length > 0;
   const isCandidate = Boolean(candidate);
   const candidateSourceRefs = candidate ? formatCandidateSourceRefs(candidate) : [];
+  const candidateEvidence = candidate
+    ? (candidateSourceRefs[0] ?? formatCandidateSource(candidate))
+    : "";
   return (
     <Modal
       title={
@@ -520,14 +523,17 @@ export function ProjectMemoryModal({
         <fieldset disabled={pending} style={modalFieldsetStyle}>
           {candidate && (
             <div style={candidateReviewCardStyle}>
-              <div style={sectionLabelStyle}>Suggested memory</div>
+              <div style={candidateReviewHeaderStyle}>
+                <div style={sectionLabelStyle}>Suggested memory</div>
+                <span className="badge badge-amber">Needs review</span>
+              </div>
               <div style={candidateReviewSummaryStyle}>
-                Edit anything below before saving. This stays out of durable project memory until
-                you confirm it.
+                Hecate found this in {candidateEvidence}. Save it only if it should become durable
+                project guidance; edit the title or body first if the wording is too broad.
               </div>
               <div style={candidateDecisionGridStyle}>
                 <ProjectMemoryCandidateFact
-                  label="Why suggested"
+                  label="Type"
                   value={
                     candidate.suggested_kind
                       ? humanMemoryLabel(candidate.suggested_kind)
@@ -535,17 +541,18 @@ export function ProjectMemoryModal({
                   }
                 />
                 <ProjectMemoryCandidateFact
-                  label="Evidence"
-                  value={candidateSourceRefs[0] ?? formatCandidateSource(candidate)}
+                  label="Why Hecate suggested it"
+                  value={formatCandidateWhy(candidate, candidateSourceRefs)}
                 />
+                <ProjectMemoryCandidateFact label="Evidence" value={candidateEvidence} />
                 <ProjectMemoryCandidateFact
                   label="Trust"
                   value={humanMemoryLabel(candidate.suggested_trust_label)}
                 />
-                <ProjectMemoryCandidateFact label="Review path" value="Pending promotion" />
+                <ProjectMemoryCandidateFact label="Status" value="Pending promotion" />
               </div>
               <details className="project-work-advanced-fields">
-                <summary>Source details</summary>
+                <summary>Evidence and payload details</summary>
                 <div style={{ ...rowDetailsBodyStyle, paddingTop: 8 }}>
                   <div style={metaLineStyle}>
                     <span>{formatCandidateSource(candidate)}</span>
@@ -802,14 +809,23 @@ function ProjectMemoryCandidateRow({
     ? humanMemoryLabel(candidate.suggested_kind)
     : "Project note";
   const trustLabel = humanMemoryLabel(candidate.suggested_trust_label);
+  const whyLabel = formatCandidateWhy(candidate, sourceRefs);
   return (
     <article aria-label={`Memory suggestion ${candidate.title}`} style={memoryEntryStyle}>
       <div className="project-support-row-header" style={rowHeaderStyle}>
         <div
-          style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 8, minWidth: 0 }}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            flex: "1 1 220px",
+            flexWrap: "wrap",
+            gap: 8,
+            minWidth: 0,
+          }}
         >
+          <span className="badge badge-muted">Suggested memory</span>
           <span className={pending ? "badge badge-amber" : "badge badge-muted"}>
-            {pending ? "Needs review" : candidate.status}
+            {pending ? "Needs review" : humanMemoryLabel(candidate.status)}
           </span>
           <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>{candidate.title}</div>
         </div>
@@ -818,12 +834,12 @@ function ProjectMemoryCandidateRow({
             <button
               className="btn btn-primary btn-sm"
               type="button"
-              aria-label={`Review memory suggestion ${candidate.title}`}
+              aria-label={`Review memory suggestion ${candidate.title} before saving`}
               disabled={pendingReject}
               onClick={onPromote}
             >
               <Icon d={Icons.check} size={12} />
-              Review and edit
+              Review to save
             </button>
             <button
               className="btn btn-ghost btn-sm"
@@ -844,16 +860,17 @@ function ProjectMemoryCandidateRow({
         style={candidateDecisionGridStyle}
         aria-label={`Memory suggestion summary ${candidate.title}`}
       >
-        <ProjectMemoryCandidateFact label="Why suggested" value={kindLabel} />
+        <ProjectMemoryCandidateFact label="Type" value={kindLabel} />
+        <ProjectMemoryCandidateFact label="Why Hecate suggested it" value={whyLabel} />
         <ProjectMemoryCandidateFact label="Evidence" value={evidenceLabel} />
         <ProjectMemoryCandidateFact label="Trust" value={trustLabel} />
         <ProjectMemoryCandidateFact
-          label="Review path"
-          value={pending ? "Save, edit first, or dismiss" : candidate.status}
+          label="Status"
+          value={pending ? "Pending promotion" : humanMemoryLabel(candidate.status)}
         />
       </div>
       <details className="project-support-details" style={rowDetailsStyle}>
-        <summary>Source details</summary>
+        <summary>Evidence and payload details</summary>
         <div style={rowDetailsBodyStyle}>
           <div style={metaLineStyle}>
             <span>{candidate.suggested_trust_label}</span>
@@ -932,6 +949,16 @@ function formatCandidateSourceRefs(candidate: ProjectMemoryCandidateRecord): str
     .filter(Boolean);
 }
 
+function formatCandidateWhy(
+  candidate: ProjectMemoryCandidateRecord,
+  sourceRefs: string[] = formatCandidateSourceRefs(candidate),
+): string {
+  if (sourceRefs.length > 0) return `Found in ${sourceRefs[0]}`;
+  const source = formatCandidateSource(candidate);
+  if (source && source !== "generated") return `Found in ${source}`;
+  return "Suggested by Project Assistant";
+}
+
 function humanMemoryLabel(value?: string): string {
   if (!value) return "not set";
   return value
@@ -979,6 +1006,14 @@ const candidateReviewCardStyle: CSSProperties = {
   gap: 8,
   minWidth: 0,
   padding: "9px 10px",
+};
+
+const candidateReviewHeaderStyle: CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  gap: 8,
+  justifyContent: "space-between",
+  minWidth: 0,
 };
 
 const candidateReviewSummaryStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectMemoryPanel.tsx
+++ b/ui/src/features/projects/ProjectMemoryPanel.tsx
@@ -126,7 +126,7 @@ export function ProjectMemoryPanel({
             }
           >
             <Icon d={firstPendingCandidate ? Icons.check : Icons.plus} size={12} />
-            {firstPendingCandidate ? "Review suggestion" : "Add memory"}
+            {firstPendingCandidate ? "Review first suggestion" : "Add memory"}
           </button>
         </div>
       </header>
@@ -501,7 +501,7 @@ export function ProjectMemoryModal({
           {pending
             ? "Saving…"
             : isCandidate
-              ? "Save to memory"
+              ? "Save to project memory"
               : entry
                 ? "Save memory"
                 : "Create memory"}
@@ -519,27 +519,46 @@ export function ProjectMemoryModal({
         {error && <InlineError message={error} />}
         <fieldset disabled={pending} style={modalFieldsetStyle}>
           {candidate && (
-            <div
-              style={{
-                background: "var(--bg2)",
-                border: "1px solid var(--border)",
-                borderRadius: "var(--radius-sm)",
-                display: "grid",
-                gap: 6,
-                padding: "9px 10px",
-              }}
-            >
-              <div style={sectionLabelStyle}>Suggestion source</div>
-              <div style={metaLineStyle}>
-                <span>{formatCandidateSource(candidate)}</span>
-                <span>{candidate.suggested_trust_label}</span>
-                <span>{candidate.status}</span>
+            <div style={candidateReviewCardStyle}>
+              <div style={sectionLabelStyle}>Suggested memory</div>
+              <div style={candidateReviewSummaryStyle}>
+                Edit anything below before saving. This stays out of durable project memory until
+                you confirm it.
               </div>
-              {candidateSourceRefs.length > 0 && (
-                <div style={{ ...subtleTextStyle }}>
-                  Source refs: {candidateSourceRefs.join(" · ")}
+              <div style={candidateDecisionGridStyle}>
+                <ProjectMemoryCandidateFact
+                  label="Why suggested"
+                  value={
+                    candidate.suggested_kind
+                      ? humanMemoryLabel(candidate.suggested_kind)
+                      : "Project note"
+                  }
+                />
+                <ProjectMemoryCandidateFact
+                  label="Evidence"
+                  value={candidateSourceRefs[0] ?? formatCandidateSource(candidate)}
+                />
+                <ProjectMemoryCandidateFact
+                  label="Trust"
+                  value={humanMemoryLabel(candidate.suggested_trust_label)}
+                />
+                <ProjectMemoryCandidateFact label="Review path" value="Pending promotion" />
+              </div>
+              <details className="project-work-advanced-fields">
+                <summary>Source details</summary>
+                <div style={{ ...rowDetailsBodyStyle, paddingTop: 8 }}>
+                  <div style={metaLineStyle}>
+                    <span>{formatCandidateSource(candidate)}</span>
+                    <span>{candidate.suggested_trust_label}</span>
+                    <span>{candidate.status}</span>
+                  </div>
+                  {candidateSourceRefs.length > 0 && (
+                    <div style={{ ...subtleTextStyle, overflowWrap: "anywhere" }}>
+                      Source refs: {candidateSourceRefs.join(" · ")}
+                    </div>
+                  )}
                 </div>
-              )}
+              </details>
             </div>
           )}
           <label style={fieldStyle}>
@@ -778,6 +797,11 @@ function ProjectMemoryCandidateRow({
   const source = formatCandidateSource(candidate);
   const sourceRefs = formatCandidateSourceRefs(candidate);
   const pending = candidate.status === "pending";
+  const evidenceLabel = sourceRefs[0] ?? source;
+  const kindLabel = candidate.suggested_kind
+    ? humanMemoryLabel(candidate.suggested_kind)
+    : "Project note";
+  const trustLabel = humanMemoryLabel(candidate.suggested_trust_label);
   return (
     <article aria-label={`Memory suggestion ${candidate.title}`} style={memoryEntryStyle}>
       <div className="project-support-row-header" style={rowHeaderStyle}>
@@ -785,21 +809,21 @@ function ProjectMemoryCandidateRow({
           style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 8, minWidth: 0 }}
         >
           <span className={pending ? "badge badge-amber" : "badge badge-muted"}>
-            {candidate.status}
+            {pending ? "Needs review" : candidate.status}
           </span>
           <div style={{ ...titleStyle, flex: 1, minWidth: 0 }}>{candidate.title}</div>
         </div>
         {pending && (
           <div style={rowActionStyle}>
             <button
-              className="btn btn-ghost btn-sm"
+              className="btn btn-primary btn-sm"
               type="button"
               aria-label={`Review memory suggestion ${candidate.title}`}
               disabled={pendingReject}
               onClick={onPromote}
             >
               <Icon d={Icons.check} size={12} />
-              Review
+              Review and edit
             </button>
             <button
               className="btn btn-ghost btn-sm"
@@ -816,8 +840,20 @@ function ProjectMemoryCandidateRow({
         )}
       </div>
       <div style={memoryBodyStyle}>{candidate.body}</div>
+      <div
+        style={candidateDecisionGridStyle}
+        aria-label={`Memory suggestion summary ${candidate.title}`}
+      >
+        <ProjectMemoryCandidateFact label="Why suggested" value={kindLabel} />
+        <ProjectMemoryCandidateFact label="Evidence" value={evidenceLabel} />
+        <ProjectMemoryCandidateFact label="Trust" value={trustLabel} />
+        <ProjectMemoryCandidateFact
+          label="Review path"
+          value={pending ? "Save, edit first, or dismiss" : candidate.status}
+        />
+      </div>
       <details className="project-support-details" style={rowDetailsStyle}>
-        <summary>Suggestion source</summary>
+        <summary>Source details</summary>
         <div style={rowDetailsBodyStyle}>
           <div style={metaLineStyle}>
             <span>{candidate.suggested_trust_label}</span>
@@ -826,11 +862,22 @@ function ProjectMemoryCandidateRow({
             <CopyableID text={candidate.id} compact />
           </div>
           {sourceRefs.length > 0 && (
-            <div style={subtleTextStyle}>Source refs: {sourceRefs.join(" · ")}</div>
+            <div style={{ ...subtleTextStyle, overflowWrap: "anywhere" }}>
+              Source refs: {sourceRefs.join(" · ")}
+            </div>
           )}
         </div>
       </details>
     </article>
+  );
+}
+
+function ProjectMemoryCandidateFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={candidateFactStyle}>
+      <span style={fieldLabelStyle}>{label}</span>
+      <span style={candidateFactValueStyle}>{value || "not set"}</span>
+    </div>
   );
 }
 
@@ -885,6 +932,15 @@ function formatCandidateSourceRefs(candidate: ProjectMemoryCandidateRecord): str
     .filter(Boolean);
 }
 
+function humanMemoryLabel(value?: string): string {
+  if (!value) return "not set";
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^\w/, (letter) => letter.toUpperCase());
+}
+
 const sectionLabelStyle: CSSProperties = {
   fontFamily: "var(--font-mono)",
   fontSize: 10,
@@ -913,6 +969,47 @@ const metaLineStyle: CSSProperties = {
   color: "var(--t3)",
   fontSize: 11,
   marginTop: 6,
+};
+
+const candidateReviewCardStyle: CSSProperties = {
+  background: "var(--bg2)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 8,
+  minWidth: 0,
+  padding: "9px 10px",
+};
+
+const candidateReviewSummaryStyle: CSSProperties = {
+  color: "var(--t2)",
+  fontSize: 12,
+  lineHeight: 1.45,
+};
+
+const candidateDecisionGridStyle: CSSProperties = {
+  display: "grid",
+  gap: 6,
+  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 140px), 1fr))",
+  marginTop: 8,
+  minWidth: 0,
+};
+
+const candidateFactStyle: CSSProperties = {
+  background: "var(--bg2)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius-sm)",
+  display: "grid",
+  gap: 3,
+  minWidth: 0,
+  padding: "7px 8px",
+};
+
+const candidateFactValueStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 12,
+  minWidth: 0,
+  overflowWrap: "anywhere",
 };
 
 const fieldStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4109,21 +4109,24 @@ describe("ProjectsView cockpit", () => {
       name: "Memory suggestion Temporary note",
     });
     expect(
-      within(rejectedSuggestion).getAllByText("rejected", { exact: true }).length,
+      within(rejectedSuggestion).getAllByText("Rejected", { exact: true }).length,
     ).toBeGreaterThan(0);
     expect(
       within(rejectedSuggestion).queryByRole("button", {
-        name: "Review memory suggestion Temporary note",
+        name: "Review memory suggestion Temporary note before saving",
       }),
     ).toBeNull();
 
     await user.click(
       screen.getByRole("button", {
-        name: "Review memory suggestion Generated summary",
+        name: "Review memory suggestion Generated summary before saving",
       }),
     );
-    expect(screen.getByRole("button", { name: "Save to project memory" })).toBeTruthy();
-    expect(screen.getByText("Suggested memory")).toBeTruthy();
+    const reviewDialog = screen.getByRole("dialog", { name: "Review memory suggestion" });
+    expect(
+      within(reviewDialog).getByRole("button", { name: "Save to project memory" }),
+    ).toBeTruthy();
+    expect(within(reviewDialog).getByText("Suggested memory")).toBeTruthy();
     expect(screen.getAllByText(/Source refs: task_run Implementation run/).length).toBeGreaterThan(
       0,
     );
@@ -7815,7 +7818,7 @@ describe("ProjectsView cockpit", () => {
     expect(within(health).getByText("Memory candidate pending review")).toBeTruthy();
     expect(
       screen.queryByRole("button", {
-        name: "Review memory suggestion Promoted convention",
+        name: "Review memory suggestion Promoted convention before saving",
       }),
     ).toBeNull();
     expect(

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -4087,7 +4087,9 @@ describe("ProjectsView cockpit", () => {
     );
 
     await openProjectWorkspaceTab(/Memory/);
-    expect(await screen.findByText("Generated summary")).toBeTruthy();
+    expect(
+      await screen.findByRole("article", { name: "Memory suggestion Generated summary" }),
+    ).toBeTruthy();
     expect(screen.getByText("Temporary note")).toBeTruthy();
     expect(screen.getAllByText("generated_summary").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Source refs: task_run Implementation run/).length).toBeGreaterThan(
@@ -4106,7 +4108,9 @@ describe("ProjectsView cockpit", () => {
     const rejectedSuggestion = screen.getByRole("article", {
       name: "Memory suggestion Temporary note",
     });
-    expect(within(rejectedSuggestion).getByText("rejected", { exact: true })).toBeTruthy();
+    expect(
+      within(rejectedSuggestion).getAllByText("rejected", { exact: true }).length,
+    ).toBeGreaterThan(0);
     expect(
       within(rejectedSuggestion).queryByRole("button", {
         name: "Review memory suggestion Temporary note",
@@ -4118,8 +4122,8 @@ describe("ProjectsView cockpit", () => {
         name: "Review memory suggestion Generated summary",
       }),
     );
-    expect(screen.getByRole("button", { name: "Save to memory" })).toBeTruthy();
-    expect(screen.getByText("Suggestion source", { selector: "div" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save to project memory" })).toBeTruthy();
+    expect(screen.getByText("Suggested memory")).toBeTruthy();
     expect(screen.getAllByText(/Source refs: task_run Implementation run/).length).toBeGreaterThan(
       0,
     );
@@ -4130,7 +4134,7 @@ describe("ProjectsView cockpit", () => {
     fireEvent.change(screen.getByLabelText("Source kind"), {
       target: { value: "operator" },
     });
-    await user.click(screen.getByRole("button", { name: "Save to memory" }));
+    await user.click(screen.getByRole("button", { name: "Save to project memory" }));
 
     expect(promoteProjectMemoryCandidate).toHaveBeenCalledWith(project.id, memoryCandidate.id, {
       title: "Generated summary",
@@ -7836,7 +7840,7 @@ describe("ProjectsView cockpit", () => {
         name: "Review memory candidate: Memory candidate pending review",
       }),
     );
-    expect(screen.getByRole("button", { name: "Save to memory" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save to project memory" })).toBeTruthy();
   });
 
   it("uses activity inbox tabs to focus activity buckets", async () => {


### PR DESCRIPTION
## Summary
- reframe pending project memory candidates as reviewable memory suggestions with clear status, evidence, trust, and next-step metadata
- make the review modal explain that suggestions remain out of durable project memory until confirmed
- keep raw/source provenance behind collapsed Source details and add narrow-width wrapping coverage

## Verification
- cd ui && bun run test -- ProjectMemoryPanel.test.tsx ProjectsView.test.tsx
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- cd ui && bun run test:e2e -- projects.spec.ts