### PR TITLE
docs: remove Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@
   <a href="https://github.com/hecatehq/hecate/actions/workflows/test.yml">
     <img alt="Test workflow" src="https://github.com/hecatehq/hecate/actions/workflows/test.yml/badge.svg?branch=master">
   </a>
-  <a href="https://goreportcard.com/report/github.com/hecatehq/hecate">
-    <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/hecatehq/hecate">
-  </a>
   <a href="go.mod">
     <img alt="Go version" src="https://img.shields.io/github/go-mod/go-version/hecatehq/hecate">
   </a>


### PR DESCRIPTION
## Summary

- remove the external Go Report Card badge and link from the README status row
- keep the repository test-workflow and Go-version badges unchanged

## Impact

Documentation-only cleanup; runtime behavior and public contracts are unchanged.

## Validation

- `just docs-format-check`
- `just docs-check` — 831 links checked, 0 errors
