### PR TITLE
Harden mobile companion and live task recovery

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
               - 'go.mod'
               - 'go.sum'
             typescript:
+              - 'tauri/mobile/**'
               - 'ui/**/*.ts'
               - 'ui/**/*.tsx'
               - 'ui/**/*.css'

--- a/tauri/package.json
+++ b/tauri/package.json
@@ -6,7 +6,8 @@
   "homepage": "https://hecate.sh",
   "scripts": {
     "tauri": "tauri",
-    "test:mobile-shell": "bun test tests"
+    "check:mobile-shell-bundle": "bun build mobile/app.js --target=browser --outdir=node_modules/.cache/hecate-mobile-shell",
+    "test:mobile-shell": "bun test tests && bun run check:mobile-shell-bundle"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.2"

--- a/ui/e2e/mobile-companion.spec.ts
+++ b/ui/e2e/mobile-companion.spec.ts
@@ -1,0 +1,109 @@
+import type { Page } from "@playwright/test";
+
+import { expect, mockGatewayAPIs, MOCK_SETTINGS_CONFIG_WITH_PROVIDERS, test } from "./fixtures";
+
+async function installMobileCompanionContext(page: Page) {
+  await page.addInitScript(() => {
+    Reflect.set(window, "__TAURI__", {});
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: `${navigator.userAgent} HecateMobile`,
+    });
+    window.localStorage.setItem("hecate.workspace", "settings");
+    window.localStorage.setItem("hecate.chatTarget", "agent");
+    window.localStorage.setItem("hecate.chatToolsEnabled", "false");
+    window.localStorage.setItem("hecate.providerFilter", "openai");
+    window.localStorage.setItem("hecate.model", "gpt-4o");
+    window.localStorage.removeItem("hecate.project");
+  });
+}
+
+test("runs and continues a rootless chat in the mobile companion console", async ({ page }) => {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  const gateway = await mockGatewayAPIs(page, {
+    settingsConfig: MOCK_SETTINGS_CONFIG_WITH_PROVIDERS,
+  });
+  let createRequest: Record<string, unknown> | null = null;
+  await page.route("/hecate/v1/chat/sessions", async (route) => {
+    if (route.request().method() === "POST") {
+      createRequest = await route.request().postDataJSON();
+    }
+    await route.fallback();
+  });
+  await installMobileCompanionContext(page);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+
+  const navigation = page.getByRole("navigation", { name: "Workspace navigation" });
+  for (const label of ["Chats", "Projects", "Tasks"]) {
+    await expect(navigation.getByRole("link", { name: label })).toBeVisible();
+  }
+  await expect(page.getByRole("link", { name: "Switch Hecate instance" })).toHaveAttribute(
+    "href",
+    "hecate-mobile://connections/",
+  );
+
+  await navigation.getByRole("button", { name: "More" }).click();
+  const moreScreens = page.getByRole("dialog", { name: "More Hecate screens" });
+  for (const label of ["Connections", "Observability", "Usage", "Settings"]) {
+    await expect(moreScreens.getByRole("link", { name: label })).toBeVisible();
+  }
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: "New Hecate chat", exact: true }).click();
+  await expect(page.getByText(/Tools off/).first()).toBeVisible();
+  await expect.poll(() => createRequest).not.toBeNull();
+  expect(createRequest).not.toHaveProperty("workspace");
+
+  const providerPicker = page.getByRole("button", { name: /provider picker/i });
+  if (!(await providerPicker.textContent())?.includes("OpenAI")) {
+    await providerPicker.click();
+    await page
+      .locator(".dropdown-menu")
+      .first()
+      .locator("[role='option']")
+      .filter({ hasText: "OpenAI" })
+      .first()
+      .click();
+  }
+  const modelPicker = page.getByRole("button", { name: /model picker/i });
+  if (!(await modelPicker.textContent())?.includes("gpt-4o")) {
+    await modelPicker.click();
+    await page
+      .locator(".dropdown-menu")
+      .first()
+      .locator("[role='option']")
+      .filter({ hasText: "gpt-4o" })
+      .first()
+      .click();
+  }
+
+  const composer = page.getByRole("textbox", { name: "Message" });
+  await composer.fill("hello from iPhone");
+  await page.getByRole("button", { name: "Send message" }).click();
+
+  await expect(page.getByText("Direct response to: hello from iPhone")).toBeVisible();
+  await expect.poll(() => gateway.chatMessagePayloads.length).toBe(1);
+  expect(gateway.chatMessagePayloads[0]).toMatchObject({
+    content: "hello from iPhone",
+    model: "gpt-4o",
+    provider: "openai",
+    tools_enabled: false,
+  });
+
+  const selectedSession = await page.evaluate(() =>
+    window.localStorage.getItem("hecate.chatSessionID"),
+  );
+  expect(selectedSession).toMatch(/^chat-e2e-/);
+  await expect(page).toHaveURL(new RegExp(`chat=${selectedSession}`));
+
+  await page.reload();
+  await page.waitForSelector(".hecate-activitybar");
+  await page.getByRole("link", { name: /Chat Hecate chat, Hecate/ }).click();
+  await expect(page.getByText("hello from iPhone", { exact: true })).toBeVisible();
+  await expect(page.getByText("Direct response to: hello from iPhone")).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => window.localStorage.getItem("hecate.chatSessionID")))
+    .toBe(selectedSession);
+});

--- a/ui/e2e/mobile-shell.spec.ts
+++ b/ui/e2e/mobile-shell.spec.ts
@@ -1,0 +1,203 @@
+import { readFile } from "node:fs/promises";
+import { extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test, type Page } from "@playwright/test";
+
+const mobileRoot = fileURLToPath(new URL("../../tauri/mobile/", import.meta.url));
+const mobileOrigin = "http://mobile.hecate.test";
+
+type MobileCall = {
+  name: string;
+  args?: Record<string, unknown>;
+};
+
+async function serveMobileShell(page: Page) {
+  await page.route(`${mobileOrigin}/**`, async (route) => {
+    const requestURL = new URL(route.request().url());
+    const relativePath =
+      requestURL.pathname === "/" ? "index.html" : decodeURIComponent(requestURL.pathname.slice(1));
+    if (!relativePath || relativePath.includes("/") || relativePath.includes("..")) {
+      await route.fulfill({ status: 404, body: "Not found" });
+      return;
+    }
+
+    try {
+      const body = await readFile(join(mobileRoot, relativePath));
+      const contentType = {
+        ".css": "text/css",
+        ".html": "text/html",
+        ".js": "text/javascript",
+      }[extname(relativePath)];
+      await route.fulfill({
+        status: 200,
+        contentType: contentType ?? "application/octet-stream",
+        body,
+      });
+    } catch {
+      await route.fulfill({ status: 404, body: "Not found" });
+    }
+  });
+}
+
+async function installNativeBridge(page: Page) {
+  await page.addInitScript(() => {
+    const signedOutStatus = {
+      phase: "signed_out",
+      signed_in: false,
+      authorizing: false,
+      message: "Sign in to choose a Hecate instance.",
+    };
+    const authorizingStatus = {
+      phase: "authorizing",
+      signed_in: false,
+      authorizing: true,
+      approval_page_available: true,
+      message: "Waiting for browser approval. Hecate will return here automatically.",
+    };
+    const signedInStatus = {
+      phase: "signed_in",
+      signed_in: true,
+      authorizing: false,
+      account_email: "operator@example.com",
+      message: "Choose a Hecate instance.",
+    };
+    const state = {
+      status: signedOutStatus,
+      completeAuthorizationOnStatus: false,
+      calls: [] as MobileCall[],
+      connections: [
+        {
+          id: "desktop-1",
+          kind: "desktop_host",
+          name: "Studio Mac",
+          version: "0.5.0-alpha.4",
+          reachable: true,
+          remote_enabled: true,
+          last_seen_at: new Date().toISOString(),
+        },
+        {
+          id: "hosted-1",
+          kind: "hosted_runtime",
+          name: "Dogfood Runtime",
+          version: "0.5.0-alpha.4",
+          reachable: false,
+          can_start: true,
+          status: "offline",
+          last_seen_at: new Date().toISOString(),
+        },
+      ],
+    };
+
+    Object.defineProperty(window, "__mobileShellTest", {
+      configurable: false,
+      enumerable: false,
+      value: state,
+    });
+    Object.defineProperty(window, "__TAURI__", {
+      configurable: false,
+      enumerable: false,
+      value: {
+        core: {
+          invoke: async (name: string, args?: Record<string, unknown>) => {
+            state.calls.push({ name, args });
+            if (name === "mobile_status") {
+              if (state.completeAuthorizationOnStatus) {
+                state.completeAuthorizationOnStatus = false;
+                state.status = signedInStatus;
+              }
+              return structuredClone(state.status);
+            }
+            if (name === "mobile_sign_in") {
+              state.status = authorizingStatus;
+              state.completeAuthorizationOnStatus = true;
+              return structuredClone(state.status);
+            }
+            if (name === "mobile_reopen_authorization") {
+              return structuredClone(authorizingStatus);
+            }
+            if (name === "mobile_connections") {
+              return structuredClone(state.connections);
+            }
+            if (name === "mobile_open_connection") {
+              return { message: "Secure Hecate session opened." };
+            }
+            if (name === "mobile_start_connection") {
+              const connection = state.connections.find(
+                (candidate) => candidate.id === args?.connectionId,
+              );
+              if (connection) {
+                connection.can_start = false;
+                connection.status = "starting";
+              }
+              return { message: "Dogfood Runtime is starting." };
+            }
+            if (name === "mobile_sign_out") {
+              state.status = signedOutStatus;
+              state.connections = [];
+              return structuredClone(state.status);
+            }
+            if (name === "mobile_notification_status") {
+              return { available: false };
+            }
+            throw new Error(`Unexpected mobile command: ${name}`);
+          },
+        },
+      },
+    });
+  });
+}
+
+test("runs the packaged mobile companion journey", async ({ page }) => {
+  await serveMobileShell(page);
+  await installNativeBridge(page);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(mobileOrigin);
+
+  await expect(page.getByRole("heading", { name: "Your Hecate, from anywhere" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sign in with Hecate" })).toBeEnabled();
+
+  await page.getByRole("button", { name: "Sign in with Hecate" }).click();
+  await expect(page.getByText("Waiting for browser approval", { exact: false })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Open browser sign-in again" })).toBeEnabled();
+
+  await expect(page.getByRole("heading", { name: "Choose Hecate" })).toBeVisible({
+    timeout: 4_000,
+  });
+  await expect(page.getByText("operator@example.com")).toBeHidden();
+  await expect(page.getByText("Hecate on Studio Mac")).toBeVisible();
+  await expect(page.getByText("Dogfood Runtime")).toBeVisible();
+
+  await page.getByRole("button", { name: "Start Dogfood Runtime" }).click();
+  await expect(page.getByText("Dogfood Runtime is starting.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Dogfood Runtime: Starting" })).toBeDisabled();
+
+  await page.getByRole("button", { name: "Open Hecate on Studio Mac" }).click();
+  await expect(page.getByRole("button", { name: "Open Hecate on Studio Mac" })).toBeEnabled();
+
+  await page.getByRole("button", { name: "Open settings" }).click();
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+  await expect(page.getByText("operator@example.com")).toBeVisible();
+  await page.getByRole("button", { name: "Back to Hecate instances" }).click();
+  await expect(page.getByRole("heading", { name: "Choose Hecate" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Open settings" }).click();
+  await page.getByRole("button", { name: "Sign out" }).click();
+  await expect(page.getByRole("heading", { name: "Your Hecate, from anywhere" })).toBeVisible();
+
+  const calls = await page.evaluate(() => {
+    const testWindow = window as typeof window & {
+      __mobileShellTest: { calls: MobileCall[] };
+    };
+    return testWindow.__mobileShellTest.calls;
+  });
+  expect(calls).toContainEqual({
+    name: "mobile_start_connection",
+    args: { connectionId: "hosted-1" },
+  });
+  expect(calls).toContainEqual({
+    name: "mobile_open_connection",
+    args: { connectionId: "desktop-1" },
+  });
+  expect(calls.some((call) => call.name === "mobile_sign_out")).toBe(true);
+});

--- a/ui/src/features/tasks/TaskDetail.test.tsx
+++ b/ui/src/features/tasks/TaskDetail.test.tsx
@@ -1148,6 +1148,16 @@ describe("TaskDetail runtime activity and patches", () => {
     expect(screen.queryByText("— stderr —")).toBeNull();
   });
 
+  it.each([
+    ["reconnecting", "Reconnecting live updates", "status"],
+    ["error", "Live updates unavailable", "alert"],
+  ] as const)("shows the %s Run stream state", (streamState, label, role) => {
+    const { render } = setup({ streamState });
+    render();
+
+    expect(screen.getByText(label)).toHaveAttribute("role", role);
+  });
+
   it("marks object-backed stderr artifacts as available when they have bytes", () => {
     const { render } = setup({
       artifacts: [

--- a/ui/src/features/tasks/TaskDetail.tsx
+++ b/ui/src/features/tasks/TaskDetail.tsx
@@ -68,7 +68,7 @@ import {
   taskSource,
 } from "./taskDetailHelpers";
 
-type StreamState = "idle" | "connecting" | "live" | "closed" | "error";
+type StreamState = "idle" | "connecting" | "reconnecting" | "live" | "closed" | "error";
 
 // RunCostBadge shows this run's cost — and, when prior runs exist
 // in the resume chain, the task-cumulative figure too. Operators
@@ -716,6 +716,16 @@ export function TaskDetail({
   );
   const visibleEvents = events.filter(isVisibleRunEvent);
   const runOutcome = run ? taskRunOutcome(run.status, run.last_error) : null;
+  const streamStatus =
+    streamState === "live"
+      ? { color: "green" as const, label: "Live updates", pulse: true }
+      : streamState === "connecting"
+        ? { color: "amber" as const, label: "Connecting live updates", pulse: true }
+        : streamState === "reconnecting"
+          ? { color: "amber" as const, label: "Reconnecting live updates", pulse: true }
+          : streamState === "error"
+            ? { color: "red" as const, label: "Live updates unavailable", pulse: false }
+            : null;
   const scheduledRunTimezone =
     run?.schedule_id && run.schedule_id === schedule?.id ? schedule.timezone : browserTimezone();
 
@@ -1668,8 +1678,23 @@ export function TaskDetail({
                 stdout{stdoutArtifact.size_bytes ? ` ${stdoutArtifact.size_bytes}b` : ""}
               </span>
             )}
-            {streamState === "live" && <Dot color="green" pulse />}
-            {streamState === "connecting" && <Dot color="amber" pulse />}
+            {streamStatus && (
+              <span
+                aria-live={streamState === "error" ? "assertive" : "polite"}
+                role={streamState === "error" ? "alert" : "status"}
+                style={{
+                  alignItems: "center",
+                  color: streamState === "error" ? "var(--red)" : "var(--t2)",
+                  display: "inline-flex",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 10,
+                  gap: 5,
+                }}
+              >
+                <Dot color={streamStatus.color} pulse={streamStatus.pulse} />
+                {streamStatus.label}
+              </span>
+            )}
             {stderrArtifact && (
               <span
                 style={{

--- a/ui/src/features/tasks/TasksView.test.tsx
+++ b/ui/src/features/tasks/TasksView.test.tsx
@@ -794,6 +794,209 @@ describe("TasksView streamed Task summaries", () => {
     );
   });
 
+  it("reconnects from the latest sequence and catches up authoritative Run detail", async () => {
+    const activeTask: TaskRecord = { ...task, status: "running" };
+    const activeRun: TaskRunRecord = {
+      ...run,
+      status: "running",
+      finished_at: undefined,
+    };
+    const streamStarts: number[] = [];
+    let emitReconnect: (() => void) | undefined;
+    vi.mocked(getTasks).mockResolvedValue({ object: "list", data: [activeTask] });
+    vi.mocked(getTaskRuns).mockResolvedValue({ object: "list", data: [activeRun] });
+    vi.mocked(streamTaskRun).mockImplementation(
+      (_taskID, _runID, onEvent, afterSequence = 0, signal) => {
+        streamStarts.push(afterSequence);
+        if (streamStarts.length === 1) {
+          onEvent({
+            event: "snapshot",
+            payload: {
+              object: "task_run_stream_event",
+              data: { sequence: 7, run: activeRun },
+            },
+          });
+          return Promise.reject(new Error("relay restarted"));
+        }
+
+        emitReconnect = () =>
+          onEvent({
+            event: "snapshot",
+            payload: {
+              object: "task_run_stream_event",
+              data: { sequence: 8, run: activeRun },
+            },
+          });
+        return new Promise<void>((_resolve, reject) => {
+          const abort = () => reject(new DOMException("Aborted", "AbortError"));
+          signal?.addEventListener("abort", abort, { once: true });
+          if (signal?.aborted) abort();
+        });
+      },
+    );
+
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    const view = render(
+      withRuntimeConsole(<TasksView />, { state, actions: createRuntimeConsoleActions() }),
+    );
+
+    expect(await screen.findByText("Reconnecting live updates")).toBeTruthy();
+    await waitFor(() => expect(streamStarts).toEqual([0, 7]), { timeout: 1_500 });
+
+    act(() => emitReconnect?.());
+
+    expect(await screen.findByText("Live updates")).toBeTruthy();
+    await waitFor(() => {
+      expect(getTaskRuns).toHaveBeenCalledTimes(2);
+      expect(getTaskApprovals).toHaveBeenCalledTimes(2);
+      expect(getTaskRunSteps).toHaveBeenCalledTimes(2);
+      expect(getTaskRunArtifacts).toHaveBeenCalledTimes(2);
+      expect(getTaskRunEvents).toHaveBeenCalledTimes(2);
+    });
+
+    view.unmount();
+  });
+
+  it("finishes authoritative catch-up before a recovered stream can apply newer state", async () => {
+    const activeTask: TaskRecord = { ...task, status: "running" };
+    const activeRun: TaskRunRecord = {
+      ...run,
+      status: "running",
+      step_count: 1,
+      finished_at: undefined,
+    };
+    const staleCatchUpRun: TaskRunRecord = { ...activeRun, step_count: 3 };
+    const recoveredRun: TaskRunRecord = { ...activeRun, step_count: 9 };
+    const catchUpRuns = deferred<Awaited<ReturnType<typeof getTaskRuns>>>();
+    const streamStarts: number[] = [];
+    vi.mocked(getTasks).mockResolvedValue({ object: "list", data: [activeTask] });
+    vi.mocked(getTaskRuns)
+      .mockResolvedValueOnce({ object: "list", data: [activeRun] })
+      .mockReturnValueOnce(catchUpRuns.promise);
+    vi.mocked(streamTaskRun).mockImplementation(
+      (_taskID, _runID, onEvent, afterSequence = 0, signal) => {
+        streamStarts.push(afterSequence);
+        if (streamStarts.length === 1) {
+          onEvent({
+            event: "snapshot",
+            payload: {
+              object: "task_run_stream_event",
+              data: { sequence: 7, run: activeRun },
+            },
+          });
+          return Promise.reject(new Error("relay restarted"));
+        }
+        onEvent({
+          event: "snapshot",
+          payload: {
+            object: "task_run_stream_event",
+            data: { sequence: 9, run: recoveredRun },
+          },
+        });
+        return new Promise<void>((_resolve, reject) => {
+          const abort = () => reject(new DOMException("Aborted", "AbortError"));
+          signal?.addEventListener("abort", abort, { once: true });
+          if (signal?.aborted) abort();
+        });
+      },
+    );
+
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    const view = render(
+      withRuntimeConsole(<TasksView />, { state, actions: createRuntimeConsoleActions() }),
+    );
+
+    expect(await screen.findByText("Reconnecting live updates")).toBeTruthy();
+    await waitFor(() => expect(getTaskRuns).toHaveBeenCalledTimes(2), { timeout: 1_500 });
+    expect(streamStarts).toEqual([0]);
+
+    await act(async () => {
+      catchUpRuns.resolve({ object: "list", data: [staleCatchUpRun] });
+      await catchUpRuns.promise;
+    });
+
+    await waitFor(() => expect(streamStarts).toEqual([0, 7]));
+    expect(await screen.findByText("Latest Run · 9 steps")).toBeTruthy();
+
+    view.unmount();
+  });
+
+  it("stops reconnecting when authoritative catch-up finds the Run terminal", async () => {
+    const activeTask: TaskRecord = { ...task, status: "running" };
+    const activeRun: TaskRunRecord = {
+      ...run,
+      status: "running",
+      finished_at: undefined,
+    };
+    const completedRun: TaskRunRecord = { ...activeRun, status: "completed" };
+    vi.mocked(getTasks).mockResolvedValue({ object: "list", data: [activeTask] });
+    vi.mocked(getTaskRuns)
+      .mockResolvedValueOnce({ object: "list", data: [activeRun] })
+      .mockResolvedValueOnce({ object: "list", data: [completedRun] });
+    vi.mocked(streamTaskRun).mockRejectedValue(new Error("relay restarted"));
+
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    render(withRuntimeConsole(<TasksView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText("Reconnecting live updates")).toBeTruthy();
+    await waitFor(() => expect(getTaskRuns).toHaveBeenCalledTimes(2), { timeout: 1_500 });
+    await waitFor(() => expect(screen.queryByText("Reconnecting live updates")).toBeNull());
+    expect(streamTaskRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts a pending reconnect when the Task view unmounts", async () => {
+    const activeTask: TaskRecord = { ...task, status: "running" };
+    const activeRun: TaskRunRecord = {
+      ...run,
+      status: "running",
+      finished_at: undefined,
+    };
+    let streamSignal: AbortSignal | undefined;
+    vi.mocked(getTasks).mockResolvedValue({ object: "list", data: [activeTask] });
+    vi.mocked(getTaskRuns).mockResolvedValue({ object: "list", data: [activeRun] });
+    vi.mocked(streamTaskRun).mockImplementation(
+      (_taskID, _runID, _onEvent, _afterSequence, signal) => {
+        streamSignal = signal;
+        return Promise.reject(new Error("relay restarted"));
+      },
+    );
+
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    const view = render(
+      withRuntimeConsole(<TasksView />, { state, actions: createRuntimeConsoleActions() }),
+    );
+
+    expect(await screen.findByText("Reconnecting live updates")).toBeTruthy();
+    expect(streamTaskRun).toHaveBeenCalledTimes(1);
+    expect(streamSignal?.aborted).toBe(false);
+
+    view.unmount();
+
+    expect(streamSignal?.aborted).toBe(true);
+    await new Promise((resolve) => window.setTimeout(resolve, 350));
+    expect(streamTaskRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a non-retryable stream failure instead of reconnecting indefinitely", async () => {
+    const activeTask: TaskRecord = { ...task, status: "running" };
+    const activeRun: TaskRunRecord = {
+      ...run,
+      status: "running",
+      finished_at: undefined,
+    };
+    vi.mocked(getTasks).mockResolvedValue({ object: "list", data: [activeTask] });
+    vi.mocked(getTaskRuns).mockResolvedValue({ object: "list", data: [activeRun] });
+    vi.mocked(streamTaskRun).mockRejectedValue(
+      new ApiError("This Run is unavailable.", 404, "not_found"),
+    );
+
+    const state = createRuntimeConsoleFixture({ session: localSession });
+    render(withRuntimeConsole(<TasksView />, { state, actions: createRuntimeConsoleActions() }));
+
+    expect(await screen.findByText("Live updates unavailable")).toHaveAttribute("role", "alert");
+    expect(streamTaskRun).toHaveBeenCalledTimes(1);
+  });
+
   it("updates latest-Run summary fields from the latest Run stream", async () => {
     const listedTask: TaskRecord = {
       ...task,

--- a/ui/src/features/tasks/TasksView.tsx
+++ b/ui/src/features/tasks/TasksView.tsx
@@ -58,9 +58,43 @@ import { formatProjectDeleteSummary } from "../projects/projectDisplay";
 import { EntityDetailPane, MasterDetailWorkspace } from "../shared/EntityWorkspace";
 import { ConfirmModal } from "../shared/ui";
 
-type StreamState = "idle" | "connecting" | "live" | "closed" | "error";
+type StreamState = "idle" | "connecting" | "reconnecting" | "live" | "closed" | "error";
 type TaskFocusRequest = { taskID: string; runID?: string; nonce: number };
 type TaskSelection = { taskID: string; runID: string };
+
+const taskRunStreamRetryBaseMS = 250;
+const taskRunStreamRetryMaxMS = 2_000;
+const taskRunStreamNonRetryableHTTPStatuses = new Set([400, 401, 403, 404]);
+
+function taskRunStatusIsTerminal(status: string): boolean {
+  return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+function taskRunStreamRetryDelayMS(attempt: number): number {
+  const exponent = Math.min(Math.max(attempt, 0), 4);
+  return Math.min(taskRunStreamRetryBaseMS * 2 ** exponent, taskRunStreamRetryMaxMS);
+}
+
+function taskRunStreamFailureIsNonRetryable(error: unknown): boolean {
+  return error instanceof ApiError && taskRunStreamNonRetryableHTTPStatuses.has(error.status);
+}
+
+function waitForTaskRunStreamRetry(signal: AbortSignal, delayMS: number): Promise<boolean> {
+  if (signal.aborted) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    const timeout = window.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, delayMS);
+    const onAbort = () => {
+      window.clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      resolve(false);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+}
 
 export function taskMatchesFilter(
   task: TaskRecord,
@@ -241,6 +275,7 @@ export function TasksView({
   const defaultTaskWorkspace = projectDefaultWorkspace(projects.activeProject);
 
   const streamCursorRef = useRef(0);
+  const selectedRunStatusRef = useRef("");
   const taskLoadGenerationRef = useRef(0);
   const scheduleMutationGenerationRef = useRef(0);
   const scheduleHistoryGenerationRef = useRef(0);
@@ -255,6 +290,7 @@ export function TasksView({
     () => runs.find((r) => r.id === selectedRunID) ?? null,
     [runs, selectedRunID],
   );
+  selectedRunStatusRef.current = selectedRun?.status ?? "";
   const schedulesByTaskID = useMemo(
     () => new Map(schedules.map((schedule) => [schedule.task_id, schedule])),
     [schedules],
@@ -341,6 +377,8 @@ export function TasksView({
         (preferredRunID && nextRuns.some((r) => r.id === preferredRunID) ? preferredRunID : "") ||
         nextRuns[0]?.id ||
         "";
+      selectedRunStatusRef.current =
+        nextRuns.find((candidate) => candidate.id === nextRunID)?.status ?? "";
       selectTaskRun(taskID, nextRunID);
       setRuns(nextRuns);
       setApprovals(approvalsRes.data ?? []);
@@ -577,106 +615,193 @@ export function TasksView({
       return;
     }
     const controller = new AbortController();
+    let disposed = false;
     setStreamState("connecting");
 
-    void streamTaskRun(
-      selectedTaskID,
-      selectedRunID,
-      ({ payload }) => {
-        const currentSelection = selectedTaskRunRef.current;
-        if (
-          currentSelection.taskID !== selectedTaskID ||
-          currentSelection.runID !== selectedRunID
-        ) {
+    const selectionIsCurrent = () => {
+      const currentSelection = selectedTaskRunRef.current;
+      return (
+        !disposed &&
+        !controller.signal.aborted &&
+        currentSelection.taskID === selectedTaskID &&
+        currentSelection.runID === selectedRunID
+      );
+    };
+
+    const catchUpAuthoritativeDetail = async () => {
+      try {
+        const loadedRunID = await loadTaskDetail(selectedTaskID, selectedRunID);
+        if (selectionIsCurrent() && loadedRunID !== null) {
+          setTaskDetailLoadError("");
+        }
+      } catch (error) {
+        if (selectionIsCurrent()) {
+          setTaskDetailLoadError(error instanceof Error ? error.message : "unknown error");
+        }
+      }
+    };
+
+    const observe = async () => {
+      let retryAttempt = 0;
+      let reconnecting = false;
+      let lastObservedRunStatus = selectedRunStatusRef.current;
+
+      while (selectionIsCurrent()) {
+        if (reconnecting) {
+          const currentRunStatus = selectedRunStatusRef.current;
+          if (currentRunStatus) lastObservedRunStatus = currentRunStatus;
+          if (taskRunStatusIsTerminal(lastObservedRunStatus)) {
+            setStreamState("closed");
+            return;
+          }
+
+          setStreamState("reconnecting");
+          await catchUpAuthoritativeDetail();
+          if (!selectionIsCurrent()) return;
+
+          const caughtUpRunStatus = selectedRunStatusRef.current;
+          if (caughtUpRunStatus) lastObservedRunStatus = caughtUpRunStatus;
+          if (taskRunStatusIsTerminal(lastObservedRunStatus)) {
+            setStreamState("closed");
+            return;
+          }
+        }
+
+        let terminalRunObserved = taskRunStatusIsTerminal(lastObservedRunStatus);
+        const attemptStartSequence = streamCursorRef.current;
+
+        try {
+          await streamTaskRun(
+            selectedTaskID,
+            selectedRunID,
+            ({ payload }) => {
+              if (!selectionIsCurrent()) return;
+              lastObservedRunStatus = payload.data.run.status;
+              terminalRunObserved =
+                payload.data.terminal === true || taskRunStatusIsTerminal(lastObservedRunStatus);
+              setStreamState(terminalRunObserved ? "closed" : "live");
+              if (payload.data.sequence > attemptStartSequence) {
+                retryAttempt = 0;
+              }
+              streamCursorRef.current = Math.max(
+                streamCursorRef.current,
+                payload.data.sequence ?? 0,
+              );
+              setRuns((cur) => {
+                const others = cur.filter((r) => r.id !== payload.data.run.id);
+                return [payload.data.run, ...others];
+              });
+              setSteps(payload.data.steps ?? []);
+              setArtifacts(payload.data.artifacts ?? []);
+              setActivity(payload.data.activity ?? []);
+              // Capture per-model-call cost when the snapshot was driven by a
+              // `model.call.completed` event. Dedup by model-call number — the
+              // SSE may replay the same event on reconnect, and we don't
+              // want a duplicate to wipe the entry. A `0` cost keeps the
+              // entry (legitimate free tier / cached model call).
+              const modelCallCostKey = streamModelCallCostKey(
+                payload.data.model_call?.model_call_index,
+              );
+              if (payload.data.model_call && modelCallCostKey !== null) {
+                setStreamModelCallCosts((prev) => {
+                  const next = new Map(prev);
+                  next.set(modelCallCostKey, payload.data.model_call!.cost_micros_usd ?? 0);
+                  return next;
+                });
+              }
+              // Approvals ride along in every snapshot now (server-side
+              // change in TaskRunStreamEventData). Treat the SSE as the
+              // source of truth so the banner stays in sync — without
+              // this, an approval created mid-stream wouldn't surface
+              // until a manual refresh, and a server-resolved one would
+              // linger in the UI for the same reason. We only overwrite
+              // when the payload actually carries the field, so older
+              // gateways that don't include it don't blank the banner.
+              if (payload.data.approvals !== undefined) {
+                setApprovals(payload.data.approvals);
+              }
+              const eventType = payload.data.event_type;
+              if (eventType && payload.data.sequence > 0) {
+                setRunEvents((cur) => {
+                  if (cur.some((event) => event.sequence === payload.data.sequence)) {
+                    return cur;
+                  }
+                  return [
+                    ...cur,
+                    {
+                      schema_version: "1",
+                      event_id: `stream-${payload.data.sequence}`,
+                      task_id: selectedTaskID,
+                      run_id: selectedRunID,
+                      sequence: payload.data.sequence,
+                      occurred_at: new Date().toISOString(),
+                      type: eventType,
+                      data: {},
+                    },
+                  ];
+                });
+              }
+              const streamedRun = payload.data.run;
+              setTasks((cur) =>
+                cur.map((task) => {
+                  if (task.id !== selectedTaskID || task.latest_run_id !== streamedRun.id) {
+                    return task;
+                  }
+                  return {
+                    ...task,
+                    status: streamedRun.status,
+                    latest_model: streamedRun.model,
+                    latest_provider: streamedRun.provider,
+                    latest_run_step_count: streamedRun.step_count ?? 0,
+                    latest_run_artifact_count: streamedRun.artifact_count ?? 0,
+                    last_error: streamedRun.last_error,
+                  };
+                }),
+              );
+            },
+            streamCursorRef.current,
+            controller.signal,
+          );
+        } catch (error) {
+          if (!selectionIsCurrent()) return;
+          if (terminalRunObserved) {
+            setStreamState("closed");
+            await catchUpAuthoritativeDetail();
+            return;
+          }
+          if (taskRunStreamFailureIsNonRetryable(error)) {
+            setStreamState("error");
+            return;
+          }
+        }
+
+        if (!selectionIsCurrent()) return;
+        if (terminalRunObserved) {
+          setStreamState("closed");
+          await catchUpAuthoritativeDetail();
           return;
         }
-        setStreamState("live");
-        streamCursorRef.current = payload.data.sequence ?? streamCursorRef.current;
-        setRuns((cur) => {
-          const others = cur.filter((r) => r.id !== payload.data.run.id);
-          return [payload.data.run, ...others];
-        });
-        setSteps(payload.data.steps ?? []);
-        setArtifacts(payload.data.artifacts ?? []);
-        setActivity(payload.data.activity ?? []);
-        // Capture per-model-call cost when the snapshot was driven by a
-        // `model.call.completed` event. Dedup by model-call number — the
-        // SSE may replay the same event on reconnect, and we don't
-        // want a duplicate to wipe the entry. A `0` cost keeps the
-        // entry (legitimate free tier / cached model call).
-        const modelCallCostKey = streamModelCallCostKey(payload.data.model_call?.model_call_index);
-        if (payload.data.model_call && modelCallCostKey !== null) {
-          setStreamModelCallCosts((prev) => {
-            const next = new Map(prev);
-            next.set(modelCallCostKey, payload.data.model_call!.cost_micros_usd ?? 0);
-            return next;
-          });
-        }
-        // Approvals ride along in every snapshot now (server-side
-        // change in TaskRunStreamEventData). Treat the SSE as the
-        // source of truth so the banner stays in sync — without
-        // this, an approval created mid-stream wouldn't surface
-        // until a manual refresh, and a server-resolved one would
-        // linger in the UI for the same reason. We only overwrite
-        // when the payload actually carries the field, so older
-        // gateways that don't include it don't blank the banner.
-        if (payload.data.approvals !== undefined) {
-          setApprovals(payload.data.approvals);
-        }
-        const eventType = payload.data.event_type;
-        if (eventType && payload.data.sequence > 0) {
-          setRunEvents((cur) => {
-            if (cur.some((event) => event.sequence === payload.data.sequence)) {
-              return cur;
-            }
-            return [
-              ...cur,
-              {
-                schema_version: "1",
-                event_id: `stream-${payload.data.sequence}`,
-                task_id: selectedTaskID,
-                run_id: selectedRunID,
-                sequence: payload.data.sequence,
-                occurred_at: new Date().toISOString(),
-                type: eventType,
-                data: {},
-              },
-            ];
-          });
-        }
-        const streamedRun = payload.data.run;
-        setTasks((cur) =>
-          cur.map((task) => {
-            if (task.id !== selectedTaskID || task.latest_run_id !== streamedRun.id) return task;
-            return {
-              ...task,
-              status: streamedRun.status,
-              latest_model: streamedRun.model,
-              latest_provider: streamedRun.provider,
-              latest_run_step_count: streamedRun.step_count ?? 0,
-              latest_run_artifact_count: streamedRun.artifact_count ?? 0,
-              last_error: streamedRun.last_error,
-            };
-          }),
-        );
-      },
-      streamCursorRef.current,
-      controller.signal,
-    )
-      .then(() => {
-        if (!controller.signal.aborted) {
-          setStreamState("closed");
-          void loadTaskDetail(selectedTaskID, selectedRunID);
-        }
-      })
-      .catch((err) => {
-        if (!controller.signal.aborted) {
-          setStreamState("error");
-          console.error(err);
-        }
-      });
 
-    return () => controller.abort();
+        const currentRunStatus = selectedRunStatusRef.current;
+        if (currentRunStatus) lastObservedRunStatus = currentRunStatus;
+        if (taskRunStatusIsTerminal(lastObservedRunStatus)) {
+          setStreamState("closed");
+          return;
+        }
+
+        setStreamState("reconnecting");
+        const retryDelay = taskRunStreamRetryDelayMS(retryAttempt);
+        retryAttempt += 1;
+        if (!(await waitForTaskRunStreamRetry(controller.signal, retryDelay))) return;
+        reconnecting = true;
+      }
+    };
+
+    void observe();
+    return () => {
+      disposed = true;
+      controller.abort();
+    };
   }, [loadTaskDetail, selectedRunID, selectedTaskID]);
 
   async function handleSelectTask(taskID: string) {


### PR DESCRIPTION
## What changed

- execute the packaged mobile companion shell in Playwright across sign-in, authorization, instance start/open, settings, and sign-out
- add a real mobile-companion console journey for navigation, rootless chat, message send, and chat continuation
- make `tauri/mobile/**` trigger the TypeScript/Playwright jobs and bundle-check `mobile/app.js`
- reconnect Task Run live updates from the latest sequence with authoritative catch-up and visible connection status

## Why

The native build packaged `tauri/mobile/app.js` as raw static content without executing its orchestration in tests. Separately, Task Run SSE failures were terminal and visually silent, so a mobile operator could stop receiving approvals and run updates after a relay/runtime restart.

## Impact

Mobile auth, instance selection, hosted runtime start/open, rootless chats, and remote Task supervision now have executable regression coverage. Live Task updates recover automatically without stale catch-up responses overwriting newer stream state.

## Validation

- `cd ui && bun run build`
- `cd ui && bun run test` — 2,698 passed
- `cd ui && bun run test:e2e` — 115 passed
- `cd tauri && bun run test:mobile-shell` — 36 passed plus browser bundle check
- post-rebase focused mobile Playwright checks — 2 passed
- native iOS simulator build/install/launch smoke test
