### PR TITLE
fix(release): preserve delivery manifest path

### DIFF
--- a/.github/workflows/release-delivery.yml
+++ b/.github/workflows/release-delivery.yml
@@ -218,6 +218,11 @@ jobs:
         run: |
           set -euo pipefail
           proposal_dir="${RUNNER_TEMP}/release-delivery-proposal"
+          manifest="${RUNNER_TEMP}/release-manifest/latest.json"
+          if [ ! -f "${manifest}" ]; then
+            echo "Canonical release manifest is unavailable for the delivery proposal." >&2
+            exit 1
+          fi
           mkdir -p "${proposal_dir}"
           git diff --binary --full-index origin/master -- \
             README.md \

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -118,10 +118,12 @@ requireText(deliveryPath, delivery, "allowed_paths:");
 requireText(deliveryPath, delivery, "Release delivery requires a stable vX.Y.Z tag");
 requireText(deliveryPath, delivery, "legacy_manifest=website/public/releases/alpha/latest.json");
 requireText(deliveryPath, delivery, '[ "$TAG" = "v0.5.0" ]');
-requireText(deliveryPath, delivery, "Legacy alpha updater manifest differs from the stable release asset.");
+requireText(
+  deliveryPath,
+  delivery,
+  "Legacy alpha updater manifest differs from the stable release asset.",
+);
 requireText(deliveryPath, delivery, "bridge_updated=${bridge_updated}");
-requireText(deliveryPath, delivery, 'manifest="${RUNNER_TEMP}/release-manifest/latest.json"');
-requireText(deliveryPath, delivery, "Canonical release manifest is unavailable for the delivery proposal.");
 requireText(deliveryPath, delivery, "The release workflow deliberately cannot push");
 requireText(
   deliveryPath,
@@ -147,6 +149,28 @@ forbidPattern(
   delivery,
   /\bgh\s+pr\s+(?:create|edit|merge|review)(?:\s|$)/m,
   "a pull-request mutation command",
+);
+
+const proposalStepStart = delivery.indexOf("      - name: Build review proposal");
+const proposalStepEnd = delivery.indexOf("      - name: Upload review proposal", proposalStepStart);
+if (proposalStepStart < 0 || proposalStepEnd < 0) {
+  fail(`${deliveryPath} must define a bounded Build review proposal step`);
+}
+const proposalStep = delivery.slice(proposalStepStart, proposalStepEnd);
+const proposalManifest = 'manifest="${RUNNER_TEMP}/release-manifest/latest.json"';
+const proposalManifestIndex = proposalStep.indexOf(proposalManifest);
+const proposalCopyIndex = proposalStep.indexOf('cp "${manifest}"');
+if (
+  proposalManifestIndex < 0 ||
+  proposalCopyIndex < 0 ||
+  proposalManifestIndex > proposalCopyIndex
+) {
+  fail(`${deliveryPath} must bind the canonical manifest before copying it into the proposal`);
+}
+requireText(
+  `${deliveryPath} Build review proposal step`,
+  proposalStep,
+  "Canonical release manifest is unavailable for the delivery proposal.",
 );
 
 requireText(websitePath, website, "github.ref == 'refs/heads/master'");

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -120,6 +120,8 @@ requireText(deliveryPath, delivery, "legacy_manifest=website/public/releases/alp
 requireText(deliveryPath, delivery, '[ "$TAG" = "v0.5.0" ]');
 requireText(deliveryPath, delivery, "Legacy alpha updater manifest differs from the stable release asset.");
 requireText(deliveryPath, delivery, "bridge_updated=${bridge_updated}");
+requireText(deliveryPath, delivery, 'manifest="${RUNNER_TEMP}/release-manifest/latest.json"');
+requireText(deliveryPath, delivery, "Canonical release manifest is unavailable for the delivery proposal.");
 requireText(deliveryPath, delivery, "The release workflow deliberately cannot push");
 requireText(
   deliveryPath,


### PR DESCRIPTION
## Summary
- rebind the downloaded canonical manifest in the delivery proposal step
- fail explicitly if that manifest is missing
- lock the cross-step path with the release workflow checker

## Verification
- `just release-workflow-check`
- `actionlint .github/workflows/release-delivery.yml`
- `git diff --check`

This unblocks rerunning delivery for the already-published `v0.5.0` release; it does not recreate or move the tag.