### PR TITLE
fix(projects): restore project deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/chromedp/chromedp v0.16.0
 	github.com/coder/acp-go-sdk v0.13.5
 	github.com/hecatehq/acp-adapter-kit v0.3.1
-	github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8
+	github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260719233717-aecf5281e3dd
 	github.com/hecatehq/claude-code-acp-adapter v0.3.1
 	github.com/hecatehq/codex-acp-adapter v0.2.1
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hecatehq/acp-adapter-kit v0.3.1 h1:rsErGVr6WfqxJnR6qigLcRolXBUCPW9KTD0LMajAkuM=
 github.com/hecatehq/acp-adapter-kit v0.3.1/go.mod h1:tqRmkI7UfnabJsmhj6GrQdTdX2GwtYcCobiSPZl8ERo=
-github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8 h1:Wycv8NJYHwTmOQDz7Nsoqc2onBsavTRY86dX49hat1w=
-github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260714141709-b1fb0b039ef8/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
+github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260719233717-aecf5281e3dd h1:XOVVhnDv6Gin+tcSh69VaCMv+orlghkHTyVjhkgKESQ=
+github.com/hecatehq/cairnline v0.1.0-alpha.6.0.20260719233717-aecf5281e3dd/go.mod h1:T7z7YVObPItUVbNv7LXSkabHpkLIdkonJaOFOwwcXEc=
 github.com/hecatehq/claude-code-acp-adapter v0.3.1 h1:kno/sbMo7R5YMl2JJ+B2s2Tg/yVxoRoYuu9wldyq6UI=
 github.com/hecatehq/claude-code-acp-adapter v0.3.1/go.mod h1:uoL8ycgbgtad7MS5f4LrykS0e9Kwnxcl3CQS2ksgKX0=
 github.com/hecatehq/codex-acp-adapter v0.2.1 h1:CY0KVHlyba5rJJdBstKKu6Y66203wnA6d+hqKVjkTW4=

--- a/internal/api/handler_project_identity_authority.go
+++ b/internal/api/handler_project_identity_authority.go
@@ -61,6 +61,9 @@ func (h *Handler) createProjectWithCairnlineAuthority(ctx context.Context, proje
 }
 
 func (h *Handler) deleteProjectWithCairnlineAuthority(ctx context.Context, projectID string) (projectapp.DeleteProjectResult, error) {
+	if h.projectCairnlineEmbeddedReplacementModeArmed() {
+		return h.deleteCairnlineOnlyProjectWithAuthority(ctx, projectID)
+	}
 	snapshot, err := cairnlinebridge.LoadSnapshot(ctx, h.cairnlineSnapshotSources(), projectID)
 	if errors.Is(err, projects.ErrNotFound) {
 		return h.deleteCairnlineOnlyProjectWithAuthority(ctx, projectID)

--- a/internal/api/project_journey_test.go
+++ b/internal/api/project_journey_test.go
@@ -89,6 +89,42 @@ func TestProjectJourneyAPI_CairnlineOnlyHandlerLaunchesWithoutNativePortableStor
 	}
 }
 
+func TestProjectJourneyAPI_CairnlineOnlyHandlerDeletesWithoutNativePortableStores(t *testing.T) {
+	t.Parallel()
+	handler := NewHandler(config.Config{
+		Server: config.ServerConfig{DataDir: t.TempDir()},
+		Projects: config.ProjectsConfig{
+			CoordinationBackend:      "cairnline",
+			CairnlineConnector:       "embedded",
+			CairnlineReadSource:      "embedded",
+			CairnlineReplacementMode: "embedded",
+		},
+	}, quietLogger(), nil, nil, nil, nil)
+	client := newAPITestClient(t, NewServer(quietLogger(), handler))
+
+	project := mustRequestJSONStatus[ProjectResponse](client, http.StatusCreated, http.MethodPost, "/hecate/v1/projects", projectJourneyJSON(t, map[string]any{
+		"name":             "Cairnline-only delete",
+		"default_provider": "ollama",
+		"default_model":    "qwen2.5-coder",
+	}))
+	projectID := project.Data.ID
+	if projectID == "" || project.Data.ReadBackend != "cairnline" {
+		t.Fatalf("project = %+v, want Cairnline-backed project", project.Data)
+	}
+	if _, ok, err := handler.projectRuntime.GetProjectDefaults(t.Context(), projectID); err != nil || !ok {
+		t.Fatalf("runtime defaults ok=%v err=%v, want Hecate overlay before delete", ok, err)
+	}
+
+	deleted := mustRequestJSONStatus[ProjectDeleteResponse](client, http.StatusOK, http.MethodDelete, "/hecate/v1/projects/"+projectID, "")
+	if deleted.Object != "project_delete" || deleted.Data.ProjectID != projectID || deleted.Data.ProjectName != project.Data.Name || deleted.Data.ProjectRuntimeRowsDeleted != 1 {
+		t.Fatalf("delete response = %+v, want Cairnline identity and Hecate runtime overlay deleted", deleted)
+	}
+	client.mustRequestStatus(http.StatusNotFound, http.MethodGet, "/hecate/v1/projects/"+projectID, "")
+	if _, ok, err := handler.projectRuntime.GetProjectDefaults(t.Context(), projectID); err != nil || ok {
+		t.Fatalf("runtime defaults after delete ok=%v err=%v, want missing", ok, err)
+	}
+}
+
 func TestProjectJourneyAPI_DiscoverStartInspectAndHandoff(t *testing.T) {
 	t.Parallel()
 	handler, server := newProjectWorkTestServer()

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -290,6 +290,92 @@ test("Projects create keeps keyboard focus inside the pending dialog", async ({ 
     .toBe(true);
 });
 
+test("Projects delete explains a failure in the dialog and retries at narrow width", async ({
+  page,
+}) => {
+  const state = await mockProjectJourneyAPIs(page);
+  const project: ProjectRecord = {
+    id: "proj_delete_retry",
+    name: "Delete retry project",
+    description: "Verify recoverable project deletion.",
+    roots: [],
+    context_sources: [],
+    created_at: NOW,
+    updated_at: NOW,
+  };
+  state.projects = [project];
+  let deleteRequests = 0;
+  await page.route("**/hecate/v1/projects/proj_delete_retry", async (route) => {
+    if (route.request().method() !== "DELETE") {
+      await route.fallback();
+      return;
+    }
+    deleteRequests += 1;
+    if (deleteRequests === 1) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            type: "gateway_error",
+            message: "project delete failed",
+            user_message: "Project could not be deleted.",
+            operator_action: "Try again, then open Observability if the failure continues.",
+          },
+        }),
+      });
+      return;
+    }
+    state.projects = [];
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "project_delete",
+        data: {
+          project_id: project.id,
+          project_name: project.name,
+          chat_sessions_deleted: 0,
+          project_work_rows_deleted: 0,
+          project_skills_deleted: 0,
+          memory_entries_deleted: 0,
+          memory_candidates_deleted: 0,
+        },
+      }),
+    });
+  });
+  await page.addInitScript((projectID) => {
+    window.localStorage.setItem("hecate.workspace", "projects");
+    window.localStorage.setItem("hecate.project", projectID);
+  }, project.id);
+
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+  const projectLink = page.getByRole("link", { name: "Open project Delete retry project" });
+  await projectLink.hover();
+  await page.getByRole("button", { name: "Delete project Delete retry project" }).click();
+  const dialog = page.getByRole("dialog", { name: "Delete project" });
+  const confirm = dialog.getByRole("button", { name: "Delete project record" });
+  await confirm.click();
+
+  await expect(dialog.getByRole("alert")).toContainText(
+    "Project could not be deleted. Try again, then open Observability if the failure continues.",
+  );
+  await expect(projectLink).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Close" })).toBeEnabled();
+  await expect(confirm).toBeFocused();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  expect(await dialog.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(
+    true,
+  );
+  await confirm.click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText("Add a project to begin")).toBeVisible();
+  expect(deleteRequests).toBe(2);
+});
+
 test("Projects guided start stays on Overview at desktop and narrow widths", async ({ page }) => {
   const state = await mockProjectJourneyAPIs(page);
   await page.addInitScript(() => {

--- a/ui/src/app/state/projects.test.tsx
+++ b/ui/src/app/state/projects.test.tsx
@@ -746,7 +746,7 @@ describe("ProjectsProvider", () => {
     expect(window.localStorage.getItem("hecate.project")).toBeNull();
   });
 
-  it("returns null and keeps local state when project deletion fails", async () => {
+  it("preserves the deletion error and keeps local state when project deletion fails", async () => {
     window.localStorage.setItem("hecate.project", project.id);
     vi.mocked(deleteProject).mockRejectedValue(new Error("delete failed"));
     const { result } = renderHook(() => useProjects(), {
@@ -755,14 +755,14 @@ describe("ProjectsProvider", () => {
       ),
     });
 
-    let deleted: ProjectDeleteRecord | null = deleteResult.data;
     await act(async () => {
-      deleted = await result.current.actions.deleteProject(project.id);
+      await expect(result.current.actions.deleteProject(project.id)).rejects.toThrow(
+        "delete failed",
+      );
     });
 
-    expect(deleted).toBeNull();
     expect(result.current.state.projects).toEqual([project]);
     expect(result.current.activeProjectID).toBe(project.id);
-    expect(result.current.state.error).toBe("delete failed");
+    expect(result.current.state.error).toBe("");
   });
 });

--- a/ui/src/app/state/projects.tsx
+++ b/ui/src/app/state/projects.tsx
@@ -332,11 +332,7 @@ export function ProjectsProvider({
         }
         return payload.data;
       } catch (error) {
-        dispatch({
-          type: "error/set",
-          value: error instanceof Error ? error.message : "Failed to delete project.",
-        });
-        return null;
+        throw error instanceof Error ? error : new Error("Failed to delete project.");
       }
     },
     [setActiveProjectID, setProjects],

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -253,6 +253,7 @@ export function ChatSidebar({
             settingsActions.setNoticeMessage("error", reason);
             return false;
           }}
+          projectScopeChangeBlockReason={chat.actions.chatOwnershipMutationBlockReason}
           beginProjectDelete={() => {
             const token = chat.actions.beginChatOwnershipMutation();
             if (token !== null) return token;

--- a/ui/src/features/projects/ProjectScopePanel.test.tsx
+++ b/ui/src/features/projects/ProjectScopePanel.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useChat } from "../../app/state/chat";
 import { ProjectsProvider, useProjects } from "../../app/state/projects";
-import { createProject, getProjects, updateProject } from "../../lib/api";
+import { ApiError, createProject, getProjects, updateProject } from "../../lib/api";
 import {
   createRuntimeConsoleActions,
   createRuntimeConsoleFixture,
@@ -101,7 +101,11 @@ const project: ProjectRecord = {
   updated_at: "2026-07-13T10:00:00Z",
 };
 
-function ReservedProjectScopePanel() {
+function ReservedProjectScopePanel({
+  onCanChangeProjectScope,
+}: {
+  onCanChangeProjectScope?: () => void;
+} = {}) {
   const chat = useChat();
   const projects = useProjects();
   const [turnAttempt, setTurnAttempt] = useState("not tried");
@@ -145,7 +149,11 @@ function ReservedProjectScopePanel() {
       <ProjectScopePanel
         noProjectDetail="Unprojected"
         emptyHint="No projects"
-        canChangeProjectScope={() => !chat.actions.chatOwnershipMutationBlockReason()}
+        canChangeProjectScope={() => {
+          onCanChangeProjectScope?.();
+          return !chat.actions.chatOwnershipMutationBlockReason();
+        }}
+        projectScopeChangeBlockReason={chat.actions.chatOwnershipMutationBlockReason}
         beginProjectDelete={chat.actions.beginChatOwnershipMutation}
         finishProjectDelete={chat.actions.finishChatOwnershipMutation}
         deleteMessage={(item) => <>Delete {item.name}?</>}
@@ -730,5 +738,97 @@ describe("ProjectScopePanel destructive chat ownership", () => {
 
     await user.click(screen.getByRole("button", { name: "Attach scope image" }));
     expect(screen.getByTestId("scope-draft-count")).toHaveTextContent("1");
+  });
+
+  it("keeps a failed project delete actionable in the dialog and retries", async () => {
+    const user = userEvent.setup();
+    const deleteResult: ProjectDeleteRecord = {
+      project_id: project.id,
+      project_name: project.name,
+      chat_sessions_deleted: 0,
+      project_work_rows_deleted: 0,
+      project_skills_deleted: 0,
+      memory_entries_deleted: 0,
+      memory_candidates_deleted: 0,
+    };
+    const deleteProject = vi
+      .fn<() => Promise<ProjectDeleteRecord | null>>()
+      .mockRejectedValueOnce(
+        new ApiError("Project could not be deleted.", 500, "gateway_error", {
+          operatorAction: "Try again after checking the gateway.",
+        }),
+      )
+      .mockResolvedValueOnce(deleteResult);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(
+        <ProjectScopePanel
+          beginProjectDelete={() => 1}
+          deleteMessage={(item) => <>Delete {item.name}?</>}
+          emptyHint="No projects"
+          finishProjectDelete={() => undefined}
+          noProjectDetail="Unprojected"
+        />,
+        { state, actions: { ...createRuntimeConsoleActions(), deleteProject } },
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Expand projects" }));
+    await user.click(screen.getByRole("button", { name: "Project Scope project" }));
+    await user.click(screen.getByRole("button", { name: "Delete project Scope project" }));
+    const dialog = screen.getByRole("dialog", { name: "Delete project" });
+    await user.click(within(dialog).getByRole("button", { name: "Delete project" }));
+
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent(
+      "Project could not be deleted. Try again after checking the gateway.",
+    );
+    expect(within(dialog).getByRole("button", { name: "Close" })).toBeEnabled();
+    await waitFor(() =>
+      expect(within(dialog).getByRole("button", { name: "Delete project" })).toHaveFocus(),
+    );
+
+    await user.click(within(dialog).getByRole("button", { name: "Delete project" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Delete project" })).toBeNull(),
+    );
+    expect(deleteProject).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows the exact ownership blocker inside the delete dialog", async () => {
+    const user = userEvent.setup();
+    const deleteProject = vi.fn<() => Promise<ProjectDeleteRecord | null>>();
+    const canChangeProjectScope = vi.fn();
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(
+        <ReservedProjectScopePanel onCanChangeProjectScope={canChangeProjectScope} />,
+        {
+          state,
+          actions: { ...createRuntimeConsoleActions(), deleteProject },
+        },
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Expand projects" }));
+    await user.click(screen.getByRole("button", { name: "Project Scope project" }));
+    await user.click(screen.getByRole("button", { name: "Attach scope image" }));
+    await user.hover(screen.getByRole("button", { name: "Project Scope project" }));
+    await user.click(screen.getByRole("button", { name: "Delete project Scope project" }));
+    const dialog = screen.getByRole("dialog", { name: "Delete project" });
+    canChangeProjectScope.mockClear();
+    await user.click(within(dialog).getByRole("button", { name: "Delete project" }));
+
+    expect(within(dialog).getByRole("alert")).toHaveTextContent(
+      "Remove attached files before changing or deleting chat ownership.",
+    );
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+    expect(canChangeProjectScope).not.toHaveBeenCalled();
+    expect(deleteProject).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/features/projects/ProjectScopePanel.tsx
+++ b/ui/src/features/projects/ProjectScopePanel.tsx
@@ -12,8 +12,9 @@ import { useProjects } from "../../app/state/projects";
 import { chooseWorkspaceDirectory } from "../../lib/api";
 import { projectDefaultWorkspace } from "../../lib/project-workspace";
 import type { ProjectDeleteRecord, ProjectRecord } from "../../types/project";
-import { ConfirmModal, Icon, Icons } from "../shared/ui";
+import { ConfirmModal, Icon, Icons, InlineError } from "../shared/ui";
 import { CreateProjectModal } from "./CreateProjectModal";
+import { projectErrorMessage } from "./projectDisplay";
 import { createProjectPayloadFromForm, type CreateProjectForm } from "./projectSettings";
 
 type ProjectScopePanelProps = {
@@ -21,6 +22,7 @@ type ProjectScopePanelProps = {
   emptyHint: string;
   deleteMessage: (project: ProjectRecord) => ReactNode;
   canChangeProjectScope?: () => boolean;
+  projectScopeChangeBlockReason?: () => string;
   beginProjectDelete: () => number | null;
   finishProjectDelete: (token: number) => void;
   onProjectDeleted?: (projectID: string, result: ProjectDeleteRecord) => void;
@@ -60,6 +62,7 @@ export function ProjectScopePanel({
   emptyHint,
   deleteMessage,
   canChangeProjectScope,
+  projectScopeChangeBlockReason,
   beginProjectDelete,
   finishProjectDelete,
   onProjectDeleted,
@@ -72,6 +75,7 @@ export function ProjectScopePanel({
   const [hoveredProjectID, setHoveredProjectID] = useState<string | null>(null);
   const [deleteProjectID, setDeleteProjectID] = useState<string | null>(null);
   const [deleteProjectPending, setDeleteProjectPending] = useState(false);
+  const [deleteProjectError, setDeleteProjectError] = useState("");
   const deleteProjectPendingRef = useRef(false);
   const [createProjectOpen, setCreateProjectOpen] = useState(false);
   const [createProjectPending, setCreateProjectPending] = useState(false);
@@ -105,6 +109,13 @@ export function ProjectScopePanel({
 
   function projectScopeChangeAllowed(): boolean {
     return !canChangeProjectScopeRef.current || canChangeProjectScopeRef.current();
+  }
+
+  function currentProjectScopeChangeBlockReason(): string {
+    return (
+      projectScopeChangeBlockReason?.().trim() ||
+      "Wait for the current chat ownership change to finish, then try again."
+    );
   }
 
   useEffect(
@@ -291,6 +302,8 @@ export function ProjectScopePanel({
                   void selectProjectScope(project.id);
                 }}
                 onDelete={() => {
+                  projects.actions.setError("");
+                  setDeleteProjectError("");
                   setDeleteProjectID(project.id);
                 }}
                 onInteractionChange={(active) => {
@@ -376,25 +389,50 @@ export function ProjectScopePanel({
           danger
           title="Delete project"
           confirmLabel="Delete project"
-          message={deleteMessage(pendingDeleteProject)}
+          message={
+            <div style={{ display: "grid", gap: 12 }}>
+              <div>{deleteMessage(pendingDeleteProject)}</div>
+              <InlineError message={deleteProjectError} />
+            </div>
+          }
           pending={deleteProjectPending}
           returnFocusRef={projectsToggleButtonRef}
           onClose={() => {
-            if (!deleteProjectPendingRef.current) setDeleteProjectID(null);
+            if (!deleteProjectPendingRef.current) {
+              setDeleteProjectID(null);
+              setDeleteProjectError("");
+            }
           }}
           onConfirm={async () => {
             if (deleteProjectPendingRef.current) return;
-            if (!projectScopeChangeAllowed()) return;
+            setDeleteProjectError("");
+            const knownBlockReason = projectScopeChangeBlockReason?.().trim() || "";
+            if (knownBlockReason) {
+              setDeleteProjectError(knownBlockReason);
+              return;
+            }
+            if (!projectScopeChangeAllowed()) {
+              setDeleteProjectError(currentProjectScopeChangeBlockReason());
+              return;
+            }
             const ownershipMutationToken = beginProjectDelete();
-            if (ownershipMutationToken === null) return;
+            if (ownershipMutationToken === null) {
+              setDeleteProjectError(currentProjectScopeChangeBlockReason());
+              return;
+            }
             deleteProjectPendingRef.current = true;
             setDeleteProjectPending(true);
             const projectID = pendingDeleteProject.id;
             try {
               const deleted = await projects.actions.deleteProject(projectID);
-              if (!deleted) return;
+              if (!deleted) {
+                setDeleteProjectError("Project could not be deleted. Try again.");
+                return;
+              }
               onProjectDeleted?.(projectID, deleted);
               setDeleteProjectID(null);
+            } catch (error) {
+              setDeleteProjectError(projectErrorMessage(error, "Failed to delete project."));
             } finally {
               finishProjectDelete(ownershipMutationToken);
               deleteProjectPendingRef.current = false;

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2461,6 +2461,59 @@ describe("ProjectsView index", () => {
     expect(actions.deleteProject).toHaveBeenCalledWith(project.id);
   });
 
+  it("keeps a failed project delete actionable in the dialog and retries", async () => {
+    resetProjectWorkMocks();
+    const user = userEvent.setup();
+    const deleteResult: ProjectDeleteRecord = {
+      project_id: project.id,
+      project_name: project.name,
+      chat_sessions_deleted: 0,
+      project_work_rows_deleted: 0,
+      project_skills_deleted: 0,
+      memory_entries_deleted: 0,
+      memory_candidates_deleted: 0,
+    };
+    const deleteProject = vi
+      .fn<() => Promise<ProjectDeleteRecord | null>>()
+      .mockRejectedValueOnce(
+        new ApiError("Project could not be deleted.", 500, "gateway_error", {
+          operatorAction: "Try again, then open Observability if the failure continues.",
+        }),
+      )
+      .mockResolvedValueOnce(deleteResult);
+    const state = createRuntimeConsoleFixture({
+      projects: [project],
+      activeProjectID: project.id,
+    });
+    render(
+      withRuntimeConsole(<WorkProjects />, {
+        state,
+        actions: { ...createRuntimeConsoleActions(), deleteProject },
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Delete project Hecate" }));
+    const dialog = screen.getByRole("dialog", { name: "Delete project" });
+    await user.click(within(dialog).getByRole("button", { name: "Delete project record" }));
+
+    const alert = await within(dialog).findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "Project could not be deleted. Try again, then open Observability if the failure continues.",
+    );
+    expect(screen.getByRole("link", { name: "Open project Hecate" })).toBeTruthy();
+    expect(within(dialog).getByRole("button", { name: "Close" })).toBeEnabled();
+    await waitFor(() =>
+      expect(within(dialog).getByRole("button", { name: "Delete project record" })).toHaveFocus(),
+    );
+
+    await user.click(within(dialog).getByRole("button", { name: "Delete project record" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Delete project" })).toBeNull(),
+    );
+    expect(deleteProject).toHaveBeenCalledTimes(2);
+  });
+
   it("returns focus to Add when a deleted project row disappears", async () => {
     resetProjectWorkMocks();
     let finishDelete: ((value: ProjectDeleteRecord | null) => void) | undefined;
@@ -2635,7 +2688,11 @@ describe("ProjectsView index", () => {
     await user.click(screen.getByRole("button", { name: "Delete project record" }));
 
     expect(deleteProject).not.toHaveBeenCalled();
-    expect(screen.getByRole("dialog", { name: "Delete project" })).toBeTruthy();
+    const dialog = screen.getByRole("dialog", { name: "Delete project" });
+    expect(dialog).toBeTruthy();
+    expect(within(dialog).getByRole("alert")).toHaveTextContent(
+      "Remove attached files before changing or deleting chat ownership.",
+    );
   });
 
   it("blocks project selection and creation while an unsent image draft exists", async () => {

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -357,6 +357,7 @@ export function ProjectsView({
   const [hoveredProjectID, setHoveredProjectID] = useState("");
   const [deleteProjectID, setDeleteProjectID] = useState("");
   const [deletePending, setDeletePending] = useState(false);
+  const [deleteProjectError, setDeleteProjectError] = useState("");
   const [createProjectOpen, setCreateProjectOpen] = useState(false);
   const [createProjectPending, setCreateProjectPending] = useState(false);
   const [createProjectError, setCreateProjectError] = useState("");
@@ -1820,13 +1821,14 @@ export function ProjectsView({
 
   async function confirmDeleteProject() {
     if (!pendingDeleteProject) return;
+    setDeleteProjectError("");
     const projectID = pendingDeleteProject.id;
     const ownershipMutationToken = chat.actions.beginChatOwnershipMutation();
     if (ownershipMutationToken === null) {
       const blockedReason =
         chat.actions.chatOwnershipMutationBlockReason() ||
         "Wait for the current chat ownership change to finish.";
-      settings.actions.setNotice({ kind: "error", message: blockedReason });
+      setDeleteProjectError(blockedReason);
       return;
     }
     setDeletePending(true);
@@ -1845,7 +1847,11 @@ export function ProjectsView({
         if (navigationRef.current?.projectID === projectID) {
           onNavigate?.({ projectID: null }, "replace");
         }
+      } else {
+        setDeleteProjectError("Project could not be deleted. Try again.");
       }
+    } catch (error) {
+      setDeleteProjectError(errorMessage(error, "Failed to delete project."));
     } finally {
       chat.actions.finishChatOwnershipMutation(ownershipMutationToken);
       setDeletePending(false);
@@ -3786,7 +3792,11 @@ export function ProjectsView({
               onRenameCancel={() => setRenamingProjectID("")}
               onRenameCommit={() => void commitRename(project)}
               onRenameStart={() => startRename(project)}
-              onDelete={() => setDeleteProjectID(project.id)}
+              onDelete={() => {
+                projects.actions.setError("");
+                setDeleteProjectError("");
+                setDeleteProjectID(project.id);
+              }}
               onOpen={() => tryOpenProject(project.id)}
             />
           ))}
@@ -4294,15 +4304,21 @@ export function ProjectsView({
             danger
             pending={deletePending}
             confirmLabel="Delete project record"
-            onClose={() => setDeleteProjectID("")}
+            onClose={() => {
+              setDeleteProjectID("");
+              setDeleteProjectError("");
+            }}
             onConfirm={confirmDeleteProject}
             returnFocusRef={addProjectButtonRef}
             message={
-              <>
-                Hecate will delete the project record, project roots, project-scoped chats, and
-                project work coordination state for <strong>{pendingDeleteProject.name}</strong>.
-                Workspace files and the git repository are not deleted.
-              </>
+              <div style={{ display: "grid", gap: 12 }}>
+                <div>
+                  Hecate will delete the project record, project roots, project-scoped chats, and
+                  project work coordination state for <strong>{pendingDeleteProject.name}</strong>.
+                  Workspace files and the git repository are not deleted.
+                </div>
+                <InlineError message={deleteProjectError} />
+              </div>
             }
           />
         )}

--- a/ui/src/features/tasks/TasksView.tsx
+++ b/ui/src/features/tasks/TasksView.tsx
@@ -742,6 +742,7 @@ export function TasksView({
               setNotice({ tone: "error", message: reason });
               return false;
             }}
+            projectScopeChangeBlockReason={chat.actions.chatOwnershipMutationBlockReason}
             beginProjectDelete={() => {
               const token = chat.actions.beginChatOwnershipMutation();
               if (token !== null) return token;


### PR DESCRIPTION
## Summary
- route Cairnline-only project deletion directly through the authoritative delete and rollback path instead of requiring absent legacy stores
- update the Cairnline pin so durable handoff command receipts are included in project cleanup
- keep API failures and ownership blockers inside the delete dialog with exact operator guidance, retry, and focus recovery
- cover state ownership, both project surfaces, narrow browser behavior, and production-shaped backend wiring

## Root cause
Production replacement mode intentionally has no native portable project stores, but deletion tried to load a native snapshot before reaching Cairnline. That returned `projects store is required` for every delete. Projects with durable handoff receipts also needed the merged Cairnline cascade fix from hecatehq/cairnline#85.

## Verification
- copied the desktop SQLite databases to an isolated data directory; the patched binary deleted the copied existing project with HTTP 200 and a follow-up GET returned 404
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test` (107 files, 2,415 tests)
- targeted Playwright deletion failure/retry test at desktop and 390px widths
- `GOCACHE=/Users/chicoxyzzy/dev/hecate/.gocache go test -race -timeout 10m ./...`
- independent backend contract review: no findings
- independent UX/accessibility review: findings fixed, final review clean