### PR TITLE
Fix mobile chat composer layout

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1332,7 +1332,7 @@ test("moves focus into and back from a phone replacement panel opened by slash c
   const composer = page.getByRole("textbox", { name: "Message" });
   await composer.fill("/settings");
   await composer.press("Escape");
-  await composer.press("Enter");
+  await page.getByRole("button", { name: "Send message" }).click();
 
   const settingsPanel = page.getByLabel("Chat settings panel");
   await expect(settingsPanel).toBeFocused();

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1236,6 +1236,93 @@ test("uses a full-width replacement panel and phone-sized chat controls", async 
   await expect(settingsButton).toBeFocused();
 });
 
+test("keeps the phone composer controls contained when dictation needs setup", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.route("/hecate/v1/dictation/options", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "dictation_options",
+        data: [
+          {
+            provider: "openai",
+            provider_kind: "cloud",
+            default_model: "gpt-4o-mini-transcribe",
+            available: false,
+            unavailable_reason: "provider credentials are missing",
+          },
+        ],
+      }),
+    }),
+  );
+  await page.evaluate(() => {
+    Object.defineProperty(window, "SpeechRecognition", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, "webkitSpeechRecognition", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+  await switchToModel(page);
+
+  const textarea = page.getByRole("textbox", { name: "Message" });
+  const form = textarea.locator("xpath=ancestor::form");
+  const messageComposer = page.getByRole("group", { name: "Message composer" });
+  const composerActions = page.getByRole("group", { name: "Composer actions" });
+  const controls = [
+    page.getByRole("button", { name: /Provider picker:/ }),
+    page.getByRole("button", { name: /Model picker:/ }),
+    page.getByRole("button", { name: "Image" }),
+    page.getByRole("button", { name: "Start dictation" }),
+    page.getByRole("button", { name: "Set up dictation provider" }),
+    page.getByRole("button", { name: "Send message" }),
+  ];
+
+  await expect(textarea).toHaveAttribute("placeholder", "Message…");
+  const dictationRouteLabel = page.getByText("Dictation route", { exact: true });
+  await expect(dictationRouteLabel).toHaveClass("sr-only");
+  await expect(dictationRouteLabel).toHaveCSS("position", "absolute");
+  const dictationRouteLabelBox = await dictationRouteLabel.boundingBox();
+  expect(dictationRouteLabelBox).not.toBeNull();
+  expect(dictationRouteLabelBox!.width).toBeLessThanOrEqual(1);
+  expect(dictationRouteLabelBox!.height).toBeLessThanOrEqual(1);
+  for (const control of controls) await expect(control).toBeVisible();
+
+  for (const surface of [form, messageComposer, composerActions]) {
+    const geometry = await surface.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+    expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+  }
+
+  const actionsBox = await composerActions.boundingBox();
+  expect(actionsBox).not.toBeNull();
+  const actionControls = controls.slice(2);
+  const actionBoxes = [];
+  for (const control of actionControls) {
+    const box = await control.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(44);
+    expect(box!.height).toBeGreaterThanOrEqual(44);
+    expect(box!.x).toBeGreaterThanOrEqual(actionsBox!.x - 1);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(actionsBox!.x + actionsBox!.width + 1);
+    actionBoxes.push(box!);
+  }
+  for (let left = 0; left < actionBoxes.length; left += 1) {
+    for (let right = left + 1; right < actionBoxes.length; right += 1) {
+      const a = actionBoxes[left]!;
+      const b = actionBoxes[right]!;
+      const horizontalOverlap = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x) > 1;
+      const verticalOverlap = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y) > 1;
+      expect(horizontalOverlap && verticalOverlap).toBe(false);
+    }
+  }
+});
+
 test("moves focus into and back from a phone replacement panel opened by slash command", async ({
   page,
 }) => {

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -163,6 +163,7 @@ export type ChatComposerProps = {
   // Cross-region ref. ChatView owns creation so onSelectSession can
   // focus the textarea without reaching into composer internals.
   textareaRef: RefObject<HTMLTextAreaElement | null>;
+  compactLayout?: boolean;
 
   // Composer gating.
   composerVisible: boolean;
@@ -262,6 +263,7 @@ export function ChatComposer(props: ChatComposerProps) {
     activeTurnKind,
     activeSessionID,
     textareaRef,
+    compactLayout = false,
     composerVisible,
     composerInputDisabled,
     workspaceModePending,
@@ -365,6 +367,10 @@ export function ChatComposer(props: ChatComposerProps) {
     : "";
   const composerStatusText =
     workspaceModeStatusText || activeTurnStatusText || baselineComposerStatus;
+  const compactComposerStatusText = workspaceModeStatusText || activeTurnStatusText;
+  const composerFooterVisible =
+    !compactLayout ||
+    Boolean(compactComposerStatusText || rawChatCancelling || projectProposalAvailable);
 
   const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
   const modKey = isMac ? "⌘" : "Ctrl";
@@ -658,6 +664,18 @@ export function ChatComposer(props: ChatComposerProps) {
     if (e.key !== "Enter") return;
     const modPressed = isMac ? e.metaKey : e.ctrlKey;
 
+    if (compactLayout) {
+      // Mobile Return is a newline. A hardware keyboard can still submit
+      // explicitly, while the visible Send button remains the primary action.
+      if (modPressed) {
+        e.preventDefault();
+        if (!workspaceModePending && !attachmentTurnInFlight) {
+          formRef.current?.requestSubmit();
+        }
+      }
+      return;
+    }
+
     if (workspaceModePending) {
       const sendGesture = modEnterMode ? modPressed : !e.shiftKey && !modPressed;
       if (sendGesture) e.preventDefault();
@@ -821,6 +839,7 @@ export function ChatComposer(props: ChatComposerProps) {
   return (
     <form
       ref={formRef}
+      className="chat-composer"
       onSubmit={handleSubmit}
       style={{
         borderTop: "1px solid var(--border)",
@@ -1257,9 +1276,11 @@ export function ChatComposer(props: ChatComposerProps) {
                   if (files.length > 0) addPendingFiles(files);
                 }}
                 placeholder={
-                  modEnterMode
-                    ? `Message… (${modKey}+Enter to send)`
-                    : "Message… (Shift+Enter for newline)"
+                  compactLayout
+                    ? "Message…"
+                    : modEnterMode
+                      ? `Message… (${modKey}+Enter to send)`
+                      : "Message… (Shift+Enter for newline)"
                 }
                 rows={1}
                 style={{
@@ -1282,17 +1303,7 @@ export function ChatComposer(props: ChatComposerProps) {
                 onInput={(e) => adjustComposerTextareaHeight(e.target as HTMLTextAreaElement)}
               />
             </div>
-            <div
-              aria-label="Composer actions"
-              role="group"
-              style={{
-                display: "flex",
-                alignItems: "flex-end",
-                gap: 6,
-                minWidth: 0,
-                padding: "0 7px 7px",
-              }}
-            >
+            <div className="chat-composer-actions" aria-label="Composer actions" role="group">
               <ChatAttachmentDrafts
                 attachments={chat.state.pendingChatAttachments}
                 acceptance={attachmentAcceptance}
@@ -1310,7 +1321,6 @@ export function ChatComposer(props: ChatComposerProps) {
                 onOpenConnections={onNavigate ? openDictationSetup : undefined}
                 onTranscript={insertDictationTranscript}
               />
-              <span aria-hidden="true" style={{ flex: 1 }} />
               <button
                 className="chat-composer-touch-action chat-composer-send"
                 type="submit"
@@ -1418,124 +1428,112 @@ export function ChatComposer(props: ChatComposerProps) {
                 : "Another chat is stopping. Wait for that request to finish."}
             </div>
           )}
-          <div
-            style={{
-              maxWidth: 820,
-              margin: "3px auto 0",
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              justifyContent: "space-between",
-              minHeight: 22,
-            }}
-          >
-            <span
-              id={workspaceModePending ? workspaceModeStatusID : undefined}
-              aria-atomic={workspaceModePending || undefined}
-              aria-label={
-                workspaceModePending
-                  ? "Workspace execution status"
-                  : agentBusy
-                    ? "Current work status"
-                    : undefined
-              }
-              aria-live={workspaceModePending ? "polite" : undefined}
-              role={workspaceModePending ? "status" : undefined}
-              style={{
-                minWidth: 0,
-                color: agentBusy ? "var(--amber)" : "var(--t3)",
-                fontFamily: "var(--font-mono)",
-                fontSize: 10,
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 8,
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
-            >
-              <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
-                {composerStatusText}
-              </span>
-              {agentBusy && onOpenTask && activeHecateTaskID && (
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-sm"
-                  onClick={() => onOpenTask(activeHecateTaskID, activeHecateRunID)}
-                  style={{
-                    flexShrink: 0,
-                    fontFamily: "var(--font-mono)",
-                    fontSize: 10,
-                    padding: "2px 6px",
-                    color: "var(--amber)",
-                  }}
-                >
-                  Open task
-                </button>
-              )}
-              {(agentBusy || chatCancelling) &&
-                (activeTurnCancellationAvailable || chatCancelling) && (
+          {composerFooterVisible && (
+            <div className="chat-composer-status-row">
+              <span
+                className="chat-composer-status"
+                id={workspaceModePending ? workspaceModeStatusID : undefined}
+                aria-atomic={workspaceModePending || undefined}
+                aria-label={
+                  workspaceModePending
+                    ? "Workspace execution status"
+                    : agentBusy
+                      ? "Current work status"
+                      : undefined
+                }
+                aria-live={workspaceModePending ? "polite" : undefined}
+                role={workspaceModePending ? "status" : undefined}
+                style={{
+                  color: agentBusy ? "var(--amber)" : "var(--t3)",
+                }}
+              >
+                <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {compactLayout ? compactComposerStatusText : composerStatusText}
+                </span>
+                {agentBusy && onOpenTask && activeHecateTaskID && (
                   <button
                     type="button"
                     className="btn btn-ghost btn-sm"
-                    aria-label={chatCancelling ? stoppingStatusText : stopActionLabel}
-                    title={
-                      chatCancelling
-                        ? stoppingStatusText
-                        : anotherChatCancelling
-                          ? "Another chat is stopping. Wait for that request to finish."
-                          : stopActionLabel
-                    }
-                    onClick={chatActions.cancelAgentChat}
-                    disabled={rawChatCancelling}
+                    onClick={() => onOpenTask(activeHecateTaskID, activeHecateRunID)}
                     style={{
                       flexShrink: 0,
                       fontFamily: "var(--font-mono)",
                       fontSize: 10,
                       padding: "2px 6px",
-                      color: "var(--danger)",
+                      color: "var(--amber)",
                     }}
                   >
-                    Stop
+                    Open task
                   </button>
                 )}
-              {projectProposalAvailable && onDraftProjectProposal && (
+                {(agentBusy || chatCancelling) &&
+                  (activeTurnCancellationAvailable || chatCancelling) && (
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-sm"
+                      aria-label={chatCancelling ? stoppingStatusText : stopActionLabel}
+                      title={
+                        chatCancelling
+                          ? stoppingStatusText
+                          : anotherChatCancelling
+                            ? "Another chat is stopping. Wait for that request to finish."
+                            : stopActionLabel
+                      }
+                      onClick={chatActions.cancelAgentChat}
+                      disabled={rawChatCancelling}
+                      style={{
+                        flexShrink: 0,
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10,
+                        padding: "2px 6px",
+                        color: "var(--danger)",
+                      }}
+                    >
+                      Stop
+                    </button>
+                  )}
+                {projectProposalAvailable && onDraftProjectProposal && (
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-sm"
+                    aria-label="Draft Project Assistant proposal from message"
+                    disabled={projectProposalDrafting}
+                    title="Draft a Project Assistant proposal from this message"
+                    onClick={() => onDraftProjectProposal()}
+                    style={{
+                      flexShrink: 0,
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 10,
+                      padding: "2px 6px",
+                      color: "var(--teal)",
+                    }}
+                  >
+                    <Icon d={Icons.projects} size={12} />
+                    {projectProposalDrafting ? "Drafting..." : "Draft proposal"}
+                  </button>
+                )}
+              </span>
+              {!compactLayout && (
                 <button
                   type="button"
-                  className="btn btn-ghost btn-sm"
-                  aria-label="Draft Project Assistant proposal from message"
-                  disabled={projectProposalDrafting}
-                  title="Draft a Project Assistant proposal from this message"
-                  onClick={() => onDraftProjectProposal()}
+                  onClick={toggleModEnterMode}
                   style={{
-                    flexShrink: 0,
                     fontFamily: "var(--font-mono)",
                     fontSize: 10,
-                    padding: "2px 6px",
-                    color: "var(--teal)",
+                    color: "var(--t3)",
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    padding: 0,
+                    whiteSpace: "nowrap",
+                    flexShrink: 0,
                   }}
                 >
-                  <Icon d={Icons.projects} size={12} />
-                  {projectProposalDrafting ? "Drafting..." : "Draft proposal"}
+                  {modEnterMode ? `${modKey}+↵ to send` : "↵ to send"}
                 </button>
               )}
-            </span>
-            <button
-              type="button"
-              onClick={toggleModEnterMode}
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 10,
-                color: "var(--t3)",
-                background: "none",
-                border: "none",
-                cursor: "pointer",
-                padding: 0,
-              }}
-            >
-              {modEnterMode ? `${modKey}+↵ to send` : "↵ to send"}
-            </button>
-          </div>
+            </div>
+          )}
         </>
       )}
     </form>

--- a/ui/src/features/chats/ChatDictationControl.tsx
+++ b/ui/src/features/chats/ChatDictationControl.tsx
@@ -370,17 +370,14 @@ export function ChatDictationControl({
             ? "Transcribing…"
             : "Finishing dictation…"
           : "";
+  const statusNeedsVisualAttention = Boolean(error || phaseLabel || unavailable);
 
   return (
     <div
+      className="chat-composer-dictation"
       role="group"
       aria-label="Dictation"
       style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 6,
-        minHeight: 28,
-        minWidth: 0,
         color: "var(--t3)",
         fontFamily: "var(--font-mono)",
         fontSize: 10,
@@ -388,7 +385,7 @@ export function ChatDictationControl({
     >
       <button
         type="button"
-        className="btn btn-ghost btn-sm chat-composer-touch-action"
+        className="btn btn-ghost btn-sm chat-composer-touch-action chat-composer-dictation-toggle"
         aria-label={phase === "recording" ? "Stop dictation recording" : "Start dictation"}
         aria-describedby={statusID}
         disabled={disabled || unavailable || phase === "requesting" || phase === "processing"}
@@ -409,9 +406,10 @@ export function ChatDictationControl({
         <Icon d={phase === "recording" ? Icons.stop : Icons.microphone} size={13} />
       </button>
       {!routeChecksLoading && routes.length > 0 && (
-        <label style={{ display: "inline-flex", alignItems: "center", gap: 5, minWidth: 0 }}>
+        <label className="chat-composer-dictation-route">
           <span className="sr-only">Dictation route</span>
           <select
+            className="chat-composer-dictation-select"
             value={selectedRouteValue}
             disabled={disabled || active}
             onChange={(event) => {
@@ -419,8 +417,6 @@ export function ChatDictationControl({
               setError("");
             }}
             style={{
-              maxWidth: 220,
-              minWidth: 92,
               background: "transparent",
               border: "none",
               borderRadius: "var(--radius-sm)",
@@ -443,16 +439,15 @@ export function ChatDictationControl({
         </label>
       )}
       <span
+        className={`chat-composer-dictation-status${
+          statusNeedsVisualAttention ? " chat-composer-dictation-status--active" : ""
+        }`}
         id={statusID}
         aria-live="polite"
         role="status"
         title={error || phaseLabel || undefined}
         style={{
-          minWidth: 0,
           color: error ? "var(--red)" : undefined,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
         }}
       >
         {error ||
@@ -461,6 +456,7 @@ export function ChatDictationControl({
       </span>
       {phase === "recording" && (
         <span
+          className="chat-composer-dictation-duration"
           aria-label={`${selectedRoute?.kind === "provider" ? "Recording" : "Dictation"} duration ${formatElapsed(elapsedSeconds)}`}
           aria-live="off"
           style={{ flexShrink: 0 }}
@@ -472,7 +468,7 @@ export function ChatDictationControl({
       {routeStatusRetryNeeded && (
         <button
           type="button"
-          className="btn btn-ghost btn-sm"
+          className="btn btn-ghost btn-sm chat-composer-dictation-action"
           aria-label="Retry dictation route check"
           disabled={disabled || active}
           onClick={retryRoutes}
@@ -485,7 +481,7 @@ export function ChatDictationControl({
       {providerSetupNeeded && onOpenConnections && (
         <button
           type="button"
-          className="btn btn-ghost btn-sm"
+          className="btn btn-ghost btn-sm chat-composer-dictation-action"
           aria-label="Set up dictation provider"
           onClick={onOpenConnections}
           style={{ padding: "3px 5px", flexShrink: 0 }}

--- a/ui/src/features/chats/ChatImageAttachments.tsx
+++ b/ui/src/features/chats/ChatImageAttachments.tsx
@@ -212,6 +212,9 @@ export function ChatAttachmentDrafts({
 
   return (
     <div
+      className="chat-composer-attachments"
+      data-has-attachments={attachments.length > 0 || undefined}
+      data-needs-attention={dragging || !canAdd || Boolean(error) || undefined}
       aria-label={acceptsFiles ? "File attachments" : "Image attachments"}
       role="group"
       onDragEnter={(event) => {
@@ -257,7 +260,10 @@ export function ChatAttachmentDrafts({
         </div>
       )}
 
-      <div style={{ display: "flex", alignItems: "center", gap: 8, minHeight: 22 }}>
+      <div
+        className="chat-composer-attachment-controls"
+        style={{ display: "flex", alignItems: "center", gap: 8, minHeight: 22 }}
+      >
         <input
           ref={inputRef}
           type="file"
@@ -298,6 +304,9 @@ export function ChatAttachmentDrafts({
           <Icon d={Icons.plus} size={11} /> {acceptsFiles ? "Files" : "Image"}
         </button>
         <span
+          className={`chat-composer-attachment-copy${
+            dragging || !canAdd ? " chat-composer-attachment-copy--active" : ""
+          }`}
           ref={unavailableStatusRef}
           id={!canAdd && unavailableReason ? reasonID : undefined}
           tabIndex={!canAdd && unavailableReason ? -1 : undefined}

--- a/ui/src/features/chats/ChatView.test.tsx
+++ b/ui/src/features/chats/ChatView.test.tsx
@@ -4932,6 +4932,19 @@ describe("ChatView Enter switch", () => {
     );
     expect(hasEnterToggle).toBe(true);
   });
+
+  it("uses a concise phone placeholder without the desktop Enter shortcut", () => {
+    stubPhoneViewport();
+    const submitChat = vi.fn(async () => undefined);
+    const { state, actions } = setup({ message: "First line" }, { submitChat });
+    render(withRuntimeConsole(<ChatView />, { state, actions }));
+
+    const composer = screen.getByRole("textbox", { name: "Message" });
+    expect(composer).toHaveAttribute("placeholder", "Message…");
+    expect(screen.queryByRole("button", { name: /↵ to send/ })).toBeNull();
+    expect(fireEvent.keyDown(composer, { key: "Enter" })).toBe(true);
+    expect(submitChat).not.toHaveBeenCalled();
+  });
 });
 
 describe("ChatView chats sidebar", () => {

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1304,7 +1304,11 @@ export function ChatView({
   }
 
   function openChatSettingsPanel() {
-    rememberRightPanelFocusOrigin();
+    if (phoneMasterDetailLayout) {
+      rightPanelReturnFocusRef.current = textareaRef.current;
+    } else {
+      rememberRightPanelFocusOrigin();
+    }
     setWorkspaceChangesOpen(false);
     setChatSettingsOpen(true);
   }

--- a/ui/src/features/chats/ChatView.tsx
+++ b/ui/src/features/chats/ChatView.tsx
@@ -1702,6 +1702,7 @@ export function ChatView({
                 activeTurnKind={activeTurnKind}
                 activeSessionID={activeSessionID}
                 textareaRef={textareaRef}
+                compactLayout={phoneMasterDetailLayout}
                 composerVisible={composerVisible}
                 composerInputDisabled={implicitSessionAllocation}
                 workspaceModePending={workspaceModePending}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7,6 +7,19 @@ body {
   margin: 0;
 }
 
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 :root {
   color-scheme: dark;
 
@@ -741,6 +754,69 @@ textarea {
   }
 }
 
+.chat-composer-actions {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  min-width: 0;
+  padding: 0 7px 7px;
+}
+
+.chat-composer-send {
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.chat-composer-dictation {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  min-width: 0;
+}
+
+.chat-composer-dictation-route {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.chat-composer-dictation-select {
+  max-width: 220px;
+  min-width: 92px;
+}
+
+.chat-composer-dictation-status {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-composer-status-row {
+  max-width: 820px;
+  min-height: 22px;
+  margin: 3px auto 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.chat-composer-status {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+  color: var(--t3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @media (max-width: 520px), (hover: none) and (pointer: coarse) {
   button:not([aria-hidden="true"]),
   .btn,
@@ -965,6 +1041,114 @@ textarea {
     overflow-y: auto;
     padding-bottom: 10px;
     padding-right: 0 !important;
+  }
+}
+
+@media (max-width: 520px) {
+  .chat-composer {
+    padding: 8px !important;
+  }
+
+  .chat-composer-actions {
+    align-items: flex-end;
+    flex-wrap: wrap;
+    overflow: hidden;
+  }
+
+  .chat-composer-attachments {
+    flex: 0 1 auto;
+    max-width: 100%;
+  }
+
+  .chat-composer-attachments[data-has-attachments="true"],
+  .chat-composer-attachments[data-needs-attention="true"] {
+    flex: 1 0 100%;
+    width: 100%;
+  }
+
+  .chat-composer-attachment-controls {
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .chat-composer-attachment-copy:not(.chat-composer-attachment-copy--active),
+  .chat-composer-dictation-status:not(.chat-composer-dictation-status--active) {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    clip-path: inset(50%) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+  }
+
+  .chat-composer-attachment-copy--active {
+    flex: 1 1 auto;
+    max-width: none !important;
+    min-width: 0;
+    overflow: visible !important;
+    text-overflow: clip !important;
+    white-space: normal !important;
+  }
+
+  .chat-composer-dictation {
+    flex: 1 1 130px;
+    display: grid;
+    grid-template-areas:
+      "toggle route action"
+      "status status status";
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 4px 6px;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  .chat-composer-dictation-toggle {
+    grid-area: toggle;
+  }
+
+  .chat-composer-dictation-route {
+    grid-area: route;
+    overflow: hidden;
+    width: 100%;
+  }
+
+  .chat-composer-dictation-select {
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .chat-composer-dictation-status--active {
+    grid-area: status;
+    line-height: 1.35;
+    margin: 2px 4px 0;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  .chat-composer-dictation-duration,
+  .chat-composer-dictation-action {
+    grid-area: action;
+    min-width: 44px;
+  }
+
+  .chat-composer-status-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .chat-composer-status {
+    align-items: center;
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+    overflow: visible;
+    white-space: normal;
   }
 }
 


### PR DESCRIPTION
## What changed

- Reworked the phone composer action rail so attachments, dictation, setup state, and Send reflow without overlapping.
- Added the missing visually-hidden utility used by the dictation route label.
- Kept mobile controls at least 44×44 and moved secondary/status copy onto responsive rows.
- Simplified the phone placeholder to `Message…`, made Return insert a newline, and removed desktop-only Enter-mode chrome on compact layouts.
- Added unit and Playwright regressions for phone keyboard behavior, overflow, touch targets, and control intersections.

## Why

The composer used one non-wrapping flex row for attachment controls, dictation controls, status text, setup, and Send. At iPhone widths, the combined intrinsic widths exceeded the composer while the mobile touch-target rules correctly expanded controls to 44px, causing labels and actions to paint over one another. The intended `sr-only` dictation label also had no CSS implementation and consumed visible width.

## Impact

Phone users get a readable, native-feeling composer with stable controls and multiline Return behavior. Desktop keyboard behavior remains unchanged.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test` — 117 files, 2691 tests passed
- Focused Playwright phone checks — 2 passed at 390×844
- Production build passed before publication
