### PR TITLE
feat(models): verify configured tool support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ internal/
   modelapp/             model listing, refresh, capability resolution, readiness
                           errors for API/chat callers
   modelcaps/            shared model capability table (streaming, tools, vision, …)
+  modelprobe/           generation-bound manual tool-support verification state,
+                          lease coordination, and safe outcome projection
   orchestrator/         task runtime: queue, runner, agent_loop, sandbox boundary
   codeintel/            native read-only code intelligence: fixed allowlisted LSP
                           and ast-grep subprocesses, protocol/result bounds,

--- a/cmd/hecate/main.go
+++ b/cmd/hecate/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hecatehq/hecate/internal/controlplane"
 	"github.com/hecatehq/hecate/internal/gateway"
 	"github.com/hecatehq/hecate/internal/governor"
+	"github.com/hecatehq/hecate/internal/modelprobe"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/pluginregistry"
 	"github.com/hecatehq/hecate/internal/profiler"
@@ -254,6 +255,7 @@ func runServe() {
 	projectRuntimeStore := buildProjectRuntimeStore(cfg, logger, sqliteClient, postgresClient)
 	pluginRegistryStore := buildPluginRegistryStore(cfg, logger, sqliteClient, postgresClient)
 	agentProfileStore := buildAgentProfileStore(cfg, logger, sqliteClient, postgresClient)
+	modelToolProbeStore := buildModelToolProbeStore(cfg, logger, sqliteClient, postgresClient)
 	// Approval state follows HECATE_BACKEND so chat transcripts, grants,
 	// and pending approval rows move together across memory/sqlite/postgres modes.
 	// Startup reconcile fires before the gateway accepts any request:
@@ -325,6 +327,7 @@ func runServe() {
 	handler.SetProjectRuntimeStore(projectRuntimeStore)
 	handler.SetPluginRegistryStore(pluginRegistryStore)
 	handler.SetAgentProfileStore(agentProfileStore)
+	handler.SetModelToolProbeStore(modelToolProbeStore)
 	handler.SetAgentApprovalStore(approvalStore)
 	if postgresClient != nil {
 		handler.SetStateCleaner(postgresClient)
@@ -908,6 +911,27 @@ func buildAgentProfileStore(cfg config.Config, logger *slog.Logger, sqliteClient
 		return store
 	default:
 		return agentprofiles.NewMemoryStore()
+	}
+}
+
+func buildModelToolProbeStore(cfg config.Config, logger *slog.Logger, sqliteClient *storage.SQLiteClient, postgresClient *storage.PostgresClient) modelprobe.Store {
+	switch cfg.Server.ControlPlaneBackend {
+	case "sqlite":
+		store, err := modelprobe.NewSQLiteStore(context.Background(), sqliteClient)
+		if err != nil {
+			logger.Error("model tool probe store init failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return store
+	case "postgres":
+		store, err := modelprobe.NewPostgresStore(context.Background(), postgresClient)
+		if err != nil {
+			logger.Error("model tool probe store init failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return store
+	default:
+		return modelprobe.NewMemoryStore()
 	}
 }
 

--- a/docs-ai/skills/backend/SKILL.md
+++ b/docs-ai/skills/backend/SKILL.md
@@ -864,6 +864,23 @@ When changing this path:
    Model listing, refresh selection, capability resolution, and readiness-error
    wrapping live in `internal/modelapp`; API handlers should render DTOs and
    map `modelapp.ReadinessError` into the existing error envelope.
+   Manual tool-support verification belongs on that same model application /
+   gateway boundary, not in a Chat handler, normal model request, or provider
+   discovery refresh. It must target one exact configured provider/model and
+   opaque provider generation, make at most one static forced-tool request, and
+   only observe its reply: never execute the tool, parse/store its arguments,
+   reuse user content, access a workspace, retry, or fail over. Persist and
+   return only safe outcome/timing metadata. Project a verification result onto
+   an effective tool capability only while that capability is `unknown`;
+   provider-native and catalog-known `none`, `basic`, and `parallel` values
+   remain authoritative. For every tools-on Hecate task, carry an active
+   supported proof as an internal durable request marker; routing and every
+   final dispatch must require the exact provider name, model, opaque
+   generation, unexpired proof, and no-failover fence. Attachment turns also
+   require explicit image support. Never mutate catalog metadata to make the
+   proof globally routable, and never let it select an Auto route or relax
+   image admission. Any automatic verification needs a separate explicit cost,
+   consent, cooldown, and operator-control design.
 3. Keep `docs/runtime/external-agents.md` aligned for operator-visible
    behavior such as launchers, env sanitisation, persistence, raw diagnostics,
    guardrails, auth/readiness probes, and troubleshooting.

--- a/docs-ai/skills/ui/SKILL.md
+++ b/docs-ai/skills/ui/SKILL.md
@@ -360,7 +360,13 @@ Each section has exactly one job: orient, inspect, compare, edit, or confirm. If
   transcript, and suggest choosing a known tool-capable model for task-backed
   turns. Put the fallback state in the chat header/status line, not as a noisy
   composer warning. Connections shows observed provider/catalog capability
-  metadata, not a global "tools on/off" override editor.
+  metadata, not a global "tools on/off" override editor. For a ready model
+  whose tool support is unknown, Connections may offer an explicit **Verify
+  tool support** action. Keep it opt-in and visibly capable of incurring one
+  provider request; never trigger it from page load, model refresh, or Chat
+  send. Render only the safe `tool_verification` outcome/times/reason, refresh
+  the shared model list after it settles, and do not offer it for Auto,
+  unready, or already-known models.
 - Hecate image attachments are independent of the Tools toggle. Keep the
   PNG/JPEG/WebP and confirmed `image_input` gates in both direct-model and
   task-backed modes; never reintroduce UI copy that asks operators to disable

--- a/docs/design/accepted/hecate-chat-model-capabilities.md
+++ b/docs/design/accepted/hecate-chat-model-capabilities.md
@@ -5,7 +5,8 @@
 > [Agent runtime](../../runtime/agent-runtime.md), and [Runtime API](../../runtime/runtime-api.md).
 > **Next action:** implement automatic capability probes and broaden e2e/product
 > hardening. Named Agent Presets are now wired into Hecate Chat as a deliberately
-> narrow immutable runtime snapshot.
+> narrow immutable runtime snapshot, and manual tool-support verification is
+> implemented.
 >
 > **Terminology note:** this design record was written while "Hecate Agent" was the
 > proposed product label for Hecate-owned tools-on chat. Current UI and
@@ -98,6 +99,12 @@ type ModelCapabilities = {
   streaming?: boolean;
   max_context_tokens?: number;
   source: "unknown" | "catalog" | "provider" | "mixed";
+  tool_verification?: {
+    status: "testing" | "supported" | "unsupported" | "inconclusive";
+    checked_at: string;
+    expires_at: string;
+    reason?: string;
+  };
 };
 ```
 
@@ -150,34 +157,63 @@ discovery API does not report image support. Image-bearing compatibility
 requests still disable cross-provider failover, revalidate the selected opaque
 provider instance immediately before dispatch, and use the bounded 32 MiB,
 60-second compatibility ingress contract.
-The original product surface is Hecate-owned, Tools-off Chat with staged
-PNG/JPEG/WebP attachments. Task-backed turns still do not accept attachment ids.
-External Agent/ACP sessions now accept bounded arbitrary files and resolve them
-against live ACP image/embedded-resource capabilities, with a private per-turn
-`resource_link` as the baseline fallback; that path does not weaken direct
-model image-capability admission.
+Hecate-owned Chat accepts staged PNG/JPEG/WebP attachments with Tools off or
+with task-backed Tools on. The task-backed path persists only an opaque input
+reference and hydrates the image immediately before its fenced agent-loop
+dispatch. External Agent/ACP sessions accept bounded arbitrary files and
+resolve them against live ACP image/embedded-resource capabilities, with a
+private per-turn `resource_link` as the baseline fallback; that path does not
+weaken direct-model image-capability admission.
 
-### Automatic probing
+### Explicit tool-support verification
 
-Automatic probing is required before this feature can feel stable for local
-and custom providers. This is a product requirement, but it must be controlled,
-observable, and never surprising.
+The first verification path is deliberately manual. In **Connections**, a
+ready model whose effective `tool_calling` value is `unknown` can offer
+**Verify tool support**. This keeps a potentially billable provider request out
+of page loads, model refreshes, and Chat send paths. It is not available for
+Auto routes, unavailable models, or models that already have a known
+provider/catalog capability.
 
-Automatic probes should:
+One operator action makes at most one bounded request to the exact configured
+provider, model, and opaque provider configuration generation. Hecate supplies
+a fixed one-message prompt, a fixed harmless `hecate_capability_probe` function
+schema, and a forced choice of that function. It observes whether the provider
+returns that function call; it does not parse or execute its arguments, invoke
+a Hecate tool, start a task, or access a workspace, chat prompt, attachment, or
+External Agent session. The request never retries or fails over to another
+provider. It can incur the selected provider's normal model-request charge.
 
-1. Run only for models that are configured and routable.
-2. Use a small, deterministic tool-calling probe request with a harmless tool
-   schema.
-3. Never execute a tool or mutate a workspace.
-4. Respect a per-provider cooldown so the gateway does not probe every page
-   load.
-5. Persist results as provider/catalog metadata with timestamp, provider, model, probe
-   status, and any safe error summary.
-6. Surface probe state in Connections and the model picker: unknown, testing,
-   tools supported, no tools, failed.
-7. Let operators disable automatic probes globally or per provider/model.
+The durable result is only a safe observation: status, checked/expiry times,
+and a bounded reason code. It contains no prompt or response text, tool
+arguments, provider endpoint, provider generation, or credentials. A matching
+active result is reused so repeated clicks do not create another provider call;
+concurrent verification requests coalesce. A provider replacement or
+configuration change makes the old observation inapplicable.
 
-A failed probe must not override a provider-native capability result.
+For an otherwise unknown capability only:
+
+- `supported` projects `tool_calling="basic"`.
+- an explicit tool-schema rejection projects `tool_calling="none"`.
+- `testing` or `inconclusive` leaves `tool_calling="unknown"`.
+
+Provider-native and catalog-known capabilities remain authoritative. A manual
+observation is shown as `tool_verification` provenance but must never override
+an effective `none`, `basic`, or `parallel` value. In particular, an
+inconclusive network, authentication, rate-limit, timeout, policy, or provider
+failure is not proof that the model lacks tool support.
+
+For every tools-on Hecate task, a matching `supported` observation may satisfy
+only an otherwise-unknown **tool** requirement. It stays bound to the same
+exact provider name, model, and generation until the proof expires, with
+failover disabled; it neither proves `image_input` nor makes an Auto route
+eligible. An attachment turn keeps its separate explicit image-support gate.
+Final dispatch rechecks those fences so a queued run, retry, or delayed stream
+cannot outlive the proof.
+
+Automatic capability verification is future work, not an implication of this
+manual action. Any proposal for it needs separate cost, consent, cooldown, and
+operator-control decisions; it must preserve the same exact-route, no-tool-
+execution, and provider-native-precedence boundaries.
 
 ## Hecate Agent Sessions
 
@@ -474,6 +510,9 @@ Minimum coverage:
 - Memory/SQLite parity for new session fields.
 - UI target picker, tools on/off switches, tools-unavailable direct fallback,
   and task/run links.
+- Manual tool-support verification for an unknown, ready configured model:
+  exact-route request fencing, one-call/coalescing behavior, safe projection
+  into `/v1/models`, and Connections result states.
 - Task-backed Hecate Chat Task Run activity projection from Task Run SSE into Chats.
 - Task-backed Hecate Chat task approval banner in Chats, including approve, reject, and a
   link to the backing Task.
@@ -525,10 +564,15 @@ Done in the core bridge:
   Chat-safe runtime snapshot; preset instructions, provider/model hints, and
   task posture are applied without importing project, browser, MCP, or
   External Agent behavior
+- Connections lets an operator explicitly verify tool support for a ready,
+  otherwise-unknown provider/model. The result is generation-bound, safe to
+  inspect in `metadata.capabilities.tool_verification`, and only projects onto
+  an unknown effective tool capability.
 
 Still required for a complete Hecate Chat tools-on experience:
 
-- automatic capability probing
+- automatic capability probing or another explicit product decision for
+  provider/model verification beyond the manual operator action
 - broader e2e/product hardening around workspace modes, profiles, automatic
   capability detection, and mixed long-running sessions
 
@@ -538,8 +582,9 @@ The missing stable-scope pieces should land in this order:
 
 1. **Automatic probing.** Add bounded, visible capability probes for configured
    models so local/custom providers can become eligible without manual edits.
-   Probes must not execute tools or mutate workspaces, and provider-native
-   capability metadata remains the stronger source when it is available.
+   Probes must not execute tools or mutate workspaces, and must preserve manual
+   verification's exact-route, consent, cost, cooldown, disable-control, and
+   provider-native-precedence boundaries.
 2. **E2E hardening.** Extend the existing browser paths to cover workspace
    modes, profiles, automatic capability detection, refresh/reconnect edges,
    and long mixed chats with queued prompts.
@@ -567,6 +612,7 @@ Prefer explicit capability records over magic. Hecate should not infer
 should know what a model can do and show that clearly to the operator. During
 alpha, task-backed tools-on execution requires a known tool-capable value
 (`basic` or `parallel`); unknown local/custom models stay visibly unknown and
-fall back to direct model chat until provider metadata or a safe probe marks
-them tool-capable. Before stable, automatic probing should make that unknown
-state much rarer without silently overwriting provider-native facts.
+fall back to direct model chat until provider metadata or an explicit safe
+verification marks them tool-capable. A future automatic scheme must not
+silently overwrite provider-native facts or surprise an operator with a paid
+provider request.

--- a/docs/operator/providers.md
+++ b/docs/operator/providers.md
@@ -100,11 +100,12 @@ The result is shown on the model row and in the model metadata:
   timeout, or other inconclusive outcomes leave the model unknown. Repair the
   route or provider state and try again later.
 
-Hecate keeps only the status, times, and a short safe reason code for this
-observation. It does not show or persist raw probe prompts, model output, tool
-arguments, credentials, endpoints, or the internal provider configuration
-identity and selected model until its displayed expiry, so changing or
-replacing that provider, switching models, or waiting for expiry requires a
+The operator-facing observation contains only the status, times, and a short
+safe reason code. Hecate does not persist raw probe prompts, model output, tool
+arguments, credentials, or endpoints. Internally, it retains the configured
+provider, selected model, and opaque configuration identity only to bind the
+observation to that route and expiry; it never exposes that identity. Changing
+or replacing the provider, switching models, or waiting for expiry requires a
 new verification. Repeated clicks reuse a current result rather than creating
 another provider call.
 

--- a/docs/operator/providers.md
+++ b/docs/operator/providers.md
@@ -10,6 +10,7 @@ Hecate uses a vendor-neutral provider layer at the runtime boundary. It treats O
 
 - [Providers vs. clients](#providers-vs-clients)
 - [Adding a provider](#adding-a-provider)
+- [Verify model tool support](#verify-model-tool-support)
 - [Built-in presets](#built-in-presets)
 - [Env-configured providers](#env-configured-providers)
 - [Anthropic prompt caching](#anthropic-prompt-caching)
@@ -72,6 +73,54 @@ Click any row in the providers table to open the edit modal:
 - **Local / custom-local** — change the endpoint URL. Save URL is disabled when the new value matches the current one.
 
 The edit modal also shows live runtime status: health, route readiness, model count, last check time, and a collapsible diagnostics section with the last error, error class, latency, and totals.
+
+## Verify model tool support
+
+Some local and custom providers can report that a model exists without saying
+whether it accepts tool definitions. When a model is both route-ready and
+marked **Tools unknown**, its row in **Connections** offers **Verify tool
+support**. This is deliberately a Connections action, not something Hecate
+does while loading a page, refreshing the model list, or sending a Chat prompt.
+
+The action sends one bounded, static request to that exact configured provider
+and model. It asks for one harmless forced function call and only observes
+whether that call is returned. Hecate does not execute the function, inspect
+its arguments, start a task, read the current workspace, or include a Chat
+prompt, attachment, or External Agent data. There is no retry or provider
+failover. Because it is a real model request, the selected provider may bill
+for it.
+
+The result is shown on the model row and in the model metadata:
+
+- **Tool support verified** — the previously unknown model is eligible for Hecate
+  Chat's task-backed tools-on turns.
+- **No tool support** — the provider explicitly rejected the tool schema;
+  normal direct model chat remains available.
+- **Tool support not confirmed** — authentication, policy, network, rate-limit,
+  timeout, or other inconclusive outcomes leave the model unknown. Repair the
+  route or provider state and try again later.
+
+Hecate keeps only the status, times, and a short safe reason code for this
+observation. It does not show or persist raw probe prompts, model output, tool
+arguments, credentials, endpoints, or the internal provider configuration
+identity and selected model until its displayed expiry, so changing or
+replacing that provider, switching models, or waiting for expiry requires a
+new verification. Repeated clicks reuse a current result rather than creating
+another provider call.
+
+Verification is evidence only for an otherwise unknown capability. It never
+overrides tool support already known from provider-native metadata or Hecate's
+catalog. Use the model's capability details and
+[`GET /v1/models`](../runtime/runtime-api.md#get-v1models) for the precise
+operator/API state.
+
+For every Hecate Chat task-backed tools-on turn, a supported result applies
+only to the same pinned provider generation and model before it expires. It
+proves tool support, not image input: an attachment turn must still explicitly
+support images. Hecate never uses the result to select an Auto route, fail over
+to another provider, or authorize a policy-rewritten model. Hecate rechecks
+those fences at every final dispatch, including a queued run, retry, or delayed
+stream.
 
 ### Deleting a provider
 

--- a/docs/runtime/chat-sessions.md
+++ b/docs/runtime/chat-sessions.md
@@ -108,6 +108,26 @@ the same root cause and a concrete first action: add a provider, open the
 blocked provider, or refresh provider/model discovery after the operator starts
 a local runtime or fixes an upstream account.
 
+Tool support is a separate model capability. When a ready configured model is
+still `tool_calling="unknown"`, Chats keeps direct model chat available rather
+than sending a tools-on turn that will fail. The operator can use
+**Connections → Verify tool support** to make one explicit, bounded test of
+that exact provider/model; Chats never starts that potentially billable request
+while loading, refreshing, or sending a prompt. The test does not receive chat
+content or a workspace and does not execute a tool. A supported result makes
+only that unknown model eligible for task-backed tools; a known provider/catalog
+capability remains authoritative. See [Providers](../operator/providers.md#verify-model-tool-support)
+and [the runtime API](runtime-api.md#post-hecatev1model-capabilitiestool-probes)
+for its safe result and failure contract.
+
+For every tools-on Hecate task, that manual proof is usable only on the exact
+provider generation and model that were verified, before the proof expires.
+An image turn additionally must use that provider's independently confirmed
+image route. The proof does not infer image support, select an Auto route,
+allow provider failover, or survive a governor model rewrite. Hecate rechecks
+those fences at every final dispatch, including a queued run, retry, or delayed
+stream.
+
 Hecate Chat also has one per-chat **Instructions** field. With tools off, the
 instructions are sent as the direct model turn's `system_prompt`. With tools
 on, the same text becomes the per-task system prompt for the Hecate-owned
@@ -543,11 +563,13 @@ flowchart LR
     API -->|"append metadata, then link bodies"| Transcript["Chat transcript metadata"]
     Transcript --> Hydrate["Direct-model history or agent-input resolver"]
     Bodies -->|"bounded transient hydration"| Hydrate
+    Verification["Manual tool verification"] -->|"matching provider, model, generation, expiry"| ToolFence["Durable tools-on task fence"]
+    ToolFence -->|"exact route only"| AgentLoop["Task-backed agent loop"]
     Hydrate -->|"canonical image blocks"| Router["Capability-aware router"]
     Router -->|"name + opaque generation"| Fence["Live provider fence"]
     Fence -->|"exact instance only"| Provider["Selected provider"]
     TurnGate -. "permit held until provider returns" .-> Provider
-    Hydrate -->|"tools-on rich prompt"| AgentLoop["Task-backed agent loop"]
+    Hydrate -->|"tools-on rich prompt"| AgentLoop
     AgentLoop -->|"atomic final-route record before I/O"| TaskFence["Durable rich-input dispatch fence"]
     TaskFence -->|"exact route on retry"| Provider
     AgentLoop -->|"artifact marker; no image body"| TaskArtifacts["Task conversation artifacts"]

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1495,7 +1495,27 @@ turn as direct model chat and showing a compact capability hint. Local/custom
 OpenAI-compatible providers often report `unknown`; Ollama models are enriched
 from the native `/api/show` capability list when available. Tool usage is a
 per-chat setting; model capability metadata is observed from provider/catalog
-data rather than edited globally.
+data rather than edited globally. An optional
+`capabilities.tool_verification` records a manual, safe observation for an
+otherwise unknown model:
+
+```json
+{
+  "status": "supported",
+  "checked_at": "2026-07-21T12:00:00Z",
+  "expires_at": "2026-08-20T12:00:00Z"
+}
+```
+
+`status` is `testing`, `supported`, `unsupported`, or `inconclusive`.
+`reason`, when present, is a bounded diagnostic classification rather than raw
+provider output. For an otherwise unknown effective capability, `supported`
+projects `tool_calling` to `basic`, and an explicit tool-schema rejection
+projects it to `none`; `testing` and `inconclusive` leave it `unknown`.
+Provider-native and catalog-known values stay authoritative, so a verification
+never overrides an effective `none`, `basic`, or `parallel` value. The opaque
+provider configuration identity that binds this observation is intentionally
+not exposed here.
 
 `capabilities.image_input` is one of `unknown`, `none`, or `supported`.
 Image-bearing Hecate Chat turns require `supported`; both `unknown` and `none`
@@ -1519,6 +1539,14 @@ without a generation is omitted. The generation is internal-only and is never
 accepted from clients or rendered in model/chat responses, errors, logs, or
 telemetry. Failed calls retain attempted provider/model and trace metadata when
 the provider received the request.
+
+For every task-backed Hecate Chat tools-on turn, a current
+`tool_verification.status` of `supported` can satisfy an otherwise-unknown tool
+requirement only through the same exact provider/model/generation fence before
+the proof expires. An attachment turn still independently requires image
+support. The proof does not permit a different provider, make an Auto route
+eligible, or survive a policy model rewrite. Hecate rechecks those fences at
+every final dispatch, including a queued run, retry, or delayed stream.
 Ordinary
 provider-compatible `/v1/chat/completions` and `/v1/messages` rich-content
 requests do not opt into this Hecate runtime requirement and preserve upstream
@@ -1535,6 +1563,76 @@ provider is credential-blocked, circuit-open, disabled, or otherwise not
 routable. When `ready=false`, show `message` and `operator_action` directly and
 use `reason`, `provider_status`, `provider_blocked_reason`, and
 `suggested_models` for compact diagnostics.
+
+### `POST /hecate/v1/model-capabilities/tool-probes`
+
+Performs an explicit, bounded verification of tool support for one configured,
+routable provider/model route. This is the API behind **Connections → Verify
+tool support**. It accepts neither Auto routing nor a workspace, prompt,
+attachment, tool definition, or provider generation from the caller.
+
+```json
+POST /hecate/v1/model-capabilities/tool-probes
+{
+  "provider": "local-runtime",
+  "model": "custom-tool-model"
+}
+
+→ 200
+{
+  "object": "model_tool_capability_probe",
+  "data": {
+    "provider": "local-runtime",
+    "model": "custom-tool-model",
+    "capabilities": {
+      "tool_calling": "basic",
+      "source": "mixed",
+      "tool_verification": {
+        "status": "supported",
+        "checked_at": "2026-07-21T12:00:00Z",
+        "expires_at": "2026-08-20T12:00:00Z"
+      }
+    },
+    "verification": {
+      "status": "supported",
+      "checked_at": "2026-07-21T12:00:00Z",
+      "expires_at": "2026-08-20T12:00:00Z"
+    },
+    "trace_id": "trace_...",
+    "performed": true
+  }
+}
+```
+
+Hecate itself supplies one static one-message request, one harmless forced
+function schema, and the exact configured provider/model route. It observes a
+returned call to that function but never parses or executes its arguments,
+starts a task, or accesses a workspace, Chat content, attachment, or ACP
+session. The request makes no provider retry or failover attempt. It can incur
+the selected provider's normal model-request charge.
+
+Hecate persists only the safe verification status, times, and bounded reason;
+it does not retain the static prompt, model response, tool arguments, provider
+endpoint, opaque provider identity, or credentials in the API result or
+verification record. A matching active result is reused, and concurrent
+requests coalesce, so `performed=false` means this response reused a current
+result or the model already had a known capability rather than sending another
+provider request. Reconfiguring or replacing the provider makes prior
+verification inapplicable.
+
+The endpoint is limited to models whose current effective `tool_calling` value
+is `unknown`. Known provider/catalog values are returned unchanged without a
+probe. A `supported` result makes only that unknown capability eligible as
+`basic`; an explicit tool-schema rejection makes it `none`; all other failures
+are `inconclusive` and leave it `unknown`.
+
+- `400 invalid_request` — provider or model is missing, or `provider` is
+  `auto`.
+- `409 provider_ambiguous` or `model_not_configured` — the provider identity is
+  ambiguous, the model is not ready, or the exact route changed during the
+  verification.
+- `503 model_tool_probe_unavailable` — this runtime cannot perform the
+  verification.
 
 ### `GET /hecate/v1/agent-adapters`
 
@@ -5407,6 +5505,10 @@ the user message and assistant output.
   `image_input="supported"`. A tools-on Task Run persists only an opaque input
   reference, hydrates the body immediately before agent-loop execution, and
   replaces image blocks with omission markers in its conversation artifact.
+  A matching manual tool-support verification can satisfy only an otherwise
+  unknown tool requirement on the exact pinned route, including a tools-on
+  Task Run without an attachment; it never substitutes for image support or
+  enables Auto/failover routing.
   Same-input resumes and retries inherit the reference. External Agent
   turns accept the staged files; text may be empty when at least one attachment
   is present. Hecate persists only immutable attachment metadata on the user

--- a/internal/api/applications.go
+++ b/internal/api/applications.go
@@ -190,5 +190,9 @@ func (h *Handler) modelApplication() *modelapp.Application {
 	if h == nil {
 		return modelapp.New(modelapp.Options{})
 	}
-	return modelapp.New(modelapp.Options{Service: h.service})
+	return modelapp.New(modelapp.Options{
+		Service:              h.service,
+		ToolProbeStore:       h.modelToolProbeStore,
+		ToolProbeCoordinator: h.modelToolProbeCoordinator,
+	})
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -22,6 +22,7 @@ import (
 	mcpclient "github.com/hecatehq/hecate/internal/mcp/client"
 	"github.com/hecatehq/hecate/internal/memory"
 	"github.com/hecatehq/hecate/internal/modelapp"
+	"github.com/hecatehq/hecate/internal/modelprobe"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/internal/pluginregistry"
 	"github.com/hecatehq/hecate/internal/profiler"
@@ -91,6 +92,8 @@ type Handler struct {
 	projectAssistantApplyMu           sync.Mutex
 	projectAssistant                  *projectassistantapp.Application
 	agentProfiles                     agentprofiles.Store
+	modelToolProbeStore               modelprobe.Store
+	modelToolProbeCoordinator         *modelprobe.Coordinator
 	browserEvidenceReadiness          BrowserEvidenceRuntimeReadinessResponse
 	agentChatRunner                   agentadapters.Runner
 	agentChatLive                     *agentChatLive
@@ -244,6 +247,7 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 
 	taskOriginRunGate := taskruncoord.NewOriginGate()
 	workspaceCoordinator := workspacecoord.NewRegistry()
+	modelToolProbeStore := modelprobe.NewMemoryStore()
 	browserInspector, browserEvidenceReadiness := browserInspectorFromConfig(cfg, logger)
 	runner := orchestrator.NewRunner(logger, taskStore, tracer, orchestrator.Config{
 		DefaultModel:           cfg.Router.DefaultModel,
@@ -416,6 +420,8 @@ func NewHandler(cfg config.Config, logger *slog.Logger, service *gateway.Service
 		projectAssistantProposals:         projectAssistantProposalStore,
 		pluginRegistry:                    pluginregistry.NewMemoryStore(),
 		agentProfiles:                     agentprofiles.NewMemoryStore(),
+		modelToolProbeStore:               modelToolProbeStore,
+		modelToolProbeCoordinator:         modelprobe.NewCoordinator(modelToolProbeStore),
 		browserEvidenceReadiness:          browserEvidenceReadiness,
 		agentChatRunner:                   agentChatRunner,
 		agentChatLive:                     agentChatLive,
@@ -625,6 +631,17 @@ func (h *Handler) SetAgentProfileStore(store agentprofiles.Store) {
 		return
 	}
 	h.agentProfiles = store
+}
+
+// SetModelToolProbeStore swaps the Hecate-owned durable capability-probe
+// state. It is wired during process composition; tests that do not call it use
+// the in-memory default from NewHandler.
+func (h *Handler) SetModelToolProbeStore(store modelprobe.Store) {
+	if store == nil {
+		return
+	}
+	h.modelToolProbeStore = store
+	h.modelToolProbeCoordinator = modelprobe.NewCoordinator(store)
 }
 
 func (h *Handler) SetAgentChatRunner(runner agentadapters.Runner) {

--- a/internal/api/handler_chat_hecate.go
+++ b/internal/api/handler_chat_hecate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hecatehq/hecate/internal/chatattachments"
 	"github.com/hecatehq/hecate/internal/chatcontext"
 	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/modelprobe"
 	"github.com/hecatehq/hecate/internal/taskapp"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/internal/telemetry"
@@ -21,6 +22,28 @@ import (
 )
 
 const hecateAgentPollInterval = 250 * time.Millisecond
+
+// activeToolCallingVerificationFence converts the current exact-route
+// capability projection into private run metadata. A model capability is not
+// enough here: only a currently active Hecate-owned proof may add the stricter
+// provider/model/generation fence to a queued tools-on task.
+func activeToolCallingVerificationFence(caps types.ModelCapabilities, provider, model string, instance types.ProviderInstanceIdentity, now time.Time) (types.ToolCallingVerificationFence, bool) {
+	verification := caps.ToolVerification
+	if caps.ToolCalling != modelcaps.ToolCallingBasic ||
+		!caps.ToolCallingVerificationApplied ||
+		verification == nil ||
+		verification.Status != modelprobe.StatusSupported ||
+		!verification.ExpiresAt.After(now.UTC()) {
+		return types.ToolCallingVerificationFence{}, false
+	}
+	fence := types.ToolCallingVerificationFence{
+		Provider:         strings.TrimSpace(provider),
+		Model:            strings.TrimSpace(model),
+		ProviderInstance: instance,
+		ExpiresAt:        verification.ExpiresAt.UTC(),
+	}
+	return fence, fence.Valid()
+}
 
 // handleCreateHecateChatMessage is the unified entry point for every
 // Hecate-side chat-message submission. It branches on toolsEnabled:
@@ -95,13 +118,54 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		}
 	}
 	caps := session.Capabilities
-	if !modelcaps.ToolCapable(caps) {
+	// A manual verification is generation- and expiry-bound. A persisted Chat
+	// snapshot is only an operator-facing hint, never durable admission proof,
+	// so resolve it again for every tools-on turn before creating a task.
+	if !modelcaps.ToolCapable(caps) || caps.ToolVerification != nil {
 		resolved, err := h.resolveModelCapabilities(r.Context(), session.Provider, session.Model)
 		if err != nil {
 			writeAgentChatModelResolutionError(w, err)
 			return
 		}
 		caps = resolved
+	}
+	admittedToolCallingVerification := types.ToolCallingVerificationFence{}
+	if caps.ToolCalling == modelcaps.ToolCallingBasic && caps.ToolCallingVerificationApplied {
+		// An applied manual proof is never valid for Auto. Resolve the exact
+		// route again so the durable task fence is bound to the current provider
+		// generation, then re-read the capability projection from that route.
+		// This closes the interval between the session snapshot and task creation.
+		requestedProvider := strings.TrimSpace(session.Provider)
+		if requestedProvider == "" || strings.EqualFold(requestedProvider, "auto") {
+			WriteError(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Verified tool support requires an exact provider route.")
+			return
+		}
+		route, routeErr := h.modelApplication().ResolveProviderRoute(r.Context(), requestedProvider, session.Model)
+		if routeErr != nil {
+			writeAgentChatModelResolutionError(w, routeErr)
+			return
+		}
+		if route.Name == "" || !route.Instance.Valid() {
+			WriteError(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Verified tool support requires a configured provider generation.")
+			return
+		}
+		session.Provider = route.Name
+		caps, routeErr = h.resolveModelCapabilities(r.Context(), route.Name, session.Model)
+		if routeErr != nil {
+			writeAgentChatModelResolutionError(w, routeErr)
+			return
+		}
+		var verified bool
+		admittedToolCallingVerification, verified = activeToolCallingVerificationFence(caps, route.Name, session.Model, route.Instance, time.Now().UTC())
+		if !verified {
+			WriteError(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Verified tool support is no longer active for this provider and model.")
+			return
+		}
+		if admittedInputProviderInstance.Valid() && admittedInputProviderInstance != route.Instance {
+			WriteError(w, http.StatusUnprocessableEntity, errCodeModelCapability, "The provider route changed while admitting this tools-on turn.")
+			return
+		}
+		admittedInputProviderInstance = route.Instance
 	}
 	if !modelcaps.ToolCapable(caps) {
 		WriteErrorDetails(w, http.StatusUnprocessableEntity, errCodeModelCapability, "Tools are unavailable for this model. Send as direct model chat or choose a tool-capable model.", ErrorDetails{
@@ -300,14 +364,15 @@ func (h *Handler) handleCreateHecateChatMessage(w http.ResponseWriter, r *http.R
 		inputRef = userID
 	}
 	task, run, err := h.hecateAgentTaskOrchestrator().StartOrContinue(runCtx, hecateAgentTaskRunCommand{
-		Session:               session,
-		Prompt:                content,
-		InputRef:              inputRef,
-		InputProviderInstance: admittedInputProviderInstance,
-		SystemPrompt:          taskSystemPrompt,
-		ForceNewTask:          forceNewTask,
-		MCPServers:            mcpServers,
-		ContextPacket:         contextPacket,
+		Session:                 session,
+		Prompt:                  content,
+		InputRef:                inputRef,
+		InputProviderInstance:   admittedInputProviderInstance,
+		ToolCallingVerification: admittedToolCallingVerification,
+		SystemPrompt:            taskSystemPrompt,
+		ForceNewTask:            forceNewTask,
+		MCPServers:              mcpServers,
+		ContextPacket:           contextPacket,
 	})
 	if err != nil {
 		completedAt := time.Now().UTC()

--- a/internal/api/handler_chat_hecate_input.go
+++ b/internal/api/handler_chat_hecate_input.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/chat"
 	"github.com/hecatehq/hecate/internal/chatapp"
 	"github.com/hecatehq/hecate/internal/chatattachments"
+	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/modelprobe"
 	"github.com/hecatehq/hecate/internal/orchestrator"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -87,6 +90,23 @@ func (h *Handler) resolveHecateAgentInput(ctx context.Context, task types.Task, 
 	if !imageCapable {
 		return orchestrator.AgentInput{}, fmt.Errorf("selected model route does not declare image-input support")
 	}
+	capabilities, err := h.resolveModelCapabilities(ctx, provider, model)
+	if err != nil {
+		return orchestrator.AgentInput{}, fmt.Errorf("resolve tool capability verification: %w", err)
+	}
+	// A manual proof can relax only the unknown tool gate. Rich input resolves
+	// the proof again from the current exact route; its provider, model,
+	// generation, and expiry are then checked at every final dispatch.
+	toolCallingVerified := capabilities.ToolCalling == modelcaps.ToolCallingBasic &&
+		capabilities.ToolVerification != nil &&
+		capabilities.ToolVerification.Status == modelprobe.StatusSupported &&
+		capabilities.ToolCallingVerificationApplied
+	toolCallingVerifiedModel := ""
+	toolCallingVerifiedUntil := time.Time{}
+	if toolCallingVerified {
+		toolCallingVerifiedModel = model
+		toolCallingVerifiedUntil = capabilities.ToolVerification.ExpiresAt
+	}
 	if h.chatImageTurnAdmission == nil || !h.chatImageTurnAdmission.Acquire(ctx) {
 		return orchestrator.AgentInput{}, fmt.Errorf("image input admission cancelled before execution")
 	}
@@ -120,10 +140,13 @@ func (h *Handler) resolveHecateAgentInput(ctx context.Context, task types.Task, 
 	return orchestrator.AgentInput{
 		Message: chatModelMessageWithAttachments(inputMessage.Content, attachments, nil),
 		Requirements: types.ChatRequestRequirements{
-			ImageInput:         true,
-			NoProviderFailover: true,
-			ExactProvider:      provider != "",
-			ProviderInstance:   providerInstance,
+			ImageInput:               true,
+			ToolCallingVerified:      toolCallingVerified,
+			ToolCallingVerifiedModel: toolCallingVerifiedModel,
+			ToolCallingVerifiedUntil: toolCallingVerifiedUntil,
+			NoProviderFailover:       true,
+			ExactProvider:            provider != "",
+			ProviderInstance:         providerInstance,
 		},
 		Release: release,
 	}, nil

--- a/internal/api/handler_chat_hecate_task.go
+++ b/internal/api/handler_chat_hecate_task.go
@@ -33,14 +33,15 @@ type hecateAgentTaskOrchestrator struct {
 }
 
 type hecateAgentTaskRunCommand struct {
-	Session               chat.Session
-	Prompt                string
-	InputRef              string
-	InputProviderInstance types.ProviderInstanceIdentity
-	SystemPrompt          string
-	ForceNewTask          bool
-	MCPServers            []types.MCPServerConfig
-	ContextPacket         chat.ContextPacket
+	Session                 chat.Session
+	Prompt                  string
+	InputRef                string
+	InputProviderInstance   types.ProviderInstanceIdentity
+	ToolCallingVerification types.ToolCallingVerificationFence
+	SystemPrompt            string
+	ForceNewTask            bool
+	MCPServers              []types.MCPServerConfig
+	ContextPacket           chat.ContextPacket
 }
 
 func (h *Handler) hecateAgentTaskOrchestrator() hecateAgentTaskOrchestrator {
@@ -135,6 +136,7 @@ func (o hecateAgentTaskOrchestrator) startNewTask(ctx context.Context, cmd hecat
 	}
 	result, err := o.runner.StartTaskWithRunInitializer(ctx, task, o.resourceID, func(run *types.TaskRun) {
 		run.InputRef = strings.TrimSpace(cmd.InputRef)
+		run.ToolCallingVerification = cmd.ToolCallingVerification
 		run.InputProviderDispatchRecorded = false
 		if run.InputRef != "" {
 			run.InputProviderInstance = cmd.InputProviderInstance
@@ -176,6 +178,7 @@ func (o hecateAgentTaskOrchestrator) continueTask(ctx context.Context, cmd hecat
 	}
 	result, err := o.runner.ContinueAgentTaskWithRunInitializer(ctx, task, run, cmd.Prompt, o.resourceID, func(nextRun *types.TaskRun) {
 		nextRun.InputRef = strings.TrimSpace(cmd.InputRef)
+		nextRun.ToolCallingVerification = cmd.ToolCallingVerification
 		nextRun.InputProviderDispatchRecorded = false
 		if nextRun.InputRef != "" {
 			nextRun.InputProviderInstance = cmd.InputProviderInstance

--- a/internal/api/handler_chat_image_turn_test.go
+++ b/internal/api/handler_chat_image_turn_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hecatehq/hecate/internal/config"
 	"github.com/hecatehq/hecate/internal/controlplane"
 	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/modelprobe"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/internal/taskstate"
 	"github.com/hecatehq/hecate/pkg/types"
@@ -118,6 +119,297 @@ func TestHecateAgentChatToolsOnHydratesImageWithoutPersistingBodyInTaskArtifacts
 			t.Fatal("image turn permit was not released after agent-loop execution")
 		}
 		defer apiHandler.chatImageTurnAdmission.Release()
+	}
+}
+
+func TestHecateAgentChatToolsOnUsesVerifiedUnknownToolSupportForImageRoute(t *testing.T) {
+	provider := imageTurnTestProvider(modelcaps.ImageInputSupported)
+	capabilities := provider.capabilities.ModelCapabilities["llama-vision"]
+	capabilities.ToolCalling = modelcaps.ToolCallingUnknown
+	provider.capabilities.ModelCapabilities["llama-vision"] = capabilities
+	provider.responses = []*types.ChatResponse{
+		{
+			Choices: []types.ChatChoice{{
+				Message: types.Message{Role: "assistant", ToolCalls: []types.ToolCall{{
+					ID:   "call_probe",
+					Type: "function",
+					Function: types.ToolCallFunction{
+						Name:      "hecate_capability_probe",
+						Arguments: "{}",
+					},
+				}}},
+			}},
+		},
+		provider.response,
+	}
+	apiHandler := imageTurnTestHandler(provider)
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+
+	probe := mustRequestJSON[ModelToolCapabilityProbeResponse](client, http.MethodPost,
+		"/hecate/v1/model-capabilities/tool-probes", `{"provider":"ollama","model":"llama-vision"}`)
+	if probe.Data.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || probe.Data.Verification == nil || probe.Data.Verification.Status != modelprobe.StatusSupported {
+		t.Fatalf("tool probe = %+v, want supported unknown-model verification", probe.Data)
+	}
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"ollama","model":"llama-vision"}`, t.TempDir()))
+	attachment := imageTurnTestUpload(t, handler, session.Data.ID, "verified-tools.png", imageTurnTestPNG(t))
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"ollama","model":"llama-vision","content":"Inspect this verified image route.","attachment_ids":["`+attachment.Data.ID+`"]}`)
+	if response.Data.Status != "completed" || response.Data.TaskID == "" {
+		t.Fatalf("tools-on verified image response = %+v, want completed task-backed turn", response.Data)
+	}
+
+	request := provider.LastRequest()
+	if !request.Requirements.ImageInput || !request.Requirements.ToolCalling || !request.Requirements.ToolCallingVerified ||
+		!request.Requirements.NoProviderFailover || !request.Requirements.ExactProvider || !request.Requirements.ProviderInstance.Valid() {
+		t.Fatalf("verified image requirements = %+v, want exact generation-fenced verification", request.Requirements)
+	}
+	if request.Requirements.ToolCallingVerifiedModel != "llama-vision" || !request.Requirements.ToolCallingVerifiedUntil.After(time.Now().UTC()) {
+		t.Fatalf("verified image proof = model %q until %s, want active model-bound proof", request.Requirements.ToolCallingVerifiedModel, request.Requirements.ToolCallingVerifiedUntil)
+	}
+	provider.mu.Lock()
+	calls := provider.calls
+	provider.mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("provider calls = %d, want one probe and one agent-loop call", calls)
+	}
+}
+
+func TestHecateAgentChatToolsOnCarriesVerifiedUnknownToolSupportWithoutAttachment(t *testing.T) {
+	provider := imageTurnTestProvider(modelcaps.ImageInputNone)
+	capabilities := provider.capabilities.ModelCapabilities["llama-vision"]
+	capabilities.ToolCalling = modelcaps.ToolCallingUnknown
+	provider.capabilities.ModelCapabilities["llama-vision"] = capabilities
+	provider.responses = []*types.ChatResponse{
+		{
+			Choices: []types.ChatChoice{{
+				Message: types.Message{Role: "assistant", ToolCalls: []types.ToolCall{{
+					ID:   "call_probe",
+					Type: "function",
+					Function: types.ToolCallFunction{
+						Name:      "hecate_capability_probe",
+						Arguments: "{}",
+					},
+				}}},
+			}},
+		},
+		provider.response,
+	}
+	apiHandler := imageTurnTestHandler(provider)
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+
+	probe := mustRequestJSON[ModelToolCapabilityProbeResponse](client, http.MethodPost,
+		"/hecate/v1/model-capabilities/tool-probes", `{"provider":"ollama","model":"llama-vision"}`)
+	if probe.Data.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || probe.Data.Verification == nil || probe.Data.Verification.Status != modelprobe.StatusSupported {
+		t.Fatalf("tool probe = %+v, want supported unknown-model verification", probe.Data)
+	}
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"ollama","model":"llama-vision"}`, t.TempDir()))
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"ollama","model":"llama-vision","content":"Use the verified tools without an attachment."}`)
+	if response.Data.Status != "completed" || response.Data.TaskID == "" || response.Data.LatestRunID == "" {
+		t.Fatalf("plain verified tools response = %+v, want completed task-backed turn", response.Data)
+	}
+
+	request := provider.LastRequest()
+	if request.Requirements.ImageInput || !request.Requirements.ToolCalling || !request.Requirements.ToolCallingVerified ||
+		!request.Requirements.NoProviderFailover || !request.Requirements.ExactProvider || !request.Requirements.ProviderInstance.Valid() {
+		t.Fatalf("plain verified requirements = %+v, want exact generation-fenced tool route without image", request.Requirements)
+	}
+	if request.Requirements.ToolCallingVerifiedModel != "llama-vision" || !request.Requirements.ToolCallingVerifiedUntil.After(time.Now().UTC()) {
+		t.Fatalf("plain verified proof = model %q until %s, want active model-bound proof", request.Requirements.ToolCallingVerifiedModel, request.Requirements.ToolCallingVerifiedUntil)
+	}
+	run, found, err := apiHandler.taskStore.GetRun(t.Context(), response.Data.TaskID, response.Data.LatestRunID)
+	if err != nil || !found {
+		t.Fatalf("GetRun() = found %v, error %v", found, err)
+	}
+	if run.InputRef != "" || !run.ToolCallingVerification.Valid() || run.ToolCallingVerification.ProviderInstance != request.Requirements.ProviderInstance || run.ToolCallingVerification.Model != "llama-vision" {
+		t.Fatalf("plain verified run fence = %+v, want durable exact tool-proof metadata", run)
+	}
+}
+
+func TestHecateAgentChatToolsOnRevalidatesExpiredToolVerificationBeforeAdmission(t *testing.T) {
+	provider := imageTurnTestProvider(modelcaps.ImageInputSupported)
+	capabilities := provider.capabilities.ModelCapabilities["llama-vision"]
+	capabilities.ToolCalling = modelcaps.ToolCallingUnknown
+	provider.capabilities.ModelCapabilities["llama-vision"] = capabilities
+	apiHandler := imageTurnTestHandler(provider)
+
+	route, err := apiHandler.modelApplication().ResolveProviderRoute(t.Context(), "ollama", "llama-vision")
+	if err != nil || !route.Instance.Valid() {
+		t.Fatalf("ResolveProviderRoute() = %+v, %v", route, err)
+	}
+	key := modelprobe.Key{Provider: route.Name, Model: "llama-vision", Instance: route.Instance, Version: modelprobe.ProbeVersion}
+	activeStore := modelprobe.NewMemoryStore()
+	imageTurnSeedToolVerification(t, activeStore, key, time.Now().UTC().Add(time.Hour))
+	apiHandler.SetModelToolProbeStore(activeStore)
+
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"ollama","model":"llama-vision"}`, t.TempDir()))
+	if session.Data.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || session.Data.Capabilities.ToolVerification == nil {
+		t.Fatalf("session capabilities = %+v, want active verified proof cached for display", session.Data.Capabilities)
+	}
+
+	expiredStore := modelprobe.NewMemoryStore()
+	imageTurnSeedToolVerification(t, expiredStore, key, time.Now().UTC().Add(-time.Minute))
+	// The dispatcher checks current capabilities before choosing the tools-on
+	// path. Let that check see the old proof, then make the handler's own
+	// admission recheck see the expired row; this is the stale session-snapshot
+	// boundary that must not create an agent task.
+	apiHandler.SetModelToolProbeStore(&toolVerificationSequentialStore{first: activeStore, next: expiredStore})
+	recorder := client.mustRequestStatus(http.StatusUnprocessableEntity, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"ollama","model":"llama-vision","content":"Do not admit a stale proof."}`)
+	if !strings.Contains(recorder.Body.String(), errCodeModelCapability) {
+		t.Fatalf("response = %s, want capability admission error", recorder.Body.String())
+	}
+	if provider.CallCount() != 0 {
+		t.Fatalf("provider calls = %d, want expired proof rejected before task dispatch", provider.CallCount())
+	}
+}
+
+func TestHecateAgentChatToolsOnRejectsVerifiedRichInputAfterGovernorModelRewrite(t *testing.T) {
+	const (
+		requestedModel = "verified-vision-requested"
+		rewrittenModel = "verified-vision-rewritten"
+	)
+	provider := imageTurnNamedTestProvider("verified-vision", modelcaps.ImageInputSupported)
+	provider.capabilities.DefaultModel = requestedModel
+	provider.capabilities.Models = []string{requestedModel, rewrittenModel}
+	unknownCapability := provider.capabilities.ModelCapabilities["llama-vision"]
+	unknownCapability.ToolCalling = modelcaps.ToolCallingUnknown
+	provider.capabilities.ModelCapabilities = map[string]types.ModelCapabilities{
+		requestedModel: unknownCapability,
+		rewrittenModel: unknownCapability,
+	}
+	apiHandler := newTestAPIHandlerWithSettings(imageTurnTestLogger(), []providers.Provider{provider}, config.Config{
+		Governor: config.GovernorConfig{PolicyRules: []config.PolicyRuleConfig{{
+			ID:             "rewrite-verified-rich-input",
+			Action:         "rewrite_model",
+			Models:         []string{requestedModel},
+			RewriteModelTo: rewrittenModel,
+		}}},
+	}, controlplane.NewMemoryStore())
+	route, err := apiHandler.modelApplication().ResolveProviderRoute(t.Context(), provider.Name(), requestedModel)
+	if err != nil || !route.Instance.Valid() {
+		t.Fatalf("ResolveProviderRoute() = %+v, %v", route, err)
+	}
+	store := modelprobe.NewMemoryStore()
+	imageTurnSeedToolVerification(t, store, modelprobe.Key{
+		Provider: route.Name, Model: requestedModel, Instance: route.Instance, Version: modelprobe.ProbeVersion,
+	}, time.Now().UTC().Add(time.Hour))
+	apiHandler.SetModelToolProbeStore(store)
+
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":%q,"model":%q}`, t.TempDir(), provider.Name(), requestedModel))
+	if session.Data.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || session.Data.Capabilities.ToolVerification == nil {
+		t.Fatalf("session capabilities = %+v, want model-bound manual proof", session.Data.Capabilities)
+	}
+	attachment := imageTurnTestUpload(t, handler, session.Data.ID, "rewrite-verified-rich-input.png", imageTurnTestPNG(t))
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":`+fmt.Sprintf("%q", provider.Name())+`,"model":`+fmt.Sprintf("%q", requestedModel)+`,"content":"Do not disclose this image after rewrite.","attachment_ids":["`+attachment.Data.ID+`"]}`)
+
+	if provider.CallCount() != 0 {
+		t.Fatalf("provider calls = %d, want governor rewrite blocked before attachment disclosure", provider.CallCount())
+	}
+	var assistant ChatMessageItem
+	for _, message := range response.Data.Messages {
+		if message.Role == "assistant" {
+			assistant = message
+		}
+	}
+	if assistant.Status != "failed" {
+		t.Fatalf("assistant = %+v, want a route-fenced failure", assistant)
+	}
+}
+
+func TestHecateAgentChatToolsOnRevalidatesToolVerificationAfterProviderReplacement(t *testing.T) {
+	original := imageTurnNamedTestProvider("vision-a", modelcaps.ImageInputSupported)
+	originalCaps := original.capabilities.ModelCapabilities["llama-vision"]
+	originalCaps.ToolCalling = modelcaps.ToolCallingUnknown
+	original.capabilities.ModelCapabilities["llama-vision"] = originalCaps
+	replacement := imageTurnNamedTestProvider("vision-a", modelcaps.ImageInputSupported)
+	replacementCaps := replacement.capabilities.ModelCapabilities["llama-vision"]
+	replacementCaps.ToolCalling = modelcaps.ToolCallingUnknown
+	replacement.capabilities.ModelCapabilities["llama-vision"] = replacementCaps
+	registry := providers.NewMutableRegistry(original)
+	apiHandler := newTestAPIHandlerWithRegistry(
+		imageTurnTestLogger(), registry, []providers.Provider{original}, config.Config{}, controlplane.NewMemoryStore(),
+	)
+
+	route, err := apiHandler.modelApplication().ResolveProviderRoute(t.Context(), "vision-a", "llama-vision")
+	if err != nil || !route.Instance.Valid() {
+		t.Fatalf("ResolveProviderRoute() = %+v, %v", route, err)
+	}
+	store := modelprobe.NewMemoryStore()
+	imageTurnSeedToolVerification(t, store, modelprobe.Key{
+		Provider: route.Name, Model: "llama-vision", Instance: route.Instance, Version: modelprobe.ProbeVersion,
+	}, time.Now().UTC().Add(time.Hour))
+	apiHandler.SetModelToolProbeStore(store)
+
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"vision-a","model":"llama-vision"}`, t.TempDir()))
+	if session.Data.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || session.Data.Capabilities.ToolVerification == nil {
+		t.Fatalf("session capabilities = %+v, want verified original generation", session.Data.Capabilities)
+	}
+
+	registry.Replace(replacement)
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"vision-a","model":"llama-vision","content":"Do not admit a replaced provider proof."}`)
+	if response.Data.TaskID != "" || len(response.Data.Messages) == 0 || response.Data.Messages[0].ToolsEnabled {
+		t.Fatalf("replacement response = %+v, want tools-on request downgraded before task admission", response.Data)
+	}
+	if original.CallCount() != 0 || replacement.CallCount() != 1 {
+		t.Fatalf("provider calls original=%d replacement=%d, want one safe direct-model fallback only", original.CallCount(), replacement.CallCount())
+	}
+}
+
+func TestHecateAgentChatToolsOnDoesNotUseManualVerificationForAuto(t *testing.T) {
+	provider := imageTurnTestProvider(modelcaps.ImageInputSupported)
+	capabilities := provider.capabilities.ModelCapabilities["llama-vision"]
+	capabilities.ToolCalling = modelcaps.ToolCallingUnknown
+	provider.capabilities.ModelCapabilities["llama-vision"] = capabilities
+	apiHandler := imageTurnTestHandler(provider)
+
+	route, err := apiHandler.modelApplication().ResolveProviderRoute(t.Context(), "ollama", "llama-vision")
+	if err != nil || !route.Instance.Valid() {
+		t.Fatalf("ResolveProviderRoute() = %+v, %v", route, err)
+	}
+	store := modelprobe.NewMemoryStore()
+	imageTurnSeedToolVerification(t, store, modelprobe.Key{
+		Provider: route.Name, Model: "llama-vision", Instance: route.Instance, Version: modelprobe.ProbeVersion,
+	}, time.Now().UTC().Add(time.Hour))
+	apiHandler.SetModelToolProbeStore(store)
+
+	handler := NewServer(imageTurnTestLogger(), apiHandler)
+	client := newTaskTestClient(t, handler)
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions",
+		fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"workspace_mode":"in_place","provider":"auto","model":"llama-vision"}`, t.TempDir()))
+	if session.Data.Capabilities.ToolCalling != modelcaps.ToolCallingUnknown || session.Data.Capabilities.ToolVerification != nil {
+		t.Fatalf("auto session capabilities = %+v, want route-bound verification withheld", session.Data.Capabilities)
+	}
+
+	response := mustRequestJSON[ChatSessionResponse](client, http.MethodPost,
+		"/hecate/v1/chat/sessions/"+session.Data.ID+"/messages",
+		`{"execution_mode":"hecate_task","tools_enabled":true,"provider":"auto","model":"llama-vision","content":"Do not admit an auto proof."}`)
+	if response.Data.TaskID != "" || len(response.Data.Messages) == 0 || response.Data.Messages[0].ToolsEnabled {
+		t.Fatalf("auto response = %+v, want manual proof withheld from tools-on task admission", response.Data)
+	}
+	if provider.CallCount() != 0 {
+		t.Fatalf("provider calls = %d, want Auto proof rejected before dispatch", provider.CallCount())
 	}
 }
 
@@ -1564,7 +1856,7 @@ func TestHecateChatImageHistoryRejectsSameNameRuntimeReplacementAfterAdmission(t
 			assistant = message
 		}
 	}
-	if assistant.Status != "failed" || !strings.Contains(assistant.Error, "changed during image admission") {
+	if assistant.Status != "failed" || !strings.Contains(assistant.Error, "changed during bound route admission") {
 		t.Fatalf("assistant = %+v, want fail-closed provider-instance replacement", assistant)
 	}
 }
@@ -2004,6 +2296,48 @@ func TestHecateChatImageTurnReleasesCurrentDraftWhenHistoryPreparationFails(t *t
 
 func imageTurnTestProvider(imageInput string) *fakeProvider {
 	return imageTurnNamedTestProvider("ollama", imageInput)
+}
+
+func imageTurnSeedToolVerification(t *testing.T, store modelprobe.Store, key modelprobe.Key, expiresAt time.Time) {
+	t.Helper()
+	now := time.Now().UTC()
+	record, acquired, err := store.Acquire(t.Context(), key, now, now.Add(time.Minute), "image-turn-tool-verification")
+	if err != nil || !acquired {
+		t.Fatalf("seed tool verification Acquire() = %+v, %t, %v", record, acquired, err)
+	}
+	record.Status = modelprobe.StatusSupported
+	record.Reason = modelprobe.ReasonNone
+	record.CheckedAt = now.Add(-time.Minute)
+	record.ExpiresAt = expiresAt.UTC()
+	if _, err := store.Complete(t.Context(), record); err != nil {
+		t.Fatalf("seed tool verification Complete() error = %v", err)
+	}
+}
+
+// toolVerificationSequentialStore drives the two admission reads in a
+// deterministic order: dispatcher capability selection first, then the
+// handler's pre-task recheck. It models a proof expiring in that narrow gap.
+type toolVerificationSequentialStore struct {
+	first modelprobe.Store
+	next  modelprobe.Store
+	gets  atomic.Int64
+}
+
+func (s *toolVerificationSequentialStore) Backend() string { return "test-sequential" }
+
+func (s *toolVerificationSequentialStore) Get(ctx context.Context, key modelprobe.Key) (modelprobe.Record, bool, error) {
+	if s.gets.Add(1) == 1 {
+		return s.first.Get(ctx, key)
+	}
+	return s.next.Get(ctx, key)
+}
+
+func (s *toolVerificationSequentialStore) Acquire(ctx context.Context, key modelprobe.Key, now, leaseUntil time.Time, leaseID string) (modelprobe.Record, bool, error) {
+	return s.next.Acquire(ctx, key, now, leaseUntil, leaseID)
+}
+
+func (s *toolVerificationSequentialStore) Complete(ctx context.Context, record modelprobe.Record) (modelprobe.Record, error) {
+	return s.next.Complete(ctx, record)
 }
 
 func imageTurnNamedTestProvider(name, imageInput string) *fakeProvider {

--- a/internal/api/handler_model_tool_probe.go
+++ b/internal/api/handler_model_tool_probe.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/hecatehq/hecate/internal/modelapp"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const maxModelToolProbeRequestBytes = 4 << 10
+
+type ModelToolCapabilityProbeRequest struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+type ModelToolCapabilityProbeResponse struct {
+	Object string                               `json:"object"`
+	Data   ModelToolCapabilityProbeResponseItem `json:"data"`
+}
+
+type ModelToolCapabilityProbeResponseItem struct {
+	Provider     string                            `json:"provider"`
+	Model        string                            `json:"model"`
+	Capabilities types.ModelCapabilities           `json:"capabilities"`
+	Verification *types.ToolCapabilityVerification `json:"verification,omitempty"`
+	TraceID      string                            `json:"trace_id,omitempty"`
+	Performed    bool                              `json:"performed"`
+}
+
+// HandleModelToolCapabilityProbe performs one explicit, harmless diagnostic
+// call for an otherwise-unknown configured provider/model. The input contains
+// no workspace or message data; Hecate supplies the static probe request.
+//
+// POST /hecate/v1/model-capabilities/tool-probes
+func (h *Handler) HandleModelToolCapabilityProbe(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxModelToolProbeRequestBytes)
+	var request ModelToolCapabilityProbeRequest
+	if !decodeJSON(w, r, &request) {
+		return
+	}
+	request.Provider = strings.TrimSpace(request.Provider)
+	request.Model = strings.TrimSpace(request.Model)
+	if request.Provider == "" || strings.EqualFold(request.Provider, "auto") || request.Model == "" {
+		WriteError(w, http.StatusBadRequest, errCodeInvalidRequest, "a configured provider and model are required")
+		return
+	}
+
+	result, err := h.modelApplication().VerifyToolCalling(r.Context(), request.Provider, request.Model)
+	if err != nil && !errors.Is(err, modelapp.ErrToolProbeNotNeeded) {
+		var readinessErr modelapp.ReadinessError
+		switch {
+		case errors.Is(err, modelapp.ErrToolProbeUnavailable):
+			WriteError(w, http.StatusServiceUnavailable, errCodeModelToolProbeUnavailable, "model tool capability probing is unavailable")
+		case errors.Is(err, modelapp.ErrProviderAmbiguous):
+			WriteError(w, http.StatusConflict, errCodeProviderAmbiguous, "provider identity is ambiguous")
+		case errors.Is(err, modelapp.ErrToolProbeRouteChanged):
+			WriteError(w, http.StatusConflict, errCodeModelNotConfigured, "selected provider/model changed while verification was running")
+		case errors.As(err, &readinessErr):
+			WriteError(w, http.StatusConflict, errCodeModelNotConfigured, "selected provider/model is not routable")
+		default:
+			WriteError(w, http.StatusConflict, errCodeModelNotConfigured, "selected provider/model is not available for verification")
+		}
+		return
+	}
+
+	WriteJSON(w, http.StatusOK, ModelToolCapabilityProbeResponse{
+		Object: "model_tool_capability_probe",
+		Data: ModelToolCapabilityProbeResponseItem{
+			Provider:     result.Provider,
+			Model:        result.Model,
+			Capabilities: result.Capabilities,
+			Verification: result.Verification,
+			TraceID:      result.TraceID,
+			Performed:    result.Performed,
+		},
+	})
+}

--- a/internal/api/handler_model_tool_probe_test.go
+++ b/internal/api/handler_model_tool_probe_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/modelprobe"
+	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestModelToolCapabilityProbeEndpointVerifiesUnknownConfiguredModel(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{
+		name:         "local-runtime",
+		defaultModel: "custom-tool-model",
+		response: &types.ChatResponse{Choices: []types.ChatChoice{{
+			Message: types.Message{Role: "assistant", ToolCalls: []types.ToolCall{{
+				ID:   "call_probe",
+				Type: "function",
+				Function: types.ToolCallFunction{
+					Name:      "hecate_capability_probe",
+					Arguments: "{}",
+				},
+			}}},
+		}}},
+		capabilities: providers.Capabilities{
+			Name:         "local-runtime",
+			Kind:         providers.KindLocal,
+			DefaultModel: "custom-tool-model",
+			Models:       []string{"custom-tool-model"},
+			ModelCapabilities: map[string]types.ModelCapabilities{
+				"custom-tool-model": {ToolCalling: modelcaps.ToolCallingUnknown},
+			},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := newTestHTTPHandlerForProviders(logger, []providers.Provider{provider}, config.Config{})
+	client := newAPITestClient(t, handler)
+
+	firstRecorder := client.mustRequest(http.MethodPost, "/hecate/v1/model-capabilities/tool-probes", `{"provider":"local-runtime","model":"custom-tool-model"}`)
+	response := decodeRecorder[ModelToolCapabilityProbeResponse](t, firstRecorder)
+	if response.Object != "model_tool_capability_probe" || !response.Data.Performed || response.Data.Provider != "local-runtime" || response.Data.Model != "custom-tool-model" {
+		t.Fatalf("probe response = %+v", response)
+	}
+	if response.Data.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || response.Data.Verification == nil || response.Data.Verification.Status != modelprobe.StatusSupported || response.Data.TraceID == "" {
+		t.Fatalf("probe response capabilities = %+v verification=%+v trace=%q, want verified basic", response.Data.Capabilities, response.Data.Verification, response.Data.TraceID)
+	}
+	if strings.Contains(firstRecorder.Body.String(), "instance_id") || strings.Contains(firstRecorder.Body.String(), "provider_instance") {
+		t.Fatalf("probe response exposed internal provider generation: %s", firstRecorder.Body.String())
+	}
+
+	provider.mu.Lock()
+	request := provider.lastRequest
+	calls := provider.calls
+	provider.mu.Unlock()
+	if calls != 1 || request.Model != "custom-tool-model" || request.Scope.ProviderHint != "local-runtime" || len(request.Tools) != 1 || request.Tools[0].Function.Name != "hecate_capability_probe" {
+		t.Fatalf("provider calls=%d request=%+v, want one static probe request", calls, request)
+	}
+
+	cached := mustRequestJSON[ModelToolCapabilityProbeResponse](client, http.MethodPost, "/hecate/v1/model-capabilities/tool-probes", `{"provider":"local-runtime","model":"custom-tool-model"}`)
+	if cached.Data.Performed || cached.Data.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || cached.Data.Verification == nil || cached.Data.Verification.Status != modelprobe.StatusSupported {
+		t.Fatalf("cached probe response = %+v, want cached verified result", cached.Data)
+	}
+	provider.mu.Lock()
+	calls = provider.calls
+	provider.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("provider calls after cached probe = %d, want 1", calls)
+	}
+
+	session := mustRequestJSON[ChatSessionResponse](client, http.MethodPost, "/hecate/v1/chat/sessions", fmt.Sprintf(`{"agent_id":"hecate","workspace":%q,"provider":"local-runtime","model":"custom-tool-model"}`, t.TempDir()))
+	if session.Data.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || session.Data.Capabilities.ToolVerification == nil || session.Data.Capabilities.ToolVerification.Status != modelprobe.StatusSupported {
+		t.Fatalf("Hecate Chat session capabilities = %+v, want the verified tool capability", session.Data.Capabilities)
+	}
+}
+
+func TestModelToolCapabilityProbeEndpointRejectsAutoRoute(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewServer(logger, NewHandler(config.Config{}, logger, nil, nil, nil, nil))
+	recorder := performRequest(t, handler, http.MethodPost, "/hecate/v1/model-capabilities/tool-probes", `{"provider":"auto","model":"custom-tool-model"}`)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "a configured provider and model are required") {
+		t.Fatalf("error response = %s", recorder.Body.String())
+	}
+}

--- a/internal/api/remote_runtime_policy.go
+++ b/internal/api/remote_runtime_policy.go
@@ -39,6 +39,7 @@ var remoteRuntimeAllowedRoutes = []remoteRuntimeRoutePattern{
 	{method: http.MethodGet, path: "/hecate/v1/providers/presets"},
 	{method: http.MethodGet, path: "/hecate/v1/providers/status"},
 	{method: http.MethodGet, path: "/hecate/v1/providers/history"},
+	{method: http.MethodPost, path: "/hecate/v1/model-capabilities/tool-probes"},
 	{method: http.MethodGet, path: "/hecate/v1/dictation/options"},
 	{method: http.MethodPost, path: "/hecate/v1/dictation/transcriptions"},
 

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -26,6 +26,7 @@ const (
 	errCodeSessionCreateConflict     = "chat.session_create_conflict"
 	errCodeClientRequestConflict     = "chat.client_request_conflict"
 	errCodeModelCapability           = "chat.model_capability_required"
+	errCodeModelToolProbeUnavailable = "model_tool_probe_unavailable"
 	errCodeModelNotConfigured        = "model_not_configured"
 	errCodeProviderAmbiguous         = "provider_ambiguous"
 	errCodeWorkspaceRequired         = "chat.workspace_required"

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -70,6 +70,7 @@ func registerHecateRuntimeRoutes(mux *http.ServeMux, handler *Handler) {
 	mux.HandleFunc("GET /hecate/v1/providers/presets", handler.HandleProviderPresets)
 	mux.HandleFunc("GET /hecate/v1/providers/status", handler.HandleProviderStatus)
 	mux.HandleFunc("GET /hecate/v1/providers/history", handler.HandleProviderHealthHistory)
+	mux.HandleFunc("POST /hecate/v1/model-capabilities/tool-probes", handler.HandleModelToolCapabilityProbe)
 	mux.HandleFunc("GET /hecate/v1/dictation/options", handler.HandleDictationOptions)
 	mux.HandleFunc("POST /hecate/v1/dictation/transcriptions", handler.HandleCreateDictationTranscription)
 }

--- a/internal/gateway/executor.go
+++ b/internal/gateway/executor.go
@@ -30,6 +30,7 @@ type ResilientExecutor struct {
 	metrics       *telemetry.Metrics
 	options       ResilienceOptions
 	sleep         func(context.Context, time.Duration) error
+	now           func() time.Time
 }
 
 type failoverHistoryEntry struct {
@@ -69,6 +70,7 @@ func NewResilientExecutor(
 		metrics:       metrics,
 		options:       normalizeResilienceOptions(options),
 		sleep:         sleepContext,
+		now:           time.Now,
 	}
 }
 
@@ -246,6 +248,15 @@ func (e *ResilientExecutor) Execute(ctx context.Context, trace *profiler.Trace, 
 			dispatchRoute := candidate
 			dispatchRoute.ProviderKind = preflight.ProviderKind
 			dispatchRoute.ProviderInstance = dispatchInstance.Identity
+			if dispatchErr := validateToolCallingVerificationFence(req, dispatchRoute, verificationNow(e.now)); dispatchErr != nil {
+				lastErr = dispatchErr
+				recordProviderCallBlocked(trace, dispatchRoute, index, dispatchErr)
+				if lastAttempt != nil {
+					lastAttempt.AttemptCount = totalAttempts
+					lastAttempt.RetryCount = totalRetries
+				}
+				return lastAttempt, dispatchErr
+			}
 			if dispatchErr := providerdispatch.RecordAttempt(ctx, dispatchRoute); dispatchErr != nil {
 				lastErr = fmt.Errorf("record provider dispatch: %w", dispatchErr)
 				recordRichInputRouteFenceBlocked(trace, dispatchRoute, index, lastErr)

--- a/internal/gateway/executor_test.go
+++ b/internal/gateway/executor_test.go
@@ -482,6 +482,120 @@ func TestResilientExecutorRejectsImageProviderReplacementDuringRetryBackoff(t *t
 	}
 }
 
+func TestResilientExecutorDoesNotRetryVerifiedToolDispatchAfterProofExpires(t *testing.T) {
+	t.Parallel()
+
+	provider := &sequenceProvider{
+		name: "vision",
+		kind: providers.KindCloud,
+		responses: []providerResponse{
+			{err: &providers.UpstreamError{StatusCode: http.StatusServiceUnavailable}},
+			{response: &types.ChatResponse{Model: "model-a"}},
+		},
+	}
+	registry := providers.NewRegistry(provider)
+	instance, ok := registry.GetInstance("vision")
+	if !ok {
+		t.Fatal("provider instance not found")
+	}
+	store := governor.NewMemoryUsageStore()
+	executor := NewResilientExecutor(
+		staticFallbackRouter{},
+		NewDefaultRoutePreflight(governor.NewStaticGovernor(config.GovernorConfig{}, store, store), registry),
+		registry,
+		nil,
+		nil,
+		nil,
+		ResilienceOptions{MaxAttempts: 2, RetryBackoff: time.Millisecond},
+	)
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	clock := now
+	executor.now = func() time.Time { return clock }
+	executor.sleep = func(context.Context, time.Duration) error {
+		clock = now.Add(time.Hour)
+		return nil
+	}
+
+	trace := profiler.NewTrace("req-verified-proof-expired-retry", nil)
+	defer trace.Finalize()
+	result, err := executor.Execute(context.Background(), trace, types.ChatRequest{
+		Model:    "model-a",
+		Scope:    types.RequestScope{ProviderHint: "vision"},
+		Messages: []types.Message{{Role: "user", Content: "continue the task"}},
+		Requirements: types.ChatRequestRequirements{
+			ToolCalling:              true,
+			ToolCallingVerified:      true,
+			ToolCallingVerifiedModel: "model-a",
+			ToolCallingVerifiedUntil: now.Add(time.Minute),
+			NoProviderFailover:       true,
+			ExactProvider:            true,
+			ProviderInstance:         instance.Identity,
+		},
+	}, types.RouteDecision{
+		Provider:         "vision",
+		ProviderInstance: instance.Identity,
+		Model:            "model-a",
+		Reason:           "verified_tool_support",
+	})
+	if err == nil || !strings.Contains(err.Error(), "expired before dispatch") {
+		t.Fatalf("Execute() error = %v, want expired verification rejection", err)
+	}
+	if result == nil || result.AttemptCount != 1 || result.RetryCount != 1 {
+		t.Fatalf("Execute() result = %+v, want one dispatched attempt and one blocked retry", result)
+	}
+	if provider.callCount != 1 {
+		t.Fatalf("provider calls = %d, want expired retry blocked before another tool-capable dispatch", provider.callCount)
+	}
+}
+
+func TestResilientExecutorAllowsVerifiedRichInputWithoutToolDispatch(t *testing.T) {
+	t.Parallel()
+
+	provider := &sequenceProvider{
+		name:      "vision",
+		kind:      providers.KindCloud,
+		responses: []providerResponse{{response: &types.ChatResponse{Model: "model-a"}}},
+	}
+	registry := providers.NewRegistry(provider)
+	instance, ok := registry.GetInstance("vision")
+	if !ok {
+		t.Fatal("provider instance not found")
+	}
+	store := governor.NewMemoryUsageStore()
+	executor := NewResilientExecutor(
+		staticFallbackRouter{},
+		NewDefaultRoutePreflight(governor.NewStaticGovernor(config.GovernorConfig{}, store, store), registry),
+		registry,
+		nil,
+		nil,
+		nil,
+		ResilienceOptions{MaxAttempts: 1},
+	)
+	trace := profiler.NewTrace("req-verified-image-only", nil)
+	defer trace.Finalize()
+	_, err := executor.Execute(context.Background(), trace, types.ChatRequest{
+		Model:    "model-a",
+		Messages: []types.Message{{Role: "user", Content: "private image"}},
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:          true,
+			ToolCallingVerified: true,
+			NoProviderFailover:  true,
+			ProviderInstance:    instance.Identity,
+		},
+	}, types.RouteDecision{
+		Provider:         "vision",
+		ProviderInstance: instance.Identity,
+		Model:            "model-a",
+		Reason:           "verified_image_only",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want image-only dispatch without a tool requirement", err)
+	}
+	if provider.callCount != 1 {
+		t.Fatalf("provider calls = %d, want one image-only dispatch", provider.callCount)
+	}
+}
+
 func TestResilientExecutorFailsOverAfterRetryableFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/preflight.go
+++ b/internal/gateway/preflight.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/governor"
 	"github.com/hecatehq/hecate/internal/providers"
@@ -124,6 +126,50 @@ func validateProviderInstanceFence(req types.ChatRequest, decision types.RouteDe
 		return fmt.Errorf("provider %q changed after bound route admission", decision.Provider)
 	}
 	return nil
+}
+
+// validateToolCallingVerificationFence rechecks Hecate's internal manual
+// proof immediately before a provider dispatch. Route selection is not
+// sufficient: a queued task, retry, or delayed stream can outlive a proof's
+// expiry.
+//
+// The marker is never supplied by an HTTP client. When it is present it must
+// remain tied to the one provider/model/generation route that admission
+// verified, with failover disabled.
+func validateToolCallingVerificationFence(req types.ChatRequest, decision types.RouteDecision, now time.Time) error {
+	// The marker is carried from Hecate Chat admission through the agent loop,
+	// including image-only steps before the loop exposes its tool catalog. It is
+	// relevant only when this dispatch actually relies on tool support.
+	if !req.Requirements.ToolCallingVerified || !req.Requirements.ToolCalling {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	if !req.Requirements.NoProviderFailover ||
+		!req.Requirements.ExactProvider ||
+		!req.Requirements.ProviderInstance.Valid() ||
+		!decision.ProviderInstance.Valid() ||
+		decision.ProviderInstance != req.Requirements.ProviderInstance ||
+		strings.TrimSpace(req.Scope.ProviderHint) != decision.Provider {
+		return fmt.Errorf("verified tool support is not bound to the dispatch route")
+	}
+	if strings.TrimSpace(req.Requirements.ToolCallingVerifiedModel) != strings.TrimSpace(decision.Model) {
+		return fmt.Errorf("verified tool support does not apply to dispatch model %q", decision.Model)
+	}
+	if !req.Requirements.ToolCallingVerifiedUntil.After(now) {
+		return errors.New("verified tool support expired before dispatch")
+	}
+	return nil
+}
+
+func verificationNow(clock func() time.Time) time.Time {
+	if clock == nil {
+		return time.Now().UTC()
+	}
+	return clock().UTC()
 }
 
 func requiresProviderInstanceFence(req types.ChatRequest) bool {

--- a/internal/gateway/service.go
+++ b/internal/gateway/service.go
@@ -70,6 +70,7 @@ type Service struct {
 	traceBodyCapture  bool
 	traceBodyMaxBytes int
 	traceBodyMode     string
+	now               func() time.Time
 }
 
 const (
@@ -207,6 +208,7 @@ func NewService(deps Dependencies) *Service {
 		traceBodyCapture:  deps.TraceBodyCapture,
 		traceBodyMaxBytes: traceBodyMaxBytes,
 		traceBodyMode:     traceBodyMode,
+		now:               time.Now,
 	}
 }
 
@@ -753,6 +755,10 @@ func (s *Service) RouteForStream(ctx context.Context, req types.ChatRequest) (*S
 			dispatchRoute := plan.Route
 			dispatchRoute.ProviderKind = plan.ProviderKind
 			dispatchRoute.ProviderInstance = dispatchInstance.Identity
+			if err := validateToolCallingVerificationFence(streamReq, dispatchRoute, verificationNow(s.now)); err != nil {
+				recordProviderCallBlocked(trace, dispatchRoute, 0, err)
+				return err
+			}
 			if err := providerdispatch.RecordAttempt(ctx, dispatchRoute); err != nil {
 				err = fmt.Errorf("record provider dispatch: %w", err)
 				recordRichInputRouteFenceBlocked(trace, dispatchRoute, 0, err)

--- a/internal/gateway/service_stream_capture_test.go
+++ b/internal/gateway/service_stream_capture_test.go
@@ -304,6 +304,63 @@ func TestRouteForStreamRejectsProviderReplacementForProviderBoundRequest(t *test
 	assertStreamProviderCallBlocked(t, tracer, "req-stream-image-replaced", RoutePreflightProviderChanged, admittedInstance.Identity.ID, "private image")
 }
 
+func TestRouteForStreamRejectsVerifiedRichInputAfterProofExpires(t *testing.T) {
+	t.Parallel()
+
+	provider := &streamingSequenceProvider{
+		sequenceProvider: sequenceProvider{name: "vision", kind: providers.KindCloud},
+	}
+	registry := providers.NewRegistry(provider)
+	instance, ok := registry.GetInstance("vision")
+	if !ok {
+		t.Fatal("provider instance not found")
+	}
+	store := governor.NewMemoryUsageStore()
+	service := NewService(Dependencies{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Router: staticFallbackRouter{route: types.RouteDecision{
+			Provider:         "vision",
+			ProviderInstance: instance.Identity,
+			Model:            "model-a",
+			Reason:           "verified_rich_input",
+		}},
+		Governor:  governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, store, store),
+		Providers: registry,
+		Tracer:    profiler.NewInMemoryTracer(nil),
+		Metrics:   telemetry.NewMetrics(),
+	})
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	clock := now
+	service.now = func() time.Time { return clock }
+
+	handle, _, err := service.RouteForStream(context.Background(), types.ChatRequest{
+		RequestID: "req-stream-verified-proof-expired",
+		Model:     "model-a",
+		Scope:     types.RequestScope{ProviderHint: "vision"},
+		Messages:  []types.Message{{Role: "user", Content: "private image"}},
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:               true,
+			ToolCalling:              true,
+			ToolCallingVerified:      true,
+			ToolCallingVerifiedModel: "model-a",
+			ToolCallingVerifiedUntil: now.Add(time.Minute),
+			NoProviderFailover:       true,
+			ExactProvider:            true,
+			ProviderInstance:         instance.Identity,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RouteForStream() error = %v", err)
+	}
+	clock = now.Add(time.Hour)
+	if err := handle.Execute(io.Discard); err == nil || !strings.Contains(err.Error(), "expired before dispatch") {
+		t.Fatalf("Execute() error = %v, want expired verification rejection", err)
+	}
+	if provider.streamCallCount != 0 {
+		t.Fatalf("stream calls = %d, want expired proof blocked before disclosure", provider.streamCallCount)
+	}
+}
+
 func TestRouteForStreamRecordsImageProviderRemovalBeforeExecute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/tool_probe.go
+++ b/internal/gateway/tool_probe.go
@@ -1,0 +1,307 @@
+package gateway
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/internal/telemetry"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const (
+	toolProbeName    = "hecate_capability_probe"
+	toolProbeTimeout = 20 * time.Second
+
+	ToolProbeSupported    = "supported"
+	ToolProbeUnsupported  = "unsupported"
+	ToolProbeInconclusive = "inconclusive"
+
+	ToolProbeReasonNone           = ""
+	ToolProbeReasonNoToolCall     = "no_tool_call"
+	ToolProbeReasonToolRejected   = "tool_rejected"
+	ToolProbeReasonAuthentication = "authentication"
+	ToolProbeReasonRateLimited    = "rate_limited"
+	ToolProbeReasonTimeout        = "timeout"
+	ToolProbeReasonNetwork        = "network"
+	ToolProbeReasonProviderFailed = "provider_failure"
+	ToolProbeReasonProviderChange = "provider_changed"
+	ToolProbeReasonPolicyDenied   = "policy_denied"
+	ToolProbeReasonConfiguration  = "configuration"
+	ToolProbeReasonUnexpected     = "unexpected_result"
+)
+
+var (
+	ErrToolProbeUnavailable    = errors.New("model tool capability probing is unavailable")
+	ErrToolProbeInvalid        = errors.New("invalid model tool capability probe")
+	ErrToolProbeModelRewritten = errors.New("model tool capability probe cannot follow a model rewrite")
+)
+
+// ToolCallingProbeRequest deliberately carries an opaque provider generation
+// fence. Its inputs are all operator-selected metadata; Hecate supplies the
+// static prompt, schema, and forced tool choice internally.
+type ToolCallingProbeRequest struct {
+	Provider         string
+	Model            string
+	ProviderInstance types.ProviderInstanceIdentity
+}
+
+// ToolCallingProbeResult contains only a safe outcome summary. It deliberately
+// omits the probe prompt, model output, tool arguments, provider endpoint, and
+// provider-generation identity.
+type ToolCallingProbeResult struct {
+	Provider string
+	Model    string
+	Status   string
+	Reason   string
+	TraceID  string
+}
+
+// ProbeToolCalling makes one bounded, exact-provider diagnostic request. It
+// never calls HandleChat, the normal executor, provider retry/failover, usage
+// finalization, health accounting, or an Hecate tool loop. A tool call is only
+// observed in the response; it is never parsed or executed.
+func (s *Service) ProbeToolCalling(ctx context.Context, input ToolCallingProbeRequest) (ToolCallingProbeResult, error) {
+	if s == nil || s.router == nil || s.preflight == nil || s.providers == nil {
+		return ToolCallingProbeResult{}, ErrToolProbeUnavailable
+	}
+	input.Provider = strings.TrimSpace(input.Provider)
+	input.Model = strings.TrimSpace(input.Model)
+	if input.Provider == "" || input.Model == "" || !input.ProviderInstance.Valid() {
+		return ToolCallingProbeResult{}, ErrToolProbeInvalid
+	}
+
+	requestID, err := newToolProbeRequestID()
+	if err != nil {
+		return ToolCallingProbeResult{}, err
+	}
+	trace := s.startToolProbeTrace(requestID)
+	defer trace.Finalize()
+	ctx, cancel := context.WithTimeout(ctx, toolProbeTimeout)
+	defer cancel()
+	ctx = telemetry.WithTraceIDs(ctx, trace.TraceID, trace.RootSpanID())
+
+	result := ToolCallingProbeResult{
+		Provider: input.Provider,
+		Model:    input.Model,
+		Status:   ToolProbeInconclusive,
+		Reason:   ToolProbeReasonUnexpected,
+		TraceID:  trace.TraceID,
+	}
+	trace.Record("model_capability.probe_started", map[string]any{
+		telemetry.AttrGenAIProviderName:         input.Provider,
+		telemetry.AttrGenAIRequestModel:         input.Model,
+		telemetry.AttrHecateRouteReason:         "operator_tool_capability_probe",
+		telemetry.AttrHecateRequestMessageCount: 1,
+	})
+	defer func() {
+		trace.Record("model_capability.probe_finished", map[string]any{
+			telemetry.AttrGenAIProviderName:        input.Provider,
+			telemetry.AttrGenAIRequestModel:        input.Model,
+			"hecate.model_capability.probe.status": result.Status,
+			"hecate.model_capability.probe.reason": result.Reason,
+		})
+	}()
+
+	req := toolProbeChatRequest(input, requestID)
+	if s.governor != nil {
+		if err := s.governor.Check(ctx, req); err != nil {
+			result.Reason = ToolProbeReasonPolicyDenied
+			return result, fmt.Errorf("%w: %v", ErrToolProbeUnavailable, err)
+		}
+		if rewrite := s.governor.RewriteResult(req); rewrite.Applied {
+			result.Reason = ToolProbeReasonPolicyDenied
+			return result, ErrToolProbeModelRewritten
+		}
+	}
+
+	decision, err := s.router.Route(ctx, req)
+	if err != nil {
+		result.Reason = ToolProbeReasonConfiguration
+		return result, fmt.Errorf("route model tool capability probe: %w", err)
+	}
+	if decision.Provider != input.Provider || decision.Model != input.Model || decision.ProviderInstance != input.ProviderInstance {
+		result.Reason = ToolProbeReasonProviderChange
+		return result, fmt.Errorf("%w: probe route changed before dispatch", ErrToolProbeUnavailable)
+	}
+	if _, err := s.preflight.Evaluate(ctx, req, decision); err != nil {
+		result.Reason = toolProbePreflightReason(err)
+		return result, fmt.Errorf("preflight model tool capability probe: %w", err)
+	}
+	instance, err := providerInstanceForDispatch(s.providers, req, decision)
+	if err != nil {
+		result.Reason = ToolProbeReasonProviderChange
+		return result, fmt.Errorf("dispatch model tool capability probe: %w", err)
+	}
+	trace.Record("provider.call.started", map[string]any{
+		telemetry.AttrGenAIProviderName: input.Provider,
+		telemetry.AttrGenAIRequestModel: input.Model,
+		telemetry.AttrHecateRouteReason: "operator_tool_capability_probe",
+	})
+	response, err := instance.Provider.Chat(ctx, req)
+	if err != nil {
+		result.Status, result.Reason = classifyToolProbeError(err)
+		trace.Record("provider.call.failed", map[string]any{
+			telemetry.AttrGenAIProviderName: input.Provider,
+			telemetry.AttrGenAIRequestModel: input.Model,
+			telemetry.AttrHecateErrorKind:   result.Reason,
+		})
+		return result, nil
+	}
+	if toolProbeResponseCallsExpectedTool(response) {
+		result.Status = ToolProbeSupported
+		result.Reason = ToolProbeReasonNone
+	} else {
+		result.Status = ToolProbeInconclusive
+		result.Reason = ToolProbeReasonNoToolCall
+	}
+	trace.Record("provider.call.succeeded", map[string]any{
+		telemetry.AttrGenAIProviderName: input.Provider,
+		telemetry.AttrGenAIRequestModel: input.Model,
+	})
+	return result, nil
+}
+
+func toolProbeChatRequest(input ToolCallingProbeRequest, requestID string) types.ChatRequest {
+	return types.ChatRequest{
+		RequestID: requestID,
+		Model:     input.Model,
+		Scope:     types.RequestScope{ProviderHint: input.Provider},
+		Requirements: types.ChatRequestRequirements{
+			NoProviderFailover: true,
+			ExactProvider:      true,
+			ProviderInstance:   input.ProviderInstance,
+		},
+		MaxTokens:   16,
+		Temperature: 0,
+		Messages: []types.Message{{
+			Role:    "user",
+			Content: "Call the hecate_capability_probe tool now. Do not answer with text.",
+		}},
+		Tools: []types.Tool{{
+			Type: "function",
+			Function: types.ToolFunction{
+				Name:        toolProbeName,
+				Description: "A harmless Hecate capability check. It has no side effects.",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+			},
+		}},
+		ToolChoice: json.RawMessage(`{"type":"function","function":{"name":"hecate_capability_probe"}}`),
+	}
+}
+
+func toolProbeResponseCallsExpectedTool(response *types.ChatResponse) bool {
+	if response == nil {
+		return false
+	}
+	for _, choice := range response.Choices {
+		for _, call := range choice.Message.ToolCalls {
+			if call.Function.Name == toolProbeName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func classifyToolProbeError(err error) (status string, reason string) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ToolProbeInconclusive, ToolProbeReasonTimeout
+	}
+	if errors.Is(err, context.Canceled) {
+		return ToolProbeInconclusive, ToolProbeReasonUnexpected
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return ToolProbeInconclusive, ToolProbeReasonTimeout
+		}
+		return ToolProbeInconclusive, ToolProbeReasonNetwork
+	}
+	var upstream *providers.UpstreamError
+	if errors.As(err, &upstream) {
+		if explicitlyRejectsToolSchema(upstream) {
+			return ToolProbeUnsupported, ToolProbeReasonToolRejected
+		}
+		switch upstream.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return ToolProbeInconclusive, ToolProbeReasonAuthentication
+		case http.StatusTooManyRequests:
+			return ToolProbeInconclusive, ToolProbeReasonRateLimited
+		case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+			return ToolProbeInconclusive, ToolProbeReasonTimeout
+		default:
+			return ToolProbeInconclusive, ToolProbeReasonProviderFailed
+		}
+	}
+	return ToolProbeInconclusive, ToolProbeReasonProviderFailed
+}
+
+func explicitlyRejectsToolSchema(upstream *providers.UpstreamError) bool {
+	if upstream == nil || (upstream.StatusCode != http.StatusBadRequest && upstream.StatusCode != http.StatusUnprocessableEntity) {
+		return false
+	}
+	text := strings.ToLower(upstream.Type + " " + upstream.Message)
+	if !strings.Contains(text, "tool") && !strings.Contains(text, "function") {
+		return false
+	}
+	// A provider can reject this diagnostic's forced selection syntax while
+	// still accepting ordinary tools. Only an explicit support denial is proof
+	// that the model cannot back Hecate tools; malformed tool_choice, unknown
+	// tool names, and generic 400/422 responses stay inconclusive.
+	if strings.Contains(text, "tool_choice") || strings.Contains(text, "tool choice") || strings.Contains(text, "forced tool") {
+		return false
+	}
+	return strings.Contains(text, "tools are not supported") ||
+		strings.Contains(text, "tool use is not supported") ||
+		strings.Contains(text, "tool calling is not supported") ||
+		strings.Contains(text, "function calling is not supported") ||
+		strings.Contains(text, "does not support function calling") ||
+		strings.Contains(text, "doesn't support function calling") ||
+		strings.Contains(text, "functions are not supported") ||
+		strings.Contains(text, "does not support tools") ||
+		strings.Contains(text, "doesn't support tools") ||
+		strings.Contains(text, "does not support tool use") ||
+		strings.Contains(text, "doesn't support tool use") ||
+		strings.Contains(text, "does not support tool calling") ||
+		strings.Contains(text, "doesn't support tool calling") ||
+		strings.Contains(text, "tools unsupported") ||
+		strings.Contains(text, "tool calling unsupported") ||
+		strings.Contains(text, "function calling unsupported")
+}
+
+func toolProbePreflightReason(err error) string {
+	if preflight, ok := AsRoutePreflightError(err); ok {
+		switch preflight.Kind {
+		case RoutePreflightProviderChanged, RoutePreflightProviderNotFound:
+			return ToolProbeReasonProviderChange
+		case RoutePreflightRouteDenied:
+			return ToolProbeReasonPolicyDenied
+		}
+	}
+	return ToolProbeReasonConfiguration
+}
+
+func (s *Service) startToolProbeTrace(requestID string) *profiler.Trace {
+	if s != nil && s.tracer != nil {
+		return s.tracer.Start(requestID)
+	}
+	return profiler.NewTrace(requestID, nil)
+}
+
+func newToolProbeRequestID() (string, error) {
+	var raw [12]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "model_tool_probe_" + hex.EncodeToString(raw[:]), nil
+}

--- a/internal/gateway/tool_probe_test.go
+++ b/internal/gateway/tool_probe_test.go
@@ -1,0 +1,382 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/catalog"
+	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/governor"
+	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/profiler"
+	"github.com/hecatehq/hecate/internal/providers"
+	"github.com/hecatehq/hecate/internal/router"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestProbeToolCallingMakesOneExactHarmlessDispatch(t *testing.T) {
+	t.Parallel()
+	provider := &toolProbeProvider{response: toolProbeResponse()}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	service := newToolProbeService(registry, instance.Identity, nil)
+
+	result, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider:         provider.Name(),
+		Model:            "custom-model",
+		ProviderInstance: instance.Identity,
+	})
+	if err != nil {
+		t.Fatalf("ProbeToolCalling() error = %v", err)
+	}
+	if result.Status != ToolProbeSupported || result.Reason != ToolProbeReasonNone || result.TraceID == "" {
+		t.Fatalf("ProbeToolCalling() = %+v", result)
+	}
+	request, calls := provider.lastRequest()
+	if calls != 1 {
+		t.Fatalf("provider calls = %d, want 1", calls)
+	}
+	if request.Requirements.ToolCalling || !request.Requirements.NoProviderFailover || !request.Requirements.ExactProvider || request.Requirements.ProviderInstance != instance.Identity {
+		t.Fatalf("probe requirements = %+v", request.Requirements)
+	}
+	if request.Scope.ProviderHint != provider.Name() || request.Model != "custom-model" || len(request.Tools) != 1 || request.Tools[0].Function.Name != toolProbeName {
+		t.Fatalf("probe request = %+v", request)
+	}
+	var choice struct {
+		Type     string `json:"type"`
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(request.ToolChoice, &choice); err != nil || choice.Type != "function" || choice.Function.Name != toolProbeName {
+		t.Fatalf("tool_choice = %s, err = %v", request.ToolChoice, err)
+	}
+	if len(request.Messages) != 1 || request.Messages[0].Content == "" || request.MaxTokens > 16 {
+		t.Fatalf("probe payload = %+v", request)
+	}
+}
+
+func TestProbeToolCallingDoesNotRetryOrFailOver(t *testing.T) {
+	t.Parallel()
+	provider := &toolProbeProvider{err: &providers.UpstreamError{StatusCode: 503, Message: "temporary upstream failure"}}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	service := newToolProbeService(registry, instance.Identity, nil)
+
+	result, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: provider.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if err != nil {
+		t.Fatalf("ProbeToolCalling() error = %v", err)
+	}
+	if result.Status != ToolProbeInconclusive || result.Reason != ToolProbeReasonProviderFailed {
+		t.Fatalf("ProbeToolCalling() = %+v", result)
+	}
+	if _, calls := provider.lastRequest(); calls != 1 {
+		t.Fatalf("provider calls = %d, want one exact attempt", calls)
+	}
+}
+
+func TestProbeToolCallingClassifiesExplicitToolRejection(t *testing.T) {
+	t.Parallel()
+	provider := &toolProbeProvider{err: &providers.UpstreamError{StatusCode: 400, Type: "invalid_request", Message: "tools are not supported by this model"}}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	service := newToolProbeService(registry, instance.Identity, nil)
+
+	result, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: provider.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if err != nil || result.Status != ToolProbeUnsupported || result.Reason != ToolProbeReasonToolRejected {
+		t.Fatalf("ProbeToolCalling() = %+v, %v", result, err)
+	}
+}
+
+func TestProbeToolCallingClassifiesExplicitFunctionCallingRejection(t *testing.T) {
+	t.Parallel()
+	provider := &toolProbeProvider{err: &providers.UpstreamError{StatusCode: 400, Type: "invalid_request", Message: "this model does not support function calling"}}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	service := newToolProbeService(registry, instance.Identity, nil)
+
+	result, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: provider.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if err != nil || result.Status != ToolProbeUnsupported || result.Reason != ToolProbeReasonToolRejected {
+		t.Fatalf("ProbeToolCalling() = %+v, %v", result, err)
+	}
+}
+
+func TestProbeToolCallingTreatsToolChoiceSyntaxRejectionAsInconclusive(t *testing.T) {
+	t.Parallel()
+	provider := &toolProbeProvider{err: &providers.UpstreamError{
+		StatusCode: 400,
+		Type:       "invalid_request",
+		Message:    "invalid tool_choice: named function selection is unsupported",
+	}}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	service := newToolProbeService(registry, instance.Identity, nil)
+
+	result, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: provider.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if err != nil || result.Status != ToolProbeInconclusive || result.Reason != ToolProbeReasonProviderFailed {
+		t.Fatalf("ProbeToolCalling() = %+v, %v, want inconclusive tool-choice syntax failure", result, err)
+	}
+}
+
+func TestProbeToolCallingTreatsGenericFunctionSchemaRejectionAsInconclusive(t *testing.T) {
+	t.Parallel()
+	provider := &toolProbeProvider{err: &providers.UpstreamError{
+		StatusCode: 422,
+		Type:       "invalid_request",
+		Message:    "function schema is invalid for this endpoint",
+	}}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	service := newToolProbeService(registry, instance.Identity, nil)
+
+	result, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: provider.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if err != nil || result.Status != ToolProbeInconclusive || result.Reason != ToolProbeReasonProviderFailed {
+		t.Fatalf("ProbeToolCalling() = %+v, %v, want inconclusive function-schema failure", result, err)
+	}
+}
+
+func TestProbeToolCallingRequiresExactReturnedToolName(t *testing.T) {
+	t.Parallel()
+	response := toolProbeResponse()
+	response.Choices[0].Message.ToolCalls[0].Function.Name = " " + toolProbeName
+	provider := &toolProbeProvider{response: response}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	service := newToolProbeService(registry, instance.Identity, nil)
+
+	result, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: provider.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if err != nil || result.Status != ToolProbeInconclusive || result.Reason != ToolProbeReasonNoToolCall {
+		t.Fatalf("ProbeToolCalling() = %+v, %v, want inconclusive exact-name mismatch", result, err)
+	}
+}
+
+func TestProbeToolCallingFencesProviderReplacementBeforeDispatch(t *testing.T) {
+	t.Parallel()
+	first := &toolProbeProvider{name: "custom", response: toolProbeResponse()}
+	replacement := &toolProbeProvider{name: "custom", response: toolProbeResponse()}
+	registry := providers.NewMutableRegistry(first)
+	instance, _ := registry.GetInstance(first.Name())
+	service := newToolProbeService(registry, instance.Identity, nil)
+	registry.Replace(replacement)
+
+	_, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: first.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if err == nil {
+		t.Fatal("ProbeToolCalling() error = nil, want generation fence failure")
+	}
+	if _, calls := first.lastRequest(); calls != 0 {
+		t.Fatalf("first provider calls = %d, want 0", calls)
+	}
+	if _, calls := replacement.lastRequest(); calls != 0 {
+		t.Fatalf("replacement provider calls = %d, want 0", calls)
+	}
+}
+
+func TestProbeToolCallingRejectsPolicyRewrite(t *testing.T) {
+	t.Parallel()
+	provider := &toolProbeProvider{response: toolProbeResponse()}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	base := governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, governor.NewMemoryUsageStore(), nil)
+	service := newToolProbeService(registry, instance.Identity, toolProbeRewriteGovernor{Governor: base})
+
+	_, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: provider.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if !errors.Is(err, ErrToolProbeModelRewritten) {
+		t.Fatalf("ProbeToolCalling() error = %v, want rewrite rejection", err)
+	}
+	if _, calls := provider.lastRequest(); calls != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls)
+	}
+}
+
+func TestServiceRejectsVerifiedToolSupportAfterGovernorModelRewrite(t *testing.T) {
+	t.Parallel()
+
+	provider := &toolProbeProvider{capabilities: providers.Capabilities{
+		Name:         "custom",
+		Kind:         providers.KindLocal,
+		DefaultModel: "custom-model",
+		Models:       []string{"custom-model", "another-model"},
+		ModelCapabilities: map[string]types.ModelCapabilities{
+			"custom-model": {
+				ImageInput:  modelcaps.ImageInputSupported,
+				ToolCalling: modelcaps.ToolCallingUnknown,
+				Source:      modelcaps.SourceProvider,
+			},
+			"another-model": {
+				ImageInput:  modelcaps.ImageInputSupported,
+				ToolCalling: modelcaps.ToolCallingUnknown,
+				Source:      modelcaps.SourceProvider,
+			},
+		},
+	}}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	base := governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, governor.NewMemoryUsageStore(), nil)
+	service := NewService(Dependencies{
+		Router:    router.NewRuleRouter("", catalog.NewRegistryCatalog(registry, nil)),
+		Governor:  toolProbeRewriteGovernor{Governor: base},
+		Providers: registry,
+		Tracer:    profiler.NewInMemoryTracer(nil),
+		Resilience: ResilienceOptions{
+			MaxAttempts:     1,
+			FailoverEnabled: false,
+		},
+	})
+
+	_, err := service.HandleChat(t.Context(), types.ChatRequest{
+		RequestID: "verified-rich-rewrite",
+		Model:     "custom-model",
+		Scope:     types.RequestScope{ProviderHint: provider.Name()},
+		Messages:  []types.Message{{Role: "user", Content: "continue the task"}},
+		Requirements: types.ChatRequestRequirements{
+			ToolCalling:              true,
+			ToolCallingVerified:      true,
+			ToolCallingVerifiedModel: "custom-model",
+			ToolCallingVerifiedUntil: time.Now().UTC().Add(time.Hour),
+			NoProviderFailover:       true,
+			ExactProvider:            true,
+			ProviderInstance:         instance.Identity,
+		},
+	})
+	if err == nil {
+		t.Fatal("HandleChat() error = nil, want rewritten model rejected before dispatch")
+	}
+	if _, calls := provider.lastRequest(); calls != 0 {
+		t.Fatalf("provider calls = %d, want rewritten tool request blocked before dispatch", calls)
+	}
+}
+
+func TestProbeToolCallingRespectsPolicyBeforeDispatch(t *testing.T) {
+	t.Parallel()
+	provider := &toolProbeProvider{response: toolProbeResponse()}
+	registry := providers.NewRegistry(provider)
+	instance, _ := registry.GetInstance(provider.Name())
+	denyingGovernor := governor.NewStaticGovernor(config.GovernorConfig{
+		DenyAll:         true,
+		MaxPromptTokens: 64_000,
+	}, governor.NewMemoryUsageStore(), nil)
+	service := newToolProbeService(registry, instance.Identity, denyingGovernor)
+
+	result, err := service.ProbeToolCalling(t.Context(), ToolCallingProbeRequest{
+		Provider: provider.Name(), Model: "custom-model", ProviderInstance: instance.Identity,
+	})
+	if !errors.Is(err, ErrToolProbeUnavailable) || result.Status != ToolProbeInconclusive || result.Reason != ToolProbeReasonPolicyDenied {
+		t.Fatalf("ProbeToolCalling() = %+v, %v, want policy denial before dispatch", result, err)
+	}
+	if _, calls := provider.lastRequest(); calls != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls)
+	}
+}
+
+func newToolProbeService(registry providers.Registry, identity types.ProviderInstanceIdentity, override governor.Governor) *Service {
+	base := governor.NewStaticGovernor(config.GovernorConfig{MaxPromptTokens: 64_000}, governor.NewMemoryUsageStore(), nil)
+	if override != nil {
+		base = nil
+	}
+	var active governor.Governor = base
+	if override != nil {
+		active = override
+	}
+	return NewService(Dependencies{
+		Router: staticFallbackRouter{route: types.RouteDecision{
+			Provider: "custom", ProviderKind: string(providers.KindLocal), ProviderInstance: identity, Model: "custom-model", Reason: "pinned_provider_model",
+		}},
+		Governor:  active,
+		Providers: registry,
+		Tracer:    profiler.NewInMemoryTracer(nil),
+		Resilience: ResilienceOptions{
+			MaxAttempts:     3,
+			FailoverEnabled: true,
+		},
+	})
+}
+
+type toolProbeProvider struct {
+	name         string
+	err          error
+	response     *types.ChatResponse
+	capabilities providers.Capabilities
+
+	mu      sync.Mutex
+	request types.ChatRequest
+	calls   int
+}
+
+func (p *toolProbeProvider) Name() string {
+	if p.name != "" {
+		return p.name
+	}
+	return "custom"
+}
+func (p *toolProbeProvider) Kind() providers.Kind { return providers.KindLocal }
+func (p *toolProbeProvider) DefaultModel() string {
+	if p.capabilities.DefaultModel != "" {
+		return p.capabilities.DefaultModel
+	}
+	return "custom-model"
+}
+func (p *toolProbeProvider) Supports(model string) bool {
+	if len(p.capabilities.Models) == 0 {
+		return true
+	}
+	for _, candidate := range p.capabilities.Models {
+		if candidate == model {
+			return true
+		}
+	}
+	return p.DefaultModel() == model
+}
+func (p *toolProbeProvider) Capabilities(context.Context) (providers.Capabilities, error) {
+	if p.capabilities.Name != "" || len(p.capabilities.Models) > 0 || p.capabilities.DefaultModel != "" {
+		return p.capabilities, nil
+	}
+	return providers.Capabilities{Name: p.Name(), Kind: p.Kind(), Models: []string{"custom-model"}, DefaultModel: "custom-model"}, nil
+}
+func (p *toolProbeProvider) Chat(_ context.Context, req types.ChatRequest) (*types.ChatResponse, error) {
+	p.mu.Lock()
+	p.request = req
+	p.calls++
+	p.mu.Unlock()
+	return p.response, p.err
+}
+func (p *toolProbeProvider) lastRequest() (types.ChatRequest, int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.request, p.calls
+}
+
+type toolProbeRewriteGovernor struct{ governor.Governor }
+
+func (g toolProbeRewriteGovernor) RewriteResult(req types.ChatRequest) governor.RewriteResult {
+	rewritten := req
+	rewritten.Model = "another-model"
+	return governor.RewriteResult{Request: rewritten, Applied: true, OriginalModel: req.Model, RewrittenModel: "another-model"}
+}
+
+func toolProbeResponse() *types.ChatResponse {
+	return &types.ChatResponse{Choices: []types.ChatChoice{{
+		Message: types.Message{Role: "assistant", ToolCalls: []types.ToolCall{{
+			ID: "call_probe", Type: "function", Function: types.ToolCallFunction{Name: toolProbeName, Arguments: "{}"},
+		}}},
+	}}}
+}

--- a/internal/modelapp/application.go
+++ b/internal/modelapp/application.go
@@ -5,16 +5,21 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/catalog"
 	"github.com/hecatehq/hecate/internal/gateway"
 	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/modelprobe"
 	"github.com/hecatehq/hecate/pkg/types"
 )
 
 var (
-	ErrServiceNotConfigured = errors.New("model service is not configured")
-	ErrProviderAmbiguous    = errors.New("provider identity is ambiguous")
+	ErrServiceNotConfigured  = errors.New("model service is not configured")
+	ErrProviderAmbiguous     = errors.New("provider identity is ambiguous")
+	ErrToolProbeUnavailable  = errors.New("model tool capability probing is unavailable")
+	ErrToolProbeNotNeeded    = errors.New("model tool capability is already known")
+	ErrToolProbeRouteChanged = errors.New("model tool capability probe route changed")
 )
 
 type Service interface {
@@ -23,12 +28,20 @@ type Service interface {
 	ProviderModelReadiness(ctx context.Context, provider, model string) (*gateway.ProviderModelReadinessResult, error)
 }
 
+type ToolProbeService interface {
+	ProbeToolCalling(ctx context.Context, input gateway.ToolCallingProbeRequest) (gateway.ToolCallingProbeResult, error)
+}
+
 type Application struct {
-	service Service
+	service              Service
+	toolProbeStore       modelprobe.Store
+	toolProbeCoordinator *modelprobe.Coordinator
 }
 
 type Options struct {
-	Service Service
+	Service              Service
+	ToolProbeStore       modelprobe.Store
+	ToolProbeCoordinator *modelprobe.Coordinator
 }
 
 type ListModelsCommand struct {
@@ -51,6 +64,18 @@ type modelCatalogSnapshot struct {
 type ReadinessError struct {
 	Cause     error
 	Readiness types.ModelReadiness
+}
+
+// ToolProbeResult is the operator-facing result of an explicit model tool
+// verification. Provider instance identity is intentionally absent: it is
+// persisted only as an internal generation fence.
+type ToolProbeResult struct {
+	Provider     string
+	Model        string
+	Capabilities types.ModelCapabilities
+	Verification *types.ToolCapabilityVerification
+	TraceID      string
+	Performed    bool
 }
 
 // ProviderAmbiguityError identifies an operator-supplied provider key that
@@ -79,7 +104,19 @@ func (e ReadinessError) Unwrap() error {
 }
 
 func New(opts Options) *Application {
-	return &Application{service: opts.Service}
+	store := opts.ToolProbeStore
+	if store == nil {
+		store = modelprobe.NewMemoryStore()
+	}
+	coordinator := opts.ToolProbeCoordinator
+	if coordinator == nil {
+		coordinator = modelprobe.NewCoordinator(store)
+	}
+	return &Application{
+		service:              opts.Service,
+		toolProbeStore:       store,
+		toolProbeCoordinator: coordinator,
+	}
 }
 
 func (app *Application) ListModels(ctx context.Context, cmd ListModelsCommand) ([]types.ModelInfo, error) {
@@ -106,9 +143,11 @@ func (app *Application) loadModelCatalog(ctx context.Context, cmd ListModelsComm
 	if err != nil {
 		return modelCatalogSnapshot{}, err
 	}
+	probeRecords := app.toolProbeRecords(ctx, result.Models)
+	now := time.Now().UTC()
 	out := make([]types.ModelInfo, 0, len(result.Models))
 	for _, item := range result.Models {
-		out = append(out, modelWithResolvedCapabilities(item))
+		out = append(out, app.modelWithResolvedCapabilities(item, probeRecords, now))
 	}
 	providerIdentities := make([]catalog.ProviderIdentity, 0, len(result.ProviderIdentities))
 	for _, identity := range result.ProviderIdentities {
@@ -116,6 +155,117 @@ func (app *Application) loadModelCatalog(ctx context.Context, cmd ListModelsComm
 		providerIdentities = append(providerIdentities, identity)
 	}
 	return modelCatalogSnapshot{models: out, providerIdentities: providerIdentities}, nil
+}
+
+// VerifyToolCalling sends one harmless, forced tool-call diagnostic to the
+// exact configured provider/model route. It never executes the returned tool.
+// Only otherwise-unknown capability values can be changed by the proof;
+// provider-native and catalog-known values remain authoritative.
+func (app *Application) VerifyToolCalling(ctx context.Context, provider, model string) (ToolProbeResult, error) {
+	provider = normalizeProvider(provider)
+	model = strings.TrimSpace(model)
+	if provider == "" || model == "" {
+		return ToolProbeResult{}, fmt.Errorf("provider and model are required")
+	}
+	if app == nil || app.service == nil || app.toolProbeCoordinator == nil {
+		return ToolProbeResult{}, ErrToolProbeUnavailable
+	}
+	snapshot, err := app.loadModelCatalog(ctx, ListModelsCommand{})
+	if err != nil {
+		return ToolProbeResult{}, err
+	}
+	item, ok, resolveErr := resolveProviderModel(snapshot.models, snapshot.providerIdentities, provider, model)
+	if resolveErr != nil {
+		return ToolProbeResult{}, resolveErr
+	}
+	if !ok {
+		err := fmt.Errorf("model %q is not available from provider %q", model, provider)
+		return ToolProbeResult{}, app.withModelReadiness(ctx, provider, model, err)
+	}
+	if !modelRouteReady(item) {
+		err := fmt.Errorf("model %q is not routable from provider %q", item.ID, item.Provider)
+		return ToolProbeResult{}, app.withModelReadiness(ctx, item.Provider, item.ID, err)
+	}
+	if !item.ProviderInstance.Valid() {
+		return ToolProbeResult{}, ErrToolProbeUnavailable
+	}
+	if item.Capabilities.ToolCalling != modelcaps.ToolCallingUnknown {
+		return ToolProbeResult{
+			Provider:     item.Provider,
+			Model:        item.ID,
+			Capabilities: item.Capabilities,
+			Verification: item.Capabilities.ToolVerification,
+		}, ErrToolProbeNotNeeded
+	}
+	service, ok := app.service.(ToolProbeService)
+	if !ok {
+		return ToolProbeResult{}, ErrToolProbeUnavailable
+	}
+
+	key := modelprobe.Key{
+		Provider: item.Provider,
+		Model:    item.ID,
+		Instance: item.ProviderInstance,
+		Version:  modelprobe.ProbeVersion,
+	}
+	traceID := ""
+	record, performed, err := app.toolProbeCoordinator.Verify(ctx, key, func(probeCtx context.Context) modelprobe.Outcome {
+		result, probeErr := service.ProbeToolCalling(probeCtx, gateway.ToolCallingProbeRequest{
+			Provider:         item.Provider,
+			Model:            item.ID,
+			ProviderInstance: item.ProviderInstance,
+		})
+		traceID = result.TraceID
+		if probeErr != nil {
+			reason := result.Reason
+			if strings.TrimSpace(reason) == "" {
+				reason = toolProbeFailureReason(probeErr)
+			}
+			return modelprobe.Outcome{
+				Status: modelprobe.StatusInconclusive,
+				Reason: reason,
+			}
+		}
+		// A provider reload after dispatch must not turn a stale proof into a
+		// valid proof for the replacement generation. The old row remains
+		// unreachable because the opaque identity is part of its key.
+		current, routeErr := app.ResolveProviderRoute(probeCtx, item.Provider, item.ID)
+		if routeErr != nil || current.Name != item.Provider || current.Instance != item.ProviderInstance {
+			return modelprobe.Outcome{Status: modelprobe.StatusInconclusive, Reason: modelprobe.ReasonProviderChanged}
+		}
+		return modelprobe.Outcome{Status: result.Status, Reason: result.Reason}
+	})
+	if err != nil {
+		return ToolProbeResult{}, err
+	}
+
+	// Read through the normal projection path so /v1/models and Hecate Chat
+	// both observe the same effective capability after a completed probe.
+	refreshed, err := app.loadModelCatalog(ctx, ListModelsCommand{})
+	if err != nil {
+		return ToolProbeResult{}, err
+	}
+	updated, found, resolveErr := resolveProviderModel(refreshed.models, refreshed.providerIdentities, item.Provider, item.ID)
+	if resolveErr != nil {
+		return ToolProbeResult{}, resolveErr
+	}
+	if !found {
+		return ToolProbeResult{}, fmt.Errorf("model tool capability probe route is no longer configured")
+	}
+	if updated.Provider != item.Provider || updated.ProviderInstance != item.ProviderInstance {
+		// The completed record is bound to the old opaque provider generation
+		// and cannot project onto the replacement. Do not return that stale
+		// observation as if it described the newly configured route.
+		return ToolProbeResult{}, ErrToolProbeRouteChanged
+	}
+	return ToolProbeResult{
+		Provider:     updated.Provider,
+		Model:        updated.ID,
+		Capabilities: updated.Capabilities,
+		Verification: record.Public(),
+		TraceID:      traceID,
+		Performed:    performed,
+	}, nil
 }
 
 func (app *Application) ResolveCapabilities(ctx context.Context, provider, model string) (types.ModelCapabilities, error) {
@@ -259,11 +409,111 @@ func (app *Application) withModelReadiness(ctx context.Context, provider, model 
 	return ReadinessError{Cause: err, Readiness: result.Readiness.ToModelReadiness()}
 }
 
-func modelWithResolvedCapabilities(item types.ModelInfo) types.ModelInfo {
+func (app *Application) modelWithResolvedCapabilities(item types.ModelInfo, probeRecords map[modelprobe.Key]modelprobe.Record, now time.Time) types.ModelInfo {
 	item.Capabilities = modelcaps.ResolveWithProviderCapability(item.ProviderFamily, item.Kind, item.ID, item.DiscoverySource, item.Capabilities)
+	item.Capabilities = applyToolVerification(item.Provider, item.ID, item.ProviderInstance, item.Capabilities, probeRecords, now)
 	item.ProviderAliases = append([]string(nil), item.ProviderAliases...)
 	item.Readiness.SuggestedModels = append([]string(nil), item.Readiness.SuggestedModels...)
 	return item
+}
+
+// toolProbeRecords reads current generation-bound observations for the whole
+// catalog in one bounded batch when the configured store supports it. The
+// fallback preserves the Store contract for narrow test doubles, while the
+// production memory and SQL stores avoid a query per model on hot list and
+// chat-admission paths.
+func (app *Application) toolProbeRecords(ctx context.Context, models []types.ModelInfo) map[modelprobe.Key]modelprobe.Record {
+	if app == nil || app.toolProbeStore == nil {
+		return nil
+	}
+	keys := make([]modelprobe.Key, 0, len(models))
+	for _, item := range models {
+		if !item.ProviderInstance.Valid() {
+			continue
+		}
+		keys = append(keys, modelprobe.Key{
+			Provider: item.Provider,
+			Model:    item.ID,
+			Instance: item.ProviderInstance,
+			Version:  modelprobe.ProbeVersion,
+		})
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	if batch, ok := app.toolProbeStore.(modelprobe.BatchStore); ok {
+		records, err := batch.GetMany(ctx, keys)
+		if err == nil {
+			return records
+		}
+		return nil
+	}
+	records := make(map[modelprobe.Key]modelprobe.Record, len(keys))
+	for _, key := range keys {
+		record, found, err := app.toolProbeStore.Get(ctx, key)
+		if err != nil || !found {
+			continue
+		}
+		records[key] = record
+	}
+	return records
+}
+
+func applyToolVerification(
+	provider, model string,
+	instance types.ProviderInstanceIdentity,
+	capabilities types.ModelCapabilities,
+	probeRecords map[modelprobe.Key]modelprobe.Record,
+	now time.Time,
+) types.ModelCapabilities {
+	// Provider/catalog metadata never supplies this Hecate-owned observation.
+	// Clear any copied internal metadata before considering the generation-bound
+	// store row for this exact model route.
+	capabilities.ToolVerification = nil
+	capabilities.ToolCallingVerificationApplied = false
+	if !instance.Valid() || len(probeRecords) == 0 {
+		return capabilities
+	}
+	record, found := probeRecords[modelprobe.Key{
+		Provider: provider,
+		Model:    model,
+		Instance: instance,
+		Version:  modelprobe.ProbeVersion,
+	}]
+	if !found || !record.Active(now) {
+		return capabilities
+	}
+	capabilities.ToolVerification = record.Public()
+	if capabilities.ToolCalling != modelcaps.ToolCallingUnknown {
+		return capabilities
+	}
+	switch record.Status {
+	case modelprobe.StatusSupported:
+		capabilities.ToolCalling = modelcaps.ToolCallingBasic
+		// The effective tool value now combines provider/catalog discovery with
+		// Hecate-owned manual evidence. Keep provenance honest rather than
+		// presenting the projected value as provider-native metadata.
+		capabilities.Source = modelcaps.SourceMixed
+		capabilities.ToolCallingVerificationApplied = true
+	case modelprobe.StatusUnsupported:
+		capabilities.ToolCalling = modelcaps.ToolCallingNone
+		capabilities.Source = modelcaps.SourceMixed
+		capabilities.ToolCallingVerificationApplied = true
+	}
+	return capabilities
+}
+
+func toolProbeFailureReason(err error) string {
+	switch {
+	case errors.Is(err, gateway.ErrToolProbeModelRewritten):
+		return modelprobe.ReasonPolicyDenied
+	case errors.Is(err, gateway.ErrToolProbeUnavailable):
+		return modelprobe.ReasonConfiguration
+	case errors.Is(err, gateway.ErrToolProbeInvalid):
+		return modelprobe.ReasonConfiguration
+	default:
+		return modelprobe.ReasonProviderFailure
+	}
 }
 
 func resolveProviderModel(models []types.ModelInfo, providerIdentities []catalog.ProviderIdentity, provider, model string) (types.ModelInfo, bool, error) {

--- a/internal/modelapp/application_test.go
+++ b/internal/modelapp/application_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/catalog"
 	"github.com/hecatehq/hecate/internal/gateway"
 	"github.com/hecatehq/hecate/internal/modelcaps"
+	"github.com/hecatehq/hecate/internal/modelprobe"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -445,6 +448,258 @@ func TestApplication_SupportsImageInputFailsClosed(t *testing.T) {
 	}
 }
 
+func TestApplication_ListModelsProjectsActiveToolVerification(t *testing.T) {
+	t.Parallel()
+
+	store := modelprobe.NewMemoryStore()
+	unknownInstance := types.ProviderInstanceIdentity{ID: "unknown-generation", Kind: types.ProviderInstanceIdentityConfiguration}
+	knownInstance := types.ProviderInstanceIdentity{ID: "known-generation", Kind: types.ProviderInstanceIdentityConfiguration}
+	seedToolProbeRecord(t, store, modelprobe.Key{
+		Provider: "local-runtime",
+		Model:    "custom-tool-model",
+		Instance: unknownInstance,
+		Version:  modelprobe.ProbeVersion,
+	}, modelprobe.StatusSupported)
+	seedToolProbeRecord(t, store, modelprobe.Key{
+		Provider: "local-runtime",
+		Model:    "known-no-tools-model",
+		Instance: knownInstance,
+		Version:  modelprobe.ProbeVersion,
+	}, modelprobe.StatusSupported)
+
+	service := &fakeModelService{models: []types.ModelInfo{
+		{
+			ID:               "custom-tool-model",
+			Provider:         "local-runtime",
+			ProviderInstance: unknownInstance,
+			Kind:             string(providers.KindLocal),
+			Capabilities:     types.ModelCapabilities{ToolCalling: modelcaps.ToolCallingUnknown},
+			Readiness:        types.ModelReadiness{Ready: true, RoutingReady: true},
+		},
+		{
+			ID:               "known-no-tools-model",
+			Provider:         "local-runtime",
+			ProviderInstance: knownInstance,
+			Kind:             string(providers.KindLocal),
+			Capabilities:     types.ModelCapabilities{ToolCalling: modelcaps.ToolCallingNone},
+			Readiness:        types.ModelReadiness{Ready: true, RoutingReady: true},
+		},
+	}}
+
+	models, err := New(Options{Service: service, ToolProbeStore: store}).ListModels(t.Context(), ListModelsCommand{})
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("models len = %d, want 2", len(models))
+	}
+	if got := models[0].Capabilities; got.ToolCalling != modelcaps.ToolCallingBasic || got.ToolVerification == nil || got.ToolVerification.Status != modelprobe.StatusSupported {
+		t.Fatalf("unknown model capabilities = %+v, want verified basic tool support", got)
+	}
+	if got := models[1].Capabilities; got.ToolCalling != modelcaps.ToolCallingNone || got.ToolVerification == nil || got.ToolVerification.Status != modelprobe.StatusSupported {
+		t.Fatalf("known model capabilities = %+v, want provider-known none preserved with verification provenance", got)
+	}
+}
+
+func TestApplication_ListModelsBatchesToolVerificationReads(t *testing.T) {
+	t.Parallel()
+
+	backing := modelprobe.NewMemoryStore()
+	store := &countingBatchProbeStore{Store: backing}
+	first := modelprobe.Key{
+		Provider: "local-runtime",
+		Model:    "custom-one",
+		Instance: types.ProviderInstanceIdentity{ID: "generation-one", Kind: types.ProviderInstanceIdentityConfiguration},
+		Version:  modelprobe.ProbeVersion,
+	}
+	second := modelprobe.Key{
+		Provider: "local-runtime",
+		Model:    "custom-two",
+		Instance: types.ProviderInstanceIdentity{ID: "generation-two", Kind: types.ProviderInstanceIdentityConfiguration},
+		Version:  modelprobe.ProbeVersion,
+	}
+	seedToolProbeRecord(t, backing, first, modelprobe.StatusSupported)
+	service := &fakeModelService{models: []types.ModelInfo{
+		{
+			ID:               first.Model,
+			Provider:         first.Provider,
+			ProviderInstance: first.Instance,
+			Kind:             string(providers.KindLocal),
+			Capabilities:     types.ModelCapabilities{ToolCalling: modelcaps.ToolCallingUnknown},
+			Readiness:        types.ModelReadiness{Ready: true, RoutingReady: true},
+		},
+		{
+			ID:               second.Model,
+			Provider:         second.Provider,
+			ProviderInstance: second.Instance,
+			Kind:             string(providers.KindLocal),
+			Capabilities:     types.ModelCapabilities{ToolCalling: modelcaps.ToolCallingUnknown},
+			Readiness:        types.ModelReadiness{Ready: true, RoutingReady: true},
+		},
+	}}
+
+	models, err := New(Options{Service: service, ToolProbeStore: store}).ListModels(t.Context(), ListModelsCommand{})
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if store.batchCalls.Load() != 1 || store.getCalls.Load() != 0 {
+		t.Fatalf("probe reads = batch %d single %d, want one batch and no per-model reads", store.batchCalls.Load(), store.getCalls.Load())
+	}
+	if len(models) != 2 || models[0].Capabilities.ToolCalling != modelcaps.ToolCallingBasic || models[1].Capabilities.ToolVerification != nil {
+		t.Fatalf("projected models = %+v, want one exact verified record", models)
+	}
+}
+
+func TestApplication_ResolveCapabilitiesDoesNotProjectManualVerificationOntoAuto(t *testing.T) {
+	t.Parallel()
+
+	store := modelprobe.NewMemoryStore()
+	instance := types.ProviderInstanceIdentity{ID: "verified-auto-generation", Kind: types.ProviderInstanceIdentityConfiguration}
+	key := modelprobe.Key{
+		Provider: "local-runtime",
+		Model:    "custom-tool-model",
+		Instance: instance,
+		Version:  modelprobe.ProbeVersion,
+	}
+	seedToolProbeRecord(t, store, key, modelprobe.StatusSupported)
+	service := &fakeModelService{models: []types.ModelInfo{{
+		ID:               key.Model,
+		Provider:         key.Provider,
+		ProviderInstance: instance,
+		Kind:             string(providers.KindLocal),
+		Capabilities:     types.ModelCapabilities{ToolCalling: modelcaps.ToolCallingUnknown},
+		Readiness:        types.ModelReadiness{Ready: true, RoutingReady: true},
+	}}}
+	app := New(Options{Service: service, ToolProbeStore: store})
+
+	auto, err := app.ResolveCapabilities(t.Context(), "auto", key.Model)
+	if err != nil {
+		t.Fatalf("ResolveCapabilities(auto) error = %v", err)
+	}
+	if auto.ToolCalling != modelcaps.ToolCallingUnknown || auto.ToolVerification != nil {
+		t.Fatalf("auto capabilities = %+v, want route-bound proof withheld", auto)
+	}
+
+	exact, err := app.ResolveCapabilities(t.Context(), key.Provider, key.Model)
+	if err != nil {
+		t.Fatalf("ResolveCapabilities(exact) error = %v", err)
+	}
+	if exact.ToolCalling != modelcaps.ToolCallingBasic || exact.Source != modelcaps.SourceMixed || exact.ToolVerification == nil || !exact.ToolCallingVerificationApplied {
+		t.Fatalf("exact capabilities = %+v, want verified exact route", exact)
+	}
+}
+
+func TestApplication_VerifyToolCallingCachesExactRouteResult(t *testing.T) {
+	t.Parallel()
+
+	instance := types.ProviderInstanceIdentity{ID: "custom-generation", Kind: types.ProviderInstanceIdentityConfiguration}
+	service := &fakeModelService{models: []types.ModelInfo{{
+		ID:               "custom-tool-model",
+		Provider:         "Local Runtime",
+		ProviderAliases:  []string{"local-runtime"},
+		ProviderInstance: instance,
+		Kind:             string(providers.KindLocal),
+		Capabilities:     types.ModelCapabilities{ToolCalling: modelcaps.ToolCallingUnknown},
+		Readiness:        types.ModelReadiness{Ready: true, RoutingReady: true},
+	}}}
+	service.toolProbe = func(_ context.Context, input gateway.ToolCallingProbeRequest) (gateway.ToolCallingProbeResult, error) {
+		service.probeRequests = append(service.probeRequests, input)
+		return gateway.ToolCallingProbeResult{
+			Provider: input.Provider,
+			Model:    input.Model,
+			Status:   gateway.ToolProbeSupported,
+			TraceID:  "trace_tool_probe",
+		}, nil
+	}
+	app := New(Options{Service: service, ToolProbeStore: modelprobe.NewMemoryStore()})
+
+	result, err := app.VerifyToolCalling(t.Context(), "local-runtime", "custom-tool-model")
+	if err != nil {
+		t.Fatalf("VerifyToolCalling() error = %v", err)
+	}
+	if !result.Performed || result.Provider != "Local Runtime" || result.Model != "custom-tool-model" || result.TraceID != "trace_tool_probe" {
+		t.Fatalf("VerifyToolCalling() result = %+v", result)
+	}
+	if result.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || result.Capabilities.Source != modelcaps.SourceMixed || result.Verification == nil || result.Verification.Status != modelprobe.StatusSupported {
+		t.Fatalf("VerifyToolCalling() capabilities = %+v verification=%+v, want verified basic", result.Capabilities, result.Verification)
+	}
+	if len(service.probeRequests) != 1 || service.probeRequests[0].Provider != "Local Runtime" || service.probeRequests[0].Model != "custom-tool-model" || service.probeRequests[0].ProviderInstance != instance {
+		t.Fatalf("probe requests = %+v, want one canonical pinned route", service.probeRequests)
+	}
+
+	cached, err := app.VerifyToolCalling(t.Context(), "local-runtime", "custom-tool-model")
+	if !errors.Is(err, ErrToolProbeNotNeeded) {
+		t.Fatalf("VerifyToolCalling(cached) error = %v, want ErrToolProbeNotNeeded", err)
+	}
+	if cached.Performed || cached.Capabilities.ToolCalling != modelcaps.ToolCallingBasic || len(service.probeRequests) != 1 {
+		t.Fatalf("VerifyToolCalling(cached) = %+v requests=%d, want cached result without dispatch", cached, len(service.probeRequests))
+	}
+}
+
+func TestApplication_VerifyToolCallingRejectsStaleGenerationResult(t *testing.T) {
+	t.Parallel()
+
+	initial := types.ProviderInstanceIdentity{ID: "generation-a", Kind: types.ProviderInstanceIdentityConfiguration}
+	replacement := types.ProviderInstanceIdentity{ID: "generation-b", Kind: types.ProviderInstanceIdentityConfiguration}
+	service := &fakeModelService{models: []types.ModelInfo{{
+		ID:               "custom-tool-model",
+		Provider:         "local-runtime",
+		ProviderInstance: initial,
+		Kind:             string(providers.KindLocal),
+		Capabilities:     types.ModelCapabilities{ToolCalling: modelcaps.ToolCallingUnknown},
+		Readiness:        types.ModelReadiness{Ready: true, RoutingReady: true},
+	}}}
+	service.toolProbe = func(_ context.Context, input gateway.ToolCallingProbeRequest) (gateway.ToolCallingProbeResult, error) {
+		service.models[0].ProviderInstance = replacement
+		return gateway.ToolCallingProbeResult{Provider: input.Provider, Model: input.Model, Status: gateway.ToolProbeSupported}, nil
+	}
+	app := New(Options{Service: service, ToolProbeStore: modelprobe.NewMemoryStore()})
+
+	_, err := app.VerifyToolCalling(t.Context(), "local-runtime", "custom-tool-model")
+	if !errors.Is(err, ErrToolProbeRouteChanged) {
+		t.Fatalf("VerifyToolCalling() error = %v, want ErrToolProbeRouteChanged", err)
+	}
+	models, listErr := app.ListModels(t.Context(), ListModelsCommand{})
+	if listErr != nil {
+		t.Fatalf("ListModels() error = %v", listErr)
+	}
+	if got := models[0].Capabilities; got.ToolCalling != modelcaps.ToolCallingUnknown || got.ToolVerification != nil {
+		t.Fatalf("replacement generation capabilities = %+v, want no stale verification", got)
+	}
+}
+
+func seedToolProbeRecord(t *testing.T, store modelprobe.Store, key modelprobe.Key, status string) {
+	t.Helper()
+	now := time.Now().UTC()
+	record, acquired, err := store.Acquire(t.Context(), key, now, now.Add(time.Minute), "seed-lease")
+	if err != nil || !acquired {
+		t.Fatalf("seed Acquire() = %+v, %t, %v", record, acquired, err)
+	}
+	record.Status = status
+	record.Reason = modelprobe.ReasonNone
+	record.CheckedAt = now
+	record.ExpiresAt = now.Add(time.Hour)
+	if _, err := store.Complete(t.Context(), record); err != nil {
+		t.Fatalf("seed Complete() error = %v", err)
+	}
+}
+
+type countingBatchProbeStore struct {
+	modelprobe.Store
+	getCalls   atomic.Int32
+	batchCalls atomic.Int32
+}
+
+func (s *countingBatchProbeStore) Get(ctx context.Context, key modelprobe.Key) (modelprobe.Record, bool, error) {
+	s.getCalls.Add(1)
+	return s.Store.Get(ctx, key)
+}
+
+func (s *countingBatchProbeStore) GetMany(ctx context.Context, keys []modelprobe.Key) (map[modelprobe.Key]modelprobe.Record, error) {
+	s.batchCalls.Add(1)
+	return s.Store.(modelprobe.BatchStore).GetMany(ctx, keys)
+}
+
 type fakeModelService struct {
 	models             []types.ModelInfo
 	providerIdentities []catalog.ProviderIdentity
@@ -456,6 +711,8 @@ type fakeModelService struct {
 	refreshCalls       int
 	readinessProvider  string
 	readinessModel     string
+	toolProbe          func(context.Context, gateway.ToolCallingProbeRequest) (gateway.ToolCallingProbeResult, error)
+	probeRequests      []gateway.ToolCallingProbeRequest
 }
 
 func (s *fakeModelService) ListModels(context.Context) (*gateway.ModelsResult, error) {
@@ -507,4 +764,11 @@ func (s *fakeModelService) ProviderModelReadiness(_ context.Context, provider, m
 		return nil, s.readinessErr
 	}
 	return &gateway.ProviderModelReadinessResult{Readiness: s.readiness}, nil
+}
+
+func (s *fakeModelService) ProbeToolCalling(ctx context.Context, input gateway.ToolCallingProbeRequest) (gateway.ToolCallingProbeResult, error) {
+	if s.toolProbe == nil {
+		return gateway.ToolCallingProbeResult{}, gateway.ErrToolProbeUnavailable
+	}
+	return s.toolProbe(ctx, input)
 }

--- a/internal/modelcaps/modelcaps.go
+++ b/internal/modelcaps/modelcaps.go
@@ -191,9 +191,9 @@ func Aggregate(capabilities []types.ModelCapabilities) types.ModelCapabilities {
 	if len(capabilities) == 0 {
 		return normalize(types.ModelCapabilities{})
 	}
-	result := normalize(capabilities[0])
+	result := aggregateCapability(capabilities[0])
 	for _, raw := range capabilities[1:] {
-		capability := normalize(raw)
+		capability := aggregateCapability(raw)
 		if result.ToolCalling != capability.ToolCalling {
 			result.ToolCalling = ToolCallingUnknown
 		}
@@ -212,6 +212,20 @@ func Aggregate(capabilities []types.ModelCapabilities) types.ModelCapabilities {
 		}
 	}
 	return result
+}
+
+// aggregateCapability removes evidence that is valid only for one provider
+// generation. An Auto route intentionally cannot inherit a manual proof even
+// when the current candidate set contains only that one route: the route may
+// be replaced before dispatch and Auto carries no matching instance fence.
+func aggregateCapability(raw types.ModelCapabilities) types.ModelCapabilities {
+	capability := normalize(raw)
+	if capability.ToolCallingVerificationApplied {
+		capability.ToolCalling = ToolCallingUnknown
+	}
+	capability.ToolVerification = nil
+	capability.ToolCallingVerificationApplied = false
+	return capability
 }
 
 func normalize(cap types.ModelCapabilities) types.ModelCapabilities {

--- a/internal/modelcaps/modelcaps_test.go
+++ b/internal/modelcaps/modelcaps_test.go
@@ -112,6 +112,34 @@ func TestAggregateReturnsOnlyCapabilitiesCommonToEveryRoute(t *testing.T) {
 	}
 }
 
+func TestAggregateDoesNotExposeRouteBoundToolVerification(t *testing.T) {
+	verified := &types.ToolCapabilityVerification{Status: "supported"}
+	got := Aggregate([]types.ModelCapabilities{
+		{ToolCalling: ToolCallingBasic, ToolVerification: verified},
+		{ToolCalling: ToolCallingBasic},
+	})
+	if got.ToolCalling != ToolCallingBasic {
+		t.Fatalf("tool calling = %q, want basic common to both routes", got.ToolCalling)
+	}
+	if got.ToolVerification != nil {
+		t.Fatalf("tool verification = %+v, want nil for auto-route aggregate", got.ToolVerification)
+	}
+}
+
+func TestAggregateRestoresUnknownWhenSingleRouteCapabilityCameFromVerification(t *testing.T) {
+	got := Aggregate([]types.ModelCapabilities{{
+		ToolCalling:                    ToolCallingBasic,
+		ToolVerification:               &types.ToolCapabilityVerification{Status: "supported"},
+		ToolCallingVerificationApplied: true,
+	}})
+	if got.ToolCalling != ToolCallingUnknown {
+		t.Fatalf("tool calling = %q, want unknown without an exact route fence", got.ToolCalling)
+	}
+	if got.ToolVerification != nil || got.ToolCallingVerificationApplied {
+		t.Fatalf("aggregate verification = %+v, want route-bound proof removed", got)
+	}
+}
+
 func TestImageCapableRequiresDeclaredSupport(t *testing.T) {
 	for _, tt := range []struct {
 		cap  string

--- a/internal/modelprobe/coordinator.go
+++ b/internal/modelprobe/coordinator.go
@@ -1,0 +1,154 @@
+package modelprobe
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+const (
+	defaultLeaseDuration        = 45 * time.Second
+	defaultVerifiedTTL          = 30 * 24 * time.Hour
+	defaultInconclusiveCooldown = 90 * time.Second
+)
+
+// Coordinator coalesces same-process requests and uses Store leases to avoid
+// duplicate paid provider calls across Hecate processes. It intentionally
+// releases its mutex before invoking the caller's probe function.
+type Coordinator struct {
+	store                Store
+	now                  func() time.Time
+	leaseDuration        time.Duration
+	verifiedTTL          time.Duration
+	inconclusiveCooldown time.Duration
+
+	mu       sync.Mutex
+	inFlight map[string]*call
+}
+
+type call struct {
+	done   chan struct{}
+	record Record
+	err    error
+}
+
+type Outcome struct {
+	Status string
+	Reason string
+}
+
+func NewCoordinator(store Store) *Coordinator {
+	if store == nil {
+		store = NewMemoryStore()
+	}
+	return &Coordinator{
+		store:                store,
+		now:                  func() time.Time { return time.Now().UTC() },
+		leaseDuration:        defaultLeaseDuration,
+		verifiedTTL:          defaultVerifiedTTL,
+		inconclusiveCooldown: defaultInconclusiveCooldown,
+		inFlight:             make(map[string]*call),
+	}
+}
+
+func (c *Coordinator) Store() Store {
+	if c == nil {
+		return nil
+	}
+	return c.store
+}
+
+// Verify returns an active cached result, joins an in-process probe, reports a
+// lease held by another process as testing, or runs exactly one caller-owned
+// probe. The caller must not execute tools: it is responsible only for a
+// single harmless capability request.
+func (c *Coordinator) Verify(ctx context.Context, key Key, run func(context.Context) Outcome) (Record, bool, error) {
+	if c == nil || c.store == nil {
+		return Record{}, false, ErrInvalid
+	}
+	key, err := NormalizeKey(key)
+	if err != nil {
+		return Record{}, false, err
+	}
+	flightKey := memoryKey(key)
+	c.mu.Lock()
+	if existing := c.inFlight[flightKey]; existing != nil {
+		c.mu.Unlock()
+		select {
+		case <-existing.done:
+			return existing.record, false, existing.err
+		case <-ctx.Done():
+			return Record{}, false, ctx.Err()
+		}
+	}
+	active := &call{done: make(chan struct{})}
+	c.inFlight[flightKey] = active
+	c.mu.Unlock()
+
+	record, performed, err := c.verify(ctx, key, run)
+
+	c.mu.Lock()
+	active.record = record
+	active.err = err
+	delete(c.inFlight, flightKey)
+	close(active.done)
+	c.mu.Unlock()
+	return record, performed, err
+}
+
+func (c *Coordinator) verify(ctx context.Context, key Key, run func(context.Context) Outcome) (Record, bool, error) {
+	now := c.nowUTC()
+	leaseID, err := randomLeaseID()
+	if err != nil {
+		return Record{}, false, err
+	}
+	record, acquired, err := c.store.Acquire(ctx, key, now, now.Add(c.leaseDuration), leaseID)
+	if err != nil || !acquired {
+		return record, false, err
+	}
+
+	outcome := Outcome{Status: StatusInconclusive, Reason: ReasonUnexpectedResult}
+	// The lease may have been acquired immediately before the operator's
+	// request disconnected. Never start a billable diagnostic once its caller
+	// has already been canceled; complete the lease with a short cooldown
+	// instead so a replacement request can decide whether to retry.
+	if run != nil && ctx.Err() == nil {
+		outcome = run(ctx)
+	}
+	completedAt := c.nowUTC()
+	completed := record
+	completed.Status = normalizeStatus(outcome.Status)
+	if completed.Status == "" || completed.Status == StatusTesting {
+		completed.Status = StatusInconclusive
+	}
+	completed.Reason = normalizeReason(outcome.Reason)
+	completed.CheckedAt = completedAt
+	if completed.Status == StatusSupported || completed.Status == StatusUnsupported {
+		completed.ExpiresAt = completedAt.Add(c.verifiedTTL)
+	} else {
+		completed.ExpiresAt = completedAt.Add(c.inconclusiveCooldown)
+	}
+	// A browser navigation or client disconnect must not leave a durable
+	// `testing` lease behind after the upstream call has already returned.
+	completeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	completed, err = c.store.Complete(completeCtx, completed)
+	return completed, true, err
+}
+
+func (c *Coordinator) nowUTC() time.Time {
+	if c == nil || c.now == nil {
+		return time.Now().UTC()
+	}
+	return c.now().UTC()
+}
+
+func randomLeaseID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw[:]), nil
+}

--- a/internal/modelprobe/memory.go
+++ b/internal/modelprobe/memory.go
@@ -1,0 +1,100 @@
+package modelprobe
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type MemoryStore struct {
+	mu      sync.Mutex
+	records map[string]Record
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{records: make(map[string]Record)}
+}
+
+func (s *MemoryStore) Backend() string { return "memory" }
+
+func (s *MemoryStore) Get(_ context.Context, key Key) (Record, bool, error) {
+	key, err := NormalizeKey(key)
+	if err != nil {
+		return Record{}, false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[memoryKey(key)]
+	return record, ok, nil
+}
+
+func (s *MemoryStore) GetMany(_ context.Context, keys []Key) (map[Key]Record, error) {
+	keys, err := normalizeKeys(keys)
+	if err != nil {
+		return nil, err
+	}
+	records := make(map[Key]Record, len(keys))
+	if len(keys) == 0 {
+		return records, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, key := range keys {
+		if record, found := s.records[memoryKey(key)]; found {
+			records[key] = record
+		}
+	}
+	return records, nil
+}
+
+func (s *MemoryStore) Acquire(_ context.Context, key Key, now time.Time, leaseUntil time.Time, leaseID string) (Record, bool, error) {
+	key, err := NormalizeKey(key)
+	if err != nil {
+		return Record{}, false, err
+	}
+	if now.IsZero() || leaseUntil.IsZero() || !leaseUntil.After(now) || leaseID == "" {
+		return Record{}, false, ErrInvalid
+	}
+	now = now.UTC()
+	leaseUntil = leaseUntil.UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if current, ok := s.records[memoryKey(key)]; ok && (current.Active(now) || current.LeaseActive(now)) {
+		return current, false, nil
+	}
+	record := Record{
+		Key:        key,
+		Status:     StatusTesting,
+		CheckedAt:  now,
+		ExpiresAt:  leaseUntil,
+		LeaseUntil: leaseUntil,
+		LeaseID:    leaseID,
+	}
+	s.records[memoryKey(key)] = record
+	return record, true, nil
+}
+
+func (s *MemoryStore) Complete(_ context.Context, record Record) (Record, error) {
+	record, err := NormalizeRecord(record)
+	if err != nil {
+		return Record{}, err
+	}
+	if record.Status == StatusTesting || record.LeaseID == "" {
+		return Record{}, ErrInvalid
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.records[memoryKey(record.Key)]
+	if !ok || current.Status != StatusTesting || current.LeaseID != record.LeaseID {
+		return Record{}, ErrLeaseLost
+	}
+	record.LeaseID = ""
+	record.LeaseUntil = time.Time{}
+	s.records[memoryKey(record.Key)] = record
+	return record, nil
+}
+
+func memoryKey(key Key) string {
+	return key.Provider + "\x00" + key.Model + "\x00" + string(key.Instance.Kind) + "\x00" + key.Instance.ID + "\x00" + strconv.Itoa(key.Version)
+}

--- a/internal/modelprobe/sql.go
+++ b/internal/modelprobe/sql.go
@@ -1,0 +1,291 @@
+package modelprobe
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/storage"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+type SQLStore struct {
+	client  storage.SQLClient
+	backend string
+	table   string
+}
+
+func NewSQLiteStore(ctx context.Context, client *storage.SQLiteClient) (*SQLStore, error) {
+	return newSQLStore(ctx, client)
+}
+
+func NewPostgresStore(ctx context.Context, client *storage.PostgresClient) (*SQLStore, error) {
+	return newSQLStore(ctx, client)
+}
+
+func newSQLStore(ctx context.Context, client storage.SQLClient) (*SQLStore, error) {
+	if client == nil || client.DB() == nil {
+		return nil, errors.New("sql client is required")
+	}
+	store := &SQLStore{
+		client:  client,
+		backend: client.Backend(),
+		table:   client.QualifiedTable("model_tool_probes"),
+	}
+	if err := store.migrate(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *SQLStore) Backend() string { return s.backend }
+
+func (s *SQLStore) migrate(ctx context.Context) error {
+	timestamp := storage.TimestampColumnDefaultZero(s.client)
+	_, err := s.client.DB().ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS `+s.table+` (
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    instance_id TEXT NOT NULL,
+    instance_kind TEXT NOT NULL,
+    probe_version INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    checked_at `+timestamp+`,
+    expires_at `+timestamp+`,
+    lease_until `+timestamp+`,
+    lease_id TEXT NOT NULL DEFAULT '',
+    reason TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (provider, model, instance_id, instance_kind, probe_version)
+)`)
+	if err != nil {
+		return fmt.Errorf("migrate %s model tool probes: %w", s.backend, err)
+	}
+	return nil
+}
+
+func (s *SQLStore) Get(ctx context.Context, key Key) (Record, bool, error) {
+	key, err := NormalizeKey(key)
+	if err != nil {
+		return Record{}, false, err
+	}
+	record, err := s.get(ctx, s.client.DB(), key, false)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Record{}, false, nil
+	}
+	if err != nil {
+		return Record{}, false, fmt.Errorf("read %s model tool probe: %w", s.backend, err)
+	}
+	return record, true, nil
+}
+
+const getManyBatchSize = 100
+
+// GetMany reads bounded groups of exact generation keys. The predicate stays
+// fully keyed rather than looking up by provider/model alone, so a same-name
+// provider replacement can never project an old probe result.
+func (s *SQLStore) GetMany(ctx context.Context, keys []Key) (map[Key]Record, error) {
+	keys, err := normalizeKeys(keys)
+	if err != nil {
+		return nil, err
+	}
+	records := make(map[Key]Record, len(keys))
+	for start := 0; start < len(keys); start += getManyBatchSize {
+		end := start + getManyBatchSize
+		if end > len(keys) {
+			end = len(keys)
+		}
+		batch := keys[start:end]
+		clauses := make([]string, 0, len(batch))
+		args := make([]any, 0, len(batch)*5)
+		for _, key := range batch {
+			clauses = append(clauses, "(provider = ? AND model = ? AND instance_id = ? AND instance_kind = ? AND probe_version = ?)")
+			args = append(args, key.Provider, key.Model, key.Instance.ID, string(key.Instance.Kind), key.Version)
+		}
+		rows, queryErr := s.client.DB().QueryContext(ctx, `
+SELECT provider, model, instance_id, instance_kind, probe_version,
+       status, checked_at, expires_at, lease_until, lease_id, reason
+FROM `+s.table+`
+WHERE `+strings.Join(clauses, " OR "), args...)
+		if queryErr != nil {
+			return nil, fmt.Errorf("batch read %s model tool probes: %w", s.backend, queryErr)
+		}
+		for rows.Next() {
+			var (
+				record       Record
+				instanceKind string
+			)
+			if scanErr := rows.Scan(
+				&record.Provider,
+				&record.Model,
+				&record.Instance.ID,
+				&instanceKind,
+				&record.Version,
+				&record.Status,
+				&record.CheckedAt,
+				&record.ExpiresAt,
+				&record.LeaseUntil,
+				&record.LeaseID,
+				&record.Reason,
+			); scanErr != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan %s model tool probe batch: %w", s.backend, scanErr)
+			}
+			record.Instance.Kind = types.ProviderInstanceIdentityKind(instanceKind)
+			normalized, normalizeErr := NormalizeRecord(record)
+			if normalizeErr != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("normalize %s model tool probe batch: %w", s.backend, normalizeErr)
+			}
+			records[normalized.Key] = normalized
+		}
+		if rowsErr := rows.Err(); rowsErr != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("iterate %s model tool probe batch: %w", s.backend, rowsErr)
+		}
+		if closeErr := rows.Close(); closeErr != nil {
+			return nil, fmt.Errorf("close %s model tool probe batch: %w", s.backend, closeErr)
+		}
+	}
+	return records, nil
+}
+
+func (s *SQLStore) Acquire(ctx context.Context, key Key, now time.Time, leaseUntil time.Time, leaseID string) (Record, bool, error) {
+	key, err := NormalizeKey(key)
+	if err != nil {
+		return Record{}, false, err
+	}
+	if now.IsZero() || leaseUntil.IsZero() || !leaseUntil.After(now) || leaseID == "" {
+		return Record{}, false, ErrInvalid
+	}
+	now = now.UTC()
+	leaseUntil = leaseUntil.UTC()
+	tx, err := s.client.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return Record{}, false, fmt.Errorf("begin %s model tool probe lease: %w", s.backend, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	current, err := s.get(ctx, tx, key, s.client.Dialect() == storage.DialectPostgres)
+	if err == nil {
+		if current.Active(now) || current.LeaseActive(now) {
+			if err := tx.Commit(); err != nil {
+				return Record{}, false, fmt.Errorf("commit %s model tool probe lease read: %w", s.backend, err)
+			}
+			return current, false, nil
+		}
+		current.Status = StatusTesting
+		current.CheckedAt = now
+		current.ExpiresAt = leaseUntil
+		current.LeaseUntil = leaseUntil
+		current.LeaseID = leaseID
+		current.Reason = ReasonNone
+		if _, err := tx.ExecContext(ctx, `
+UPDATE `+s.table+`
+SET status = ?, checked_at = ?, expires_at = ?, lease_until = ?, lease_id = ?, reason = ?
+WHERE provider = ? AND model = ? AND instance_id = ? AND instance_kind = ? AND probe_version = ?`,
+			current.Status, current.CheckedAt, current.ExpiresAt, current.LeaseUntil, current.LeaseID, current.Reason,
+			key.Provider, key.Model, key.Instance.ID, string(key.Instance.Kind), key.Version,
+		); err != nil {
+			return Record{}, false, fmt.Errorf("lease %s model tool probe: %w", s.backend, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return Record{}, false, fmt.Errorf("commit %s model tool probe lease: %w", s.backend, err)
+		}
+		return current, true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return Record{}, false, fmt.Errorf("read %s model tool probe lease: %w", s.backend, err)
+	}
+	record := Record{
+		Key:        key,
+		Status:     StatusTesting,
+		CheckedAt:  now,
+		ExpiresAt:  leaseUntil,
+		LeaseUntil: leaseUntil,
+		LeaseID:    leaseID,
+	}
+	result, err := tx.ExecContext(ctx, `
+INSERT INTO `+s.table+` (
+    provider, model, instance_id, instance_kind, probe_version,
+    status, checked_at, expires_at, lease_until, lease_id, reason
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(provider, model, instance_id, instance_kind, probe_version) DO NOTHING`,
+		key.Provider, key.Model, key.Instance.ID, string(key.Instance.Kind), key.Version,
+		record.Status, record.CheckedAt, record.ExpiresAt, record.LeaseUntil, record.LeaseID, record.Reason,
+	)
+	if err != nil {
+		return Record{}, false, fmt.Errorf("create %s model tool probe lease: %w", s.backend, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return Record{}, false, fmt.Errorf("inspect %s model tool probe lease: %w", s.backend, err)
+	}
+	if rows == 0 {
+		if err := tx.Commit(); err != nil {
+			return Record{}, false, fmt.Errorf("commit %s model tool probe lease collision: %w", s.backend, err)
+		}
+		current, _, err := s.Get(ctx, key)
+		return current, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Record{}, false, fmt.Errorf("commit %s model tool probe lease: %w", s.backend, err)
+	}
+	return record, true, nil
+}
+
+func (s *SQLStore) Complete(ctx context.Context, record Record) (Record, error) {
+	record, err := NormalizeRecord(record)
+	if err != nil {
+		return Record{}, err
+	}
+	if record.Status == StatusTesting || record.LeaseID == "" {
+		return Record{}, ErrInvalid
+	}
+	result, err := s.client.DB().ExecContext(ctx, `
+UPDATE `+s.table+`
+SET status = ?, checked_at = ?, expires_at = ?, lease_until = ?, lease_id = '', reason = ?
+WHERE provider = ? AND model = ? AND instance_id = ? AND instance_kind = ? AND probe_version = ?
+  AND status = ? AND lease_id = ?`,
+		record.Status, record.CheckedAt, record.ExpiresAt, time.Time{}, record.Reason,
+		record.Provider, record.Model, record.Instance.ID, string(record.Instance.Kind), record.Version,
+		StatusTesting, record.LeaseID,
+	)
+	if err != nil {
+		return Record{}, fmt.Errorf("complete %s model tool probe: %w", s.backend, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return Record{}, fmt.Errorf("inspect %s model tool probe completion: %w", s.backend, err)
+	}
+	if rows != 1 {
+		return Record{}, ErrLeaseLost
+	}
+	record.LeaseUntil = time.Time{}
+	record.LeaseID = ""
+	return record, nil
+}
+
+type probeQueryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func (s *SQLStore) get(ctx context.Context, queryer probeQueryer, key Key, lock bool) (Record, error) {
+	query := `
+SELECT status, checked_at, expires_at, lease_until, lease_id, reason
+FROM ` + s.table + `
+WHERE provider = ? AND model = ? AND instance_id = ? AND instance_kind = ? AND probe_version = ?`
+	if lock && s.client.Dialect() == storage.DialectPostgres {
+		query += " FOR UPDATE"
+	}
+	record := Record{Key: key}
+	err := queryer.QueryRowContext(ctx, query,
+		key.Provider, key.Model, key.Instance.ID, string(key.Instance.Kind), key.Version,
+	).Scan(&record.Status, &record.CheckedAt, &record.ExpiresAt, &record.LeaseUntil, &record.LeaseID, &record.Reason)
+	if err != nil {
+		return Record{}, err
+	}
+	return NormalizeRecord(record)
+}

--- a/internal/modelprobe/store.go
+++ b/internal/modelprobe/store.go
@@ -1,0 +1,211 @@
+// Package modelprobe owns Hecate's narrow, operator-triggered model tool
+// capability verification state. It is deliberately independent of provider
+// discovery: provider-native metadata remains authoritative and this package
+// stores no user prompt, response text, tool arguments, endpoint, or secret.
+package modelprobe
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+const (
+	ProbeVersion = 1
+
+	StatusTesting      = "testing"
+	StatusSupported    = "supported"
+	StatusUnsupported  = "unsupported"
+	StatusInconclusive = "inconclusive"
+
+	ReasonNone             = ""
+	ReasonNoToolCall       = "no_tool_call"
+	ReasonToolRejected     = "tool_rejected"
+	ReasonAuthentication   = "authentication"
+	ReasonRateLimited      = "rate_limited"
+	ReasonTimeout          = "timeout"
+	ReasonNetwork          = "network"
+	ReasonProviderFailure  = "provider_failure"
+	ReasonProviderChanged  = "provider_changed"
+	ReasonPolicyDenied     = "policy_denied"
+	ReasonConfiguration    = "configuration"
+	ReasonUnexpectedResult = "unexpected_result"
+)
+
+var (
+	ErrLeaseLost = errors.New("model tool probe lease was lost")
+	ErrInvalid   = errors.New("invalid model tool probe record")
+)
+
+// Key is internal-only because Instance is an opaque provider-generation
+// fence. It must never be emitted in HTTP responses or telemetry.
+type Key struct {
+	Provider string
+	Model    string
+	Instance types.ProviderInstanceIdentity
+	Version  int
+}
+
+// Record is durable Hecate runtime state for a single provider/model
+// generation. LeaseID is a private fence used only by Complete.
+type Record struct {
+	Key
+	Status     string
+	CheckedAt  time.Time
+	ExpiresAt  time.Time
+	LeaseUntil time.Time
+	LeaseID    string
+	Reason     string
+}
+
+// Store provides durable single-probe reservations. Acquire never holds the
+// transaction over an upstream call; Complete must present the lease returned
+// by Acquire, preventing a stale response from overwriting a newer attempt.
+type Store interface {
+	Backend() string
+	Get(ctx context.Context, key Key) (Record, bool, error)
+	Acquire(ctx context.Context, key Key, now time.Time, leaseUntil time.Time, leaseID string) (record Record, acquired bool, err error)
+	Complete(ctx context.Context, record Record) (Record, error)
+}
+
+// BatchStore is an optional read extension for catalog projection. Durable
+// stores implement it so listing a large provider catalog does not turn one
+// model-capability request into one query per model. Callers retain the Store
+// fallback for narrow test doubles and third-party in-memory implementations.
+type BatchStore interface {
+	GetMany(ctx context.Context, keys []Key) (map[Key]Record, error)
+}
+
+func NormalizeKey(key Key) (Key, error) {
+	key.Provider = strings.TrimSpace(key.Provider)
+	key.Model = strings.TrimSpace(key.Model)
+	if key.Version <= 0 {
+		key.Version = ProbeVersion
+	}
+	if key.Provider == "" || key.Model == "" || !key.Instance.Valid() {
+		return Key{}, ErrInvalid
+	}
+	return key, nil
+}
+
+func normalizeKeys(keys []Key) ([]Key, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	normalized := make([]Key, 0, len(keys))
+	seen := make(map[Key]struct{}, len(keys))
+	for _, raw := range keys {
+		key, err := NormalizeKey(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, found := seen[key]; found {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, key)
+	}
+	return normalized, nil
+}
+
+func NormalizeRecord(record Record) (Record, error) {
+	key, err := NormalizeKey(record.Key)
+	if err != nil {
+		return Record{}, err
+	}
+	record.Key = key
+	record.Status = normalizeStatus(record.Status)
+	record.Reason = normalizeReason(record.Reason)
+	if record.Status == "" {
+		return Record{}, ErrInvalid
+	}
+	if !record.CheckedAt.IsZero() {
+		record.CheckedAt = record.CheckedAt.UTC()
+	}
+	if !record.ExpiresAt.IsZero() {
+		record.ExpiresAt = record.ExpiresAt.UTC()
+	}
+	if !record.LeaseUntil.IsZero() {
+		record.LeaseUntil = record.LeaseUntil.UTC()
+	}
+	record.LeaseID = strings.TrimSpace(record.LeaseID)
+	if record.Status == StatusTesting && (record.LeaseID == "" || record.LeaseUntil.IsZero()) {
+		return Record{}, ErrInvalid
+	}
+	return record, nil
+}
+
+func (record Record) Active(now time.Time) bool {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return !record.ExpiresAt.IsZero() && now.Before(record.ExpiresAt)
+}
+
+func (record Record) LeaseActive(now time.Time) bool {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return record.Status == StatusTesting && !record.LeaseUntil.IsZero() && now.Before(record.LeaseUntil)
+}
+
+func (record Record) Public() *types.ToolCapabilityVerification {
+	if record.Status == "" {
+		return nil
+	}
+	return &types.ToolCapabilityVerification{
+		Status:    record.Status,
+		CheckedAt: record.CheckedAt,
+		ExpiresAt: record.ExpiresAt,
+		Reason:    record.Reason,
+	}
+}
+
+func normalizeStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case StatusTesting:
+		return StatusTesting
+	case StatusSupported:
+		return StatusSupported
+	case StatusUnsupported:
+		return StatusUnsupported
+	case StatusInconclusive:
+		return StatusInconclusive
+	default:
+		return ""
+	}
+}
+
+func normalizeReason(reason string) string {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case ReasonNone:
+		return ReasonNone
+	case ReasonNoToolCall:
+		return ReasonNoToolCall
+	case ReasonToolRejected:
+		return ReasonToolRejected
+	case ReasonAuthentication:
+		return ReasonAuthentication
+	case ReasonRateLimited:
+		return ReasonRateLimited
+	case ReasonTimeout:
+		return ReasonTimeout
+	case ReasonNetwork:
+		return ReasonNetwork
+	case ReasonProviderFailure:
+		return ReasonProviderFailure
+	case ReasonProviderChanged:
+		return ReasonProviderChanged
+	case ReasonPolicyDenied:
+		return ReasonPolicyDenied
+	case ReasonConfiguration:
+		return ReasonConfiguration
+	case ReasonUnexpectedResult:
+		return ReasonUnexpectedResult
+	default:
+		return ReasonUnexpectedResult
+	}
+}

--- a/internal/modelprobe/store_test.go
+++ b/internal/modelprobe/store_test.go
@@ -1,0 +1,193 @@
+package modelprobe
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hecatehq/hecate/internal/storage"
+	"github.com/hecatehq/hecate/pkg/types"
+)
+
+func TestStoreLeaseAndGenerationConformance(t *testing.T) {
+	t.Parallel()
+	for _, factory := range []struct {
+		name string
+		new  func(*testing.T) Store
+	}{
+		{name: "memory", new: func(*testing.T) Store { return NewMemoryStore() }},
+		{name: "sqlite", new: newSQLiteStore},
+	} {
+		factory := factory
+		t.Run(factory.name, func(t *testing.T) {
+			t.Parallel()
+			store := factory.new(t)
+			now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+			key := testKey("generation-a")
+			lease, acquired, err := store.Acquire(t.Context(), key, now, now.Add(time.Minute), "lease-a")
+			if err != nil || !acquired || lease.Status != StatusTesting {
+				t.Fatalf("Acquire() = %+v, %t, %v", lease, acquired, err)
+			}
+			joined, acquired, err := store.Acquire(t.Context(), key, now.Add(time.Second), now.Add(time.Minute), "lease-b")
+			if err != nil || acquired || joined.LeaseID != "lease-a" {
+				t.Fatalf("joined Acquire() = %+v, %t, %v", joined, acquired, err)
+			}
+
+			lease.Status = StatusSupported
+			lease.Reason = ReasonNone
+			lease.CheckedAt = now.Add(2 * time.Second)
+			lease.ExpiresAt = now.Add(24 * time.Hour)
+			completed, err := store.Complete(t.Context(), lease)
+			if err != nil || completed.Status != StatusSupported || completed.LeaseID != "" {
+				t.Fatalf("Complete() = %+v, %v", completed, err)
+			}
+			cached, acquired, err := store.Acquire(t.Context(), key, now.Add(time.Minute), now.Add(2*time.Minute), "lease-c")
+			if err != nil || acquired || cached.Status != StatusSupported {
+				t.Fatalf("cached Acquire() = %+v, %t, %v", cached, acquired, err)
+			}
+
+			stale := completed
+			stale.LeaseID = "wrong-lease"
+			if _, err := store.Complete(t.Context(), stale); !errors.Is(err, ErrLeaseLost) && !errors.Is(err, ErrInvalid) {
+				t.Fatalf("stale Complete() error = %v, want lease failure", err)
+			}
+			if _, found, err := store.Get(t.Context(), testKey("generation-b")); err != nil || found {
+				t.Fatalf("Get(new generation) = found %t, err %v", found, err)
+			}
+
+			expired, acquired, err := store.Acquire(t.Context(), key, now.Add(25*time.Hour), now.Add(25*time.Hour+time.Minute), "lease-d")
+			if err != nil || !acquired || expired.LeaseID != "lease-d" {
+				t.Fatalf("Acquire(expired) = %+v, %t, %v", expired, acquired, err)
+			}
+		})
+	}
+}
+
+func TestStoreGetManyReturnsOnlyExactGenerationRecords(t *testing.T) {
+	t.Parallel()
+	for _, factory := range []struct {
+		name string
+		new  func(*testing.T) Store
+	}{
+		{name: "memory", new: func(*testing.T) Store { return NewMemoryStore() }},
+		{name: "sqlite", new: newSQLiteStore},
+	} {
+		factory := factory
+		t.Run(factory.name, func(t *testing.T) {
+			t.Parallel()
+			store := factory.new(t)
+			batch, ok := store.(BatchStore)
+			if !ok {
+				t.Fatalf("%T does not implement BatchStore", store)
+			}
+			now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+			key := testKey("generation-a")
+			lease, acquired, err := store.Acquire(t.Context(), key, now, now.Add(time.Minute), "batch-lease")
+			if err != nil || !acquired {
+				t.Fatalf("Acquire() = %+v, %t, %v", lease, acquired, err)
+			}
+			lease.Status = StatusSupported
+			lease.CheckedAt = now
+			lease.ExpiresAt = now.Add(time.Hour)
+			if _, err := store.Complete(t.Context(), lease); err != nil {
+				t.Fatalf("Complete() error = %v", err)
+			}
+
+			records, err := batch.GetMany(t.Context(), []Key{key, key, testKey("generation-b")})
+			if err != nil {
+				t.Fatalf("GetMany() error = %v", err)
+			}
+			if len(records) != 1 || records[key].Status != StatusSupported {
+				t.Fatalf("GetMany() = %+v, want only supported generation-a record", records)
+			}
+		})
+	}
+}
+
+func TestCoordinatorCoalescesProviderCalls(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	coordinator := NewCoordinator(store)
+	coordinator.now = func() time.Time { return time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC) }
+	started := make(chan struct{})
+	release := make(chan struct{})
+	results := make(chan Record, 2)
+	errs := make(chan error, 2)
+	var calls atomic.Int32
+	for range 2 {
+		go func() {
+			record, _, err := coordinator.Verify(context.Background(), testKey("generation-a"), func(context.Context) Outcome {
+				calls.Add(1)
+				select {
+				case started <- struct{}{}:
+				default:
+				}
+				<-release
+				return Outcome{Status: StatusSupported}
+			})
+			results <- record
+			errs <- err
+		}()
+	}
+	<-started
+	close(release)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("Verify() error = %v", err)
+		}
+		if record := <-results; record.Status != StatusSupported {
+			t.Fatalf("Verify() record = %+v", record)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("probe calls = %d, want 1", got)
+	}
+}
+
+func TestCoordinatorSkipsProbeWhenCallerIsAlreadyCanceled(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	coordinator := NewCoordinator(store)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	called := false
+
+	record, performed, err := coordinator.Verify(ctx, testKey("generation-a"), func(context.Context) Outcome {
+		called = true
+		return Outcome{Status: StatusSupported}
+	})
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !performed || called || record.Status != StatusInconclusive || record.Reason != ReasonUnexpectedResult {
+		t.Fatalf("Verify() = record %+v performed=%t called=%t, want completed inconclusive without provider call", record, performed, called)
+	}
+}
+
+func testKey(instance string) Key {
+	return Key{
+		Provider: "local-provider",
+		Model:    "custom-model",
+		Instance: types.ProviderInstanceIdentity{ID: instance, Kind: types.ProviderInstanceIdentityConfiguration},
+		Version:  ProbeVersion,
+	}
+}
+
+func newSQLiteStore(t *testing.T) Store {
+	t.Helper()
+	client, err := storage.NewSQLiteClient(context.Background(), storage.SQLiteConfig{
+		Path: filepath.Join(t.TempDir(), "modelprobe.db"),
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	store, err := NewSQLiteStore(context.Background(), client)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error = %v", err)
+	}
+	return store
+}

--- a/internal/orchestrator/executor_agent_loop_chat.go
+++ b/internal/orchestrator/executor_agent_loop_chat.go
@@ -125,10 +125,11 @@ func agentLoopChatRequest(spec ExecutionSpec, messages []types.Message, tools []
 	// tasks that didn't specify a provider.
 	requirements := spec.ChatRequirements
 	// Rich input needs one candidate that is explicitly capable of both the
-	// image and the tool catalog. Ordinary Task Runs retain their established
-	// optimistic behavior for providers whose capability discovery is unknown;
-	// the provider remains the authority for a normal tool-call rejection.
-	requirements.ToolCalling = requirements.ImageInput && len(tools) > 0
+	// image and the tool catalog. A Hecate-owned manual proof is also an
+	// explicit tool capability requirement, even without an image: it carries
+	// a private exact-provider/generation/model/expiry fence. Ordinary Task
+	// Runs retain their established optimistic behavior for unknown discovery.
+	requirements.ToolCalling = len(tools) > 0 && (requirements.ImageInput || requirements.ToolCallingVerified)
 	return types.ChatRequest{
 		RequestID:    spec.RequestID,
 		Model:        spec.Run.Model,

--- a/internal/orchestrator/executor_agent_loop_model_call_test.go
+++ b/internal/orchestrator/executor_agent_loop_model_call_test.go
@@ -365,6 +365,21 @@ func TestAgentLoopChatRequestLeavesUnknownToolCapabilitiesRoutableWithoutRichInp
 	if !richRequest.Requirements.ToolCalling {
 		t.Fatalf("rich tool request requirements = %+v, want hard tool-capability requirement", richRequest.Requirements)
 	}
+
+	fence := types.ToolCallingVerificationFence{
+		Provider:         "local-runtime",
+		Model:            spec.Run.Model,
+		ProviderInstance: types.ProviderInstanceIdentity{ID: "verified-generation", Kind: types.ProviderInstanceIdentityConfiguration},
+		ExpiresAt:        time.Now().UTC().Add(time.Hour),
+	}
+	spec.Run.Provider = fence.Provider
+	spec.ChatRequirements = fence.ToolCallingRequirements()
+	verifiedRequest := agentLoopChatRequest(spec, nil, agentToolDefinitions())
+	if verifiedRequest.Requirements.ImageInput || !verifiedRequest.Requirements.ToolCalling || !verifiedRequest.Requirements.ToolCallingVerified ||
+		!verifiedRequest.Requirements.NoProviderFailover || !verifiedRequest.Requirements.ExactProvider || verifiedRequest.Requirements.ProviderInstance != fence.ProviderInstance ||
+		verifiedRequest.Requirements.ToolCallingVerifiedModel != fence.Model || verifiedRequest.Scope.ProviderHint != fence.Provider {
+		t.Fatalf("verified plain tool request = %+v scope=%+v, want durable exact tool-proof fence without image", verifiedRequest.Requirements, verifiedRequest.Scope)
+	}
 }
 
 func TestAgentLoopModelCall_ErrorRecordsAttemptedProviderInstance(t *testing.T) {

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -920,6 +920,11 @@ func (r *Runner) startTaskWithOptions(ctx context.Context, task types.Task, idge
 	}
 	if sameInputSource != nil && task.ExecutionKind == "agent_loop" && strings.TrimSpace(options.AppendPrompt) == "" {
 		prior := *sameInputSource
+		// A manually verified unknown tool capability is a run-scoped execution
+		// fence, not a session display hint. Retain it for a same-input retry or
+		// resume so every new dispatch still checks the original provider/model/
+		// generation/expiry proof instead of reverting to optimistic routing.
+		run.ToolCallingVerification = prior.ToolCallingVerification
 		run.InputRef = strings.TrimSpace(prior.InputRef)
 		if run.InputRef != "" && prior.InputProviderInstance.Valid() {
 			run.InputProviderInstance = prior.InputProviderInstance
@@ -1466,6 +1471,12 @@ func (r *Runner) executeRun(ctx context.Context, trace *profiler.Trace, task typ
 		if agentInput.Release != nil {
 			defer agentInput.Release()
 		}
+	} else if task.ExecutionKind == "agent_loop" && run.ToolCallingVerification.Valid() {
+		// Plain tools-on Hecate Chat has no rich-input resolver. Project its
+		// durable manual-proof fence directly into the execution request so a
+		// queued or retried run is still exact-provider, generation, model, and
+		// expiry bound at every final gateway dispatch.
+		agentInput.Requirements = run.ToolCallingVerification.ToolCallingRequirements()
 	}
 	var inputMessage *types.Message
 	if task.ExecutionKind == "agent_loop" && strings.TrimSpace(run.InputRef) != "" {

--- a/internal/orchestrator/runner_lifecycle_test.go
+++ b/internal/orchestrator/runner_lifecycle_test.go
@@ -597,6 +597,67 @@ func TestResumeTaskCarriesForwardContextPacket(t *testing.T) {
 	}
 }
 
+func TestRetryTaskCarriesForwardPlainToolVerificationFence(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := taskstate.NewMemoryStore()
+	runner := NewRunner(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		store,
+		nil,
+		Config{QueueWorkers: 0},
+	)
+	now := time.Now().UTC()
+	fence := types.ToolCallingVerificationFence{
+		Provider:         "local-runtime",
+		Model:            "custom-model",
+		ProviderInstance: types.ProviderInstanceIdentity{ID: "verified-generation", Kind: types.ProviderInstanceIdentityConfiguration},
+		ExpiresAt:        now.Add(time.Hour),
+	}
+	task := types.Task{
+		ID:                "task-retry-tool-verification",
+		Title:             "retry verified tools",
+		Prompt:            "retry me",
+		ExecutionKind:     "agent_loop",
+		RequestedProvider: fence.Provider,
+		RequestedModel:    fence.Model,
+		WorkingDirectory:  t.TempDir(),
+		Status:            "failed",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	run := types.TaskRun{
+		ID:                      "run-retry-tool-verification",
+		TaskID:                  task.ID,
+		Number:                  1,
+		Status:                  "failed",
+		Provider:                fence.Provider,
+		Model:                   fence.Model,
+		StartedAt:               now,
+		FinishedAt:              now,
+		ToolCallingVerification: fence,
+	}
+	if _, err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	result, err := runner.RetryTask(ctx, task, run, defaultResourceID)
+	if err != nil {
+		t.Fatalf("RetryTask: %v", err)
+	}
+	stored, found, err := store.GetRun(ctx, task.ID, result.Run.ID)
+	if err != nil || !found {
+		t.Fatalf("GetRun(%q) found=%v err=%v", result.Run.ID, found, err)
+	}
+	if stored.InputRef != "" || stored.ToolCallingVerification != fence {
+		t.Fatalf("retry run = %+v, want the original plain tool-proof fence", stored)
+	}
+}
+
 func TestRetryTaskCarriesForwardOnlySourceContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/hecatehq/hecate/internal/catalog"
 	"github.com/hecatehq/hecate/internal/modelcaps"
@@ -164,7 +165,7 @@ func (r *RuleRouter) routeExplicitProvider(ctx context.Context, req types.ChatRe
 		}
 	}
 	if req.Requirements.ProviderInstance.Valid() && entry.ProviderInstance != req.Requirements.ProviderInstance {
-		return types.RouteDecision{}, fmt.Errorf("provider %q configuration changed during image admission", explicitProvider)
+		return types.RouteDecision{}, fmt.Errorf("provider %q configuration changed during bound route admission", explicitProvider)
 	}
 	if !supportsRequest(entry, routedModel, req) {
 		return types.RouteDecision{}, fmt.Errorf("provider %q model %q does not satisfy required %s support", explicitProvider, routedModel, requestCapabilityLabel(req.Requirements))
@@ -284,7 +285,28 @@ func supportsRequest(entry catalog.Entry, model string, req types.ChatRequest) b
 	if req.Requirements.ImageInput && !modelcaps.ImageCapable(capability) {
 		return false
 	}
-	return !req.Requirements.ToolCalling || modelcaps.ToolCapable(capability)
+	if !req.Requirements.ToolCalling || modelcaps.ToolCapable(capability) {
+		return true
+	}
+	return verifiedToolCallingApplies(entry, model, req)
+}
+
+// verifiedToolCallingApplies is intentionally narrower than an ordinary tool
+// capability check. The marker comes only from Hecate's final task admission
+// after an operator-triggered probe has been projected for this exact provider
+// generation. Requiring every route fence keeps a proof from one provider from
+// authorizing auto-routing, a model rewrite, or provider failover.
+func verifiedToolCallingApplies(entry catalog.Entry, model string, req types.ChatRequest) bool {
+	if !req.Requirements.ToolCallingVerified ||
+		!req.Requirements.NoProviderFailover ||
+		!req.Requirements.ExactProvider ||
+		!req.Requirements.ProviderInstance.Valid() ||
+		entry.ProviderInstance != req.Requirements.ProviderInstance ||
+		strings.TrimSpace(req.Requirements.ToolCallingVerifiedModel) != strings.TrimSpace(model) ||
+		!req.Requirements.ToolCallingVerifiedUntil.After(time.Now().UTC()) {
+		return false
+	}
+	return requestscope.Normalize(req.Scope).ProviderHint == entry.Name
 }
 
 func requestCapabilityLabel(requirements types.ChatRequestRequirements) string {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hecatehq/hecate/internal/catalog"
 	"github.com/hecatehq/hecate/internal/config"
+	"github.com/hecatehq/hecate/internal/modelcaps"
 	"github.com/hecatehq/hecate/internal/providers"
 	"github.com/hecatehq/hecate/pkg/types"
 )
@@ -414,6 +415,84 @@ func TestRuleRouterRequiresImageAndToolCapabilitiesOnSameCandidate(t *testing.T)
 	})
 }
 
+func TestRuleRouterAllowsVerifiedUnknownToolsOnlyForExactRichInputRoute(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{
+		name:            "verified-vision",
+		kind:            providers.KindCloud,
+		defaultModel:    "custom-vision",
+		supportedModels: []string{"custom-vision"},
+		capabilities: providers.Capabilities{
+			Name:            "verified-vision",
+			Kind:            providers.KindCloud,
+			DefaultModel:    "custom-vision",
+			Models:          []string{"custom-vision"},
+			DiscoverySource: "provider",
+			ModelCapabilities: map[string]types.ModelCapabilities{
+				"custom-vision": {
+					ImageInput:  modelcaps.ImageInputSupported,
+					ToolCalling: modelcaps.ToolCallingUnknown,
+					Source:      modelcaps.SourceProvider,
+				},
+			},
+		},
+	}
+	registry := providers.NewRegistry(provider)
+	instance, ok := registry.GetInstance(provider.Name())
+	if !ok || !instance.Identity.Valid() {
+		t.Fatalf("provider instance = %+v, found=%t, want valid identity", instance, ok)
+	}
+	router := NewRuleRouter("", catalog.NewRegistryCatalog(registry, nil))
+	request := types.ChatRequest{
+		Model: "custom-vision",
+		Scope: types.RequestScope{ProviderHint: provider.Name()},
+		Requirements: types.ChatRequestRequirements{
+			ImageInput:         true,
+			ToolCalling:        true,
+			NoProviderFailover: true,
+			ExactProvider:      true,
+			ProviderInstance:   instance.Identity,
+		},
+	}
+
+	if _, err := router.Route(context.Background(), request); err == nil {
+		t.Fatal("Route() error = nil, want unknown tool capability rejected without verification")
+	}
+	request.Requirements.ToolCallingVerified = true
+	request.Requirements.ToolCallingVerifiedModel = "custom-vision"
+	request.Requirements.ToolCallingVerifiedUntil = time.Now().UTC().Add(time.Hour)
+	if _, err := router.Route(context.Background(), request); err != nil {
+		t.Fatalf("Route() error = %v, want generation-fenced verified route", err)
+	}
+	request.Requirements.ImageInput = false
+	if _, err := router.Route(context.Background(), request); err != nil {
+		t.Fatalf("Route() plain verified tool request error = %v, want exact generation-fenced route without image", err)
+	}
+	request.Requirements.ImageInput = true
+	request.Requirements.ToolCallingVerifiedModel = "different-model"
+	if _, err := router.Route(context.Background(), request); err == nil {
+		t.Fatal("Route() error = nil, want model-mismatched verification rejected")
+	}
+	request.Requirements.ToolCallingVerifiedModel = "custom-vision"
+	request.Requirements.ToolCallingVerifiedUntil = time.Now().UTC().Add(-time.Second)
+	if _, err := router.Route(context.Background(), request); err == nil {
+		t.Fatal("Route() error = nil, want expired verification rejected")
+	}
+	request.Requirements.ToolCallingVerifiedUntil = time.Now().UTC().Add(time.Hour)
+
+	request.Requirements.ProviderInstance = types.ProviderInstanceIdentity{}
+	if _, err := router.Route(context.Background(), request); err == nil {
+		t.Fatal("Route() error = nil, want unfenced verification rejected")
+	}
+
+	request.Requirements.ProviderInstance = instance.Identity
+	request.Requirements.NoProviderFailover = false
+	if _, err := router.Route(context.Background(), request); err == nil {
+		t.Fatal("Route() error = nil, want failover-capable verification rejected")
+	}
+}
+
 func TestRuleRouterRejectsExpectedProviderInstanceAfterSameNameReplacement(t *testing.T) {
 	t.Parallel()
 
@@ -455,7 +534,7 @@ func TestRuleRouterRejectsExpectedProviderInstanceAfterSameNameReplacement(t *te
 
 	request.Requirements.ProviderInstance = admitted.ProviderInstance
 	registry.Replace(newVisionProvider())
-	if _, err := router.Route(context.Background(), request); err == nil || !strings.Contains(err.Error(), "configuration changed during image admission") {
+	if _, err := router.Route(context.Background(), request); err == nil || !strings.Contains(err.Error(), "configuration changed during bound route admission") {
 		t.Fatalf("Route() error = %v, want expected-instance rejection", err)
 	}
 }

--- a/internal/taskstate/conformance_test.go
+++ b/internal/taskstate/conformance_test.go
@@ -1593,6 +1593,15 @@ func runStoreTaskRunStepRoundTrip(t *testing.T, store Store) {
 			ID:   "runtime-rich-input-disclosed",
 			Kind: types.ProviderInstanceIdentityRuntime,
 		},
+		ToolCallingVerification: types.ToolCallingVerificationFence{
+			Provider: "fixture-cloud",
+			Model:    "fixture-tools-unknown",
+			ProviderInstance: types.ProviderInstanceIdentity{
+				ID:   "runtime-tool-verification",
+				Kind: types.ProviderInstanceIdentityRuntime,
+			},
+			ExpiresAt: time.Date(2030, time.January, 2, 3, 4, 5, 0, time.UTC),
+		},
 	}
 	if _, err := store.CreateRun(ctx, run); err != nil {
 		t.Fatalf("CreateRun: %v", err)
@@ -1612,6 +1621,9 @@ func runStoreTaskRunStepRoundTrip(t *testing.T, store Store) {
 	}
 	if gotRun.InputRef != run.InputRef || gotRun.InputProviderInstance != run.InputProviderInstance || gotRun.InputProviderDispatchRecorded != run.InputProviderDispatchRecorded || gotRun.InputProviderDisclosedInstance != run.InputProviderDisclosedInstance {
 		t.Fatalf("GetRun rich-input fence = ref %q admitted %+v dispatched %t disclosed %+v, want %q/%+v/%t/%+v", gotRun.InputRef, gotRun.InputProviderInstance, gotRun.InputProviderDispatchRecorded, gotRun.InputProviderDisclosedInstance, run.InputRef, run.InputProviderInstance, run.InputProviderDispatchRecorded, run.InputProviderDisclosedInstance)
+	}
+	if gotRun.ToolCallingVerification != run.ToolCallingVerification {
+		t.Fatalf("GetRun tool-calling verification fence = %+v, want %+v", gotRun.ToolCallingVerification, run.ToolCallingVerification)
 	}
 
 	for i, status := range []string{"running", "completed"} {

--- a/pkg/types/chat.go
+++ b/pkg/types/chat.go
@@ -95,9 +95,21 @@ type ChatRequestRequirements struct {
 	// ToolCalling requires each route candidate to declare tool-call support.
 	// Rich-input agent turns set this alongside ImageInput so Auto routing cannot
 	// combine image support from one provider with tool support from another.
-	// Ordinary tool turns may leave it false to retain their established
-	// optimistic behavior for providers with unknown capability discovery.
+	// A manually verified tools-on task also sets it with a private exact-route
+	// fence. Ordinary tool turns may otherwise leave it false to retain their
+	// established optimistic behavior for providers with unknown capability
+	// discovery.
 	ToolCalling bool
+	// ToolCallingVerified carries a Hecate-owned, generation/model/expiry-bound
+	// manual proof for an otherwise-unknown tool capability. It is accepted by
+	// routing only with an exact, no-failover provider fence; it is never
+	// accepted from or emitted to HTTP clients.
+	ToolCallingVerified bool `json:"-"`
+	// ToolCallingVerifiedModel and ToolCallingVerifiedUntil make the internal
+	// verification proof reject a governor model rewrite and expire while a
+	// queued or long-running Hecate task is still alive.
+	ToolCallingVerifiedModel string    `json:"-"`
+	ToolCallingVerifiedUntil time.Time `json:"-"`
 	// NoProviderFailover keeps retries on the selected provider but prevents a
 	// request from crossing into another provider. It also requires the gateway
 	// to revalidate the selected provider instance immediately before every
@@ -310,6 +322,25 @@ type ModelCapabilities struct {
 	// snapshot combines dimensions from provider-native metadata and Hecate's
 	// catalog inference; it must not be presented as wholly provider-reported.
 	Source string `json:"source,omitempty"`
+	// ToolVerification is an operator-triggered, provider-generation-bound
+	// observation for an otherwise unknown tool-calling capability. It never
+	// contains request content, tool arguments, provider credentials, or an
+	// endpoint. Known provider/catalog capabilities remain authoritative.
+	ToolVerification *ToolCapabilityVerification `json:"tool_verification,omitempty"`
+	// ToolCallingVerificationApplied is internal merge metadata. It identifies
+	// a `basic`/`none` value projected from one route-bound verification so an
+	// Auto aggregate can safely restore the otherwise-unknown value.
+	ToolCallingVerificationApplied bool `json:"-"`
+}
+
+// ToolCapabilityVerification is the safe, operator-facing summary of one
+// manual tool-calling capability probe. The internal provider-instance fence
+// used to bind this record is deliberately omitted from the API contract.
+type ToolCapabilityVerification struct {
+	Status    string    `json:"status,omitempty"`
+	CheckedAt time.Time `json:"checked_at,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	Reason    string    `json:"reason,omitempty"`
 }
 
 // ReadinessSummary is the compact operator-facing answer to "can Hecate use

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 )
 
@@ -209,6 +210,47 @@ type MCPServerConfig struct {
 	ApprovalPolicy string
 }
 
+// ToolCallingVerificationFence is the private execution proof created from an
+// operator-triggered tool-capability probe. It is intentionally narrower than
+// a model capability: only this exact provider generation and model may use
+// it, and callers must still check ExpiresAt immediately before dispatch.
+//
+// Task-run persistence retains this internal fence so queued and retried
+// Hecate Chat work cannot lose the admission boundary. Public task-run
+// renderers intentionally omit it.
+type ToolCallingVerificationFence struct {
+	Provider         string
+	Model            string
+	ProviderInstance ProviderInstanceIdentity
+	ExpiresAt        time.Time
+}
+
+func (fence ToolCallingVerificationFence) Valid() bool {
+	return strings.TrimSpace(fence.Provider) != "" &&
+		strings.TrimSpace(fence.Model) != "" &&
+		fence.ProviderInstance.Valid() &&
+		!fence.ExpiresAt.IsZero()
+}
+
+// ToolCallingRequirements projects the private durable fence into the
+// request-scoped constraints enforced by routing and final gateway dispatch.
+// It deliberately does not decide whether the proof is still live; that must
+// happen immediately before every provider attempt.
+func (fence ToolCallingVerificationFence) ToolCallingRequirements() ChatRequestRequirements {
+	if !fence.Valid() {
+		return ChatRequestRequirements{}
+	}
+	return ChatRequestRequirements{
+		ToolCalling:              true,
+		ToolCallingVerified:      true,
+		ToolCallingVerifiedModel: strings.TrimSpace(fence.Model),
+		ToolCallingVerifiedUntil: fence.ExpiresAt.UTC(),
+		NoProviderFailover:       true,
+		ExactProvider:            true,
+		ProviderInstance:         fence.ProviderInstance,
+	}
+}
+
 type TaskRun struct {
 	ID     string
 	TaskID string
@@ -278,6 +320,11 @@ type TaskRun struct {
 	// fence for a disclosure boundary. Public task-run renderers intentionally
 	// omit it.
 	InputProviderDisclosedInstance ProviderInstanceIdentity
+	// ToolCallingVerification carries the private manual-proof fence for a
+	// tools-on Hecate Chat run without rich input. It is zero for ordinary task
+	// runs, which retain their existing optimistic unknown-capability behavior.
+	// Public task-run renderers intentionally omit it.
+	ToolCallingVerification ToolCallingVerificationFence
 	// ScheduleID and ScheduleOccurrenceID identify the durable schedule
 	// occurrence that created this run. They are both empty for manually
 	// started runs. ScheduledFor is the occurrence's nominal wall-clock time,

--- a/ui/src/app/runtimeConsoleDashboard.ts
+++ b/ui/src/app/runtimeConsoleDashboard.ts
@@ -81,8 +81,14 @@ export async function resolveDashboardSnapshot(args: {
   activeChatSessionID: string;
   previous: DashboardPreviousState;
   /**
-   * Fires once the essentials wave (health + session + models +
-   * settingsConfig) resolves, before the secondary wave starts.
+   * Optional model-catalog loader. The providers/models slice supplies this
+   * in production so every catalog response commits through its shared
+   * freshness fence; standalone callers use the API client directly.
+   */
+  loadModels?: () => Promise<ModelResponse>;
+  /**
+   * Fires once the essentials wave (health + session + settingsConfig)
+   * resolves, before the secondary wave starts.
    * The hook uses this to commit just enough state to clear the
    * Connecting gate so the rest of the dashboard can load behind a
    * rendered shell rather than a blocking spinner.
@@ -94,6 +100,7 @@ export async function resolveDashboardSnapshot(args: {
   const results = await loadDashboardResults({
     onEssentials: args.onEssentials ? (essentials) => args.onEssentials!(essentials) : undefined,
     onChatSessionsReadStart: args.onChatSessionsReadStart,
+    loadModels: args.loadModels,
     previousSettingsConfig: args.previous.settingsConfig,
   });
   const health = requireFulfilledDashboardResult(results.health);
@@ -169,6 +176,7 @@ export function deriveSessionState(sessionInfo: SessionResponse["data"] | null):
 async function loadDashboardResults(opts: {
   onEssentials?: (essentials: DashboardEssentials) => void;
   onChatSessionsReadStart?: () => void;
+  loadModels?: () => Promise<ModelResponse>;
   previousSettingsConfig: ConfiguredStateResponse["data"] | null;
 }): Promise<DashboardResults> {
   // Wave 1 — essentials. Three parallel calls drive everything the
@@ -223,10 +231,11 @@ async function loadDashboardResults(opts: {
     opts.previousSettingsConfig,
   );
   const configured = resolvedSettingsConfig?.providers ?? [];
+  const loadModels = opts.loadModels ?? getModels;
   opts.onChatSessionsReadStart?.();
   const chatSessionsRequest = getChatSessions();
   const secondary: Promise<unknown>[] = [
-    getModels().then(
+    loadModels().then(
       (r) => {
         models = { status: "fulfilled", value: r };
       },

--- a/ui/src/app/state/coordinators/dashboard.test.tsx
+++ b/ui/src/app/state/coordinators/dashboard.test.tsx
@@ -1,0 +1,204 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDashboardActions } from "./dashboard";
+import { ChatProvider } from "../chat";
+import { ProvidersAndModelsProvider, useProvidersAndModels } from "../providersAndModels";
+import { RuntimeProvider } from "../runtime";
+import type { ModelResponse } from "../../../types/model";
+
+vi.mock("../../../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../../../lib/api")>("../../../lib/api");
+  return {
+    ...actual,
+    getHealth: vi.fn(),
+    getSession: vi.fn(),
+    getModels: vi.fn(),
+    getProviders: vi.fn(),
+    getAgentAdapters: vi.fn(),
+    getChatSessions: vi.fn(),
+    getSettingsConfig: vi.fn(),
+    getRuntimeStats: vi.fn(),
+  };
+});
+
+import * as api from "../../../lib/api";
+
+const initialModels = [
+  {
+    id: "custom-tool-model",
+    owned_by: "Local Runtime",
+    metadata: {
+      provider: "Local Runtime",
+      capabilities: { tool_calling: "unknown" },
+      readiness: { ready: true, routing_ready: true },
+    },
+  },
+];
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <RuntimeProvider>
+      <ProvidersAndModelsProvider initialState={{ models: initialModels }}>
+        <ChatProvider>{children}</ChatProvider>
+      </ProvidersAndModelsProvider>
+    </RuntimeProvider>
+  );
+}
+
+function useDashboardHarness() {
+  const providersAndModels = useProvidersAndModels();
+  const dashboard = useDashboardActions({
+    settingsConfig: null,
+    setSettingsConfig: () => {},
+    setSettingsError: () => {},
+    applyChatSession: () => {},
+    syncHecateSelectionFromSession: () => {},
+    refreshRuntimeState: async () => {},
+  });
+  return { dashboard, providersAndModels };
+}
+
+function setupDashboardReads() {
+  vi.mocked(api.getHealth).mockResolvedValue({ status: "ok", time: "2026-07-21T00:00:00Z" });
+  vi.mocked(api.getSession).mockResolvedValue({
+    object: "session",
+    data: {
+      role: "operator",
+      runtime_host: {
+        id: "runtime_1",
+        label: "Test host",
+        runtime_mode: "local",
+        operator_access: "local_operator",
+        local_only_actions_available: true,
+      },
+    },
+  });
+  vi.mocked(api.getProviders).mockResolvedValue({ object: "list", data: [] });
+  vi.mocked(api.getAgentAdapters).mockResolvedValue({ object: "list", data: [] });
+  vi.mocked(api.getChatSessions).mockResolvedValue({ object: "chat_sessions", data: [] });
+  vi.mocked(api.getSettingsConfig).mockResolvedValue({
+    object: "settings",
+    data: { backend: "memory", providers: [], policy_rules: [], events: [] },
+  });
+  vi.mocked(api.getRuntimeStats).mockResolvedValue({
+    object: "runtime_stats",
+    data: {},
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupDashboardReads();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useDashboardActions model catalog ownership", () => {
+  it("publishes dashboard catalog results through the providers/models slice", async () => {
+    vi.mocked(api.getModels).mockResolvedValue({
+      object: "list",
+      data: [
+        {
+          ...initialModels[0],
+          metadata: {
+            ...initialModels[0].metadata,
+            capabilities: { tool_calling: "basic" },
+          },
+        },
+      ],
+    });
+    const { result } = renderHook(() => useDashboardHarness(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.dashboard.loadDashboard();
+    });
+
+    expect(result.current.providersAndModels.state.models[0]?.metadata?.capabilities).toMatchObject(
+      {
+        tool_calling: "basic",
+      },
+    );
+  });
+
+  it("does not let a stale dashboard catalog block a newer provider refresh", async () => {
+    let resolveDashboardModels: (value: ModelResponse) => void = () => {};
+    let resolveRefreshModels: (value: ModelResponse) => void = () => {};
+    vi.mocked(api.getModels)
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveDashboardModels = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRefreshModels = resolve;
+        }),
+      );
+    const { result } = renderHook(() => useDashboardHarness(), { wrapper: Wrapper });
+
+    let dashboardLoad: Promise<void> | undefined;
+    act(() => {
+      dashboardLoad = result.current.dashboard.loadDashboard();
+    });
+    await waitFor(() => {
+      expect(api.getModels).toHaveBeenCalledTimes(1);
+    });
+
+    let providerRefresh: Promise<void> | undefined;
+    act(() => {
+      providerRefresh = result.current.dashboard.refreshProviders();
+    });
+    await waitFor(() => {
+      expect(api.getModels).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      resolveDashboardModels({
+        object: "list",
+        data: [
+          {
+            ...initialModels[0],
+            metadata: {
+              ...initialModels[0].metadata,
+              capabilities: { tool_calling: "none" },
+            },
+          },
+        ],
+      });
+      await dashboardLoad;
+    });
+    expect(
+      result.current.providersAndModels.state.models[0]?.metadata?.capabilities?.tool_calling,
+    ).toBe("unknown");
+
+    await act(async () => {
+      resolveRefreshModels({
+        object: "list",
+        data: [
+          {
+            ...initialModels[0],
+            metadata: {
+              ...initialModels[0].metadata,
+              capabilities: {
+                tool_calling: "basic",
+                tool_verification: { status: "supported" },
+              },
+            },
+          },
+        ],
+      });
+      await providerRefresh;
+    });
+
+    expect(result.current.providersAndModels.state.models[0]?.metadata?.capabilities).toMatchObject(
+      {
+        tool_calling: "basic",
+        tool_verification: { status: "supported" },
+      },
+    );
+  });
+});

--- a/ui/src/app/state/coordinators/dashboard.ts
+++ b/ui/src/app/state/coordinators/dashboard.ts
@@ -46,7 +46,7 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
     setHecateRTKPath,
   } = runtime.actions;
   const { providers, agentAdapters } = providersAndModels.state;
-  const { setProviders, setModels, setAgentAdapters, setAgentAdapterApprovalMode } =
+  const { setProviders, loadModelCatalog, setAgentAdapters, setAgentAdapterApprovalMode } =
     providersAndModels.actions;
   const { activeChatSession, chatSessions } = chat.state;
   const {
@@ -93,6 +93,11 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
     try {
       const snapshot = await resolveDashboardSnapshot({
         activeChatSessionID: dashboardActiveChatSessionID,
+        // Model catalog responses are committed by the provider/model slice,
+        // which owns the shared mutation and request-order freshness fence.
+        // The dashboard still receives the data for its snapshot contract but
+        // must not publish a second, unfenced model write below.
+        loadModels: loadModelCatalog,
         previous: {
           providers,
           agentAdapters,
@@ -120,7 +125,6 @@ export function useDashboardActions(params: UseDashboardActionsParams) {
 
       setHealth(snapshot.health);
       setSessionInfo(snapshot.sessionInfo);
-      setModels(snapshot.models);
       setProviders(snapshot.providers);
       setAgentAdapters(snapshot.agentAdapters);
       const liveChatSessions = snapshot.chatSessions.filter(

--- a/ui/src/app/state/providersAndModels.test.tsx
+++ b/ui/src/app/state/providersAndModels.test.tsx
@@ -2,22 +2,26 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  modelToolSupportKey,
   ProvidersAndModelsProvider,
   useEnsureProviderPresetsLoaded,
   useProvidersAndModels,
 } from "./providersAndModels";
 import type { ReactNode } from "react";
 
+const getProvidersMock = vi.fn();
+const getModelsMock = vi.fn();
 const getProviderPresetsMock = vi.fn();
 const probeAgentAdapterMock = vi.fn();
+const verifyModelToolSupportMock = vi.fn();
 const warnMock = vi.fn();
 
 vi.mock("../../lib/api", () => ({
+  getProviders: (...args: unknown[]) => getProvidersMock(...args),
+  getModels: (...args: unknown[]) => getModelsMock(...args),
   getProviderPresets: (...args: unknown[]) => getProviderPresetsMock(...args),
   probeAgentAdapter: (...args: unknown[]) => probeAgentAdapterMock(...args),
-  // Stubs for other api symbols the slice imports — unused in these tests.
-  getProviders: vi.fn(),
-  getModels: vi.fn(),
+  verifyModelToolSupport: (...args: unknown[]) => verifyModelToolSupportMock(...args),
 }));
 
 vi.mock("../../lib/log", () => ({
@@ -31,8 +35,11 @@ function Wrapper({ children }: { children: ReactNode }) {
 }
 
 beforeEach(() => {
+  getProvidersMock.mockReset();
+  getModelsMock.mockReset();
   getProviderPresetsMock.mockReset();
   probeAgentAdapterMock.mockReset();
+  verifyModelToolSupportMock.mockReset();
   warnMock.mockReset();
 });
 
@@ -199,5 +206,156 @@ describe("probeAgentAdapter", () => {
       status: "ready",
     });
     expect(result.current.state.agentAdapterHealthLoadingByID.has("codex")).toBe(false);
+  });
+});
+
+describe("verifyModelToolSupport", () => {
+  it("dedupes one provider/model diagnostic and refreshes the catalog projection", async () => {
+    let resolveProbe: (value: unknown) => void = () => {};
+    verifyModelToolSupportMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveProbe = resolve;
+      }),
+    );
+    getProvidersMock.mockResolvedValue({ object: "provider_status", data: [] });
+    getModelsMock.mockResolvedValue({
+      object: "list",
+      data: [
+        {
+          id: "custom-tool-model",
+          owned_by: "Local Runtime",
+          metadata: {
+            provider: "Local Runtime",
+            capabilities: {
+              tool_calling: "basic",
+              tool_verification: { status: "supported" },
+            },
+            readiness: { ready: true, routing_ready: true },
+          },
+        },
+      ],
+    });
+    const ProviderModelWrapper = ({ children }: { children: ReactNode }) => (
+      <ProvidersAndModelsProvider
+        initialState={{
+          models: [
+            {
+              id: "custom-tool-model",
+              owned_by: "Local Runtime",
+              metadata: {
+                provider: "Local Runtime",
+                capabilities: { tool_calling: "unknown" },
+                readiness: { ready: true, routing_ready: true },
+              },
+            },
+          ],
+        }}
+      >
+        {children}
+      </ProvidersAndModelsProvider>
+    );
+    const { result } = renderHook(() => useProvidersAndModels(), { wrapper: ProviderModelWrapper });
+    let first: Promise<unknown> | undefined;
+    let second: Promise<unknown> | undefined;
+
+    act(() => {
+      first = result.current.actions.verifyModelToolSupport("Local Runtime", "custom-tool-model");
+      second = result.current.actions.verifyModelToolSupport("Local Runtime", "custom-tool-model");
+    });
+
+    const key = modelToolSupportKey("Local Runtime", "custom-tool-model");
+    expect(verifyModelToolSupportMock).toHaveBeenCalledTimes(1);
+    expect(verifyModelToolSupportMock).toHaveBeenCalledWith("Local Runtime", "custom-tool-model");
+    expect(result.current.state.modelToolSupportLoadingByKey.has(key)).toBe(true);
+
+    await act(async () => {
+      resolveProbe({
+        object: "model_tool_capability_probe",
+        data: {
+          provider: "Local Runtime",
+          model: "custom-tool-model",
+          capabilities: {
+            tool_calling: "basic",
+            tool_verification: { status: "supported" },
+          },
+          verification: { status: "supported" },
+          performed: true,
+        },
+      });
+      await Promise.all([first, second]);
+    });
+
+    expect(getProvidersMock).toHaveBeenCalledTimes(1);
+    expect(getModelsMock).toHaveBeenCalledTimes(1);
+    expect(result.current.state.modelToolSupportLoadingByKey.has(key)).toBe(false);
+    expect(result.current.state.models[0]?.metadata?.capabilities).toMatchObject({
+      tool_calling: "basic",
+      tool_verification: { status: "supported" },
+    });
+  });
+
+  it("keeps a successful probe result when the best-effort catalog refresh fails", async () => {
+    verifyModelToolSupportMock.mockResolvedValueOnce({
+      object: "model_tool_capability_probe",
+      data: {
+        provider: "Local Runtime",
+        model: "custom-tool-model",
+        capabilities: {
+          tool_calling: "basic",
+          tool_verification: {
+            status: "supported",
+            checked_at: "2026-07-21T10:00:00Z",
+          },
+        },
+        verification: {
+          status: "supported",
+          checked_at: "2026-07-21T10:00:00Z",
+        },
+        performed: true,
+      },
+    });
+    getProvidersMock.mockRejectedValueOnce(new Error("provider status unavailable"));
+    getModelsMock.mockRejectedValueOnce(new Error("model catalog unavailable"));
+    const ProviderModelWrapper = ({ children }: { children: ReactNode }) => (
+      <ProvidersAndModelsProvider
+        initialState={{
+          models: [
+            {
+              id: "custom-tool-model",
+              owned_by: "Local Runtime",
+              metadata: {
+                provider: "Local Runtime",
+                capabilities: { tool_calling: "unknown" },
+                readiness: { ready: true, routing_ready: true },
+              },
+            },
+          ],
+        }}
+      >
+        {children}
+      </ProvidersAndModelsProvider>
+    );
+    const { result } = renderHook(() => useProvidersAndModels(), { wrapper: ProviderModelWrapper });
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.actions.verifyModelToolSupport(
+        "Local Runtime",
+        "custom-tool-model",
+      );
+    });
+
+    expect(outcome).toMatchObject({ ok: true });
+    expect(warnMock).toHaveBeenCalledWith(
+      "providersAndModels.refresh.failed",
+      expect.objectContaining({
+        providers: "provider status unavailable",
+        models: "model catalog unavailable",
+      }),
+    );
+    expect(result.current.state.models[0]?.metadata?.capabilities).toMatchObject({
+      tool_calling: "basic",
+      tool_verification: { status: "supported" },
+    });
   });
 });

--- a/ui/src/app/state/providersAndModels.test.tsx
+++ b/ui/src/app/state/providersAndModels.test.tsx
@@ -455,4 +455,101 @@ describe("verifyModelToolSupport", () => {
       tool_verification: { status: "supported" },
     });
   });
+
+  it("applies the newest catalog refresh when an older response returns first", async () => {
+    let resolveOlderModels: (value: unknown) => void = () => {};
+    let resolveNewerModels: (value: unknown) => void = () => {};
+    getProvidersMock.mockResolvedValue({ object: "provider_status", data: [] });
+    getModelsMock
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveOlderModels = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveNewerModels = resolve;
+        }),
+      );
+    const ProviderModelWrapper = ({ children }: { children: ReactNode }) => (
+      <ProvidersAndModelsProvider
+        initialState={{
+          models: [
+            {
+              id: "custom-tool-model",
+              owned_by: "Local Runtime",
+              metadata: {
+                provider: "Local Runtime",
+                capabilities: { tool_calling: "unknown" },
+                readiness: { ready: true, routing_ready: true },
+              },
+            },
+          ],
+        }}
+      >
+        {children}
+      </ProvidersAndModelsProvider>
+    );
+    const { result } = renderHook(() => useProvidersAndModels(), { wrapper: ProviderModelWrapper });
+
+    let olderRefresh: Promise<void> | undefined;
+    act(() => {
+      olderRefresh = result.current.actions.refreshProviders();
+    });
+    await waitFor(() => {
+      expect(getModelsMock).toHaveBeenCalledTimes(1);
+    });
+
+    let newerRefresh: Promise<void> | undefined;
+    act(() => {
+      newerRefresh = result.current.actions.refreshProviders();
+    });
+    await waitFor(() => {
+      expect(getModelsMock).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      resolveOlderModels({
+        object: "list",
+        data: [
+          {
+            id: "custom-tool-model",
+            owned_by: "Local Runtime",
+            metadata: {
+              provider: "Local Runtime",
+              capabilities: { tool_calling: "none" },
+              readiness: { ready: true, routing_ready: true },
+            },
+          },
+        ],
+      });
+      await olderRefresh;
+    });
+    expect(result.current.state.models[0]?.metadata?.capabilities?.tool_calling).toBe("unknown");
+
+    await act(async () => {
+      resolveNewerModels({
+        object: "list",
+        data: [
+          {
+            id: "custom-tool-model",
+            owned_by: "Local Runtime",
+            metadata: {
+              provider: "Local Runtime",
+              capabilities: {
+                tool_calling: "basic",
+                tool_verification: { status: "supported" },
+              },
+              readiness: { ready: true, routing_ready: true },
+            },
+          },
+        ],
+      });
+      await newerRefresh;
+    });
+    expect(result.current.state.models[0]?.metadata?.capabilities).toMatchObject({
+      tool_calling: "basic",
+      tool_verification: { status: "supported" },
+    });
+  });
 });

--- a/ui/src/app/state/providersAndModels.test.tsx
+++ b/ui/src/app/state/providersAndModels.test.tsx
@@ -358,4 +358,101 @@ describe("verifyModelToolSupport", () => {
       tool_verification: { status: "supported" },
     });
   });
+
+  it("does not let an older catalog refresh erase a completed verification", async () => {
+    let resolveStaleModels: (value: unknown) => void = () => {};
+    getProvidersMock.mockResolvedValue({ object: "provider_status", data: [] });
+    getModelsMock
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStaleModels = resolve;
+        }),
+      )
+      .mockResolvedValueOnce({
+        object: "list",
+        data: [
+          {
+            id: "custom-tool-model",
+            owned_by: "Local Runtime",
+            metadata: {
+              provider: "Local Runtime",
+              capabilities: {
+                tool_calling: "basic",
+                tool_verification: { status: "supported" },
+              },
+              readiness: { ready: true, routing_ready: true },
+            },
+          },
+        ],
+      });
+    verifyModelToolSupportMock.mockResolvedValueOnce({
+      object: "model_tool_capability_probe",
+      data: {
+        provider: "Local Runtime",
+        model: "custom-tool-model",
+        capabilities: {
+          tool_calling: "basic",
+          tool_verification: { status: "supported" },
+        },
+        verification: { status: "supported" },
+        performed: true,
+      },
+    });
+    const ProviderModelWrapper = ({ children }: { children: ReactNode }) => (
+      <ProvidersAndModelsProvider
+        initialState={{
+          models: [
+            {
+              id: "custom-tool-model",
+              owned_by: "Local Runtime",
+              metadata: {
+                provider: "Local Runtime",
+                capabilities: { tool_calling: "unknown" },
+                readiness: { ready: true, routing_ready: true },
+              },
+            },
+          ],
+        }}
+      >
+        {children}
+      </ProvidersAndModelsProvider>
+    );
+    const { result } = renderHook(() => useProvidersAndModels(), { wrapper: ProviderModelWrapper });
+
+    let staleRefresh: Promise<void> | undefined;
+    act(() => {
+      staleRefresh = result.current.actions.refreshProviders();
+    });
+    await waitFor(() => {
+      expect(getModelsMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await result.current.actions.verifyModelToolSupport("Local Runtime", "custom-tool-model");
+    });
+    expect(result.current.state.models[0]?.metadata?.capabilities?.tool_calling).toBe("basic");
+
+    await act(async () => {
+      resolveStaleModels({
+        object: "list",
+        data: [
+          {
+            id: "custom-tool-model",
+            owned_by: "Local Runtime",
+            metadata: {
+              provider: "Local Runtime",
+              capabilities: { tool_calling: "unknown" },
+              readiness: { ready: true, routing_ready: true },
+            },
+          },
+        ],
+      });
+      await staleRefresh;
+    });
+
+    expect(result.current.state.models[0]?.metadata?.capabilities).toMatchObject({
+      tool_calling: "basic",
+      tool_verification: { status: "supported" },
+    });
+  });
 });

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -201,9 +201,11 @@ export function ProvidersAndModelsProvider({
     new Map<string, Promise<VerifyModelToolSupportResult>>(),
   );
   // A catalog response can be older than an explicit model mutation (notably a
-  // completed tool-support verification). Track each local model write so an
-  // already-running refresh cannot erase newer operator-visible evidence.
-  const modelsRevisionRef = useRef(0);
+  // completed tool-support verification). Track those local writes separately
+  // from catalog refreshes: a catalog result must neither erase newer evidence
+  // nor prevent a newer refresh from replacing an older refresh.
+  const modelsMutationRevisionRef = useRef(0);
+  const latestModelsRefreshRef = useRef(0);
 
   const setProviders = useCallback(
     (next: SetStateAction<ProviderStatusResponse["data"]>) =>
@@ -220,7 +222,7 @@ export function ProvidersAndModelsProvider({
     [],
   );
   const applyModels = useCallback((next: SetStateAction<ModelResponse["data"]>) => {
-    modelsRevisionRef.current += 1;
+    modelsMutationRevisionRef.current += 1;
     dispatch({ type: "models/set", next });
   }, []);
   const setModels = applyModels;
@@ -248,14 +250,19 @@ export function ProvidersAndModelsProvider({
   );
 
   const refreshProviders = useCallback(async () => {
-    const modelsRevisionAtStart = modelsRevisionRef.current;
+    const modelsMutationRevisionAtStart = modelsMutationRevisionRef.current;
+    const refreshID = ++latestModelsRefreshRef.current;
     try {
       const [pResult, mResult] = await Promise.allSettled([getProviders(), getModels()]);
       if (pResult.status === "fulfilled") {
         dispatch({ type: "providers/set", next: pResult.value.data ?? [] });
       }
-      if (mResult.status === "fulfilled" && modelsRevisionRef.current === modelsRevisionAtStart) {
-        applyModels(mResult.value.data ?? []);
+      if (
+        mResult.status === "fulfilled" &&
+        modelsMutationRevisionRef.current === modelsMutationRevisionAtStart &&
+        latestModelsRefreshRef.current === refreshID
+      ) {
+        dispatch({ type: "models/set", next: mResult.value.data ?? [] });
       }
       if (pResult.status === "rejected" || mResult.status === "rejected") {
         warn("providersAndModels.refresh.failed", {
@@ -280,7 +287,7 @@ export function ProvidersAndModelsProvider({
         err: error instanceof Error ? error.message : String(error),
       });
     }
-  }, [applyModels]);
+  }, []);
 
   const probeAgentAdapter = useCallback(async (adapterID: string): Promise<ProbeAdapterResult> => {
     if (!adapterID) return { ok: false, error: "Adapter id required to probe." };

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -200,6 +200,10 @@ export function ProvidersAndModelsProvider({
   const verifyModelToolSupportInFlightRef = useRef(
     new Map<string, Promise<VerifyModelToolSupportResult>>(),
   );
+  // A catalog response can be older than an explicit model mutation (notably a
+  // completed tool-support verification). Track each local model write so an
+  // already-running refresh cannot erase newer operator-visible evidence.
+  const modelsRevisionRef = useRef(0);
 
   const setProviders = useCallback(
     (next: SetStateAction<ProviderStatusResponse["data"]>) =>
@@ -215,10 +219,11 @@ export function ProvidersAndModelsProvider({
     () => dispatch({ type: "providerPresetsLoaded/mark" }),
     [],
   );
-  const setModels = useCallback(
-    (next: SetStateAction<ModelResponse["data"]>) => dispatch({ type: "models/set", next }),
-    [],
-  );
+  const applyModels = useCallback((next: SetStateAction<ModelResponse["data"]>) => {
+    modelsRevisionRef.current += 1;
+    dispatch({ type: "models/set", next });
+  }, []);
+  const setModels = applyModels;
   const setAgentAdapters = useCallback(
     (next: SetStateAction<AgentAdapterRecord[]>) => dispatch({ type: "agentAdapters/set", next }),
     [],
@@ -243,13 +248,14 @@ export function ProvidersAndModelsProvider({
   );
 
   const refreshProviders = useCallback(async () => {
+    const modelsRevisionAtStart = modelsRevisionRef.current;
     try {
       const [pResult, mResult] = await Promise.allSettled([getProviders(), getModels()]);
       if (pResult.status === "fulfilled") {
         dispatch({ type: "providers/set", next: pResult.value.data ?? [] });
       }
-      if (mResult.status === "fulfilled") {
-        dispatch({ type: "models/set", next: mResult.value.data ?? [] });
+      if (mResult.status === "fulfilled" && modelsRevisionRef.current === modelsRevisionAtStart) {
+        applyModels(mResult.value.data ?? []);
       }
       if (pResult.status === "rejected" || mResult.status === "rejected") {
         warn("providersAndModels.refresh.failed", {
@@ -274,7 +280,7 @@ export function ProvidersAndModelsProvider({
         err: error instanceof Error ? error.message : String(error),
       });
     }
-  }, []);
+  }, [applyModels]);
 
   const probeAgentAdapter = useCallback(async (adapterID: string): Promise<ProbeAdapterResult> => {
     if (!adapterID) return { ok: false, error: "Adapter id required to probe." };
@@ -322,25 +328,23 @@ export function ProvidersAndModelsProvider({
           const probe = await verifyModelToolSupportRequest(normalizedProvider, normalizedModel);
           // Apply the returned projection first so the operator sees the
           // result even if the best-effort catalog refresh is delayed.
-          dispatch({
-            type: "models/set",
-            next: (current) =>
-              current.map((entry) =>
-                entry.id === probe.data.model && entry.metadata?.provider === probe.data.provider
-                  ? {
-                      ...entry,
-                      metadata: {
-                        ...entry.metadata,
-                        capabilities: {
-                          ...probe.data.capabilities,
-                          tool_verification:
-                            probe.data.verification ?? probe.data.capabilities.tool_verification,
-                        },
+          applyModels((current) =>
+            current.map((entry) =>
+              entry.id === probe.data.model && entry.metadata?.provider === probe.data.provider
+                ? {
+                    ...entry,
+                    metadata: {
+                      ...entry.metadata,
+                      capabilities: {
+                        ...probe.data.capabilities,
+                        tool_verification:
+                          probe.data.verification ?? probe.data.capabilities.tool_verification,
                       },
-                    }
-                  : entry,
-              ),
-          });
+                    },
+                  }
+                : entry,
+            ),
+          );
           // The proof is provider-generation-bound. Reload both model catalog
           // and provider status after the bounded explicit action rather than
           // guessing at any other affected route. This refresh is strictly
@@ -372,7 +376,7 @@ export function ProvidersAndModelsProvider({
       verifyModelToolSupportInFlightRef.current.set(key, verification);
       return verification;
     },
-    [refreshProviders],
+    [applyModels, refreshProviders],
   );
 
   const actions = useMemo<ProvidersAndModelsActions>(

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -11,7 +11,8 @@
 //   - Map mutators for the adapter-health map and the per-adapter
 //     loading flag avoid the "rebuild the whole map in the
 //     caller" boilerplate that every probe path used.
-//   - Domain actions (refreshProviders, probeAgentAdapter) own the
+//   - Domain actions (refreshProviders, probeAgentAdapter,
+//     verifyModelToolSupport) own the
 //     API call + the state update. They return Results so the shim
 //     wires success / error to the global notice banner without the
 //     slice importing cross-cut state.
@@ -40,10 +41,11 @@ import {
   getModels,
   getProviderPresets,
   probeAgentAdapter as probeAgentAdapterRequest,
+  verifyModelToolSupport as verifyModelToolSupportRequest,
 } from "../../lib/api";
 import { warn } from "../../lib/log";
 import type { AgentAdapterHealthRecord, AgentAdapterRecord } from "../../types/agent-adapter";
-import type { ModelResponse } from "../../types/model";
+import type { ModelResponse, ModelToolCapabilityProbeResponse } from "../../types/model";
 import type { ProviderPresetRecord, ProviderStatusResponse } from "../../types/provider";
 
 export type ProvidersAndModelsState = {
@@ -61,6 +63,7 @@ export type ProvidersAndModelsState = {
   agentAdapterApprovalMode: string;
   agentAdapterHealthByID: Map<string, AgentAdapterHealthRecord>;
   agentAdapterHealthLoadingByID: Map<string, true>;
+  modelToolSupportLoadingByKey: Map<string, true>;
 };
 
 type SetStateAction<T> = T | ((prev: T) => T);
@@ -68,6 +71,14 @@ type SetStateAction<T> = T | ((prev: T) => T);
 export type ProbeAdapterResult =
   | { ok: true; health: AgentAdapterHealthRecord }
   | { ok: false; error: string };
+
+export type VerifyModelToolSupportResult =
+  | { ok: true; probe: ModelToolCapabilityProbeResponse }
+  | { ok: false; error: string };
+
+export function modelToolSupportKey(provider: string, model: string): string {
+  return `${provider.trim().toLowerCase()}\0${model.trim()}`;
+}
 
 export type ProvidersAndModelsActions = {
   setProviders: (next: SetStateAction<ProviderStatusResponse["data"]>) => void;
@@ -81,6 +92,10 @@ export type ProvidersAndModelsActions = {
   setAgentAdapterHealthLoading: (adapterID: string, loading: boolean) => void;
   refreshProviders: () => Promise<void>;
   probeAgentAdapter: (adapterID: string) => Promise<ProbeAdapterResult>;
+  verifyModelToolSupport: (
+    provider: string,
+    model: string,
+  ) => Promise<VerifyModelToolSupportResult>;
 };
 
 type ProvidersAndModelsContextValue = {
@@ -97,7 +112,8 @@ type Action =
   | { type: "agentAdapterApprovalMode/set"; value: string }
   | { type: "agentAdapterHealth/set"; adapterID: string; record: AgentAdapterHealthRecord }
   | { type: "agentAdapterHealth/clear"; adapterID: string }
-  | { type: "agentAdapterHealthLoading/set"; adapterID: string; loading: boolean };
+  | { type: "agentAdapterHealthLoading/set"; adapterID: string; loading: boolean }
+  | { type: "modelToolSupportLoading/set"; key: string; loading: boolean };
 
 const initialState: ProvidersAndModelsState = {
   providers: [],
@@ -108,6 +124,7 @@ const initialState: ProvidersAndModelsState = {
   agentAdapterApprovalMode: "",
   agentAdapterHealthByID: new Map(),
   agentAdapterHealthLoadingByID: new Map(),
+  modelToolSupportLoadingByKey: new Map(),
 };
 
 function resolve<T>(prev: T, next: SetStateAction<T>): T {
@@ -151,6 +168,18 @@ function reducer(state: ProvidersAndModelsState, action: Action): ProvidersAndMo
       next.delete(action.adapterID);
       return { ...state, agentAdapterHealthLoadingByID: next };
     }
+    case "modelToolSupportLoading/set": {
+      const map = state.modelToolSupportLoadingByKey;
+      if (action.loading) {
+        const next = new Map(map);
+        next.set(action.key, true);
+        return { ...state, modelToolSupportLoadingByKey: next };
+      }
+      if (!map.has(action.key)) return state;
+      const next = new Map(map);
+      next.delete(action.key);
+      return { ...state, modelToolSupportLoadingByKey: next };
+    }
   }
 }
 
@@ -168,6 +197,9 @@ export function ProvidersAndModelsProvider({
     seededState ? { ...initialState, ...seededState } : initialState,
   );
   const probeAgentAdapterInFlightRef = useRef(new Map<string, Promise<ProbeAdapterResult>>());
+  const verifyModelToolSupportInFlightRef = useRef(
+    new Map<string, Promise<VerifyModelToolSupportResult>>(),
+  );
 
   const setProviders = useCallback(
     (next: SetStateAction<ProviderStatusResponse["data"]>) =>
@@ -219,8 +251,28 @@ export function ProvidersAndModelsProvider({
       if (mResult.status === "fulfilled") {
         dispatch({ type: "models/set", next: mResult.value.data ?? [] });
       }
-    } catch {
-      // Best-effort background refresh — ignore errors.
+      if (pResult.status === "rejected" || mResult.status === "rejected") {
+        warn("providersAndModels.refresh.failed", {
+          providers:
+            pResult.status === "rejected"
+              ? pResult.reason instanceof Error
+                ? pResult.reason.message
+                : String(pResult.reason)
+              : undefined,
+          models:
+            mResult.status === "rejected"
+              ? mResult.reason instanceof Error
+                ? mResult.reason.message
+                : String(mResult.reason)
+              : undefined,
+        });
+      }
+    } catch (error) {
+      // Best-effort background refresh — report the failure without making
+      // a completed provider operation look unsuccessful.
+      warn("providersAndModels.refresh.failed", {
+        err: error instanceof Error ? error.message : String(error),
+      });
     }
   }, []);
 
@@ -253,6 +305,76 @@ export function ProvidersAndModelsProvider({
     return probe;
   }, []);
 
+  const verifyModelToolSupport = useCallback(
+    async (provider: string, model: string): Promise<VerifyModelToolSupportResult> => {
+      const normalizedProvider = provider.trim();
+      const normalizedModel = model.trim();
+      if (!normalizedProvider || !normalizedModel) {
+        return { ok: false, error: "Provider and model are required to verify tool support." };
+      }
+      const key = modelToolSupportKey(normalizedProvider, normalizedModel);
+      const inFlight = verifyModelToolSupportInFlightRef.current.get(key);
+      if (inFlight) return inFlight;
+
+      const verification: Promise<VerifyModelToolSupportResult> = (async () => {
+        dispatch({ type: "modelToolSupportLoading/set", key, loading: true });
+        try {
+          const probe = await verifyModelToolSupportRequest(normalizedProvider, normalizedModel);
+          // Apply the returned projection first so the operator sees the
+          // result even if the best-effort catalog refresh is delayed.
+          dispatch({
+            type: "models/set",
+            next: (current) =>
+              current.map((entry) =>
+                entry.id === probe.data.model && entry.metadata?.provider === probe.data.provider
+                  ? {
+                      ...entry,
+                      metadata: {
+                        ...entry.metadata,
+                        capabilities: {
+                          ...probe.data.capabilities,
+                          tool_verification:
+                            probe.data.verification ?? probe.data.capabilities.tool_verification,
+                        },
+                      },
+                    }
+                  : entry,
+              ),
+          });
+          // The proof is provider-generation-bound. Reload both model catalog
+          // and provider status after the bounded explicit action rather than
+          // guessing at any other affected route. This refresh is strictly
+          // best-effort: the probe result above remains authoritative until a
+          // later catalog response replaces it.
+          try {
+            await refreshProviders();
+          } catch (error) {
+            // refreshProviders normally handles its own transport failures,
+            // but keep the completed diagnostic independent if that contract
+            // ever changes.
+            warn("modelToolSupport.refresh.failed", {
+              provider: normalizedProvider,
+              model: normalizedModel,
+              err: error instanceof Error ? error.message : String(error),
+            });
+          }
+          return { ok: true, probe };
+        } catch (error) {
+          return {
+            ok: false,
+            error: error instanceof Error ? error.message : "Failed to verify tool support.",
+          };
+        } finally {
+          verifyModelToolSupportInFlightRef.current.delete(key);
+          dispatch({ type: "modelToolSupportLoading/set", key, loading: false });
+        }
+      })();
+      verifyModelToolSupportInFlightRef.current.set(key, verification);
+      return verification;
+    },
+    [refreshProviders],
+  );
+
   const actions = useMemo<ProvidersAndModelsActions>(
     () => ({
       setProviders,
@@ -266,6 +388,7 @@ export function ProvidersAndModelsProvider({
       setAgentAdapterHealthLoading,
       refreshProviders,
       probeAgentAdapter,
+      verifyModelToolSupport,
     }),
     [
       setProviders,
@@ -279,6 +402,7 @@ export function ProvidersAndModelsProvider({
       setAgentAdapterHealthLoading,
       refreshProviders,
       probeAgentAdapter,
+      verifyModelToolSupport,
     ],
   );
 

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -90,6 +90,7 @@ export type ProvidersAndModelsActions = {
   setAgentAdapterHealth: (adapterID: string, record: AgentAdapterHealthRecord) => void;
   clearAgentAdapterHealth: (adapterID: string) => void;
   setAgentAdapterHealthLoading: (adapterID: string, loading: boolean) => void;
+  loadModelCatalog: () => Promise<ModelResponse>;
   refreshProviders: () => Promise<void>;
   probeAgentAdapter: (adapterID: string) => Promise<ProbeAdapterResult>;
   verifyModelToolSupport: (
@@ -226,6 +227,18 @@ export function ProvidersAndModelsProvider({
     dispatch({ type: "models/set", next });
   }, []);
   const setModels = applyModels;
+  const loadModelCatalog = useCallback(async (): Promise<ModelResponse> => {
+    const modelsMutationRevisionAtStart = modelsMutationRevisionRef.current;
+    const refreshID = ++latestModelsRefreshRef.current;
+    const response = await getModels();
+    if (
+      modelsMutationRevisionRef.current === modelsMutationRevisionAtStart &&
+      latestModelsRefreshRef.current === refreshID
+    ) {
+      dispatch({ type: "models/set", next: response.data ?? [] });
+    }
+    return response;
+  }, []);
   const setAgentAdapters = useCallback(
     (next: SetStateAction<AgentAdapterRecord[]>) => dispatch({ type: "agentAdapters/set", next }),
     [],
@@ -250,19 +263,10 @@ export function ProvidersAndModelsProvider({
   );
 
   const refreshProviders = useCallback(async () => {
-    const modelsMutationRevisionAtStart = modelsMutationRevisionRef.current;
-    const refreshID = ++latestModelsRefreshRef.current;
     try {
-      const [pResult, mResult] = await Promise.allSettled([getProviders(), getModels()]);
+      const [pResult, mResult] = await Promise.allSettled([getProviders(), loadModelCatalog()]);
       if (pResult.status === "fulfilled") {
         dispatch({ type: "providers/set", next: pResult.value.data ?? [] });
-      }
-      if (
-        mResult.status === "fulfilled" &&
-        modelsMutationRevisionRef.current === modelsMutationRevisionAtStart &&
-        latestModelsRefreshRef.current === refreshID
-      ) {
-        dispatch({ type: "models/set", next: mResult.value.data ?? [] });
       }
       if (pResult.status === "rejected" || mResult.status === "rejected") {
         warn("providersAndModels.refresh.failed", {
@@ -287,7 +291,7 @@ export function ProvidersAndModelsProvider({
         err: error instanceof Error ? error.message : String(error),
       });
     }
-  }, []);
+  }, [loadModelCatalog]);
 
   const probeAgentAdapter = useCallback(async (adapterID: string): Promise<ProbeAdapterResult> => {
     if (!adapterID) return { ok: false, error: "Adapter id required to probe." };
@@ -397,6 +401,7 @@ export function ProvidersAndModelsProvider({
       setAgentAdapterHealth,
       clearAgentAdapterHealth,
       setAgentAdapterHealthLoading,
+      loadModelCatalog,
       refreshProviders,
       probeAgentAdapter,
       verifyModelToolSupport,
@@ -411,6 +416,7 @@ export function ProvidersAndModelsProvider({
       setAgentAdapterHealth,
       clearAgentAdapterHealth,
       setAgentAdapterHealthLoading,
+      loadModelCatalog,
       refreshProviders,
       probeAgentAdapter,
       verifyModelToolSupport,

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ProvidersView } from "./ProvidersView";
 import { AddProviderModal } from "./AddProviderModal";
+import { modelToolSupportKey } from "../../app/state/providersAndModels";
 import { discoverLocalProviders, getDictationOptions } from "../../lib/api";
 import {
   createRuntimeConsoleActions,
@@ -512,6 +513,328 @@ describe("ProvidersView edit modal", () => {
     expect(screen.getByText("m2")).toBeTruthy();
     // Only the default model row carries the badge.
     expect(screen.getByText("default")).toBeTruthy();
+  });
+
+  it("offers an explicit tool-support verification only for a ready unknown model", async () => {
+    const verifyModelToolSupport = vi.fn(async () => ({
+      ok: true,
+      probe: {
+        object: "model_tool_capability_probe",
+        data: {
+          provider: "ollama",
+          model: "m2",
+          capabilities: { tool_calling: "basic" },
+          verification: { status: "supported" },
+          performed: true,
+        },
+      },
+    }));
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [makeConfigured("ollama", { kind: "local", default_model: "m1" })],
+      },
+      providers: [
+        makeStatus("ollama", {
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          models: ["m1", "m2", "m3"],
+          model_count: 3,
+        }),
+      ],
+      models: [
+        {
+          id: "m1",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: { tool_calling: "basic" },
+            readiness: { ready: true, routing_ready: true },
+          },
+        },
+        {
+          id: "m2",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: { tool_calling: "unknown" },
+            readiness: { ready: true, routing_ready: true },
+          },
+        },
+        {
+          id: "m3",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: { tool_calling: "unknown" },
+            readiness: { ready: false, routing_ready: false },
+          },
+        },
+      ],
+    });
+    const actions = { ...createRuntimeConsoleActions(), verifyModelToolSupport };
+
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Ollama"));
+    const verify = screen.getByRole("button", { name: "Verify tool support" });
+    expect(verify).toHaveAttribute(
+      "title",
+      expect.stringContaining("Hecate never executes the returned tool"),
+    );
+    expect(screen.getAllByText("Tool support unknown")).toHaveLength(2);
+
+    await user.click(verify);
+    expect(verifyModelToolSupport).toHaveBeenCalledWith("ollama", "m2");
+  });
+
+  it("shows model-specific progress while tool-support verification is in flight", async () => {
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [makeConfigured("ollama", { kind: "local" })],
+      },
+      providers: [
+        makeStatus("ollama", {
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          models: ["m2"],
+          model_count: 1,
+        }),
+      ],
+      models: [
+        {
+          id: "m2",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: {
+              tool_calling: "unknown",
+              tool_verification: { status: "testing" },
+            },
+            readiness: { ready: true, routing_ready: true },
+          },
+        },
+      ],
+      modelToolSupportLoadingByKey: new Map([[modelToolSupportKey("ollama", "m2"), true]]),
+    });
+
+    render(
+      withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }),
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Ollama"));
+    expect(screen.getByText("Verifying tool support")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Verifying…" })).toBeDisabled();
+  });
+
+  it("shows accessible verification details and lets current no-tool metadata override an old success", async () => {
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [makeConfigured("ollama", { kind: "local" })],
+      },
+      providers: [
+        makeStatus("ollama", {
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          models: ["m2"],
+          model_count: 1,
+        }),
+      ],
+      models: [
+        {
+          id: "m2",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: {
+              tool_calling: "none",
+              tool_verification: {
+                status: "supported",
+                checked_at: "2026-07-21T10:00:00Z",
+                expires_at: "2026-08-20T10:00:00Z",
+                reason: "The fixed diagnostic tool call succeeded.",
+              },
+            },
+            readiness: { ready: true, routing_ready: true },
+          },
+        },
+      ],
+    });
+
+    render(
+      withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }),
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Ollama"));
+
+    expect(screen.getByText("Tool support unavailable")).toBeTruthy();
+    expect(screen.queryByText("Tool support verified")).toBeNull();
+    const details = screen.getByRole("group", {
+      name: "Tool support verification details for m2",
+    });
+    expect(within(details).getByText("Checked:")).toBeTruthy();
+    expect(within(details).getByText("Expires:")).toBeTruthy();
+    expect(within(details).getByText("Reason:")).toBeTruthy();
+    expect(within(details).getByText("The fixed diagnostic tool call succeeded.")).toBeTruthy();
+    expect(details.querySelectorAll("time")).toHaveLength(2);
+  });
+
+  it("lets current tool-capable metadata override an old negative verification", async () => {
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [makeConfigured("ollama", { kind: "local" })],
+      },
+      providers: [
+        makeStatus("ollama", {
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          models: ["m2"],
+          model_count: 1,
+        }),
+      ],
+      models: [
+        {
+          id: "m2",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: {
+              tool_calling: "basic",
+              tool_verification: { status: "unsupported" },
+            },
+            readiness: { ready: true, routing_ready: true },
+          },
+        },
+      ],
+    });
+
+    render(
+      withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }),
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Ollama"));
+
+    expect(screen.getByText("Tool support available")).toBeTruthy();
+    expect(screen.queryByText("No tool support")).toBeNull();
+  });
+
+  it("keeps a failed tool-support verification inline with its model", async () => {
+    const verifyModelToolSupport = vi.fn(async () => ({
+      ok: false,
+      error: "The selected provider/model is not available for verification.",
+    }));
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [makeConfigured("ollama", { kind: "local" })],
+      },
+      providers: [
+        makeStatus("ollama", {
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          models: ["m2"],
+          model_count: 1,
+        }),
+      ],
+      models: [
+        {
+          id: "m2",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: { tool_calling: "unknown" },
+            readiness: { ready: true, routing_ready: true },
+          },
+        },
+      ],
+    });
+    const actions = { ...createRuntimeConsoleActions(), verifyModelToolSupport };
+
+    render(withRuntimeConsole(<ProvidersView />, { state, actions }));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Ollama"));
+    await user.click(screen.getByRole("button", { name: "Verify tool support" }));
+    const error = await screen.findByText(
+      "The selected provider/model is not available for verification.",
+    );
+    expect(error).toHaveAttribute("role", "status");
+  });
+
+  it("does not offer tool-support verification for known or unready models", async () => {
+    const state = createRuntimeConsoleFixture({
+      session: localSession,
+      providerPresets: presets,
+      settingsConfig: {
+        ...emptySettingsConfig(),
+        providers: [makeConfigured("ollama", { kind: "local" })],
+      },
+      providers: [
+        makeStatus("ollama", {
+          kind: "local",
+          healthy: true,
+          status: "healthy",
+          routing_ready: true,
+          models: ["known", "not-ready"],
+          model_count: 2,
+        }),
+      ],
+      models: [
+        {
+          id: "known",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: { tool_calling: "basic" },
+            readiness: { ready: true, routing_ready: true },
+          },
+        },
+        {
+          id: "not-ready",
+          owned_by: "ollama",
+          metadata: {
+            provider: "ollama",
+            capabilities: { tool_calling: "unknown" },
+            readiness: { ready: false, routing_ready: false },
+          },
+        },
+      ],
+    });
+
+    render(
+      withRuntimeConsole(<ProvidersView />, { state, actions: createRuntimeConsoleActions() }),
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Ollama"));
+    expect(screen.queryByRole("button", { name: "Verify tool support" })).toBeNull();
   });
 });
 

--- a/ui/src/features/providers/ProvidersView.tsx
+++ b/ui/src/features/providers/ProvidersView.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
-import { useProvidersAndModels } from "../../app/state/providersAndModels";
+import { modelToolSupportKey, useProvidersAndModels } from "../../app/state/providersAndModels";
 import { useSettings } from "../../app/state/settings";
 import {
   useWiredDashboardActions,
   useWiredProviderActions,
 } from "../../app/state/coordinators/wired";
+import type { ModelRecord, ToolCapabilityVerificationRecord } from "../../types/model";
 import type { ConfiguredProviderRecord, ProviderRecord } from "../../types/provider";
-import { formatLocaleTime } from "../../lib/format";
+import { formatLocaleDateTime, formatLocaleTime } from "../../lib/format";
 import {
   providerFleetRepairHint,
   providerReadinessMeaning,
@@ -84,6 +85,7 @@ export function ProvidersView() {
   const settingsConfig = settings.state.config;
   const providers = providersAndModels.state.providers;
   const models = providersAndModels.state.models;
+  const modelToolSupportLoadingByKey = providersAndModels.state.modelToolSupportLoadingByKey;
   const providerPresets = providersAndModels.state.providerPresets;
   const [selectedID, setSelectedID] = useState<string | null>(null);
   const [pendingKey, setPendingKey] = useState("");
@@ -93,6 +95,7 @@ export function ProvidersView() {
   const [pendingAccountID, setPendingAccountID] = useState("");
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [deleteConfirmID, setDeleteConfirmID] = useState<string | null>(null);
+  const [modelToolSupportErrors, setModelToolSupportErrors] = useState(new Map<string, string>());
 
   // Auto-poll model discovery only when there's something to discover for —
   // either at least one configured provider, or the Add modal is open
@@ -999,6 +1002,23 @@ export function ProvidersView() {
                 >
                   {selectedStatus.models.map((m) => {
                     const displayModel = modelDisplayName(m);
+                    const catalogModel = findSelectedProviderModel(models, m, selectedStatus.name);
+                    const capabilities = catalogModel?.metadata?.capabilities;
+                    const verification = capabilities?.tool_verification;
+                    const verificationProvider = catalogModel?.metadata?.provider ?? "";
+                    const verificationKey = modelToolSupportKey(verificationProvider, m);
+                    const verificationInProgress =
+                      Boolean(modelToolSupportLoadingByKey.get(verificationKey)) ||
+                      verification?.status === "testing";
+                    const canVerifyToolSupport =
+                      Boolean(verificationProvider) &&
+                      capabilities?.tool_calling === "unknown" &&
+                      modelReadyForToolVerification(catalogModel);
+                    const verificationLabel = toolVerificationLabel(
+                      verification,
+                      capabilities?.tool_calling,
+                    );
+                    const verificationError = modelToolSupportErrors.get(verificationKey);
                     return (
                       <div
                         key={m}
@@ -1006,6 +1026,8 @@ export function ProvidersView() {
                         style={{
                           display: "flex",
                           alignItems: "center",
+                          flexWrap: "wrap",
+                          gap: 6,
                           padding: "5px 0",
                           borderBottom: "1px solid var(--border)",
                         }}
@@ -1027,6 +1049,113 @@ export function ProvidersView() {
                         {m === selectedConfig.default_model && (
                           <span className="badge badge-teal" style={{ fontSize: 9 }}>
                             default
+                          </span>
+                        )}
+                        {verificationLabel && (
+                          <span
+                            className="badge badge-neutral"
+                            style={{ fontSize: 9 }}
+                            title={toolVerificationTitle(verification, capabilities?.tool_calling)}
+                          >
+                            {verificationLabel}
+                          </span>
+                        )}
+                        {verification && (
+                          <div
+                            role="group"
+                            aria-label={`Tool support verification details for ${displayModel}`}
+                            style={{
+                              flexBasis: "100%",
+                              margin: 0,
+                              color: "var(--t2)",
+                              fontSize: 10,
+                              lineHeight: 1.35,
+                            }}
+                          >
+                            <dl
+                              style={{
+                                display: "flex",
+                                flexWrap: "wrap",
+                                gap: "2px 12px",
+                                margin: 0,
+                              }}
+                            >
+                              <div style={{ display: "flex", gap: 4 }}>
+                                <dt style={{ color: "var(--t3)" }}>Checked:</dt>
+                                <dd style={{ margin: 0 }}>
+                                  {verification.checked_at ? (
+                                    <time dateTime={verification.checked_at}>
+                                      {formatVerificationTimestamp(verification.checked_at)}
+                                    </time>
+                                  ) : (
+                                    "Not recorded"
+                                  )}
+                                </dd>
+                              </div>
+                              <div style={{ display: "flex", gap: 4 }}>
+                                <dt style={{ color: "var(--t3)" }}>Expires:</dt>
+                                <dd style={{ margin: 0 }}>
+                                  {verification.expires_at ? (
+                                    <time dateTime={verification.expires_at}>
+                                      {formatVerificationTimestamp(verification.expires_at)}
+                                    </time>
+                                  ) : (
+                                    "Not recorded"
+                                  )}
+                                </dd>
+                              </div>
+                              <div style={{ display: "flex", flexBasis: "100%", gap: 4 }}>
+                                <dt style={{ color: "var(--t3)", flexShrink: 0 }}>Reason:</dt>
+                                <dd style={{ margin: 0, overflowWrap: "anywhere" }}>
+                                  {verification.reason || "No diagnostic reason was recorded."}
+                                </dd>
+                              </div>
+                            </dl>
+                          </div>
+                        )}
+                        {canVerifyToolSupport && (
+                          <button
+                            type="button"
+                            className="btn btn-ghost btn-sm"
+                            disabled={verificationInProgress}
+                            aria-busy={verificationInProgress || undefined}
+                            title={
+                              verificationInProgress
+                                ? "Tool support verification is already in progress."
+                                : "Make one harmless provider request to confirm tool calling. Hecate never executes the returned tool; the request may count toward provider usage."
+                            }
+                            onClick={() => {
+                              setModelToolSupportErrors((current) => {
+                                const next = new Map(current);
+                                next.delete(verificationKey);
+                                return next;
+                              });
+                              void providersAndModels.actions
+                                .verifyModelToolSupport(verificationProvider, m)
+                                .then((result) => {
+                                  if (result.ok) return;
+                                  setModelToolSupportErrors((current) => {
+                                    const next = new Map(current);
+                                    next.set(verificationKey, result.error);
+                                    return next;
+                                  });
+                                });
+                            }}
+                          >
+                            {verificationInProgress ? "Verifying…" : "Verify tool support"}
+                          </button>
+                        )}
+                        {verificationError && (
+                          <span
+                            role="status"
+                            style={{
+                              flexBasis: "100%",
+                              fontSize: 11,
+                              color: "var(--red)",
+                              lineHeight: 1.35,
+                            }}
+                          >
+                            {verificationError}
                           </span>
                         )}
                       </div>
@@ -1139,6 +1268,89 @@ function statColor(tone: ConnectionStatTone): string {
     case "muted":
       return "var(--t3)";
   }
+}
+
+function findSelectedProviderModel(
+  models: ModelRecord[],
+  model: string,
+  runtimeProviderName: string,
+): ModelRecord | undefined {
+  // Do not fall back to aliases here. This action makes an exact paid
+  // provider request, so a temporarily mismatched model/status snapshot must
+  // hide the action rather than accidentally verifying a sibling route.
+  return models.find(
+    (entry) => entry.id === model && entry.metadata?.provider === runtimeProviderName,
+  );
+}
+
+function modelReadyForToolVerification(model: ModelRecord | undefined): boolean {
+  const readiness = model?.metadata?.readiness;
+  return readiness?.ready === true && readiness.routing_ready !== false;
+}
+
+function toolVerificationLabel(
+  verification: ToolCapabilityVerificationRecord | undefined,
+  toolCalling: string | undefined,
+): string {
+  // A stored verification is historical diagnostic evidence. Current
+  // authoritative capability metadata wins when it explicitly says that
+  // this model cannot call tools, including while an old observation remains
+  // visible below for operator auditability.
+  if (toolCalling === "none" && verification) {
+    return "Tool support unavailable";
+  }
+  // Provider/catalog capability data supersedes a conflicting historical
+  // probe. Keep the record visible for audit, but do not let its old negative
+  // result make a currently tool-capable model look unavailable.
+  if (
+    (toolCalling === "basic" || toolCalling === "parallel") &&
+    verification?.status === "unsupported"
+  ) {
+    return "Tool support available";
+  }
+  switch (verification?.status) {
+    case "testing":
+      return "Verifying tool support";
+    case "supported":
+      return "Tool support verified";
+    case "unsupported":
+      return "No tool support";
+    case "inconclusive":
+      return "Tool support not confirmed";
+    default:
+      return toolCalling === "unknown" ? "Tool support unknown" : "";
+  }
+}
+
+function toolVerificationTitle(
+  verification: ToolCapabilityVerificationRecord | undefined,
+  toolCalling: string | undefined,
+): string {
+  if (toolCalling === "none") {
+    return "Current capability metadata says this model does not support tool calling. Any earlier verification record is retained below for audit.";
+  }
+  if (
+    (toolCalling === "basic" || toolCalling === "parallel") &&
+    verification?.status === "unsupported"
+  ) {
+    return "Current capability metadata says this model supports tool calling. The earlier negative verification record is retained below for audit.";
+  }
+  switch (verification?.status) {
+    case "testing":
+      return "A tool support verification is in progress.";
+    case "supported":
+      return "Tool support was verified with one explicit, harmless provider request.";
+    case "unsupported":
+      return "The provider explicitly rejected the fixed tool schema during verification.";
+    case "inconclusive":
+      return "Hecate could not confirm tool support. Resolve provider issues and verify again.";
+    default:
+      return "Tool support has not been confirmed for this model.";
+  }
+}
+
+function formatVerificationTimestamp(value: string): string {
+  return formatLocaleDateTime(value) || "Not recorded";
 }
 
 function isProviderRoutingReady(

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -89,6 +89,7 @@ import {
   updateProjectWorkRole,
   updateProjectWorkItem,
   uploadChatAttachment,
+  verifyModelToolSupport,
   type ApiError,
 } from "./api";
 
@@ -1729,6 +1730,46 @@ describe("api client", () => {
         "/hecate/v1/chat/grants/grant-1",
         expect.objectContaining({ method: "DELETE" }),
       );
+    });
+  });
+
+  describe("verifyModelToolSupport", () => {
+    it("posts one configured provider/model pair and returns the capability projection", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          object: "model_tool_capability_probe",
+          data: {
+            provider: "Local Runtime",
+            model: "custom-tool-model",
+            capabilities: {
+              tool_calling: "basic",
+              tool_verification: {
+                status: "supported",
+                checked_at: "2026-07-21T10:00:00Z",
+                expires_at: "2026-08-20T10:00:00Z",
+              },
+            },
+            verification: {
+              status: "supported",
+              checked_at: "2026-07-21T10:00:00Z",
+              expires_at: "2026-08-20T10:00:00Z",
+            },
+            performed: true,
+          },
+        }),
+      );
+
+      const result = await verifyModelToolSupport("Local Runtime", "custom-tool-model");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/hecate/v1/model-capabilities/tool-probes",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ provider: "Local Runtime", model: "custom-tool-model" }),
+        }),
+      );
+      expect(result.data.capabilities.tool_calling).toBe("basic");
+      expect(result.data.verification?.status).toBe("supported");
     });
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -5,7 +5,7 @@ import type {
   RuntimeStatsResponse,
   SessionResponse,
 } from "../types/runtime";
-import type { ModelResponse } from "../types/model";
+import type { ModelResponse, ModelToolCapabilityProbeResponse } from "../types/model";
 import type { ContextPacketResponse } from "../types/context";
 import type {
   ConfiguredStateResponse,
@@ -331,6 +331,19 @@ export async function getSession(): Promise<SessionResponse> {
 
 export async function getModels(): Promise<ModelResponse> {
   return fetchJSON<ModelResponse>("/v1/models");
+}
+
+// verifyModelToolSupport sends one explicit diagnostic request for a single
+// configured provider/model route. The gateway supplies a fixed, harmless
+// tool schema and never executes a returned tool call.
+export async function verifyModelToolSupport(
+  provider: string,
+  model: string,
+): Promise<ModelToolCapabilityProbeResponse> {
+  return fetchJSON<ModelToolCapabilityProbeResponse>(
+    `${HECATE_API}/model-capabilities/tool-probes`,
+    { method: "POST", body: { provider, model } },
+  );
 }
 
 export async function getProviders(): Promise<ProviderStatusResponse> {

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -146,6 +146,7 @@ export type RuntimeConsoleFixtureState = {
   agentAdapterApprovalMode: string;
   agentAdapterHealthByID: Map<string, AgentAdapterHealthRecord>;
   agentAdapterHealthLoadingByID: Map<string, true>;
+  modelToolSupportLoadingByKey: Map<string, true>;
   pendingThread: ChatMessage[] | null;
   chatTargetBySessionID: Map<string, HecateChatTarget>;
   defaultChatTarget: ChatTarget;
@@ -239,6 +240,7 @@ export function createRuntimeConsoleFixture(
     agentAdapterApprovalMode: "",
     agentAdapterHealthByID: new Map(),
     agentAdapterHealthLoadingByID: new Map(),
+    modelToolSupportLoadingByKey: new Map(),
     pendingThread: null,
     chatTargetBySessionID: new Map(),
     defaultChatTarget: "agent",
@@ -331,6 +333,7 @@ export type RuntimeConsoleFixtureActions = {
   ) => Promise<boolean>;
   setHecateRTKEnabled: (enabled: boolean) => Promise<boolean>;
   probeAgentAdapter: (adapterID: string) => Promise<unknown>;
+  verifyModelToolSupport: (provider: string, model: string) => Promise<unknown>;
   authenticateAgentAdapter: (adapterID: string) => Promise<boolean>;
   logoutAgentAdapter: (adapterID: string) => Promise<boolean>;
   dismissNotice: () => void;
@@ -422,6 +425,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
     setChatConfigOption: async () => true,
     setHecateRTKEnabled: async () => true,
     probeAgentAdapter: async () => null,
+    verifyModelToolSupport: async () => null,
     authenticateAgentAdapter: async () => true,
     logoutAgentAdapter: async () => true,
     dismissNotice: () => undefined,

--- a/ui/src/test/runtime-console-render.tsx
+++ b/ui/src/test/runtime-console-render.tsx
@@ -76,6 +76,7 @@ function providersAndModelsInitialState(fixture: RuntimeConsoleFixtureState) {
     agentAdapterApprovalMode: fixture.agentAdapterApprovalMode,
     agentAdapterHealthByID: fixture.agentAdapterHealthByID,
     agentAdapterHealthLoadingByID: fixture.agentAdapterHealthLoadingByID,
+    modelToolSupportLoadingByKey: fixture.modelToolSupportLoadingByKey,
   };
 }
 
@@ -220,6 +221,7 @@ function buildOverrides(actions: RuntimeConsoleFixtureActions): CoordinatorOverr
     providersAndModelsSlice: {
       refreshProviders: actions.refreshProviders,
       probeAgentAdapter: actions.probeAgentAdapter,
+      verifyModelToolSupport: actions.verifyModelToolSupport,
     },
     projectsSlice: {
       setActiveProjectID: actions.setActiveProjectID,

--- a/ui/src/types/model.ts
+++ b/ui/src/types/model.ts
@@ -15,12 +15,23 @@ export type ModelRecord = {
 
 export type ModelCapabilitiesRecord = {
   tool_calling?: "unknown" | "none" | "basic" | "parallel" | string;
+  // An explicit, operator-triggered tool-call diagnostic. This stays
+  // separate from catalog/provider capability provenance so the UI can show
+  // why an otherwise-unknown route is now eligible for task-backed tools.
+  tool_verification?: ToolCapabilityVerificationRecord;
   image_input?: "unknown" | "none" | "supported" | string;
   streaming?: boolean;
   max_context_tokens?: number;
   source?: "unknown" | "catalog" | "provider" | "mixed" | string;
   note?: string;
   updated_at?: string;
+};
+
+export type ToolCapabilityVerificationRecord = {
+  status?: "testing" | "supported" | "unsupported" | "inconclusive" | string;
+  checked_at?: string;
+  expires_at?: string;
+  reason?: string;
 };
 
 export type ModelReadinessRecord = {
@@ -41,6 +52,18 @@ export type ModelReadinessRecord = {
 export type ModelResponse = {
   object: string;
   data: ModelRecord[];
+};
+
+export type ModelToolCapabilityProbeResponse = {
+  object: string;
+  data: {
+    provider: string;
+    model: string;
+    capabilities: ModelCapabilitiesRecord;
+    verification?: ToolCapabilityVerificationRecord;
+    trace_id?: string;
+    performed: boolean;
+  };
 };
 
 export type ModelFilter = "all" | "local" | "cloud";


### PR DESCRIPTION
## Summary

- add an explicit Connections action to verify tool support for an otherwise-unknown configured model
- persist safe, generation-bound verification results and batch their catalog reads
- bind verified tools-on Hecate Chat tasks to the exact provider, model, configuration generation, and expiry through retries and streaming dispatch
- show verification state, timestamps, and reason details in Connections

## Why

Local and custom providers can expose a model without declaring whether it accepts Hecate's tool catalog. This gives operators an opt-in, bounded verification path without sending Chat content or executing a returned tool.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test -count=1 -p 1 ./...`
- `go test -race -timeout 10m ./...`
- `go test -tags e2e -count=1 -timeout 3m ./e2e/...`
- `bun run typecheck`, `bun run lint`, `bun run format:check`, `bun run test`, and `bun run build`
- documentation and Mermaid validation
