### PR TITLE
fix(ui): prevent desktop composer control overlap

### DIFF
--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1381,6 +1381,102 @@ test("keeps desktop composer actions separate when image input and dictation nee
   await expectSeparatedActions();
 });
 
+test("keeps repair actions out of active dictation in a narrow desktop composer", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.route("/hecate/v1/dictation/options", (route) =>
+    route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ error: { message: "dictation routes unavailable" } }),
+    }),
+  );
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hecate.dictationProvider", "client:web-speech:browser-managed");
+    class BrowserManagedSpeechRecognition {
+      lang = "";
+      continuous = false;
+      interimResults = false;
+      maxAlternatives = 1;
+      onresult: ((event: Event) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onend: (() => void) | null = null;
+
+      start() {}
+
+      stop() {}
+
+      abort() {}
+    }
+    Object.defineProperty(window, "SpeechRecognition", {
+      configurable: true,
+      value: BrowserManagedSpeechRecognition,
+    });
+  });
+  await page.reload();
+  await page.waitForSelector(".hecate-activitybar");
+  await switchToModel(page);
+
+  const retry = page.getByRole("button", { name: "Retry dictation route check" });
+  await expect(retry).toBeVisible();
+  await page.getByRole("button", { name: "Chat settings" }).click();
+  await expect(page.getByLabel("Chat settings panel")).toBeVisible();
+  const splitComposerBox = await page
+    .getByRole("group", { name: "Message composer" })
+    .boundingBox();
+  expect(splitComposerBox).not.toBeNull();
+  expect(splitComposerBox!.width).toBeLessThanOrEqual(360);
+
+  await page.getByRole("button", { name: "Start dictation" }).click();
+
+  const composerActions = page.getByRole("group", { name: "Composer actions" });
+  const dictationControls = composerActions.locator(".chat-composer-dictation");
+  const activeItems = [
+    {
+      name: "stop dictation",
+      locator: page.getByRole("button", { name: "Stop dictation recording" }),
+    },
+    {
+      name: "dictation route",
+      locator: page.getByRole("combobox", { name: "Dictation route" }),
+    },
+    {
+      name: "dictation status",
+      locator: composerActions.locator(".chat-composer-dictation-status--active"),
+    },
+    { name: "dictation duration", locator: page.getByLabel("Dictation duration 0:00") },
+    { name: "send", locator: page.getByRole("button", { name: "Send message" }) },
+  ];
+  await expect(retry).toHaveCount(0);
+  expect(
+    await dictationControls.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+  ).toBe(true);
+
+  const actionsBox = await composerActions.boundingBox();
+  expect(actionsBox).not.toBeNull();
+  const itemBoxes = [];
+  for (const item of activeItems) {
+    await expect(item.locator).toBeVisible();
+    const box = await item.locator.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(actionsBox!.x - 1);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(actionsBox!.x + actionsBox!.width + 1);
+    expect(box!.y).toBeGreaterThanOrEqual(actionsBox!.y - 1);
+    expect(box!.y + box!.height).toBeLessThanOrEqual(actionsBox!.y + actionsBox!.height + 1);
+    itemBoxes.push({ ...box!, name: item.name });
+  }
+  for (let left = 0; left < itemBoxes.length; left += 1) {
+    for (let right = left + 1; right < itemBoxes.length; right += 1) {
+      const a = itemBoxes[left]!;
+      const b = itemBoxes[right]!;
+      const horizontalOverlap = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x) > 1;
+      const verticalOverlap = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y) > 1;
+      expect(horizontalOverlap && verticalOverlap, `${a.name} overlaps ${b.name}`).toBe(false);
+    }
+  }
+});
+
 test("keeps the phone composer controls contained when dictation needs setup", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.route("/hecate/v1/dictation/options", (route) =>

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1445,7 +1445,7 @@ test("keeps repair actions out of active dictation in a narrow desktop composer"
       name: "dictation status",
       locator: composerActions.locator(".chat-composer-dictation-status--active"),
     },
-    { name: "dictation duration", locator: page.getByLabel("Dictation duration 0:00") },
+    { name: "dictation duration", locator: page.getByLabel(/^Dictation duration /) },
     { name: "send", locator: page.getByRole("button", { name: "Send message" }) },
   ];
   await expect(retry).toHaveCount(0);

--- a/ui/e2e/chat.spec.ts
+++ b/ui/e2e/chat.spec.ts
@@ -1236,6 +1236,151 @@ test("uses a full-width replacement panel and phone-sized chat controls", async 
   await expect(settingsButton).toBeFocused();
 });
 
+test("keeps desktop composer actions separate when image input and dictation need setup", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.route("/hecate/v1/dictation/options", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "dictation_options",
+        data: [
+          {
+            provider: "openai",
+            provider_kind: "cloud",
+            default_model: "gpt-4o-mini-transcribe",
+            available: false,
+            unavailable_reason: "provider credentials are missing",
+          },
+        ],
+      }),
+    }),
+  );
+  await page.evaluate(() => {
+    Object.defineProperty(window, "SpeechRecognition", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, "webkitSpeechRecognition", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+  await switchToModel(page);
+
+  const composerActions = page.getByRole("group", { name: "Composer actions" });
+  const dictationRoute = page.getByRole("combobox", { name: "Dictation route" });
+  const dictationSetup = page.getByRole("button", { name: "Set up dictation provider" });
+  const actionItems = [
+    { name: "image button", locator: page.getByRole("button", { name: "Image" }) },
+    {
+      name: "image status",
+      locator: composerActions.locator(".chat-composer-attachment-copy--active"),
+    },
+    {
+      name: "dictation button",
+      locator: page.getByRole("button", { name: "Start dictation" }),
+    },
+    {
+      name: "dictation route",
+      locator: dictationRoute,
+    },
+    {
+      name: "dictation status",
+      locator: composerActions.locator(".chat-composer-dictation-status--active"),
+    },
+    {
+      name: "dictation setup",
+      locator: dictationSetup,
+    },
+    {
+      name: "send button",
+      locator: page.getByRole("button", { name: "Send message" }),
+    },
+  ];
+
+  for (const item of actionItems) await expect(item.locator).toBeVisible();
+  const dictationRouteLabel = page.getByText("Dictation route", { exact: true });
+  await expect(dictationRouteLabel).toHaveClass("sr-only");
+  await expect(dictationRouteLabel).toHaveCSS("position", "absolute");
+  const dictationRouteLabelBox = await dictationRouteLabel.boundingBox();
+  expect(dictationRouteLabelBox).not.toBeNull();
+  expect(dictationRouteLabelBox!.width).toBeLessThanOrEqual(1);
+  expect(dictationRouteLabelBox!.height).toBeLessThanOrEqual(1);
+
+  async function expectSeparatedActions() {
+    const actionsBox = await composerActions.boundingBox();
+    expect(actionsBox).not.toBeNull();
+    const attachmentControls = composerActions.locator(".chat-composer-attachment-controls");
+    const dictationControls = composerActions.locator(".chat-composer-dictation");
+    for (const surface of [composerActions, attachmentControls, dictationControls]) {
+      expect(
+        await surface.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+      ).toBe(true);
+    }
+    await expect(attachmentControls).toHaveCSS("overflow", "visible");
+    await expect(dictationControls).toHaveCSS("overflow", "visible");
+
+    const itemBoxes = [];
+    for (const item of actionItems) {
+      const box = await item.locator.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.x).toBeGreaterThanOrEqual(actionsBox!.x - 1);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(actionsBox!.x + actionsBox!.width + 1);
+      expect(box!.y).toBeGreaterThanOrEqual(actionsBox!.y - 1);
+      expect(box!.y + box!.height).toBeLessThanOrEqual(actionsBox!.y + actionsBox!.height + 1);
+      itemBoxes.push({ ...box!, name: item.name });
+    }
+    expect(itemBoxes.find((item) => item.name === "image status")!.width).toBeGreaterThanOrEqual(
+      120,
+    );
+    for (let left = 0; left < itemBoxes.length; left += 1) {
+      for (let right = left + 1; right < itemBoxes.length; right += 1) {
+        const a = itemBoxes[left]!;
+        const b = itemBoxes[right]!;
+        const horizontalOverlap = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x) > 1;
+        const verticalOverlap = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y) > 1;
+        expect(horizontalOverlap && verticalOverlap, `${a.name} overlaps ${b.name}`).toBe(false);
+      }
+    }
+  }
+
+  await expectSeparatedActions();
+  await page.getByRole("button", { name: "Chat settings" }).click();
+  await expect(page.getByLabel("Chat settings panel")).toBeVisible();
+  await expect(page.getByRole("separator", { name: "Resize right panel" })).toBeVisible();
+  const splitComposerBox = await page
+    .getByRole("group", { name: "Message composer" })
+    .boundingBox();
+  expect(splitComposerBox).not.toBeNull();
+  expect(splitComposerBox!.width).toBeLessThanOrEqual(360);
+  await expectSeparatedActions();
+  await dictationRoute.focus();
+  await expect(dictationRoute).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(dictationSetup).toBeFocused();
+  await expect(dictationSetup).toHaveCSS("outline-style", "solid");
+  await expect(dictationSetup).toHaveCSS("outline-offset", "2px");
+  const clippingAncestors = await dictationSetup.evaluate((element) => {
+    const clippedBy = [];
+    for (let ancestor = element.parentElement; ancestor; ancestor = ancestor.parentElement) {
+      const style = getComputedStyle(ancestor);
+      if (style.overflowX !== "visible" || style.overflowY !== "visible") {
+        clippedBy.push(ancestor.className || ancestor.tagName);
+      }
+      if (ancestor.classList.contains("chat-composer-surface")) break;
+    }
+    return clippedBy;
+  });
+  expect(clippingAncestors).toEqual([]);
+  await page.getByRole("button", { name: "Chat settings" }).click();
+  await expect(page.getByLabel("Chat settings panel")).toHaveCount(0);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await expectSeparatedActions();
+});
+
 test("keeps the phone composer controls contained when dictation needs setup", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.route("/hecate/v1/dictation/options", (route) =>
@@ -1272,12 +1417,16 @@ test("keeps the phone composer controls contained when dictation needs setup", a
   const form = textarea.locator("xpath=ancestor::form");
   const messageComposer = page.getByRole("group", { name: "Message composer" });
   const composerActions = page.getByRole("group", { name: "Composer actions" });
+  const dictationRoute = page.getByRole("combobox", { name: "Dictation route" });
+  const imageStatus = composerActions.locator(".chat-composer-attachment-copy--active");
+  const dictationStatus = composerActions.locator(".chat-composer-dictation-status--active");
+  const dictationSetup = page.getByRole("button", { name: "Set up dictation provider" });
   const controls = [
     page.getByRole("button", { name: /Provider picker:/ }),
     page.getByRole("button", { name: /Model picker:/ }),
     page.getByRole("button", { name: "Image" }),
     page.getByRole("button", { name: "Start dictation" }),
-    page.getByRole("button", { name: "Set up dictation provider" }),
+    dictationSetup,
     page.getByRole("button", { name: "Send message" }),
   ];
 
@@ -1290,6 +1439,8 @@ test("keeps the phone composer controls contained when dictation needs setup", a
   expect(dictationRouteLabelBox!.width).toBeLessThanOrEqual(1);
   expect(dictationRouteLabelBox!.height).toBeLessThanOrEqual(1);
   for (const control of controls) await expect(control).toBeVisible();
+  for (const item of [dictationRoute, imageStatus, dictationStatus])
+    await expect(item).toBeVisible();
 
   for (const surface of [form, messageComposer, composerActions]) {
     const geometry = await surface.evaluate((element) => ({
@@ -1301,16 +1452,29 @@ test("keeps the phone composer controls contained when dictation needs setup", a
 
   const actionsBox = await composerActions.boundingBox();
   expect(actionsBox).not.toBeNull();
-  const actionControls = controls.slice(2);
+  const actionItems = [
+    ...controls.slice(2).map((locator, index) => ({
+      name: ["image button", "dictation button", "dictation setup", "send button"][index]!,
+      locator,
+      touchTarget: true,
+    })),
+    { name: "dictation route", locator: dictationRoute, touchTarget: true },
+    { name: "image status", locator: imageStatus, touchTarget: false },
+    { name: "dictation status", locator: dictationStatus, touchTarget: false },
+  ];
   const actionBoxes = [];
-  for (const control of actionControls) {
-    const box = await control.boundingBox();
+  for (const item of actionItems) {
+    const box = await item.locator.boundingBox();
     expect(box).not.toBeNull();
-    expect(box!.width).toBeGreaterThanOrEqual(44);
-    expect(box!.height).toBeGreaterThanOrEqual(44);
+    if (item.touchTarget) {
+      expect(box!.width).toBeGreaterThanOrEqual(44);
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+    }
     expect(box!.x).toBeGreaterThanOrEqual(actionsBox!.x - 1);
     expect(box!.x + box!.width).toBeLessThanOrEqual(actionsBox!.x + actionsBox!.width + 1);
-    actionBoxes.push(box!);
+    expect(box!.y).toBeGreaterThanOrEqual(actionsBox!.y - 1);
+    expect(box!.y + box!.height).toBeLessThanOrEqual(actionsBox!.y + actionsBox!.height + 1);
+    actionBoxes.push({ ...box!, name: item.name });
   }
   for (let left = 0; left < actionBoxes.length; left += 1) {
     for (let right = left + 1; right < actionBoxes.length; right += 1) {
@@ -1318,9 +1482,11 @@ test("keeps the phone composer controls contained when dictation needs setup", a
       const b = actionBoxes[right]!;
       const horizontalOverlap = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x) > 1;
       const verticalOverlap = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y) > 1;
-      expect(horizontalOverlap && verticalOverlap).toBe(false);
+      expect(horizontalOverlap && verticalOverlap, `${a.name} overlaps ${b.name}`).toBe(false);
     }
   }
+  await dictationSetup.focus();
+  await expect(dictationSetup).toBeFocused();
 });
 
 test("moves focus into and back from a phone replacement panel opened by slash command", async ({

--- a/ui/src/features/chats/ChatComposer.tsx
+++ b/ui/src/features/chats/ChatComposer.tsx
@@ -1127,6 +1127,7 @@ export function ChatComposer(props: ChatComposerProps) {
             </div>
           )}
           <div
+            className="chat-composer-surface"
             aria-label="Message composer"
             role="group"
             style={{

--- a/ui/src/features/chats/ChatDictationControl.test.tsx
+++ b/ui/src/features/chats/ChatDictationControl.test.tsx
@@ -249,6 +249,24 @@ describe("ChatDictationControl", () => {
     );
   });
 
+  it("hides route repair actions while browser dictation is active", async () => {
+    localStorage.setItem("hecate.dictationProvider", BROWSER_SPEECH_ROUTE_ID);
+    installSpeechRecognitionMocks();
+    vi.mocked(getDictationOptions).mockRejectedValue(new Error("network unavailable"));
+    const user = userEvent.setup();
+    render(<ChatDictationControl onOpenConnections={vi.fn()} onTranscript={vi.fn()} />);
+
+    const route = await screen.findByRole("combobox", { name: "Dictation route" });
+    await waitFor(() => expect(route).toHaveValue(BROWSER_SPEECH_ROUTE_ID));
+    expect(screen.getByRole("button", { name: "Retry dictation route check" })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: "Start dictation" }));
+
+    expect(screen.getByRole("button", { name: "Stop dictation recording" })).toBeEnabled();
+    expect(screen.getByLabelText("Dictation duration 0:00")).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Retry dictation route check" })).toBeNull();
+  });
+
   it("explains that non-secure web origins cannot request a microphone", async () => {
     Object.defineProperty(window, "isSecureContext", { configurable: true, value: false });
     render(<ChatDictationControl onTranscript={vi.fn()} />);

--- a/ui/src/features/chats/ChatDictationControl.test.tsx
+++ b/ui/src/features/chats/ChatDictationControl.test.tsx
@@ -263,7 +263,7 @@ describe("ChatDictationControl", () => {
     await user.click(screen.getByRole("button", { name: "Start dictation" }));
 
     expect(screen.getByRole("button", { name: "Stop dictation recording" })).toBeEnabled();
-    expect(screen.getByLabelText("Dictation duration 0:00")).toBeVisible();
+    expect(screen.getByLabelText(/^Dictation duration /)).toBeVisible();
     expect(screen.queryByRole("button", { name: "Retry dictation route check" })).toBeNull();
   });
 

--- a/ui/src/features/chats/ChatDictationControl.tsx
+++ b/ui/src/features/chats/ChatDictationControl.tsx
@@ -465,7 +465,7 @@ export function ChatDictationControl({
           {formatElapsed(elapsedSeconds)}
         </span>
       )}
-      {routeStatusRetryNeeded && (
+      {!active && routeStatusRetryNeeded && (
         <button
           type="button"
           className="btn btn-ghost btn-sm chat-composer-dictation-action"
@@ -478,7 +478,7 @@ export function ChatDictationControl({
           Retry
         </button>
       )}
-      {providerSetupNeeded && onOpenConnections && (
+      {!active && providerSetupNeeded && onOpenConnections && (
         <button
           type="button"
           className="btn btn-ghost btn-sm chat-composer-dictation-action"

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -754,6 +754,10 @@ textarea {
   }
 }
 
+.chat-composer-surface {
+  container: chat-composer-surface / inline-size;
+}
+
 .chat-composer-actions {
   display: flex;
   align-items: flex-end;
@@ -767,8 +771,23 @@ textarea {
   margin-left: auto;
 }
 
+.chat-composer-attachments {
+  flex: 0 1 220px;
+  min-width: 0;
+}
+
+.chat-composer-attachment-controls {
+  min-width: 0;
+}
+
+.chat-composer-attachment-copy {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .chat-composer-dictation {
   display: flex;
+  flex: 1 1 360px;
   align-items: center;
   gap: 6px;
   min-height: 28px;
@@ -777,9 +796,10 @@ textarea {
 
 .chat-composer-dictation-route {
   display: inline-flex;
+  flex-shrink: 0;
   align-items: center;
   gap: 5px;
-  min-width: 0;
+  min-width: 92px;
 }
 
 .chat-composer-dictation-select {
@@ -815,6 +835,86 @@ textarea {
   font-size: 10px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+@media (min-width: 521px) {
+  @container chat-composer-surface (max-width: 680px) {
+    .chat-composer-actions {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .chat-composer-attachments {
+      grid-column: 1;
+      grid-row: 1;
+      width: 100%;
+    }
+
+    .chat-composer-dictation {
+      grid-column: 1;
+      grid-row: 2;
+      width: 100%;
+    }
+
+    .chat-composer-send {
+      align-self: end;
+      grid-column: 2;
+      grid-row: 1 / span 2;
+    }
+  }
+
+  @container chat-composer-surface (max-width: 360px) {
+    .chat-composer-actions {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .chat-composer-attachments,
+    .chat-composer-dictation,
+    .chat-composer-send {
+      grid-column: 1;
+    }
+
+    .chat-composer-dictation {
+      display: grid;
+      grid-template-areas:
+        "toggle route action"
+        "status status status";
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 4px 6px;
+      max-width: 100%;
+    }
+
+    .chat-composer-dictation-toggle {
+      grid-area: toggle;
+    }
+
+    .chat-composer-dictation-route {
+      grid-area: route;
+      min-width: 0;
+      width: 100%;
+    }
+
+    .chat-composer-dictation-select {
+      max-width: 100%;
+      min-width: 0;
+      width: 100%;
+    }
+
+    .chat-composer-dictation-status {
+      grid-area: status;
+    }
+
+    .chat-composer-dictation-duration,
+    .chat-composer-dictation-action {
+      grid-area: action;
+    }
+
+    .chat-composer-send {
+      grid-row: 3;
+      justify-self: end;
+      margin-left: 0;
+    }
+  }
 }
 
 @media (max-width: 520px), (hover: none) and (pointer: coarse) {
@@ -1112,6 +1212,7 @@ textarea {
 
   .chat-composer-dictation-route {
     grid-area: route;
+    min-width: 0;
     overflow: hidden;
     width: 100%;
   }


### PR DESCRIPTION
## What changed

- give the attachment and dictation groups explicit responsive sizing
- reflow composer actions from one row to two rows based on composer width
- use a compact three-row layout when a desktop split pane narrows the composer below 360px
- keep route-repair actions out of the compact action cell while dictation is active
- preserve the existing phone layout and visible keyboard focus rings
- add geometry, overflow, touch-target, and keyboard-focus regression coverage

## Why

Long attachment and dictation setup messages could overflow their flex items and paint over adjacent controls in the desktop chat composer. Viewport media queries also missed cases where the right-side settings panel narrowed only the chat pane.

The composer now responds to its own container width, so its controls remain distinct in ordinary desktop, wide desktop, and narrow split-pane layouts.

## User impact

Image status, dictation route/status/setup, and Send remain readable and operable without overlapping. Mobile behavior remains unchanged.

## Validation

- `bun run lint`
- `bun run format:check`
- `bun run build`
- `bun run test` — 117 files, 2,714 tests
- `bun run test:e2e -- --workers=4` — 117 tests
- independent responsive/accessibility and regression-test reviews — no remaining findings
