### PR TITLE
Expose runtime host supervision posture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,14 @@ HECATE_ALLOW_NON_LOOPBACK_BIND=0
 # address is not the URL clients should use, e.g. Docker or a reverse proxy.
 # HECATE_PUBLIC_URL=http://127.0.0.1:8765
 
-# DataDir is where the gateway puts auto-generated state. The bootstrap
-# file stores the generated settings encryption key here unless
+# Operator-facing name for this Hecate runtime host. The UI defaults to the
+# machine hostname and shows this label in the status bar so a remote browser
+# can tell where files, tasks, and External Agents are running.
+# HECATE_RUNTIME_HOST_LABEL=MacBook
+
+# DataDir is where the gateway puts auto-generated state. The runtime-host file
+# stores the stable runtime ID here. The bootstrap file stores the generated
+# settings encryption key here unless
 # HECATE_BOOTSTRAP_FILE is set explicitly.
 #
 # Leave commented out unless you need to override:

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/retention"
 	"github.com/hecatehq/hecate/internal/router"
+	"github.com/hecatehq/hecate/internal/runtimehost"
 	"github.com/hecatehq/hecate/internal/secrets"
 	"github.com/hecatehq/hecate/internal/storage"
 	"github.com/hecatehq/hecate/internal/taskstate"
@@ -74,6 +75,17 @@ func runServe() {
 		os.Exit(1)
 	}
 	cfg.Server.ControlPlaneSecretKey = boot.ControlPlaneSecretKey
+	runtimeHost, err := runtimehost.Resolve(cfg.Server.DataDir, cfg.Server.RuntimeHostLabel)
+	if err != nil {
+		slog.Error(
+			"runtime host identity init failed",
+			slog.String("path", filepath.Join(cfg.Server.DataDir, runtimehost.StateFilename)),
+			slog.Any("error", err),
+		)
+		os.Exit(1)
+	}
+	cfg.Server.RuntimeHostID = runtimeHost.ID
+	cfg.Server.RuntimeHostLabel = runtimeHost.Label
 
 	otelResource, err := telemetry.BuildResource(context.Background(), telemetry.ResourceOptions{
 		ServiceName:       cfg.OTel.ServiceName,

--- a/docs-ai/core/project-context.md
+++ b/docs-ai/core/project-context.md
@@ -67,7 +67,8 @@ proposal records. Hecate keeps the `/hecate/v1/projects*` API and operator UI as
 its facade over that state; do not add a second Hecate-native portable store,
 backend selector, mirror, migration route, or fallback authority.
 
-Hecate still owns execution concerns: Agent Presets, provider/model defaults,
+Hecate still owns execution concerns: stable runtime host identity and remote
+supervision posture, Agent Presets, provider/model defaults,
 task and External Agent dispatch, approvals, sandbox and workspace operations,
 runtime references, context snapshots, traces, and the operator shell.
 Assignment launch and preflight therefore combine Cairnline coordination state

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -39,6 +39,7 @@ authenticating reverse proxy is your access-control boundary.
 
 - [Image pinning](#image-pinning)
 - [Remote runtime mode](#remote-runtime-mode)
+- [Remote supervision from another device](#remote-supervision-from-another-device)
 - [Binary install](#binary-install)
 - [Desktop app](#desktop-app)
 - [Resetting state](#resetting-state)
@@ -134,6 +135,48 @@ may restrict or forbid shared/account-delegated use of browser or CLI login
 state; Hecate does not interpret, bypass, or relax those terms. For anything
 beyond personal remote use, use vendor-supported API keys, team/project
 credentials, enterprise tokens, or future vendor auth flows.
+
+## Remote supervision from another device
+
+A phone or another browser can act as an operator surface for a Hecate runtime
+running on a laptop, workstation, VM, or container. The remote browser does not
+receive that host's filesystem, credentials, or processes. It sends supervised
+operations to the named runtime host, and work continues to execute there.
+
+```text
+Phone or remote browser
+        |
+        | authenticated operator request
+        v
+Hecate runtime host: MacBook
+        +-- chats, tasks, approvals, and traces
+        +-- workspaces, credentials, and External Agents
+        +-- embedded Cairnline project coordination
+```
+
+Set `HECATE_RUNTIME_HOST_LABEL` to a short operator-facing name such as
+`MacBook`. Hecate gives the runtime a stable opaque ID in
+`hecate.runtime-host.json`; the ID follows that Hecate data directory across
+restarts, while changing the label does not change the ID. The operator shell
+shows `On MacBook` for local access and `Supervising MacBook` when the request
+arrives through trusted remote-runtime identity. `GET /hecate/v1/whoami`
+exposes the same runtime identity and supervision posture to other clients.
+
+Hecate does not currently provision a public endpoint, tunnel, device pairing,
+or account system. The operator must provide the authenticated proxy, private
+network, VPN, or surrounding control plane. For Hecate's explicit remote-safe
+route policy, use remote runtime mode behind a trusted proxy as described
+above; do not expose the header secret directly to a browser. A self-hosted
+non-loopback bind with shared tokens remains an operator-managed deployment and
+does not activate trusted remote-runtime identity or its local-only route
+blocks.
+
+This is remote supervision of one runtime host, not process migration. Chats,
+tasks, approvals, credentials, workspaces, execution references, and running
+External Agents remain attached to that host. Cairnline owns the portable
+project coordination model, but Hecate currently uses its embedded local store;
+moving or sharing that graph between runtime hosts still requires an explicit
+coordination transport and host-readiness checks.
 
 ## Image pinning
 
@@ -346,6 +389,11 @@ the bootstrap key, not as env-only storage: Hecate persists that key to
 any existing bootstrap key, and the bootstrap path must be writable. Back up the
 env/secret-manager value and the bootstrap file with the same care as the
 database; if they diverge, the env value wins on the next startup.
+
+Runtime host identity is separate, non-secret state in
+`HECATE_DATA_DIR/hecate.runtime-host.json`. Include that file when restoring the
+same named runtime host. Omitting it creates a new runtime ID on the next start
+without changing the bootstrap encryption key or stored credentials.
 
 ## Storage backend
 

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -525,11 +525,17 @@ sibling workspaces outside the registered project root.
 
 Hecate's Projects API and cockpit use the embedded [Cairnline](https://github.com/hecatehq/cairnline) coordination store. Cairnline owns the portable project graph: project identity, roots, context-source and skill metadata, roles, work items, assignments, evidence, reviews, handoffs, accepted project memory, memory candidates, and Project Assistant proposal records.
 
-Hecate owns the host-specific layer around that graph: Agent Presets, provider and model selection, task and External Agent launch, workspace and Git side effects, approvals, sandboxing, chats, execution references, context snapshots, traces, and the operator UI. Starting an assignment resolves Cairnline coordination intent into Hecate runtime behavior; Cairnline records never bypass Hecate policy.
+Hecate owns the host-specific layer around that graph: runtime host identity, Agent Presets, provider and model selection, task and External Agent launch, workspace and Git side effects, approvals, sandboxing, chats, execution references, context snapshots, traces, and the operator UI. Starting an assignment resolves Cairnline coordination intent into Hecate runtime behavior; Cairnline records never bypass Hecate policy. A remote operator can supervise this layer on its named runtime host, but the browser does not move running work or host-local state to another device.
 
 The Hecate facade remains at `/hecate/v1/projects*`, so the Projects UI does not depend on Cairnline's transport. Hecate stores embedded Cairnline state under its local data directory. There is no Hecate-native coordination backend, backend selector, mirror, or migration endpoint. A process-local project mutation fence only prevents Hecate cleanup rollback from interleaving with an acknowledged facade write to the same Cairnline graph; it does not store or duplicate coordination records. Multi-project Project Assistant operations, including chat moves, admit their complete project set together. Alpha dogfood records created by the removed native store are intentionally not migrated.
 
 Cairnline itself remains agent-neutral and can also be used directly over MCP by other agent hosts. A separately installed Cairnline connector is future work; Hecate currently uses the embedded Go package.
+
+Cross-host continuity therefore has two distinct checks: the project
+coordination graph must be reachable on the target host, and that host must have
+the required project root, Agent Preset, provider/model route, credentials, and
+External Agent adapter. Hecate does not currently claim that a task, chat, or
+running process can migrate between runtime hosts.
 
 ## What Projects V1 Does Not Do
 

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -30,6 +30,13 @@ Hecate assumes the operator trusts their own machine, local user account, and se
   servers, mount tools, grant secrets, or make connector network calls.
 - Do not run Hecate on a shared host where untrusted local users can access the gateway port or data directory.
 
+The runtime host ID and `HECATE_RUNTIME_HOST_LABEL` are display and continuity
+metadata, not authentication credentials. A remote browser must still reach
+Hecate through the deployment's authenticated access boundary. When the shell
+says `Supervising <host>`, files, tasks, credentials, and External Agents remain
+on that runtime host; the browser has not acquired a local shell or copied the
+runtime state to its device.
+
 ## Runtime boundaries
 
 Hecate has different execution and shell-access surfaces with different trust

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -79,6 +79,43 @@ discovery. Hecate-native `/hecate/v1/*` routes are
 explicitly classified for remote mode, and route coverage tests fail when a new
 registered route is not marked remote-safe or local-only.
 
+`GET /hecate/v1/whoami` always identifies the Hecate runtime host in addition
+to the operator session:
+
+```json
+{
+  "object": "session",
+  "data": {
+    "role": "operator",
+    "runtime_host": {
+      "id": "runtime_00112233445566778899aabb",
+      "label": "MacBook",
+      "runtime_mode": "remote_runtime",
+      "operator_access": "remote_supervision",
+      "public_url": "https://hecate.example.com",
+      "local_only_actions_available": false
+    },
+    "remote_identity": {
+      "actor_id": "actor_1",
+      "org_id": "org_1",
+      "project_id": "project_1",
+      "runtime_id": "runtime_00112233445566778899aabb"
+    }
+  }
+}
+```
+
+Local requests report `runtime_mode: "local"`,
+`operator_access: "local_operator"`, and
+`local_only_actions_available: true`; `remote_identity` is omitted. Trusted
+remote-runtime requests report the proxy-provided `runtime_id` as the canonical
+`runtime_host.id`, `operator_access: "remote_supervision"`, and
+`local_only_actions_available: false`. `public_url` is present only when
+`HECATE_PUBLIC_URL` is configured. The stable local runtime ID is generated in
+`HECATE_DATA_DIR/hecate.runtime-host.json`; the operator-facing label comes from
+`HECATE_RUNTIME_HOST_LABEL` or the machine hostname. Neither field grants
+access.
+
 Remote mode disables local model providers by default. In that default posture,
 local presets are omitted, `kind=local` provider creates/updates are rejected,
 env-preconfigured local providers are skipped, and existing local provider rows

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/ratelimit"
 	"github.com/hecatehq/hecate/internal/remoteruntime"
+	"github.com/hecatehq/hecate/internal/runtimehost"
 	"github.com/hecatehq/hecate/internal/sandbox"
 	"github.com/hecatehq/hecate/internal/secrets"
 	"github.com/hecatehq/hecate/internal/taskruncoord"
@@ -48,6 +49,7 @@ import (
 
 type Handler struct {
 	config                            config.Config
+	runtimeHost                       runtimehost.Identity
 	logger                            *slog.Logger
 	service                           *gateway.Service
 	controlPlane                      controlplane.Store
@@ -196,6 +198,10 @@ type StateCleaner interface {
 // one place. taskQueue may be nil — the runner falls back to its default
 // in-process queue, which is what the test fixtures rely on.
 func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service, cpStore controlplane.Store, taskStore taskstate.Store, taskQueue orchestrator.RunQueue, providerRuntimes ...ProviderRuntime) *Handler {
+	runtimeHost := runtimehost.NewEphemeral(cfg.Server.RuntimeHostLabel)
+	if id := strings.TrimSpace(cfg.Server.RuntimeHostID); id != "" {
+		runtimeHost.ID = id
+	}
 	var providerRuntime ProviderRuntime
 	if len(providerRuntimes) > 0 {
 		providerRuntime = providerRuntimes[0]
@@ -370,6 +376,7 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 	}
 	h := &Handler{
 		config:                            cfg,
+		runtimeHost:                       runtimeHost,
 		logger:                            logger,
 		service:                           service,
 		controlPlane:                      cpStore,
@@ -788,13 +795,26 @@ func (h *Handler) HandleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) HandleSession(w http.ResponseWriter, r *http.Request) {
+	runtimeHost := RuntimeHostResponseItem{
+		ID:                        h.runtimeHost.ID,
+		Label:                     h.runtimeHost.Label,
+		RuntimeMode:               "local",
+		OperatorAccess:            "local_operator",
+		PublicURL:                 strings.TrimSpace(h.config.Server.PublicURL),
+		LocalOnlyActionsAvailable: true,
+	}
 	item := SessionResponseItem{
-		Role: "operator",
+		Role:        "operator",
+		RuntimeHost: runtimeHost,
 		Capabilities: SessionCapabilitiesItem{
 			LocalProvidersAllowed: h.config.LocalProvidersAllowed(),
 		},
 	}
 	if identity, ok := remoteruntime.FromContext(r.Context()); ok {
+		item.RuntimeHost.ID = identity.RuntimeID
+		item.RuntimeHost.RuntimeMode = "remote_runtime"
+		item.RuntimeHost.OperatorAccess = "remote_supervision"
+		item.RuntimeHost.LocalOnlyActionsAvailable = false
 		item.RemoteIdentity = &RemoteIdentityResponseItem{
 			ActorID:   identity.ActorID,
 			OrgID:     identity.OrgID,

--- a/internal/api/handler_session_test.go
+++ b/internal/api/handler_session_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/remoteruntime"
+)
+
+func TestSessionReportsLocalRuntimeHost(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{
+		Server: config.ServerConfig{
+			RuntimeHostID:    "runtime_00112233445566778899aabb",
+			RuntimeHostLabel: "MacBook",
+			PublicURL:        "https://hecate.example.test",
+		},
+	}, logger, nil, nil, nil, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/hecate/v1/whoami", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response SessionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	host := response.Data.RuntimeHost
+	if host.ID != "runtime_00112233445566778899aabb" || host.Label != "MacBook" {
+		t.Fatalf("runtime_host identity = %+v", host)
+	}
+	if host.RuntimeMode != "local" || host.OperatorAccess != "local_operator" {
+		t.Fatalf("runtime_host posture = %+v", host)
+	}
+	if !host.LocalOnlyActionsAvailable {
+		t.Fatal("local_only_actions_available = false, want true")
+	}
+	if host.PublicURL != "https://hecate.example.test" {
+		t.Fatalf("public_url = %q", host.PublicURL)
+	}
+}
+
+func TestSessionReportsTrustedRemoteSupervisionHost(t *testing.T) {
+	const secret = "cloud-runtime-secret-123456"
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{
+		Server: config.ServerConfig{
+			RemoteRuntimeMode:   true,
+			RemoteRuntimeSecret: secret,
+			RuntimeHostID:       "runtime_00112233445566778899aabb",
+			RuntimeHostLabel:    "MacBook",
+		},
+	}, logger, nil, nil, nil, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/hecate/v1/whoami", nil)
+	req.Header.Set(remoteruntime.HeaderRuntimeSecret, secret)
+	req.Header.Set(remoteruntime.HeaderActorID, "actor_1")
+	req.Header.Set(remoteruntime.HeaderOrgID, "org_1")
+	req.Header.Set(remoteruntime.HeaderProjectID, "proj_1")
+	req.Header.Set(remoteruntime.HeaderRuntimeID, "remote_runtime_1")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response SessionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	host := response.Data.RuntimeHost
+	if host.ID != "remote_runtime_1" {
+		t.Fatalf("runtime_host.id = %q, want trusted remote runtime id", host.ID)
+	}
+	if host.Label != "MacBook" || host.RuntimeMode != "remote_runtime" || host.OperatorAccess != "remote_supervision" {
+		t.Fatalf("runtime_host posture = %+v", host)
+	}
+	if host.LocalOnlyActionsAvailable {
+		t.Fatal("local_only_actions_available = true, want false")
+	}
+}
+
+func TestSessionAlwaysReportsRuntimeHostIdentity(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{}, logger, nil, nil, nil, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/hecate/v1/whoami", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var response SessionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Data.RuntimeHost.ID == "" || response.Data.RuntimeHost.Label == "" {
+		t.Fatalf("runtime_host = %+v, want non-empty identity", response.Data.RuntimeHost)
+	}
+}

--- a/internal/api/openai.go
+++ b/internal/api/openai.go
@@ -242,8 +242,18 @@ type SessionResponse struct {
 // actor propagated by the proxy.
 type SessionResponseItem struct {
 	Role           string                      `json:"role"`
+	RuntimeHost    RuntimeHostResponseItem     `json:"runtime_host"`
 	RemoteIdentity *RemoteIdentityResponseItem `json:"remote_identity,omitempty"`
 	Capabilities   SessionCapabilitiesItem     `json:"capabilities,omitempty"`
+}
+
+type RuntimeHostResponseItem struct {
+	ID                        string `json:"id"`
+	Label                     string `json:"label"`
+	RuntimeMode               string `json:"runtime_mode"`
+	OperatorAccess            string `json:"operator_access"`
+	PublicURL                 string `json:"public_url,omitempty"`
+	LocalOnlyActionsAvailable bool   `json:"local_only_actions_available"`
 }
 
 type SessionCapabilitiesItem struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hecatehq/hecate/internal/browserrunner"
+	"github.com/hecatehq/hecate/internal/runtimehost"
 	"github.com/hecatehq/hecate/internal/telemetry"
 )
 
@@ -47,18 +48,22 @@ type ServerConfig struct {
 	RemoteAllowACPTerminals           bool
 	PersonalRemoteExternalAgentLogins bool
 	PublicURL                         string
-	DataDir                           string
-	BootstrapFile                     string
-	ControlPlaneBackend               string
-	ControlPlaneKey                   string
-	ControlPlaneSecretKey             string
-	TasksBackend                      string
-	TaskApprovalPolicies              []string
-	TaskQueueBackend                  string
-	TaskQueueWorkers                  int
-	TaskQueueBuffer                   int
-	TaskQueueLeaseSeconds             int
-	TaskMaxConcurrentPerTenant        int
+	// RuntimeHostID is resolved from data-directory runtime-host state by
+	// cmd/hecate. It is not loaded directly from the environment.
+	RuntimeHostID              string
+	RuntimeHostLabel           string
+	DataDir                    string
+	BootstrapFile              string
+	ControlPlaneBackend        string
+	ControlPlaneKey            string
+	ControlPlaneSecretKey      string
+	TasksBackend               string
+	TaskApprovalPolicies       []string
+	TaskQueueBackend           string
+	TaskQueueWorkers           int
+	TaskQueueBuffer            int
+	TaskQueueLeaseSeconds      int
+	TaskMaxConcurrentPerTenant int
 	// TaskReconcileInterval controls how often the periodic reconciler
 	// scans for runs stuck in "running" past 3× the lease duration.
 	// Default 30s. Set via HECATE_TASK_RECONCILE_INTERVAL (Go duration
@@ -505,7 +510,8 @@ func LoadFromEnv() Config {
 			PersonalRemoteExternalAgentLogins: personalRemoteExternalAgentLogins,
 			// PublicURL is written to hecate.runtime.json for local
 			// diagnostics. Empty means derive from Address.
-			PublicURL: getEnv("HECATE_PUBLIC_URL", ""),
+			PublicURL:        getEnv("HECATE_PUBLIC_URL", ""),
+			RuntimeHostLabel: getEnv("HECATE_RUNTIME_HOST_LABEL", ""),
 			// Default `.data/` keeps the auto-generated bootstrap file
 			// (AES-GCM key for persisted provider secrets) out of the repo root so a stray
 			// `git add .` can't sweep it up. Docker overrides this to /data
@@ -674,6 +680,9 @@ func (c Config) Validate() error {
 		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
 			errs = append(errs, fmt.Errorf("HECATE_PUBLIC_URL must be an absolute http(s) URL (got %q)", publicURL))
 		}
+	}
+	if err := runtimehost.ValidateLabel(c.Server.RuntimeHostLabel); err != nil {
+		errs = append(errs, fmt.Errorf("HECATE_RUNTIME_HOST_LABEL: %w", err))
 	}
 	for _, origin := range c.Server.AllowedOrigins {
 		if !validAllowedOrigin(origin) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -613,6 +613,28 @@ func TestValidateRejectsInvalidPublicURL(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvRuntimeHostLabel(t *testing.T) {
+	t.Setenv("HECATE_RUNTIME_HOST_LABEL", "MacBook")
+
+	cfg := LoadFromEnv()
+	if cfg.Server.RuntimeHostLabel != "MacBook" {
+		t.Fatalf("RuntimeHostLabel = %q, want MacBook", cfg.Server.RuntimeHostLabel)
+	}
+}
+
+func TestValidateRejectsInvalidRuntimeHostLabel(t *testing.T) {
+	cfg := LoadFromEnv()
+	cfg.Server.RuntimeHostLabel = "MacBook\nspoofed"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want invalid runtime host label error")
+	}
+	if !strings.Contains(err.Error(), "HECATE_RUNTIME_HOST_LABEL") {
+		t.Fatalf("Validate() error = %q, want HECATE_RUNTIME_HOST_LABEL", err)
+	}
+}
+
 func TestValidateRejectsInvalidAllowedOrigin(t *testing.T) {
 	cfg := LoadFromEnv()
 	cfg.Server.AllowedOrigins = []string{"http://localhost:5173/app"}

--- a/internal/runtimehost/identity.go
+++ b/internal/runtimehost/identity.go
@@ -1,0 +1,185 @@
+package runtimehost
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	StateFilename = "hecate.runtime-host.json"
+	idPrefix      = "runtime_"
+	idRandomBytes = 12
+	maxLabelRunes = 80
+	defaultLabel  = "This device"
+)
+
+// Identity names one Hecate runtime installation. The opaque ID follows its
+// data directory; Label describes the host running it now.
+type Identity struct {
+	ID    string
+	Label string
+}
+
+type persistedIdentity struct {
+	RuntimeHostID string `json:"runtime_host_id"`
+}
+
+// Resolve loads or creates the identity attached to one Hecate data
+// directory. It is deliberately file-backed across all storage tiers because
+// it identifies the runtime host, not a portable or backend-owned record.
+func Resolve(dataDir, configuredLabel string) (Identity, error) {
+	dataDir = strings.TrimSpace(dataDir)
+	if dataDir == "" {
+		return Identity{}, errors.New("runtime host data directory is required")
+	}
+	if err := ValidateLabel(configuredLabel); err != nil {
+		return Identity{}, err
+	}
+
+	path := filepath.Join(dataDir, StateFilename)
+	state, err := load(path)
+	if err == nil {
+		return Identity{ID: state.RuntimeHostID, Label: ResolveLabel(configuredLabel)}, nil
+	}
+	if !os.IsNotExist(err) {
+		return Identity{}, fmt.Errorf("read runtime host identity %q: %w", path, err)
+	}
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return Identity{}, fmt.Errorf("create runtime host data directory: %w", err)
+	}
+
+	id, err := NewID()
+	if err != nil {
+		return Identity{}, err
+	}
+	state = persistedIdentity{RuntimeHostID: id}
+	if err := create(path, state); err != nil {
+		if os.IsExist(err) {
+			state, err = load(path)
+		}
+		if err != nil {
+			return Identity{}, fmt.Errorf("persist runtime host identity %q: %w", path, err)
+		}
+	}
+	return Identity{ID: state.RuntimeHostID, Label: ResolveLabel(configuredLabel)}, nil
+}
+
+func load(path string) (persistedIdentity, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return persistedIdentity{}, err
+	}
+	var state persistedIdentity
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return persistedIdentity{}, fmt.Errorf("decode runtime host identity: %w", err)
+	}
+	if err := ValidateID(state.RuntimeHostID); err != nil {
+		return persistedIdentity{}, err
+	}
+	return state, nil
+}
+
+func create(path string, state persistedIdentity) (err error) {
+	raw, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	keep := false
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+		if !keep || err != nil {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err = file.Write(raw); err != nil {
+		return err
+	}
+	if err = file.Sync(); err != nil {
+		return err
+	}
+	keep = true
+	return nil
+}
+
+// NewEphemeral returns a process-scoped identity for embedders that construct
+// the API without cmd/hecate's durable bootstrap path.
+func NewEphemeral(configuredLabel string) Identity {
+	id, err := NewID()
+	if err != nil {
+		// Runtime identity is informational, not an authorization credential.
+		// Keep the API contract non-empty even on a failed system RNG.
+		id = fmt.Sprintf("%s%024x", idPrefix, time.Now().UTC().UnixNano())
+	}
+	return Identity{ID: id, Label: ResolveLabel(configuredLabel)}
+}
+
+func NewID() (string, error) {
+	random := make([]byte, idRandomBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate runtime host id: %w", err)
+	}
+	return idPrefix + hex.EncodeToString(random), nil
+}
+
+func ValidateID(id string) error {
+	if id != strings.TrimSpace(id) {
+		return errors.New("runtime host id has invalid format")
+	}
+	encoded := strings.TrimPrefix(id, idPrefix)
+	if encoded == id || len(encoded) != idRandomBytes*2 {
+		return errors.New("runtime host id has invalid format")
+	}
+	if _, err := hex.DecodeString(encoded); err != nil {
+		return errors.New("runtime host id has invalid format")
+	}
+	return nil
+}
+
+// ResolveLabel returns the configured operator-facing label or the machine
+// hostname. Hostnames that are unsuitable for display fall back to a neutral
+// label; explicitly configured invalid labels fail startup through ValidateLabel.
+func ResolveLabel(configured string) string {
+	if label := strings.TrimSpace(configured); label != "" {
+		return label
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return defaultLabel
+	}
+	hostname = strings.TrimSpace(hostname)
+	if hostname == "" || ValidateLabel(hostname) != nil {
+		return defaultLabel
+	}
+	return hostname
+}
+
+func ValidateLabel(label string) error {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return nil
+	}
+	if utf8.RuneCountInString(label) > maxLabelRunes {
+		return fmt.Errorf("runtime host label must be at most %d characters", maxLabelRunes)
+	}
+	if strings.IndexFunc(label, unicode.IsControl) >= 0 {
+		return errors.New("runtime host label must not contain control characters")
+	}
+	return nil
+}

--- a/internal/runtimehost/identity_test.go
+++ b/internal/runtimehost/identity_test.go
@@ -1,0 +1,102 @@
+package runtimehost
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewIDProducesValidDistinctRuntimeIDs(t *testing.T) {
+	first, err := NewID()
+	if err != nil {
+		t.Fatalf("NewID() first error = %v", err)
+	}
+	second, err := NewID()
+	if err != nil {
+		t.Fatalf("NewID() second error = %v", err)
+	}
+	if first == second {
+		t.Fatalf("NewID() returned duplicate id %q", first)
+	}
+	if err := ValidateID(first); err != nil {
+		t.Fatalf("ValidateID(%q) error = %v", first, err)
+	}
+}
+
+func TestValidateIDRejectsMalformedRuntimeIDs(t *testing.T) {
+	for _, id := range []string{"", "runtime_", "host_001122", "runtime_not-hex", " runtime_00112233445566778899aabb "} {
+		if err := ValidateID(id); err == nil {
+			t.Fatalf("ValidateID(%q) error = nil, want invalid format", id)
+		}
+	}
+}
+
+func TestResolvePersistsRuntimeIdentityAcrossRestarts(t *testing.T) {
+	dataDir := t.TempDir()
+
+	first, err := Resolve(dataDir, "MacBook")
+	if err != nil {
+		t.Fatalf("Resolve() first error = %v", err)
+	}
+	second, err := Resolve(dataDir, "Renamed MacBook")
+	if err != nil {
+		t.Fatalf("Resolve() second error = %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("runtime id changed across resolves: first=%q second=%q", first.ID, second.ID)
+	}
+	if second.Label != "Renamed MacBook" {
+		t.Fatalf("label = %q, want Renamed MacBook", second.Label)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dataDir, StateFilename))
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var state persistedIdentity
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("decode state: %v", err)
+	}
+	if state.RuntimeHostID != first.ID {
+		t.Fatalf("persisted runtime id = %q, want %q", state.RuntimeHostID, first.ID)
+	}
+}
+
+func TestResolveRejectsCorruptOrInvalidIdentity(t *testing.T) {
+	for name, raw := range map[string]string{
+		"corrupt json": "{not json",
+		"invalid id":   `{"runtime_host_id":"runtime_invalid"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			path := filepath.Join(dataDir, StateFilename)
+			if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			if _, err := Resolve(dataDir, "MacBook"); err == nil {
+				t.Fatal("Resolve() error = nil, want invalid state error")
+			}
+		})
+	}
+}
+
+func TestValidateLabelAllowsOperatorNamesAndRejectsUnsafeDisplayText(t *testing.T) {
+	for _, label := range []string{"", "MacBook", "Build host 2"} {
+		if err := ValidateLabel(label); err != nil {
+			t.Fatalf("ValidateLabel(%q) error = %v", label, err)
+		}
+	}
+	for _, label := range []string{"MacBook\nspoofed", strings.Repeat("a", maxLabelRunes+1)} {
+		if err := ValidateLabel(label); err == nil {
+			t.Fatalf("ValidateLabel(%q) error = nil, want rejection", label)
+		}
+	}
+}
+
+func TestResolveLabelPrefersConfiguredValue(t *testing.T) {
+	if got := ResolveLabel("  MacBook  "); got != "MacBook" {
+		t.Fatalf("ResolveLabel() = %q, want MacBook", got)
+	}
+}

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -517,7 +517,16 @@ export async function mockGatewayAPIs(
     r.fulfill(
       ok({
         object: "session",
-        data: { role: "operator" },
+        data: {
+          role: "operator",
+          runtime_host: {
+            id: "runtime_test",
+            label: "Test host",
+            runtime_mode: "local",
+            operator_access: "local_operator",
+            local_only_actions_available: true,
+          },
+        },
       }),
     ),
   );

--- a/ui/e2e/shell.spec.ts
+++ b/ui/e2e/shell.spec.ts
@@ -18,7 +18,7 @@ test("shows the status bar with brand and session label", async ({ page }) => {
   const bar = page.locator(".hecate-statusbar");
   await expect(bar).toBeVisible();
   await expect(bar.locator(".hecate-statusbar__brand")).toHaveText("hecate");
-  await expect(bar).toContainText("Local");
+  await expect(bar).toContainText("On Test host");
 });
 
 test("status bar shows configured provider count and model count", async ({ page }) => {

--- a/ui/src/app/App.css
+++ b/ui/src/app/App.css
@@ -192,6 +192,14 @@ html[data-tauri-os="macos"] .hecate-shell {
   opacity: 0.5;
 }
 
+.hecate-statusbar__session {
+  min-width: 0;
+  max-width: min(34vw, 280px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .hecate-statusbar__path {
   min-width: 0;
   overflow: hidden;
@@ -293,6 +301,10 @@ html[data-tauri-os="macos"] .hecate-shell {
   .hecate-statusbar__runtime,
   .hecate-statusbar__session {
     flex: 0 0 auto;
+  }
+
+  .hecate-statusbar__session {
+    max-width: 54vw;
   }
 
   .hecate-statusbar__path {

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -6,6 +6,7 @@ import { useChat } from "./state/chat";
 import {
   createRuntimeConsoleActions,
   createRuntimeConsoleFixture,
+  createRuntimeHostFixture,
   type RuntimeConsoleFixtureActions,
 } from "../test/runtime-console-fixture";
 import { withRuntimeConsole } from "../test/runtime-console-render";
@@ -2170,8 +2171,11 @@ describe("ConsoleShell theme toggle", () => {
 // field genuinely missing). The workspace branch renders the embedded
 // views, which fan out fetches on mount; we stub fetch globally here so
 // those calls don't blow up under jsdom.
-describe("status bar version chip", () => {
-  function renderWorkspace(healthOverrides: Record<string, unknown> | null) {
+describe("status bar runtime identity", () => {
+  function renderWorkspace(
+    healthOverrides: Record<string, unknown> | null,
+    sessionInfo: ReturnType<typeof createRuntimeConsoleFixture>["sessionInfo"] = null,
+  ) {
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -2187,6 +2191,7 @@ describe("status bar version chip", () => {
       // anything else replaces the whole object so the render branch
       // sees the version we feed it (or its absence).
       health: healthOverrides as never,
+      sessionInfo,
     });
     render(
       withRuntimeConsole(<ConsoleShell activeWorkspace="overview" onSelectWorkspace={() => {}} />, {
@@ -2231,5 +2236,47 @@ describe("status bar version chip", () => {
     // to 4. Assert by counting separators.
     const sepCount = statusbar!.querySelectorAll(".hecate-statusbar__sep").length;
     expect(sepCount).toBe(3);
+  });
+
+  it("shows the named local runtime host", () => {
+    renderWorkspace(
+      { status: "ok", time: "2026-04-25T00:00:00Z" },
+      {
+        role: "operator",
+        runtime_host: createRuntimeHostFixture({ id: "runtime_1", label: "MacBook" }),
+      },
+    );
+
+    expect(screen.getByText("On MacBook")).toHaveAttribute(
+      "title",
+      expect.stringContaining("run on this host"),
+    );
+  });
+
+  it("shows remote supervision without implying execution moved to the browser", () => {
+    renderWorkspace(
+      { status: "ok", time: "2026-04-25T00:00:00Z" },
+      {
+        role: "operator",
+        runtime_host: createRuntimeHostFixture({
+          id: "runtime_1",
+          label: "MacBook",
+          runtime_mode: "remote_runtime",
+          operator_access: "remote_supervision",
+          local_only_actions_available: false,
+        }),
+        remote_identity: {
+          actor_id: "actor_1",
+          org_id: "org_1",
+          project_id: "proj_1",
+          runtime_id: "runtime_1",
+        },
+      },
+    );
+
+    expect(screen.getByText("Supervising MacBook")).toHaveAttribute(
+      "title",
+      expect.stringContaining("run on that host"),
+    );
   });
 });

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -738,7 +738,13 @@ function AuthenticatedShell({
           </>
         )}
         <span className="hecate-statusbar__sep hecate-statusbar__sep--session">|</span>
-        <span className="hecate-statusbar__session">{session.label}</span>
+        <span
+          aria-label={session.title}
+          className="hecate-statusbar__session"
+          title={session.title}
+        >
+          {session.label}
+        </span>
         <span className="hecate-statusbar__sep hecate-statusbar__sep--providers">|</span>
         {/* "configured" = providers in the CP store (operator-added).
             "models" is intersected with the configured set so the count

--- a/ui/src/app/runtimeConsoleDashboard.test.ts
+++ b/ui/src/app/runtimeConsoleDashboard.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "../lib/api";
+import { createRuntimeHostFixture } from "../test/runtime-console-fixture";
+import type { SessionResponse } from "../types/runtime";
 import { deriveSessionState, resolveDashboardSnapshot } from "./runtimeConsoleDashboard";
 
 vi.mock("../lib/api", async () => {
@@ -32,7 +34,13 @@ const emptyPrev = {
 
 function setupAllResolved() {
   vi.mocked(api.getHealth).mockResolvedValue({ status: "ok", time: "2026-05-05T00:00:00Z" });
-  vi.mocked(api.getSession).mockResolvedValue({ object: "session", data: { role: "operator" } });
+  vi.mocked(api.getSession).mockResolvedValue({
+    object: "session",
+    data: {
+      role: "operator",
+      runtime_host: createRuntimeHostFixture({ id: "runtime_1", label: "MacBook" }),
+    },
+  });
   vi.mocked(api.getModels).mockResolvedValue({ object: "list", data: [] });
   vi.mocked(api.getProviders).mockResolvedValue({ object: "list", data: [] });
   vi.mocked(api.getProviderPresets).mockResolvedValue({ object: "list", data: [] });
@@ -57,23 +65,50 @@ afterEach(() => {
 });
 
 describe("deriveSessionState", () => {
-  it("returns the local label without cloud identity", () => {
-    expect(deriveSessionState(null)).toEqual({ label: "Local" });
-    expect(deriveSessionState({ role: "operator" })).toEqual({ label: "Local" });
+  it("reports a failed runtime-host load without guessing local posture", () => {
+    expect(deriveSessionState(null)).toEqual({
+      label: "Runtime unavailable",
+      title: "Runtime host identity did not load.",
+    });
+    expect(deriveSessionState({ role: "operator" } as SessionResponse["data"])).toEqual({
+      label: "Runtime unavailable",
+      title: "Runtime host identity did not load.",
+    });
   });
 
-  it("returns the hosted label with cloud identity", () => {
-    expect(
-      deriveSessionState({
-        role: "operator",
-        remote_identity: {
-          actor_id: "actor_1",
-          org_id: "org_1",
-          project_id: "proj_1",
-          runtime_id: "rt_1",
-        },
-      }),
-    ).toEqual({ label: "Hosted" });
+  it("names the local execution host", () => {
+    const state = deriveSessionState({
+      role: "operator",
+      runtime_host: createRuntimeHostFixture({ id: "runtime_1", label: "MacBook" }),
+    });
+
+    expect(state.label).toBe("On MacBook");
+    expect(state.title).toContain("Files, tasks, and External Agents run on this host");
+    expect(state.title).toContain("Runtime ID: runtime_1");
+  });
+
+  it("names the remotely supervised execution host", () => {
+    const state = deriveSessionState({
+      role: "operator",
+      runtime_host: {
+        ...createRuntimeHostFixture({ id: "runtime_1", label: "MacBook" }),
+        runtime_mode: "remote_runtime",
+        operator_access: "remote_supervision",
+        local_only_actions_available: false,
+        public_url: "https://hecate.example.test",
+      },
+      remote_identity: {
+        actor_id: "actor_1",
+        org_id: "org_1",
+        project_id: "proj_1",
+        runtime_id: "runtime_1",
+      },
+    });
+
+    expect(state.label).toBe("Supervising MacBook");
+    expect(state.title).toContain("Files, tasks, and External Agents run on that host");
+    expect(state.title).toContain("Host-local actions are unavailable");
+    expect(state.title).toContain("Public URL: https://hecate.example.test");
   });
 });
 
@@ -370,7 +405,10 @@ describe("resolveDashboardSnapshot", () => {
     expect(onEssentials).toHaveBeenCalledTimes(1);
     const essentials = onEssentials.mock.calls[0][0];
     expect(essentials.health.status).toBe("ok");
-    expect(essentials.sessionInfo).toEqual({ role: "operator" });
+    expect(essentials.sessionInfo).toEqual({
+      role: "operator",
+      runtime_host: createRuntimeHostFixture({ id: "runtime_1", label: "MacBook" }),
+    });
     expect(essentials.settingsConfig?.providers).toEqual([]);
 
     // Secondary is still pending — finish it so the outer promise

--- a/ui/src/app/runtimeConsoleDashboard.ts
+++ b/ui/src/app/runtimeConsoleDashboard.ts
@@ -10,7 +10,6 @@ import {
   getRuntimeStats,
   getSession,
 } from "../lib/api";
-import { isRemoteRuntimeSession } from "../lib/runtime-utils";
 import type { HealthResponse, RuntimeStatsResponse, SessionResponse } from "../types/runtime";
 import type { ModelResponse } from "../types/model";
 import type { ConfiguredStateResponse, ProviderStatusResponse } from "../types/provider";
@@ -19,6 +18,7 @@ import type { ChatSessionRecord, ChatSessionsResponse } from "../types/chat";
 
 export type SessionState = {
   label: string;
+  title: string;
 };
 
 export type DashboardPreviousState = {
@@ -145,7 +145,25 @@ export async function resolveDashboardSnapshot(args: {
 }
 
 export function deriveSessionState(sessionInfo: SessionResponse["data"] | null): SessionState {
-  return { label: isRemoteRuntimeSession(sessionInfo) ? "Hosted" : "Local" };
+  if (!sessionInfo?.runtime_host) {
+    return {
+      label: "Runtime unavailable",
+      title: "Runtime host identity did not load.",
+    };
+  }
+  const host = sessionInfo.runtime_host;
+  const remote = host.operator_access === "remote_supervision";
+  const executionBoundary = remote
+    ? `This browser supervises ${host.label}. Files, tasks, and External Agents run on that host.`
+    : `Hecate is running on ${host.label}. Files, tasks, and External Agents run on this host.`;
+  const localOnlyActions = host.local_only_actions_available
+    ? "Host-local actions are available."
+    : "Host-local actions are unavailable.";
+  const publicURL = host.public_url ? ` Public URL: ${host.public_url}.` : "";
+  return {
+    label: remote ? `Supervising ${host.label}` : `On ${host.label}`,
+    title: `${executionBoundary} ${localOnlyActions} Runtime ID: ${host.id}.${publicURL}`,
+  };
 }
 
 async function loadDashboardResults(opts: {

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -19,6 +19,7 @@ import { readProjectAssistantChatHandoff } from "../../lib/project-assistant-cha
 import {
   createRuntimeConsoleActions,
   createRuntimeConsoleFixture,
+  createRuntimeHostFixture,
 } from "../../test/runtime-console-fixture";
 import { withRuntimeConsole } from "../../test/runtime-console-render";
 import type { ProjectRecord } from "../../types/project";
@@ -2463,6 +2464,11 @@ describe("ChatView input", () => {
       agentAdapters: [],
       sessionInfo: {
         role: "operator",
+        runtime_host: createRuntimeHostFixture({
+          runtime_mode: "remote_runtime",
+          operator_access: "remote_supervision",
+          local_only_actions_available: false,
+        }),
         remote_identity: {
           actor_id: "actor_1",
           org_id: "org_1",
@@ -7026,6 +7032,11 @@ describe("ChatView external-agent target", () => {
         agentWorkspace: "",
         sessionInfo: {
           role: "operator",
+          runtime_host: createRuntimeHostFixture({
+            runtime_mode: "remote_runtime",
+            operator_access: "remote_supervision",
+            local_only_actions_available: false,
+          }),
           remote_identity: {
             actor_id: "actor_1",
             org_id: "org_1",

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -8,6 +8,7 @@ import { discoverLocalProviders } from "../../lib/api";
 import {
   createRuntimeConsoleActions,
   createRuntimeConsoleFixture,
+  createRuntimeHostFixture,
 } from "../../test/runtime-console-fixture";
 import { withRuntimeConsole } from "../../test/runtime-console-render";
 import type {
@@ -221,6 +222,11 @@ describe("ProvidersView add provider modal", () => {
       session: { label: "Hosted" },
       sessionInfo: {
         role: "operator",
+        runtime_host: createRuntimeHostFixture({
+          runtime_mode: "remote_runtime",
+          operator_access: "remote_supervision",
+          local_only_actions_available: false,
+        }),
         remote_identity: {
           actor_id: "actor_1",
           org_id: "org_1",
@@ -900,6 +906,11 @@ describe("ProvidersView table renders", () => {
     const state = createRuntimeConsoleFixture({
       sessionInfo: {
         role: "operator",
+        runtime_host: createRuntimeHostFixture({
+          runtime_mode: "remote_runtime",
+          operator_access: "remote_supervision",
+          local_only_actions_available: false,
+        }),
         remote_identity: {
           actor_id: "actor_1",
           org_id: "org_1",

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -8,6 +8,7 @@ import { SettingsView } from "./SettingsView";
 import {
   createRuntimeConsoleActions,
   createRuntimeConsoleFixture,
+  createRuntimeHostFixture,
 } from "../../test/runtime-console-fixture";
 import { withRuntimeConsole } from "../../test/runtime-console-render";
 
@@ -915,6 +916,11 @@ describe("Connections external-agent panel", () => {
         withAdapter({
           sessionInfo: {
             role: "operator",
+            runtime_host: createRuntimeHostFixture({
+              runtime_mode: "remote_runtime",
+              operator_access: "remote_supervision",
+              local_only_actions_available: false,
+            }),
             remote_identity: {
               actor_id: "actor_1",
               org_id: "org_1",

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -292,6 +292,13 @@ describe("api client", () => {
           invalid_token: false,
           role: "admin",
           source: "anonymous",
+          runtime_host: {
+            id: "runtime_test",
+            label: "Test host",
+            runtime_mode: "local",
+            operator_access: "local_operator",
+            local_only_actions_available: true,
+          },
           capabilities: {
             local_providers_allowed: true,
           },
@@ -306,6 +313,7 @@ describe("api client", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(result.data.role).toBe("admin");
+    expect(result.data.runtime_host.label).toBe("Test host");
     expect(result.data.capabilities?.local_providers_allowed).toBe(true);
   });
 

--- a/ui/src/lib/runtime-utils.test.ts
+++ b/ui/src/lib/runtime-utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { createRuntimeHostFixture } from "../test/runtime-console-fixture";
+
 import {
   buildSpanWaterfall,
   buildTraceTimeline,
@@ -140,10 +142,17 @@ describe("runtime-utils", () => {
 
   it("detects remote runtime sessions from cloud identity", () => {
     expect(isRemoteRuntimeSession(null)).toBe(false);
-    expect(isRemoteRuntimeSession({ role: "operator" })).toBe(false);
+    expect(
+      isRemoteRuntimeSession({ role: "operator", runtime_host: createRuntimeHostFixture() }),
+    ).toBe(false);
     expect(
       isRemoteRuntimeSession({
         role: "operator",
+        runtime_host: createRuntimeHostFixture({
+          runtime_mode: "remote_runtime",
+          operator_access: "remote_supervision",
+          local_only_actions_available: false,
+        }),
         remote_identity: {
           actor_id: "actor-1",
           org_id: "org-1",

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -128,7 +128,19 @@ function defaultBackendMock(
     if (url === "/hecate/v1/whoami") {
       return jsonResponse({
         object: "session",
-        data: { authenticated: true, invalid_token: false, role: "admin", source: "anonymous" },
+        data: {
+          authenticated: true,
+          invalid_token: false,
+          role: "admin",
+          source: "anonymous",
+          runtime_host: {
+            id: "runtime_test",
+            label: "Test host",
+            runtime_mode: "local",
+            operator_access: "local_operator",
+            local_only_actions_available: true,
+          },
+        },
       });
     }
     if (url === "/v1/models") return jsonResponse({ object: "list", data: [] });
@@ -3654,10 +3666,10 @@ describe("useRuntimeConsole", () => {
     expect(window.localStorage.getItem("hecate.chatSessionID")).toBe("a1");
   });
 
-  it("settles into a Local session after the dashboard loads", async () => {
+  it("settles into the named local runtime after the dashboard loads", async () => {
     const { result } = renderRuntimeConsoleHook();
     await waitFor(() => expect(result.current.state.loading).toBe(false));
-    expect(result.current.state.session.label).toBe("Local");
+    expect(result.current.state.session.label).toBe("On Test host");
   });
 
   // Regression for the "ModelPicker blinks fast when picking Ollama

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -50,6 +50,19 @@ import type { ChatMessage } from "../lib/api";
 
 type SessionState = { label: string };
 
+export function createRuntimeHostFixture(
+  overrides: Partial<SessionResponse["data"]["runtime_host"]> = {},
+): SessionResponse["data"]["runtime_host"] {
+  return {
+    id: "runtime_test",
+    label: "Test host",
+    runtime_mode: "local",
+    operator_access: "local_operator",
+    local_only_actions_available: true,
+    ...overrides,
+  };
+}
+
 export type RuntimeConsoleFixtureState = {
   usageSummary: UsageSummaryResponse["data"] | null;
   activeChatSession: ChatSessionRecord | null;

--- a/ui/src/types/runtime.ts
+++ b/ui/src/types/runtime.ts
@@ -11,6 +11,14 @@ export type SessionResponse = {
   object: string;
   data: {
     role: string;
+    runtime_host: {
+      id: string;
+      label: string;
+      runtime_mode: "local" | "remote_runtime";
+      operator_access: "local_operator" | "remote_supervision";
+      public_url?: string;
+      local_only_actions_available: boolean;
+    };
     remote_identity?: {
       actor_id: string;
       org_id: string;


### PR DESCRIPTION
## Summary

- persist a stable, non-secret runtime host ID beside Hecate's data-directory state and support an operator-defined host label
- extend `GET /hecate/v1/whoami` with typed runtime identity, execution mode, operator access posture, public URL, and local-action availability
- show `On <host>` or `Supervising <host>` in the operator shell, with responsive truncation and an execution-boundary tooltip
- document how a phone or remote browser supervises work on a named Hecate host

## Architecture

Runtime identity remains Hecate-owned host state in `hecate.runtime-host.json`. It is separate from bootstrap secrets and from Cairnline's portable project coordination graph.

Trusted remote-runtime identity determines remote supervision posture and preserves the existing remote route policy. This does not add a tunnel, public endpoint, account system, device pairing, process migration, autonomous execution, or durable memory writes.

## Verification

- `go test -race -timeout 10m ./...`
- `go vet ./...`
- `cd ui && bun run typecheck`
- `cd ui && bun run test`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `just docs-format-check`
- live shell smoke test at 1440x900 and 390x844
