### PR TITLE
feat(website): center the agent operator workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -89,6 +89,15 @@ jobs:
         run: bun --bun run test:e2e
         working-directory: website
 
+      - name: Upload browser diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: website-browser-diagnostics-${{ github.run_attempt }}
+          path: website/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -81,12 +81,12 @@ jobs:
         run: bun --bun run format:check
         working-directory: website
 
-      - name: Check
-        run: bun --bun run check
+      - name: Install Chromium
+        run: bunx playwright install --with-deps chromium
         working-directory: website
 
-      - name: Build
-        run: bun --bun run build
+      - name: Build, browser, and accessibility tests
+        run: bun --bun run test:e2e
         working-directory: website
 
       - name: Upload Pages artifact

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ website/dist/
 website/.astro/
 website/.vercel/
 website/.netlify/
+website/test-results/
+website/playwright-report/
 
 # Tauri desktop app
 tauri/node_modules/

--- a/docs-ai/core/verification.md
+++ b/docs-ai/core/verification.md
@@ -8,8 +8,8 @@ Do not create a PR, push an update to an existing PR, mark a PR ready for
 review, or ask for merge until the verification for every touched
 implementation surface has passed locally:
 
-- Touch `ui/`, `website/`, `.ts`, `.tsx`, `.js`, `.jsx`, CSS, Vitest, or
-  Playwright files: run the UI checks listed below.
+- Touch `ui/` or its workflow: run the UI checks listed below.
+- Touch `website/` or its workflow: run the website checks listed below.
 - Touch Go files, Go modules, backend config, or e2e helpers: run the Go
   checks listed below.
 - Touch both frontend and backend surfaces: run both ladders.
@@ -92,6 +92,22 @@ Markdown and `.mdc` docs are also formatted with Oxfmt through
 fragment validation; Oxfmt only normalizes text formatting.
 
 When updating snapshots, review the diff carefully. Accidental snapshot churn is the most common silent regression vector.
+
+## Website verification ladder
+
+| Step             | Command                     | When                                                           |
+| ---------------- | --------------------------- | -------------------------------------------------------------- |
+| Type/shape check | `just website-check`        | After any Astro or TypeScript edit                             |
+| Lint             | `just website-lint`         | Before claiming done; also covered by Website CI               |
+| Format check     | `just website-format-check` | Before claiming done; also covered by Website CI               |
+| Production build | `just website-build`        | Before claiming done                                           |
+| Browser suite    | `just website-test-e2e`     | Website behavior, responsive layout, metadata, or a11y changes |
+
+Install the matching local Chromium once with
+`cd website && bunx playwright install chromium`. The browser suite rebuilds
+the static site, starts the production preview, and tests desktop plus narrow
+and standard phone viewports. Visual judgment, real Safari/Firefox rendering,
+screen-reader behavior, and external-link availability remain manual checks.
 
 ## Test layer choice (quick guide)
 

--- a/docs-ai/core/verification.md
+++ b/docs-ai/core/verification.md
@@ -105,9 +105,10 @@ When updating snapshots, review the diff carefully. Accidental snapshot churn is
 
 Install the matching local Chromium once with
 `cd website && bunx playwright install chromium`. The browser suite rebuilds
-the static site, starts the production preview, and tests desktop plus narrow
-and standard phone viewports. Visual judgment, real Safari/Firefox rendering,
-screen-reader behavior, and external-link availability remain manual checks.
+the static site, starts the production preview, and tests desktop, standard and
+narrow phones, short tablets, and phone landscape. Visual judgment, real
+Safari/Firefox rendering, screen-reader behavior, and external-link
+availability remain manual checks.
 
 ## Test layer choice (quick guide)
 

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -148,11 +148,13 @@ just website-install
 just website-dev       # Astro dev server
 just website-check     # astro check + TypeScript
 just website-build     # production build
+just website-test-e2e  # production-preview browser + accessibility tests
 ```
 
-Website-only pull requests run the dedicated Website workflow (`astro check` +
-production build) and do not wake the main Hecate Go/Rust/UI test workflow.
-Pushes to `master` deploy `website/dist` to GitHub Pages.
+Website-only pull requests run the dedicated Website workflow (lint, format,
+Astro/TypeScript checks, production build, and Chromium browser/accessibility
+tests) and do not wake the main Hecate Go/Rust/UI test workflow. Pushes to
+`master` deploy `website/dist` to GitHub Pages.
 
 ## Reset state
 
@@ -180,6 +182,7 @@ just ui-test-e2e       # UI end-to-end tests (Playwright)
 just website-lint      # website oxlint checks
 just website-format-check # website Oxfmt formatting check
 just website-format    # format website source with Oxfmt
+just website-test-e2e  # production-preview browser + accessibility tests
 just docs-format-check # Markdown and .mdc Oxfmt formatting check
 just docs-format       # format tracked Markdown and .mdc docs with Oxfmt
 just format-check      # Go + UI + website + docs formatting check
@@ -217,16 +220,16 @@ Oxfmt for formatting; lychee still validates links and fragments.
 GitHub Actions is split by surface so small changes do not wake the whole
 project:
 
-| Workflow                  | Trigger                                                                    | Purpose                                                                                              |
-| ------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `test.yml`                | Every PR; pushes to `master` except markdown-only and website-only changes | Main quality gate: Go, UI, e2e, Docker smoke, Tauri Rust tests, and gated desktop bundle validation. |
-| `website.yml`             | Website changes                                                            | Astro check/build and GitHub Pages deploy for [hecate.sh](https://hecate.sh).                        |
-| `links.yml`               | PRs and pushes                                                             | Markdown formatting, link, fragment, and Mermaid validation.                                         |
-| `maintenance.yml`         | Nightly and manual dispatch                                                | Repeatable maintenance and race-test report, with external link drift kept informational.            |
-| `cursor-agent-update.yml` | Weekly and manual dispatch                                                 | Validate official Cursor Agent artifacts and open a human-reviewed two-Dockerfile pin update.        |
-| `release.yml`             | `v*` tags and manual dispatch                                              | Goreleaser artifacts, Docker images, signed desktop bundles, updater manifest, delivery proposal.    |
-| `release-delivery.yml`    | Release workflow call and manual recovery                                  | Validate a published manifest and upload a bounded documentation patch for review.                   |
-| `tauri-build.yml`         | Manual dispatch only                                                       | Explicit desktop bundle rebuild/debug run from the Actions tab.                                      |
+| Workflow                  | Trigger                                                                    | Purpose                                                                                                       |
+| ------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `test.yml`                | Every PR; pushes to `master` except markdown-only and website-only changes | Main quality gate: Go, UI, e2e, Docker smoke, Tauri Rust tests, and gated desktop bundle validation.          |
+| `website.yml`             | Website changes                                                            | Lint, format, Astro/TypeScript build, browser/accessibility tests, and [hecate.sh](https://hecate.sh) deploy. |
+| `links.yml`               | PRs and pushes                                                             | Markdown formatting, link, fragment, and Mermaid validation.                                                  |
+| `maintenance.yml`         | Nightly and manual dispatch                                                | Repeatable maintenance and race-test report, with external link drift kept informational.                     |
+| `cursor-agent-update.yml` | Weekly and manual dispatch                                                 | Validate official Cursor Agent artifacts and open a human-reviewed two-Dockerfile pin update.                 |
+| `release.yml`             | `v*` tags and manual dispatch                                              | Goreleaser artifacts, Docker images, signed desktop bundles, updater manifest, delivery proposal.             |
+| `release-delivery.yml`    | Release workflow call and manual recovery                                  | Validate a published manifest and upload a bounded documentation patch for review.                            |
+| `tauri-build.yml`         | Manual dispatch only                                                       | Explicit desktop bundle rebuild/debug run from the Actions tab.                                               |
 
 The main `Test` workflow starts every PR with a path filter. Go, TypeScript,
 Docker, and Tauri Rust jobs run only when their inputs changed, while workflow

--- a/just/website.just
+++ b/just/website.just
@@ -28,6 +28,10 @@ website-format-check: _website-deps
 website-build: _website-deps
 	cd website && bun --bun run build
 
+# Run the production-build website browser and accessibility checks.
+website-test-e2e: _website-deps
+	cd website && bun --bun run test:e2e
+
 # Preview the built Astro website.
 website-preview: _website-deps
 	cd website && bun --bun run preview

--- a/website/README.md
+++ b/website/README.md
@@ -13,7 +13,7 @@ just website-install
 just website-dev       # local Astro dev server
 just website-check     # astro check + TypeScript
 just website-build     # production build
-just website-test-e2e  # desktop + phone browser and accessibility checks
+just website-test-e2e  # desktop, compact, and phone browser/a11y checks
 just website-preview   # preview website/dist
 ```
 

--- a/website/README.md
+++ b/website/README.md
@@ -13,11 +13,25 @@ just website-install
 just website-dev       # local Astro dev server
 just website-check     # astro check + TypeScript
 just website-build     # production build
+just website-test-e2e  # desktop + phone browser and accessibility checks
 just website-preview   # preview website/dist
 ```
 
 The `just` recipes force package scripts through Bun (`bun --bun run ...`) so
 Astro does not accidentally use a mismatched system Node runtime.
+
+The browser suite runs against the production preview in Chromium. Install the
+matching browser once before the first local run:
+
+```bash
+cd website
+bunx playwright install chromium
+```
+
+It covers semantic navigation, metadata, release-link wording, responsive
+overflow, image loading, the zero-client-JavaScript boundary, and automated
+WCAG A/AA checks. Visual judgment, real Safari/Firefox rendering, screen-reader
+behavior, and external-link availability remain manual checks.
 
 ## Deployment
 

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -5,56 +5,66 @@
     "": {
       "name": "hecate-website",
       "dependencies": {
-        "astro": "^7.0.0",
+        "astro": "^7.1.6",
       },
       "devDependencies": {
-        "@astrojs/check": "^0.9.9",
-        "@types/node": "^26.0.0",
+        "@astrojs/check": "^0.9.10",
+        "@axe-core/playwright": "^4.12.1",
+        "@playwright/test": "^1.62.1",
+        "@types/node": "^26.1.2",
         "oxfmt": "^0.61.0",
-        "oxlint": "^1.65.0",
+        "oxlint": "^1.77.0",
         "oxlint-tsgolint": "7.0.2001",
         "typescript": "^6.0.3",
       },
     },
   },
+  "overrides": {
+    "fast-uri": "3.1.5",
+    "postcss": "8.5.25",
+    "sharp": "0.35.3",
+    "svgo": "4.0.2",
+  },
   "packages": {
-    "@astrojs/check": ["@astrojs/check@0.9.9", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg=="],
+    "@astrojs/check": ["@astrojs/check@0.9.10", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^18.0.0" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "./bin/astro-check.js" } }, "sha512-zgx/UQMozdjOa3bOxjgeCFdtpE3c9rRX6xHwa+2QXvy8z8Akifu2AtubHyv/zzC2znO8dl8fFWL4K+Ba9kS8HQ=="],
 
     "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
-    "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.2.3", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.2.3", "@astrojs/compiler-binding-darwin-x64": "0.2.3", "@astrojs/compiler-binding-linux-arm64-gnu": "0.2.3", "@astrojs/compiler-binding-linux-arm64-musl": "0.2.3", "@astrojs/compiler-binding-linux-x64-gnu": "0.2.3", "@astrojs/compiler-binding-linux-x64-musl": "0.2.3", "@astrojs/compiler-binding-wasm32-wasi": "0.2.3", "@astrojs/compiler-binding-win32-arm64-msvc": "0.2.3", "@astrojs/compiler-binding-win32-x64-msvc": "0.2.3" } }, "sha512-Xz3iBNse+hXXD25IXxsuXEt2ai8klAWE15CRm/EQBc9+aE3jXaF07DZx+iakk3HC6NHvWlEPzLPyxsLgPzOJsw=="],
+    "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.3.2", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.3.2", "@astrojs/compiler-binding-darwin-x64": "0.3.2", "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.2", "@astrojs/compiler-binding-linux-arm64-musl": "0.3.2", "@astrojs/compiler-binding-linux-x64-gnu": "0.3.2", "@astrojs/compiler-binding-linux-x64-musl": "0.3.2", "@astrojs/compiler-binding-wasm32-wasi": "0.3.2", "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.2", "@astrojs/compiler-binding-win32-x64-msvc": "0.3.2" } }, "sha512-8w/9CWmYrAJJ8N0SY3O43ws2BgxoW6u3QsD8u2mE140lMYAlwh+tlNoUeSBq22wVheFuiBbR212l6ixZ2IIgCQ=="],
 
-    "@astrojs/compiler-binding-darwin-arm64": ["@astrojs/compiler-binding-darwin-arm64@0.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sJIHeL1ONXEBLob8ZaXfmX6iCftUno08G/cMXj2FJnL0xNbHuELcEq1mjxHVFHNgUYu4P7xJNm2mpc0zUEPoKw=="],
+    "@astrojs/compiler-binding-darwin-arm64": ["@astrojs/compiler-binding-darwin-arm64@0.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MM8tn8CSimcfytaOla4b6acN8mKWiL/rlAA1fpT3/Wl7dNGSE4y8FjTN/zJVNnb63CsLWG5zZwCt01TXtDKh9g=="],
 
-    "@astrojs/compiler-binding-darwin-x64": ["@astrojs/compiler-binding-darwin-x64@0.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-P0NYu6aaIeLCqFfszxxBHL0a5WRaYigNVbDoO654Gi5Q2au5duDb5xZBv5EqUg4qnQVC173FXNvGZu1M7nk+/w=="],
+    "@astrojs/compiler-binding-darwin-x64": ["@astrojs/compiler-binding-darwin-x64@0.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-2lXOlzf8xb7jLomRsf/aswh61/NnGusynB2OwFkK6k4pmOtpfXMYnG0PLfXrEvxXYj69NdCnmUYXtHDd+JOOag=="],
 
-    "@astrojs/compiler-binding-linux-arm64-gnu": ["@astrojs/compiler-binding-linux-arm64-gnu@0.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-PqVN5AqhuDqfx3ejaerwrC8codpV9jnyKV+IOel027qsJ1anFUJLdjUlY8VVys0xgd8lmqveX11OkcaQj/otTg=="],
+    "@astrojs/compiler-binding-linux-arm64-gnu": ["@astrojs/compiler-binding-linux-arm64-gnu@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-BmU3kWj7qnLrd4vzm49zFEPJ5oFnn1tCT4Vt9hZbqdU5Cmb8GZl7fn6VFsnNfe7B18a2gIFtVzbLINtYl5kBjQ=="],
 
-    "@astrojs/compiler-binding-linux-arm64-musl": ["@astrojs/compiler-binding-linux-arm64-musl@0.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-O3e2CbN4yTsRguWYNnRd0p5YQ0H3fb7KpcR0W4R319q/gq5B1pJ7eqNbiO3b8g2AuiEcRTiUz5jeGT9j69cxOQ=="],
+    "@astrojs/compiler-binding-linux-arm64-musl": ["@astrojs/compiler-binding-linux-arm64-musl@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw=="],
 
-    "@astrojs/compiler-binding-linux-x64-gnu": ["@astrojs/compiler-binding-linux-x64-gnu@0.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-hbLBjXVp+96psMe7/7uqyrquGiULXANrq6REVxxPK/I5VzebZ7LHmSfykmByUbLyR1u+K6CTBKgvdQsK2L+2Xw=="],
+    "@astrojs/compiler-binding-linux-x64-gnu": ["@astrojs/compiler-binding-linux-x64-gnu@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q=="],
 
-    "@astrojs/compiler-binding-linux-x64-musl": ["@astrojs/compiler-binding-linux-x64-musl@0.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-vIiEvOwrJfHZMaTmqUCrFTIwMYL0+PD3Rvy7kFDQgERyx3zhaw8CPa01MCCqa+/sj344BGrXKZ6ti37SgNLMhw=="],
+    "@astrojs/compiler-binding-linux-x64-musl": ["@astrojs/compiler-binding-linux-x64-musl@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ=="],
 
-    "@astrojs/compiler-binding-wasm32-wasi": ["@astrojs/compiler-binding-wasm32-wasi@0.2.3", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-p9S2X8z/mUR2SMzAVJRFMCt8YaalKR+pjl2DgpdjzCQc6ww4bo8kiy54tgKqxZeNF5c+/2tCDTQIxVSm9V1FsA=="],
+    "@astrojs/compiler-binding-wasm32-wasi": ["@astrojs/compiler-binding-wasm32-wasi@0.3.2", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.2.0" }, "cpu": "none" }, "sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw=="],
 
-    "@astrojs/compiler-binding-win32-arm64-msvc": ["@astrojs/compiler-binding-win32-arm64-msvc@0.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-vcCG6JttIb5vbSmcxO2O398hpVj7lQ349iS7cjgYP6ZuLVEnw+9qPAr2MM2kJkU5wEGZqJ2gyi/M7UJoPwH1iQ=="],
+    "@astrojs/compiler-binding-win32-arm64-msvc": ["@astrojs/compiler-binding-win32-arm64-msvc@0.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-ESruf+6Qkl1trHUFxI6GSf6t52j8yN2kCNSzMWdzt7V/T09tFHrYzrVaJQohb2C9bJUH76pNvX6Zb51+xCQc9Q=="],
 
-    "@astrojs/compiler-binding-win32-x64-msvc": ["@astrojs/compiler-binding-win32-x64-msvc@0.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-hKssjNvC36e00Inb1GW1JsVyCFSCGnIjKem4S8q0VIW6cpWAUpvYB4qQU2HIDGD6SDX0ork4F5sWkNWkp2hrGQ=="],
+    "@astrojs/compiler-binding-win32-x64-msvc": ["@astrojs/compiler-binding-win32-x64-msvc@0.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-wzzVrEbOwbsLWOdEbocskjMRx2aZPxJ7ZbmL+jnpBamFwmigm+2M/wzuM6JWncocgYwLic1csSpalBh96kQKXA=="],
 
-    "@astrojs/compiler-rs": ["@astrojs/compiler-rs@0.2.3", "", { "dependencies": { "@astrojs/compiler-binding": "0.2.3" } }, "sha512-JRAtRcPxS4JeAZEIQFQ6GecBs/Wyp4m6/E8vBNxSgVfo1AtRVLUqRCl5oCGOZ0X/BSBB3Vef/7IlzyiGKi2ORA=="],
+    "@astrojs/compiler-rs": ["@astrojs/compiler-rs@0.3.2", "", { "dependencies": { "@astrojs/compiler-binding": "0.3.2" } }, "sha512-xlx/T7JovIKduu4ucbTQUxQ5+Q8wxkHxhLjnZk3VlJbhbQ9RLvvuDk1p2YYFYFQ5y14dVm3FGGO4isQXa4F+Tg=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw=="],
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.2", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ=="],
 
     "@astrojs/language-server": ["@astrojs/language-server@2.16.10", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.4", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.70", "volar-service-emmet": "0.0.70", "volar-service-html": "0.0.70", "volar-service-prettier": "0.0.70", "volar-service-typescript": "0.0.70", "volar-service-typescript-twoslash-queries": "0.0.70", "volar-service-yaml": "0.0.70", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "./bin/nodeServer.js" } }, "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w=="],
 
-    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.9.1" } }, "sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A=="],
+    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.5", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.2", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "satteri": "^0.9.1" } }, "sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
-    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
@@ -162,57 +172,61 @@
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -268,43 +282,45 @@
 
     "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.71.0", "", { "os": "android", "cpu": "arm" }, "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.77.0", "", { "os": "android", "cpu": "arm" }, "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.71.0", "", { "os": "android", "cpu": "arm64" }, "sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.77.0", "", { "os": "android", "cpu": "arm64" }, "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.71.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.77.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.71.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.77.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.71.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.77.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.71.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.71.0", "", { "os": "linux", "cpu": "arm" }, "sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.71.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.71.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.71.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.77.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.71.0", "", { "os": "linux", "cpu": "none" }, "sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.71.0", "", { "os": "linux", "cpu": "none" }, "sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.71.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.77.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.71.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.71.0", "", { "os": "linux", "cpu": "x64" }, "sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.71.0", "", { "os": "none", "cpu": "arm64" }, "sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.77.0", "", { "os": "none", "cpu": "arm64" }, "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.71.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.77.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.71.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.77.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.71.0", "", { "os": "win32", "cpu": "x64" }, "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.77.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw=="],
+
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.3", "", { "os": "android", "cpu": "arm64" }, "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g=="],
 
@@ -368,7 +384,7 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
-    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -396,9 +412,9 @@
 
     "am-i-vibing": ["am-i-vibing@0.4.0", "", { "dependencies": { "process-ancestry": "^0.1.0" }, "bin": { "am-i-vibing": "dist/cli.mjs" } }, "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
@@ -406,7 +422,9 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
-    "astro": ["astro@7.0.2", "", { "dependencies": { "@astrojs/compiler-rs": "^0.2.2", "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-satteri": "0.3.2", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.0" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-Rj31HS85pVSfiQTxKTwH6vTmF8y57iRfkgb1uiCTtdLIh3jlUKPAPXtEmHXRKp/PdTS00D4EXYlWXypY+AVVCA=="],
+    "astro": ["astro@7.1.6", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.2", "@astrojs/internal-helpers": "0.10.2", "@astrojs/markdown-satteri": "0.3.5", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.3.0", "jsonc-parser": "^3.3.1", "magic-string": "^1.0.0", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.2" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-83x9rYbHazMaZkYrAFRVZXSQx2moFkz0F7cjTDUF3GWfS0a3p2vZXG1ZdhV86rStHApQCodBJW+XTD37xISIrQ=="],
+
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -424,13 +442,9 @@
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
-
-    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
@@ -438,7 +452,7 @@
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@2.0.1", "", {}, "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w=="],
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
@@ -478,7 +492,7 @@
 
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -500,7 +514,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -512,9 +526,11 @@
 
     "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
 
@@ -544,15 +560,9 @@
 
     "is-docker": ["is-docker@4.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
-
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
-    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
-
-    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -586,7 +596,7 @@
 
     "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
-    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+    "magic-string": ["magic-string@1.1.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g=="],
 
     "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
 
@@ -608,9 +618,9 @@
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
-    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
-    "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
+    "neotraverse": ["neotraverse@1.0.1", "", {}, "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w=="],
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 
@@ -634,7 +644,7 @@
 
     "oxfmt": ["oxfmt@0.61.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.61.0", "@oxfmt/binding-android-arm64": "0.61.0", "@oxfmt/binding-darwin-arm64": "0.61.0", "@oxfmt/binding-darwin-x64": "0.61.0", "@oxfmt/binding-freebsd-x64": "0.61.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0", "@oxfmt/binding-linux-arm-musleabihf": "0.61.0", "@oxfmt/binding-linux-arm64-gnu": "0.61.0", "@oxfmt/binding-linux-arm64-musl": "0.61.0", "@oxfmt/binding-linux-ppc64-gnu": "0.61.0", "@oxfmt/binding-linux-riscv64-gnu": "0.61.0", "@oxfmt/binding-linux-riscv64-musl": "0.61.0", "@oxfmt/binding-linux-s390x-gnu": "0.61.0", "@oxfmt/binding-linux-x64-gnu": "0.61.0", "@oxfmt/binding-linux-x64-musl": "0.61.0", "@oxfmt/binding-openharmony-arm64": "0.61.0", "@oxfmt/binding-win32-arm64-msvc": "0.61.0", "@oxfmt/binding-win32-ia32-msvc": "0.61.0", "@oxfmt/binding-win32-x64-msvc": "0.61.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ=="],
 
-    "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
+    "oxlint": ["oxlint@1.77.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.77.0", "@oxlint/binding-android-arm64": "1.77.0", "@oxlint/binding-darwin-arm64": "1.77.0", "@oxlint/binding-darwin-x64": "1.77.0", "@oxlint/binding-freebsd-x64": "1.77.0", "@oxlint/binding-linux-arm-gnueabihf": "1.77.0", "@oxlint/binding-linux-arm-musleabihf": "1.77.0", "@oxlint/binding-linux-arm64-gnu": "1.77.0", "@oxlint/binding-linux-arm64-musl": "1.77.0", "@oxlint/binding-linux-ppc64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-musl": "1.77.0", "@oxlint/binding-linux-s390x-gnu": "1.77.0", "@oxlint/binding-linux-x64-gnu": "1.77.0", "@oxlint/binding-linux-x64-musl": "1.77.0", "@oxlint/binding-openharmony-arm64": "1.77.0", "@oxlint/binding-win32-arm64-msvc": "1.77.0", "@oxlint/binding-win32-ia32-msvc": "1.77.0", "@oxlint/binding-win32-x64-msvc": "1.77.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
@@ -656,7 +666,11 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
     "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
 
@@ -676,15 +690,7 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
-    "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
-
-    "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
-
-    "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
-
     "request-light": ["request-light@0.7.0", "", {}, "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="],
-
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -700,7 +706,7 @@
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" } }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 
     "shiki": ["shiki@4.3.0", "", { "dependencies": { "@shikijs/core": "4.3.0", "@shikijs/engine-javascript": "4.3.0", "@shikijs/engine-oniguruma": "4.3.0", "@shikijs/langs": "4.3.0", "@shikijs/themes": "4.3.0", "@shikijs/types": "4.3.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NKKjWzR6LIGL3sXBrWDw9sDS9cxx42/DkysaNqJEeOWE8Kix5gpak0bc00OfDVEO4oyXSyz8+aRaqKoBD1yo7A=="],
 
@@ -712,13 +718,13 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
+    "svgo": ["svgo@4.0.2", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng=="],
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
@@ -812,9 +818,7 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
-    "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
-
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
@@ -824,7 +828,7 @@
 
     "yaml-language-server": ["yaml-language-server@1.20.0", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "prettier": "^3.5.0", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.7.1" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA=="],
 
-    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+    "yargs": ["yargs@18.1.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^8.2.1", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg=="],
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
@@ -834,27 +838,33 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@bruits/satteri-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
-    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
-
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vscode-css-languageservice/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
 
     "vscode-languageserver/vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
 
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
 
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
-
-    "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 

--- a/website/e2e/homepage.spec.ts
+++ b/website/e2e/homepage.spec.ts
@@ -93,18 +93,24 @@ test("describes release destinations and platform readiness truthfully", async (
 });
 
 test("loads bounded, described product imagery without layout overflow", async ({ page }) => {
-  await page.locator("footer").scrollIntoViewIfNeeded();
-  await expect
-    .poll(() =>
-      page
-        .locator("img")
-        .evaluateAll((images) =>
-          images.every((image) => (image as HTMLImageElement).naturalWidth > 0),
+  const belowFoldImages = page.locator(".product-figure img");
+  await expect(belowFoldImages).toHaveCount(3);
+  for (const image of await belowFoldImages.all()) {
+    await expect(image).toHaveAttribute("loading", "lazy");
+    await image.scrollIntoViewIfNeeded();
+    await expect
+      .poll(() =>
+        image.evaluate(
+          (element) =>
+            (element as HTMLImageElement).complete &&
+            (element as HTMLImageElement).naturalWidth > 0,
         ),
-    )
-    .toBeTruthy();
+      )
+      .toBeTruthy();
+  }
 
-  const imageState = await page.locator("img").evaluateAll((images) =>
+  const images = page.locator("img");
+  const imageState = await images.evaluateAll((images) =>
     images.map((image) => ({
       alt: image.getAttribute("alt"),
       complete: (image as HTMLImageElement).complete,
@@ -125,11 +131,11 @@ test("loads bounded, described product imagery without layout overflow", async (
   }
 
   await expect(page.locator(".hero__media img")).toHaveAttribute("fetchpriority", "high");
-  const belowFoldImages = page.locator(".product-figure img");
-  await expect(belowFoldImages).toHaveCount(3);
-  for (const image of await belowFoldImages.all()) {
-    await expect(image).toHaveAttribute("loading", "lazy");
-  }
+
+  await page.evaluate(() => {
+    document.documentElement.style.scrollBehavior = "auto";
+    window.scrollTo(0, 0);
+  });
 
   const layout = await page.evaluate(() => {
     const interactive = Array.from(document.querySelectorAll<HTMLElement>("a, button"));
@@ -148,7 +154,6 @@ test("loads bounded, described product imagery without layout overflow", async (
   expect(layout.documentWidth).toBeLessThanOrEqual(layout.viewportWidth + 1);
   expect(layout.outside).toEqual([]);
 
-  await page.evaluate(() => window.scrollTo(0, 0));
   const primaryAction = page.locator(".hero").getByRole("link", { name: "View latest release" });
   await expect(primaryAction).toHaveCount(1);
   const actionBox = await primaryAction.boundingBox();

--- a/website/e2e/homepage.spec.ts
+++ b/website/e2e/homepage.spec.ts
@@ -84,8 +84,13 @@ test("describes release destinations and platform readiness truthfully", async (
     await expect(link).toContainText("View release");
   }
 
-  await expect(page.getByText("macOS Apple Silicon launch-tested", { exact: false })).toBeVisible();
-  await expect(page.getByText("Linux and Windows experimental", { exact: false })).toBeVisible();
+  await expect(page.getByRole("group", { name: "Desktop release platforms" })).toHaveCount(1);
+  await expect(platformLinks.nth(0)).toContainText("macOS");
+  await expect(platformLinks.nth(0)).toContainText("Apple Silicon · launch-tested");
+  await expect(platformLinks.nth(1)).toContainText("Linux");
+  await expect(platformLinks.nth(1)).toContainText("experimental");
+  await expect(platformLinks.nth(2)).toContainText("Windows");
+  await expect(platformLinks.nth(2)).toContainText("experimental");
   await expect(page.getByText("External Agents remain trusted subprocesses.")).toBeVisible();
   await expect(
     page.getByText("Embedded Cairnline owns portable project identity", { exact: false }),
@@ -145,7 +150,11 @@ test("loads bounded, described product imagery without layout overflow", async (
       outside: interactive
         .map((element) => {
           const rect = element.getBoundingClientRect();
-          return { label: element.textContent?.trim() ?? "", left: rect.left, right: rect.right };
+          return {
+            label: element.textContent?.trim() ?? "",
+            left: rect.left + window.scrollX,
+            right: rect.right + window.scrollX,
+          };
         })
         .filter(({ left, right }) => left < -1 || right > viewportWidth + 1),
       viewportWidth,
@@ -156,13 +165,28 @@ test("loads bounded, described product imagery without layout overflow", async (
 
   const primaryAction = page.locator(".hero").getByRole("link", { name: "View latest release" });
   await expect(primaryAction).toHaveCount(1);
-  const actionBox = await primaryAction.boundingBox();
-  expect(actionBox).not.toBeNull();
-  expect(actionBox!.y + actionBox!.height).toBeLessThanOrEqual(page.viewportSize()!.height);
-
-  const statusBox = await page.locator(".hero__status").boundingBox();
-  expect(statusBox).not.toBeNull();
-  expect(statusBox!.y + statusBox!.height).toBeLessThanOrEqual(page.viewportSize()!.height);
+  const firstViewport = await page.evaluate(() => {
+    const bounds = (selector: string) => {
+      const element = document.querySelector<HTMLElement>(selector)!;
+      const rect = element.getBoundingClientRect();
+      return {
+        bottom: rect.bottom + window.scrollY,
+        top: rect.top + window.scrollY,
+        visible: getComputedStyle(element).display !== "none",
+      };
+    };
+    return {
+      action: bounds(".hero .button--primary"),
+      status: bounds(".hero__status"),
+      title: bounds("h1"),
+    };
+  });
+  expect(firstViewport.title.top).toBeLessThan(page.viewportSize()!.height / 2);
+  expect(firstViewport.action.top).toBeGreaterThanOrEqual(0);
+  expect(firstViewport.action.bottom).toBeLessThanOrEqual(page.viewportSize()!.height);
+  if (firstViewport.status.visible) {
+    expect(firstViewport.status.bottom).toBeLessThanOrEqual(page.viewportSize()!.height);
+  }
 });
 
 test("meets automated WCAG A and AA checks", async ({ page }) => {

--- a/website/e2e/homepage.spec.ts
+++ b/website/e2e/homepage.spec.ts
@@ -1,0 +1,169 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+const latestRelease = "https://github.com/hecatehq/hecate/releases/latest";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+test("publishes complete identity and sharing metadata", async ({ page, request }) => {
+  await expect(page).toHaveTitle("Hecate — Agent Runtime and Operator Console");
+
+  const description = page.locator('meta[name="description"]');
+  await expect(description).toHaveCount(1);
+  await expect(description).toHaveAttribute("content", /agent runtime and operator console/i);
+
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", "https://hecate.sh/");
+  await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute("content", "#070b0c");
+  await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+    "content",
+    /Run agents\. Keep control\./,
+  );
+  await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+    "content",
+    "https://hecate.sh/product/chat-workspace-diff.png",
+  );
+  await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+    "content",
+    "summary_large_image",
+  );
+
+  await expect(page.locator('script:not([type="application/ld+json"])')).toHaveCount(0);
+
+  const [robots, sitemap, socialImage] = await Promise.all([
+    request.get("/robots.txt"),
+    request.get("/sitemap.xml"),
+    request.get("/product/chat-workspace-diff.png"),
+  ]);
+  expect(robots.ok()).toBeTruthy();
+  expect(await robots.text()).toContain("Sitemap: https://hecate.sh/sitemap.xml");
+  expect(sitemap.ok()).toBeTruthy();
+  expect(await sitemap.text()).toContain("<loc>https://hecate.sh/</loc>");
+  expect(socialImage.ok()).toBeTruthy();
+});
+
+test("keeps navigation semantic, keyboard reachable, and internally valid", async ({ page }) => {
+  await expect(page.locator("header")).toHaveCount(1);
+  await expect(page.locator("main")).toHaveCount(1);
+  await expect(page.locator("footer")).toHaveCount(1);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Run agents. Keep control.");
+
+  await page.keyboard.press("Tab");
+  const skipLink = page.getByRole("link", { name: "Skip to content" });
+  await expect(skipLink).toBeFocused();
+  await expect(skipLink).toBeVisible();
+  await expect(skipLink).toHaveCSS("outline-style", "solid");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("main")).toBeFocused();
+
+  const fragments = await page
+    .locator('a[href^="#"]')
+    .evaluateAll((links) => links.map((link) => link.getAttribute("href")));
+  for (const fragment of fragments) {
+    expect(fragment, "same-page link must have a non-empty fragment").toMatch(/^#[\w-]+$/);
+    await expect(page.locator(fragment!)).toHaveCount(1);
+  }
+
+  const insecureExternalLinks = await page.locator('a[href^="http:"]').count();
+  expect(insecureExternalLinks).toBe(0);
+});
+
+test("describes release destinations and platform readiness truthfully", async ({ page }) => {
+  const primaryReleaseLinks = page.getByRole("link", { name: "View latest release" });
+  await expect(primaryReleaseLinks).toHaveCount(2);
+  for (const link of await primaryReleaseLinks.all()) {
+    await expect(link).toHaveAttribute("href", latestRelease);
+  }
+
+  const platformLinks = page.locator(".download-row");
+  await expect(platformLinks).toHaveCount(3);
+  for (const link of await platformLinks.all()) {
+    await expect(link).toHaveAttribute("href", latestRelease);
+    await expect(link).toContainText("View release");
+  }
+
+  await expect(page.getByText("macOS Apple Silicon launch-tested", { exact: false })).toBeVisible();
+  await expect(page.getByText("Linux and Windows experimental", { exact: false })).toBeVisible();
+  await expect(page.getByText("External Agents remain trusted subprocesses.")).toBeVisible();
+  await expect(
+    page.getByText("Embedded Cairnline owns portable project identity", { exact: false }),
+  ).toBeVisible();
+});
+
+test("loads bounded, described product imagery without layout overflow", async ({ page }) => {
+  await page.locator("footer").scrollIntoViewIfNeeded();
+  await expect
+    .poll(() =>
+      page
+        .locator("img")
+        .evaluateAll((images) =>
+          images.every((image) => (image as HTMLImageElement).naturalWidth > 0),
+        ),
+    )
+    .toBeTruthy();
+
+  const imageState = await page.locator("img").evaluateAll((images) =>
+    images.map((image) => ({
+      alt: image.getAttribute("alt"),
+      complete: (image as HTMLImageElement).complete,
+      height: image.getAttribute("height"),
+      naturalHeight: (image as HTMLImageElement).naturalHeight,
+      naturalWidth: (image as HTMLImageElement).naturalWidth,
+      width: image.getAttribute("width"),
+    })),
+  );
+  expect(imageState.length).toBeGreaterThanOrEqual(5);
+  for (const image of imageState) {
+    expect(image.alt).not.toBeNull();
+    expect(Number(image.width)).toBeGreaterThan(0);
+    expect(Number(image.height)).toBeGreaterThan(0);
+    expect(image.complete).toBeTruthy();
+    expect(image.naturalWidth).toBeGreaterThan(0);
+    expect(image.naturalHeight).toBeGreaterThan(0);
+  }
+
+  await expect(page.locator(".hero__media img")).toHaveAttribute("fetchpriority", "high");
+  const belowFoldImages = page.locator(".product-figure img");
+  await expect(belowFoldImages).toHaveCount(3);
+  for (const image of await belowFoldImages.all()) {
+    await expect(image).toHaveAttribute("loading", "lazy");
+  }
+
+  const layout = await page.evaluate(() => {
+    const interactive = Array.from(document.querySelectorAll<HTMLElement>("a, button"));
+    const viewportWidth = document.documentElement.clientWidth;
+    return {
+      documentWidth: document.documentElement.scrollWidth,
+      outside: interactive
+        .map((element) => {
+          const rect = element.getBoundingClientRect();
+          return { label: element.textContent?.trim() ?? "", left: rect.left, right: rect.right };
+        })
+        .filter(({ left, right }) => left < -1 || right > viewportWidth + 1),
+      viewportWidth,
+    };
+  });
+  expect(layout.documentWidth).toBeLessThanOrEqual(layout.viewportWidth + 1);
+  expect(layout.outside).toEqual([]);
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const primaryAction = page.locator(".hero").getByRole("link", { name: "View latest release" });
+  await expect(primaryAction).toHaveCount(1);
+  const actionBox = await primaryAction.boundingBox();
+  expect(actionBox).not.toBeNull();
+  expect(actionBox!.y + actionBox!.height).toBeLessThanOrEqual(page.viewportSize()!.height);
+
+  const statusBox = await page.locator(".hero__status").boundingBox();
+  expect(statusBox).not.toBeNull();
+  expect(statusBox!.y + statusBox!.height).toBeLessThanOrEqual(page.viewportSize()!.height);
+});
+
+test("meets automated WCAG A and AA checks", async ({ page }) => {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+
+  expect(results.violations).toEqual([]);
+});

--- a/website/package.json
+++ b/website/package.json
@@ -12,21 +12,30 @@
     "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev",
     "build": "bun run check && ASTRO_TELEMETRY_DISABLED=1 astro build",
     "check": "ASTRO_TELEMETRY_DISABLED=1 astro check && tsc --noEmit",
-    "lint": "oxlint -c ../.oxlintrc.json --type-aware src astro.config.mjs --ignore-pattern src/env.d.ts",
-    "format": "oxfmt --write src astro.config.mjs package.json",
-    "format:check": "oxfmt --check src astro.config.mjs package.json",
-    "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview"
+    "lint": "oxlint -c ../.oxlintrc.json --type-aware src e2e astro.config.mjs playwright.config.ts --ignore-pattern src/env.d.ts",
+    "format": "oxfmt --write src e2e astro.config.mjs playwright.config.ts package.json",
+    "format:check": "oxfmt --check src e2e astro.config.mjs playwright.config.ts package.json",
+    "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview",
+    "test:e2e": "bun --bun run build && playwright test"
   },
   "dependencies": {
-    "astro": "^7.0.0"
+    "astro": "^7.1.6"
   },
   "devDependencies": {
-    "@astrojs/check": "^0.9.9",
-    "@types/node": "^26.0.0",
+    "@astrojs/check": "^0.9.10",
+    "@axe-core/playwright": "^4.12.1",
+    "@playwright/test": "^1.62.1",
+    "@types/node": "^26.1.2",
     "oxfmt": "^0.61.0",
-    "oxlint": "^1.65.0",
+    "oxlint": "^1.77.0",
     "oxlint-tsgolint": "7.0.2001",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "fast-uri": "3.1.5",
+    "postcss": "8.5.25",
+    "sharp": "0.35.3",
+    "svgo": "4.0.2"
   },
   "packageManager": "bun@1.3.13"
 }

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -39,6 +39,23 @@ export default defineConfig({
         viewport: { width: 320, height: 800 },
       },
     },
+    {
+      name: "short-tablet",
+      use: {
+        ...devices["Desktop Chrome"],
+        hasTouch: true,
+        viewport: { width: 980, height: 600 },
+      },
+    },
+    {
+      name: "landscape-phone",
+      use: {
+        ...devices["Desktop Chrome"],
+        hasTouch: true,
+        isMobile: true,
+        viewport: { width: 844, height: 390 },
+      },
+    },
   ],
   webServer: {
     command: "bun run preview -- --host 127.0.0.1 --port 4321",

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: "list",
+  timeout: 20_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: "http://127.0.0.1:4321",
+    colorScheme: "dark",
+    locale: "en-US",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "desktop",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "phone",
+      use: {
+        ...devices["Desktop Chrome"],
+        hasTouch: true,
+        isMobile: true,
+        viewport: { width: 390, height: 844 },
+      },
+    },
+    {
+      name: "narrow-phone",
+      use: {
+        ...devices["Desktop Chrome"],
+        hasTouch: true,
+        isMobile: true,
+        viewport: { width: 320, height: 800 },
+      },
+    },
+  ],
+  webServer: {
+    command: "bun run preview -- --host 127.0.0.1 --port 4321",
+    url: "http://127.0.0.1:4321",
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -56,6 +56,15 @@ export default defineConfig({
         viewport: { width: 844, height: 390 },
       },
     },
+    {
+      name: "compact-landscape",
+      use: {
+        ...devices["Desktop Chrome"],
+        hasTouch: true,
+        isMobile: true,
+        viewport: { width: 568, height: 320 },
+      },
+    },
   ],
   webServer: {
     command: "bun run preview -- --host 127.0.0.1 --port 4321",

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://hecate.sh/sitemap.xml

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hecate.sh/</loc>
+  </url>
+</urlset>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,33 +1,49 @@
 ---
 import "../styles/global.css";
 
-// GitHub owns the stable release index and download assets. Keeping the site
-// out of this metadata path makes release publication independent of Pages.
-const latestRelease = "https://github.com/hecatehq/hecate/releases/latest";
+const repository = "https://github.com/hecatehq/hecate";
+const latestRelease = `${repository}/releases/latest`;
+const quickStart = `${repository}#quick-start`;
+const deploymentGuide = `${repository}/blob/master/docs/operator/deployment.md`;
+const desktopGuide = `${repository}/blob/master/docs/operator/desktop-app.md`;
+const securityGuide = `${repository}/blob/master/docs/operator/security.md`;
+const knownLimitations = `${repository}/blob/master/docs/operator/known-limitations.md`;
+const acpGuide = `${repository}/blob/master/docs/runtime/acp.md`;
+const license = `${repository}/blob/master/LICENSE`;
 
-const capabilityRows = [
-  [
-    "Chats and routing",
-    "Talk to models through OpenAI-compatible and Anthropic-shaped APIs with health, failover, and usage visibility.",
-  ],
-  [
-    "Projects and memory",
-    "Keep work areas, workspace roots, assignments, context snapshots, evidence, and approved memory together.",
-  ],
-  [
-    "Supervised agents",
-    "Run Codex, Claude Code, Cursor, and Grok Build from Hecate while their CLIs keep their own accounts and runtime behavior.",
-  ],
-  [
-    "Observable work",
-    "Keep approvals, traces, route reports, artifacts, diffs, logs, usage, and final output close to the decision that produced them.",
-  ],
+const operatorSteps = [
+  {
+    number: "01",
+    title: "Configure",
+    body: "Connect model providers and choose the workspace. Agent Presets shape model routing, instructions, and Hecate-owned execution posture; External Agent presets select the agent and its launch options.",
+  },
+  {
+    number: "02",
+    title: "Launch",
+    body: "Start a Hecate Chat, queue a durable Hecate-native Task, or open a supervised External Agent session through ACP.",
+  },
+  {
+    number: "03",
+    title: "Supervise",
+    body: "Follow streamed activity, stop work, and resolve approvals when Hecate policy or an External Agent requests them.",
+  },
+  {
+    number: "04",
+    title: "Review",
+    body: "Inspect final output, artifacts, Git diffs, route decisions, traces, token usage, and provider-reported cost where available—then retry, resume, or hand the work off.",
+  },
+];
+
+const surfaces = [
+  ["Hecate-native Tasks", "Durable agent_loop Runs with policy and evidence"],
+  ["External Agents", "Codex · Claude Code · Cursor Agent · Grok Build"],
+  ["ACP clients", "Use Hecate's native runtime through hecate acp serve"],
 ];
 
 const downloadRows = [
-  ["macOS", "Apple Silicon", latestRelease, "View release"],
-  ["Linux", "x86_64", latestRelease, "View release"],
-  ["Windows", "x86_64", latestRelease, "View release"],
+  ["macOS", "Apple Silicon · launch-tested", "View release"],
+  ["Linux", "x86_64 · experimental", "View release"],
+  ["Windows", "x86_64 · experimental", "View release"],
 ];
 ---
 
@@ -36,136 +52,361 @@ const downloadRows = [
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#070b0c" />
     <meta
       name="description"
-      content="Hecate is an AI workspace and runtime for projects, chats, providers, memory, approvals, traces, and supervised external agents."
+      content="Hecate is an open-source agent runtime and operator console for configuring, launching, supervising, and reviewing AI agent work."
     />
+
+    <link rel="canonical" href="https://hecate.sh/" />
     <link rel="icon" href="/brand/png/mark-trivium-black-64.png" sizes="64x64" />
-    <title>Hecate - AI Workspace and Runtime</title>
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Hecate" />
+    <meta property="og:title" content="Hecate — Run agents. Keep control." />
+    <meta
+      property="og:description"
+      content="Configure models and coding agents, supervise work, review changes, and trace every run from one operator console."
+    />
+    <meta property="og:url" content="https://hecate.sh/" />
+    <meta property="og:image" content="https://hecate.sh/product/chat-workspace-diff.png" />
+    <meta property="og:image:width" content="1280" />
+    <meta property="og:image:height" content="800" />
+    <meta
+      property="og:image:alt"
+      content="Hecate showing an agent transcript beside a Git change review"
+    />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Hecate — Run agents. Keep control." />
+    <meta
+      name="twitter:description"
+      content="Configure models and coding agents, supervise work, review changes, and trace every run from one operator console."
+    />
+    <meta name="twitter:image" content="https://hecate.sh/product/chat-workspace-diff.png" />
+    <meta
+      name="twitter:image:alt"
+      content="Hecate showing an agent transcript beside a Git change review"
+    />
+
+    <title>Hecate — Agent Runtime and Operator Console</title>
   </head>
   <body>
-    <header class="site-nav" aria-label="Primary navigation">
-      <a class="site-brand" href="/" aria-label="Hecate home">
-        <img src="/brand/png/mark-trivium-white-64.png" alt="" />
+    <a class="skip-link" href="#main-content">Skip to content</a>
+
+    <header class="site-nav">
+      <a class="site-brand" href="/" aria-label="Hecate home" translate="no">
+        <img
+          src="/brand/png/mark-trivium-white-64.png"
+          alt=""
+          width="64"
+          height="64"
+          decoding="async"
+        />
         <span>hecate</span>
       </a>
-      <nav class="site-links">
+      <nav class="site-links" aria-label="Primary navigation">
+        <a href="#operator-loop">Workflow</a>
         <a href="#download">Download</a>
-        <a href="#workflow">Projects</a>
-        <a href="#runtime">Runtime</a>
-        <a href="https://github.com/hecatehq/hecate">GitHub</a>
+        <a href={quickStart}>Docs</a>
+        <a href={repository}>GitHub</a>
       </nav>
     </header>
 
-    <main>
+    <main id="main-content" tabindex="-1">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero__media" aria-hidden="true">
-          <img src="/product/chat-workspace-diff.png" alt="" />
+          <img
+            src="/product/chat-workspace-diff.png"
+            alt=""
+            width="1280"
+            height="800"
+            fetchpriority="high"
+            decoding="async"
+          />
         </div>
         <div class="hero__copy">
-          <p class="eyebrow">AI workspace and runtime</p>
-          <h1 id="hero-title">hecate</h1>
+          <p class="eyebrow">Agent runtime + operator console</p>
+          <h1 id="hero-title">
+            <span class="hero__wordmark" translate="no">hecate</span>
+            <span class="hero__claim">Run agents. Keep control.</span>
+          </h1>
           <p class="lede">
-            Run Hecate on your machine as the personal control plane for AI work:
-            projects, chats, model providers, memory, approvals, diffs, traces,
-            and supervised external agents in one UI.
+            Connect models and coding agents, launch work with an explicit workspace and
+            runtime posture, review approvals and diffs, and trace what happened—from one
+            operator console.
           </p>
 
-          <div class="hero__actions" aria-label="Primary actions">
-            <a class="button button--primary" href={latestRelease}>Download latest</a>
-            <a class="button button--ghost" href="#download">Other platforms</a>
-            <a class="button button--quiet" href="https://github.com/hecatehq/hecate">View source</a>
+          <div class="hero__actions">
+            <a class="button button--primary" href={latestRelease}>View latest release</a>
+            <a class="button button--ghost" href="#operator-loop">See the operator loop</a>
+            <a class="button button--quiet" href={repository}>View source</a>
           </div>
 
-          <p class="hero__release">
-            <a href="https://github.com/hecatehq/hecate/releases">all releases</a>
-            · <a href="https://github.com/hecatehq/hecate">GitHub</a>
+          <p class="hero__status">
+            Stable pre-1.0 · macOS Apple Silicon launch-tested · Linux and Windows
+            experimental
           </p>
         </div>
       </section>
 
-      <section class="download" id="download" aria-labelledby="download-title">
-        <div class="section-heading">
-          <p class="eyebrow">stable releases</p>
-          <h2 id="download-title">Install the local console.</h2>
+      <section class="surfaces" aria-labelledby="surfaces-title">
+        <div class="section-heading section-heading--compact">
+          <p class="eyebrow">Compatible by design</p>
+          <h2 id="surfaces-title">Bring the agents you already use.</h2>
           <p>
-            Start with the desktop app, Docker image, or source checkout. Hecate
-            runs locally by default and keeps the runtime boundary visible.
+            Hecate runs its own durable Tasks, supervises installed coding-agent CLIs
+            through ACP, and exposes its native runtime to ACP-capable clients.
           </p>
         </div>
 
-        <div class="download-table" aria-label="Download options">
-          {downloadRows.map(([platform, detail, url, action]) => (
-            <a class="download-row" href={url}>
+        <div>
+          <ul class="surface-list">
+            {surfaces.map(([title, body]) => (
+              <li>
+                <strong>{title}</strong>
+                <span>{body}</span>
+              </li>
+            ))}
+          </ul>
+          <p class="section-note">
+            External Agent CLIs are installed separately. Their vendor accounts, billing,
+            and internal runtime stay with them.
+          </p>
+        </div>
+      </section>
+
+      <section class="operator-loop" id="operator-loop" aria-labelledby="operator-loop-title">
+        <div class="section-heading">
+          <p class="eyebrow">Operator loop</p>
+          <h2 id="operator-loop-title">From intent to evidence.</h2>
+          <p>
+            Prepare the work, run the right agent, follow what happens, and review the
+            result without losing the execution boundary.
+          </p>
+        </div>
+
+        <ol class="workflow-list">
+          {operatorSteps.map((step) => (
+            <li>
+              <span class="workflow-number" aria-hidden="true">{step.number}</span>
+              <h3>{step.title}</h3>
+              <p>{step.body}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section class="visual-band" aria-labelledby="review-title">
+        <figure class="product-figure product-figure--review">
+          <div class="product-frame">
+            <img
+              src="/product/chat-workspace-diff.png"
+              alt="Hecate transcript beside the changed-files review with a rendered Git diff"
+              width="1280"
+              height="800"
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
+          <figcaption>Chat, Task Run, trace, and workspace changes stay connected.</figcaption>
+        </figure>
+        <div class="visual-band__copy">
+          <p class="eyebrow">Change review</p>
+          <h2 id="review-title">Review the work, not just the answer.</h2>
+          <p>
+            Keep the transcript beside its Task Run, trace, files, and Git diff. Hecate
+            preserves the evidence needed to understand what changed and why.
+          </p>
+        </div>
+      </section>
+
+      <section class="interoperability" id="acp" aria-labelledby="acp-title">
+        <div class="section-heading">
+          <p class="eyebrow">Agent Client Protocol</p>
+          <h2 id="acp-title">ACP works in both directions.</h2>
+          <p>
+            Use Hecate as the console around external agents, or use Hecate's native
+            runtime from another ACP-capable client.
+          </p>
+        </div>
+
+        <div class="interoperability__grid">
+          <article>
+            <p class="direction">Agents → Hecate</p>
+            <h3>Supervise external agents.</h3>
+            <p>
+              Codex, Claude Code, Cursor Agent, and Grok Build connect through ACP. Hecate
+              adds session supervision, optional diagnostics, permission handling, and Git
+              diff review without taking over their accounts or internal runtime.
+            </p>
+          </article>
+          <article>
+            <p class="direction">Hecate → ACP clients</p>
+            <h3>Bring the native runtime with you.</h3>
+            <p>
+              <code translate="no">hecate acp serve</code> turns ACP prompts into durable
+              Tasks and Runs while Hecate retains routing, policy, approvals, artifacts,
+              and observability.
+            </p>
+          </article>
+        </div>
+
+        <div class="coordination-boundary">
+          <strong>Portable coordination. Enforced execution.</strong>
+          <p>
+            Embedded Cairnline owns portable project identity, roles, work items,
+            assignments, and handoffs. Hecate resolves that intent into presets, routes,
+            workspaces, and execution; coordination records never grant runtime permission
+            by themselves.
+          </p>
+        </div>
+
+        <a class="text-link" href={acpGuide}>Read the ACP contract <span aria-hidden="true">→</span></a>
+      </section>
+
+      <section class="visual-band visual-band--reverse" aria-labelledby="control-title">
+        <div class="visual-band__copy">
+          <p class="eyebrow">Operator control</p>
+          <h2 id="control-title">Native policy stays visible.</h2>
+          <p>
+            Hecate-native Tasks keep tool posture, blocking approvals, artifacts, and run
+            state in view. External Agent approvals appear when their ACP adapter requests
+            permission; Hecate does not claim universal interception inside a vendor CLI.
+          </p>
+        </div>
+        <figure class="product-figure product-figure--approval">
+          <div class="product-frame">
+            <img
+              src="/product/approval-required.png"
+              alt="A Hecate Task Run waiting for approval before writing a file"
+              width="1280"
+              height="800"
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
+          <figcaption>A native file-write approval blocks the Task Run before execution.</figcaption>
+        </figure>
+      </section>
+
+      <section class="visual-band" aria-labelledby="observe-title">
+        <figure class="product-figure product-figure--observe">
+          <div class="product-frame">
+            <img
+              src="/product/observe.png"
+              alt="Hecate observability view with request status, route, timing, and spans"
+              width="1280"
+              height="800"
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
+          <figcaption>Route reports and OpenTelemetry traces explain what happened.</figcaption>
+        </figure>
+        <div class="visual-band__copy">
+          <p class="eyebrow">Observability</p>
+          <h2 id="observe-title">Understand every route and run.</h2>
+          <p>
+            Inspect route choices, skipped providers, timing, trace spans, token usage, and
+            provider-reported cost where available. The trace ID stays attached to the work
+            that produced it.
+          </p>
+        </div>
+      </section>
+
+      <section class="deployment" id="download" aria-labelledby="download-title">
+        <div class="section-heading">
+          <p class="eyebrow">Run it where the work lives</p>
+          <h2 id="download-title">Desktop, Docker, source, or Cloud.</h2>
+          <p>
+            Start with the desktop app, run Hecate on infrastructure you control, or use
+            Hecate Cloud for hosted and authenticated remote access.
+          </p>
+          <div class="inline-actions">
+            <a class="text-link" href={desktopGuide}>Desktop guide <span aria-hidden="true">→</span></a>
+            <a class="text-link" href={deploymentGuide}>Docker and source <span aria-hidden="true">→</span></a>
+            <a class="text-link" href="https://hecatehq.com">Hecate Cloud <span aria-hidden="true">→</span></a>
+          </div>
+        </div>
+
+        <div class="download-table" aria-label="Desktop release platforms">
+          {downloadRows.map(([platform, detail, action]) => (
+            <a class="download-row" href={latestRelease}>
               <span class="download-platform">{platform}</span>
               <span class="download-detail">{detail}</span>
               <span class="download-action">{action}</span>
             </a>
           ))}
-        </div>
-      </section>
-
-      <section class="workflow" id="workflow" aria-labelledby="workflow-title">
-        <div class="workflow__copy">
-          <p class="eyebrow">project workflow</p>
-          <h2 id="workflow-title">One workspace for personal and project agents.</h2>
-          <p>
-            Start with a project, attach workspace roots when files matter, and
-            keep chats, tasks, external-agent sessions, context, memory, and
-            evidence connected to the same work.
-          </p>
-        </div>
-
-        <div class="feature-strip" aria-label="Hecate capability highlights">
-          {capabilityRows.map(([title, body]) => (
-            <div class="feature-row">
-              <strong>{title}</strong>
-              <span>{body}</span>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section class="visual-band" aria-labelledby="approval-title">
-        <div class="visual-band__media">
-          <img src="/product/approval-required.png" alt="Hecate chat screen with an approval required before a file write" />
-        </div>
-        <div class="visual-band__copy" id="runtime">
-          <p class="eyebrow">operator control</p>
-          <h2 id="approval-title">Agents wait before crossing the line.</h2>
-          <p>
-            Hecate keeps file writes, tool actions, approvals, artifacts, and run context
-            visible before supervised work changes the workspace.
+          <p class="download-note">
+            Linux and Windows bundles are CI-built but have not completed the same
+            real-machine installation smoke tests as macOS Apple Silicon.
           </p>
         </div>
       </section>
 
-      <section class="visual-band visual-band--reverse" aria-labelledby="observe-title">
-        <div class="visual-band__copy">
-          <p class="eyebrow">observability</p>
-          <h2 id="observe-title">Route reports and traces are first-class.</h2>
-          <p>
-            Hecate is OpenTelemetry-first: requests surface trace IDs, route decisions,
-            timing, token usage, and provider-reported cost where available.
-          </p>
+      <section class="trust" id="trust" aria-labelledby="trust-title">
+        <div class="section-heading section-heading--compact">
+          <p class="eyebrow">Execution boundary</p>
+          <h2 id="trust-title">Know what Hecate controls.</h2>
         </div>
-        <div class="visual-band__media">
-          <img src="/product/observe.png" alt="Hecate observability screen with recent requests and spans" />
+
+        <ul class="trust-list">
+          <li>
+            <strong>Native Tasks are supervised execution, not a VM.</strong>
+            <span>
+              Hecate applies workspace, process, Git, policy, and approval seams, with OS
+              isolation wrappers where available.
+            </span>
+          </li>
+          <li>
+            <strong>External Agents remain trusted subprocesses.</strong>
+            <span>
+              Install them from sources you trust; Hecate does not sandbox or authenticate
+              their internal runtime.
+            </span>
+          </li>
+          <li>
+            <strong>Local is a default boundary, not the whole product.</strong>
+            <span>
+              Hecate binds to loopback by default and can also run behind an authenticated
+              access layer or as a hosted runtime.
+            </span>
+          </li>
+        </ul>
+
+        <div class="trust-links">
+          <a class="text-link" href={securityGuide}>Security model <span aria-hidden="true">→</span></a>
+          <a class="text-link" href={knownLimitations}>Known limitations <span aria-hidden="true">→</span></a>
         </div>
       </section>
 
-      <section class="cloud-bridge" aria-labelledby="cloud-title">
+      <section class="final-cta" aria-labelledby="final-title">
         <div>
-          <p class="eyebrow">remote option</p>
-          <h2 id="cloud-title">Use Hecate away from your desk.</h2>
+          <p class="eyebrow">Stable pre-1.0</p>
+          <h2 id="final-title">Put every run in view.</h2>
         </div>
         <p>
-          hecate.sh is the open-source Hecate runtime and app. Hecate Cloud is
-          the separate hosted deployment and access layer for opening that same
-          Hecate UI from a browser.
+          Hecate is useful today while its APIs, storage, and operational behavior continue
+          to evolve across stable v0.x releases.
         </p>
-        <a class="button button--ghost" href="https://hecatehq.com">Hecate Cloud</a>
+        <div class="final-cta__actions">
+          <a class="button button--primary" href={latestRelease}>View latest release</a>
+          <a class="button button--ghost" href={quickStart}>Read the quick start</a>
+        </div>
       </section>
     </main>
+
+    <footer class="site-footer">
+      <p><span translate="no">Hecate</span> — open-source agent runtime and operator console.</p>
+      <nav aria-label="Footer navigation">
+        <a href={quickStart}>Docs</a>
+        <a href={securityGuide}>Security</a>
+        <a href={knownLimitations}>Known limitations</a>
+        <a href={latestRelease}>Releases</a>
+        <a href={license}>MIT License</a>
+      </nav>
+    </footer>
   </body>
 </html>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -331,7 +331,7 @@ const downloadRows = [
           </div>
         </div>
 
-        <div class="download-table" aria-label="Desktop release platforms">
+        <div class="download-table" role="group" aria-label="Desktop release platforms">
           {downloadRows.map(([platform, detail, action]) => (
             <a class="download-row" href={latestRelease}>
               <span class="download-platform">{platform}</span>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1073,6 +1073,42 @@ code {
   }
 }
 
+@media (min-width: 480px) and (max-width: 720px) and (max-height: 450px) {
+  :root {
+    --nav-height: 76px;
+  }
+
+  .site-nav {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-top: 0;
+  }
+
+  .site-brand {
+    min-height: 44px;
+  }
+
+  .site-links {
+    width: auto;
+    overflow: visible;
+    justify-content: flex-end;
+    gap: clamp(0.55rem, 2vw, 1rem);
+    padding-bottom: 0;
+    font-size: 0.8rem;
+  }
+
+  .hero {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+
+  .lede {
+    display: none;
+  }
+}
+
 @media (max-height: 700px) and (min-width: 981px) {
   .hero {
     min-height: 590px;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1028,6 +1028,51 @@ code {
   }
 }
 
+@media (max-width: 980px) and (max-height: 700px) {
+  .hero {
+    align-items: center;
+    min-height: calc(100svh - var(--nav-height));
+    padding-top: clamp(1rem, 4vh, 2rem);
+    padding-bottom: clamp(1rem, 4vh, 2rem);
+  }
+
+  .hero h1 {
+    margin-bottom: 0.75rem;
+  }
+
+  .hero__wordmark {
+    font-size: clamp(4rem, 9vw, 6.5rem);
+  }
+
+  .hero__claim {
+    margin-top: 0.65rem;
+    font-size: clamp(1.7rem, 4vw, 2.5rem);
+  }
+
+  .lede {
+    margin-bottom: 1rem;
+    font-size: 1rem;
+    line-height: 1.4;
+  }
+
+  .hero__actions {
+    align-items: center;
+    flex-direction: row;
+    gap: 0.6rem;
+  }
+
+  .hero .button {
+    width: auto;
+    min-height: 2.75rem;
+    padding: 0.6rem 1rem;
+  }
+
+  .hero .button--quiet,
+  .hero__status {
+    display: none;
+  }
+}
+
 @media (max-height: 700px) and (min-width: 981px) {
   .hero {
     min-height: 590px;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -2,15 +2,18 @@
   color-scheme: dark;
   --bg: #070b0c;
   --bg-2: #0b1012;
+  --bg-3: #101719;
   --ink: #f5f7ef;
-  --muted: #9aa6a1;
-  --faint: #606a67;
+  --muted: #a5afab;
+  --faint: #7c8783;
   --line: rgba(245, 247, 239, 0.16);
-  --line-strong: rgba(245, 247, 239, 0.28);
+  --line-strong: rgba(245, 247, 239, 0.3);
   --teal: #13c8b5;
-  --teal-soft: rgba(19, 200, 181, 0.14);
+  --teal-dark: #071e1b;
+  --teal-soft: rgba(19, 200, 181, 0.13);
   --gold: #f0bd62;
-  --danger: #e05f5f;
+  --nav-height: 76px;
+  --page-pad: clamp(1rem, 5vw, 5rem);
   font-family:
     Inter,
     ui-sans-serif,
@@ -35,14 +38,16 @@ body {
 }
 
 html {
+  color-scheme: dark;
   scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--nav-height) + 1rem);
 }
 
 body {
   overflow-x: hidden;
   background:
-    linear-gradient(180deg, rgba(19, 200, 181, 0.1), transparent 32rem),
-    linear-gradient(110deg, rgba(240, 189, 98, 0.08), transparent 34rem), var(--bg);
+    linear-gradient(180deg, rgba(19, 200, 181, 0.09), transparent 34rem),
+    linear-gradient(112deg, rgba(240, 189, 98, 0.055), transparent 36rem), var(--bg);
   color: var(--ink);
 }
 
@@ -52,15 +57,31 @@ body::before {
   z-index: -2;
   content: "";
   background-image:
-    linear-gradient(rgba(245, 247, 239, 0.042) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(245, 247, 239, 0.036) 1px, transparent 1px);
+    linear-gradient(rgba(245, 247, 239, 0.038) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(245, 247, 239, 0.032) 1px, transparent 1px);
   background-size: 72px 72px;
   mask-image: linear-gradient(110deg, black, transparent 78%);
+}
+
+::selection {
+  color: var(--bg);
+  background: var(--teal);
 }
 
 a {
   color: inherit;
   text-decoration: none;
+  touch-action: manipulation;
+}
+
+a:focus-visible,
+main:focus-visible {
+  outline: 3px solid var(--teal);
+  outline-offset: 4px;
+}
+
+main:focus-visible {
+  outline-offset: -4px;
 }
 
 img {
@@ -68,29 +89,102 @@ img {
   max-width: 100%;
 }
 
+h1,
+h2,
+h3,
+p,
+figure {
+  margin-top: 0;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+p,
+li,
+figcaption {
+  text-wrap: pretty;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: clamp(2.25rem, 5vw, 5rem);
+  font-weight: 680;
+  line-height: 0.96;
+  letter-spacing: -0.045em;
+}
+
+h3 {
+  margin-bottom: 0;
+  font-size: clamp(1.3rem, 2.2vw, 2rem);
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+}
+
+code {
+  padding: 0.14rem 0.32rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: var(--teal);
+  background: rgba(245, 247, 239, 0.035);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.9em;
+}
+
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 100;
+  padding: 0.72rem 1rem;
+  border: 1px solid var(--teal);
+  border-radius: 6px;
+  color: var(--bg);
+  background: var(--teal);
+  font-weight: 800;
+  transform: translateY(-160%);
+  transition: transform 140ms ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 .site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  min-height: 76px;
-  padding: 0 clamp(1rem, 4vw, 4rem);
+  gap: 1.2rem;
+  min-height: var(--nav-height);
+  padding-inline: max(var(--page-pad), env(safe-area-inset-left))
+    max(var(--page-pad), env(safe-area-inset-right));
   border-bottom: 1px solid var(--line);
-  background: rgba(7, 11, 12, 0.74);
+  background: rgba(7, 11, 12, 0.86);
   backdrop-filter: blur(18px);
 }
 
 .site-brand,
 .site-links,
-.hero__actions {
+.hero__actions,
+.inline-actions,
+.trust-links,
+.final-cta__actions {
   display: flex;
   align-items: center;
 }
 
 .site-brand {
+  flex: 0 0 auto;
   gap: 0.7rem;
-  font-weight: 800;
-  letter-spacing: 0;
+  min-height: 44px;
+  font-size: 1.05rem;
+  font-weight: 820;
 }
 
 .site-brand img {
@@ -99,12 +193,15 @@ img {
 }
 
 .site-links {
-  gap: clamp(0.9rem, 3vw, 2rem);
+  gap: clamp(1rem, 3vw, 2rem);
   color: var(--muted);
   font-size: 0.93rem;
 }
 
 .site-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
   transition:
     color 160ms ease,
     transform 160ms ease;
@@ -119,9 +216,10 @@ img {
   position: relative;
   display: grid;
   align-items: center;
-  min-height: min(760px, calc(100svh - 116px));
+  min-height: clamp(620px, calc(100svh - var(--nav-height)), 780px);
   overflow: hidden;
-  padding: clamp(2rem, 6vw, 5rem) clamp(1rem, 5vw, 5rem);
+  padding: clamp(2.5rem, 6vw, 5rem) max(var(--page-pad), env(safe-area-inset-right))
+    clamp(3rem, 7vw, 5rem) max(var(--page-pad), env(safe-area-inset-left));
   border-bottom: 1px solid var(--line);
   isolation: isolate;
 }
@@ -129,19 +227,19 @@ img {
 .hero::after {
   position: absolute;
   inset: auto 0 0;
-  height: 32%;
+  height: 28%;
   content: "";
-  background: linear-gradient(180deg, transparent, rgba(7, 11, 12, 0.92));
+  background: linear-gradient(180deg, transparent, rgba(7, 11, 12, 0.96));
   pointer-events: none;
 }
 
 .hero__media {
   position: absolute;
   top: 50%;
-  right: clamp(-33rem, -18vw, -12rem);
+  right: clamp(-34rem, -18vw, -12rem);
   z-index: -1;
   width: min(86vw, 72rem);
-  opacity: 0.78;
+  opacity: 0.63;
   transform: translateY(-50%);
   animation: media-rise 760ms ease both;
 }
@@ -151,15 +249,15 @@ img {
   inset: 0;
   content: "";
   background:
-    linear-gradient(90deg, var(--bg) 0%, rgba(7, 11, 12, 0.44) 28%, transparent 58%),
-    linear-gradient(180deg, transparent 54%, rgba(7, 11, 12, 0.74));
+    linear-gradient(90deg, var(--bg) 0%, rgba(7, 11, 12, 0.63) 30%, transparent 62%),
+    linear-gradient(180deg, rgba(7, 11, 12, 0.02) 48%, rgba(7, 11, 12, 0.86));
 }
 
 .hero__media img {
   width: 100%;
   border: 1px solid var(--line-strong);
   border-radius: 8px;
-  box-shadow: 0 28px 110px rgba(0, 0, 0, 0.48);
+  box-shadow: 0 28px 110px rgba(0, 0, 0, 0.5);
 }
 
 .hero__copy {
@@ -169,7 +267,8 @@ img {
   animation: rise 640ms ease both;
 }
 
-.eyebrow {
+.eyebrow,
+.direction {
   margin: 0 0 0.9rem;
   color: var(--teal);
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
@@ -180,37 +279,43 @@ img {
   text-transform: uppercase;
 }
 
-h1,
-h2,
-p {
-  margin-top: 0;
+.hero h1 {
+  margin-bottom: 1.2rem;
 }
 
-h1 {
-  margin-bottom: 1rem;
-  font-size: clamp(5rem, 15vw, 12rem);
-  font-weight: 680;
+.hero__wordmark,
+.hero__claim {
+  display: block;
+}
+
+.hero__wordmark {
+  font-size: clamp(5rem, 14vw, 11.5rem);
+  font-weight: 690;
   line-height: 0.82;
-  letter-spacing: 0;
+  letter-spacing: -0.055em;
 }
 
-h2 {
-  margin-bottom: 0;
-  font-size: clamp(2.25rem, 5.4vw, 5.3rem);
+.hero__claim {
+  max-width: 44rem;
+  margin-top: 1.5rem;
+  font-size: clamp(2rem, 4.4vw, 4.35rem);
   font-weight: 660;
-  line-height: 0.95;
-  letter-spacing: 0;
+  line-height: 0.96;
+  letter-spacing: -0.045em;
 }
 
 .lede {
-  max-width: 45rem;
+  max-width: 44rem;
   margin-bottom: 1.5rem;
   color: var(--ink);
-  font-size: clamp(1.1rem, 1.8vw, 1.46rem);
-  line-height: 1.5;
+  font-size: clamp(1.08rem, 1.65vw, 1.38rem);
+  line-height: 1.52;
 }
 
-.hero__actions {
+.hero__actions,
+.inline-actions,
+.trust-links,
+.final-cta__actions {
   flex-wrap: wrap;
   gap: 0.8rem;
 }
@@ -221,11 +326,13 @@ h2 {
   justify-content: center;
   min-width: 9.4rem;
   min-height: 3rem;
-  padding: 0 1.15rem;
+  padding: 0.72rem 1.15rem;
   border: 1px solid var(--line);
   border-radius: 8px;
   color: var(--ink);
-  font-weight: 780;
+  font-weight: 800;
+  line-height: 1.15;
+  text-align: center;
   transition:
     transform 180ms ease,
     border-color 180ms ease,
@@ -235,22 +342,27 @@ h2 {
 
 .button:hover {
   transform: translateY(-2px);
-  border-color: rgba(245, 247, 239, 0.5);
+  border-color: rgba(245, 247, 239, 0.52);
 }
 
 .button--primary {
-  color: #06100e;
+  color: #04110e;
   background: var(--teal);
   border-color: var(--teal);
 }
 
+.button--primary:hover {
+  background: #32d5c4;
+  border-color: #32d5c4;
+}
+
 .button--ghost {
-  background: rgba(245, 247, 239, 0.045);
+  background: rgba(245, 247, 239, 0.05);
 }
 
 .button--quiet {
   min-width: 0;
-  padding-inline: 0;
+  padding-inline: 0.2rem;
   border-color: transparent;
   color: var(--muted);
 }
@@ -261,73 +373,301 @@ h2 {
   border-color: transparent;
 }
 
-.hero__release {
-  max-width: 44rem;
-  margin: 1.1rem 0 0;
+.hero__status {
+  max-width: 46rem;
+  margin: 1.15rem 0 0;
   color: var(--muted);
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: clamp(0.78rem, 1.05vw, 0.93rem);
-  letter-spacing: 0;
+  font-size: clamp(0.76rem, 1vw, 0.9rem);
   line-height: 1.6;
 }
 
-.hero__release a {
-  color: var(--muted);
-  text-decoration: underline;
-  text-decoration-color: rgba(154, 166, 161, 0.4);
-  text-underline-offset: 0.18em;
-  transition:
-    color 180ms ease,
-    text-decoration-color 180ms ease;
-}
-
-.hero__release a:hover {
-  color: var(--ink);
-  text-decoration-color: var(--ink);
-}
-
-.hero__release-tag {
-  color: var(--ink);
-}
-
-.download,
-.workflow,
+.surfaces,
+.operator-loop,
 .visual-band,
-.cloud-bridge {
-  padding: clamp(3.5rem, 8vw, 7rem) clamp(1rem, 5vw, 5rem);
+.interoperability,
+.deployment,
+.trust,
+.final-cta,
+.site-footer {
+  padding: clamp(3.8rem, 8vw, 7.5rem) max(var(--page-pad), env(safe-area-inset-right))
+    clamp(3.8rem, 8vw, 7.5rem) max(var(--page-pad), env(safe-area-inset-left));
 }
 
-.download {
+.surfaces,
+.deployment {
   display: grid;
-  grid-template-columns: minmax(0, 0.84fr) minmax(20rem, 1.16fr);
-  gap: clamp(2rem, 7vw, 7rem);
+  grid-template-columns: minmax(0, 0.82fr) minmax(22rem, 1.18fr);
+  gap: clamp(2.5rem, 7vw, 7rem);
   border-bottom: 1px solid var(--line);
-  background: rgba(11, 16, 18, 0.72);
+  background: rgba(11, 16, 18, 0.76);
 }
 
 .section-heading {
-  max-width: 44rem;
+  max-width: 58rem;
 }
 
-.section-heading p:not(.eyebrow) {
-  margin: 1.1rem 0 0;
+.section-heading--compact {
+  max-width: 42rem;
+}
+
+.section-heading > p:not(.eyebrow),
+.visual-band__copy > p:not(.eyebrow),
+.final-cta > p {
+  max-width: 44rem;
+  margin: 1.25rem 0 0;
   color: var(--muted);
-  font-size: clamp(1rem, 1.6vw, 1.2rem);
+  font-size: clamp(1.03rem, 1.55vw, 1.24rem);
+  line-height: 1.62;
+}
+
+.surface-list,
+.workflow-list,
+.trust-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.surface-list {
+  border-top: 1px solid var(--line);
+}
+
+.surface-list li {
+  display: grid;
+  grid-template-columns: minmax(10rem, 0.42fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  padding: 1.35rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.surface-list strong {
+  color: var(--ink);
+}
+
+.surface-list span {
+  min-width: 0;
+  color: var(--muted);
   line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.section-note,
+.download-note {
+  margin: 1rem 0 0;
+  color: var(--faint);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.operator-loop {
+  border-bottom: 1px solid var(--line);
+}
+
+.operator-loop .section-heading {
+  margin-bottom: clamp(2.5rem, 6vw, 5rem);
+}
+
+.workflow-list {
+  border-top: 1px solid var(--line-strong);
+}
+
+.workflow-list li {
+  display: grid;
+  grid-template-columns: 5rem minmax(9rem, 0.36fr) minmax(0, 1fr);
+  gap: clamp(1rem, 3vw, 3rem);
+  align-items: baseline;
+  padding: clamp(1.35rem, 2.5vw, 2.15rem) 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.workflow-number {
+  color: var(--teal);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.84rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.workflow-list p {
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 1.3vw, 1.14rem);
+  line-height: 1.62;
+}
+
+.visual-band {
+  display: grid;
+  grid-template-columns: minmax(22rem, 1.22fr) minmax(0, 0.78fr);
+  gap: clamp(2.5rem, 7vw, 6.5rem);
+  align-items: center;
+  border-bottom: 1px solid var(--line);
+}
+
+.visual-band--reverse {
+  grid-template-columns: minmax(0, 0.78fr) minmax(22rem, 1.22fr);
+  background: var(--bg-2);
+}
+
+.visual-band__copy {
+  max-width: 43rem;
+}
+
+.product-figure {
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+.product-frame {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: #020405;
+  box-shadow: 0 24px 76px rgba(0, 0, 0, 0.28);
+}
+
+.product-frame::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  box-shadow: inset 0 0 54px rgba(0, 0, 0, 0.38);
+  pointer-events: none;
+}
+
+.product-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top center;
+  transition: transform 360ms ease;
+}
+
+.product-figure--review .product-frame,
+.product-figure--approval .product-frame {
+  aspect-ratio: 2.25 / 1;
+}
+
+.product-figure--observe .product-frame {
+  aspect-ratio: 1.75 / 1;
+}
+
+.product-figure:hover .product-frame img {
+  transform: scale(1.012);
+}
+
+.product-figure figcaption {
+  margin-top: 0.75rem;
+  color: var(--faint);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.interoperability {
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(90deg, rgba(19, 200, 181, 0.08), transparent 46%), var(--bg-3);
+}
+
+.interoperability > .section-heading {
+  margin-bottom: clamp(2.5rem, 6vw, 5rem);
+}
+
+.interoperability__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line-strong);
+  border-bottom: 1px solid var(--line);
+}
+
+.interoperability article {
+  min-width: 0;
+  padding: clamp(1.7rem, 3vw, 3rem) clamp(0rem, 3vw, 3rem);
+}
+
+.interoperability article:first-child {
+  padding-left: 0;
+  border-right: 1px solid var(--line);
+}
+
+.interoperability article:last-child {
+  padding-right: 0;
+}
+
+.direction {
+  margin-bottom: 1rem;
+  color: var(--gold);
+}
+
+.interoperability article > p:last-child,
+.coordination-boundary p {
+  margin: 1rem 0 0;
+  color: var(--muted);
+  line-height: 1.62;
+}
+
+.coordination-boundary {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.38fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  padding: clamp(1.7rem, 3vw, 2.5rem) 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.coordination-boundary strong {
+  font-size: 1.08rem;
+  line-height: 1.4;
+}
+
+.coordination-boundary p {
+  margin-top: 0;
+}
+
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 44px;
+  color: var(--teal);
+  font-weight: 800;
+  text-decoration: underline;
+  text-decoration-color: rgba(19, 200, 181, 0.38);
+  text-underline-offset: 0.22em;
+  transition:
+    color 160ms ease,
+    text-decoration-color 160ms ease,
+    transform 160ms ease;
+}
+
+.text-link:hover {
+  color: var(--ink);
+  text-decoration-color: var(--ink);
+  transform: translateX(2px);
+}
+
+.interoperability > .text-link {
+  margin-top: 1rem;
+}
+
+.deployment {
+  background: rgba(11, 16, 18, 0.76);
+}
+
+.inline-actions {
+  margin-top: 1.3rem;
 }
 
 .download-table {
   display: grid;
   align-content: start;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--line-strong);
 }
 
 .download-row {
   display: grid;
-  grid-template-columns: minmax(7rem, 0.5fr) minmax(8rem, 0.5fr) minmax(10rem, 0.72fr);
+  grid-template-columns: minmax(7rem, 0.45fr) minmax(12rem, 0.75fr) minmax(7rem, 0.36fr);
   gap: 1rem;
   align-items: center;
-  min-height: 4.6rem;
+  min-height: 4.8rem;
   border-bottom: 1px solid var(--line);
   transition:
     border-color 160ms ease,
@@ -336,13 +676,13 @@ h2 {
 
 .download-row:hover {
   transform: translateX(4px);
-  border-color: rgba(19, 200, 181, 0.5);
+  border-color: rgba(19, 200, 181, 0.52);
 }
 
 .download-platform {
   color: var(--ink);
-  font-size: clamp(1.05rem, 1.8vw, 1.32rem);
-  font-weight: 800;
+  font-size: clamp(1.05rem, 1.8vw, 1.3rem);
+  font-weight: 820;
 }
 
 .download-detail {
@@ -353,101 +693,97 @@ h2 {
   justify-self: end;
   color: var(--teal);
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 0.86rem;
+  font-size: 0.84rem;
 }
 
-.workflow {
+.trust {
   display: grid;
-  grid-template-columns: minmax(0, 0.92fr) minmax(20rem, 1.08fr);
-  gap: clamp(2rem, 7vw, 7rem);
-  align-items: start;
+  grid-template-columns: minmax(0, 0.72fr) minmax(22rem, 1.28fr);
+  gap: clamp(2.5rem, 7vw, 7rem);
   border-bottom: 1px solid var(--line);
 }
 
-.workflow__copy p,
-.visual-band__copy p,
-.cloud-bridge p {
-  max-width: 42rem;
+.trust-list {
+  border-top: 1px solid var(--line-strong);
+}
+
+.trust-list li {
+  display: grid;
+  grid-template-columns: minmax(13rem, 0.48fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  padding: 1.35rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.trust-list strong {
+  line-height: 1.45;
+}
+
+.trust-list span {
   color: var(--muted);
-  font-size: clamp(1.05rem, 1.7vw, 1.3rem);
   line-height: 1.58;
 }
 
-.feature-strip {
+.trust-links {
+  grid-column: 2;
+  margin-top: -1.2rem;
+}
+
+.final-cta {
   display: grid;
-  border-top: 1px solid var(--line);
-}
-
-.feature-row {
-  display: grid;
-  grid-template-columns: minmax(9rem, 0.36fr) minmax(0, 1fr);
-  gap: 1.4rem;
-  padding: 1.24rem 0;
-  border-bottom: 1px solid var(--line);
-}
-
-.feature-row strong {
-  color: var(--ink);
-  font-size: 1rem;
-}
-
-.feature-row span {
-  color: var(--muted);
-  line-height: 1.56;
-}
-
-.visual-band {
-  display: grid;
-  grid-template-columns: minmax(20rem, 1.16fr) minmax(0, 0.84fr);
-  gap: clamp(2rem, 7vw, 6rem);
-  align-items: center;
-  border-bottom: 1px solid var(--line);
-}
-
-.visual-band--reverse {
-  grid-template-columns: minmax(0, 0.84fr) minmax(20rem, 1.16fr);
-  background: var(--bg-2);
-}
-
-.visual-band__media {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  background: #020405;
-}
-
-.visual-band__media::after {
-  position: absolute;
-  inset: 0;
-  content: "";
-  box-shadow: inset 0 0 72px rgba(0, 0, 0, 0.42);
-  pointer-events: none;
-}
-
-.visual-band__media img {
-  width: 100%;
-}
-
-.visual-band__copy {
-  max-width: 42rem;
-}
-
-.cloud-bridge {
-  display: grid;
-  grid-template-columns: minmax(0, 0.92fr) minmax(18rem, 0.84fr) auto;
-  gap: clamp(1.4rem, 4vw, 4rem);
+  grid-template-columns: minmax(0, 0.9fr) minmax(18rem, 0.72fr) auto;
+  gap: clamp(1.8rem, 4vw, 4rem);
   align-items: end;
-  background: linear-gradient(90deg, rgba(19, 200, 181, 0.1), transparent 54%), #060909;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(90deg, rgba(19, 200, 181, 0.12), transparent 58%), #060909;
 }
 
-.cloud-bridge h2 {
-  max-width: 58rem;
+.final-cta h2 {
+  max-width: 52rem;
 }
 
-.cloud-bridge p {
+.final-cta > p {
   margin-bottom: 0;
   font-size: 1rem;
+}
+
+.final-cta__actions {
+  justify-content: flex-end;
+}
+
+.site-footer {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  padding-top: 2.3rem;
+  padding-bottom: max(2.3rem, env(safe-area-inset-bottom));
+  color: var(--muted);
+  background: #050708;
+}
+
+.site-footer p {
+  max-width: 30rem;
+  margin-bottom: 0;
+  line-height: 1.55;
+}
+
+.site-footer nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.25rem 1.2rem;
+}
+
+.site-footer a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  transition: color 160ms ease;
+}
+
+.site-footer a:hover {
+  color: var(--ink);
 }
 
 @keyframes rise {
@@ -467,90 +803,143 @@ h2 {
     transform: translateY(calc(-50% + 1.2rem));
   }
   to {
-    opacity: 0.78;
+    opacity: 0.63;
     transform: translateY(-50%);
   }
 }
 
+@keyframes media-fade {
+  from {
+    opacity: 0;
+    transform: translateY(0.8rem);
+  }
+  to {
+    opacity: 0.38;
+    transform: translateY(0);
+  }
+}
+
 @media (max-width: 980px) {
-  .site-nav {
-    align-items: flex-start;
-    flex-direction: column;
-    justify-content: center;
-    min-height: 112px;
-  }
-
-  .site-links {
-    width: 100%;
-    justify-content: space-between;
-    gap: 0.7rem;
-    font-size: 0.86rem;
-  }
-
   .hero {
     align-items: end;
-    min-height: auto;
-    padding-top: 9.8rem;
+    min-height: 720px;
+    padding-top: 11rem;
   }
 
   .hero__media {
     top: 2.5rem;
     right: -18rem;
-    width: 44rem;
-    opacity: 0.44;
+    width: 48rem;
+    opacity: 0.38;
     transform: none;
+    animation-name: media-fade;
   }
 
   .hero__media::after {
     background:
-      linear-gradient(180deg, transparent 10%, rgba(7, 11, 12, 0.72) 62%, var(--bg)),
-      linear-gradient(90deg, rgba(7, 11, 12, 0.08), rgba(7, 11, 12, 0.52));
+      linear-gradient(180deg, transparent 8%, rgba(7, 11, 12, 0.68) 60%, var(--bg)),
+      linear-gradient(90deg, rgba(7, 11, 12, 0.1), rgba(7, 11, 12, 0.58));
   }
 
-  .download,
-  .workflow,
+  .surfaces,
+  .deployment,
+  .trust,
   .visual-band,
   .visual-band--reverse,
-  .cloud-bridge {
+  .final-cta {
     grid-template-columns: 1fr;
   }
 
-  .cloud-bridge {
+  .visual-band__copy {
+    max-width: 54rem;
+  }
+
+  .visual-band--reverse .visual-band__copy {
+    order: 2;
+  }
+
+  .visual-band--reverse .product-figure {
+    order: 1;
+  }
+
+  .trust-links {
+    grid-column: auto;
+    margin-top: -1.5rem;
+  }
+
+  .final-cta {
     align-items: start;
+  }
+
+  .final-cta__actions {
+    justify-content: flex-start;
   }
 }
 
-@media (max-width: 680px) {
+@media (max-width: 720px) {
+  :root {
+    --nav-height: 112px;
+  }
+
+  .site-nav {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0;
+    min-height: var(--nav-height);
+    padding-top: max(0.5rem, env(safe-area-inset-top));
+  }
+
+  .site-brand {
+    min-height: 48px;
+  }
+
   .site-links {
-    flex-wrap: wrap;
-    justify-content: flex-start;
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.65rem;
+    font-size: 0.86rem;
   }
 
   .hero,
-  .download,
-  .workflow,
+  .surfaces,
+  .operator-loop,
   .visual-band,
-  .cloud-bridge {
-    padding-inline: 1rem;
-  }
-
-  .download {
-    padding-top: 2rem;
+  .interoperability,
+  .deployment,
+  .trust,
+  .final-cta,
+  .site-footer {
+    padding-right: max(1rem, env(safe-area-inset-right));
+    padding-left: max(1rem, env(safe-area-inset-left));
   }
 
   .hero {
-    padding-bottom: 2.7rem;
+    min-height: auto;
+    padding-top: 7rem;
+    padding-bottom: 2rem;
   }
 
-  h1 {
-    font-size: clamp(4.6rem, 27vw, 7rem);
+  .hero__media {
+    right: -22rem;
+    width: 43rem;
+  }
+
+  .hero__wordmark {
+    font-size: clamp(4.8rem, 27vw, 7rem);
+  }
+
+  .hero__claim {
+    margin-top: 1.25rem;
+    font-size: clamp(2.05rem, 10vw, 3rem);
   }
 
   h2 {
-    font-size: clamp(2rem, 11vw, 3.4rem);
+    font-size: clamp(2.1rem, 11vw, 3.4rem);
   }
 
-  .hero__actions {
+  .hero__actions,
+  .final-cta__actions {
     align-items: stretch;
     flex-direction: column;
   }
@@ -560,11 +949,45 @@ h2 {
   }
 
   .button--quiet {
-    min-height: 2.2rem;
+    min-height: 2.5rem;
   }
 
-  .download-row,
-  .feature-row {
+  .surface-list li,
+  .trust-list li,
+  .coordination-boundary {
+    grid-template-columns: 1fr;
+    gap: 0.55rem;
+  }
+
+  .workflow-list li {
+    grid-template-columns: 2.6rem minmax(0, 1fr);
+    gap: 0.8rem 0.9rem;
+  }
+
+  .workflow-list p {
+    grid-column: 2;
+  }
+
+  .interoperability__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .interoperability article {
+    padding: 1.7rem 0;
+  }
+
+  .interoperability article:first-child {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .product-figure--review .product-frame,
+  .product-figure--approval .product-frame,
+  .product-figure--observe .product-frame {
+    aspect-ratio: 1.65 / 1;
+  }
+
+  .download-row {
     grid-template-columns: 1fr;
     gap: 0.35rem;
     padding: 1rem 0;
@@ -573,19 +996,54 @@ h2 {
   .download-action {
     justify-self: start;
   }
+
+  .site-footer {
+    flex-direction: column;
+    padding-top: 2rem;
+  }
+
+  .site-footer nav {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 380px) {
+  .hero {
+    padding-top: 5rem;
+  }
+
+  .hero .button--quiet {
+    display: none;
+  }
+
+  .site-links {
+    overflow-x: auto;
+    justify-content: flex-start;
+    padding-bottom: 0.2rem;
+    scrollbar-width: thin;
+  }
+
+  .site-links a {
+    flex: 0 0 auto;
+  }
 }
 
 @media (max-height: 700px) and (min-width: 981px) {
   .hero {
-    min-height: 584px;
+    min-height: 590px;
   }
 
-  h1 {
-    font-size: clamp(4.6rem, 11vw, 8rem);
+  .hero__wordmark {
+    font-size: clamp(4.7rem, 10vw, 8rem);
+  }
+
+  .hero__claim {
+    margin-top: 1rem;
+    font-size: clamp(1.85rem, 3.6vw, 3.2rem);
   }
 
   .lede {
-    font-size: 1.06rem;
+    font-size: 1.04rem;
   }
 }
 


### PR DESCRIPTION
## Why

The public homepage described individual capabilities, but it did not explain Hecate's core operator loop or its execution boundaries clearly enough.

## What changed

- Center the homepage on configuring, launching, supervising, and reviewing agent work.
- Clarify Hecate-native Tasks, supervised External Agents, ACP in both directions, and the Cairnline coordination boundary.
- State platform maturity and trusted-subprocess limits directly.
- Improve responsive composition, keyboard focus, semantic landmarks, image loading, social metadata, robots, and sitemap coverage.
- Add production-preview Playwright and Axe checks across desktop, phone, and 320px layouts.
- Refresh compatible website build dependencies and pin patched transitive versions after a clean high-severity audit.

## Verification

- go build ./...
- just format-check
- just agent-docs-check
- just check-links
- just website-lint
- just website-build
- bun audit --audit-level high
- bun --bun run test:e2e (30 passed across six viewports)
- repeated responsive image/layout stress run (30 passed)

## Review

Two independent reviews covered implementation, CI, accessibility, product accuracy, security posture, and Hecate/Cairnline ownership. All actionable findings were fixed and the final diff was re-reviewed.
