### PR TITLE
Clarify Hecate splash positioning

### DIFF
--- a/tauri/splash/index.html
+++ b/tauri/splash/index.html
@@ -279,7 +279,7 @@
     <canvas class="glitch-field" id="glitch-field" aria-hidden="true"></canvas>
     <div class="screen-overlay" aria-hidden="true"></div>
     <main class="splash" aria-label="Hecate is starting">
-      <div class="lockup" role="img" aria-label="Hecate — local-first agent runtime and operator console">
+      <div class="lockup" role="img" aria-label="Hecate — agent runtime and operator console">
         <svg class="mark brand-primary" viewBox="0 0 256 256" fill="none" aria-hidden="true">
           <g stroke="currentColor" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
             <path d="M128 36 L128 128" />
@@ -290,7 +290,7 @@
         </svg>
         <div class="copy">
           <div class="wordmark brand-primary">hecate</div>
-          <div class="tagline">Local-First Agent Runtime · Operator Console</div>
+          <div class="tagline">Agent Runtime · Operator Console</div>
         </div>
       </div>
       <div class="status" id="status">

--- a/tauri/splash/index.html
+++ b/tauri/splash/index.html
@@ -279,7 +279,7 @@
     <canvas class="glitch-field" id="glitch-field" aria-hidden="true"></canvas>
     <div class="screen-overlay" aria-hidden="true"></div>
     <main class="splash" aria-label="Hecate is starting">
-      <div class="lockup" role="img" aria-label="Hecate — AI Gateway and Agent Runtime">
+      <div class="lockup" role="img" aria-label="Hecate — local-first agent runtime and operator console">
         <svg class="mark brand-primary" viewBox="0 0 256 256" fill="none" aria-hidden="true">
           <g stroke="currentColor" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
             <path d="M128 36 L128 128" />
@@ -290,11 +290,11 @@
         </svg>
         <div class="copy">
           <div class="wordmark brand-primary">hecate</div>
-          <div class="tagline">AI Gateway · Agent Runtime</div>
+          <div class="tagline">Local-First Agent Runtime · Operator Console</div>
         </div>
       </div>
       <div class="status" id="status">
-        <span>Starting gateway</span>
+        <span>Starting local gateway</span>
         <span class="status-dots" aria-hidden="true">
           <span class="status-dot"></span>
           <span class="status-dot"></span>
@@ -302,9 +302,9 @@
         </span>
       </div>
       <section class="failure" id="failure-panel" aria-live="polite">
-        <div class="failure-title">Gateway failed to start</div>
+        <div class="failure-title">Local gateway failed to start</div>
         <p class="failure-copy">
-          Hecate could not launch the local sidecar. Use the native Hecate menu to open the gateway log or data directory.
+          Hecate's local gateway did not become ready. Use the native Hecate menu to open the Gateway log or data directory.
         </p>
         <div class="failure-detail">
           <div class="failure-row">


### PR DESCRIPTION
## Summary

- Position the desktop splash as Hecate’s agent runtime and operator console.
- Keep “local gateway” terminology only in startup diagnostics, where it maps to the actual sidecar and Gateway log.

## Why

The splash still framed Hecate primarily as an AI gateway. Hecate’s product identity is the agent runtime and operator console; locality is a deployment and privacy posture, not the headline.

## Validation

- Rendered the splash at the 900×600 desktop minimum.
- `just tauri-rust-test`
- `git diff --check`
