### PR TITLE
test(agentadapters): refresh Cursor installer checksum

### DIFF
--- a/internal/agentadapters/dockerfile_test.go
+++ b/internal/agentadapters/dockerfile_test.go
@@ -50,7 +50,7 @@ func TestDockerfilesPinSameCursorInstallerChecksum(t *testing.T) {
 
 	dev := readDockerfile(t, "Dockerfile")
 	release := readDockerfile(t, "Dockerfile.release")
-	const want = "d15e655a16bf4cd5551003d41e428c330bdca3a6904c1cd4e0a279e3d50f73e5"
+	const want = "113bd5068597904810a94daf6056fa2f3f45829e1c4e52937dfe3b3d009d2a23"
 
 	devChecksum := dockerfileArgValue(dev, "CURSOR_INSTALL_SHA256")
 	releaseChecksum := dockerfileArgValue(release, "CURSOR_INSTALL_SHA256")


### PR DESCRIPTION
## Summary

- Update the Cursor installer integrity test to the checksum merged in #901.

## Why

The source and release Dockerfiles correctly pin the reviewed current installer,
but the independent expected-hash assertion still named the prior upstream
script. That made the Linux race suite fail despite a successful Docker build.

## Validation

- `go test -race -count=1 ./internal/agentadapters`
- `go test -race -timeout 10m ./...`
