### PR TITLE
test(ui): wait for Cloud account state

### DIFF
--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -496,7 +496,7 @@ describe("SettingsView", () => {
     render(withRuntimeConsole(<SettingsView />, { state, actions }));
 
     const section = await screen.findByTestId("desktop-cloud-connection");
-    expect(within(section).getByText("alice@example.com")).toBeTruthy();
+    expect(await within(section).findByText("alice@example.com")).toBeTruthy();
     await user.click(
       within(section).getByRole("switch", { name: "Remote access for this computer" }),
     );


### PR DESCRIPTION
## What changed

- wait for the signed-in Hecate Cloud account state before asserting the account email in the desktop settings test

## Why

The Cloud connection section mounts immediately in its loading state, while the account status is populated asynchronously. The test waited only for the section container and then queried the email synchronously, so normal CI scheduling could observe “Checking Hecate Cloud account…” and fail.

This is a test-only follow-up to #941; production behavior is unchanged.

## Impact

Removes the async race while preserving the assertion that the signed-in account is rendered before remote-access controls are exercised.

## Validation

- failing scenario: 20 consecutive focused runs passed
- `bun run lint`
- `bun run format:check`
- `bun run build`
- `bun run test` — 117 files, 2,713 tests passed
- `git diff --check`
