### PR TITLE
test: stabilize chat restore fence

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2644,11 +2644,16 @@ func TestRevertChatWorkspaceFilesRestoresSelectedCurrentPaths(t *testing.T) {
 		client.handler.ServeHTTP(recorder, request)
 		revertDone <- recorder
 	}()
+	// The request reaches the injected restore fence only after bounded Git
+	// snapshots and lifecycle admission checks. Keep the fence assertion
+	// deterministic on a loaded race/build host without changing the production
+	// writer-drain or lifecycle semantics under test.
+	const restoreFenceTimeout = 15 * time.Second
 	select {
 	case <-blockingRunner.restoreStarted:
 	case recorder := <-revertDone:
 		t.Fatalf("revert completed before restore fence: status=%d body=%s", recorder.Code, recorder.Body.String())
-	case <-time.After(3 * time.Second):
+	case <-time.After(restoreFenceTimeout):
 		close(blockingRunner.restoreRelease)
 		t.Fatal("revert did not reach blocked restore")
 	}


### PR DESCRIPTION
## Summary

- Extend the test-only observation deadline for the chat workspace restore fence from 3 to 15 seconds.
- Preserve the existing cleanup, writer-drain, and lifecycle-admission assertions.

## Why

The handler legitimately performs multiple bounded Git snapshots and lifecycle checks before it reaches the injected restore fence. Under a heavily loaded race/build host, the previous three-second test budget could expire while that setup was still in progress. No runtime timeout, sandbox, writer-fence, or lifecycle behavior changes.

## Validation

- `go test -race -count=5 -run "^TestRevertChatWorkspaceFilesRestoresSelectedCurrentPaths$" -timeout 10m ./internal/api`
- `go test -race -count=1 -timeout 10m ./...` before the non-overlapping master fixture-synchronization rebase
- `go vet ./...`
- independent review: approved; the rebase retained the code-intelligence synchronization already merged into master