### PR TITLE
fix(desktop): simplify cloud instance selection

### DIFF
--- a/docs/operator/desktop-app.md
+++ b/docs/operator/desktop-app.md
@@ -114,15 +114,19 @@ What works:
   this computer. The separate **Remote access** toggle registers it and
   maintains the outbound relay when the operator explicitly enables that
   access. Turning Remote access off preserves the signed-in account; signing
-  out revokes the app session and computer registration.
-- The same section lists **Cloud instances** available to the signed-in
-  account: hosted runtimes and the owner's registered desktop Hecates. A
-  desktop with remote access off remains visible but cannot be opened. A
-  Cloud-managed stopped runtime can be started from the list. Opening an
-  available entry creates a short-lived browser session and shows that
-  runtime's normal Hecate UI in a separate native window. Chats, Tasks, and
-  Projects created there remain owned by that selected runtime; opening it is
-  remote supervision, not process, workspace, or session migration.
+  out revokes the app session and computer registration. New registrations use
+  the operating system hostname unless `HECATE_DESKTOP_HOST_NAME` overrides it.
+- The same section lists **Other Hecate instances** available to the signed-in
+  account: hosted runtimes and the owner's other registered computers. The
+  current computer appears only in **Remote access for this computer** and
+  cannot be opened through Cloud back into itself. A computer with remote
+  access off remains visible but cannot be opened. A Cloud-managed stopped
+  runtime can be started from the list. Opening an available entry creates a
+  short-lived browser session and shows that runtime's normal Hecate UI in a
+  separate window of the same native app. It does not launch or install a
+  second Hecate app. Chats, Tasks, and Projects created there remain owned by
+  that selected runtime; opening it is remote supervision, not process,
+  workspace, or session migration.
 - A remote runtime window is incognito and receives no Tauri command
   capability. The native layer keeps the Cloud account bearer, one-time
   bootstrap URL, desktop relay ticket, and server-authored navigation paths out

--- a/tauri/src-tauri/Cargo.lock
+++ b/tauri/src-tauri/Cargo.lock
@@ -1835,6 +1835,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures-util",
+ "gethostname",
  "keyring",
  "log",
  "rand 0.9.4",

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ tauri-plugin-process = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 tokio-tungstenite = { version = "0.28", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
+gethostname = "1.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust", "vendored"] }

--- a/tauri/src-tauri/src/desktop/cloud_connection.rs
+++ b/tauri/src-tauri/src/desktop/cloud_connection.rs
@@ -484,6 +484,8 @@ impl CloudConnectionSupervisor {
             .collect::<Vec<_>>()
             .await;
         self.ensure_authorized_generation(generation)?;
+        let current_host_id = self.current_host_id()?;
+        let connections = without_current_desktop_host(connections, current_host_id.as_deref());
         Ok(connections)
     }
 
@@ -573,6 +575,10 @@ impl CloudConnectionSupervisor {
             .into_iter()
             .find(|candidate| candidate.id == connection_id)
             .ok_or_else(|| "That Hecate connection is no longer available.".to_string())?;
+        let current_host_id = self.current_host_id()?;
+        if is_current_desktop_host(&connection, current_host_id.as_deref()) {
+            return Err("This computer is already open in the main Hecate window.".to_string());
+        }
         if !connection.reachable {
             return Err(format!("{} is currently offline.", connection.name));
         }
@@ -747,6 +753,14 @@ impl CloudConnectionSupervisor {
             );
         }
         Ok(())
+    }
+
+    fn current_host_id(&self) -> Result<Option<String>, String> {
+        self.inner
+            .state
+            .lock()
+            .map(|state| state.preferences.host_id.clone())
+            .map_err(|_| "Hecate Cloud account state is unavailable.".to_string())
     }
 
     async fn fetch_runtime_connections(
@@ -1851,7 +1865,19 @@ pub fn new_remote_runtime_secret() -> String {
 }
 
 fn default_host_name() -> String {
-    for key in ["HECATE_DESKTOP_HOST_NAME", "HOSTNAME", "COMPUTERNAME"] {
+    if let Ok(value) = std::env::var("HECATE_DESKTOP_HOST_NAME") {
+        let value = value.trim();
+        if !value.is_empty() {
+            return value.to_string();
+        }
+    }
+    if let Some(value) = gethostname::gethostname().to_str() {
+        let value = value.trim();
+        if !value.is_empty() {
+            return value.to_string();
+        }
+    }
+    for key in ["HOSTNAME", "COMPUTERNAME"] {
         if let Ok(value) = std::env::var(key) {
             let value = value.trim();
             if !value.is_empty() {
@@ -1859,7 +1885,25 @@ fn default_host_name() -> String {
             }
         }
     }
-    "Hecate desktop app".to_string()
+    "Hecate computer".to_string()
+}
+
+fn is_current_desktop_host(
+    connection: &CloudRuntimeConnection,
+    current_host_id: Option<&str>,
+) -> bool {
+    connection.kind == "desktop_host"
+        && current_host_id.is_some_and(|host_id| host_id == connection.id)
+}
+
+fn without_current_desktop_host(
+    connections: Vec<CloudRuntimeConnection>,
+    current_host_id: Option<&str>,
+) -> Vec<CloudRuntimeConnection> {
+    connections
+        .into_iter()
+        .filter(|connection| !is_current_desktop_host(connection, current_host_id))
+        .collect()
 }
 
 fn validated_local_base_url(base_url: Option<String>) -> Result<String, String> {
@@ -4606,6 +4650,35 @@ mod tests {
             readiness_path: Some("/api/v1/app/runtimes/runtime_1/readiness".to_string()),
             browser_origin: Some("https://runtime-1.hecate.example/".to_string()),
         }
+    }
+
+    #[test]
+    fn current_desktop_host_is_omitted_without_guessing_from_its_name() {
+        let runtime = hosted_runtime_connection();
+        let mut current = runtime.clone();
+        current.id = "host_current".to_string();
+        current.kind = "desktop_host".to_string();
+        current.name = "Shared name".to_string();
+        let mut other = current.clone();
+        other.id = "host_other".to_string();
+
+        let visible = without_current_desktop_host(
+            vec![runtime.clone(), current.clone(), other.clone()],
+            Some("host_current"),
+        );
+        assert_eq!(
+            visible
+                .iter()
+                .map(|connection| connection.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["runtime_1", "host_other"]
+        );
+        assert!(is_current_desktop_host(&current, Some("host_current")));
+        assert!(!is_current_desktop_host(&other, Some("host_current")));
+        assert!(!is_current_desktop_host(&runtime, Some("runtime_1")));
+
+        let unfiltered = without_current_desktop_host(vec![runtime, current, other], None);
+        assert_eq!(unfiltered.len(), 3);
     }
 
     #[test]

--- a/tauri/src-tauri/src/desktop/mod.rs
+++ b/tauri/src-tauri/src/desktop/mod.rs
@@ -300,7 +300,7 @@ async fn cloud_runtime_open(
         return Ok(CloudRuntimeOpenResult {
             connection_id: connection_id.to_string(),
             name,
-            message: "The existing secure Hecate window was focused.".to_string(),
+            message: "Focused the existing Hecate window.".to_string(),
         });
     }
     let prepared = match supervisor.prepare_runtime_open(connection_id).await {
@@ -405,8 +405,11 @@ async fn cloud_runtime_open(
     })?;
     Ok(CloudRuntimeOpenResult {
         connection_id: prepared.connection.id,
+        message: format!(
+            "Opened {} in a new Hecate window.",
+            prepared.connection.name
+        ),
         name: prepared.connection.name,
-        message: "A secure Hecate session was opened in a separate window.".to_string(),
     })
 }
 

--- a/ui/src/features/settings/DesktopCloudSettings.tsx
+++ b/ui/src/features/settings/DesktopCloudSettings.tsx
@@ -148,7 +148,7 @@ function DesktopCloudConnectionSettings() {
       <section style={{ marginBottom: 20 }} data-testid="desktop-cloud-connection">
         <SectionHeader
           title="Hecate Cloud"
-          description="Sign in to manage Cloud instances. Remote access is a separate control for making this computer available from other devices."
+          description="Sign in to open Cloud runtimes and other computers. Remote access controls whether this computer can be opened elsewhere."
           meta={status?.running ? "connected" : signedIn ? "signed in" : undefined}
         />
         <div className="card" style={{ overflow: "hidden" }}>
@@ -179,7 +179,7 @@ function DesktopCloudConnectionSettings() {
                       "Hecate Cloud status could not be read. Check the desktop configuration and try again."
                     : authorizing
                       ? "Approve the sign-in request in your browser. This window updates automatically."
-                      : "Sign in to manage Cloud instances from this app. Remote access to this computer stays off until you enable it."}
+                      : "Sign in to open Cloud runtimes and other computers. Remote access to this computer stays off until you enable it."}
                 </div>
               </div>
               <div style={{ display: "flex", gap: 8 }}>
@@ -409,8 +409,8 @@ function DesktopCloudRuntimeSettings({
   return (
     <section style={{ marginBottom: 20 }} data-testid="desktop-cloud-runtimes">
       <SectionHeader
-        title="Cloud instances"
-        description="Hosted runtimes and registered computers for this account. Computers with remote access off remain visible but cannot be opened."
+        title="Other Hecate instances"
+        description="Hosted runtimes and your other computers. Each opens in its own Hecate window."
         meta={
           loading
             ? undefined
@@ -428,10 +428,10 @@ function DesktopCloudRuntimeSettings({
       />
       <div className="card" style={{ overflow: "hidden" }}>
         {loading ? (
-          <CloudMessage>Loading Cloud instances…</CloudMessage>
+          <CloudMessage>Loading other Hecate instances…</CloudMessage>
         ) : connections.length === 0 && !error ? (
           <CloudMessage>
-            No hosted runtimes or registered computers are available for this account.
+            No other runtimes or computers are available for this account.
           </CloudMessage>
         ) : (
           <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
@@ -525,7 +525,7 @@ function CloudRuntimeConnectionRow({
             lineHeight: 1.5,
           }}
         >
-          <span>{connection.kind === "hosted_runtime" ? "Hosted runtime" : "Desktop"}</span>
+          <span>{connection.kind === "hosted_runtime" ? "Hosted runtime" : "Computer"}</span>
           {connection.version && <span>Version {connection.version}</span>}
           <span>
             Last seen{" "}

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -229,7 +229,9 @@ describe("SettingsView", () => {
     const section = await screen.findByTestId("desktop-cloud-connection");
     expect(within(section).getByText("Hecate Cloud account")).toBeTruthy();
     expect(
-      within(section).getByText(/Sign in to manage Cloud instances from this app/i),
+      within(section).getByText(
+        "Sign in to open Cloud runtimes and other computers. Remote access controls whether this computer can be opened elsewhere.",
+      ),
     ).toBeTruthy();
     expect(within(section).getByText(/Remote access to this computer stays off/i)).toBeTruthy();
     expect(within(section).queryByText(/hec CLI/i)).toBeNull();
@@ -509,7 +511,7 @@ describe("SettingsView", () => {
     await waitFor(() => expect(screen.queryByTestId("desktop-cloud-runtimes")).toBeNull());
   });
 
-  it("lists Cloud instances and starts or opens only eligible targets", async () => {
+  it("lists other Hecate instances and starts or opens only eligible targets", async () => {
     Reflect.set(window, "__TAURI_INTERNALS__", {});
     tauriInvokeMock.mockImplementation((command: string) => {
       if (command === "cloud_connection_status") {
@@ -601,7 +603,7 @@ describe("SettingsView", () => {
         return Promise.resolve({
           connection_id: "runtime_online",
           name: "Production",
-          message: "A secure Hecate session was opened in a separate window.",
+          message: "Opened Production in a new Hecate window.",
         });
       }
       throw new Error(`Unexpected command: ${command}`);
@@ -610,7 +612,9 @@ describe("SettingsView", () => {
     render(withRuntimeConsole(<SettingsView />, { state, actions }));
 
     const section = await screen.findByTestId("desktop-cloud-runtimes");
+    expect(within(section).getByText("Other Hecate instances")).toBeTruthy();
     expect(await within(section).findByText("Production")).toBeTruthy();
+    expect(within(section).getAllByText("Computer")).toHaveLength(2);
     expect(within(section).getAllByText("Version 0.5.0-alpha.5")).toHaveLength(3);
     expect(within(section).getByRole("button", { name: "Open Production" })).toBeTruthy();
     expect(within(section).getByRole("button", { name: "Start Staging" })).toBeTruthy();
@@ -633,7 +637,7 @@ describe("SettingsView", () => {
       connectionId: "runtime_online",
     });
     expect(within(section).getByRole("status")).toHaveTextContent(
-      "A secure Hecate session was opened in a separate window.",
+      "Opened Production in a new Hecate window.",
     );
   });
 

--- a/ui/src/lib/cloud-connection.test.ts
+++ b/ui/src/lib/cloud-connection.test.ts
@@ -247,7 +247,7 @@ describe("desktop cloud runtime bridge", () => {
       .mockResolvedValueOnce({
         connection_id: "runtime_1",
         name: "Production",
-        message: "A secure Hecate session was opened in a separate window.",
+        message: "Opened Production in a new Hecate window.",
         open_url: "https://must-not-cross-ipc.example",
       });
 
@@ -261,7 +261,7 @@ describe("desktop cloud runtime bridge", () => {
     await expect(openDesktopCloudRuntime("runtime_1")).resolves.toEqual({
       connection_id: "runtime_1",
       name: "Production",
-      message: "A secure Hecate session was opened in a separate window.",
+      message: "Opened Production in a new Hecate window.",
     });
     expect(invokeMock).toHaveBeenNthCalledWith(1, "cloud_runtime_start", {
       connectionId: "runtime_1",


### PR DESCRIPTION
## Summary

- hide the current computer from the remote target list using its exact persisted Cloud host ID
- reject attempts to open the current computer through Cloud back into itself
- clarify that real remote targets open in another window of the same Hecate app
- register new computers with the operating system hostname instead of the generic desktop-app fallback

## Verification

- UI typecheck, lint, format check, and full suite: 117 files / 2,713 tests
- Tauri Rust suite: 101 tests
- Rust and docs formatting checks
- production dogfood: signed in, listed the two real targets, opened Dogfood Runtime in a new Hecate window, and shut down cleanly

The live self-filter path was not re-registered during dogfood because that would enable persistent remote access on the Mac; the exact-host projection and self-open guard are covered by the native regression test.