### PR TITLE
ci(mobile): build iOS and Android companions

### DIFF
--- a/.github/workflows/_tauri-mobile-shared.yml
+++ b/.github/workflows/_tauri-mobile-shared.yml
@@ -1,0 +1,163 @@
+name: tauri-mobile-shared
+
+# Reusable unsigned mobile compilation. Called by:
+#   - test.yml                (required PR validation)
+#   - release.yml             (pre-publication release gate)
+#   - tauri-mobile-build.yml  (manual build with downloadable artifacts)
+#
+# Store signing and upload intentionally live outside this workflow. Pull
+# requests never receive Apple or Google credentials.
+
+on:
+  workflow_call:
+    inputs:
+      uploadArtifacts:
+        description: 'Upload the simulator app and debug APK for manual installs.'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  ios:
+    name: iOS Simulator
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # The checked-in Xcode build phase invokes node directly.
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios-sim
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          workspaces: tauri/src-tauri -> target
+          shared-key: mobile-ios-simulator
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Set up just
+        uses: extractions/setup-just@v4
+
+      - name: Install Apple mobile build tools
+        run: brew install xcodegen libimobiledevice
+
+      - name: Build unsigned iOS Simulator app
+        run: just tauri-ios-build-debug
+
+      - name: Verify iOS bundle
+        run: |
+          app="tauri/src-tauri/gen/apple/build/arm64-sim/Hecate.app"
+          test -d "$app"
+          test "$(plutil -extract CFBundleIdentifier raw -o - "$app/Info.plist")" = "sh.hecate.mobile"
+
+      # Uploading an app directory directly loses executable modes. A ditto
+      # archive preserves the simulator bundle exactly.
+      - name: Archive iOS Simulator app
+        if: inputs.uploadArtifacts
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent \
+            tauri/src-tauri/gen/apple/build/arm64-sim/Hecate.app \
+            "$RUNNER_TEMP/Hecate-iOS-Simulator-arm64.zip"
+
+      - name: Upload iOS Simulator app
+        if: inputs.uploadArtifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: hecate-ios-simulator-${{ github.sha }}
+          path: ${{ runner.temp }}/Hecate-iOS-Simulator-arm64.zip
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  android:
+    name: Android arm64 debug APK
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+          cache-dependency-path: |
+            tauri/src-tauri/gen/android/**/*.gradle*
+            tauri/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          packages: 'platform-tools platforms;android-36 build-tools;35.0.0 build-tools;36.0.0 ndk;29.0.14206865'
+
+      - name: Select Android NDK
+        run: |
+          ndk_home="$ANDROID_HOME/ndk/29.0.14206865"
+          test -d "$ndk_home"
+          echo "NDK_HOME=$ndk_home" >> "$GITHUB_ENV"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          workspaces: tauri/src-tauri -> target
+          shared-key: mobile-android-arm64
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Set up just
+        uses: extractions/setup-just@v4
+
+      - name: Build Android debug APK
+        run: just tauri-android-build-debug aarch64
+
+      - name: Verify Android package
+        run: |
+          apk="tauri/src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk"
+          test -f "$apk"
+          "$ANDROID_HOME/build-tools/36.0.0/aapt" dump badging "$apk" |
+            grep -Fq "package: name='sh.hecate.mobile'"
+
+      - name: Upload Android debug APK
+        if: inputs.uploadArtifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: hecate-android-debug-${{ github.sha }}
+          path: tauri/src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,9 @@ permissions:
   packages: write   # push images to ghcr.io
 
 jobs:
-  goreleaser:
+  validate-release-ref:
+    name: Validate release ref
     runs-on: ubuntu-latest
-    outputs:
-      release_body_sha256: ${{ steps.release-body.outputs.sha256 }}
     steps:
       - name: Validate release ref
         env:
@@ -37,6 +36,23 @@ jobs:
             exit 1
           fi
 
+  # Compile both native mobile targets before creating any public release
+  # assets. Store signing and upload remain separate credentialed operations.
+  mobile:
+    name: Tauri mobile builds
+    needs: validate-release-ref
+    uses: ./.github/workflows/_tauri-mobile-shared.yml
+    permissions:
+      contents: read
+    with:
+      uploadArtifacts: false
+
+  goreleaser:
+    needs: [validate-release-ref, mobile]
+    runs-on: ubuntu-latest
+    outputs:
+      release_body_sha256: ${{ steps.release-body.outputs.sha256 }}
+    steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/tauri-mobile-build.yml
+++ b/.github/workflows/tauri-mobile-build.yml
@@ -1,0 +1,22 @@
+name: tauri-mobile-build
+
+# Manual unsigned mobile build. This is useful for simulator testing and
+# Android sideloading without exposing store signing credentials.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: tauri-mobile-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mobile:
+    uses: ./.github/workflows/_tauri-mobile-shared.yml
+    permissions:
+      contents: read
+    with:
+      uploadArtifacts: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       typescript: ${{ steps.filter.outputs.typescript }}
       tauri: ${{ steps.filter.outputs.tauri }}
+      mobile: ${{ steps.filter.outputs.mobile }}
       desktop: ${{ steps.filter.outputs.desktop }}
       workflow: ${{ steps.filter.outputs.workflow }}
       docker: ${{ steps.filter.outputs.docker }}
@@ -82,6 +83,11 @@ jobs:
               - 'ui/e2e/**'
             tauri:
               - 'tauri/**'
+            mobile:
+              - 'tauri/**'
+              - 'scripts/mobile-version.ts'
+              - 'scripts/resolve-tauri-version.ts'
+              - 'scripts/stamp-version.ts'
             desktop:
               - 'tauri/**'
               - 'scripts/resolve-tauri-version.ts'
@@ -102,7 +108,10 @@ jobs:
   test-tauri-rust:
     name: Tauri Rust tests
     needs: changes
-    if: needs.changes.outputs.tauri == 'true' || needs.changes.outputs.workflow == 'true'
+    if: |
+      needs.changes.outputs.tauri == 'true' ||
+      needs.changes.outputs.mobile == 'true' ||
+      needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -486,6 +495,48 @@ jobs:
       - name: E2E tests
         run: bun run test:e2e
 
+  tauri-mobile:
+    name: Tauri mobile builds
+    # Mobile target compilation is intentionally last, alongside the desktop
+    # matrix, so cheap failures do not consume macOS/Android build minutes.
+    needs:
+      - changes
+      - test-tauri-rust
+      - lint-go
+      - test-go-linux-race
+      - test-go-windows-bootstrap
+      - test-go-macos-bootstrap
+      - build-hecate
+      - e2e
+      - e2e-ollama
+      - docker-smoke
+      - typescript
+      - typescript-e2e
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      (
+        needs.changes.outputs.workflow == 'true' ||
+        needs.changes.outputs.mobile == 'true'
+      ) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-tauri-rust.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.lint-go.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-go-linux-race.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-go-windows-bootstrap.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.test-go-macos-bootstrap.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.build-hecate.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.e2e.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.e2e-ollama.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.docker-smoke.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.typescript.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.typescript-e2e.result)
+    uses: ./.github/workflows/_tauri-mobile-shared.yml
+    permissions:
+      contents: read
+    with:
+      uploadArtifacts: false
+
   tauri-desktop:
     name: Tauri desktop bundles
     # Keep this explicit list in sync with every cheap/required PR check. The
@@ -554,6 +605,7 @@ jobs:
       - docker-smoke
       - typescript
       - typescript-e2e
+      - tauri-mobile
       - tauri-desktop
     runs-on: ubuntu-latest
     steps:

--- a/docs-ai/skills/tauri/SKILL.md
+++ b/docs-ai/skills/tauri/SKILL.md
@@ -69,7 +69,7 @@ tauri/
 
 | Recipe                  | What it does                                                                                                             |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `just tauri-install`    | `bun install` inside `tauri/`                                                                                            |
+| `just tauri-install`    | `bun install --frozen-lockfile` inside `tauri/`                                                                          |
 | `just tauri-version`    | runs `scripts/stamp-version.ts` — stamps desktop and mobile version metadata to the current git tag (or `TAURI_VERSION`) |
 | `just tauri-sidecar`    | `just build` then copies `hecate` → `tauri/src-tauri/binaries/hecate-{triple}`                                           |
 | `just tauri-dev`        | `tauri-sidecar` + `tauri-install` + `bunx tauri dev`                                                                     |
@@ -310,14 +310,16 @@ not part of `verify` because it opens a GUI window.
 
 ## CI pipeline
 
-Three workflow files split responsibilities:
+Six workflow files split responsibilities:
 
-| File                                  | Trigger              | What it does                                                                                                 |
-| ------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `.github/workflows/_tauri-shared.yml` | `workflow_call` only | Reusable matrix build. Single source of truth for Tauri build steps.                                         |
-| `.github/workflows/release.yml`       | tag push (`v*`)      | Goreleaser job, then calls `_tauri-shared.yml` with `tagName` set → bundles upload to the GitHub Release.    |
-| `.github/workflows/test.yml`          | PR / `master` push   | Main test gate. Its `Tauri desktop bundles` job calls `_tauri-shared.yml` after cheaper checks pass or skip. |
-| `.github/workflows/tauri-build.yml`   | manual dispatch      | Explicit desktop rebuild/debug run from the Actions tab.                                                     |
+| File                                         | Trigger              | What it does                                                                                 |
+| -------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------- |
+| `.github/workflows/_tauri-shared.yml`        | `workflow_call` only | Reusable desktop matrix and signed updater publication.                                      |
+| `.github/workflows/_tauri-mobile-shared.yml` | `workflow_call` only | Reusable unsigned iOS Simulator and Android debug compilation.                               |
+| `.github/workflows/release.yml`              | tag push (`v*`)      | Runs the mobile preflight, Goreleaser, then `_tauri-shared.yml` for desktop Release uploads. |
+| `.github/workflows/test.yml`                 | PR / `master` push   | Main test gate. Required desktop and mobile callers start after cheaper checks pass or skip. |
+| `.github/workflows/tauri-build.yml`          | manual dispatch      | Explicit desktop rebuild/debug run from the Actions tab.                                     |
+| `.github/workflows/tauri-mobile-build.yml`   | manual dispatch      | Uploads a short-lived simulator archive and Android debug APK for testing.                   |
 
 **Matrix** (same for both callers):
 
@@ -327,21 +329,35 @@ Three workflow files split responsibilities:
 | `ubuntu-22.04`   | `x86_64-unknown-linux-gnu` | `.deb`, `.AppImage` |
 | `windows-latest` | `x86_64-pc-windows-msvc`   | `.msi`              |
 
+**Mobile compile matrix:**
+
+| Runner         | Target                          | Output                                    |
+| -------------- | ------------------------------- | ----------------------------------------- |
+| `macos-latest` | `aarch64-apple-ios-sim`         | unsigned iOS Simulator `Hecate.app`       |
+| `ubuntu-24.04` | `aarch64-linux-android` / arm64 | runner-debug-signed Android universal APK |
+
 **Steps per matrix leg** (in `_tauri-shared.yml`): Rust + Go + Bun setup → Linux Tauri 2 prereqs (webkit2gtk-4.1, libxdo, patchelf, …) → `just ui-install` → `just tauri-sidecar <matrix-target>` (builds `hecate` with the tag injected, then stages it as `binaries/hecate-{triple}[.exe]`) → `cd tauri && bun install --frozen-lockfile` → `bun scripts/stamp-version.ts` → `tauri-apps/tauri-action@v0` (build, conditionally upload).
 
-**PR-run behaviour:** `test.yml` owns PR validation. Its path filter scopes the
-desktop matrix to changes that could plausibly break a Tauri build (`tauri/**`,
-`cmd/hecate/**`, `Justfile`, `just/**`, version scripts, release
-packaging files, and `.github/workflows/*.yml`). UI-only PRs do not trigger the
-desktop matrix; they are covered by the TypeScript jobs and by `build-hecate`,
-which rebuilds the embedded UI. The desktop matrix waits for the cheaper Go,
-TypeScript, e2e, Docker smoke, and Tauri Rust jobs to pass (or skip by path
-filter) before it starts, and it does not upload unsigned bundles.
+**PR-run behaviour:** `test.yml` owns PR validation. Its path filters scope the
+desktop and mobile matrices to changes that could plausibly break their Tauri
+builds (`tauri/**`, `cmd/hecate/**`, `Justfile`, `just/**`, version scripts,
+release packaging files, and `.github/workflows/*.yml`). UI-only PRs do not
+trigger either matrix; they are covered by the TypeScript jobs and by
+`build-hecate`, which rebuilds the embedded UI. Both native matrices wait for
+the cheaper Go, TypeScript, e2e, Docker smoke, and Tauri Rust jobs to pass (or
+skip by path filter) before they start. They run in parallel and do not upload
+PR artifacts.
 `concurrency: cancel-in-progress: true` cancels older runs on the same ref.
 `tauri-build.yml` is manual-only for explicit desktop reruns/debugging; dispatch
 it from a PR branch when a reviewer needs a pre-merge bundle to test-launch.
+`tauri-mobile-build.yml` is the equivalent mobile workflow and preserves the
+iOS app in a `ditto` archive so its executable modes survive artifact download.
 
-**Release-run behaviour:** `concurrency: cancel-in-progress: false` — a half-cancelled release is worse than waiting. The `tauri` job has `needs: goreleaser` so the GitHub Release entry exists before tauri-action's upload tries to attach to it.
+**Release-run behaviour:** `concurrency: cancel-in-progress: false` — a
+half-cancelled release is worse than waiting. Release ref validation runs first,
+then the unsigned mobile matrix. `goreleaser` cannot publish until both mobile
+targets compile. The desktop `tauri` job still has `needs: goreleaser` so the
+GitHub Release entry exists before tauri-action's upload tries to attach to it.
 
 ### Pipeline footguns
 

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -195,6 +195,10 @@ just verify-desktop    # desktop-specific Rust/Tauri check
 just release vX.Y.Z    # verify, then run the release script
 ```
 
+Pull-request CI runs both mobile recipes on their native hosted runners after
+the cheaper checks pass. The manual `tauri-mobile-build` Actions workflow also
+uploads a simulator bundle and debug APK for short-lived testing.
+
 The race detector is the strongest correctness check (and the slowest); CI runs it on every push. The Go e2e suite also includes binary-level External Agent approval smokes for SQLite startup reconcile and durable grant persistence; run them with `go test -tags e2e -run 'TestApproval' ./e2e` when touching approval storage or cmd/hecate startup wiring. Gateway e2e helpers auto-set `PROVIDER_<NAME>_PRECONFIGURED=1` for providers described with `PROVIDER_<NAME>_*` vars; when a test posts an explicit model that the fake `/v1/models` endpoint does not advertise, seed it with `PROVIDER_<NAME>_MODELS` instead of reintroducing provider default-model env vars. `test-docker-smoke` requires Docker but doesn't need any other infrastructure — it spins up its own compose project to avoid colliding with a developer's running stack. `verify-desktop` runs the Tauri Rust test suite and requires Rust/Cargo. `test-tauri-smoke` builds only the packaged macOS `.app`, waits for the sidecar gateway to answer `/healthz`, quits Hecate, and confirms the sidecar exits. The native smoke is opt-in because it opens a real GUI window.
 
 Before cutting a public tag, run `just verify` and follow the checklist in [Release](release.md).

--- a/docs/contributor/release.md
+++ b/docs/contributor/release.md
@@ -62,28 +62,32 @@ channel endpoint.
 
 ## What a release produces
 
-Every `v*` tag fires `.github/workflows/release.yml`, which expands into
-five Actions jobs:
+Every `v*` tag fires `.github/workflows/release.yml`, which expands into these
+ordered stages:
 
-1. **`goreleaser`** (~5–10 min) — multi-arch Go binary tarballs for
+1. **Release ref and mobile preflight** — rejects non-tag manual dispatches,
+   then compiles the unsigned iOS Simulator app and Android arm64 debug APK.
+   Both native targets must compile before any public artifact is created.
+   These are validation builds, not signed TestFlight or Google Play uploads.
+2. **`goreleaser`** (~5–10 min) — multi-arch Go binary tarballs for
    `linux+darwin × amd64+arm64`; each tarball includes `hecate`. It also
    publishes multi-arch Docker images on
    `ghcr.io/hecatehq/hecate`, source tarball, checksums, GitHub Release
    entry.
-2. **`tauri / build`** (matrix, ~10–15 min, runs after goreleaser) —
+3. **`tauri / build`** (matrix, ~10–15 min, runs after goreleaser) —
    three legs building native desktop bundles and uploading them to the same
    Release entry: `.dmg` (macOS arm64), `.deb` + `.AppImage` (Linux x86_64),
    `.msi` (Windows x86_64). This is packaging validation, not platform
    confidence: maintainers currently launch-test the macOS Apple Silicon
    desktop path only. Linux and Windows desktop bundles are CI-built but not
    manually exercised on real machines yet.
-3. **`tauri / publish updater manifest`** — stitches signed updater payloads
+4. **`tauri / publish updater manifest`** — stitches signed updater payloads
    into `latest.json` and uploads the GitHub Release copy.
-4. **`tauri / publish updater manifest to website`** — commits the same
+5. **`tauri / publish updater manifest to website`** — commits the same
    manifest to `website/public/releases/alpha/`, dispatches the website
    deploy, and blocks until `https://hecate.sh/releases/alpha/latest.json`
    serves the new version.
-5. **`update-release-docs`** — reads the actual uploaded Release assets and
+6. **`update-release-docs`** — reads the actual uploaded Release assets and
    refreshes the README Desktop app table plus pinned Docker/tarball examples.
    This runs only after the Tauri matrix succeeds, so it never links to bundles
    that were not published.
@@ -91,6 +95,8 @@ five Actions jobs:
 Acceptance after the run:
 
 - All release jobs green.
+- The unsigned iOS Simulator and Android arm64 debug compile gates are green.
+  They deliberately do not attach mobile binaries to the GitHub Release.
 - Release entry marked **Pre-release** for `-alpha.N` tags.
 - Release entry has non-empty notes: the annotated tag's Markdown for a
   substantive release, otherwise GoReleaser's generated changelog. The desktop
@@ -215,8 +221,8 @@ goreleaser release --snapshot --clean
 Builds Go binaries for `linux+darwin × amd64+arm64` and per-arch Docker
 images into `./dist`, skips publishing to GHCR, skips the GitHub release.
 ~2–3 minutes; surfaces almost every config issue you'd otherwise hit on
-the real tag push. **Does not exercise the Tauri matrix** — that's
-GitHub-Actions-only.
+the real tag push. **Does not exercise the desktop or mobile Tauri matrices** —
+those are GitHub-Actions-only.
 
 `bun scripts/release.ts` runs this for you unless you pass
 `--skip-snapshot`.

--- a/docs/operator/mobile-app.md
+++ b/docs/operator/mobile-app.md
@@ -143,8 +143,10 @@ links are intentionally not part of this version.
   Hecate Cloud from the app. Manually registered runtimes must be started by
   their own operator.
 - Store signing is wired but still requires maintainer-owned Apple and Google
-  credentials. Store metadata, privacy disclosures, release CI, and real-device
-  smoke tests remain release gates.
+  credentials. Store metadata, privacy disclosures, signed store-delivery CI,
+  and real-device smoke tests remain release gates. Unsigned iOS Simulator and
+  Android debug compilation already run in pull-request CI and before a tagged
+  release publishes public artifacts.
 
 ## Build prerequisites
 
@@ -188,6 +190,23 @@ Outputs:
 
 These commands build only the mobile Cloud companion. They do not build or
 stage the desktop Go sidecar.
+
+## Mobile CI
+
+Relevant pull requests must pass both mobile compilation jobs in
+`.github/workflows/_tauri-mobile-shared.yml`:
+
+- an unsigned Apple Silicon iOS Simulator `.app` on macOS;
+- an arm64 Android debug APK on Ubuntu.
+
+The same reusable workflow runs as the first tagged-release preflight. A broken
+mobile target therefore blocks Go, Docker, and desktop artifacts from being
+published. Neither job receives Apple or Google signing credentials.
+
+For a downloadable test build, dispatch `tauri-mobile-build` from the Actions
+tab. Its artifacts are retained for seven days. The iOS artifact is
+simulator-only; the Android artifact is debug-signed by the ephemeral CI runner
+and may be sideloaded, but neither is a store-release artifact.
 
 ## Store identity and signed builds
 

--- a/just/tauri.just
+++ b/just/tauri.just
@@ -17,7 +17,7 @@
 
 # Install native app dependencies.
 tauri-install:
-	cd tauri && bun install
+	cd tauri && bun install --frozen-lockfile
 
 # Stamp Cargo.toml, package.json, and tauri.conf.json with the current release
 # version. Resolution order: TAURI_VERSION env var -> latest git tag ->

--- a/tauri/package.json
+++ b/tauri/package.json
@@ -2,6 +2,7 @@
   "name": "hecate-app",
   "version": "0.5.0-alpha.4",
   "private": true,
+  "packageManager": "bun@1.3.13",
   "homepage": "https://hecate.sh",
   "scripts": {
     "tauri": "tauri",


### PR DESCRIPTION
## What changed

- Add a reusable native mobile workflow that compiles an unsigned iOS
  Simulator app and an arm64 Android debug APK.
- Make both mobile builds required for relevant pull requests.
- Run the same mobile compile gate before a tagged release can publish public
  artifacts.
- Add a manual workflow that uploads short-lived simulator/debug artifacts.
- Pin Tauri installs to the committed Bun lockfile and document the CI/release
  boundary.

## Why

Mobile shell tests were running, but neither native target was compiled in CI.
A broken Xcode or Gradle target could therefore reach a release tag unnoticed.

Store signing remains separate: pull requests receive no Apple or Google
credentials, and CI artifacts are explicitly simulator/debug builds rather
than TestFlight or Play Store releases.

## Validation

- `actionlint .github/workflows/*.yml`
- `just docs-check`
- `bun install --frozen-lockfile`
- `bun run test:mobile-shell` — 36 passed
- `just tauri-rust-test` — 88 passed
- Local iOS Simulator build — `sh.hecate.mobile`
- Local Android arm64 debug APK build — `sh.hecate.mobile`, compile SDK 36
