### PR TITLE
fix(release): preserve notes from signed tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,34 +93,17 @@ jobs:
       # keep GoReleaser's generated changelog. A maintainer may instead create
       # an annotated tag with substantive Markdown notes; preserve that public
       # release contract by passing the annotation to GoReleaser explicitly.
+      # The helper removes Git's separately reported signature bytes without
+      # normalizing the Markdown through shell command substitution.
       - name: Prepare release notes
         id: release-notes
         env:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          tag_ref="refs/tags/${TAG}"
-          tag_type=$(git cat-file -t "$tag_ref")
-          if [[ "$tag_type" == "commit" ]]; then
-            echo "args=release --clean" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [[ "$tag_type" != "tag" ]]; then
-            echo "Release ref ${TAG} points to unsupported object type ${tag_type}." >&2
-            exit 1
-          fi
-          tag_notes=$(git for-each-ref --format='%(contents)' "$tag_ref")
-          if [[ "$tag_notes" == "$TAG" ]]; then
-            echo "args=release --clean" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [[ -z "${tag_notes//[[:space:]]/}" ]]; then
-            echo "Release tag ${TAG} has an empty annotation." >&2
-            exit 1
-          fi
           notes_path="$RUNNER_TEMP/release-notes.md"
-          printf '%s\n' "$tag_notes" > "$notes_path"
-          echo "args=release --clean --release-notes=$notes_path" >> "$GITHUB_OUTPUT"
+          release_args=$(bun scripts/prepare-release-notes.ts "$TAG" "$notes_path")
+          printf 'args=%s\n' "$release_args" >> "$GITHUB_OUTPUT"
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,9 @@ jobs:
           bun-version-file: ui/package.json
 
       - name: Validate release workflows
-        run: bun scripts/check-release-workflows.ts
+        run: |
+          bun test scripts/prepare-release-notes.test.ts
+          bun scripts/check-release-workflows.ts
 
       - uses: dorny/paths-filter@v4
         id: filter

--- a/docs/contributor/release.md
+++ b/docs/contributor/release.md
@@ -217,6 +217,12 @@ commit changelog. Keep `--cleanup=verbatim` on Markdown annotations: Git's
 default cleanup treats lines beginning with `#` as comments and would silently
 strip the release title and section headings.
 
+Signed annotated tags follow the same rules. The release workflow reads Git's
+signature as a separate byte range and removes only that exact suffix before
+classifying or publishing the annotation. A signed version-only tag therefore
+still uses the generated changelog, while substantive Markdown is passed to
+GoReleaser byte-for-byte without the public signature block.
+
 The version stamp commit stays on `master`. This keeps the visible Tauri
 metadata, including the mobile store build numbers, aligned with the latest
 release instead of hiding the release version on the tag only.

--- a/just/release.just
+++ b/just/release.just
@@ -3,6 +3,7 @@
 
 # Check protected-branch release delivery and updater artifact selection.
 release-workflow-check:
+	bun test scripts/prepare-release-notes.test.ts
 	bun scripts/check-release-workflows.ts
 
 # Validate release-only dependencies without running the full verification

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -38,6 +38,8 @@ const deliveryPath = ".github/workflows/release-delivery.yml";
 const websitePath = ".github/workflows/website.yml";
 const testPath = ".github/workflows/test.yml";
 const tauriBuildPath = ".github/workflows/tauri-build.yml";
+const releaseNotesHelperPath = "scripts/prepare-release-notes.ts";
+const releaseJustPath = "just/release.just";
 
 const tauri = read(tauriPath);
 const release = read(releasePath);
@@ -45,6 +47,8 @@ const delivery = read(deliveryPath);
 const website = read(websitePath);
 const test = read(testPath);
 const tauriBuild = read(tauriBuildPath);
+const releaseNotesHelper = read(releaseNotesHelperPath);
+const releaseJust = read(releaseJustPath);
 
 forbidText(tauriPath, tauri, "publish-updater-website:");
 forbidText(tauriPath, tauri, "actions: write");
@@ -61,6 +65,17 @@ forbidText(releasePath, release, "git push origin master");
 requireText(releasePath, release, "uses: ./.github/workflows/release-delivery.yml");
 requireText(releasePath, release, "expected_release_body_sha256:");
 forbidText(releasePath, release, "actions: write");
+requireText(
+  releasePath,
+  release,
+  'release_args=$(bun scripts/prepare-release-notes.ts "$TAG" "$notes_path")',
+);
+forbidText(releasePath, release, "tag_notes=$(git for-each-ref");
+requireText(releaseNotesHelperPath, releaseNotesHelper, "%(contents:size)");
+requireText(releaseNotesHelperPath, releaseNotesHelper, "%(contents:signature)");
+requireText(releaseNotesHelperPath, releaseNotesHelper, "writeFileSync(notesPath, annotation)");
+requireText(testPath, test, "bun test scripts/prepare-release-notes.test.ts");
+requireText(releaseJustPath, releaseJust, "bun test scripts/prepare-release-notes.test.ts");
 
 const deliveryCallerStart = release.indexOf("  prepare-release-delivery:");
 if (deliveryCallerStart < 0) {
@@ -145,5 +160,5 @@ if (normalizedSyntheticNotes !== "alpha.4 notes") {
 }
 
 console.log(
-  "release-workflow-check: read-only delivery proposal, scoped updater uploads, and post-merge website verification OK",
+  "release-workflow-check: signed tag notes, read-only delivery proposal, scoped updater uploads, and post-merge website verification OK",
 );

--- a/scripts/prepare-release-notes.test.ts
+++ b/scripts/prepare-release-notes.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { prepareReleaseNotes } from "./prepare-release-notes";
+
+const generatedChangelogArgs = "release --clean";
+const repos: string[] = [];
+const sshSignature = Buffer.from(
+  [
+    "-----BEGIN SSH SIGNATURE-----",
+    "U1NIU0lHAAAAAQAAACMAAAALc3NoLWVkMjU1MTkAAAAgZmFrZS1maXh0dXJl",
+    "-----END SSH SIGNATURE-----",
+    "",
+  ].join("\n"),
+);
+const pgpSignature = Buffer.from(
+  [
+    "-----BEGIN PGP SIGNATURE-----",
+    "",
+    "ZmFrZS1maXh0dXJl",
+    "=AAAA",
+    "-----END PGP SIGNATURE-----",
+    "",
+  ].join("\n"),
+);
+
+function git(cwd: string, args: string[], input?: Buffer): Buffer {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: null,
+    input,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${Buffer.from(result.stderr ?? []).toString("utf8")}`,
+    );
+  }
+  return Buffer.from(result.stdout ?? []);
+}
+
+function createRepo(): string {
+  const cwd = mkdtempSync(join(tmpdir(), "hecate-release-notes-"));
+  repos.push(cwd);
+  git(cwd, ["init", "--quiet"]);
+  git(cwd, ["config", "user.name", "Hecate Test"]);
+  git(cwd, ["config", "user.email", "test@hecate.invalid"]);
+  git(cwd, ["config", "commit.gpgSign", "false"]);
+  git(cwd, ["config", "tag.gpgSign", "false"]);
+  writeFileSync(join(cwd, "fixture.txt"), "fixture\n");
+  git(cwd, ["add", "fixture.txt"]);
+  git(cwd, ["commit", "--quiet", "--no-gpg-sign", "-m", "fixture"]);
+  return cwd;
+}
+
+function createLightweightTag(cwd: string, tag: string): void {
+  git(cwd, ["update-ref", `refs/tags/${tag}`, "HEAD"]);
+}
+
+function createBlobTag(cwd: string, tag: string): void {
+  const oid = git(cwd, ["hash-object", "-w", "--stdin"], Buffer.from("blob\n"))
+    .toString("ascii")
+    .trim();
+  git(cwd, ["update-ref", `refs/tags/${tag}`, oid]);
+}
+
+function createAnnotatedTag(
+  cwd: string,
+  tag: string,
+  annotation: Buffer,
+  signature = Buffer.alloc(0),
+): void {
+  const commit = git(cwd, ["rev-parse", "HEAD"]).toString("ascii").trim();
+  const header = Buffer.from(
+    [
+      `object ${commit}`,
+      "type commit",
+      `tag ${tag}`,
+      "tagger Hecate Test <test@hecate.invalid> 1700000000 +0000",
+      "",
+      "",
+    ].join("\n"),
+  );
+  const object = Buffer.concat([header, annotation, signature]);
+  const oid = git(cwd, ["hash-object", "-t", "tag", "-w", "--stdin"], object)
+    .toString("ascii")
+    .trim();
+  git(cwd, ["update-ref", `refs/tags/${tag}`, oid]);
+}
+
+function notesPath(cwd: string): string {
+  return join(cwd, "release-notes.md");
+}
+
+afterEach(() => {
+  for (const repo of repos.splice(0)) {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+describe("prepareReleaseNotes", () => {
+  test("keeps lightweight tags on the generated changelog path", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3";
+    const output = notesPath(cwd);
+    createLightweightTag(cwd, tag);
+
+    expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(generatedChangelogArgs);
+    expect(existsSync(output)).toBe(false);
+  });
+
+  test("keeps unsigned version-only annotations on the generated changelog path", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3-alpha.4";
+    const output = notesPath(cwd);
+    createAnnotatedTag(cwd, tag, Buffer.from(`${tag}\r\n\r\n`));
+
+    expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(generatedChangelogArgs);
+    expect(existsSync(output)).toBe(false);
+  });
+
+  test("writes unsigned Markdown byte-for-byte", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3-alpha.5";
+    const output = notesPath(cwd);
+    const markdown = Buffer.from("# Release\n\n- first\n- second\n\n");
+    createAnnotatedTag(cwd, tag, markdown);
+
+    expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(
+      `${generatedChangelogArgs} --release-notes=${output}`,
+    );
+    expect(readFileSync(output).equals(markdown)).toBe(true);
+  });
+
+  test.each([
+    ["SSH", sshSignature],
+    ["PGP", pgpSignature],
+  ])("strips an exact %s signature suffix from Markdown", (_kind, signature) => {
+    const cwd = createRepo();
+    const tag = "v1.2.3-alpha.6";
+    const output = notesPath(cwd);
+    const markdown = Buffer.from("# Signed release\r\n\r\nPreserve ✨ exactly.\r\n\r\n");
+    createAnnotatedTag(cwd, tag, markdown, signature);
+
+    expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(
+      `${generatedChangelogArgs} --release-notes=${output}`,
+    );
+    const written = readFileSync(output);
+    expect(written.equals(markdown)).toBe(true);
+    expect(written.includes(Buffer.from("BEGIN"))).toBe(false);
+  });
+
+  test("recognizes a signed version-only annotation", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3-alpha.7";
+    const output = notesPath(cwd);
+    createAnnotatedTag(cwd, tag, Buffer.from(`${tag}\n`), sshSignature);
+
+    expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(generatedChangelogArgs);
+    expect(existsSync(output)).toBe(false);
+  });
+
+  test.each([
+    ["tag with an empty annotation", Buffer.alloc(0), Buffer.alloc(0)],
+    ["tag with only a signature", Buffer.from("\n"), pgpSignature],
+  ])("rejects a %s", (_kind, annotation, signature) => {
+    const cwd = createRepo();
+    const tag = "v1.2.3-alpha.8";
+    createAnnotatedTag(cwd, tag, annotation, signature);
+
+    expect(() => prepareReleaseNotes({ cwd, tag, notesPath: notesPath(cwd) })).toThrow(
+      `Release tag ${tag} has an empty annotation.`,
+    );
+  });
+
+  test("rejects a release ref with an unsupported object type", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3-alpha.9";
+    createBlobTag(cwd, tag);
+
+    expect(() => prepareReleaseNotes({ cwd, tag, notesPath: notesPath(cwd) })).toThrow(
+      `Release ref ${tag} points to unsupported object type blob.`,
+    );
+  });
+
+  test("exposes the same behavior through the workflow CLI", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3-alpha.10";
+    const output = notesPath(cwd);
+    createAnnotatedTag(cwd, tag, Buffer.from(`${tag}\n`), pgpSignature);
+
+    const result = spawnSync(
+      process.execPath,
+      [join(import.meta.dir, "prepare-release-notes.ts"), tag, output],
+      {
+        cwd,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(`${generatedChangelogArgs}\n`);
+    expect(result.stderr).toBe("");
+  });
+});

--- a/scripts/prepare-release-notes.ts
+++ b/scripts/prepare-release-notes.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const generatedChangelogArgs = "release --clean";
+const maxGitOutputBytes = 2 * 1024 * 1024;
+const refFormat = "%(refname)%00%(contents:size)%00%(contents:signature)%00%(contents)";
+
+interface PrepareReleaseNotesOptions {
+  cwd: string;
+  tag: string;
+  notesPath: string;
+}
+
+interface TagContents {
+  contents: Buffer;
+  signature: Buffer;
+}
+
+function runGit(cwd: string, args: string[]): Buffer {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: null,
+    maxBuffer: maxGitOutputBytes,
+  });
+  if (result.error) {
+    throw new Error(`git ${args[0]} failed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = Buffer.from(result.stderr ?? [])
+      .toString("utf8")
+      .trim();
+    throw new Error(`git ${args[0]} failed${stderr ? `: ${stderr}` : ""}`);
+  }
+  return Buffer.from(result.stdout ?? []);
+}
+
+function readTagContents(cwd: string, tagRef: string): TagContents {
+  const output = runGit(cwd, ["for-each-ref", `--format=${refFormat}`, "--count=1", tagRef]);
+  if (output.length === 0) {
+    throw new Error(`Release ref ${tagRef} was not found.`);
+  }
+
+  const refEnd = output.indexOf(0);
+  const sizeEnd = refEnd < 0 ? -1 : output.indexOf(0, refEnd + 1);
+  const signatureEnd = sizeEnd < 0 ? -1 : output.indexOf(0, sizeEnd + 1);
+  if (refEnd < 0 || sizeEnd < 0 || signatureEnd < 0) {
+    throw new Error(`Git returned a malformed release-tag record for ${tagRef}.`);
+  }
+
+  const actualRef = output.subarray(0, refEnd);
+  if (!actualRef.equals(Buffer.from(tagRef, "utf8"))) {
+    throw new Error(`Git returned an unexpected release ref for ${tagRef}.`);
+  }
+
+  const sizeText = output.subarray(refEnd + 1, sizeEnd).toString("ascii");
+  if (!/^(0|[1-9]\d*)$/.test(sizeText)) {
+    throw new Error(`Git returned an invalid annotation size for ${tagRef}.`);
+  }
+  const contentsSize = Number(sizeText);
+  if (!Number.isSafeInteger(contentsSize) || contentsSize > maxGitOutputBytes) {
+    throw new Error(`Release tag ${tagRef} has an unsupported annotation size.`);
+  }
+
+  const contentsStart = signatureEnd + 1;
+  const contentsEnd = contentsStart + contentsSize;
+  if (contentsEnd !== output.length - 1 || output[contentsEnd] !== 0x0a) {
+    throw new Error(`Git returned a truncated or ambiguous annotation for ${tagRef}.`);
+  }
+
+  return {
+    signature: output.subarray(sizeEnd + 1, signatureEnd),
+    contents: output.subarray(contentsStart, contentsEnd),
+  };
+}
+
+function stripSignature(tagRef: string, contents: Buffer, signature: Buffer): Buffer {
+  if (signature.length === 0) {
+    return contents;
+  }
+  if (
+    signature.length > contents.length ||
+    !contents.subarray(contents.length - signature.length).equals(signature)
+  ) {
+    throw new Error(`Git did not report the signature as an exact suffix of ${tagRef}.`);
+  }
+  return contents.subarray(0, contents.length - signature.length);
+}
+
+function isWhitespaceOnly(contents: Buffer): boolean {
+  return contents.every((byte) => byte === 0x20 || (byte >= 0x09 && byte <= 0x0d));
+}
+
+function withoutTrailingLineEndings(contents: Buffer): Buffer {
+  let end = contents.length;
+  while (end > 0 && contents[end - 1] === 0x0a) {
+    end -= 1;
+    if (end > 0 && contents[end - 1] === 0x0d) {
+      end -= 1;
+    }
+  }
+  return contents.subarray(0, end);
+}
+
+function isNonEmptySingleLine(value: string): boolean {
+  return (
+    value.length > 0 && !value.includes("\0") && !value.includes("\r") && !value.includes("\n")
+  );
+}
+
+export function prepareReleaseNotes({ cwd, tag, notesPath }: PrepareReleaseNotesOptions): string {
+  if (!isNonEmptySingleLine(tag)) {
+    throw new Error("Release tag must be a non-empty single-line ref name.");
+  }
+  if (!isNonEmptySingleLine(notesPath)) {
+    throw new Error("Release notes path must be a non-empty single-line path.");
+  }
+
+  const tagRef = `refs/tags/${tag}`;
+  const objectType = runGit(cwd, ["cat-file", "-t", tagRef]).toString("ascii").trim();
+  if (objectType === "commit") {
+    return generatedChangelogArgs;
+  }
+  if (objectType !== "tag") {
+    throw new Error(`Release ref ${tag} points to unsupported object type ${objectType}.`);
+  }
+
+  const { contents, signature } = readTagContents(cwd, tagRef);
+  const annotation = stripSignature(tagRef, contents, signature);
+  if (isWhitespaceOnly(annotation)) {
+    throw new Error(`Release tag ${tag} has an empty annotation.`);
+  }
+  if (withoutTrailingLineEndings(annotation).equals(Buffer.from(tag, "utf8"))) {
+    return generatedChangelogArgs;
+  }
+
+  writeFileSync(notesPath, annotation);
+  return `${generatedChangelogArgs} --release-notes=${notesPath}`;
+}
+
+if (import.meta.main) {
+  const [tag, notesPath, ...extraArgs] = process.argv.slice(2);
+  if (!tag || !notesPath || extraArgs.length > 0) {
+    console.error("usage: bun scripts/prepare-release-notes.ts <tag> <notes-path>");
+    process.exit(2);
+  }
+
+  try {
+    process.stdout.write(`${prepareReleaseNotes({ cwd: process.cwd(), tag, notesPath })}\n`);
+  } catch (error) {
+    console.error(`prepare-release-notes: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## What changed

- replace the inline Bash tag-annotation extraction with a tested Bun helper
- frame Git ref output by byte size, remove only the exact `%(contents:signature)` suffix, and write substantive Markdown without decoding or newline normalization
- keep lightweight and signed/unsigned version-only tags on GoReleaser's generated-changelog path
- run keyless SSH/PGP regression fixtures in both CI and `just release-workflow-check`
- document signed annotated-tag behavior for release operators

## Why

`%(contents)` includes an annotated tag's public signature block. The previous shell command therefore misclassified signed version-only tags as custom release notes and could publish the signature. Bash command substitution also removed trailing newlines from substantive Markdown.

The published `v0.5.0-alpha.5` tag is unsigned, so the current release is unaffected. This prevents the issue before alpha.6.

## Impact

Signed tags now behave like unsigned tags: version-only annotations use the generated changelog, while substantive Markdown reaches GoReleaser byte-for-byte without the signature block. Malformed or ambiguous Git output fails closed.

## Validation

- `just release-workflow-check` — 10 focused tests and workflow guards pass
- `actionlint .github/workflows/release.yml .github/workflows/test.yml`
- Oxfmt and Oxlint on the touched TypeScript scripts
- `just docs-check`
- `cd ui && bun run typecheck`
- `just ui-format-check ui-lint`
- `go build ./...`
- real alpha.5 annotation extraction matched the original annotation SHA-256 byte-for-byte
- two independent release-safety reviews: approved with no blockers

The broad UI suite is resource/order-sensitive in this sandbox: the two-worker pass completed 2,696/2,698 tests before an unchanged `DesktopUpdateControl` file failed, then that file passed 10/10 in isolation; the one-worker pass completed 2,694/2,698 before an unchanged `RolesModal` file failed, then that file passed 7/7 in isolation. A targeted rerun of all files that timed out under default concurrency passed 473/473. GitHub CI will run the authoritative full matrix.

Documentation was updated; no Mermaid diagram changes were needed.
