### PR TITLE
fix(projects): clarify setup detail disclosures

### DIFF
--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -334,16 +334,16 @@ test("Projects guided start stays on Overview at desktop and narrow widths", asy
   ).toBeVisible();
   await expect(memorySuggestion.getByText("Workspace guidance").first()).toBeVisible();
   await expect(memorySuggestion.getByText("Pending promotion")).toBeVisible();
-  await expect(memorySuggestion.getByText("Show payload details")).toBeVisible();
+  await expect(memorySuggestion.getByText("Show source and field details")).toBeVisible();
   const memoryTechnicalDetails = memorySuggestion.locator("details").filter({
-    hasText: "Show payload details",
+    hasText: "Show source and field details",
   });
   await expect(memoryTechnicalDetails).not.toHaveAttribute("open", "");
   await expect(memorySuggestion.locator("dt", { hasText: "suggested_kind" }).first()).toBeHidden();
   expect(
     await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1),
   ).toBe(true);
-  await memorySuggestion.getByText("Show payload details").click();
+  await memorySuggestion.getByText("Show source and field details").click();
   await expect(memoryTechnicalDetails).toHaveAttribute("open", "");
   await expect(memorySuggestion.locator("dt", { hasText: "suggested_kind" }).first()).toBeVisible();
   await page.setViewportSize({ width: 390, height: 844 });

--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -271,7 +271,7 @@ describe("ProjectAssistantPanel", () => {
     expect(handlers.onApply).toHaveBeenCalledTimes(1);
   });
 
-  it("summarizes memory suggestions before technical payload details", async () => {
+  it("summarizes memory suggestions before source and field details", async () => {
     const user = userEvent.setup();
     renderAssistantPanel({
       proposal: {
@@ -333,11 +333,13 @@ describe("ProjectAssistantPanel", () => {
       ),
     ).toBeTruthy();
     const technicalDetails = within(suggestion)
-      .getByText("Show payload details", { selector: "summary" })
+      .getByText("Show source and field details", { selector: "summary" })
       .closest("details");
     expect(technicalDetails).not.toHaveAttribute("open");
 
-    await user.click(within(suggestion).getByText("Show payload details", { selector: "summary" }));
+    await user.click(
+      within(suggestion).getByText("Show source and field details", { selector: "summary" }),
+    );
     expect(technicalDetails).toHaveAttribute("open");
     expect(within(suggestion).getByText("suggested_kind")).toBeTruthy();
     expect(within(suggestion).getAllByText("workspace_guidance").length).toBeGreaterThan(0);

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -825,11 +825,11 @@ function ProjectAssistantMemorySuggestionAction({
       </div>
       <figure style={assistantMemoryBodyStyle}>
         <blockquote style={assistantMemoryQuoteStyle}>
-          {bodyPreview || "No memory text supplied. Review the technical details before applying."}
+          {bodyPreview || "No memory text supplied. Review the source details before applying."}
         </blockquote>
         {body && bodyPreview !== body && (
           <figcaption style={assistantMemoryCaptionStyle}>
-            Preview only. Open technical details for the full proposed text.
+            Preview only. Open source and field details for the full proposed text.
           </figcaption>
         )}
       </figure>
@@ -857,7 +857,7 @@ function ProjectAssistantMemorySuggestionAction({
       </div>
       {(targetEntries.length > 0 || patchEntries.length > 0) && (
         <details style={assistantTechnicalDetailsStyle}>
-          <summary style={assistantTechnicalSummaryStyle}>Show payload details</summary>
+          <summary style={assistantTechnicalSummaryStyle}>Show source and field details</summary>
           <div style={assistantPatchGridStyle}>
             {targetEntries.length > 0 && (
               <ProjectAssistantFieldGroup title="Target" entries={targetEntries} />

--- a/ui/src/features/projects/ProjectSettingsPanel.test.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.test.tsx
@@ -354,12 +354,31 @@ describe("ProjectSettingsPanel", () => {
       />,
     );
 
-    expect(screen.getByText("No folders attached.")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Create worktree" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Find worktrees" })).toBeDisabled();
+    const rootlessHelp = screen.getByText(
+      "No folders attached. Add a folder before creating or finding worktrees.",
+    );
+    const createWorktreeButton = screen.getByRole("button", { name: "Create worktree" });
+    const findWorktreesButton = screen.getByRole("button", { name: "Find worktrees" });
+    expect(rootlessHelp).toBeTruthy();
+    expect(createWorktreeButton).toBeDisabled();
+    expect(createWorktreeButton).toHaveAttribute("aria-describedby", rootlessHelp.id);
+    expect(createWorktreeButton).toHaveAttribute(
+      "title",
+      "Add a folder before creating a worktree",
+    );
+    expect(findWorktreesButton).toBeDisabled();
+    expect(findWorktreesButton).toHaveAttribute("aria-describedby", rootlessHelp.id);
+    expect(findWorktreesButton).toHaveAttribute("title", "Add a folder before finding worktrees");
 
     await userEvent.click(screen.getByRole("button", { name: "Add folder" }));
     expect(await screen.findAllByText("/workspace/research")).toHaveLength(2);
+    expect(screen.queryByText("No folders attached.", { exact: false })).toBeNull();
+    expect(createWorktreeButton).toBeEnabled();
+    expect(createWorktreeButton).not.toHaveAttribute("aria-describedby");
+    expect(createWorktreeButton).not.toHaveAttribute("title");
+    expect(findWorktreesButton).toBeEnabled();
+    expect(findWorktreesButton).not.toHaveAttribute("aria-describedby");
+    expect(findWorktreesButton).not.toHaveAttribute("title");
     await userEvent.click(screen.getByRole("button", { name: "Save settings" }));
 
     expect(onSave).toHaveBeenCalledWith(

--- a/ui/src/features/projects/ProjectSettingsPanel.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.tsx
@@ -152,6 +152,8 @@ export function ProjectSettingsPanel({
   const workspace =
     selectedFormRoot?.path || projectDefaultWorkspaceFromRoots(form.roots, form.defaultRootID);
   const rootCount = form.roots.length;
+  const isRootless = rootCount === 0;
+  const rootlessWorktreeHelpID = "project-settings-rootless-worktree-help";
 
   return (
     <div
@@ -354,22 +356,35 @@ export function ProjectSettingsPanel({
                   <button
                     className="btn btn-ghost btn-sm"
                     type="button"
-                    disabled={rootCount === 0}
+                    aria-describedby={isRootless ? rootlessWorktreeHelpID : undefined}
+                    disabled={isRootless}
                     onClick={onOpenCreateWorktree}
+                    title={isRootless ? "Add a folder before creating a worktree" : undefined}
                   >
                     Create worktree
                   </button>
                   <button
                     className="btn btn-ghost btn-sm"
                     type="button"
-                    disabled={rootsPending || rootCount === 0}
+                    aria-describedby={isRootless ? rootlessWorktreeHelpID : undefined}
+                    disabled={rootsPending || isRootless}
                     onClick={() => void onDiscoverRoots()}
+                    title={
+                      isRootless
+                        ? "Add a folder before finding worktrees"
+                        : rootsPending
+                          ? "Wait for worktree discovery to finish"
+                          : undefined
+                    }
                   >
                     {rootsPending ? "Finding…" : "Find worktrees"}
                   </button>
-                  <span style={subtleTextStyle}>
-                    {rootCount === 0
-                      ? "No folders attached."
+                  <span
+                    id={isRootless ? rootlessWorktreeHelpID : undefined}
+                    style={subtleTextStyle}
+                  >
+                    {isRootless
+                      ? "No folders attached. Add a folder before creating or finding worktrees."
                       : `${rootCount} folder${rootCount === 1 ? "" : "s"}`}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- rename the Project Assistant memory-suggestion disclosure to source and field details instead of payload details
- add visible and accessible rootless guidance for disabled Settings worktree actions
- cover the copy and disabled-control behavior in focused UI tests and the Projects journey E2E

## Tests
- cd ui && bun run test -- ProjectSettingsPanel.test.tsx ProjectAssistantPanel.test.tsx
- cd ui && bun run test:e2e -- e2e/projects.spec.ts -g "Projects journey: setup, first work, assignment, evidence, closeout"
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- git diff --check