### PR TITLE
fix(projects): collapse assistant changed fields

### DIFF
--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -266,7 +266,14 @@ describe("ProjectAssistantPanel", () => {
       within(assistant).getByText("Review proposed changes", { selector: "summary" }),
     );
     expect(within(assistant).getByText("trace_setup")).toBeTruthy();
-    expect(within(assistant).getByText("Editor")).toBeTruthy();
+    const changedFields = within(assistant)
+      .getByText("Show changed fields", { selector: "summary" })
+      .closest("details");
+    expect(changedFields).not.toHaveAttribute("open");
+    expect(within(assistant).getByText("Editor")).not.toBeVisible();
+    await user.click(within(assistant).getByText("Show changed fields", { selector: "summary" }));
+    expect(changedFields).toHaveAttribute("open");
+    expect(within(assistant).getByText("Editor")).toBeVisible();
     await user.click(within(assistant).getByRole("button", { name: "Apply setup" }));
     expect(handlers.onApply).toHaveBeenCalledTimes(1);
   });

--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -249,7 +249,12 @@ describe("ProjectAssistantPanel", () => {
         summary: "Add a role and preserve guidance as a memory suggestion.",
         requires_confirmation: true,
         trace_id: "trace_setup",
-        actions: [{ kind: "create_role", patch: { name: "Editor" } }],
+        actions: [
+          {
+            kind: "create_role",
+            patch: { id: "role_editor", project_id: "proj_1", name: "Editor" },
+          },
+        ],
       },
       setupFirst: true,
     });
@@ -270,7 +275,7 @@ describe("ProjectAssistantPanel", () => {
       .getByText("Show changed fields", { selector: "summary" })
       .closest("details");
     expect(changedFields).not.toHaveAttribute("open");
-    expect(within(assistant).getByText("Name: Editor")).toBeVisible();
+    expect(within(assistant).getByText("Name: Editor · 2 more")).toBeVisible();
     expect(within(assistant).getByText("name")).not.toBeVisible();
     await user.click(within(assistant).getByText("Show changed fields", { selector: "summary" }));
     expect(changedFields).toHaveAttribute("open");

--- a/ui/src/features/projects/ProjectAssistantPanel.test.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.test.tsx
@@ -270,10 +270,11 @@ describe("ProjectAssistantPanel", () => {
       .getByText("Show changed fields", { selector: "summary" })
       .closest("details");
     expect(changedFields).not.toHaveAttribute("open");
-    expect(within(assistant).getByText("Editor")).not.toBeVisible();
+    expect(within(assistant).getByText("Name: Editor")).toBeVisible();
+    expect(within(assistant).getByText("name")).not.toBeVisible();
     await user.click(within(assistant).getByText("Show changed fields", { selector: "summary" }));
     expect(changedFields).toHaveAttribute("open");
-    expect(within(assistant).getByText("Editor")).toBeVisible();
+    expect(within(assistant).getByText("name")).toBeVisible();
     await user.click(within(assistant).getByRole("button", { name: "Apply setup" }));
     expect(handlers.onApply).toHaveBeenCalledTimes(1);
   });

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -768,20 +768,26 @@ function ProjectAssistantActionRow({
 
   const targetEntries = Object.entries(action.target ?? {});
   const patchEntries = Object.entries(action.patch ?? {});
+  const hasFieldDetails = targetEntries.length > 0 || patchEntries.length > 0;
   return (
     <div style={assistantActionStyle}>
       <div style={assistantActionHeaderStyle}>
         <span className="badge badge-muted">{projectAssistantActionLabel(action.kind)}</span>
         {action.reason && <span style={subtleTextStyle}>{action.reason}</span>}
       </div>
-      <div style={assistantPatchGridStyle}>
-        {targetEntries.length > 0 && (
-          <ProjectAssistantFieldGroup title="Target" entries={targetEntries} />
-        )}
-        {patchEntries.length > 0 && (
-          <ProjectAssistantFieldGroup title="Patch" entries={patchEntries} />
-        )}
-      </div>
+      {hasFieldDetails && (
+        <details style={assistantTechnicalDetailsStyle}>
+          <summary style={assistantTechnicalSummaryStyle}>Show changed fields</summary>
+          <div style={assistantPatchGridStyle}>
+            {targetEntries.length > 0 && (
+              <ProjectAssistantFieldGroup title="Target" entries={targetEntries} />
+            )}
+            {patchEntries.length > 0 && (
+              <ProjectAssistantFieldGroup title="Patch" entries={patchEntries} />
+            )}
+          </div>
+        </details>
+      )}
     </div>
   );
 }

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -769,12 +769,14 @@ function ProjectAssistantActionRow({
   const targetEntries = Object.entries(action.target ?? {});
   const patchEntries = Object.entries(action.patch ?? {});
   const hasFieldDetails = targetEntries.length > 0 || patchEntries.length > 0;
+  const summary = projectAssistantActionSummary(patchEntries, targetEntries);
   return (
     <div style={assistantActionStyle}>
       <div style={assistantActionHeaderStyle}>
         <span className="badge badge-muted">{projectAssistantActionLabel(action.kind)}</span>
         {action.reason && <span style={subtleTextStyle}>{action.reason}</span>}
       </div>
+      {summary && <div style={assistantActionSummaryStyle}>{summary}</div>}
       {hasFieldDetails && (
         <details style={assistantTechnicalDetailsStyle}>
           <summary style={assistantTechnicalSummaryStyle}>Show changed fields</summary>
@@ -1003,6 +1005,20 @@ function projectAssistantActionLabel(kind: string): string {
     default:
       return kind.replace(/_/g, " ");
   }
+}
+
+function projectAssistantActionSummary(
+  patchEntries: Array<[string, unknown]>,
+  targetEntries: Array<[string, unknown]>,
+): string {
+  const entries = patchEntries.length > 0 ? patchEntries : targetEntries;
+  if (entries.length === 0) return "";
+  const visibleEntries = entries.slice(0, 2);
+  const summary = visibleEntries
+    .map(([key, value]) => `${assistantHumanLabel(key)}: ${formatAssistantValue(value)}`)
+    .join(" · ");
+  const remaining = entries.length - visibleEntries.length;
+  return remaining > 0 ? `${summary} · ${remaining} more` : summary;
 }
 
 function projectAssistantFollowUpActions({
@@ -1476,6 +1492,14 @@ const assistantActionHeaderStyle: CSSProperties = {
   flexWrap: "wrap",
   gap: 8,
   minWidth: 0,
+};
+
+const assistantActionSummaryStyle: CSSProperties = {
+  color: "var(--t1)",
+  fontSize: 12,
+  lineHeight: 1.45,
+  minWidth: 0,
+  overflowWrap: "anywhere",
 };
 
 const assistantPatchGridStyle: CSSProperties = {

--- a/ui/src/features/projects/ProjectAssistantPanel.tsx
+++ b/ui/src/features/projects/ProjectAssistantPanel.tsx
@@ -1011,14 +1011,45 @@ function projectAssistantActionSummary(
   patchEntries: Array<[string, unknown]>,
   targetEntries: Array<[string, unknown]>,
 ): string {
-  const entries = patchEntries.length > 0 ? patchEntries : targetEntries;
+  const prioritizedEntries = projectAssistantPrioritizedSummaryEntries(
+    patchEntries.length > 0 ? patchEntries : targetEntries,
+  );
+  const readableEntries = prioritizedEntries.filter(
+    ([key]) => projectAssistantSummaryKeyPriority(key) < 10,
+  );
+  const entries = readableEntries.length > 0 ? readableEntries : prioritizedEntries;
   if (entries.length === 0) return "";
   const visibleEntries = entries.slice(0, 2);
   const summary = visibleEntries
     .map(([key, value]) => `${assistantHumanLabel(key)}: ${formatAssistantValue(value)}`)
     .join(" · ");
-  const remaining = entries.length - visibleEntries.length;
+  const remaining = prioritizedEntries.length - visibleEntries.length;
   return remaining > 0 ? `${summary} · ${remaining} more` : summary;
+}
+
+function projectAssistantSummaryKeyPriority(key: string): number {
+  const priority = new Map([
+    ["name", 0],
+    ["title", 1],
+    ["brief", 2],
+    ["summary", 3],
+    ["status", 4],
+    ["destination_kind", 5],
+    ["role_id", 6],
+    ["owner_role_id", 7],
+  ]);
+  return priority.get(key) ?? (key.endsWith("_id") || key === "id" ? 20 : 10);
+}
+
+function projectAssistantPrioritizedSummaryEntries(
+  entries: Array<[string, unknown]>,
+): Array<[string, unknown]> {
+  return [...entries].sort(([leftKey], [rightKey]) => {
+    const leftPriority = projectAssistantSummaryKeyPriority(leftKey);
+    const rightPriority = projectAssistantSummaryKeyPriority(rightKey);
+    if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+    return 0;
+  });
 }
 
 function projectAssistantFollowUpActions({


### PR DESCRIPTION
## Summary
- keep generic Project Assistant proposal actions focused on the action and reason first
- move exact Target/Patch field lists behind a Show changed fields disclosure
- cover the collapsed/expanded behavior in focused Assistant panel tests

## Tests
- cd ui && bun run test -- ProjectAssistantPanel.test.tsx
- cd ui && bun run test:e2e -- e2e/projects.spec.ts -g "Projects journey: setup, first work, assignment, evidence, closeout"
- cd ui && bun run typecheck
- cd ui && bun run lint
- cd ui && bun run format:check
- git diff --check