### PR TITLE
feat(tasks): add exact Chat and Task handoffs

### DIFF
--- a/docs/design/accepted/interaction-execution-terminology.md
+++ b/docs/design/accepted/interaction-execution-terminology.md
@@ -65,7 +65,10 @@ not use `run_id`.
 
 When both objects exist, navigation preserves their exact identity: Chat links
 target a Chat and, when known, a Message; Task links target a Task and, when
-known, a Run.
+known, a Run. A Run with a persisted Chat source exposes that canonical
+Chat/Turn/Message identity as `source_ref`; clients do not reconstruct it by
+matching transcript `task_id` / `run_id` fields. Retry and resume Runs retain
+the source reference without creating a new Chat Turn.
 
 ## Naming Rules
 

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -365,6 +365,12 @@ committed ceiling.
 - `prior_cost_micros_usd` — cumulative spend of every prior run in this run's resume chain. Cumulative-across-task = `prior + total`.
 - `model_call_count` — completed provider model calls accounted to this Run. It is always present, including explicit `0`, and is distinct from `step_count` because Steps also include tools and control activity.
 - `model` / `provider` / `provider_kind` — what was actually used (after routing). May differ from the task's `requested_*` when the operator picked auto. Agent-loop runs preserve these fields for both streaming and non-streaming model calls.
+- `source_ref` — present when the Run carries a canonical source Chat Turn in
+  its persisted context packet. `kind="chat_turn"` includes the exact
+  `chat_session_id`, `turn_id`, and `message_id`. Retry and resume Runs retain
+  that source while receiving their own new `run_id`, so clients can return to
+  the originating Chat Turn without inferring provenance from transcript
+  fields.
 
 ## Lifecycle endpoints
 

--- a/internal/api/handler_chat_hecate_test.go
+++ b/internal/api/handler_chat_hecate_test.go
@@ -173,6 +173,9 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 	if firstRun.ID == "" {
 		t.Fatalf("first run %q not found in runs: %+v", first.Data.LatestRunID, runs.Data)
 	}
+	if firstRun.SourceRef == nil || firstRun.SourceRef.Kind != "chat_turn" || firstRun.SourceRef.ChatSessionID != session.Data.ID || firstRun.SourceRef.TurnID != assistant.TurnID || firstRun.SourceRef.MessageID != assistant.ID {
+		t.Fatalf("first run source_ref = %+v, want chat %q turn %q message %q", firstRun.SourceRef, session.Data.ID, assistant.TurnID, assistant.ID)
+	}
 	if assistant.RequestID != firstRun.RequestID || assistant.TraceID != firstRun.TraceID || assistant.SpanID != firstRun.RootSpanID {
 		t.Fatalf("assistant trace linkage = request %q trace %q span %q, want backing run request %q trace %q span %q",
 			assistant.RequestID, assistant.TraceID, assistant.SpanID, firstRun.RequestID, firstRun.TraceID, firstRun.RootSpanID)
@@ -180,6 +183,9 @@ func TestHecateAgentChatCreatesVisibleTaskAndContinuesSameTask(t *testing.T) {
 	secondRun := findTaskRunItem(runs.Data, second.Data.LatestRunID)
 	if secondRun.ID == "" {
 		t.Fatalf("second run %q not found in runs: %+v", second.Data.LatestRunID, runs.Data)
+	}
+	if secondRun.SourceRef == nil || secondRun.SourceRef.Kind != "chat_turn" || secondRun.SourceRef.ChatSessionID != session.Data.ID || secondRun.SourceRef.TurnID != secondAssistant.TurnID || secondRun.SourceRef.MessageID != secondAssistant.ID {
+		t.Fatalf("second run source_ref = %+v, want chat %q turn %q message %q", secondRun.SourceRef, session.Data.ID, secondAssistant.TurnID, secondAssistant.ID)
 	}
 	if secondAssistant.RequestID != secondRun.RequestID || secondAssistant.TraceID != secondRun.TraceID || secondAssistant.SpanID != secondRun.RootSpanID {
 		t.Fatalf("second assistant trace linkage = request %q trace %q span %q, want backing run request %q trace %q span %q",

--- a/internal/api/handler_tasks.go
+++ b/internal/api/handler_tasks.go
@@ -774,6 +774,14 @@ func renderTaskRun(run types.TaskRun, parentTasks ...types.Task) TaskRunItem {
 		item.ProjectID = firstNonEmptyString(item.ProjectID, refs.ProjectID)
 		item.WorkItemID = firstNonEmptyString(item.WorkItemID, refs.WorkItemID)
 		item.AssignmentID = firstNonEmptyString(item.AssignmentID, refs.AssignmentID)
+		if refs.TaskID == run.TaskID && refs.RunID == run.ID && refs.SessionID != "" && refs.TurnID != "" && refs.MessageID != "" {
+			item.SourceRef = &TaskRunSourceRefItem{
+				Kind:          "chat_turn",
+				ChatSessionID: refs.SessionID,
+				TurnID:        refs.TurnID,
+				MessageID:     refs.MessageID,
+			}
+		}
 	}
 	if !run.StartedAt.IsZero() {
 		item.StartedAt = run.StartedAt.UTC().Format(time.RFC3339Nano)

--- a/internal/api/handler_tasks_render_test.go
+++ b/internal/api/handler_tasks_render_test.go
@@ -141,6 +141,71 @@ func TestRenderTaskRunUsesContextPacketProjectLinkageFallback(t *testing.T) {
 	}
 }
 
+func TestRenderTaskRun_ExposesCanonicalChatTurnSource(t *testing.T) {
+	t.Parallel()
+
+	packet, err := json.Marshal(chat.ContextPacket{
+		Version: "chat.context.v1",
+		Refs: &chat.ContextRefs{
+			SessionID: "chat_1",
+			TurnID:    "turn_1",
+			MessageID: "message_1",
+			TaskID:    "task_1",
+			RunID:     "run_2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal context packet: %v", err)
+	}
+
+	item := renderTaskRun(types.TaskRun{
+		ID:            "run_2",
+		TaskID:        "task_1",
+		Status:        "completed",
+		ContextPacket: packet,
+	})
+	if item.SourceRef == nil {
+		t.Fatal("source_ref = nil, want canonical chat turn source")
+	}
+	if got := *item.SourceRef; got.Kind != "chat_turn" || got.ChatSessionID != "chat_1" || got.TurnID != "turn_1" || got.MessageID != "message_1" {
+		t.Fatalf("source_ref = %+v, want exact chat/turn/message", got)
+	}
+}
+
+func TestRenderTaskRun_OmitsMismatchedChatTurnSource(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		refs chat.ContextRefs
+	}{
+		{
+			name: "different task",
+			refs: chat.ContextRefs{SessionID: "chat_1", TurnID: "turn_1", MessageID: "message_1", TaskID: "task_other", RunID: "run_1"},
+		},
+		{
+			name: "different run",
+			refs: chat.ContextRefs{SessionID: "chat_1", TurnID: "turn_1", MessageID: "message_1", TaskID: "task_1", RunID: "run_other"},
+		},
+		{
+			name: "incomplete chat identity",
+			refs: chat.ContextRefs{SessionID: "chat_1", TurnID: "turn_1", TaskID: "task_1", RunID: "run_1"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			packet, err := json.Marshal(chat.ContextPacket{Version: "chat.context.v1", Refs: &tc.refs})
+			if err != nil {
+				t.Fatalf("marshal context packet: %v", err)
+			}
+			item := renderTaskRun(types.TaskRun{ID: "run_1", TaskID: "task_1", ContextPacket: packet})
+			if item.SourceRef != nil {
+				t.Fatalf("source_ref = %+v, want omitted", item.SourceRef)
+			}
+		})
+	}
+}
+
 func TestRenderTaskItem_ExposesAgentPresetRuntimePolicySnapshot(t *testing.T) {
 	t.Parallel()
 	toolsEnabled := false

--- a/internal/api/task_run_stream_projector_test.go
+++ b/internal/api/task_run_stream_projector_test.go
@@ -2,12 +2,87 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
 )
+
+func TestTaskRunStreamProjector_LiveStateProjectsCanonicalChatSourceRef(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	now := time.Now().UTC()
+	task := types.Task{
+		ID:         "task-chat-source-live",
+		Title:      "chat source live",
+		Prompt:     "project source",
+		OriginKind: "chat",
+		OriginID:   "chat_live",
+		Status:     "running",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	run := types.TaskRun{
+		ID:        "run-chat-source-live",
+		TaskID:    task.ID,
+		Number:    1,
+		Status:    "running",
+		StartedAt: now,
+		ContextPacket: json.RawMessage(`{
+			"id":"ctx_live",
+			"version":"chat.context.v1",
+			"refs":{"session_id":"chat_live","turn_id":"turn_live","message_id":"message_live","task_id":"task-chat-source-live","run_id":"run-chat-source-live"}
+		}`),
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+
+	state, err := newTaskRunStreamProjector(store).projectEvent(ctx, task.ID, run.ID, types.TaskRunEvent{
+		Sequence:  3,
+		EventType: "run.updated",
+	})
+	if err != nil {
+		t.Fatalf("projectEvent() error = %v", err)
+	}
+	assertTaskRunSourceRef(t, state.Run.SourceRef, "chat_live", "turn_live", "message_live")
+}
+
+func TestTaskRunStreamProjector_RawRunnerEventProjectsCanonicalChatSourceRef(t *testing.T) {
+	t.Parallel()
+
+	run := types.TaskRun{
+		ID:     "run-chat-source-replay",
+		TaskID: "task-chat-source-replay",
+		Status: "completed",
+		ContextPacket: json.RawMessage(`{
+			"id":"ctx_replay",
+			"version":"chat.context.v1",
+			"refs":{"session_id":"chat_replay","turn_id":"turn_replay","message_id":"message_replay","task_id":"task-chat-source-replay","run_id":"run-chat-source-replay"}
+		}`),
+	}
+	state, err := newTaskRunStreamProjector(nil).projectEvent(
+		context.Background(),
+		run.TaskID,
+		run.ID,
+		types.TaskRunEvent{
+			Sequence:  4,
+			EventType: "run.finished",
+			Data:      map[string]any{"run": run},
+		},
+	)
+	if err != nil {
+		t.Fatalf("projectEvent() error = %v", err)
+	}
+	assertTaskRunSourceRef(t, state.Run.SourceRef, "chat_replay", "turn_replay", "message_replay")
+}
 
 func TestTaskRunStreamProjector_ModelCallCompletedMergesOverlayWithLiveState(t *testing.T) {
 	t.Parallel()
@@ -148,6 +223,11 @@ func TestTaskRunStreamProjector_SnapshotEventDataUsesCurrentStreamShape(t *testi
 			ID:     "run-shape",
 			TaskID: "task-shape",
 			Status: "running",
+			ContextPacket: json.RawMessage(`{
+				"id":"ctx_shape",
+				"version":"chat.context.v1",
+				"refs":{"session_id":"chat_shape","turn_id":"turn_shape","message_id":"message_shape","task_id":"task-shape","run_id":"run-shape"}
+			}`),
 		}),
 		Approvals: []TaskApprovalItem{{
 			ID:     "approval-shape",
@@ -166,6 +246,27 @@ func TestTaskRunStreamProjector_SnapshotEventDataUsesCurrentStreamShape(t *testi
 	}
 	if len(approvals) != 1 {
 		t.Fatalf("snapshot approvals = %d, want 1", len(approvals))
+	}
+	run, ok := snapshot["run"].(map[string]any)
+	if !ok {
+		t.Fatalf("snapshot run = %#v, want JSON object", snapshot["run"])
+	}
+	sourceRef, ok := run["source_ref"].(map[string]any)
+	if !ok {
+		t.Fatalf("snapshot run source_ref = %#v, want JSON object", run["source_ref"])
+	}
+	if sourceRef["kind"] != "chat_turn" || sourceRef["chat_session_id"] != "chat_shape" || sourceRef["turn_id"] != "turn_shape" || sourceRef["message_id"] != "message_shape" {
+		t.Fatalf("snapshot source_ref = %#v, want exact wire keys and values", sourceRef)
+	}
+}
+
+func assertTaskRunSourceRef(t *testing.T, ref *TaskRunSourceRefItem, sessionID, turnID, messageID string) {
+	t.Helper()
+	if ref == nil {
+		t.Fatal("SourceRef = nil, want canonical Chat source")
+	}
+	if ref.Kind != "chat_turn" || ref.ChatSessionID != sessionID || ref.TurnID != turnID || ref.MessageID != messageID {
+		t.Fatalf("SourceRef = %+v, want chat_turn/%s/%s/%s", ref, sessionID, turnID, messageID)
 	}
 }
 

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -267,15 +267,23 @@ type TaskRunItem struct {
 	// PriorCostMicrosUSD is the cumulative LLM spend of every prior
 	// run in this run's resume chain (zero for fresh runs). Add it
 	// to TotalCostMicrosUSD to get the task-level cumulative spend.
-	PriorCostMicrosUSD int64  `json:"prior_cost_micros_usd,omitempty"`
-	LastError          string `json:"last_error,omitempty"`
-	StartedAt          string `json:"started_at,omitempty"`
-	FinishedAt         string `json:"finished_at,omitempty"`
-	RequestID          string `json:"request_id,omitempty"`
-	TraceID            string `json:"trace_id,omitempty"`
-	RootSpanID         string `json:"root_span_id,omitempty"`
-	OtelStatusCode     string `json:"otel_status_code,omitempty"`
-	OtelStatusMessage  string `json:"otel_status_message,omitempty"`
+	PriorCostMicrosUSD int64                 `json:"prior_cost_micros_usd,omitempty"`
+	LastError          string                `json:"last_error,omitempty"`
+	StartedAt          string                `json:"started_at,omitempty"`
+	FinishedAt         string                `json:"finished_at,omitempty"`
+	RequestID          string                `json:"request_id,omitempty"`
+	TraceID            string                `json:"trace_id,omitempty"`
+	RootSpanID         string                `json:"root_span_id,omitempty"`
+	OtelStatusCode     string                `json:"otel_status_code,omitempty"`
+	OtelStatusMessage  string                `json:"otel_status_message,omitempty"`
+	SourceRef          *TaskRunSourceRefItem `json:"source_ref,omitempty"`
+}
+
+type TaskRunSourceRefItem struct {
+	Kind          string `json:"kind"`
+	ChatSessionID string `json:"chat_session_id"`
+	TurnID        string `json:"turn_id"`
+	MessageID     string `json:"message_id"`
 }
 
 type TaskRunStreamEventData struct {

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -211,7 +211,11 @@ type StartTaskResult struct {
 }
 
 type startTaskOptions struct {
-	ResumeFromRun  *types.TaskRun
+	ResumeFromRun *types.TaskRun
+	// RetryFromRun carries same-input state into a fresh Run. Unlike
+	// ResumeFromRun, it does not inherit workspace, cost, or conversation
+	// checkpoints and emits no resume event.
+	RetryFromRun   *types.TaskRun
 	ResumeReason   string
 	AppendPrompt   string
 	RunInitializer func(*types.TaskRun)
@@ -515,6 +519,16 @@ func (r *Runner) StartTask(ctx context.Context, task types.Task, idgen func(pref
 	return r.startTaskWithOptions(ctx, task, idgen, startTaskOptions{})
 }
 
+// RetryTask creates a fresh Run while retaining canonical source provenance
+// from the selected Run's context packet. It intentionally does not resume
+// execution state or emit run.resumed_from_event.
+func (r *Runner) RetryTask(ctx context.Context, task types.Task, run types.TaskRun, idgen func(prefix string) string) (*StartTaskResult, error) {
+	if !types.IsTerminalTaskRunStatus(run.Status) {
+		return nil, fmt.Errorf("task run %q is not retryable", run.ID)
+	}
+	return r.startTaskWithOptions(ctx, task, idgen, startTaskOptions{RetryFromRun: &run})
+}
+
 func (r *Runner) SetOriginRunGate(gate *taskruncoord.Gate) {
 	if r == nil {
 		return
@@ -794,21 +808,26 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 			run.WorkspacePath = prior.WorkspacePath
 			run.WorkspaceID = firstNonEmpty(prior.WorkspaceID, run.WorkspaceID)
 		}
-		if task.ExecutionKind == "agent_loop" && strings.TrimSpace(options.AppendPrompt) == "" {
-			run.InputRef = strings.TrimSpace(prior.InputRef)
-			if run.InputRef != "" && prior.InputProviderInstance.Valid() {
-				run.InputProviderInstance = prior.InputProviderInstance
-				run.InputProviderDispatchRecorded = prior.InputProviderDispatchRecorded
-				run.Provider = strings.TrimSpace(prior.Provider)
-				run.ProviderKind = strings.TrimSpace(prior.ProviderKind)
-				run.Model = firstNonEmpty(strings.TrimSpace(prior.Model), run.Model)
-			}
-		}
 		// Inherit cumulative cost from the source run so the per-task
 		// cost ceiling holds across the entire resume chain. Source's
 		// PriorCost (chain so far excluding source) + Total (source's
 		// own spend) gives the new run its accurate prior accumulator.
 		run.PriorCostMicrosUSD = prior.PriorCostMicrosUSD + prior.TotalCostMicrosUSD
+	}
+	sameInputSource := options.RetryFromRun
+	if sameInputSource == nil {
+		sameInputSource = options.ResumeFromRun
+	}
+	if sameInputSource != nil && task.ExecutionKind == "agent_loop" && strings.TrimSpace(options.AppendPrompt) == "" {
+		prior := *sameInputSource
+		run.InputRef = strings.TrimSpace(prior.InputRef)
+		if run.InputRef != "" && prior.InputProviderInstance.Valid() {
+			run.InputProviderInstance = prior.InputProviderInstance
+			run.InputProviderDispatchRecorded = prior.InputProviderDispatchRecorded
+			run.Provider = strings.TrimSpace(prior.Provider)
+			run.ProviderKind = strings.TrimSpace(prior.ProviderKind)
+			run.Model = firstNonEmpty(strings.TrimSpace(prior.Model), run.Model)
+		}
 	}
 	var provisionPlan workspaceProvisionPlan
 	if strings.TrimSpace(run.WorkspacePath) == "" {
@@ -841,8 +860,12 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 			return nil, err
 		}
 	}
-	if options.ResumeFromRun != nil && len(run.ContextPacket) == 0 && len(options.ResumeFromRun.ContextPacket) > 0 {
-		run.ContextPacket = cloneRunContextPacketForNewRun(options.ResumeFromRun.ContextPacket, task.ID, run.ID, idgen)
+	contextSource := options.RetryFromRun
+	if contextSource == nil {
+		contextSource = options.ResumeFromRun
+	}
+	if contextSource != nil && len(run.ContextPacket) == 0 && len(contextSource.ContextPacket) > 0 {
+		run.ContextPacket = cloneRunContextPacketForNewRun(contextSource.ContextPacket, task.ID, run.ID, run.WorkspacePath, idgen)
 	}
 	if options.RunInitializer != nil {
 		options.RunInitializer(&run)
@@ -916,7 +939,7 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 	}, nil
 }
 
-func cloneRunContextPacketForNewRun(raw json.RawMessage, taskID, runID string, idgen func(string) string) json.RawMessage {
+func cloneRunContextPacketForNewRun(raw json.RawMessage, taskID, runID, workspacePath string, idgen func(string) string) json.RawMessage {
 	if len(raw) == 0 {
 		return nil
 	}
@@ -937,6 +960,11 @@ func cloneRunContextPacketForNewRun(raw json.RawMessage, taskID, runID string, i
 	refs["task_id"] = taskID
 	refs["run_id"] = runID
 	packet["refs"] = refs
+	if workspacePath = strings.TrimSpace(workspacePath); workspacePath != "" {
+		packet["workspace"] = workspacePath
+	} else {
+		delete(packet, "workspace")
+	}
 	updated, err := json.Marshal(packet)
 	if err != nil {
 		return append(json.RawMessage(nil), raw...)

--- a/internal/orchestrator/runner_lifecycle_test.go
+++ b/internal/orchestrator/runner_lifecycle_test.go
@@ -449,7 +449,7 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 		InputProviderDispatchRecorded: true,
 		ContextPacket: json.RawMessage(`{
 			"id":"ctx_old",
-			"refs":{"session_id":"chat_1","run_id":"run-resume-source"},
+			"refs":{"session_id":"chat_1","turn_id":"turn_1","message_id":"message_1","task_id":"task-resume-context","run_id":"run-resume-source"},
 			"items":[{"kind":"transcript","trust_level":"runtime_state","origin":"chat.transcript","title":"Chat transcript","included":true}]
 		}`),
 	}
@@ -469,11 +469,125 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 		t.Fatalf("GetRun(%q) found=%v err=%v", result.Run.ID, found, err)
 	}
 	assertCopiedRunContextPacket(t, stored.ContextPacket, task.ID, result.Run.ID)
+	assertRunContextSourceRefs(t, stored.ContextPacket, "chat_1", "turn_1", "message_1")
 	if stored.InputRef != run.InputRef {
 		t.Fatalf("InputRef = %q, want inherited %q", stored.InputRef, run.InputRef)
 	}
 	if stored.Provider != run.Provider || stored.ProviderKind != run.ProviderKind || stored.Model != run.Model || stored.InputProviderInstance != inputProviderInstance || !stored.InputProviderDispatchRecorded {
 		t.Fatalf("inherited input route = provider %q kind %q model %q instance %+v dispatched=%t, want %q/%q/%q/%+v/true", stored.Provider, stored.ProviderKind, stored.Model, stored.InputProviderInstance, stored.InputProviderDispatchRecorded, run.Provider, run.ProviderKind, run.Model, inputProviderInstance)
+	}
+}
+
+func TestRetryTaskCarriesForwardOnlySourceContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := NewRunner(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store,
+		nil,
+		Config{QueueWorkers: 0},
+	)
+
+	now := time.Now().UTC()
+	inputProviderInstance := types.ProviderInstanceIdentity{ID: "runtime-retry-source-input", Kind: types.ProviderInstanceIdentityRuntime}
+	task := types.Task{
+		ID:                "task-retry-source-context",
+		Title:             "retry source context",
+		Prompt:            "retry me from scratch",
+		ExecutionKind:     "agent_loop",
+		RequestedProvider: "fresh-provider",
+		RequestedModel:    "fresh-model",
+		WorkingDirectory:  t.TempDir(),
+		Status:            "failed",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	run := types.TaskRun{
+		ID:                             "run-retry-source-context",
+		TaskID:                         task.ID,
+		Number:                         1,
+		Status:                         "failed",
+		StartedAt:                      now,
+		FinishedAt:                     now,
+		InputRef:                       "msg_prior_input",
+		Provider:                       "prior-provider",
+		ProviderKind:                   "cloud",
+		Model:                          "prior-model",
+		InputProviderInstance:          inputProviderInstance,
+		InputProviderDispatchRecorded:  true,
+		InputProviderDisclosedInstance: inputProviderInstance,
+		PriorCostMicrosUSD:             150,
+		TotalCostMicrosUSD:             25,
+		ContextPacket: json.RawMessage(`{
+			"id":"ctx_old_retry",
+			"workspace":"/prior/workspace",
+			"refs":{
+				"session_id":"chat_retry",
+				"turn_id":"turn_retry",
+				"message_id":"msg_retry",
+				"task_id":"task-retry-source-context",
+				"run_id":"run-retry-source-context"
+			},
+			"items":[{"kind":"transcript","trust_level":"runtime_state","origin":"chat.transcript","title":"Chat transcript","included":true}]
+		}`),
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	result, err := runner.RetryTask(ctx, task, run, defaultResourceID)
+	if err != nil {
+		t.Fatalf("RetryTask: %v", err)
+	}
+	stored, found, err := store.GetRun(ctx, task.ID, result.Run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun(%q) found=%v err=%v", result.Run.ID, found, err)
+	}
+	assertCopiedRunContextPacket(t, stored.ContextPacket, task.ID, result.Run.ID)
+
+	var packet struct {
+		Workspace string `json:"workspace"`
+		Refs      struct {
+			SessionID string `json:"session_id"`
+			TurnID    string `json:"turn_id"`
+			MessageID string `json:"message_id"`
+		} `json:"refs"`
+	}
+	if err := json.Unmarshal(stored.ContextPacket, &packet); err != nil {
+		t.Fatalf("Unmarshal ContextPacket: %v", err)
+	}
+	if packet.Refs.SessionID != "chat_retry" || packet.Refs.TurnID != "turn_retry" || packet.Refs.MessageID != "msg_retry" {
+		t.Fatalf("source refs = %+v, want chat_retry/turn_retry/msg_retry", packet.Refs)
+	}
+	if packet.Workspace != stored.WorkspacePath || packet.Workspace == "/prior/workspace" {
+		t.Fatalf("context workspace = %q, want new Run workspace %q", packet.Workspace, stored.WorkspacePath)
+	}
+	if stored.InputRef != run.InputRef {
+		t.Fatalf("InputRef = %q, want inherited same-input ref %q", stored.InputRef, run.InputRef)
+	}
+	if stored.Provider != run.Provider || stored.ProviderKind != run.ProviderKind || stored.Model != run.Model || stored.InputProviderInstance != inputProviderInstance || !stored.InputProviderDispatchRecorded {
+		t.Fatalf("same-input route = provider %q kind %q model %q admitted %+v dispatched=%t, want %q/%q/%q/%+v/true", stored.Provider, stored.ProviderKind, stored.Model, stored.InputProviderInstance, stored.InputProviderDispatchRecorded, run.Provider, run.ProviderKind, run.Model, inputProviderInstance)
+	}
+	if stored.InputProviderDisclosedInstance.Valid() {
+		t.Fatalf("new retry disclosed instance = %+v, want empty until this Run reaches provider I/O", stored.InputProviderDisclosedInstance)
+	}
+	if stored.PriorCostMicrosUSD != 0 {
+		t.Fatalf("PriorCostMicrosUSD = %d, want fresh cost chain", stored.PriorCostMicrosUSD)
+	}
+
+	events, err := store.ListRunEvents(ctx, task.ID, stored.ID, 0, 50)
+	if err != nil {
+		t.Fatalf("ListRunEvents: %v", err)
+	}
+	for _, event := range events {
+		if event.EventType == "run.resumed_from_event" {
+			t.Fatalf("fresh retry emitted %q", event.EventType)
+		}
 	}
 }
 
@@ -682,5 +796,22 @@ func assertCopiedRunContextPacket(t *testing.T, raw json.RawMessage, taskID, run
 	}
 	if got, _ := refs["run_id"].(string); got != runID {
 		t.Fatalf("refs.run_id = %q, want %q", got, runID)
+	}
+}
+
+func assertRunContextSourceRefs(t *testing.T, raw json.RawMessage, sessionID, turnID, messageID string) {
+	t.Helper()
+	var packet struct {
+		Refs struct {
+			SessionID string `json:"session_id"`
+			TurnID    string `json:"turn_id"`
+			MessageID string `json:"message_id"`
+		} `json:"refs"`
+	}
+	if err := json.Unmarshal(raw, &packet); err != nil {
+		t.Fatalf("Unmarshal ContextPacket source refs: %v", err)
+	}
+	if packet.Refs.SessionID != sessionID || packet.Refs.TurnID != turnID || packet.Refs.MessageID != messageID {
+		t.Fatalf("source refs = %+v, want %s/%s/%s", packet.Refs, sessionID, turnID, messageID)
 	}
 }

--- a/internal/taskapp/application.go
+++ b/internal/taskapp/application.go
@@ -60,6 +60,7 @@ func IsValidationError(err error) bool {
 
 type Runner interface {
 	StartTask(context.Context, types.Task, func(string) string) (*orchestrator.StartTaskResult, error)
+	RetryTask(context.Context, types.Task, types.TaskRun, func(string) string) (*orchestrator.StartTaskResult, error)
 	ResumeTaskWithBudget(context.Context, types.Task, types.TaskRun, string, int64, func(string) string) (*orchestrator.StartTaskResult, error)
 	ContinueAgentTask(context.Context, types.Task, types.TaskRun, string, func(string) string) (*orchestrator.StartTaskResult, error)
 	RetryTaskFromModelCall(context.Context, types.Task, types.TaskRun, int, string, func(string) string) (*orchestrator.StartTaskResult, error)
@@ -499,7 +500,7 @@ func (app *Application) RetryTaskRun(ctx context.Context, task types.Task, run t
 	if app.runner == nil {
 		return nil, ErrRunnerNotConfigured
 	}
-	result, err := app.runner.StartTask(ctx, task, app.idgen)
+	result, err := app.runner.RetryTask(ctx, task, run, app.idgen)
 	return result, mapOtherActiveRunError(err)
 }
 

--- a/internal/taskapp/application_test.go
+++ b/internal/taskapp/application_test.go
@@ -15,6 +15,9 @@ import (
 type recordingTaskApplicationRunner struct {
 	startCalls int
 	startTask  types.Task
+	retryCalls int
+	retryTask  types.Task
+	retryRun   types.TaskRun
 
 	resumeCalls  int
 	resumeTask   types.Task
@@ -43,6 +46,14 @@ func (r *recordingTaskApplicationRunner) StartTask(_ context.Context, task types
 	r.startTask = task
 	run := types.TaskRun{ID: "run_started", TaskID: task.ID, Status: "queued"}
 	return &orchestrator.StartTaskResult{Task: task, Run: run}, nil
+}
+
+func (r *recordingTaskApplicationRunner) RetryTask(_ context.Context, task types.Task, run types.TaskRun, _ func(string) string) (*orchestrator.StartTaskResult, error) {
+	r.retryCalls++
+	r.retryTask = task
+	r.retryRun = run
+	retried := types.TaskRun{ID: "run_retried", TaskID: task.ID, Status: "queued"}
+	return &orchestrator.StartTaskResult{Task: task, Run: retried}, nil
 }
 
 func (r *recordingTaskApplicationRunner) ResumeTaskWithBudget(_ context.Context, task types.Task, run types.TaskRun, reason string, budgetMicrosUSD int64, _ func(string) string) (*orchestrator.StartTaskResult, error) {
@@ -96,7 +107,7 @@ func (r *recordingTaskApplicationRunner) ResolveTaskApproval(_ context.Context, 
 }
 
 func (r *recordingTaskApplicationRunner) totalCalls() int {
-	return r.startCalls + r.resumeCalls + r.continueCalls + r.retryFromModelCallCalls + r.cancelCalls + r.resolveCalls
+	return r.startCalls + r.retryCalls + r.resumeCalls + r.continueCalls + r.retryFromModelCallCalls + r.cancelCalls + r.resolveCalls
 }
 
 func newTestTaskApplication(store taskstate.Store, runner Runner) *Application {
@@ -343,6 +354,42 @@ func TestTaskApplication_StartTaskRejectsActiveRunBeforeRunner(t *testing.T) {
 	}
 	if runner.startCalls != 0 {
 		t.Fatalf("runner start calls = %d, want 0", runner.startCalls)
+	}
+}
+
+func TestTaskApplication_RetryDispatchesSourceRun(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := &recordingTaskApplicationRunner{}
+	app := newTestTaskApplication(store, runner)
+	task := createTaskForAppTest(t, ctx, store, types.Task{
+		ID:          "task_retry",
+		Status:      "failed",
+		LatestRunID: "run_failed",
+	})
+	run := createRunForAppTest(t, ctx, store, types.TaskRun{
+		ID:     task.LatestRunID,
+		TaskID: task.ID,
+		Status: "failed",
+	})
+
+	result, err := app.RetryTaskRun(ctx, task, run)
+	if err != nil {
+		t.Fatalf("RetryTaskRun() error = %v", err)
+	}
+	if runner.retryCalls != 1 {
+		t.Fatalf("retry calls = %d, want 1", runner.retryCalls)
+	}
+	if runner.retryTask.ID != task.ID || runner.retryRun.ID != run.ID {
+		t.Fatalf("retry source = task %q run %q, want task %q run %q", runner.retryTask.ID, runner.retryRun.ID, task.ID, run.ID)
+	}
+	if runner.startCalls != 0 {
+		t.Fatalf("fresh start calls = %d, want 0", runner.startCalls)
+	}
+	if result.Run.ID != "run_retried" {
+		t.Fatalf("result run ID = %q, want run_retried", result.Run.ID)
 	}
 }
 

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1640,9 +1640,7 @@ test("Hecate Chat sends direct model turns when selected model lacks tools", asy
     });
 });
 
-test("Hecate Agent local-provider onboarding renders the real final answer after completion", async ({
-  page,
-}) => {
+test("Hecate Chat preserves exact Task Run and source Turn navigation", async ({ page }) => {
   await page.unrouteAll({ behavior: "ignoreErrors" });
   await page.addInitScript(() => {
     window.localStorage.setItem("hecate.chatTarget", "agent");
@@ -1738,15 +1736,20 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
       messages: [
         {
           id: "msg-user-e2e",
+          turn_id: "turn-hecate-e2e",
+          turn_kind: "hecate_task",
           execution_mode: "hecate_task",
           segment_id: "task:task-hecate-e2e",
           task_id: "task-hecate-e2e",
+          run_id: "run-hecate-e2e",
           role: "user",
           content: "show diff",
           created_at: "2026-05-06T10:00:00Z",
         },
         {
           id: "msg-assistant-e2e",
+          turn_id: "turn-hecate-e2e",
+          turn_kind: "hecate_task",
           execution_mode: "hecate_task",
           segment_id: "task:task-hecate-e2e",
           task_id: "task-hecate-e2e",
@@ -1785,6 +1788,110 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
     });
   });
 
+  const task = {
+    id: "task-hecate-e2e",
+    title: "show diff",
+    prompt: "show diff",
+    execution_kind: "agent_loop",
+    execution_profile: "chat_agent",
+    origin_kind: "chat",
+    origin_id: "chat-hecate-e2e",
+    status: "completed",
+    latest_run_id: "run-hecate-e2e",
+    latest_run_step_count: 0,
+    latest_run_artifact_count: 0,
+  };
+  const run = {
+    id: "run-hecate-e2e",
+    task_id: "task-hecate-e2e",
+    number: 1,
+    status: "completed",
+    model_call_count: 1,
+    model: "qwen2.5",
+    provider: "lmstudio",
+    source_ref: {
+      kind: "chat_turn",
+      chat_session_id: "chat-hecate-e2e",
+      turn_id: "turn-hecate-e2e",
+      message_id: "msg-assistant-e2e",
+    },
+  };
+  await page.route(/\/hecate\/v1\/tasks(?:\/.*)?(?:\?.*)?$/, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const suffix = url.pathname.replace("/hecate/v1/tasks", "").replace(/^\/+/, "");
+    const parts = suffix ? suffix.split("/").map((part) => decodeURIComponent(part)) : [];
+    if (request.method() !== "GET") {
+      await route.fulfill({ status: 405, body: "" });
+      return;
+    }
+    if (parts.length === 0) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "tasks", data: [task] }),
+      });
+      return;
+    }
+    if (parts.length === 1 && parts[0] === task.id) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "task", data: task }),
+      });
+      return;
+    }
+    if (parts[0] !== task.id) {
+      await route.fulfill({ status: 404, body: "" });
+      return;
+    }
+    if (parts.length === 2 && parts[1] === "runs") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "task_runs", data: [run] }),
+      });
+      return;
+    }
+    if (parts.length === 2 && parts[1] === "approvals") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "task_approvals", data: [] }),
+      });
+      return;
+    }
+    if (parts[1] === "runs" && parts[2] === run.id && parts[3] === "stream") {
+      await route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+      return;
+    }
+    if (parts[1] === "runs" && parts[2] === run.id && parts[3] === "steps") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "task_steps", data: [] }),
+      });
+      return;
+    }
+    if (parts[1] === "runs" && parts[2] === run.id && parts[3] === "artifacts") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "task_artifacts", data: [] }),
+      });
+      return;
+    }
+    if (parts[1] === "runs" && parts[2] === run.id && parts[3] === "events") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ object: "task_run_events", data: [], next_after_sequence: 0 }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 404, body: "" });
+  });
+
   await page.goto("/");
   await page.waitForSelector(".hecate-activitybar");
 
@@ -1810,6 +1917,26 @@ test("Hecate Agent local-provider onboarding renders the real final answer after
       workspace: "/tmp/hecate-e2e-workspace",
     });
   await expect(page.locator("body")).toContainText("qwen2.5");
+
+  const runLink = page.getByRole("link", { name: /Open Run run-hecate/i });
+  await expect(runLink).toHaveAttribute("href", "/tasks?task=task-hecate-e2e&run=run-hecate-e2e");
+  await runLink.click();
+  await expect(page).toHaveURL(/\/tasks\?task=task-hecate-e2e&run=run-hecate-e2e$/);
+  const taskHeading = page.getByRole("heading", { name: "show diff" });
+  await expect(taskHeading).toBeFocused();
+
+  const sourceLink = page.getByRole("link", { name: "Open source Chat Turn" });
+  await expect(sourceLink).toHaveAttribute(
+    "href",
+    "/chats?chat=chat-hecate-e2e&message=msg-assistant-e2e",
+  );
+  await sourceLink.click();
+  await expect(page).toHaveURL(/\/chats\?chat=chat-hecate-e2e&message=msg-assistant-e2e$/);
+  await expect(page.getByText("Command output:")).toBeVisible();
+  await expect(page.locator("#msg-assistant-e2e")).toBeFocused();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/tasks\?task=task-hecate-e2e&run=run-hecate-e2e$/);
 });
 
 test("Hecate Chat can move tools on, tools off, then tools on again in one transcript", async ({

--- a/ui/src/app/AppShell.test.tsx
+++ b/ui/src/app/AppShell.test.tsx
@@ -11,7 +11,6 @@ import {
 } from "../test/runtime-console-fixture";
 import { withRuntimeConsole } from "../test/runtime-console-render";
 import {
-  getChatSession,
   getProjectAssignments,
   getProjectActivity,
   getProjectCollaborationArtifacts,
@@ -31,17 +30,19 @@ import type {
   ProjectWorkItemRecord,
 } from "../types/project";
 
-const tasksViewProbe = vi.hoisted(() => ({ render: vi.fn() }));
+const tasksViewProbe = vi.hoisted(() => ({ render: vi.fn(), focusIntent: vi.fn() }));
 
 vi.mock("../features/tasks/TasksView", () => {
   return {
     TasksView: (props: {
       focusRequest?: { taskID: string; runID?: string; nonce: number } | null;
-      onOpenChat?: (sessionID: string, taskID?: string, runID?: string) => void;
+      focusIntent?: { taskID: string; runID?: string; nonce: number } | null;
+      onOpenChat?: (sessionID: string, messageID?: string) => void;
     }) => {
       tasksViewProbe.render(props.focusRequest);
+      tasksViewProbe.focusIntent(props.focusIntent);
       return (
-        <button type="button" onClick={() => props.onOpenChat?.("chat_task", "task_1", "run_1")}>
+        <button type="button" onClick={() => props.onOpenChat?.("chat_task", "message_task")}>
           Open linked Task chat
         </button>
       );
@@ -62,17 +63,6 @@ vi.mock("../lib/api", async (importOriginal) => {
   };
   return {
     ...actual,
-    getChatSession: vi.fn(async () => ({
-      object: "chat_session",
-      data: {
-        id: "chat_task",
-        agent_id: "hecate",
-        title: "Task chat",
-        status: "completed",
-        workspace: "",
-        messages: [],
-      },
-    })),
     getProjectActivity: vi.fn(async () => ({
       object: "project_activity",
       data: emptyActivityData(),
@@ -276,18 +266,7 @@ function resetProjectWorkMocks() {
     updated_at: "",
   };
   tasksViewProbe.render.mockClear();
-  vi.mocked(getChatSession).mockReset();
-  vi.mocked(getChatSession).mockResolvedValue({
-    object: "chat_session",
-    data: {
-      id: "chat_task",
-      agent_id: "hecate",
-      title: "Task chat",
-      status: "completed",
-      workspace: "",
-      messages: [],
-    },
-  });
+  tasksViewProbe.focusIntent.mockClear();
   vi.mocked(getProjectActivity).mockResolvedValue({
     object: "project_activity",
     data: emptyActivityData(),
@@ -373,10 +352,20 @@ describe("getAvailableWorkspaces", () => {
     expect(settings?.label).toBe("Settings");
   });
 
-  it("treats a present bare Tasks route as authoritative over imperative focus", () => {
+  it("keeps routed Task loading stable and separate from explicit focus intent", () => {
     const imperativeFocus = { taskID: "task_1", runID: "run_1", nonce: 1 };
 
     expect(resolveTaskFocusRequest(undefined, imperativeFocus)).toBe(imperativeFocus);
+    expect(resolveTaskFocusRequest({ taskID: "task_1", runID: "run_1" }, imperativeFocus)).toEqual({
+      taskID: "task_1",
+      runID: "run_1",
+      nonce: 0,
+    });
+    expect(resolveTaskFocusRequest({ taskID: "task_2", runID: "run_2" }, imperativeFocus)).toEqual({
+      taskID: "task_2",
+      runID: "run_2",
+      nonce: 0,
+    });
     expect(resolveTaskFocusRequest({ taskID: null, runID: null }, imperativeFocus)).toBeNull();
   });
 });
@@ -556,20 +545,89 @@ describe("ConsoleShell navigation", () => {
       ),
     );
 
-    fireEvent.click(await screen.findByRole("button", { name: "Open Run 1" }, { timeout: 30_000 }));
+    const runLink = await screen.findByRole("link", { name: "Open Run 1" }, { timeout: 30_000 });
+    expect(runLink).toHaveAttribute("href", "/tasks?task=task_1&run=run_1");
+    fireEvent.click(runLink);
 
     expect(onTaskNavigate).toHaveBeenCalledWith({ taskID: "task_1", runID: "run_1" });
     expect(onSelectWorkspace).not.toHaveBeenCalledWith("tasks");
   }, 35_000);
 
-  it("loads a Chat addressed by the URL", async () => {
-    const selectChatSession = vi.fn(async () => true);
+  it("discards an unacknowledged Task focus intent after the operator leaves", async () => {
+    const onTaskNavigate = vi.fn();
+    const state = createRuntimeConsoleFixture({
+      chatTarget: "agent",
+      activeChatSessionID: "chat_1",
+      activeChatSession: {
+        id: "chat_1",
+        agent_id: "hecate",
+        execution_mode: "hecate_task",
+        title: "Repo work",
+        provider: "openai",
+        model: "gpt-4o-mini",
+        status: "completed",
+        messages: [
+          {
+            id: "message_1",
+            role: "assistant",
+            content: "Done.",
+            turn_kind: "hecate_task",
+            execution_mode: "hecate_task",
+            task_id: "task_1",
+            run_id: "run_1",
+            status: "completed",
+          },
+        ],
+      } as any,
+    });
+    const actions = createRuntimeConsoleActions();
+    const view = render(
+      withRuntimeConsole(
+        <ConsoleShell
+          activeWorkspace="chats"
+          onSelectWorkspace={() => {}}
+          onTaskNavigate={onTaskNavigate}
+        />,
+        { state, actions },
+      ),
+    );
+
+    fireEvent.click(await screen.findByRole("link", { name: "Open Run 1" }, { timeout: 30_000 }));
+    expect(onTaskNavigate).toHaveBeenCalledWith({ taskID: "task_1", runID: "run_1" });
+
+    view.rerender(
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="connections" onSelectWorkspace={() => {}} />,
+        { state, actions },
+      ),
+    );
+    await act(async () => Promise.resolve());
+
+    view.rerender(
+      withRuntimeConsole(
+        <ConsoleShell
+          activeWorkspace="tasks"
+          onSelectWorkspace={() => {}}
+          taskNavigation={{ taskID: "task_1", runID: "run_1" }}
+        />,
+        { state, actions },
+      ),
+    );
+    await screen.findByRole("button", { name: "Open linked Task chat" }, { timeout: 30_000 });
+
+    expect(tasksViewProbe.focusIntent).toHaveBeenLastCalledWith(null);
+  }, 35_000);
+
+  it("loads a Chat addressed by the URL and aborts route ownership on cleanup", async () => {
+    const selectChatSession = vi.fn(
+      async (_sessionID: string, _options?: { signal?: AbortSignal }) => true,
+    );
     const state = createRuntimeConsoleFixture({
       activeChatSessionID: "",
       activeChatSession: null,
     });
 
-    render(
+    const view = render(
       withRuntimeConsole(
         <ConsoleShell
           activeWorkspace="chats"
@@ -580,7 +638,22 @@ describe("ConsoleShell navigation", () => {
       ),
     );
 
-    await waitFor(() => expect(selectChatSession).toHaveBeenCalledWith("chat_routed"));
+    await waitFor(() =>
+      expect(selectChatSession).toHaveBeenCalledWith(
+        "chat_routed",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
+    const signal = selectChatSession.mock.calls[0]?.[1]?.signal;
+
+    view.rerender(
+      withRuntimeConsole(
+        <ConsoleShell activeWorkspace="connections" onSelectWorkspace={() => {}} />,
+        { state, actions: { ...createRuntimeConsoleActions(), selectChatSession } },
+      ),
+    );
+
+    expect(signal?.aborted).toBe(true);
   });
 
   it("does not reapply the old Chat URL while a sidebar selection is completing", async () => {
@@ -656,7 +729,12 @@ describe("ConsoleShell navigation", () => {
       ),
     );
 
-    await waitFor(() => expect(selectChatSession).toHaveBeenCalledWith("chat_routed"));
+    await waitFor(() =>
+      expect(selectChatSession).toHaveBeenCalledWith(
+        "chat_routed",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
     fireEvent.click(await screen.findByText("Chat B", undefined, { timeout: 30_000 }));
     await waitFor(() => expect(selectChatSession).toHaveBeenCalledWith("chat_b"));
     await act(async () => resolveRoutedSelection?.(false));
@@ -670,19 +748,9 @@ describe("ConsoleShell navigation", () => {
     );
   }, 35_000);
 
-  it("drops an in-flight Task-to-Chat lookup after newer workspace navigation", async () => {
-    let resolveChatLookup:
-      | ((value: Awaited<ReturnType<typeof getChatSession>>) => void)
-      | undefined;
-    vi.mocked(getChatSession).mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveChatLookup = resolve;
-        }),
-    );
+  it("navigates from a Task Run to its canonical source Chat message", async () => {
     const selectChatSession = vi.fn(async () => true);
     const onChatNavigate = vi.fn();
-    const onSelectWorkspace = vi.fn();
     const state = createRuntimeConsoleFixture();
 
     render(
@@ -690,7 +758,7 @@ describe("ConsoleShell navigation", () => {
         <ConsoleShell
           activeWorkspace="tasks"
           onChatNavigate={onChatNavigate}
-          onSelectWorkspace={onSelectWorkspace}
+          onSelectWorkspace={() => {}}
           taskNavigation={{ taskID: "task_1", runID: "run_1" }}
         />,
         { state, actions: { ...createRuntimeConsoleActions(), selectChatSession } },
@@ -700,41 +768,99 @@ describe("ConsoleShell navigation", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Open linked Task chat" }, { timeout: 30_000 }),
     );
-    await waitFor(() => expect(getChatSession).toHaveBeenCalledWith("chat_task"));
-    fireEvent.click(screen.getByRole("link", { name: "Connections" }));
-    expect(onSelectWorkspace).toHaveBeenCalledWith("connections");
-    await act(async () =>
-      resolveChatLookup?.({
-        object: "chat_session",
-        data: {
-          id: "chat_task",
-          agent_id: "hecate",
-          title: "Task chat",
-          status: "completed",
-          workspace: "",
-          messages: [],
-        },
-      }),
-    );
 
-    await waitFor(() => expect(selectChatSession).not.toHaveBeenCalled());
-    expect(onChatNavigate).not.toHaveBeenCalled();
+    expect(onChatNavigate).toHaveBeenCalledWith({
+      chatID: "chat_task",
+      messageID: "message_task",
+    });
+    expect(selectChatSession).not.toHaveBeenCalled();
   });
 
-  it("drops an in-flight Task-to-Chat lookup after parent-driven route navigation", async () => {
-    let resolveChatLookup:
-      | ((value: Awaited<ReturnType<typeof getChatSession>>) => void)
-      | undefined;
-    vi.mocked(getChatSession).mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveChatLookup = resolve;
-        }),
+  it("discards an unacknowledged Chat focus intent after the operator leaves", async () => {
+    const onChatNavigate = vi.fn();
+    const actions = createRuntimeConsoleActions();
+    const taskState = createRuntimeConsoleFixture();
+    const view = render(
+      <>
+        <button type="button">Persistent focus sentinel</button>
+        {withRuntimeConsole(
+          <ConsoleShell
+            activeWorkspace="tasks"
+            onChatNavigate={onChatNavigate}
+            onSelectWorkspace={() => {}}
+            taskNavigation={{ taskID: "task_1", runID: "run_1" }}
+          />,
+          { state: taskState, actions },
+        )}
+      </>,
     );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Open linked Task chat" }, { timeout: 30_000 }),
+    );
+    expect(onChatNavigate).toHaveBeenCalledWith({
+      chatID: "chat_task",
+      messageID: "message_task",
+    });
+
+    view.rerender(
+      <>
+        <button type="button">Persistent focus sentinel</button>
+        {withRuntimeConsole(
+          <ConsoleShell activeWorkspace="connections" onSelectWorkspace={() => {}} />,
+          { state: taskState, actions },
+        )}
+      </>,
+    );
+    const sentinel = screen.getByRole("button", { name: "Persistent focus sentinel" });
+    sentinel.focus();
+    await act(async () => Promise.resolve());
+
+    const chatState = createRuntimeConsoleFixture({
+      chatTarget: "agent",
+      activeChatSessionID: "chat_task",
+      activeChatSession: {
+        id: "chat_task",
+        agent_id: "hecate",
+        title: "Source chat",
+        provider: "openai",
+        model: "gpt-4o-mini",
+        status: "completed",
+        messages: [
+          {
+            id: "message_task",
+            role: "assistant",
+            content: "Source answer",
+            created_at: "2026-07-19T10:00:00Z",
+          },
+        ],
+      } as any,
+    });
+    view.rerender(
+      <>
+        <button type="button">Persistent focus sentinel</button>
+        {withRuntimeConsole(
+          <ConsoleShell
+            activeWorkspace="chats"
+            chatNavigation={{ chatID: "chat_task", messageID: "message_task" }}
+            onChatNavigate={onChatNavigate}
+            onSelectWorkspace={() => {}}
+          />,
+          { state: chatState, actions },
+        )}
+      </>,
+    );
+
+    await screen.findByText("Source answer", undefined, { timeout: 30_000 });
+    expect(document.activeElement).toBe(sentinel);
+  }, 35_000);
+
+  it("lets the committed Chat route own Task-to-Chat selection", async () => {
     const selectChatSession = vi.fn(async () => true);
     const onChatNavigate = vi.fn();
     const state = createRuntimeConsoleFixture();
     const actions = { ...createRuntimeConsoleActions(), selectChatSession };
+
     const view = render(
       withRuntimeConsole(
         <ConsoleShell
@@ -750,40 +876,25 @@ describe("ConsoleShell navigation", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Open linked Task chat" }, { timeout: 30_000 }),
     );
-    await waitFor(() => expect(getChatSession).toHaveBeenCalledWith("chat_task"));
+    expect(selectChatSession).not.toHaveBeenCalled();
 
     view.rerender(
       withRuntimeConsole(
         <ConsoleShell
-          activeWorkspace="tasks"
+          activeWorkspace="chats"
+          chatNavigation={{ chatID: "chat_task", messageID: "message_task" }}
           onChatNavigate={onChatNavigate}
           onSelectWorkspace={() => {}}
-          taskNavigation={{ taskID: "task_2", runID: "run_2" }}
         />,
         { state, actions },
       ),
     );
     await waitFor(() =>
-      expect(tasksViewProbe.render).toHaveBeenLastCalledWith(
-        expect.objectContaining({ taskID: "task_2", runID: "run_2" }),
+      expect(selectChatSession).toHaveBeenCalledWith(
+        "chat_task",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
       ),
     );
-    await act(async () =>
-      resolveChatLookup?.({
-        object: "chat_session",
-        data: {
-          id: "chat_task",
-          agent_id: "hecate",
-          title: "Task chat",
-          status: "completed",
-          workspace: "",
-          messages: [],
-        },
-      }),
-    );
-
-    await waitFor(() => expect(selectChatSession).not.toHaveBeenCalled());
-    expect(onChatNavigate).not.toHaveBeenCalled();
   });
 
   it("keeps routed Task focus stable when its navigation object is recreated", async () => {

--- a/ui/src/app/AppShell.tsx
+++ b/ui/src/app/AppShell.tsx
@@ -21,7 +21,6 @@ import {
 } from "./navigation";
 import type { ChatUsageRecord } from "../types/chat";
 import { DesktopUpdateCenter } from "../features/shared/DesktopUpdateControl";
-import { getChatSession } from "../lib/api";
 import { usePersistedState } from "../lib/persistedState";
 import { isTauriOnMacOS } from "../lib/tauri";
 import type { ProviderFilter } from "../types/provider";
@@ -80,6 +79,7 @@ type WorkspaceDefinition = {
 };
 
 type TaskFocusRequest = { taskID: string; runID?: string; nonce: number };
+type ChatFocusRequest = { chatID: string; messageID: string; nonce: number };
 type TraceFocusRequest = { requestID: string; nonce: number };
 type ProjectChatRequest = {
   projectID: string;
@@ -361,9 +361,11 @@ function AuthenticatedShell({
   const runtimeVersion = runtimeVersionLabel(runtime.state.health?.version);
   const workspaces = getAvailableWorkspaces();
   const [taskFocusRequest, setTaskFocusRequest] = useState<TaskFocusRequest | null>(null);
+  const [chatFocusRequest, setChatFocusRequest] = useState<ChatFocusRequest | null>(null);
   const [traceFocusRequest, setTraceFocusRequest] = useState<TraceFocusRequest | null>(null);
   const routedChatSelectionRef = useRef<string | null>(null);
   const taskChatNavigationGenerationRef = useRef(0);
+  const taskChatSelectionAbortRef = useRef<AbortController | null>(null);
   const routedNavigationIdentityRef = useRef({
     workspace: activeWorkspace,
     chatNavigationPresent: chatNavigation !== undefined,
@@ -388,6 +390,8 @@ function AuthenticatedShell({
 
   const invalidateTaskChatNavigation = useCallback(() => {
     taskChatNavigationGenerationRef.current += 1;
+    taskChatSelectionAbortRef.current?.abort();
+    taskChatSelectionAbortRef.current = null;
   }, []);
 
   useEffect(() => {
@@ -425,6 +429,46 @@ function AuthenticatedShell({
     taskNavigation !== undefined,
   ]);
 
+  useEffect(() => {
+    setChatFocusRequest((current) => {
+      if (!current) return current;
+      if (activeWorkspace !== "chats") return null;
+      if (
+        chatNavigation !== undefined &&
+        (chatNavigation?.chatID !== current.chatID ||
+          (chatNavigation?.messageID ?? "") !== current.messageID)
+      ) {
+        return null;
+      }
+      return current;
+    });
+  }, [
+    activeWorkspace,
+    chatNavigation?.chatID,
+    chatNavigation?.messageID,
+    chatNavigation !== undefined,
+  ]);
+
+  useEffect(() => {
+    setTaskFocusRequest((current) => {
+      if (!current) return current;
+      if (activeWorkspace !== "tasks") return null;
+      if (
+        taskNavigation !== undefined &&
+        (taskNavigation?.taskID !== current.taskID ||
+          (current.runID && taskNavigation?.runID !== current.runID))
+      ) {
+        return null;
+      }
+      return current;
+    });
+  }, [
+    activeWorkspace,
+    taskNavigation?.runID,
+    taskNavigation?.taskID,
+    taskNavigation !== undefined,
+  ]);
+
   const handleWorkspaceSelection = useCallback(
     (workspace: WorkspaceID) => {
       routedChatSelectionRef.current = null;
@@ -443,7 +487,8 @@ function AuthenticatedShell({
     if (routedChatSelectionRef.current === chatID) return;
     routedChatSelectionRef.current = chatID;
     let cancelled = false;
-    void selectChatSessionRef.current(chatID).then((selected) => {
+    const controller = new AbortController();
+    void selectChatSessionRef.current(chatID, { signal: controller.signal }).then((selected) => {
       const ownsRoutedSelection = routedChatSelectionRef.current === chatID;
       if (ownsRoutedSelection) routedChatSelectionRef.current = null;
       if (cancelled || selected || !ownsRoutedSelection) return;
@@ -454,6 +499,7 @@ function AuthenticatedShell({
     });
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [activeWorkspace, chatNavigation?.chatID, onChatNavigate]);
 
@@ -550,33 +596,31 @@ function AuthenticatedShell({
     onSelectWorkspace("chats");
   }
 
-  async function openChatFromTask(sessionID: string, taskID?: string, runID?: string) {
+  async function openChatFromTask(sessionID: string, messageID?: string) {
     const navigationGeneration = ++taskChatNavigationGenerationRef.current;
+    setChatFocusRequest({ chatID: sessionID, messageID: messageID ?? "", nonce: Date.now() });
     chatActions.setChatTarget("agent");
-    let messageID: string | null = null;
-    if (taskID || runID) {
-      try {
-        const snapshot = await getChatSession(sessionID);
-        const messages = snapshot.data.messages ?? [];
-        const matchesExecution = (message: (typeof messages)[number]) =>
-          (!taskID || message.task_id === taskID) && (!runID || message.run_id === runID);
-        messageID =
-          messages.find((message) => message.role === "user" && matchesExecution(message))?.id ??
-          messages.find(matchesExecution)?.id ??
-          null;
-      } catch {
-        // Session selection owns the visible error and stale-target behavior.
-      }
-    }
-    if (taskChatNavigationGenerationRef.current !== navigationGeneration) return;
-    const selected = await chatActions.selectChatSession(sessionID);
-    if (!selected || taskChatNavigationGenerationRef.current !== navigationGeneration) return;
     if (onChatNavigate) {
-      onChatNavigate({ chatID: sessionID, messageID });
-    } else {
-      onSelectWorkspace("chats");
+      onChatNavigate({ chatID: sessionID, messageID: messageID || null });
+      return;
     }
+    const controller = new AbortController();
+    taskChatSelectionAbortRef.current = controller;
+    const selected = await chatActions.selectChatSession(sessionID, { signal: controller.signal });
+    if (taskChatSelectionAbortRef.current === controller) {
+      taskChatSelectionAbortRef.current = null;
+    }
+    if (!selected || taskChatNavigationGenerationRef.current !== navigationGeneration) return;
+    onSelectWorkspace("chats");
   }
+
+  const handleChatFocusRequestHandled = useCallback((nonce: number) => {
+    setChatFocusRequest((current) => (current?.nonce === nonce ? null : current));
+  }, []);
+
+  const handleTaskFocusRequestHandled = useCallback((nonce: number) => {
+    setTaskFocusRequest((current) => (current?.nonce === nonce ? null : current));
+  }, []);
 
   function openTraceFromChat(requestID: string) {
     invalidateTaskChatNavigation();
@@ -686,7 +730,9 @@ function AuthenticatedShell({
               {activeWorkspace === "chats" && (
                 <ChatView
                   focusMessageID={chatNavigation?.messageID}
+                  focusRequest={chatFocusRequest}
                   onNavigate={handleWorkspaceSelection}
+                  onFocusRequestHandled={handleChatFocusRequestHandled}
                   onMessageFocusUnavailable={handleMissingChatMessage}
                   onOpenTask={openTaskFromChat}
                   onOpenTrace={openTraceFromChat}
@@ -697,6 +743,8 @@ function AuthenticatedShell({
               {activeWorkspace === "tasks" && (
                 <TasksView
                   focusRequest={routedTaskFocusRequest}
+                  focusIntent={taskFocusRequest}
+                  onFocusRequestHandled={handleTaskFocusRequestHandled}
                   onOpenChat={openChatFromTask}
                   onOpenTrace={openTraceFromChat}
                   onSelectionChange={handleTaskSelection}

--- a/ui/src/app/state/coordinators/chat.ts
+++ b/ui/src/app/state/coordinators/chat.ts
@@ -482,6 +482,7 @@ export type CreateChatSessionOptions = {
 
 export type SelectChatSessionOptions = {
   draft?: string;
+  signal?: AbortSignal;
 };
 
 type ChatActionsReturn = {
@@ -3288,6 +3289,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     id: string,
     options: SelectChatSessionOptions = {},
   ): Promise<boolean> {
+    if (options.signal?.aborted) return false;
     if (blockWhileChatOwnershipMutationRuns("switching chats")) return false;
     if (blockWhileChatCancellationOwnsSession(id, "opening this chat")) return false;
     const attachmentTurnSessionID = chatAttachmentTurnSessionID();
@@ -3345,8 +3347,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
     }
     setMessage(targetDraft);
     const selectionTransferSnapshot = getMessageSnapshot();
-    const restoreAttachmentOwner = () => {
-      if (!isCurrentActiveChatTransition(selectionGeneration)) return;
+    const restoreSourceSelection = () => {
+      if (!isCurrentActiveChatTransition(selectionGeneration)) return false;
       const liveComposerSnapshot = getMessageSnapshot();
       const restoredComposer =
         liveComposerSnapshot.revision === selectionTransferSnapshot.revision &&
@@ -3359,9 +3361,16 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       setAgentWorkspaceBranch(sourceWorkspaceBranch);
       setMessage(restoredComposer);
       rememberChatComposerDraft(sourceSessionID, restoredComposer);
+      return true;
     };
+    let selectionSettled = false;
+    const abortSelection = () => {
+      if (selectionSettled) return;
+      if (restoreSourceSelection()) claimChatSessionIntent();
+    };
+    options.signal?.addEventListener("abort", abortSelection, { once: true });
     try {
-      const payload = await getChatSession(id);
+      const payload = await getChatSession(id, options.signal);
       const latest = await latestSessionAfterCancellation(
         id,
         cancellationEpoch,
@@ -3376,7 +3385,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         hasChatAttachmentTurn() &&
         (!liveAttachmentTurnSessionID || id !== liveAttachmentTurnSessionID)
       ) {
-        restoreAttachmentOwner();
+        restoreSourceSelection();
         params.setNoticeMessage(
           "error",
           "Wait for the attachment response before switching chats.",
@@ -3384,7 +3393,7 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
         return false;
       }
       if (id !== sourceSessionID && hasPendingChatAttachments()) {
-        restoreAttachmentOwner();
+        restoreSourceSelection();
         params.setNoticeMessage("error", "Remove attached files before switching chats.");
         return false;
       }
@@ -3402,10 +3411,11 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       completeActiveChatTransition(selectionGeneration);
       return true;
     } catch (error) {
+      if (options.signal?.aborted) return false;
       if (!isCurrentActiveChatTransition(selectionGeneration)) return false;
       if (isChatSessionDeleted(id)) return false;
       if (hasPendingChatAttachments() || hasChatAttachmentTurn()) {
-        restoreAttachmentOwner();
+        restoreSourceSelection();
         setChatErrorState(error, "failed to load agent chat");
         return false;
       }
@@ -3420,6 +3430,8 @@ export function useChatActions(params: UseChatActionsParams): ChatActionsReturn 
       completeActiveChatTransition(selectionGeneration);
       return false;
     } finally {
+      selectionSettled = true;
+      options.signal?.removeEventListener("abort", abortSelection);
       completeActiveChatTransition(selectionGeneration);
     }
   }

--- a/ui/src/features/chats/ChatTranscript.tsx
+++ b/ui/src/features/chats/ChatTranscript.tsx
@@ -1,5 +1,7 @@
 import { memo, useEffect, useRef, useState, type ReactNode } from "react";
 
+import { isPlainNavigationClick, taskNavigationURL } from "../../app/navigation";
+
 import { useChat } from "../../app/state/chat";
 import { useChatActions } from "../../app/state/coordinators/chat";
 import { useChatTarget } from "../../app/state/derived";
@@ -71,6 +73,7 @@ type Props = {
   isHecateAgentChat: boolean;
   activeSessionID: string;
   focusMessageID?: string | null;
+  focusRequest?: { chatID: string; messageID: string; nonce: number } | null;
 
   // Transcript content.
   transcriptItems: TranscriptItem[];
@@ -82,11 +85,12 @@ type Props = {
   // messages list when there's nothing to show yet.
   emptyState: ReactNode;
 
-  // Cross-region navigation. onOpenTask / onOpenTrace fall back to
-  // onNavigate when the parent doesn't wire them.
+  // Cross-region navigation. Exact Task links remain native anchors when
+  // onOpenTask is absent; trace navigation retains its workspace fallback.
   onNavigate?: (workspace: "connections" | "tasks" | "overview" | "settings" | "projects") => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
+  onFocusRequestHandled?: (nonce: number) => void;
   onOpenWorkspaceChanges?: () => void;
   canOpenProject: () => boolean;
   onOpenProject: (projectID: string) => boolean;
@@ -154,6 +158,7 @@ export function ChatTranscript({
   isHecateAgentChat,
   activeSessionID,
   focusMessageID,
+  focusRequest,
   transcriptItems,
   visibleMessageCount,
   streaming,
@@ -161,6 +166,7 @@ export function ChatTranscript({
   onNavigate,
   onOpenTask,
   onOpenTrace,
+  onFocusRequestHandled,
   onOpenWorkspaceChanges,
   canOpenProject,
   onOpenProject,
@@ -183,6 +189,7 @@ export function ChatTranscript({
   const [atBottom, setAtBottom] = useState(true);
   const [copiedMsgId, setCopiedMsgId] = useState<string | null>(null);
   const copiedMsgTimerRef = useRef<number | null>(null);
+  const handledFocusRequestNonceRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
@@ -218,6 +225,24 @@ export function ChatTranscript({
     target.scrollIntoView({ behavior: "instant", block: "center" });
   }, [activeSessionID, focusMessageID, visibleMessageCount]);
 
+  useEffect(() => {
+    if (
+      !focusRequest ||
+      focusRequest.nonce < 1 ||
+      focusRequest.chatID !== activeSessionID ||
+      handledFocusRequestNonceRef.current === focusRequest.nonce
+    ) {
+      return;
+    }
+    const target = focusRequest.messageID
+      ? document.getElementById(focusRequest.messageID)
+      : scrollRef.current;
+    if (!target || (focusRequest.messageID && !scrollRef.current?.contains(target))) return;
+    target.focus({ preventScroll: true });
+    handledFocusRequestNonceRef.current = focusRequest.nonce;
+    onFocusRequestHandled?.(focusRequest.nonce);
+  }, [activeSessionID, focusRequest, onFocusRequestHandled, visibleMessageCount]);
+
   function handleScroll() {
     const el = scrollRef.current;
     if (!el) return;
@@ -246,13 +271,12 @@ export function ChatTranscript({
   }
 
   // Stable handler identities so the memoized rows below can bail out of
-  // re-rendering. onOpenTask/onOpenTrace fold in the onNavigate fallback so
-  // the row never needs onNavigate directly.
+  // re-rendering. Task links only intercept when exact SPA navigation is
+  // available; otherwise their exact href remains native.
   const handleCopy = useStableCallback(copyMsg);
-  const handleOpenTask = useStableCallback((taskID: string, runID?: string) => {
-    if (onOpenTask) onOpenTask(taskID, runID);
-    else onNavigate?.("tasks");
-  });
+  const handleOpenTask = useStableCallback((taskID: string, runID?: string) =>
+    onOpenTask?.(taskID, runID),
+  );
   const handleOpenTrace = useStableCallback((requestID: string) => {
     if (onOpenTrace) onOpenTrace(requestID);
     else onNavigate?.("overview");
@@ -323,7 +347,10 @@ export function ChatTranscript({
     <div style={{ flex: 1, overflow: "hidden", position: "relative" }}>
       <div
         ref={scrollRef}
+        aria-label="Chat transcript"
+        className="cross-surface-focus-target"
         onScroll={handleScroll}
+        tabIndex={-1}
         style={{ height: "100%", overflowY: "auto", padding: "16px 0" }}
       >
         {(() => {
@@ -348,7 +375,7 @@ export function ChatTranscript({
                 copiedDebug={copiedMsgId === `${m.id}:debug`}
                 turnPrompt={turnPrompt}
                 onCopy={handleCopy}
-                onOpenTask={handleOpenTask}
+                onOpenTask={onOpenTask ? handleOpenTask : undefined}
                 onOpenTrace={handleOpenTrace}
                 onOpenProjectProposal={handleOpenProjectProposal}
                 onOpenWorkspaceChanges={workspaceChangesHandler}
@@ -475,7 +502,7 @@ type ChatTranscriptRowProps = {
   copiedDebug: boolean;
   turnPrompt?: string;
   onCopy: (id: string, text: string) => void;
-  onOpenTask: (taskID: string, runID?: string) => void;
+  onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace: (requestID: string) => void;
   onOpenProjectProposal: (message: VisibleChatMessage, activity: ChatActivityRecord) => void;
   onOpenWorkspaceChanges?: () => void;
@@ -552,7 +579,14 @@ const ChatTranscriptRow = memo(function ChatTranscriptRow({
           ? {
               label: formatTaskLinkLabel(taskID, taskRunID),
               title: formatTaskLinkTitle(taskID, taskRunID),
-              onClick: () => onOpenTask(taskID, taskRunID),
+              href: taskNavigationURL(window.location, { taskID, runID: taskRunID }),
+              onClick: onOpenTask
+                ? (event) => {
+                    if (!isPlainNavigationClick(event)) return;
+                    event.preventDefault();
+                    onOpenTask(taskID, taskRunID);
+                  }
+                : undefined,
             }
           : undefined
       }

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -3352,7 +3352,7 @@ describe("ChatView input", () => {
     });
     render(withRuntimeConsole(<ChatView onOpenTask={onOpenTask} />, { state, actions }));
     const user = userEvent.setup();
-    const executionLink = screen.getByRole("button", { name: /Open Run hecate_abcde/i });
+    const executionLink = screen.getByRole("link", { name: /Open Run hecate_abcde/i });
     expect(screen.queryByText("Turn task_1")).toBeNull();
     expect(screen.queryByTitle("Turn ID turn_task_1")).toBeNull();
     expect(executionLink).toHaveAttribute(
@@ -3362,6 +3362,84 @@ describe("ChatView input", () => {
 
     await user.click(executionLink);
     expect(onOpenTask).toHaveBeenCalledWith("task_hecate_123456", "run_hecate_abcdef");
+  });
+
+  it("keeps exact Task navigation native and focuses an explicitly requested Chat message", async () => {
+    const onFocusRequestHandled = vi.fn();
+    const { state, actions } = setup({
+      chatTarget: "agent",
+      defaultChatToolsEnabled: false,
+      activeChatSessionID: "chat_1",
+      activeChatSession: {
+        id: "chat_1",
+        execution_mode: "hecate_task",
+        title: "Repo work",
+        task_id: "task_hecate_123456",
+        latest_run_id: "run_hecate_abcdef",
+        provider: "ollama",
+        model: "qwen2.5-coder",
+        workspace: "/tmp/hecate",
+        status: "completed",
+        messages: [
+          {
+            id: "m1",
+            turn_id: "turn_task_1",
+            turn_kind: "hecate_task",
+            execution_mode: "hecate_task",
+            segment_id: "task:task_hecate_123456",
+            task_id: "task_hecate_123456",
+            run_id: "run_hecate_abcdef",
+            role: "user",
+            content: "inspect this repo",
+            created_at: "2026-05-03T10:00:00Z",
+          },
+          {
+            id: "m2",
+            turn_id: "turn_task_1",
+            turn_kind: "hecate_task",
+            execution_mode: "hecate_task",
+            segment_id: "task:task_hecate_123456",
+            task_id: "task_hecate_123456",
+            run_id: "run_hecate_abcdef",
+            role: "assistant",
+            content: "Done.",
+            status: "completed",
+            created_at: "2026-05-03T10:00:01Z",
+          },
+        ],
+      } as any,
+    });
+    render(
+      withRuntimeConsole(
+        <ChatView
+          focusRequest={{ chatID: "chat_1", messageID: "m2", nonce: 7 }}
+          onFocusRequestHandled={onFocusRequestHandled}
+        />,
+        { state, actions },
+      ),
+    );
+
+    const message = document.getElementById("m2");
+    await waitFor(() => expect(document.activeElement).toBe(message));
+    expect(onFocusRequestHandled).toHaveBeenCalledWith(7);
+
+    const taskLink = screen.getByRole("link", { name: /Open Run hecate_abcde/i });
+    let defaultPrevented = true;
+    document.addEventListener(
+      "click",
+      (event) => {
+        defaultPrevented = event.defaultPrevented;
+        event.preventDefault();
+      },
+      { once: true },
+    );
+    fireEvent.click(taskLink);
+
+    expect(defaultPrevented).toBe(false);
+    expect(taskLink).toHaveAttribute(
+      "href",
+      "/tasks?task=task_hecate_123456&run=run_hecate_abcdef",
+    );
   });
 
   it("does not borrow the session task link for direct model messages", () => {
@@ -3541,8 +3619,8 @@ describe("ChatView input", () => {
     expect(screen.getAllByLabelText("Tools off segment using smollm2:135m")).toHaveLength(2);
     expect(screen.getByLabelText("Tools on segment using qwen2.5-coder")).toBeTruthy();
     expect(screen.getByText(/Task first · completed/)).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /Open Run second/i })).toBeNull();
-    expect(screen.getAllByRole("button", { name: /Open Run first/i })).toHaveLength(1);
+    expect(screen.queryByRole("link", { name: /Open Run second/i })).toBeNull();
+    expect(screen.getAllByRole("link", { name: /Open Run first/i })).toHaveLength(1);
     expect(screen.getAllByText(/direct model chat/)).toHaveLength(2);
     expect(screen.getByLabelText("Tools on segment using qwen2.5-coder").children[1]).toHaveStyle({
       background: "var(--bg2)",
@@ -8485,6 +8563,55 @@ describe("ChatView session focus", () => {
     await waitFor(() =>
       expect(onMessageFocusUnavailable).toHaveBeenCalledWith("s1", "message-missing"),
     );
+  });
+
+  it("focuses the transcript once for an explicit Chat request without a message", async () => {
+    const onFocusRequestHandled = vi.fn();
+    const focusRequest = { chatID: "s1", messageID: "", nonce: 12 };
+    const { state, actions } = setup({
+      activeChatSessionID: "s1",
+      activeChatSession: linkedHecateChatFixture(),
+    });
+    const view = render(
+      withRuntimeConsole(
+        <ChatView focusRequest={focusRequest} onFocusRequestHandled={onFocusRequestHandled} />,
+        { state, actions },
+      ),
+    );
+
+    const transcript = screen.getByLabelText("Chat transcript");
+    await waitFor(() => expect(document.activeElement).toBe(transcript));
+    expect(onFocusRequestHandled).toHaveBeenCalledTimes(1);
+    expect(onFocusRequestHandled).toHaveBeenCalledWith(12);
+
+    view.rerender(
+      withRuntimeConsole(
+        <ChatView
+          focusRequest={{ ...focusRequest }}
+          onFocusRequestHandled={onFocusRequestHandled}
+        />,
+        { state, actions },
+      ),
+    );
+    expect(onFocusRequestHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it("scrolls passive message addressing without moving focus", () => {
+    const { state, actions } = setup({
+      activeChatSessionID: "s1",
+      activeChatSession: linkedHecateChatFixture([
+        { id: "message-present", role: "user", content: "Hello" },
+      ]),
+    });
+    const view = render(withRuntimeConsole(<ChatView />, { state, actions }));
+    const searchInput = screen.getByRole("textbox", { name: "Search chats" });
+    searchInput.focus();
+
+    view.rerender(
+      withRuntimeConsole(<ChatView focusMessageID="message-present" />, { state, actions }),
+    );
+
+    expect(document.activeElement).toBe(searchInput);
   });
 
   it("focuses the message textarea when a sidebar chat row is clicked", async () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -82,10 +82,12 @@ import {
 
 type Props = {
   focusMessageID?: string | null;
+  focusRequest?: { chatID: string; messageID: string; nonce: number } | null;
   onNavigate?: (workspace: "connections" | "tasks" | "overview" | "settings" | "projects") => void;
   onOpenTask?: (taskID: string, runID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
   onMessageFocusUnavailable?: (sessionID: string, messageID: string) => void;
+  onFocusRequestHandled?: (nonce: number) => void;
   onSelectChat?: (sessionID: string, mode?: "push" | "replace") => void;
   onSelectChatIntent?: (sessionID: string) => void;
 };
@@ -129,10 +131,12 @@ function chatAttachmentsDisabledReason({
 
 export function ChatView({
   focusMessageID,
+  focusRequest,
   onNavigate,
   onOpenTask,
   onOpenTrace,
   onMessageFocusUnavailable,
+  onFocusRequestHandled,
   onSelectChat,
   onSelectChatIntent,
 }: Props) {
@@ -1323,10 +1327,12 @@ export function ChatView({
                 isHecateAgentChat={isHecateAgentChat}
                 activeSessionID={activeSessionID}
                 focusMessageID={focusMessageID}
+                focusRequest={focusRequest}
                 transcriptItems={transcriptItems}
                 visibleMessageCount={visibleMessages.length}
                 streaming={streaming}
                 onNavigate={onNavigate}
+                onFocusRequestHandled={onFocusRequestHandled}
                 onOpenTask={onOpenTask}
                 onOpenTrace={onOpenTrace}
                 onOpenWorkspaceChanges={() => {

--- a/ui/src/features/tasks/TaskDetail.test.tsx
+++ b/ui/src/features/tasks/TaskDetail.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -203,11 +203,85 @@ describe("TaskDetail run picker", () => {
     const onOpenChat = vi.fn();
     const { render, user } = setup({
       task: makeTask({ origin_kind: "chat", origin_id: "chat_123" }),
+      run: makeRun({
+        source_ref: {
+          kind: "chat_turn",
+          chat_session_id: "chat_123",
+          turn_id: "turn_123",
+          message_id: "message_123",
+        },
+      }),
       onOpenChat,
     });
     render();
-    await user.click(screen.getByRole("button", { name: "Open source chat" }));
-    expect(onOpenChat).toHaveBeenCalledWith("chat_123", "task-1", "run-1");
+    const link = screen.getByRole("link", { name: "Open source Chat Turn" });
+    expect(link).toHaveAttribute("href", "/chats?chat=chat_123&message=message_123");
+    expect(link).toHaveAttribute("title", "Open source Chat Turn turn_123");
+    await user.click(link);
+    expect(onOpenChat).toHaveBeenCalledWith("chat_123", "message_123");
+  });
+
+  it("keeps modified source-chat clicks as native navigation", () => {
+    const onOpenChat = vi.fn();
+    const { render } = setup({
+      task: makeTask({ origin_kind: "chat", origin_id: "chat_123" }),
+      onOpenChat,
+    });
+    render();
+    const link = screen.getByRole("link", { name: "Open source Chat" });
+    document.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    fireEvent.click(link, { ctrlKey: true });
+    expect(onOpenChat).not.toHaveBeenCalled();
+  });
+
+  it("keeps the exact source anchor native without an SPA callback", () => {
+    const { render } = setup({
+      task: makeTask({ origin_kind: "chat", origin_id: "chat_123" }),
+      run: makeRun({
+        source_ref: {
+          kind: "chat_turn",
+          chat_session_id: "chat_123",
+          turn_id: "turn_123",
+          message_id: "message_123",
+        },
+      }),
+    });
+    render();
+    const link = screen.getByRole("link", { name: "Open source Chat Turn" });
+    let defaultPrevented = true;
+    document.addEventListener(
+      "click",
+      (event) => {
+        defaultPrevented = event.defaultPrevented;
+        event.preventDefault();
+      },
+      { once: true },
+    );
+
+    fireEvent.click(link);
+
+    expect(defaultPrevented).toBe(false);
+    expect(link).toHaveAttribute("href", "/chats?chat=chat_123&message=message_123");
+  });
+
+  it("focuses the task heading for an explicit cross-surface request", async () => {
+    const onFocusRequestHandled = vi.fn();
+    const { render } = setup({ focusRequestNonce: 42, onFocusRequestHandled });
+    render();
+
+    const heading = screen.getByRole("heading", { name: "List the working directory" });
+    await waitFor(() => expect(document.activeElement).toBe(heading));
+    expect(onFocusRequestHandled).toHaveBeenCalledWith(42);
+  });
+
+  it("does not focus or acknowledge passive routed Task addressing", () => {
+    const onFocusRequestHandled = vi.fn();
+    const { render } = setup({ focusRequestNonce: 0, onFocusRequestHandled });
+    render();
+
+    const heading = screen.getByRole("heading", { name: "List the working directory" });
+    expect(document.activeElement).not.toBe(heading);
+    expect(onFocusRequestHandled).not.toHaveBeenCalled();
   });
 
   it("shows standalone source metadata", () => {
@@ -222,7 +296,7 @@ describe("TaskDetail run picker", () => {
     });
     render();
     expect(screen.getByText("Project assignment")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Open source chat" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Open source chat" })).toBeNull();
   });
 
   it("hides the picker when there are zero runs", () => {

--- a/ui/src/features/tasks/TaskDetail.tsx
+++ b/ui/src/features/tasks/TaskDetail.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { chatNavigationURL, isPlainNavigationClick } from "../../app/navigation";
 import type { ContextPacketRecord } from "../../types/context";
 import type {
   TaskActivityRecord,
@@ -49,6 +50,7 @@ import {
   taskActivityArtifactSize,
   taskActivityToTranscriptActivity,
   taskBadgeProps,
+  taskChatSourceRef,
   taskRunOutcome,
   taskSource,
 } from "./taskDetailHelpers";
@@ -355,6 +357,7 @@ function TaskApprovalCallout({
 
 type Props = {
   task: TaskRecord;
+  focusRequestNonce?: number;
   run: TaskRunRecord | null;
   runs: TaskRunRecord[];
   selectedRunID: string;
@@ -386,7 +389,8 @@ type Props = {
   // reason is the operator's annotation for why they're branching —
   // stored in run events and shown in the timeline.
   onRetryFromModelCall: (modelCall: number, reason: string) => void;
-  onOpenChat?: (sessionID: string, taskID?: string, runID?: string) => void;
+  onOpenChat?: (sessionID: string, messageID?: string) => void;
+  onFocusRequestHandled?: (nonce: number) => void;
   // onResumeRaisingCeiling raises the task's per-task cost ceiling
   // and resumes the run in one server-side transaction. Surfaced
   // only when the run failed with otel_status_message =
@@ -406,6 +410,7 @@ type Props = {
 
 export function TaskDetail({
   task,
+  focusRequestNonce,
   run,
   runs,
   selectedRunID,
@@ -426,6 +431,7 @@ export function TaskDetail({
   onRefresh,
   onRetryFromModelCall,
   onOpenChat,
+  onFocusRequestHandled,
   onResumeRaisingCeiling,
   onApplyPatch,
   onRevertPatch,
@@ -433,6 +439,7 @@ export function TaskDetail({
   onOpenTrace,
 }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
   const [runPickerOpen, setRunPickerOpen] = useState(false);
   const [expandedStepID, setExpandedStepID] = useState<string>("");
   const [previewPatchID, setPreviewPatchID] = useState<string>("");
@@ -443,6 +450,7 @@ export function TaskDetail({
   const previewPatch = artifacts.find((a) => a.id === previewPatchID && a.kind === "patch") ?? null;
   const pendingApprovals = approvals.filter((a) => a.status === "pending");
   const source = taskSource(task);
+  const sourceChat = taskChatSourceRef(task, run);
   const requestedAutoProvider = run?.provider?.toLowerCase() === "auto";
   const resolvedProviderID = run?.provider && !requestedAutoProvider ? run.provider : "";
   const routeProviderLabel = resolvedProviderID
@@ -467,6 +475,12 @@ export function TaskDetail({
     setExpandedStepID("");
   }, [selectedRunID]);
 
+  useEffect(() => {
+    if (!focusRequestNonce || focusRequestNonce < 1 || !titleRef.current) return;
+    titleRef.current.focus({ preventScroll: true });
+    onFocusRequestHandled?.(focusRequestNonce);
+  }, [focusRequestNonce, onFocusRequestHandled]);
+
   return (
     <div
       style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", minWidth: 0 }}
@@ -484,8 +498,12 @@ export function TaskDetail({
         }}
       >
         <Badge {...taskBadgeProps(task.status, task.last_error)} />
-        <span
+        <h1
+          ref={titleRef}
+          className="cross-surface-focus-target"
+          tabIndex={-1}
           style={{
+            margin: 0,
             fontWeight: 500,
             fontSize: 13,
             color: "var(--t0)",
@@ -496,17 +514,32 @@ export function TaskDetail({
           }}
         >
           {task.title || task.prompt || "Untitled"}
-        </span>
-        {source.kind === "chat" && task.origin_id && onOpenChat ? (
-          <button
+        </h1>
+        {sourceChat ? (
+          <a
             className="btn btn-ghost btn-sm"
-            type="button"
-            onClick={() => onOpenChat?.(task.origin_id!, task.id, run?.id)}
-            title={`Open source chat ${task.origin_id}`}
-            style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}
+            href={chatNavigationURL(window.location, {
+              chatID: sourceChat.chatSessionID,
+              messageID: sourceChat.messageID,
+            })}
+            onClick={
+              onOpenChat
+                ? (event) => {
+                    if (!isPlainNavigationClick(event)) return;
+                    event.preventDefault();
+                    onOpenChat(sourceChat.chatSessionID, sourceChat.messageID || undefined);
+                  }
+                : undefined
+            }
+            title={
+              sourceChat.turnID
+                ? `Open source Chat Turn ${sourceChat.turnID}`
+                : `Open source chat ${sourceChat.chatSessionID}`
+            }
+            style={{ fontFamily: "var(--font-mono)", fontSize: 10, textDecoration: "none" }}
           >
-            Open source chat
-          </button>
+            {sourceChat.messageID ? "Open source Chat Turn" : "Open source Chat"}
+          </a>
         ) : (
           <span
             className="badge badge-muted"

--- a/ui/src/features/tasks/TasksView.tsx
+++ b/ui/src/features/tasks/TasksView.tsx
@@ -113,12 +113,16 @@ function TaskStartState({
 
 export function TasksView({
   focusRequest,
+  focusIntent,
+  onFocusRequestHandled,
   onOpenChat,
   onOpenTrace,
   onSelectionChange,
 }: {
   focusRequest?: TaskFocusRequest | null;
-  onOpenChat?: (sessionID: string, taskID?: string, runID?: string) => void;
+  focusIntent?: TaskFocusRequest | null;
+  onFocusRequestHandled?: (nonce: number) => void;
+  onOpenChat?: (sessionID: string, messageID?: string) => void;
   onOpenTrace?: (requestID: string) => void;
   onSelectionChange?: (
     taskID: string | null,
@@ -783,6 +787,12 @@ export function TasksView({
       {selectedTask ? (
         <TaskDetail
           task={selectedTask}
+          focusRequestNonce={
+            focusIntent?.taskID === selectedTaskID &&
+            (!focusIntent.runID || focusIntent.runID === selectedRunID)
+              ? focusIntent.nonce
+              : undefined
+          }
           run={selectedRun}
           runs={runs}
           selectedRunID={selectedRunID}
@@ -797,6 +807,7 @@ export function TasksView({
           notice={notice}
           onSelectRun={(id) => void handleSelectRun(id)}
           onOpenChat={onOpenChat}
+          onFocusRequestHandled={onFocusRequestHandled}
           onResolveApproval={(approval, decision) => void handleResolveApproval(approval, decision)}
           onCancelRun={() => void handleCancelRun()}
           onRetryRun={() => void handleRetryRun()}

--- a/ui/src/features/tasks/taskDetailHelpers.test.ts
+++ b/ui/src/features/tasks/taskDetailHelpers.test.ts
@@ -5,6 +5,7 @@ import type {
   TaskArtifactRecord,
   TaskRecord,
   TaskRunEventRecord,
+  TaskRunRecord,
 } from "../../types/task";
 
 import {
@@ -34,6 +35,7 @@ import {
   taskActivityToTranscriptActivity,
   taskBadgeProps,
   taskBadgeStatus,
+  taskChatSourceRef,
   taskRunOutcome,
 } from "./taskDetailHelpers";
 
@@ -77,6 +79,17 @@ function runEvent(overrides: Partial<TaskRunEventRecord> = {}): TaskRunEventReco
     occurred_at: "2026-05-28T00:00:00Z",
     type: "run.started",
     data: {},
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<TaskRunRecord> = {}): TaskRunRecord {
+  return {
+    id: "r_1",
+    task_id: "t_1",
+    number: 1,
+    status: "completed",
+    model_call_count: 1,
     ...overrides,
   };
 }
@@ -146,6 +159,44 @@ describe("taskBadgeProps", () => {
       label: "rejected",
     });
     expect(taskBadgeProps("cancelled", "operator cancelled")).toEqual({ status: "cancelled" });
+  });
+});
+
+describe("taskChatSourceRef", () => {
+  it("uses the selected Run's canonical Chat Turn source", () => {
+    expect(
+      taskChatSourceRef(
+        task({ origin_kind: "chat", origin_id: "chat_1" }),
+        run({
+          source_ref: {
+            kind: "chat_turn",
+            chat_session_id: "chat_1",
+            turn_id: "turn_1",
+            message_id: "message_1",
+          },
+        }),
+      ),
+    ).toEqual({ chatSessionID: "chat_1", turnID: "turn_1", messageID: "message_1" });
+  });
+
+  it("does not infer an exact Turn from mismatched Run provenance", () => {
+    expect(
+      taskChatSourceRef(
+        task({ origin_kind: "chat", origin_id: "chat_1" }),
+        run({
+          source_ref: {
+            kind: "chat_turn",
+            chat_session_id: "chat_other",
+            turn_id: "turn_other",
+            message_id: "message_other",
+          },
+        }),
+      ),
+    ).toEqual({ chatSessionID: "chat_1", turnID: "", messageID: "" });
+  });
+
+  it("omits source navigation for standalone Tasks", () => {
+    expect(taskChatSourceRef(task(), run())).toBeNull();
   });
 });
 

--- a/ui/src/features/tasks/taskDetailHelpers.ts
+++ b/ui/src/features/tasks/taskDetailHelpers.ts
@@ -4,6 +4,7 @@ import type {
   TaskArtifactRecord,
   TaskRecord,
   TaskRunEventRecord,
+  TaskRunRecord,
 } from "../../types/task";
 
 export const STEP_STATUS_COLOR: Record<string, string> = {
@@ -102,6 +103,35 @@ export function taskSource(task: TaskRecord): TaskSource {
     label: "Standalone",
     title: "Created directly in Tasks",
   };
+}
+
+export type TaskChatSourceRef = {
+  chatSessionID: string;
+  turnID: string;
+  messageID: string;
+};
+
+export function taskChatSourceRef(
+  task: TaskRecord,
+  run: TaskRunRecord | null,
+): TaskChatSourceRef | null {
+  const chatSessionID = (task.origin_id ?? "").trim();
+  if ((task.origin_kind ?? "").trim() !== "chat" || !chatSessionID) return null;
+
+  const sourceRef = run?.source_ref;
+  if (
+    !run ||
+    run.task_id !== task.id ||
+    sourceRef?.kind !== "chat_turn" ||
+    sourceRef.chat_session_id.trim() !== chatSessionID
+  ) {
+    return { chatSessionID, turnID: "", messageID: "" };
+  }
+
+  const turnID = sourceRef.turn_id.trim();
+  const messageID = sourceRef.message_id.trim();
+  if (!turnID || !messageID) return { chatSessionID, turnID: "", messageID: "" };
+  return { chatSessionID, turnID, messageID };
 }
 
 export type TaskRunOutcome = {

--- a/ui/src/features/transcript/TranscriptMessageRow.test.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.test.tsx
@@ -389,7 +389,7 @@ describe("TranscriptMessageRow", () => {
         onCopy={onCopy}
         runtimeMeta="Run run_123 · 2.0s"
         runtimeMetaTitle="Run run_123 · Native session native_123"
-        taskLink={{ label: "Task task_123", onClick: vi.fn() }}
+        taskLink={{ label: "Task task_123", href: "/tasks?task=task_123", onClick: vi.fn() }}
         traceLink={{ label: "Trace req_1234", title: "request req_1234", onClick: vi.fn() }}
         turnPrompt="What changed?"
       />,
@@ -419,12 +419,19 @@ describe("TranscriptMessageRow", () => {
         {...baseProps}
         runtimeMeta="Run run_123 · 2.0s"
         runtimeMetaTitle="Run run_123 · Native session native_123"
-        taskLink={{ label: "Task task_123", onClick: onOpenTask }}
+        taskLink={{
+          label: "Task task_123",
+          href: "/tasks?task=task_123",
+          onClick: onOpenTask,
+        }}
         traceLink={{ label: "Trace req_1234", onClick: onOpenTrace }}
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Open Task task_123" }));
+    const taskLink = screen.getByRole("link", { name: "Open Task task_123" });
+    expect(taskLink).toHaveAttribute("href", "/tasks?task=task_123");
+    document.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    await user.click(taskLink);
     await user.click(screen.getByRole("button", { name: "Open Trace req_1234" }));
 
     expect(onOpenTask).toHaveBeenCalledTimes(1);
@@ -701,11 +708,16 @@ describe("TranscriptMessageRow", () => {
       <TranscriptMessageRow
         {...baseProps}
         activities={activities}
-        taskLink={{ label: "Task task_123", onClick: onOpenTask }}
+        taskLink={{
+          label: "Task task_123",
+          href: "/tasks?task=task_123",
+          onClick: onOpenTask,
+        }}
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Open Task task_123" }));
+    document.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    await user.click(screen.getByRole("link", { name: "Open Task task_123" }));
     expect(onOpenTask).toHaveBeenCalledTimes(1);
 
     await user.click(screen.getByText(/1 failed tool/));
@@ -753,7 +765,7 @@ describe("TranscriptMessageRow", () => {
       <TranscriptMessageRow
         {...baseProps}
         activities={activities}
-        taskLink={{ label: "Task task_123", onClick: vi.fn() }}
+        taskLink={{ label: "Task task_123", href: "/tasks?task=task_123", onClick: vi.fn() }}
       />,
     );
 

--- a/ui/src/features/transcript/TranscriptMessageRow.tsx
+++ b/ui/src/features/transcript/TranscriptMessageRow.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
 
 import type {
   ChatActivityRecord,
@@ -70,7 +77,12 @@ export function TranscriptMessageRow({
   badge?: string;
   runtimeMeta?: string;
   runtimeMetaTitle?: string;
-  taskLink?: { label: string; title?: string; onClick: () => void };
+  taskLink?: {
+    label: string;
+    title?: string;
+    href: string;
+    onClick?: (event: ReactMouseEvent<HTMLAnchorElement>) => void;
+  };
   traceLink?: { label: string; title?: string; onClick: () => void };
   changedFilesLink?: { label: string; title?: string; onClick?: () => void };
   activities?: ChatActivityRecord[];
@@ -159,8 +171,10 @@ export function TranscriptMessageRow({
   return (
     <div
       id={id}
+      className="cross-surface-focus-target"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      tabIndex={-1}
       style={{ padding: "4px 16px 12px", maxWidth: 820, margin: "0 auto", width: "100%" }}
     >
       <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
@@ -203,9 +217,10 @@ export function TranscriptMessageRow({
               </span>
             )}
             {isAssistant && taskLink && (
-              <HeaderMetaButton
+              <HeaderMetaLink
                 label={taskLink.label}
                 title={taskLink.title}
+                href={taskLink.href}
                 onClick={taskLink.onClick}
               />
             )}
@@ -429,7 +444,12 @@ function ProjectAssistantProposalActivity({
 function renderAgentActivityAdvanced(
   activity: ChatActivityRecord,
   options: {
-    taskLink?: { label: string; title?: string; onClick: () => void };
+    taskLink?: {
+      label: string;
+      title?: string;
+      href: string;
+      onClick?: (event: ReactMouseEvent<HTMLAnchorElement>) => void;
+    };
     diffStat?: string;
     diff?: string;
   },
@@ -476,15 +496,15 @@ function renderAgentActivityAdvanced(
         This tool failed. Open the backing task for the full run output and approval history.
       </div>
       <div>
-        <button
-          type="button"
+        <a
           className="btn btn-ghost btn-sm"
+          href={options.taskLink.href}
           onClick={options.taskLink.onClick}
           title={`Open ${options.taskLink.label} output`}
-          style={{ fontSize: 10, padding: "2px 7px" }}
+          style={{ fontSize: 10, padding: "2px 7px", textDecoration: "none" }}
         >
           Open task output
-        </button>
+        </a>
       </div>
     </div>
   );
@@ -1109,6 +1129,39 @@ function HeaderMetaButton({
     >
       {label}
     </button>
+  );
+}
+
+function HeaderMetaLink({
+  label,
+  title,
+  href,
+  onClick,
+}: {
+  label: string;
+  title?: string;
+  href: string;
+  onClick?: (event: ReactMouseEvent<HTMLAnchorElement>) => void;
+}) {
+  return (
+    <a
+      className="btn btn-ghost btn-sm"
+      href={href}
+      onClick={onClick}
+      title={title}
+      aria-label={`Open ${label}`}
+      style={{
+        borderColor: "var(--border)",
+        color: "var(--t2)",
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        gap: 4,
+        padding: "1px 6px",
+        textDecoration: "none",
+      }}
+    >
+      {label}
+    </a>
   );
 }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1053,8 +1053,13 @@ export async function createChatSession(
   });
 }
 
-export async function getChatSession(id: string): Promise<ChatSessionResponse> {
-  return fetchJSON<ChatSessionResponse>(`${HECATE_API}/chat/sessions/${encodeURIComponent(id)}`);
+export async function getChatSession(
+  id: string,
+  signal?: AbortSignal,
+): Promise<ChatSessionResponse> {
+  return fetchJSON<ChatSessionResponse>(`${HECATE_API}/chat/sessions/${encodeURIComponent(id)}`, {
+    signal,
+  });
 }
 
 export async function updateChatSession(id: string, title: string): Promise<ChatSessionResponse> {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -694,6 +694,12 @@ textarea {
   outline-offset: 2px;
 }
 
+.cross-surface-focus-target:focus {
+  border-radius: var(--radius-sm);
+  outline: 2px solid var(--teal);
+  outline-offset: 2px;
+}
+
 /* ─── Btn ─── */
 .btn {
   display: inline-flex;

--- a/ui/src/test/runtime-console-composition.test.tsx
+++ b/ui/src/test/runtime-console-composition.test.tsx
@@ -4359,6 +4359,7 @@ describe("useRuntimeConsole", () => {
         },
       });
       let resolveSlowSelection: ((response: Response) => void) | undefined;
+      let resolveLatestSelection: ((response: Response) => void) | undefined;
       fetchMock.mockImplementation(
         withSessions(
           [
@@ -4371,7 +4372,9 @@ describe("useRuntimeConsole", () => {
                 resolveSlowSelection = resolve;
               }),
             "/hecate/v1/chat/sessions/chat_latest": () =>
-              jsonResponse(selectedSession("chat_latest")),
+              new Promise<Response>((resolve) => {
+                resolveLatestSelection = resolve;
+              }),
           },
         ),
       );
@@ -4379,19 +4382,35 @@ describe("useRuntimeConsole", () => {
       const { result } = renderRuntimeConsoleHook();
       await waitFor(() => expect(result.current.state.loading).toBe(false));
 
+      const slowController = new AbortController();
       let slowSelection!: Promise<boolean>;
       act(() => {
         slowSelection = result.current.actions.selectChatSession("chat_slow", {
           draft: "Assignment draft",
+          signal: slowController.signal,
         });
       });
       await waitFor(() => expect(result.current.state.activeChatSessionID).toBe("chat_slow"));
 
-      await act(async () => {
-        await result.current.actions.selectChatSession("chat_latest", {
+      let latestSelection!: Promise<boolean>;
+      act(() => {
+        latestSelection = result.current.actions.selectChatSession("chat_latest", {
           draft: "Latest chat draft",
         });
       });
+      await waitFor(() => expect(result.current.state.activeChatSessionID).toBe("chat_latest"));
+      expect(result.current.state.activeChatSession).toBeNull();
+
+      act(() => slowController.abort());
+      expect(result.current.state.activeChatSessionID).toBe("chat_latest");
+      expect(result.current.state.message).toBe("Latest chat draft");
+
+      let latestSelected = false;
+      await act(async () => {
+        resolveLatestSelection?.(jsonResponse(selectedSession("chat_latest")));
+        latestSelected = await latestSelection;
+      });
+      expect(latestSelected).toBe(true);
       expect(result.current.state.activeChatSessionID).toBe("chat_latest");
       expect(result.current.state.activeChatSession?.id).toBe("chat_latest");
       expect(result.current.state.message).toBe("Latest chat draft");
@@ -4406,6 +4425,93 @@ describe("useRuntimeConsole", () => {
       expect(result.current.state.activeChatSession?.id).toBe("chat_latest");
       expect(result.current.state.message).toBe("Latest chat draft");
     });
+
+    it.each(["success", "failure"] as const)(
+      "restores the source selection immediately when an aborted Chat load later settles with %s",
+      async (settlement) => {
+        const selectedSession = (id: string) => ({
+          object: "chat_session",
+          data: {
+            id,
+            title: id,
+            agent_id: "hecate",
+            status: "completed",
+            messages: [],
+            provider: "openai",
+            model: "gpt-4o-mini",
+            workspace: `/workspace/${id}`,
+            workspace_branch: `branch-${id}`,
+            created_at: "2026-04-20T00:00:00Z",
+            updated_at: "2026-04-20T00:00:00Z",
+          },
+        });
+        let resolveTarget: ((response: Response) => void) | undefined;
+        let rejectTarget: ((reason: Error) => void) | undefined;
+        fetchMock.mockImplementation(
+          withSessions(
+            [
+              { id: "chat_source", title: "Source chat" },
+              { id: "chat_target", title: "Target chat" },
+            ],
+            {
+              "/hecate/v1/chat/sessions/chat_source": () =>
+                jsonResponse(selectedSession("chat_source")),
+              "/hecate/v1/chat/sessions/chat_target": () =>
+                new Promise<Response>((resolve, reject) => {
+                  resolveTarget = resolve;
+                  rejectTarget = reject;
+                }),
+            },
+          ),
+        );
+
+        const { result } = renderRuntimeConsoleHook();
+        await waitFor(() => expect(result.current.state.loading).toBe(false));
+        await act(async () => {
+          await result.current.actions.selectChatSession("chat_source", {
+            draft: "Source draft",
+          });
+        });
+        act(() => result.current.actions.setMessage("Edited source draft"));
+
+        const controller = new AbortController();
+        let targetSelection!: Promise<boolean>;
+        act(() => {
+          targetSelection = result.current.actions.selectChatSession("chat_target", {
+            draft: "Target draft",
+            signal: controller.signal,
+          });
+        });
+        await waitFor(() => expect(result.current.state.activeChatSessionID).toBe("chat_target"));
+
+        act(() => controller.abort());
+
+        await waitFor(() => expect(result.current.state.activeChatSessionID).toBe("chat_source"));
+        expect(result.current.state.activeChatSession?.id).toBe("chat_source");
+        expect(result.current.state.agentWorkspace).toBe("/workspace/chat_source");
+        expect(result.current.state.agentWorkspaceBranch).toBe("branch-chat_source");
+        expect(result.current.state.message).toBe("Edited source draft");
+        expect(result.current.state.chatError).toBe("");
+        expect(result.current.state.notice).toBeNull();
+
+        let selected = true;
+        await act(async () => {
+          if (settlement === "success") {
+            resolveTarget?.(jsonResponse(selectedSession("chat_target")));
+          } else {
+            rejectTarget?.(new Error("late target failure"));
+          }
+          selected = await targetSelection;
+        });
+
+        expect(selected).toBe(false);
+        expect(result.current.state.activeChatSessionID).toBe("chat_source");
+        expect(result.current.state.activeChatSession?.id).toBe("chat_source");
+        expect(result.current.state.message).toBe("Edited source draft");
+        expect(result.current.state.chatError).toBe("");
+        expect(result.current.state.notice).toBeNull();
+      },
+    );
 
     it("keeps a late dashboard snapshot from replacing a newer linked-chat selection", async () => {
       window.localStorage.setItem("hecate.chatSessionID", "chat_previous");

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -284,7 +284,10 @@ export type RuntimeConsoleFixtureActions = {
   submitToolResults: () => Promise<void>;
   runRetention: () => Promise<void>;
   restoreSavedComposerDraft: (sessionID: string) => boolean;
-  selectChatSession: (id: string, options?: { draft?: string }) => Promise<boolean>;
+  selectChatSession: (
+    id: string,
+    options?: { draft?: string; signal?: AbortSignal },
+  ) => Promise<boolean>;
   startNewChat: () => void;
   upsertPolicyRule: (payload: unknown) => Promise<void>;
   updateToolResult: (index: number, result: string) => void;

--- a/ui/src/types/task.ts
+++ b/ui/src/types/task.ts
@@ -110,6 +110,14 @@ export type TaskRunRecord = {
   root_span_id?: string;
   otel_status_code?: string;
   otel_status_message?: string;
+  source_ref?: TaskRunSourceRefRecord;
+};
+
+export type TaskRunSourceRefRecord = {
+  kind: "chat_turn";
+  chat_session_id: string;
+  turn_id: string;
+  message_id: string;
 };
 
 export type TaskRunsResponse = {


### PR DESCRIPTION
## Summary

- expose each Task Run's canonical persisted Chat Turn source as `source_ref`, including fetched and SSE-projected run shapes
- preserve exact Task + Run links in Chat and exact Chat + Message/Turn links in Task
- make cross-surface navigation route-first, cancellable, focus-aware, and usable through native anchors
- preserve canonical Chat provenance through retry and resume while keeping retry execution state fresh
- remove transcript scanning and legacy source inference

## Why

Chats and Tasks are distinct product surfaces, but related records need a lossless handoff. Previously, Task-to-Chat navigation could depend on scanning the current transcript, while retry could start from a fresh context that dropped the original Chat source. That made exact navigation incomplete and sensitive to UI state.

This change makes the persisted Run context the single source of truth, so both directions remain exact across refreshes, streams, retries, resumes, and workspace changes.

## Impact

Operators can move from a Chat Turn to its exact Task Run and back to the exact source Turn. Navigation transfers focus only for explicit user intent, preserves normal native-link behavior, and safely restores the previous Chat/composer if routed selection is aborted.

The new behavior intentionally has no legacy transcript-inference compatibility path.

## Validation

- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./...`
- `bun run test` — 107 files, 2,400 tests
- `go vet ./...`
- `go build ./...`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `just docs-check`
- `just format-check`
- focused Playwright Chat → Task Run → source Chat Turn journey
