### PR TITLE
Curate desktop update notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 # A tag-push and a manual dispatch on the same ref shouldn't fight.
@@ -17,12 +17,14 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write   # create the GitHub release + upload archives
-  packages: write   # push images to ghcr.io
+  contents: write # create the GitHub release + upload archives
+  packages: write # push images to ghcr.io
 
 jobs:
   validate-release-ref:
     name: Validate release ref
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Validate release ref
@@ -33,6 +35,25 @@ jobs:
           set -euo pipefail
           if [[ "$REF_TYPE" != "tag" || ! "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Release workflow requires a stable vX.Y.Z tag ref; got ${REF_TYPE} ${REF_NAME}." >&2
+            exit 1
+          fi
+
+      - name: Checkout release history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify release commit is on master
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --force origin "refs/heads/master:refs/remotes/origin/master"
+          tag_commit="$(git rev-parse --verify "refs/tags/${REF_NAME}^{commit}")"
+          master_commit="$(git rev-parse --verify refs/remotes/origin/master)"
+          if ! git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/master; then
+            echo "Release tag ${REF_NAME} points to ${tag_commit}, which is not on origin/master (${master_commit})." >&2
             exit 1
           fi
 
@@ -56,7 +77,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0   # goreleaser needs full history to compute the changelog
+          fetch-depth: 0 # goreleaser needs full history to compute the changelog
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -131,9 +152,9 @@ jobs:
     needs: goreleaser
     uses: ./.github/workflows/_tauri-shared.yml
     secrets: inherit
+    # tauri-action uploads bundles and latest.json to the existing Release.
     permissions:
-      contents: write   # tauri-action uploads bundles and latest.json
-                        # to the existing GitHub Release.
+      contents: write
     with:
       tagName: ${{ github.ref_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The release helper's ordinary tags contain only the version and should
-      # keep GoReleaser's generated changelog. A maintainer may instead create
-      # an annotated tag with substantive Markdown notes; preserve that public
-      # release contract by passing the annotation to GoReleaser explicitly.
-      # The helper removes Git's separately reported signature bytes without
-      # normalizing the Markdown through shell command substitution.
+      # Every public tag carries reviewed, curated Markdown. The helper rejects
+      # lightweight and version-only tags, removes Git's separately reported
+      # signature bytes, and passes the annotation to GoReleaser without
+      # normalizing it through shell command substitution.
       - name: Prepare release notes
         id: release-notes
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Every public tag carries reviewed, curated Markdown. The helper rejects
-      # lightweight and version-only tags, removes Git's separately reported
-      # signature bytes, and passes the annotation to GoReleaser without
-      # normalizing it through shell command substitution.
+      # lightweight and version-only tags, requires the signature-stripped
+      # annotation to match docs/releases/<tag>.md in the tagged commit, and
+      # passes those bytes to GoReleaser without shell normalization.
       - name: Prepare release notes
         id: release-notes
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Validate release workflows
         run: |
-          bun test scripts/prepare-release-notes.test.ts
+          bun test scripts/release-notes.test.ts scripts/prepare-release-notes.test.ts
           bun scripts/check-release-workflows.ts
 
       - uses: dorny/paths-filter@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ tauri/                  native desktop app (Tauri 2.x); wraps hecate as a sideca
 scripts/
   release.ts            cut a release: curated notes validation, pre-flight,
                           snapshot, version stamp, tag, push
-                          (`bun scripts/release.ts vX.Y.Z --notes <path>`)
+                          (`bun scripts/release.ts vX.Y.Z --notes docs/releases/vX.Y.Z.md`)
   stamp-version.ts      stamp Tauri version files to current git tag / TAURI_VERSION
 e2e/                    binary-startup tests; build tag e2e (sub-tags: ollama, docker)
 docs/                   long-form references (architecture, runtime API, events, ...)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,9 @@ ui/                     React/Vite operator UI, embedded via //go:embed ui/dist
 tauri/                  native desktop app (Tauri 2.x); wraps hecate as a sidecar,
                           webview loads http://127.0.0.1:{port}/ served by the gateway
 scripts/
-  release.ts            cut a release: pre-flight, goreleaser snapshot, Tauri
-                          version stamp, tag, push  (`bun scripts/release.ts vX.Y.Z`)
+  release.ts            cut a release: curated notes validation, pre-flight,
+                          snapshot, version stamp, tag, push
+                          (`bun scripts/release.ts vX.Y.Z --notes <path>`)
   stamp-version.ts      stamp Tauri version files to current git tag / TAURI_VERSION
 e2e/                    binary-startup tests; build tag e2e (sub-tags: ollama, docker)
 docs/                   long-form references (architecture, runtime API, events, ...)
@@ -235,14 +236,14 @@ Full ladder: [`docs-ai/core/verification.md`](docs-ai/core/verification.md).
 
 ## Recipes
 
-| Task                                                                        | Where                                                                                                                                                                               |
-| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Add a passthrough wire field (the seven-step chain — most-redone task here) | [`docs-ai/skills/providers/SKILL.md`](docs-ai/skills/providers/SKILL.md)                                                                                                            |
-| Add an MCP tool / persisted run-event type / test helper cheat-sheet        | [`docs-ai/skills/backend/SKILL.md`](docs-ai/skills/backend/SKILL.md)                                                                                                                |
-| UI recipes (SSE-driven state field, paired pickers, snapshot refresh)       | [`docs-ai/skills/ui/SKILL.md`](docs-ai/skills/ui/SKILL.md)                                                                                                                          |
-| Native desktop app (sidecar lifecycle, bundling, Tauri commands)            | [`docs-ai/skills/tauri/SKILL.md`](docs-ai/skills/tauri/SKILL.md)                                                                                                                    |
-| Cut a release tag                                                           | `bun scripts/release.ts vX.Y.Z` — checks worktree, snapshot dry-run, stamps Tauri versions, tags, pushes. Full procedure: [`docs-ai/tasks/release.md`](docs/contributor/release.md) |
-| Stamp Tauri version files                                                   | `bun scripts/stamp-version.ts` (or `just tauri-version`) — syncs desktop and mobile version metadata to the current git tag                                                         |
+| Task                                                                        | Where                                                                                                                                                                                                                                             |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add a passthrough wire field (the seven-step chain — most-redone task here) | [`docs-ai/skills/providers/SKILL.md`](docs-ai/skills/providers/SKILL.md)                                                                                                                                                                          |
+| Add an MCP tool / persisted run-event type / test helper cheat-sheet        | [`docs-ai/skills/backend/SKILL.md`](docs-ai/skills/backend/SKILL.md)                                                                                                                                                                              |
+| UI recipes (SSE-driven state field, paired pickers, snapshot refresh)       | [`docs-ai/skills/ui/SKILL.md`](docs-ai/skills/ui/SKILL.md)                                                                                                                                                                                        |
+| Native desktop app (sidecar lifecycle, bundling, Tauri commands)            | [`docs-ai/skills/tauri/SKILL.md`](docs-ai/skills/tauri/SKILL.md)                                                                                                                                                                                  |
+| Cut a release tag                                                           | `bun scripts/release.ts vX.Y.Z --notes docs/releases/vX.Y.Z.md` — validates curated notes and the worktree, runs the snapshot, stamps Tauri versions, tags, and pushes. Full procedure: [`docs-ai/tasks/release.md`](docs/contributor/release.md) |
+| Stamp Tauri version files                                                   | `bun scripts/stamp-version.ts` (or `just tauri-version`) — syncs desktop and mobile version metadata to the current git tag                                                                                                                       |
 
 ## Gotchas
 

--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -18,6 +18,11 @@ Before running the release script, verify:
 2. **`just verify` exits 0** — full gate: `docs-env-check`, race suite, docker-smoke, UI unit + e2e. See [`../core/verification.md`](../core/verification.md). Mandatory; calling out a skip in release notes is acceptable only when the risk is named.
 3. **`goreleaser` is installed.** `which goreleaser`. Install via `go install github.com/goreleaser/goreleaser/v2@latest` if missing.
 4. **Docker is reachable unless `--skip-snapshot` is intentional.** `just release` runs this check before the expensive verify gate because the Goreleaser snapshot builds local Docker images.
+5. **Curated notes are reviewed and committed.** Copy `docs/releases/template.md`
+   to `docs/releases/vX.Y.Z.md`, replace the placeholder title exactly, keep
+   `## Highlights` to one through six bullets, and name any security or
+   breaking/risky impact. The helper requires `--notes` and refuses an
+   untracked, oversized, or malformed file.
 
 ## Cut the release
 
@@ -28,23 +33,20 @@ checks goreleaser on PATH and Docker availability for the snapshot, fires a
 snapshot dry-run, then prompts before tagging:
 
 ```bash
-just release vX.Y.Z
+just release vX.Y.Z --notes docs/releases/vX.Y.Z.md
 ```
 
 To skip the snapshot dry-run (e.g. already ran it manually):
 
 ```bash
-just release v0.2.0 --skip-snapshot
+just release v0.5.1 --notes docs/releases/v0.5.1.md --skip-snapshot
 ```
 
-The release helper creates an annotated tag whose message is only the version,
-so ordinary releases use GoReleaser's generated changelog. For a substantive
-release, create an annotated tag manually from a reviewed Markdown file. The
-release workflow detects that non-version annotation and passes it to
-GoReleaser as the public GitHub Release body. Create that tag with
-`git tag -a --cleanup=verbatim vX.Y.Z -F /tmp/release-notes.md`; without
-`--cleanup=verbatim`, Git treats Markdown headings as comments and silently
-strips them from the annotation.
+The helper validates the committed Markdown before the expensive gate and
+again immediately before tagging. It creates the annotated tag with
+`--cleanup=verbatim -F`, preserving Markdown headings, then CI passes those
+exact bytes to GoReleaser as the public GitHub Release body. Lightweight tags,
+version-only annotations, and generated changelog fallbacks fail closed.
 
 ## Tauri desktop app
 
@@ -146,8 +148,8 @@ Acceptance:
   artifact (or that the exact delivery is already present on `master`).
 - The release-delivery PR has an approving review of its latest push, Required
   checks and Links are green, and it is merged normally.
-- GitHub Releases page has the latest stable entry and non-empty notes from
-  either a substantive tag annotation or GoReleaser's generated changelog. The Tauri matrix must attach bundles through
+- GitHub Releases page has the latest stable entry and the reviewed curated
+  Markdown from the tag. The Tauri matrix must attach bundles through
   `releaseId`; passing only `tagName` to tauri-action v1 rewrites the existing
   release body.
 - Goreleaser-side artifacts attached: tarballs for each `goos/goarch`, source tarball, checksums. Each binary tarball contains `hecate`.
@@ -167,7 +169,9 @@ Acceptance:
   `v0.5.0`. The git tag itself keeps the `v`. Same applies to tarball names.
   The `/healthz` `version` field also reports the bare semver.
 - **`.env_file` in compose overrides Dockerfile `ENV`.** The compose stack pins `HECATE_DATA_DIR=/data` and `HECATE_SQLITE_PATH=/data/hecate.db` in the service `environment:` block — which wins over `env_file:` — so a developer's relative `.data` source-dev path can't be carried into the container and break `docker compose cp /data/...`. Any new Dockerfile `ENV` that conflicts with a source-dev default in `.env.example` needs the same treatment in `docker-compose.yml`, or this footgun recurs.
-- **First-tag changelog is all-history.** Goreleaser builds the auto-changelog from git log between previous and current tags; if there's no previous tag, it includes every commit since the initial commit. Inspect the snapshot output before tagging.
+- **Public notes never come from the generated changelog.** The versioned,
+  reviewed Markdown file is mandatory because raw commit dumps are noisy in
+  both GitHub and the desktop updater.
 - **Don't run snapshot from a clean checkout, then `git add -A`.** The snapshot writes ~50 MB of binaries into `./dist`; a sweeping `git add` will pick them up if `dist/` isn't gitignored.
 - **`ui/dist/.gitkeep` must be tracked.** The `//go:embed all:ui/dist` directive in `embed.go` fails at compile time if `ui/dist` is completely absent from the tree. `.gitignore` keeps `ui/dist/*` but un-ignores `.gitkeep` via negation — the negation only works if `/dist/` (not `dist/`) is the rule anchoring the goreleaser output directory. If `go build` fails with `pattern all:ui/dist: no matching files found`, check that `ui/dist/.gitkeep` is tracked (`git ls-files ui/dist/`) and that `.gitignore` anchors the root dist rule with a leading `/`.
 - **`Dockerfile.release` is what goreleaser uses, not `Dockerfile`.** `Dockerfile` is the source-build image used by `docker compose up --build`; `Dockerfile.release` copies the prebuilt binary into the published GHCR image. They are two build paths for the same runtime shape, so any runtime package, bundled External Agent CLI/adapter, `ENV` var, volume, or default must land in both.

--- a/docs-ai/tasks/release.md
+++ b/docs-ai/tasks/release.md
@@ -45,8 +45,10 @@ just release v0.5.1 --notes docs/releases/v0.5.1.md --skip-snapshot
 The helper validates the committed Markdown before the expensive gate and
 again immediately before tagging. It creates the annotated tag with
 `--cleanup=verbatim -F`, preserving Markdown headings, then CI passes those
-exact bytes to GoReleaser as the public GitHub Release body. Lightweight tags,
-version-only annotations, and generated changelog fallbacks fail closed.
+exact bytes to GoReleaser as the public GitHub Release body only after comparing
+them byte-for-byte with `docs/releases/vX.Y.Z.md` in the tagged commit.
+Lightweight tags, version-only annotations, missing/mismatched audit files, and
+generated changelog fallbacks fail closed.
 
 ## Tauri desktop app
 

--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -195,7 +195,7 @@ just tauri-ios-build-debug # unsigned Apple Silicon iOS Simulator companion
 just tauri-android-build-debug aarch64 # Android arm64 debug APK; requires SDK/NDK/JDK env
 just verify            # full gate: docs/env check, Go, Docker, UI, build
 just verify-desktop    # desktop-specific Rust/Tauri check
-just release vX.Y.Z    # verify, then run the release script
+just release vX.Y.Z --notes docs/releases/vX.Y.Z.md # verify, then release
 ```
 
 Pull-request CI runs both mobile recipes on their native hosted runners after

--- a/docs/contributor/release.md
+++ b/docs/contributor/release.md
@@ -240,26 +240,47 @@ in the same change so future releases do not drift.
 
 ## Recovery
 
-If artifact packaging or signing fails before the GitHub Release has a valid
-three-platform `latest.json`, clean up and retag:
+Do not mutate tags, Releases, or package state while the release workflow can
+still publish. If the run is active, cancel it and wait for every job to stop:
 
 ```bash
-git push --delete origin vX.Y.Z
-git tag -d vX.Y.Z
-# fix root cause, retag, retry
+gh run cancel RUN_ID --repo hecatehq/hecate
+gh run watch RUN_ID --repo hecatehq/hecate
 ```
 
-Tag deletion on GitHub also clears the dangling Release entry (if one was
-created before the failure step). The Tauri version stamp commit remains on
-`master`; that is fine when retrying the same version because the release script
-will find the Tauri files already stamped and skip creating a duplicate stamp
-commit. If the version is abandoned entirely, revert or supersede the stamp with
-the next release version before tagging again. Goreleaser's release pipeline is
-mostly idempotent — a clean retag at a fixed commit produces the same artifacts.
+Classify the result before cleanup:
 
-For Tauri-side failures, the `.dmg` / `.deb` / `.AppImage` / `.msi` may be
-partially uploaded. `tauri-action` uploads with `--clobber`, so a retag
-re-uploads cleanly without manual cleanup.
+- If the Release entry, bundles, signatures, and three-platform `latest.json`
+  are complete and only protected delivery failed, keep the Release, tag, and
+  GHCR state and use the delivery-only recovery below.
+- If a complete public release is later found to be bad, publish a patch
+  release. Do not rewrite version history or make the GitHub and GHCR `latest`
+  pointers disagree by moving or deleting the completed tag.
+- If packaging or signing failed before a complete public release existed,
+  clean up the incomplete Release and tag before retrying.
+
+For that last case, use the exact failed stable version:
+
+```bash
+failed=vX.Y.Z
+if gh release view "$failed" --repo hecatehq/hecate >/dev/null 2>&1; then
+  gh release delete "$failed" --repo hecatehq/hecate --cleanup-tag --yes
+else
+  git push --delete origin "$failed"
+fi
+git tag -d "$failed" 2>/dev/null || true
+```
+
+`gh release delete --cleanup-tag` removes the GitHub Release and its remote
+tag. A local tag is separate, and deleting either one does not remove a GHCR
+package version. If Goreleaser started, complete the GHCR inspection and
+rollback below before retagging. The Tauri version stamp commit remains on
+`master`; that is correct when retrying the same version because the release
+script skips an already-applied stamp. If the version is abandoned, supersede
+the stamp with the next release version.
+
+Deleting the incomplete Release also removes partially uploaded Tauri assets.
+There is no separate `.dmg`, `.deb`, `.AppImage`, or `.msi` cleanup step.
 
 Do **not** delete or move a valid release tag because only the post-release
 delivery proposal failed. When the Release entry, bundles, signatures, and
@@ -320,48 +341,69 @@ gh release delete-asset vX.Y.Z data.tar.gz \
 If the macOS leg fails during Apple notarization with HTTP 403 and wording like
 "a required agreement is missing or has expired", the repository state is not
 the root cause. An Apple Developer account holder must accept the current
-agreements in Apple Developer/App Store Connect, then the same version can be
-retagged. When GitHub has already created a release entry, clean it up with:
-
-```bash
-gh release delete vX.Y.Z --cleanup-tag --yes
-git tag -d vX.Y.Z 2>/dev/null || true
-```
-
-Leave the version stamp commit on `master` when retrying the same version; the
-release script will detect the files are already stamped.
+agreements in Apple Developer/App Store Connect. After the run stops, use the
+incomplete-release cleanup above and then retry the same reviewed version.
 
 If Goreleaser already pushed container images before a later release job failed,
 the failed version tag may remain in GHCR and the `latest` tag may temporarily
 point at the failed release. `gh release delete --cleanup-tag` does **not**
-delete container package versions. Verify and repair GHCR explicitly:
+delete container package versions.
+
+Choose `last_good` explicitly from a complete stable Release. Verify it before
+changing GHCR. The token used here needs package-admin access and
+`read:packages`; restoring `latest` needs `write:packages`, and deleting the
+failed version needs `delete:packages`. Ordinary repository access is not
+enough.
 
 ```bash
 failed=vX.Y.Z
 failed_image=${failed#v}
-last_good=0.2.0-alpha.4
+last_good=vA.B.C
+last_good_image=${last_good#v}
 
-docker manifest inspect ghcr.io/hecatehq/hecate:${failed_image}
-docker manifest inspect ghcr.io/hecatehq/hecate:latest
+docker buildx imagetools inspect "ghcr.io/hecatehq/hecate:${failed_image}"
+docker buildx imagetools inspect "ghcr.io/hecatehq/hecate:${last_good_image}"
+docker buildx imagetools inspect ghcr.io/hecatehq/hecate:latest
 
-# If your token has delete:packages, remove the failed tagged package version:
-version_id=$(gh api /orgs/hecatehq/packages/container/hecate/versions \
-  | jq -r --arg tag "$failed_image" \
-      '.[] | select(.metadata.container.tags | index($tag)) | .id')
-test -n "$version_id"
-gh api -X DELETE /orgs/hecatehq/packages/container/hecate/versions/"$version_id"
-
-# If delete is not available, at least restore latest to the last successful
-# release. This requires write:packages.
+# Restore the mutable pointer first so cleanup cannot extend an outage.
 gh auth token | docker login ghcr.io -u "$(gh api user --jq .login)" --password-stdin
 docker buildx imagetools create \
   -t ghcr.io/hecatehq/hecate:latest \
-  ghcr.io/hecatehq/hecate:${last_good}
+  "ghcr.io/hecatehq/hecate:${last_good_image}"
+
+latest_digest="$(docker buildx imagetools inspect ghcr.io/hecatehq/hecate:latest \
+  --format '{{json .Manifest}}' | jq -r .digest)"
+last_good_digest="$(docker buildx imagetools inspect \
+  "ghcr.io/hecatehq/hecate:${last_good_image}" \
+  --format '{{json .Manifest}}' | jq -r .digest)"
+test "$latest_digest" = "$last_good_digest"
+
+# Resolve exactly one package version, even when the package has many pages.
+version_id="$(gh api --paginate --slurp \
+  -H 'Accept: application/vnd.github+json' \
+  '/orgs/hecatehq/packages/container/hecate/versions?per_page=100' \
+  | jq -er --arg tag "$failed_image" \
+      '[.[][] | select(.metadata.container.tags | index($tag))] as $matches
+       | if ($matches | length) == 1 then $matches[0].id
+         else error("expected exactly one GHCR version tagged \($tag); found \($matches | length)")
+         end')"
+gh api --method DELETE \
+  "/orgs/hecatehq/packages/container/hecate/versions/${version_id}"
+
+if docker buildx imagetools inspect \
+  "ghcr.io/hecatehq/hecate:${failed_image}" >/dev/null 2>&1; then
+  echo "failed GHCR tag still resolves" >&2
+  exit 1
+fi
+test "$(docker buildx imagetools inspect ghcr.io/hecatehq/hecate:latest \
+  --format '{{json .Manifest}}' | jq -r .digest)" = "$last_good_digest"
 ```
 
-Afterward, confirm `latest` and the last good tag resolve to the same manifest
-digests. If the failed image tag could not be deleted, note it in the failed
-release incident and delete it later with a token that has `delete:packages`.
+If the failed image was never published, skip this GHCR subsection. If package
+permissions are unavailable, restore `latest` if authorized, record the exact
+failed tag, and escalate its deletion to a package administrator. Do not claim
+that GitHub Release cleanup removed it. Retag only after the incomplete Release,
+remote and local tags, and any failed GHCR tag are clean.
 
 ## Image build
 

--- a/docs/contributor/release.md
+++ b/docs/contributor/release.md
@@ -167,9 +167,10 @@ The script validates that the notes file is repository-local, tracked, and
 unchanged after preflight. It then uses that file verbatim for the annotated
 tag (`git tag --cleanup=verbatim -F`), so `git show vX.Y.Z`, the GitHub Release,
 and the desktop updater all share one reviewed source. CI fails closed for a
-lightweight tag or version-only annotation instead of publishing a generated
-commit changelog. Keep the versioned notes file in the repository as the audit
-record for the release.
+lightweight tag, version-only annotation, missing versioned notes file, or any
+byte-level difference between that committed file and the tag annotation
+instead of publishing a generated or substituted changelog. Keep the versioned
+notes file in the repository as the audit record for the release.
 
 Signed annotated tags follow the same rules. The release workflow reads Git's
 signature as a separate byte range and removes only that exact suffix before

--- a/docs/contributor/release.md
+++ b/docs/contributor/release.md
@@ -71,10 +71,10 @@ Acceptance after the run:
   approves its latest push and merges it through protected `master`.
 - The GitHub Release is not marked pre-release, and
   `/releases/latest/download/latest.json` resolves to its signed manifest.
-- Release entry has non-empty notes: the annotated tag's Markdown for a
-  substantive release, otherwise GoReleaser's generated changelog. The desktop
-  matrix uploads by release id so it cannot replace those notes while attaching
-  bundles.
+- Release entry has the reviewed Markdown from the annotated tag. Lightweight
+  tags, version-only annotations, and generated commit dumps are rejected. The
+  desktop matrix uploads by release id so it cannot replace those notes while
+  attaching bundles.
 - Goreleaser-side artifacts attached: tarballs for each goos/goarch + checksums.
   Each tarball contains `hecate`.
 - Tauri-side bundles attached: 1 `.dmg`, 1 `.deb`, 1 `.AppImage`, 1 `.msi`.
@@ -129,8 +129,16 @@ The canonical entry point is the `just release` recipe, which first runs a
 fast release preflight, then `just verify`, then delegates to
 `scripts/release.ts`:
 
+Start from [`docs/releases/template.md`](../releases/template.md), replace the
+placeholder version, and commit the finished file as
+`docs/releases/vX.Y.Z.md`. The title must be exactly `# Hecate vX.Y.Z`; the
+single `## Highlights` section must contain one through six concise bullets.
+Security and breaking/risky changes should be called out explicitly when they
+apply. The full file is bounded to 12,000 characters so the desktop updater
+receives the same reviewed body as GitHub.
+
 ```bash
-just release vX.Y.Z
+just release vX.Y.Z --notes docs/releases/vX.Y.Z.md
 ```
 
 It performs, in order: clean-worktree check, strict `master`/`main` check,
@@ -145,46 +153,28 @@ Pass `--skip-snapshot` to skip the dry-run when you've already validated
 locally:
 
 ```bash
-just release vX.Y.Z --skip-snapshot
+just release vX.Y.Z --notes docs/releases/vX.Y.Z.md --skip-snapshot
 ```
 
 Pass `--yes` only for non-interactive release automation after the preflight
 and verification gate have passed:
 
 ```bash
-bun scripts/release.ts vX.Y.Z --skip-snapshot --yes
+bun scripts/release.ts vX.Y.Z --notes docs/releases/vX.Y.Z.md --skip-snapshot --yes
 ```
 
-The script's annotated tag message is just the version string, so GoReleaser
-publishes its generated changelog for ordinary releases. For a substantive
-release, tag manually with reviewed Markdown. The release workflow detects a
-non-version annotation and passes it to GoReleaser as the GitHub Release body:
-
-```bash
-TAURI_VERSION=X.Y.Z bun scripts/stamp-version.ts
-git add tauri/src-tauri/Cargo.toml tauri/src-tauri/Cargo.lock \
-        tauri/src-tauri/tauri.conf.json \
-        tauri/src-tauri/tauri.ios.conf.json \
-        tauri/src-tauri/tauri.android.conf.json \
-        tauri/src-tauri/gen/apple/project.yml \
-        tauri/src-tauri/gen/apple/hecate-app_iOS/Info.plist \
-        tauri/package.json
-git commit -m "chore(tauri): stamp version X.Y.Z"
-git tag -a --cleanup=verbatim vX.Y.Z -F /tmp/release-notes.md
-git push origin HEAD:master vX.Y.Z
-```
-
-The annotation remains visible through `git show vX.Y.Z`; the same content is
-published on GitHub. A version-only annotation continues to use the generated
-commit changelog. Keep `--cleanup=verbatim` on Markdown annotations: Git's
-default cleanup treats lines beginning with `#` as comments and would silently
-strip the release title and section headings.
+The script validates that the notes file is repository-local, tracked, and
+unchanged after preflight. It then uses that file verbatim for the annotated
+tag (`git tag --cleanup=verbatim -F`), so `git show vX.Y.Z`, the GitHub Release,
+and the desktop updater all share one reviewed source. CI fails closed for a
+lightweight tag or version-only annotation instead of publishing a generated
+commit changelog. Keep the versioned notes file in the repository as the audit
+record for the release.
 
 Signed annotated tags follow the same rules. The release workflow reads Git's
 signature as a separate byte range and removes only that exact suffix before
-classifying or publishing the annotation. A signed version-only tag therefore
-still uses the generated changelog, while substantive Markdown is passed to
-GoReleaser byte-for-byte without the public signature block.
+validating and publishing the Markdown byte-for-byte without the public
+signature block.
 
 The version stamp commit stays on `master`. This keeps the visible Tauri
 metadata, including the mobile store build numbers, aligned with the latest
@@ -207,11 +197,10 @@ those are GitHub-Actions-only.
 `bun scripts/release.ts` runs this for you unless you pass
 `--skip-snapshot`.
 
-**Inspect the auto-generated changelog.** The first tag in the repo lists
-every commit since the dawn of git history; subsequent tags list only commits
-since the previous tag. If the changelog is unusable, tune
-`.goreleaser.yaml`'s `changelog.filters` or use `--release-notes <file>` to
-override before tagging.
+**Review the curated notes.** The snapshot validates build configuration; it
+is not the source of public prose. Re-read the committed versioned notes before
+confirming the tag and keep the Highlights useful to someone deciding whether
+to install the update. The release script prints the exact path to review.
 
 Pre-flight checks before the snapshot run (the script enforces these):
 

--- a/docs/releases/template.md
+++ b/docs/releases/template.md
@@ -1,0 +1,25 @@
+# Hecate vX.Y.Z
+
+<!-- Delete every instructional comment after replacing it; validation rejects comments. -->
+
+<!-- Replace this comment with one sentence describing why this release matters. -->
+
+## Highlights
+
+<!-- Add one through six concise, operator-facing bullets. -->
+
+## Security
+
+<!-- Add security impact, or say that no security action is required. -->
+
+## Breaking or risky changes
+
+<!-- Add migrations/risks, or say that none are known. -->
+
+## Verification
+
+<!-- List the release gate and any manual platform checks that passed. -->
+
+## Known limitations
+
+<!-- Link to tracked limitations that matter for this release. -->

--- a/just/release.just
+++ b/just/release.just
@@ -3,7 +3,7 @@
 
 # Check protected-branch release delivery and updater artifact selection.
 release-workflow-check:
-	bun test scripts/prepare-release-notes.test.ts
+	bun test scripts/release-notes.test.ts scripts/prepare-release-notes.test.ts
 	bun scripts/check-release-workflows.ts
 
 # Validate release-only dependencies without running the full verification
@@ -14,7 +14,7 @@ release-preflight version *args:
 
 # Check release-only dependencies, run verification, then cut a release tag.
 # Optional args pass through to scripts/release.ts, for example:
-# just release vX.Y.Z --skip-snapshot.
+# just release vX.Y.Z --notes docs/releases/vX.Y.Z.md --skip-snapshot.
 # Verify and cut a release tag.
 release version *args:
 	bun scripts/release.ts {{version}} {{args}} --preflight-only

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -42,6 +42,7 @@ const releaseNotesHelperPath = "scripts/prepare-release-notes.ts";
 const releaseNotesInputPath = "scripts/release-notes.ts";
 const releaseNotesInputTestPath = "scripts/release-notes.test.ts";
 const releaseJustPath = "just/release.just";
+const releaseGuidePath = "docs/contributor/release.md";
 const goreleaserPath = ".goreleaser.yaml";
 const tauriConfigPath = "tauri/src-tauri/tauri.conf.json";
 const releaseScriptPath = "scripts/release.ts";
@@ -59,6 +60,7 @@ const releaseNotesHelper = read(releaseNotesHelperPath);
 const releaseNotesInput = read(releaseNotesInputPath);
 const releaseNotesInputTest = read(releaseNotesInputTestPath);
 const releaseJust = read(releaseJustPath);
+const releaseGuide = read(releaseGuidePath);
 const goreleaser = read(goreleaserPath);
 const tauriConfig = read(tauriConfigPath);
 const releaseScript = read(releaseScriptPath);
@@ -76,12 +78,57 @@ forbidText(tauriConfigPath, tauriConfig, "https://hecate.sh/releases/alpha/lates
 requireText(releaseScriptPath, releaseScript, "version must be a stable vX.Y.Z tag");
 requireText(releaseScriptPath, releaseScript, "--notes <path>");
 requireText(releaseScriptPath, releaseScript, '"--cleanup=verbatim"');
-requireText(releaseScriptPath, releaseScript, 'version, "-F", "-"');
+requireText(releaseScriptPath, releaseScript, '"-F", "-", version, releaseCommit');
 requireText(releaseScriptPath, releaseScript, "input: notesInStampedCommit.bytes");
 requireText(releaseScriptPath, releaseScript, '"hash-object", `--path=${notes.relativePath}`');
 requireText(releaseScriptPath, releaseScript, '"commit", "--only"');
+requireText(releaseScriptPath, releaseScript, 'revision = "HEAD"');
+requireText(releaseScriptPath, releaseScript, "`${revision}:${relativePath}`");
+requireText(releaseScriptPath, releaseScript, "headBeforeStamp !== localCommit");
+requireText(releaseScriptPath, releaseScript, 'const releaseCommit = run("git rev-parse HEAD"');
+requireText(
+  releaseScriptPath,
+  releaseScript,
+  "notesAtTag.relativePath,\n  version,\n  releaseCommit",
+);
+requireText(releaseScriptPath, releaseScript, '"--atomic"');
+requireText(releaseScriptPath, releaseScript, "`${releaseCommit}:refs/heads/${branch}`");
+requireText(releaseScriptPath, releaseScript, "`refs/tags/${version}:refs/tags/${version}`");
+forbidText(releaseScriptPath, releaseScript, "`HEAD:${branch}`");
+requireText(releaseScriptPath, releaseScript, "docs/contributor/release.md#recovery");
+forbidText(
+  releaseScriptPath,
+  releaseScript,
+  "git push --delete origin ${version} && git tag -d ${version}",
+);
 forbidText(releaseScriptPath, releaseScript, '["tag", "-a", version, "-m", version]');
+const releaseCommitCapture = releaseScript.indexOf("const releaseCommit =");
+const explicitTag = releaseScript.indexOf('["tag", "-a", "--cleanup=verbatim"');
+const atomicPush = releaseScript.indexOf('"--atomic"', explicitTag);
+if (
+  releaseCommitCapture < 0 ||
+  explicitTag < 0 ||
+  atomicPush < 0 ||
+  !(releaseCommitCapture < explicitTag && explicitTag < atomicPush)
+) {
+  fail(`${releaseScriptPath} must pin the release commit before tagging and atomic publication`);
+}
 requireText(releaseLinksScriptPath, releaseLinksScript, "tag must be a stable vX.Y.Z tag");
+
+requireText(releaseGuidePath, releaseGuide, 'gh release delete "$failed"');
+requireText(releaseGuidePath, releaseGuide, "--cleanup-tag --yes");
+requireText(releaseGuidePath, releaseGuide, "--paginate --slurp");
+requireText(releaseGuidePath, releaseGuide, "`read:packages`");
+requireText(releaseGuidePath, releaseGuide, "`write:packages`");
+requireText(releaseGuidePath, releaseGuide, "`delete:packages`");
+requireText(releaseGuidePath, releaseGuide, "docker buildx imagetools create");
+requireText(releaseGuidePath, releaseGuide, 'test "$latest_digest" = "$last_good_digest"');
+forbidText(
+  releaseGuidePath,
+  releaseGuide,
+  "Tag deletion on GitHub also clears the dangling Release entry",
+);
+forbidText(releaseGuidePath, releaseGuide, "last_good=0.2.0-alpha.4");
 
 forbidText(tauriPath, tauri, "publish-updater-website:");
 forbidText(tauriPath, tauri, "actions: write");
@@ -164,6 +211,37 @@ requireText(releasePath, release, "uses: ./.github/workflows/release-delivery.ym
 requireText(releasePath, release, "expected_release_body_sha256:");
 requireText(releasePath, release, "Release workflow requires a stable vX.Y.Z tag ref");
 forbidText(releasePath, release, "actions: write");
+
+const validateReleaseStart = release.indexOf("  validate-release-ref:");
+const mobileStart = release.indexOf("  mobile:", validateReleaseStart);
+if (validateReleaseStart < 0 || mobileStart < 0) {
+  fail(`${releasePath} must validate release tags before mobile and publication jobs`);
+}
+const validateRelease = release.slice(validateReleaseStart, mobileStart);
+requireText(releasePath, validateRelease, "contents: read");
+requireText(releasePath, validateRelease, "persist-credentials: false");
+requireText(
+  releasePath,
+  validateRelease,
+  'git fetch --no-tags --force origin "refs/heads/master:refs/remotes/origin/master"',
+);
+requireText(releasePath, validateRelease, '"refs/tags/${REF_NAME}^{commit}"');
+requireText(
+  releasePath,
+  validateRelease,
+  'git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/master',
+);
+const validateCheckout = validateRelease.indexOf("Checkout release history");
+const validateFetch = validateRelease.indexOf("git fetch --no-tags --force origin");
+const validateContainment = validateRelease.indexOf("git merge-base --is-ancestor");
+if (
+  validateCheckout < 0 ||
+  validateFetch < 0 ||
+  validateContainment < 0 ||
+  !(validateCheckout < validateFetch && validateFetch < validateContainment)
+) {
+  fail(`${releasePath} must fetch master before checking release-tag containment`);
+}
 requireText(
   releasePath,
   release,

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -78,7 +78,7 @@ requireText(
 );
 forbidText(tauriConfigPath, tauriConfig, "https://hecate.sh/releases/alpha/latest.json");
 requireText(releaseScriptPath, releaseScript, "version must be a stable vX.Y.Z tag");
-requireText(releaseScriptPath, releaseScript, "--notes <path>");
+requireText(releaseScriptPath, releaseScript, "--notes docs/releases/vX.Y.Z.md");
 requireText(releaseScriptPath, releaseScript, '"--cleanup=verbatim"');
 requireText(releaseScriptPath, releaseScript, '"-F", "-", version, releaseCommit');
 requireText(releaseScriptPath, releaseScript, "input: notesInStampedCommit.bytes");
@@ -309,6 +309,11 @@ requireText(
   releaseNotesInputTestPath,
   releaseNotesInputTest,
   "requires one to six highlight bullets",
+);
+requireText(
+  releaseNotesInputTestPath,
+  releaseNotesInputTest,
+  "rejects a noncanonical repository-local release notes path",
 );
 const releaseNotesTestCommand =
   "bun test scripts/release-notes.test.ts scripts/prepare-release-notes.test.ts";

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -82,18 +82,25 @@ requireText(releaseScriptPath, releaseScript, '"-F", "-", version, releaseCommit
 requireText(releaseScriptPath, releaseScript, "input: notesInStampedCommit.bytes");
 requireText(releaseScriptPath, releaseScript, '"hash-object", `--path=${notes.relativePath}`');
 forbidText(releaseScriptPath, releaseScript, '"commit", "--only"');
-requireText(releaseScriptPath, releaseScript, "GIT_INDEX_FILE: temporaryIndex");
-requireText(releaseScriptPath, releaseScript, '["read-tree", localCommit]');
+forbidText(releaseScriptPath, releaseScript, "GIT_INDEX_FILE");
+requireText(releaseScriptPath, releaseScript, '["worktree", "add", "--detach"');
 requireText(
   releaseScriptPath,
   releaseScript,
-  'capturedStampTree = execFileSync("git", ["write-tree"]',
+  '["hash-object", `--path=${stampPath}`, "--", stampPath]',
 );
+requireText(releaseScriptPath, releaseScript, "cwd: stampCheckout");
+requireText(releaseScriptPath, releaseScript, 'const capturedStampTree = execFileSync("git"');
 requireText(releaseScriptPath, releaseScript, "releaseTree !== capturedStampTree");
-requireText(releaseScriptPath, releaseScript, "realIndexTree !== reviewedTree");
-requireText(releaseScriptPath, releaseScript, '["read-tree", releaseCommit]');
+requireText(releaseScriptPath, releaseScript, '["worktree", "remove", "--force"');
 requireText(releaseScriptPath, releaseScript, 'revision = "HEAD"');
 requireText(releaseScriptPath, releaseScript, "`${revision}:${relativePath}`");
+requireText(
+  releaseScriptPath,
+  releaseScript,
+  "!revisionContainsPath(localCommit, stampScriptPath)",
+);
+forbidText(releaseScriptPath, releaseScript, "existsSync(stampScript)");
 requireText(releaseScriptPath, releaseScript, "headBeforeStamp !== localCommit");
 requireText(releaseScriptPath, releaseScript, "let releaseCommit = localCommit");
 requireText(
@@ -106,8 +113,7 @@ requireText(
   releaseScript,
   "changedStampPaths.filter((path) => !stampPaths.includes(path))",
 );
-requireText(releaseScriptPath, releaseScript, "unstampedHead !== localCommit");
-requireText(releaseScriptPath, releaseScript, "headAfterStamp !== releaseCommit");
+requireText(releaseScriptPath, releaseScript, "headAfterStamp !== localCommit");
 requireText(
   releaseScriptPath,
   releaseScript,

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -85,7 +85,19 @@ requireText(releaseScriptPath, releaseScript, '"commit", "--only"');
 requireText(releaseScriptPath, releaseScript, 'revision = "HEAD"');
 requireText(releaseScriptPath, releaseScript, "`${revision}:${relativePath}`");
 requireText(releaseScriptPath, releaseScript, "headBeforeStamp !== localCommit");
-requireText(releaseScriptPath, releaseScript, 'const releaseCommit = run("git rev-parse HEAD"');
+requireText(releaseScriptPath, releaseScript, "let releaseCommit = localCommit");
+requireText(
+  releaseScriptPath,
+  releaseScript,
+  "stampParents.length !== 2 || stampParents[1] !== localCommit",
+);
+requireText(
+  releaseScriptPath,
+  releaseScript,
+  "changedStampPaths.filter((path) => !stampPaths.includes(path))",
+);
+requireText(releaseScriptPath, releaseScript, "unstampedHead !== localCommit");
+requireText(releaseScriptPath, releaseScript, "headAfterStamp !== releaseCommit");
 requireText(
   releaseScriptPath,
   releaseScript,
@@ -102,7 +114,7 @@ forbidText(
   "git push --delete origin ${version} && git tag -d ${version}",
 );
 forbidText(releaseScriptPath, releaseScript, '["tag", "-a", version, "-m", version]');
-const releaseCommitCapture = releaseScript.indexOf("const releaseCommit =");
+const releaseCommitCapture = releaseScript.indexOf("let releaseCommit = localCommit");
 const explicitTag = releaseScript.indexOf('["tag", "-a", "--cleanup=verbatim"');
 const atomicPush = releaseScript.indexOf('"--atomic"', explicitTag);
 if (

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -81,7 +81,17 @@ requireText(releaseScriptPath, releaseScript, '"--cleanup=verbatim"');
 requireText(releaseScriptPath, releaseScript, '"-F", "-", version, releaseCommit');
 requireText(releaseScriptPath, releaseScript, "input: notesInStampedCommit.bytes");
 requireText(releaseScriptPath, releaseScript, '"hash-object", `--path=${notes.relativePath}`');
-requireText(releaseScriptPath, releaseScript, '"commit", "--only"');
+forbidText(releaseScriptPath, releaseScript, '"commit", "--only"');
+requireText(releaseScriptPath, releaseScript, "GIT_INDEX_FILE: temporaryIndex");
+requireText(releaseScriptPath, releaseScript, '["read-tree", localCommit]');
+requireText(
+  releaseScriptPath,
+  releaseScript,
+  'capturedStampTree = execFileSync("git", ["write-tree"]',
+);
+requireText(releaseScriptPath, releaseScript, "releaseTree !== capturedStampTree");
+requireText(releaseScriptPath, releaseScript, "realIndexTree !== reviewedTree");
+requireText(releaseScriptPath, releaseScript, '["read-tree", releaseCommit]');
 requireText(releaseScriptPath, releaseScript, 'revision = "HEAD"');
 requireText(releaseScriptPath, releaseScript, "`${revision}:${relativePath}`");
 requireText(releaseScriptPath, releaseScript, "headBeforeStamp !== localCommit");

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -39,6 +39,7 @@ const websitePath = ".github/workflows/website.yml";
 const testPath = ".github/workflows/test.yml";
 const tauriBuildPath = ".github/workflows/tauri-build.yml";
 const releaseNotesHelperPath = "scripts/prepare-release-notes.ts";
+const releaseNotesHelperTestPath = "scripts/prepare-release-notes.test.ts";
 const releaseNotesInputPath = "scripts/release-notes.ts";
 const releaseNotesInputTestPath = "scripts/release-notes.test.ts";
 const releaseJustPath = "just/release.just";
@@ -57,6 +58,7 @@ const website = read(websitePath);
 const test = read(testPath);
 const tauriBuild = read(tauriBuildPath);
 const releaseNotesHelper = read(releaseNotesHelperPath);
+const releaseNotesHelperTest = read(releaseNotesHelperTestPath);
 const releaseNotesInput = read(releaseNotesInputPath);
 const releaseNotesInputTest = read(releaseNotesInputTestPath);
 const releaseJust = read(releaseJustPath);
@@ -278,7 +280,24 @@ requireText(
 forbidText(releasePath, release, "tag_notes=$(git for-each-ref");
 requireText(releaseNotesHelperPath, releaseNotesHelper, "%(contents:size)");
 requireText(releaseNotesHelperPath, releaseNotesHelper, "%(contents:signature)");
+requireText(releaseNotesHelperPath, releaseNotesHelper, "`docs/releases/${tag}.md`");
+requireText(
+  releaseNotesHelperPath,
+  releaseNotesHelper,
+  "`${tagRef}^{commit}:${committedNotesPath}`",
+);
+requireText(releaseNotesHelperPath, releaseNotesHelper, "!committedNotes.equals(annotation)");
 requireText(releaseNotesHelperPath, releaseNotesHelper, "writeFileSync(notesPath, annotation)");
+requireText(
+  releaseNotesHelperTestPath,
+  releaseNotesHelperTest,
+  "rejects a tag whose commit omits the canonical release notes",
+);
+requireText(
+  releaseNotesHelperTestPath,
+  releaseNotesHelperTest,
+  "rejects a tag annotation that differs from the committed release notes",
+);
 requireText(
   releaseNotesHelperPath,
   releaseNotesHelper,

--- a/scripts/check-release-workflows.ts
+++ b/scripts/check-release-workflows.ts
@@ -39,6 +39,8 @@ const websitePath = ".github/workflows/website.yml";
 const testPath = ".github/workflows/test.yml";
 const tauriBuildPath = ".github/workflows/tauri-build.yml";
 const releaseNotesHelperPath = "scripts/prepare-release-notes.ts";
+const releaseNotesInputPath = "scripts/release-notes.ts";
+const releaseNotesInputTestPath = "scripts/release-notes.test.ts";
 const releaseJustPath = "just/release.just";
 const goreleaserPath = ".goreleaser.yaml";
 const tauriConfigPath = "tauri/src-tauri/tauri.conf.json";
@@ -54,6 +56,8 @@ const website = read(websitePath);
 const test = read(testPath);
 const tauriBuild = read(tauriBuildPath);
 const releaseNotesHelper = read(releaseNotesHelperPath);
+const releaseNotesInput = read(releaseNotesInputPath);
+const releaseNotesInputTest = read(releaseNotesInputTestPath);
 const releaseJust = read(releaseJustPath);
 const goreleaser = read(goreleaserPath);
 const tauriConfig = read(tauriConfigPath);
@@ -70,6 +74,13 @@ requireText(
 );
 forbidText(tauriConfigPath, tauriConfig, "https://hecate.sh/releases/alpha/latest.json");
 requireText(releaseScriptPath, releaseScript, "version must be a stable vX.Y.Z tag");
+requireText(releaseScriptPath, releaseScript, "--notes <path>");
+requireText(releaseScriptPath, releaseScript, '"--cleanup=verbatim"');
+requireText(releaseScriptPath, releaseScript, 'version, "-F", "-"');
+requireText(releaseScriptPath, releaseScript, "input: notesInStampedCommit.bytes");
+requireText(releaseScriptPath, releaseScript, '"hash-object", `--path=${notes.relativePath}`');
+requireText(releaseScriptPath, releaseScript, '"commit", "--only"');
+forbidText(releaseScriptPath, releaseScript, '["tag", "-a", version, "-m", version]');
 requireText(releaseLinksScriptPath, releaseLinksScript, "tag must be a stable vX.Y.Z tag");
 
 forbidText(tauriPath, tauri, "publish-updater-website:");
@@ -162,8 +173,22 @@ forbidText(releasePath, release, "tag_notes=$(git for-each-ref");
 requireText(releaseNotesHelperPath, releaseNotesHelper, "%(contents:size)");
 requireText(releaseNotesHelperPath, releaseNotesHelper, "%(contents:signature)");
 requireText(releaseNotesHelperPath, releaseNotesHelper, "writeFileSync(notesPath, annotation)");
-requireText(testPath, test, "bun test scripts/prepare-release-notes.test.ts");
-requireText(releaseJustPath, releaseJust, "bun test scripts/prepare-release-notes.test.ts");
+requireText(
+  releaseNotesHelperPath,
+  releaseNotesHelper,
+  "validateCuratedReleaseNotes(markdown, tag)",
+);
+requireText(releaseNotesInputPath, releaseNotesInput, "MAX_RELEASE_NOTES_CHARACTERS = 12_000");
+requireText(releaseNotesInputPath, releaseNotesInput, "exactly one ## Highlights section");
+requireText(
+  releaseNotesInputTestPath,
+  releaseNotesInputTest,
+  "requires one to six highlight bullets",
+);
+const releaseNotesTestCommand =
+  "bun test scripts/release-notes.test.ts scripts/prepare-release-notes.test.ts";
+requireText(testPath, test, releaseNotesTestCommand);
+requireText(releaseJustPath, releaseJust, releaseNotesTestCommand);
 
 const deliveryCallerStart = release.indexOf("  prepare-release-delivery:");
 if (deliveryCallerStart < 0) {

--- a/scripts/prepare-release-notes.test.ts
+++ b/scripts/prepare-release-notes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { prepareReleaseNotes } from "./prepare-release-notes";
@@ -70,7 +70,15 @@ function createAnnotatedTag(
   tag: string,
   annotation: Buffer,
   signature = Buffer.alloc(0),
+  committedNotes: Buffer | null = annotation,
 ): void {
+  if (committedNotes !== null) {
+    const releaseDirectory = join(cwd, "docs", "releases");
+    mkdirSync(releaseDirectory, { recursive: true });
+    writeFileSync(join(releaseDirectory, `${tag}.md`), committedNotes);
+    git(cwd, ["add", `docs/releases/${tag}.md`]);
+    git(cwd, ["commit", "--quiet", "--no-gpg-sign", "-m", `release notes for ${tag}`]);
+  }
   const commit = git(cwd, ["rev-parse", "HEAD"]).toString("ascii").trim();
   const header = Buffer.from(
     [
@@ -120,6 +128,14 @@ afterEach(() => {
 });
 
 describe("prepareReleaseNotes", () => {
+  test("rejects non-stable release tag names before resolving Git objects", () => {
+    const cwd = createRepo();
+
+    expect(() =>
+      prepareReleaseNotes({ cwd, tag: "v1.2.3-rc.1", notesPath: notesPath(cwd) }),
+    ).toThrow("Release tag v1.2.3-rc.1 must use stable vX.Y.Z format.");
+  });
+
   test("rejects lightweight tags without curated notes", () => {
     const cwd = createRepo();
     const tag = "v1.2.3";
@@ -173,6 +189,32 @@ describe("prepareReleaseNotes", () => {
     const written = readFileSync(output);
     expect(written.equals(markdown)).toBe(true);
     expect(written.includes(Buffer.from("BEGIN"))).toBe(false);
+  });
+
+  test("rejects a tag whose commit omits the canonical release notes", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3";
+    const output = notesPath(cwd);
+    createAnnotatedTag(cwd, tag, curatedNotes(tag), Buffer.alloc(0), null);
+
+    expect(() => prepareReleaseNotes({ cwd, tag, notesPath: output })).toThrow(
+      `Tagged commit for ${tag} must contain canonical release notes at docs/releases/${tag}.md.`,
+    );
+    expect(existsSync(output)).toBe(false);
+  });
+
+  test("rejects a tag annotation that differs from the committed release notes", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3";
+    const output = notesPath(cwd);
+    const annotation = curatedNotes(tag);
+    const committedNotes = Buffer.concat([annotation, Buffer.from("\nDifferent audit record.\n")]);
+    createAnnotatedTag(cwd, tag, annotation, Buffer.alloc(0), committedNotes);
+
+    expect(() => prepareReleaseNotes({ cwd, tag, notesPath: output })).toThrow(
+      `Release tag ${tag} annotation must match docs/releases/${tag}.md byte-for-byte.`,
+    );
+    expect(existsSync(output)).toBe(false);
   });
 
   test("rejects a signed version-only annotation", () => {

--- a/scripts/prepare-release-notes.test.ts
+++ b/scripts/prepare-release-notes.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { prepareReleaseNotes } from "./prepare-release-notes";
 
-const generatedChangelogArgs = "release --clean";
+const releaseArgs = "release --clean";
 const repos: string[] = [];
 const sshSignature = Buffer.from(
   [
@@ -93,6 +93,26 @@ function notesPath(cwd: string): string {
   return join(cwd, "release-notes.md");
 }
 
+function curatedNotes(tag: string, lineEnding = "\n"): Buffer {
+  return Buffer.from(
+    [
+      `# Hecate ${tag}`,
+      "",
+      "A short operator-facing summary.",
+      "",
+      "## Highlights",
+      "",
+      "- Makes updates easier to review.",
+      "- Keeps the complete notes available.",
+      "",
+      "## Security",
+      "",
+      "- No security action is required.",
+      "",
+    ].join(lineEnding),
+  );
+}
+
 afterEach(() => {
   for (const repo of repos.splice(0)) {
     rmSync(repo, { recursive: true, force: true });
@@ -100,35 +120,39 @@ afterEach(() => {
 });
 
 describe("prepareReleaseNotes", () => {
-  test("keeps lightweight tags on the generated changelog path", () => {
+  test("rejects lightweight tags without curated notes", () => {
     const cwd = createRepo();
     const tag = "v1.2.3";
     const output = notesPath(cwd);
     createLightweightTag(cwd, tag);
 
-    expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(generatedChangelogArgs);
+    expect(() => prepareReleaseNotes({ cwd, tag, notesPath: output })).toThrow(
+      `Release tag ${tag} must be annotated with curated Markdown notes.`,
+    );
     expect(existsSync(output)).toBe(false);
   });
 
-  test("keeps unsigned version-only annotations on the generated changelog path", () => {
+  test("rejects unsigned version-only annotations", () => {
     const cwd = createRepo();
-    const tag = "v1.2.3-alpha.4";
+    const tag = "v1.2.3";
     const output = notesPath(cwd);
     createAnnotatedTag(cwd, tag, Buffer.from(`${tag}\r\n\r\n`));
 
-    expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(generatedChangelogArgs);
+    expect(() => prepareReleaseNotes({ cwd, tag, notesPath: output })).toThrow(
+      `Release tag ${tag} contains only its version, not curated release notes.`,
+    );
     expect(existsSync(output)).toBe(false);
   });
 
   test("writes unsigned Markdown byte-for-byte", () => {
     const cwd = createRepo();
-    const tag = "v1.2.3-alpha.5";
+    const tag = "v1.2.3";
     const output = notesPath(cwd);
-    const markdown = Buffer.from("# Release\n\n- first\n- second\n\n");
+    const markdown = curatedNotes(tag);
     createAnnotatedTag(cwd, tag, markdown);
 
     expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(
-      `${generatedChangelogArgs} --release-notes=${output}`,
+      `${releaseArgs} --release-notes=${output}`,
     );
     expect(readFileSync(output).equals(markdown)).toBe(true);
   });
@@ -138,26 +162,28 @@ describe("prepareReleaseNotes", () => {
     ["PGP", pgpSignature],
   ])("strips an exact %s signature suffix from Markdown", (_kind, signature) => {
     const cwd = createRepo();
-    const tag = "v1.2.3-alpha.6";
+    const tag = "v1.2.3";
     const output = notesPath(cwd);
-    const markdown = Buffer.from("# Signed release\r\n\r\nPreserve ✨ exactly.\r\n\r\n");
+    const markdown = curatedNotes(tag, "\r\n");
     createAnnotatedTag(cwd, tag, markdown, signature);
 
     expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(
-      `${generatedChangelogArgs} --release-notes=${output}`,
+      `${releaseArgs} --release-notes=${output}`,
     );
     const written = readFileSync(output);
     expect(written.equals(markdown)).toBe(true);
     expect(written.includes(Buffer.from("BEGIN"))).toBe(false);
   });
 
-  test("recognizes a signed version-only annotation", () => {
+  test("rejects a signed version-only annotation", () => {
     const cwd = createRepo();
-    const tag = "v1.2.3-alpha.7";
+    const tag = "v1.2.3";
     const output = notesPath(cwd);
     createAnnotatedTag(cwd, tag, Buffer.from(`${tag}\n`), sshSignature);
 
-    expect(prepareReleaseNotes({ cwd, tag, notesPath: output })).toBe(generatedChangelogArgs);
+    expect(() => prepareReleaseNotes({ cwd, tag, notesPath: output })).toThrow(
+      `Release tag ${tag} contains only its version, not curated release notes.`,
+    );
     expect(existsSync(output)).toBe(false);
   });
 
@@ -166,7 +192,7 @@ describe("prepareReleaseNotes", () => {
     ["tag with only a signature", Buffer.from("\n"), pgpSignature],
   ])("rejects a %s", (_kind, annotation, signature) => {
     const cwd = createRepo();
-    const tag = "v1.2.3-alpha.8";
+    const tag = "v1.2.3";
     createAnnotatedTag(cwd, tag, annotation, signature);
 
     expect(() => prepareReleaseNotes({ cwd, tag, notesPath: notesPath(cwd) })).toThrow(
@@ -176,7 +202,7 @@ describe("prepareReleaseNotes", () => {
 
   test("rejects a release ref with an unsupported object type", () => {
     const cwd = createRepo();
-    const tag = "v1.2.3-alpha.9";
+    const tag = "v1.2.3";
     createBlobTag(cwd, tag);
 
     expect(() => prepareReleaseNotes({ cwd, tag, notesPath: notesPath(cwd) })).toThrow(
@@ -186,9 +212,9 @@ describe("prepareReleaseNotes", () => {
 
   test("exposes the same behavior through the workflow CLI", () => {
     const cwd = createRepo();
-    const tag = "v1.2.3-alpha.10";
+    const tag = "v1.2.3";
     const output = notesPath(cwd);
-    createAnnotatedTag(cwd, tag, Buffer.from(`${tag}\n`), pgpSignature);
+    createAnnotatedTag(cwd, tag, curatedNotes(tag), pgpSignature);
 
     const result = spawnSync(
       process.execPath,
@@ -200,7 +226,29 @@ describe("prepareReleaseNotes", () => {
     );
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe(`${generatedChangelogArgs}\n`);
+    expect(result.stdout).toBe(`${releaseArgs} --release-notes=${output}\n`);
     expect(result.stderr).toBe("");
+    expect(readFileSync(output).equals(curatedNotes(tag))).toBe(true);
+  });
+
+  test("fails the workflow CLI for an uncurated tag", () => {
+    const cwd = createRepo();
+    const tag = "v1.2.3";
+    const output = notesPath(cwd);
+    createAnnotatedTag(cwd, tag, Buffer.from(`${tag}\n`));
+
+    const result = spawnSync(
+      process.execPath,
+      [join(import.meta.dir, "prepare-release-notes.ts"), tag, output],
+      {
+        cwd,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("contains only its version, not curated release notes");
+    expect(existsSync(output)).toBe(false);
   });
 });

--- a/scripts/prepare-release-notes.ts
+++ b/scripts/prepare-release-notes.ts
@@ -3,7 +3,9 @@
 import { spawnSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
 
-const generatedChangelogArgs = "release --clean";
+import { validateCuratedReleaseNotes } from "./release-notes";
+
+const releaseArgs = "release --clean";
 const maxGitOutputBytes = 2 * 1024 * 1024;
 const refFormat = "%(refname)%00%(contents:size)%00%(contents:signature)%00%(contents)";
 
@@ -120,7 +122,7 @@ export function prepareReleaseNotes({ cwd, tag, notesPath }: PrepareReleaseNotes
   const tagRef = `refs/tags/${tag}`;
   const objectType = runGit(cwd, ["cat-file", "-t", tagRef]).toString("ascii").trim();
   if (objectType === "commit") {
-    return generatedChangelogArgs;
+    throw new Error(`Release tag ${tag} must be annotated with curated Markdown notes.`);
   }
   if (objectType !== "tag") {
     throw new Error(`Release ref ${tag} points to unsupported object type ${objectType}.`);
@@ -132,11 +134,19 @@ export function prepareReleaseNotes({ cwd, tag, notesPath }: PrepareReleaseNotes
     throw new Error(`Release tag ${tag} has an empty annotation.`);
   }
   if (withoutTrailingLineEndings(annotation).equals(Buffer.from(tag, "utf8"))) {
-    return generatedChangelogArgs;
+    throw new Error(`Release tag ${tag} contains only its version, not curated release notes.`);
   }
 
+  let markdown: string;
+  try {
+    markdown = new TextDecoder("utf-8", { fatal: true }).decode(annotation);
+  } catch {
+    throw new Error(`Release tag ${tag} notes must be valid UTF-8 Markdown.`);
+  }
+  validateCuratedReleaseNotes(markdown, tag);
+
   writeFileSync(notesPath, annotation);
-  return `${generatedChangelogArgs} --release-notes=${notesPath}`;
+  return `${releaseArgs} --release-notes=${notesPath}`;
 }
 
 if (import.meta.main) {

--- a/scripts/prepare-release-notes.ts
+++ b/scripts/prepare-release-notes.ts
@@ -115,6 +115,9 @@ export function prepareReleaseNotes({ cwd, tag, notesPath }: PrepareReleaseNotes
   if (!isNonEmptySingleLine(tag)) {
     throw new Error("Release tag must be a non-empty single-line ref name.");
   }
+  if (!/^v\d+\.\d+\.\d+$/.test(tag)) {
+    throw new Error(`Release tag ${tag} must use stable vX.Y.Z format.`);
+  }
   if (!isNonEmptySingleLine(notesPath)) {
     throw new Error("Release notes path must be a non-empty single-line path.");
   }
@@ -144,6 +147,21 @@ export function prepareReleaseNotes({ cwd, tag, notesPath }: PrepareReleaseNotes
     throw new Error(`Release tag ${tag} notes must be valid UTF-8 Markdown.`);
   }
   validateCuratedReleaseNotes(markdown, tag);
+
+  const committedNotesPath = `docs/releases/${tag}.md`;
+  let committedNotes: Buffer;
+  try {
+    committedNotes = runGit(cwd, ["cat-file", "blob", `${tagRef}^{commit}:${committedNotesPath}`]);
+  } catch {
+    throw new Error(
+      `Tagged commit for ${tag} must contain canonical release notes at ${committedNotesPath}.`,
+    );
+  }
+  if (!committedNotes.equals(annotation)) {
+    throw new Error(
+      `Release tag ${tag} annotation must match ${committedNotesPath} byte-for-byte.`,
+    );
+  }
 
   writeFileSync(notesPath, annotation);
   return `${releaseArgs} --release-notes=${notesPath}`;

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -180,12 +180,30 @@ describe("validateCuratedReleaseNotes", () => {
     });
   });
 
-  test("rejects tab-delimited headings that the updater cannot render canonically", () => {
-    const markdown = "# Hecate v1.2.3\n\n##\tHighlights\n\n- Visible update.";
-
+  test.each([
+    "# Hecate v1.2.3\n\n##\tHighlights\n\n- Visible update.",
+    "# Hecate v1.2.3\n\n## Highlights\n\n- Visible update.\n\n##\tSecurity\n\n- Fixed.",
+    "# Hecate v1.2.3\n\n## Highlights\n\n- Visible update.\n\n  ##\tBreaking changes\n\n- Changed.",
+  ])("rejects tab-delimited headings that the updater cannot render canonically", (markdown) => {
     expect(() => validateCuratedReleaseNotes(markdown, "v1.2.3")).toThrow(
-      "release notes must contain exactly one ## Highlights section.",
+      "release note headings must use an ASCII space after the # marker.",
     );
+  });
+
+  test("allows tab-delimited heading examples inside fenced code", () => {
+    const markdown = [
+      "# Hecate v1.2.3",
+      "",
+      "## Highlights",
+      "",
+      "- Visible update.",
+      "",
+      "```md",
+      "##\tExample",
+      "```",
+    ].join("\n");
+
+    expect(() => validateCuratedReleaseNotes(markdown, "v1.2.3")).not.toThrow();
   });
 
   test.each(["+ Visible update.", "  - Visible update.", "-\tVisible update."])(

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -9,6 +9,7 @@ import {
   parseReleaseCommandArgs,
   validateCuratedReleaseNotes,
 } from "./release-notes";
+import { parseMarkdownBlocks } from "../ui/src/lib/markdown";
 
 const temporaryDirectories: string[] = [];
 
@@ -149,6 +150,26 @@ describe("validateCuratedReleaseNotes", () => {
       ),
     ).toThrow("release notes must not contain HTML comments; remove all template guidance.");
   });
+
+  test.each(["-", "*"])("accepts and renders the canonical %s highlight marker", (marker) => {
+    const markdown = `# Hecate v1.2.3\n\n## Highlights\n\n${marker} Visible update.`;
+
+    expect(() => validateCuratedReleaseNotes(markdown, "v1.2.3")).not.toThrow();
+    expect(parseMarkdownBlocks(`${marker} Visible update.`)).toEqual([
+      { type: "ul", text: "", items: ["Visible update."] },
+    ]);
+  });
+
+  test.each(["+ Visible update.", "  - Visible update.", "-\tVisible update."])(
+    "rejects a highlight form the updater would not render as a list: %s",
+    (highlight) => {
+      const markdown = `# Hecate v1.2.3\n\n## Highlights\n\n${highlight}`;
+
+      expect(() => validateCuratedReleaseNotes(markdown, "v1.2.3")).toThrow(
+        "## Highlights must contain at least one bullet.",
+      );
+    },
+  );
 
   test("requires content for every included section", () => {
     expect(() =>

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -10,6 +10,7 @@ import {
   validateCuratedReleaseNotes,
 } from "./release-notes";
 import { parseMarkdownBlocks } from "../ui/src/lib/markdown";
+import { buildReleaseNotesPresentation } from "../ui/src/lib/release-notes";
 
 const temporaryDirectories: string[] = [];
 
@@ -158,6 +159,33 @@ describe("validateCuratedReleaseNotes", () => {
     expect(parseMarkdownBlocks(`${marker} Visible update.`)).toEqual([
       { type: "ul", text: "", items: ["Visible update."] },
     ]);
+  });
+
+  test.each([
+    ["LF", "\n"],
+    ["CRLF", "\r\n"],
+    ["CR", "\r"],
+  ])("accepts and renders %s line endings consistently", (_name, separator) => {
+    const markdown = ["# Hecate v1.2.3", "", "## Highlights", "", "- Visible update."].join(
+      separator,
+    );
+
+    expect(() => validateCuratedReleaseNotes(markdown, "v1.2.3")).not.toThrow();
+    const featured = buildReleaseNotesPresentation(markdown)?.featuredMarkdown ?? "";
+    expect(featured).toBe("## Highlights\n\n- Visible update.");
+    expect(parseMarkdownBlocks(featured)).toContainEqual({
+      type: "ul",
+      text: "",
+      items: ["Visible update."],
+    });
+  });
+
+  test("rejects tab-delimited headings that the updater cannot render canonically", () => {
+    const markdown = "# Hecate v1.2.3\n\n##\tHighlights\n\n- Visible update.";
+
+    expect(() => validateCuratedReleaseNotes(markdown, "v1.2.3")).toThrow(
+      "release notes must contain exactly one ## Highlights section.",
+    );
   });
 
   test.each(["+ Visible update.", "  - Visible update.", "-\tVisible update."])(

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  MAX_RELEASE_NOTES_CHARACTERS,
+  loadCuratedReleaseNotes,
+  parseReleaseCommandArgs,
+  validateCuratedReleaseNotes,
+} from "./release-notes";
+
+const temporaryDirectories: string[] = [];
+
+function validNotes(version = "v1.2.3"): string {
+  return [
+    `# Hecate ${version}`,
+    "",
+    "A short operator-facing summary.",
+    "",
+    "## Highlights",
+    "",
+    "- Makes updates easier to review.",
+    "- Keeps the complete technical notes available.",
+    "",
+    "## Breaking or risky changes",
+    "",
+    "- No migration is required.",
+    "",
+  ].join("\n");
+}
+
+function temporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("parseReleaseCommandArgs", () => {
+  test("accepts curated notes with release controls in any order", () => {
+    expect(
+      parseReleaseCommandArgs([
+        "--preflight-only",
+        "v1.2.3",
+        "--notes",
+        "docs/releases/v1.2.3.md",
+        "--skip-snapshot",
+        "--yes",
+      ]),
+    ).toEqual({
+      version: "v1.2.3",
+      notesPath: "docs/releases/v1.2.3.md",
+      skipSnapshot: true,
+      preflightOnly: true,
+      assumeYes: true,
+    });
+  });
+
+  test("requires an explicit notes path", () => {
+    expect(() => parseReleaseCommandArgs(["v1.2.3"])).toThrow(
+      "--notes is required so the published release and desktop updater never fall back to a commit dump.",
+    );
+    expect(() => parseReleaseCommandArgs(["v1.2.3", "--notes"])).toThrow(
+      "--notes requires a Markdown file path.",
+    );
+  });
+
+  test("rejects ambiguous or unknown arguments", () => {
+    expect(() =>
+      parseReleaseCommandArgs(["v1.2.3", "--notes", "one.md", "--notes", "two.md"]),
+    ).toThrow("--notes may be supplied only once.");
+    expect(() => parseReleaseCommandArgs(["v1.2.3", "extra", "--notes", "one.md"])).toThrow(
+      "unexpected positional argument: extra",
+    );
+    expect(() => parseReleaseCommandArgs(["v1.2.3", "--notes", "one.md", "--force"])).toThrow(
+      "unknown option: --force",
+    );
+  });
+});
+
+describe("validateCuratedReleaseNotes", () => {
+  test("accepts a bounded release with concise highlights", () => {
+    expect(() => validateCuratedReleaseNotes(validNotes(), "v1.2.3")).not.toThrow();
+  });
+
+  test("keeps the versioned release template invalid until it is filled in", () => {
+    const template = readFileSync(resolve(import.meta.dir, "../docs/releases/template.md"), "utf8");
+    expect(() =>
+      validateCuratedReleaseNotes(template.replace("vX.Y.Z", "v1.2.3"), "v1.2.3"),
+    ).toThrow("release notes must not contain HTML comments; remove all template guidance.");
+  });
+
+  test("requires the exact versioned title and one real Highlights section", () => {
+    expect(() => validateCuratedReleaseNotes(validNotes("v1.2.4"), "v1.2.3")).toThrow(
+      "release notes must begin with exactly: # Hecate v1.2.3",
+    );
+    expect(() =>
+      validateCuratedReleaseNotes("# Hecate v1.2.3\n\n## Changelog\n\n- raw commit", "v1.2.3"),
+    ).toThrow("release notes must contain exactly one ## Highlights section.");
+    expect(() =>
+      validateCuratedReleaseNotes(
+        "# Hecate v1.2.3\n\n```md\n## Highlights\n- hidden fixture\n```",
+        "v1.2.3",
+      ),
+    ).toThrow("release notes must contain exactly one ## Highlights section.");
+    expect(() =>
+      validateCuratedReleaseNotes(
+        [
+          "# Hecate v1.2.3",
+          "",
+          "`````md",
+          "`````md",
+          "## Highlights",
+          "- still inside the real fence",
+          "`````",
+        ].join("\n"),
+        "v1.2.3",
+      ),
+    ).toThrow("release notes must contain exactly one ## Highlights section.");
+  });
+
+  test("requires one to six highlight bullets", () => {
+    expect(() =>
+      validateCuratedReleaseNotes("# Hecate v1.2.3\n\n## Highlights\n\nNothing changed.", "v1.2.3"),
+    ).toThrow("## Highlights must contain at least one bullet.");
+
+    const bullets = Array.from({ length: 7 }, (_, index) => `- Change ${index + 1}`).join("\n");
+    expect(() =>
+      validateCuratedReleaseNotes(`# Hecate v1.2.3\n\n## Highlights\n\n${bullets}`, "v1.2.3"),
+    ).toThrow("## Highlights must contain no more than six concise bullets.");
+
+    expect(() =>
+      validateCuratedReleaseNotes(
+        "# Hecate v1.2.3\n\n## Highlights\n\n```md\n- not a real highlight\n```",
+        "v1.2.3",
+      ),
+    ).toThrow("## Highlights must contain at least one bullet.");
+
+    expect(() =>
+      validateCuratedReleaseNotes(
+        "# Hecate v1.2.3\n\n## Highlights\n\n<!--\n- hidden draft\n-->",
+        "v1.2.3",
+      ),
+    ).toThrow("release notes must not contain HTML comments; remove all template guidance.");
+  });
+
+  test("requires content for every included section", () => {
+    expect(() =>
+      validateCuratedReleaseNotes(
+        "# Hecate v1.2.3\n\n## Highlights\n\n- Ready.\n\n## Security\n\n## Verification\n\n- Passed.",
+        "v1.2.3",
+      ),
+    ).toThrow("## Security must contain release information or be removed.");
+  });
+
+  test("rejects notes that the updater cannot carry in full", () => {
+    const oversized = `${validNotes()}\n${"x".repeat(MAX_RELEASE_NOTES_CHARACTERS)}`;
+    expect(() => validateCuratedReleaseNotes(oversized, "v1.2.3")).toThrow(
+      "release notes must be at most 12,000 characters so the updater receives them in full.",
+    );
+  });
+});
+
+describe("loadCuratedReleaseNotes", () => {
+  test("loads a repository-local Markdown file without changing its bytes", () => {
+    const root = temporaryDirectory("hecate-release-root-");
+    const notesDirectory = join(root, "docs", "releases");
+    mkdirSync(notesDirectory, { recursive: true });
+    const markdown = validNotes();
+    writeFileSync(join(notesDirectory, "v1.2.3.md"), markdown);
+
+    expect(
+      loadCuratedReleaseNotes({
+        root,
+        version: "v1.2.3",
+        notesPath: "docs/releases/v1.2.3.md",
+      }),
+    ).toMatchObject({ relativePath: "docs/releases/v1.2.3.md", markdown });
+  });
+
+  test("rejects files outside the repository and invalid UTF-8", () => {
+    const root = temporaryDirectory("hecate-release-root-");
+    const external = temporaryDirectory("hecate-release-external-");
+    const externalPath = join(external, "v1.2.3.md");
+    writeFileSync(externalPath, validNotes());
+    expect(() =>
+      loadCuratedReleaseNotes({ root, version: "v1.2.3", notesPath: externalPath }),
+    ).toThrow("release notes must be a file inside the Hecate repository.");
+
+    const notesDirectory = join(root, "docs", "releases");
+    mkdirSync(notesDirectory, { recursive: true });
+    writeFileSync(join(notesDirectory, "v1.2.3.md"), Buffer.from([0xc3, 0x28]));
+    expect(() =>
+      loadCuratedReleaseNotes({
+        root,
+        version: "v1.2.3",
+        notesPath: "docs/releases/v1.2.3.md",
+      }),
+    ).toThrow("release notes must be valid UTF-8 Markdown.");
+  });
+});

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -251,6 +251,21 @@ describe("loadCuratedReleaseNotes", () => {
     ).toMatchObject({ relativePath: "docs/releases/v1.2.3.md", markdown });
   });
 
+  test("rejects a noncanonical repository-local release notes path", () => {
+    const root = temporaryDirectory("hecate-release-root-");
+    const notesDirectory = join(root, "docs", "other");
+    mkdirSync(notesDirectory, { recursive: true });
+    writeFileSync(join(notesDirectory, "v1.2.3.md"), validNotes());
+
+    expect(() =>
+      loadCuratedReleaseNotes({
+        root,
+        version: "v1.2.3",
+        notesPath: "docs/other/v1.2.3.md",
+      }),
+    ).toThrow("release notes path must be exactly docs/releases/v1.2.3.md.");
+  });
+
   test("rejects files outside the repository and invalid UTF-8", () => {
     const root = temporaryDirectory("hecate-release-root-");
     const external = temporaryDirectory("hecate-release-external-");

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -1,0 +1,259 @@
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep as pathSeparator } from "node:path";
+
+export const MAX_RELEASE_NOTES_CHARACTERS = 12_000;
+
+export type ReleaseCommandOptions = {
+  version: string;
+  notesPath: string;
+  skipSnapshot: boolean;
+  preflightOnly: boolean;
+  assumeYes: boolean;
+};
+
+export type CuratedReleaseNotes = {
+  absolutePath: string;
+  relativePath: string;
+  bytes: Buffer;
+  markdown: string;
+};
+
+export function parseReleaseCommandArgs(args: string[]): ReleaseCommandOptions {
+  let version = "";
+  let notesPath = "";
+  let skipSnapshot = false;
+  let preflightOnly = false;
+  let assumeYes = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--notes") {
+      if (notesPath) throw new Error("--notes may be supplied only once.");
+      const value = args[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("--notes requires a Markdown file path.");
+      }
+      notesPath = value;
+      index += 1;
+      continue;
+    }
+    if (argument === "--skip-snapshot") {
+      skipSnapshot = true;
+      continue;
+    }
+    if (argument === "--preflight-only") {
+      preflightOnly = true;
+      continue;
+    }
+    if (argument === "--yes") {
+      assumeYes = true;
+      continue;
+    }
+    if (argument.startsWith("--")) throw new Error(`unknown option: ${argument}`);
+    if (version) throw new Error(`unexpected positional argument: ${argument}`);
+    version = argument;
+  }
+
+  if (!version) throw new Error("a release version is required.");
+  if (!notesPath) {
+    throw new Error(
+      "--notes is required so the published release and desktop updater never fall back to a commit dump.",
+    );
+  }
+
+  return { version, notesPath, skipSnapshot, preflightOnly, assumeYes };
+}
+
+export function loadCuratedReleaseNotes({
+  root,
+  version,
+  notesPath,
+}: {
+  root: string;
+  version: string;
+  notesPath: string;
+}): CuratedReleaseNotes {
+  let rootPath: string;
+  let absolutePath: string;
+  try {
+    rootPath = realpathSync(root);
+    absolutePath = realpathSync(resolve(rootPath, notesPath));
+  } catch {
+    throw new Error(`release notes file was not found: ${notesPath}`);
+  }
+
+  const relativePath = relative(rootPath, absolutePath);
+  if (
+    !relativePath ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${pathSeparator}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error("release notes must be a file inside the Hecate repository.");
+  }
+  if (!relativePath.toLowerCase().endsWith(".md")) {
+    throw new Error("release notes must use a .md file.");
+  }
+  if (!statSync(absolutePath).isFile()) {
+    throw new Error(`release notes path is not a regular file: ${notesPath}`);
+  }
+
+  let bytes: Buffer;
+  let markdown: string;
+  try {
+    bytes = readFileSync(absolutePath);
+    markdown = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("release notes must be valid UTF-8 Markdown.");
+  }
+  validateCuratedReleaseNotes(markdown, version);
+
+  return {
+    absolutePath,
+    relativePath: relativePath.split(pathSeparator).join("/"),
+    bytes,
+    markdown,
+  };
+}
+
+export function validateCuratedReleaseNotes(markdown: string, version: string): void {
+  if (markdown.includes("\0")) throw new Error("release notes must not contain NUL bytes.");
+  if (Array.from(markdown).length > MAX_RELEASE_NOTES_CHARACTERS) {
+    throw new Error(
+      `release notes must be at most ${MAX_RELEASE_NOTES_CHARACTERS.toLocaleString("en-US")} characters so the updater receives them in full.`,
+    );
+  }
+
+  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  const firstContentLine = lines.find((line) => line.trim().length > 0)?.trim();
+  const expectedTitle = `# Hecate ${version}`;
+  if (firstContentLine !== expectedTitle) {
+    throw new Error(`release notes must begin with exactly: ${expectedTitle}`);
+  }
+  if (markdown.includes("<!--")) {
+    throw new Error("release notes must not contain HTML comments; remove all template guidance.");
+  }
+
+  const headings = markdownHeadings(lines);
+  const highlights = headings.filter(
+    (heading) => heading.level === 2 && normalizeHeading(heading.title) === "highlights",
+  );
+  if (highlights.length !== 1) {
+    throw new Error("release notes must contain exactly one ## Highlights section.");
+  }
+
+  const highlightsStart = highlights[0].line + 1;
+  const highlightsEnd =
+    headings.find(
+      (heading) => heading.line > highlights[0].line && heading.level <= highlights[0].level,
+    )?.line ?? lines.length;
+  const highlightItems = markdownBulletLines(lines.slice(highlightsStart, highlightsEnd));
+  if (highlightItems.length === 0) {
+    throw new Error("## Highlights must contain at least one bullet.");
+  }
+  if (highlightItems.length > 6) {
+    throw new Error("## Highlights must contain no more than six concise bullets.");
+  }
+
+  for (const heading of headings.filter((candidate) => candidate.level === 2)) {
+    const sectionEnd =
+      headings.find(
+        (candidate) => candidate.line > heading.line && candidate.level <= heading.level,
+      )?.line ?? lines.length;
+    if (!markdownSectionHasContent(lines.slice(heading.line + 1, sectionEnd))) {
+      throw new Error(`## ${heading.title} must contain release information or be removed.`);
+    }
+  }
+}
+
+function markdownSectionHasContent(lines: string[]): boolean {
+  let fence: { character: "`" | "~"; length: number } | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      const character = marker[0] as "`" | "~";
+      if (!fence) fence = { character, length: marker.length };
+      else if (
+        character === fence.character &&
+        marker.length >= fence.length &&
+        fenceMatch[2].trim() === ""
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+    if (line.trim()) return true;
+  }
+
+  return false;
+}
+
+function markdownBulletLines(lines: string[]): string[] {
+  const bulletLines: string[] = [];
+  let fence: { character: "`" | "~"; length: number } | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      const character = marker[0] as "`" | "~";
+      if (!fence) fence = { character, length: marker.length };
+      else if (
+        character === fence.character &&
+        marker.length >= fence.length &&
+        fenceMatch[2].trim() === ""
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+    if (!fence && /^\s{0,3}[-*+]\s+\S/.test(line)) bulletLines.push(line);
+  }
+
+  return bulletLines;
+}
+
+type MarkdownHeading = {
+  level: number;
+  line: number;
+  title: string;
+};
+
+function markdownHeadings(lines: string[]): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = [];
+  let fence: { character: "`" | "~"; length: number } | null = null;
+
+  lines.forEach((line, index) => {
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      const character = marker[0] as "`" | "~";
+      if (!fence) fence = { character, length: marker.length };
+      else if (
+        character === fence.character &&
+        marker.length >= fence.length &&
+        fenceMatch[2].trim() === ""
+      ) {
+        fence = null;
+      }
+      return;
+    }
+    if (fence) return;
+
+    const match = /^(#{1,6})[ \t]+(.+?)\s*$/.exec(line);
+    if (!match) return;
+    headings.push({
+      level: match[1].length,
+      line: index,
+      title: match[2].replace(/[ \t]+#+[ \t]*$/, "").trim(),
+    });
+  });
+
+  return headings;
+}
+
+function normalizeHeading(value: string): string {
+  return value.trim().toLocaleLowerCase("en-US").replace(/\s+/g, " ");
+}

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -247,7 +247,10 @@ function markdownHeadings(lines: string[]): MarkdownHeading[] {
     }
     if (fence) return;
 
-    const match = /^(#{1,6})[ \t]+(.+?)\s*$/.exec(line);
+    // The updater's block renderer recognizes ATX headings only when the
+    // marker is followed by an ASCII space. Keep curated notes canonical so a
+    // tab-delimited heading cannot reappear as a literal paragraph.
+    const match = /^(#{1,6}) +(.+?)\s*$/.exec(line);
     if (!match) return;
     headings.push({
       level: match[1].length,

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -209,7 +209,12 @@ function markdownBulletLines(lines: string[]): string[] {
       }
       continue;
     }
-    if (!fence && /^\s{0,3}[-*+]\s+\S/.test(line)) bulletLines.push(line);
+    // Keep this syntax aligned with the updater's intentionally small
+    // Markdown renderer. Canonical release highlights use an unindented dash
+    // or asterisk followed by an ASCII space; accepting broader CommonMark
+    // forms here would let reviewed notes degrade into literal paragraphs in
+    // the update dialog.
+    if (!fence && /^[-*] +\S/.test(line)) bulletLines.push(line);
   }
 
   return bulletLines;

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -125,6 +125,9 @@ export function validateCuratedReleaseNotes(markdown: string, version: string): 
   }
 
   const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  if (markdownHasTabDelimitedHeading(lines)) {
+    throw new Error("release note headings must use an ASCII space after the # marker.");
+  }
   const firstContentLine = lines.find((line) => line.trim().length > 0)?.trim();
   const expectedTitle = `# Hecate ${version}`;
   if (firstContentLine !== expectedTitle) {
@@ -164,6 +167,30 @@ export function validateCuratedReleaseNotes(markdown: string, version: string): 
       throw new Error(`## ${heading.title} must contain release information or be removed.`);
     }
   }
+}
+
+function markdownHasTabDelimitedHeading(lines: string[]): boolean {
+  let fence: { character: "`" | "~"; length: number } | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      const character = marker[0] as "`" | "~";
+      if (!fence) fence = { character, length: marker.length };
+      else if (
+        character === fence.character &&
+        marker.length >= fence.length &&
+        fenceMatch[2].trim() === ""
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+    if (!fence && /^ {0,3}#{1,6}\t/.test(line)) return true;
+  }
+
+  return false;
 }
 
 function markdownSectionHasContent(lines: string[]): boolean {

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -94,6 +94,11 @@ export function loadCuratedReleaseNotes({
   if (!relativePath.toLowerCase().endsWith(".md")) {
     throw new Error("release notes must use a .md file.");
   }
+  const normalizedRelativePath = relativePath.split(pathSeparator).join("/");
+  const expectedRelativePath = `docs/releases/${version}.md`;
+  if (normalizedRelativePath !== expectedRelativePath) {
+    throw new Error(`release notes path must be exactly ${expectedRelativePath}.`);
+  }
   if (!statSync(absolutePath).isFile()) {
     throw new Error(`release notes path is not a regular file: ${notesPath}`);
   }
@@ -110,7 +115,7 @@ export function loadCuratedReleaseNotes({
 
   return {
     absolutePath,
-    relativePath: relativePath.split(pathSeparator).join("/"),
+    relativePath: normalizedRelativePath,
     bytes,
     markdown,
   };

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -347,6 +347,17 @@ if (headBeforeStamp !== localCommit) {
       `  current:  ${headBeforeStamp}`,
   );
 }
+const stampPaths = [
+  "tauri/src-tauri/Cargo.toml",
+  "tauri/src-tauri/Cargo.lock",
+  "tauri/src-tauri/tauri.conf.json",
+  "tauri/src-tauri/tauri.ios.conf.json",
+  "tauri/src-tauri/tauri.android.conf.json",
+  "tauri/src-tauri/gen/apple/project.yml",
+  "tauri/src-tauri/gen/apple/hecate-app_iOS/Info.plist",
+  "tauri/package.json",
+];
+let releaseCommit = localCommit;
 const stampScript = resolve(root, "scripts/stamp-version.ts");
 if (existsSync(stampScript)) {
   // execFileSync (no shell) so that paths/args with spaces or special
@@ -365,16 +376,6 @@ if (existsSync(stampScript)) {
   // make the tag disagree with the store artifacts that CI builds from it.
   const stampDirty = run("git status --porcelain", { silent: true });
   if (stampDirty) {
-    const stampPaths = [
-      "tauri/src-tauri/Cargo.toml",
-      "tauri/src-tauri/Cargo.lock",
-      "tauri/src-tauri/tauri.conf.json",
-      "tauri/src-tauri/tauri.ios.conf.json",
-      "tauri/src-tauri/tauri.android.conf.json",
-      "tauri/src-tauri/gen/apple/project.yml",
-      "tauri/src-tauri/gen/apple/hecate-app_iOS/Info.plist",
-      "tauri/package.json",
-    ];
     execFileSync("git", ["add", "--", ...stampPaths], { cwd: root, stdio: "inherit" });
     execFileSync(
       "git",
@@ -384,11 +385,53 @@ if (existsSync(stampScript)) {
         stdio: "inherit",
       },
     );
+
+    releaseCommit = run("git rev-parse HEAD", { silent: true });
+    const stampParents = execFileSync("git", ["rev-list", "--parents", "-n", "1", releaseCommit], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+      .trim()
+      .split(/\s+/);
+    if (stampParents.length !== 2 || stampParents[1] !== localCommit) {
+      fail(
+        "the version stamp must create exactly one commit directly on the reviewed release commit; HEAD moved concurrently.",
+      );
+    }
+    const changedStampPaths = execFileSync(
+      "git",
+      ["diff-tree", "--no-commit-id", "--name-only", "-r", "-z", releaseCommit],
+      {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+      .split("\0")
+      .filter(Boolean);
+    const unexpectedStampPaths = changedStampPaths.filter((path) => !stampPaths.includes(path));
+    if (changedStampPaths.length === 0 || unexpectedStampPaths.length > 0) {
+      fail(
+        "the version stamp commit changed files outside the release allowlist:\n" +
+          `  ${unexpectedStampPaths.join("\n  ") || "(stamp commit had no changed files)"}`,
+      );
+    }
     console.log("  committed Tauri version stamp");
   } else {
+    const unstampedHead = run("git rev-parse HEAD", { silent: true });
+    if (unstampedHead !== localCommit) {
+      fail("HEAD moved while confirming that no version stamp commit was needed.");
+    }
+    releaseCommit = unstampedHead;
     console.log("  Tauri files already at correct version — no commit needed");
   }
 } else {
+  const unstampedHead = run("git rev-parse HEAD", { silent: true });
+  if (unstampedHead !== localCommit) {
+    fail("HEAD moved while the missing version stamp script was being checked.");
+  }
+  releaseCommit = unstampedHead;
   console.warn("  scripts/stamp-version.ts not found — skipping Tauri stamp");
 }
 
@@ -398,7 +441,10 @@ if (dirtyAfterStamp) {
   run("git status --short");
   process.exit(1);
 }
-const releaseCommit = run("git rev-parse HEAD", { silent: true });
+const headAfterStamp = run("git rev-parse HEAD", { silent: true });
+if (headAfterStamp !== releaseCommit) {
+  fail("HEAD changed after the version stamp was validated; restart the release.");
+}
 
 // ── Tag and push ──────────────────────────────────────────────────────────────
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,14 +2,14 @@
 // release.ts — cut a Hecate release tag and push it to CI.
 //
 // Usage:
-//   bun scripts/release.ts <version>                 # e.g. v0.5.0
-//   bun scripts/release.ts v0.5.0 --skip-snapshot    # skip goreleaser dry-run
-//   bun scripts/release.ts v0.5.0 --skip-snapshot --yes
-//   bun scripts/release.ts v0.5.0 --preflight-only   # validate local release deps
+//   bun scripts/release.ts <version> --notes <path>               # e.g. v0.5.1
+//   bun scripts/release.ts v0.5.1 --notes docs/releases/v0.5.1.md --skip-snapshot
+//   bun scripts/release.ts v0.5.1 --notes docs/releases/v0.5.1.md --preflight-only
 //
 // The script runs pre-flight checks, fires a goreleaser snapshot dry-run so
-// you can inspect the changelog before anything is published, stamps the Tauri
-// app version, then commits, tags, and pushes the branch + tag on explicit
+// you can inspect the artifacts before anything is published, validates the
+// reviewed release notes, stamps the Tauri app version, then commits, tags,
+// and pushes the branch + tag on explicit
 // confirmation. CI takes it from there (~5-10 min).
 //
 // Recovery if the CI run fails:
@@ -20,6 +20,13 @@
 import { execSync, execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { resolve } from "path";
+
+import {
+  loadCuratedReleaseNotes,
+  parseReleaseCommandArgs,
+  validateCuratedReleaseNotes,
+} from "./release-notes";
+import type { CuratedReleaseNotes, ReleaseCommandOptions } from "./release-notes";
 
 const root = resolve(import.meta.dir, "..");
 
@@ -33,8 +40,8 @@ function run(cmd: string, opts: { silent?: boolean } = {}): string {
   }).trim();
 }
 
-function confirm(question: string): boolean {
-  if (process.argv.includes("--yes")) {
+function confirm(question: string, assumeYes: boolean): boolean {
+  if (assumeYes) {
     console.log(`${question} [y/N] y (--yes)`);
     return true;
   }
@@ -65,30 +72,82 @@ function commandErrorOutput(error: unknown): string {
   return maybeError.message ?? String(error);
 }
 
+type ReviewedReleaseNotes = {
+  bytes: Buffer;
+  objectId: string;
+};
+
+function readReviewedReleaseNotes(relativePath: string, version: string): ReviewedReleaseNotes {
+  let bytes: Buffer;
+  let objectId: string;
+  try {
+    objectId = execFileSync("git", ["rev-parse", `HEAD:${relativePath}`], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    bytes = execFileSync("git", ["cat-file", "blob", objectId], {
+      cwd: root,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    fail(
+      `release notes must be tracked in the reviewed release commit: ${relativePath}\n` +
+        `  Git said: ${commandErrorOutput(error)}`,
+    );
+  }
+
+  let markdown: string;
+  try {
+    markdown = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail(`reviewed release notes must be valid UTF-8 Markdown: ${relativePath}`);
+  }
+  try {
+    validateCuratedReleaseNotes(markdown, version);
+  } catch (error) {
+    fail(`reviewed release notes are not publishable: ${(error as Error).message}`);
+  }
+  return { bytes, objectId };
+}
+
+function worktreeReleaseNotesObjectId(notes: CuratedReleaseNotes): string {
+  try {
+    return execFileSync(
+      "git",
+      ["hash-object", `--path=${notes.relativePath}`, "--", notes.absolutePath],
+      {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    ).trim();
+  } catch (error) {
+    fail(
+      `could not compare release notes with the reviewed commit: ${notes.relativePath}\n` +
+        `  Git said: ${commandErrorOutput(error)}`,
+    );
+  }
+}
+
 function sep(label: string) {
   console.log(`\n── ${label} ${"─".repeat(Math.max(0, 72 - label.length - 4))}`);
 }
 
 // ── Args ──────────────────────────────────────────────────────────────────────
 
-const args = process.argv.slice(2);
-const version = args.find((a) => !a.startsWith("--")) ?? "";
-const skipSnapshot = args.includes("--skip-snapshot");
-const preflightOnly = args.includes("--preflight-only");
-
-if (!version) {
+let commandOptions: ReleaseCommandOptions;
+try {
+  commandOptions = parseReleaseCommandArgs(process.argv.slice(2));
+} catch (error) {
   console.error(
-    "usage: bun scripts/release.ts <version> [--skip-snapshot] [--preflight-only] [--yes]",
+    "usage: bun scripts/release.ts <version> --notes <path> [--skip-snapshot] [--preflight-only] [--yes]",
   );
   console.error("       version: vX.Y.Z  (e.g. v0.5.0)");
+  console.error(`\nerror: ${(error as Error).message}`);
   process.exit(1);
 }
-
-const allowedFlags = new Set(["--skip-snapshot", "--preflight-only", "--yes"]);
-const unknownFlags = args.filter((a) => a.startsWith("--") && !allowedFlags.has(a));
-if (unknownFlags.length > 0) {
-  fail(`unknown option${unknownFlags.length === 1 ? "" : "s"}: ${unknownFlags.join(", ")}`);
-}
+const { version, notesPath, skipSnapshot, preflightOnly, assumeYes } = commandOptions;
 
 // ── Validate version format ───────────────────────────────────────────────────
 
@@ -97,6 +156,12 @@ if (!/^v\d+\.\d+\.\d+$/.test(version)) {
 }
 
 const semver = version.replace(/^v/, ""); // bare semver (no leading v)
+let releaseNotes: CuratedReleaseNotes;
+try {
+  releaseNotes = loadCuratedReleaseNotes({ root, version, notesPath });
+} catch (error) {
+  fail((error as Error).message);
+}
 
 // ── Pre-flight ────────────────────────────────────────────────────────────────
 
@@ -124,6 +189,19 @@ if (branch !== "master" && branch !== "main") {
 console.log(`  branch    : ${branch}`);
 const localCommit = run("git rev-parse HEAD", { silent: true });
 console.log(`  commit    : ${localCommit.slice(0, 7)}`);
+
+// Resolve notes from HEAD as well as the working tree. Git's assume-unchanged
+// and skip-worktree bits can hide local edits from both status and ls-files.
+// Comparing object IDs through Git's clean filter catches those edits without
+// rejecting a clean checkout whose platform line-ending policy differs.
+const reviewedReleaseNotes = readReviewedReleaseNotes(releaseNotes.relativePath, version);
+if (worktreeReleaseNotesObjectId(releaseNotes) !== reviewedReleaseNotes.objectId) {
+  fail(
+    `release notes do not match the reviewed release commit: ${releaseNotes.relativePath}\n` +
+      "  Restore the committed bytes or commit and review the intended notes before releasing.",
+  );
+}
+console.log(`  notes     : ${releaseNotes.relativePath} (curated)`);
 
 // 3. Refresh origin before checking the candidate. This makes the local tag
 // uniqueness check authoritative for existing remote tags and prevents a
@@ -227,9 +305,8 @@ if (!skipSnapshot) {
   console.log("(builds binaries + Docker images locally without publishing)\n");
   execSync("goreleaser release --snapshot --clean", { cwd: root, stdio: "inherit" });
   console.log("\nSnapshot written to ./dist.");
-  console.log("\nCheck the changelog before tagging:");
-  console.log("  cat dist/CHANGELOG.md");
-  console.log("\nIf this is the first tag the changelog includes all history — expected.");
+  console.log("\nReview the curated notes that will be published:");
+  console.log(`  cat ${releaseNotes.relativePath}`);
 }
 
 // ── Confirm ───────────────────────────────────────────────────────────────────
@@ -244,12 +321,21 @@ const remote = (() => {
 })();
 console.log(`  tag    : ${version}`);
 console.log(`  remote : ${remote}`);
+console.log(`  notes  : ${releaseNotes.relativePath}`);
 
-if (!confirm("\nStamp Tauri version, tag, and push branch + tag?")) abort("cancelled by user");
+if (!confirm("\nStamp Tauri version, tag, and push branch + tag?", assumeYes)) {
+  abort("cancelled by user");
+}
 
 // ── Stamp Tauri version ───────────────────────────────────────────────────────
 
 sep("Tauri version stamp");
+const dirtyBeforeStamp = run("git status --porcelain", { silent: true });
+if (dirtyBeforeStamp) {
+  console.error("error: working tree changed after preflight. Commit or stash changes first.");
+  run("git status --short");
+  process.exit(1);
+}
 const stampScript = resolve(root, "scripts/stamp-version.ts");
 if (existsSync(stampScript)) {
   // execFileSync (no shell) so that paths/args with spaces or special
@@ -268,25 +354,25 @@ if (existsSync(stampScript)) {
   // make the tag disagree with the store artifacts that CI builds from it.
   const stampDirty = run("git status --porcelain", { silent: true });
   if (stampDirty) {
+    const stampPaths = [
+      "tauri/src-tauri/Cargo.toml",
+      "tauri/src-tauri/Cargo.lock",
+      "tauri/src-tauri/tauri.conf.json",
+      "tauri/src-tauri/tauri.ios.conf.json",
+      "tauri/src-tauri/tauri.android.conf.json",
+      "tauri/src-tauri/gen/apple/project.yml",
+      "tauri/src-tauri/gen/apple/hecate-app_iOS/Info.plist",
+      "tauri/package.json",
+    ];
+    execFileSync("git", ["add", "--", ...stampPaths], { cwd: root, stdio: "inherit" });
     execFileSync(
       "git",
-      [
-        "add",
-        "tauri/src-tauri/Cargo.toml",
-        "tauri/src-tauri/Cargo.lock",
-        "tauri/src-tauri/tauri.conf.json",
-        "tauri/src-tauri/tauri.ios.conf.json",
-        "tauri/src-tauri/tauri.android.conf.json",
-        "tauri/src-tauri/gen/apple/project.yml",
-        "tauri/src-tauri/gen/apple/hecate-app_iOS/Info.plist",
-        "tauri/package.json",
-      ],
-      { cwd: root, stdio: "inherit" },
+      ["commit", "--only", "-m", `chore(tauri): stamp version ${semver}`, "--", ...stampPaths],
+      {
+        cwd: root,
+        stdio: "inherit",
+      },
     );
-    execFileSync("git", ["commit", "-m", `chore(tauri): stamp version ${semver}`], {
-      cwd: root,
-      stdio: "inherit",
-    });
     console.log("  committed Tauri version stamp");
   } else {
     console.log("  Tauri files already at correct version — no commit needed");
@@ -295,10 +381,36 @@ if (existsSync(stampScript)) {
   console.warn("  scripts/stamp-version.ts not found — skipping Tauri stamp");
 }
 
+const dirtyAfterStamp = run("git status --porcelain", { silent: true });
+if (dirtyAfterStamp) {
+  console.error("error: working tree contains changes outside the version stamp.");
+  run("git status --short");
+  process.exit(1);
+}
+
 // ── Tag and push ──────────────────────────────────────────────────────────────
 
 sep("Tag and push");
-execFileSync("git", ["tag", "-a", version, "-m", version], { cwd: root, stdio: "inherit" });
+let notesAtTag: CuratedReleaseNotes;
+try {
+  notesAtTag = loadCuratedReleaseNotes({ root, version, notesPath });
+} catch (error) {
+  fail((error as Error).message);
+}
+const notesInStampedCommit = readReviewedReleaseNotes(notesAtTag.relativePath, version);
+if (
+  worktreeReleaseNotesObjectId(notesAtTag) !== notesInStampedCommit.objectId ||
+  !notesInStampedCommit.bytes.equals(reviewedReleaseNotes.bytes)
+) {
+  fail(
+    "release notes changed in the working tree or stamped commit after preflight; restart from a clean reviewed checkout.",
+  );
+}
+execFileSync("git", ["tag", "-a", "--cleanup=verbatim", version, "-F", "-"], {
+  cwd: root,
+  input: notesInStampedCommit.bytes,
+  stdio: ["pipe", "inherit", "inherit"],
+});
 console.log(`Tagged ${version}`);
 
 execFileSync("git", ["push", "origin", `HEAD:${branch}`, version], { cwd: root, stdio: "inherit" });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,7 +2,7 @@
 // release.ts — cut a Hecate release tag and push it to CI.
 //
 // Usage:
-//   bun scripts/release.ts <version> --notes <path>               # e.g. v0.5.1
+//   bun scripts/release.ts <version> --notes docs/releases/vX.Y.Z.md
 //   bun scripts/release.ts v0.5.1 --notes docs/releases/v0.5.1.md --skip-snapshot
 //   bun scripts/release.ts v0.5.1 --notes docs/releases/v0.5.1.md --preflight-only
 //
@@ -157,7 +157,7 @@ try {
   commandOptions = parseReleaseCommandArgs(process.argv.slice(2));
 } catch (error) {
   console.error(
-    "usage: bun scripts/release.ts <version> --notes <path> [--skip-snapshot] [--preflight-only] [--yes]",
+    "usage: bun scripts/release.ts <version> --notes docs/releases/vX.Y.Z.md [--skip-snapshot] [--preflight-only] [--yes]",
   );
   console.error("       version: vX.Y.Z  (e.g. v0.5.0)");
   console.error(`\nerror: ${(error as Error).message}`);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -17,7 +17,7 @@
 //   # docs/contributor/release.md#recovery
 
 import { execSync, execFileSync } from "child_process";
-import { existsSync, mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
 
@@ -131,6 +131,18 @@ function worktreeReleaseNotesObjectId(notes: CuratedReleaseNotes): string {
       `could not compare release notes with the reviewed commit: ${notes.relativePath}\n` +
         `  Git said: ${commandErrorOutput(error)}`,
     );
+  }
+}
+
+function revisionContainsPath(revision: string, relativePath: string): boolean {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${revision}:${relativePath}`], {
+      cwd: root,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -359,86 +371,108 @@ const stampPaths = [
   "tauri/package.json",
 ];
 let releaseCommit = localCommit;
-const stampScript = resolve(root, "scripts/stamp-version.ts");
-if (existsSync(stampScript)) {
-  // execFileSync (no shell) so that paths/args with spaces or special
-  // characters can't be interpreted as shell metacharacters. CodeQL also
-  // flags the template-string form as "shell command built from
-  // environment values" — execFileSync makes that warning go away because
-  // args are passed to the process verbatim.
-  execFileSync("bun", [stampScript], {
+const stampScriptPath = "scripts/stamp-version.ts";
+if (!revisionContainsPath(localCommit, stampScriptPath)) {
+  fail(`the reviewed release commit does not contain the required ${stampScriptPath} script.`);
+}
+
+// Status can hide assume-unchanged and skip-worktree edits. Refuse hidden
+// stamp-surface changes explicitly, then derive the release commit in a
+// detached checkout whose bytes come only from the reviewed commit.
+for (const stampPath of stampPaths) {
+  const reviewedObject = execFileSync("git", ["rev-parse", `${localCommit}:${stampPath}`], {
     cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  const worktreeObject = execFileSync(
+    "git",
+    ["hash-object", `--path=${stampPath}`, "--", stampPath],
+    {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  ).trim();
+  if (worktreeObject !== reviewedObject) {
+    fail(
+      `version-stamp input differs from the reviewed release commit: ${stampPath}\n` +
+        "  Restore or commit the hidden worktree edit before releasing.",
+    );
+  }
+}
+
+const temporaryWorktreeRoot = mkdtempSync(join(tmpdir(), "hecate-release-worktree-"));
+const stampCheckout = join(temporaryWorktreeRoot, "checkout");
+let checkoutAdded = false;
+let checkoutRemoved = false;
+let cleanupHint = "";
+let stampFailure: unknown = null;
+try {
+  execFileSync("git", ["worktree", "add", "--detach", stampCheckout, localCommit], {
+    cwd: root,
+    stdio: "inherit",
+  });
+  checkoutAdded = true;
+  const isolatedStampScript = resolve(stampCheckout, stampScriptPath);
+  execFileSync("bun", [isolatedStampScript], {
+    cwd: stampCheckout,
     stdio: "inherit",
     env: { ...process.env, TAURI_VERSION: semver },
   });
 
-  // If stamping dirtied the tree, commit every desktop and mobile version
-  // surface before tagging. Leaving the platform overlays untracked would
-  // make the tag disagree with the store artifacts that CI builds from it.
-  const stampDirty = run("git status --porcelain", { silent: true });
+  const stampDirty = execFileSync("git", ["status", "--porcelain"], {
+    cwd: stampCheckout,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
   if (stampDirty) {
-    // Capture the stamp in an isolated index. `git commit --only <paths>`
-    // re-reads those paths from the worktree, so a concurrent edit after
-    // staging could otherwise enter the release commit without review.
-    const temporaryIndexDirectory = mkdtempSync(join(tmpdir(), "hecate-release-index-"));
-    const temporaryIndex = join(temporaryIndexDirectory, "index");
-    const temporaryIndexEnvironment = { ...process.env, GIT_INDEX_FILE: temporaryIndex };
-    let capturedStampTree = "";
-    try {
-      execFileSync("git", ["read-tree", localCommit], {
-        cwd: root,
-        env: temporaryIndexEnvironment,
-        stdio: "inherit",
-      });
-      execFileSync("git", ["add", "--", ...stampPaths], {
-        cwd: root,
-        env: temporaryIndexEnvironment,
-        stdio: "inherit",
-      });
-      capturedStampTree = execFileSync("git", ["write-tree"], {
-        cwd: root,
-        env: temporaryIndexEnvironment,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      }).trim();
+    execFileSync("git", ["add", "--", ...stampPaths], {
+      cwd: stampCheckout,
+      stdio: "inherit",
+    });
+    const capturedStampTree = execFileSync("git", ["write-tree"], {
+      cwd: stampCheckout,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    execFileSync("git", ["commit", "-m", `chore(tauri): stamp version ${semver}`], {
+      cwd: stampCheckout,
+      stdio: "inherit",
+    });
 
-      execFileSync("git", ["commit", "-m", `chore(tauri): stamp version ${semver}`], {
-        cwd: root,
-        env: temporaryIndexEnvironment,
-        stdio: "inherit",
-      });
-    } finally {
-      rmSync(temporaryIndexDirectory, { recursive: true, force: true });
-    }
-
-    releaseCommit = run("git rev-parse HEAD", { silent: true });
+    releaseCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: stampCheckout,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
     const stampParents = execFileSync("git", ["rev-list", "--parents", "-n", "1", releaseCommit], {
-      cwd: root,
+      cwd: stampCheckout,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     })
       .trim()
       .split(/\s+/);
     if (stampParents.length !== 2 || stampParents[1] !== localCommit) {
-      fail(
-        "the version stamp must create exactly one commit directly on the reviewed release commit; HEAD moved concurrently.",
+      throw new Error(
+        "the version stamp must create exactly one commit directly on the reviewed release commit.",
       );
     }
     const releaseTree = execFileSync("git", ["rev-parse", `${releaseCommit}^{tree}`], {
-      cwd: root,
+      cwd: stampCheckout,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     }).trim();
     if (releaseTree !== capturedStampTree) {
-      fail(
-        "the version stamp commit differs from the exact tree captured before commit hooks ran.",
+      throw new Error(
+        "the version stamp commit differs from the exact isolated tree captured before commit hooks ran.",
       );
     }
     const changedStampPaths = execFileSync(
       "git",
       ["diff-tree", "--no-commit-id", "--name-only", "-r", "-z", releaseCommit],
       {
-        cwd: root,
+        cwd: stampCheckout,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       },
@@ -447,41 +481,56 @@ if (existsSync(stampScript)) {
       .filter(Boolean);
     const unexpectedStampPaths = changedStampPaths.filter((path) => !stampPaths.includes(path));
     if (changedStampPaths.length === 0 || unexpectedStampPaths.length > 0) {
-      fail(
+      throw new Error(
         "the version stamp commit changed files outside the release allowlist:\n" +
           `  ${unexpectedStampPaths.join("\n  ") || "(stamp commit had no changed files)"}`,
       );
     }
-    const reviewedTree = execFileSync("git", ["rev-parse", `${localCommit}^{tree}`], {
-      cwd: root,
+    const isolatedDirtyAfterCommit = execFileSync("git", ["status", "--porcelain"], {
+      cwd: stampCheckout,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     }).trim();
-    const realIndexTree = execFileSync("git", ["write-tree"], {
-      cwd: root,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    }).trim();
-    if (realIndexTree !== reviewedTree) {
-      fail("the real Git index changed concurrently while the version stamp was committed.");
+    if (isolatedDirtyAfterCommit) {
+      throw new Error(
+        "the version stamp changed files outside its captured commit:\n" +
+          `  ${isolatedDirtyAfterCommit}`,
+      );
     }
-    execFileSync("git", ["read-tree", releaseCommit], { cwd: root, stdio: "inherit" });
-    console.log("  committed Tauri version stamp");
+    console.log("  prepared isolated Tauri version stamp commit");
   } else {
-    const unstampedHead = run("git rev-parse HEAD", { silent: true });
-    if (unstampedHead !== localCommit) {
-      fail("HEAD moved while confirming that no version stamp commit was needed.");
-    }
-    releaseCommit = unstampedHead;
+    releaseCommit = localCommit;
     console.log("  Tauri files already at correct version — no commit needed");
   }
-} else {
-  const unstampedHead = run("git rev-parse HEAD", { silent: true });
-  if (unstampedHead !== localCommit) {
-    fail("HEAD moved while the missing version stamp script was being checked.");
+} catch (error) {
+  stampFailure = error;
+} finally {
+  if (checkoutAdded) {
+    try {
+      execFileSync("git", ["worktree", "remove", "--force", stampCheckout], {
+        cwd: root,
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+      checkoutRemoved = true;
+    } catch (error) {
+      const cleanupFailure = commandErrorOutput(error);
+      const originalFailure = stampFailure ? `${commandErrorOutput(stampFailure)}\n  ` : "";
+      stampFailure = new Error(
+        `${originalFailure}temporary worktree cleanup also failed: ${cleanupFailure}`,
+      );
+      cleanupHint =
+        `\n  Temporary checkout retained for recovery: ${stampCheckout}` +
+        `\n  Remove it after inspection with: git worktree remove --force ${stampCheckout}`;
+    }
   }
-  releaseCommit = unstampedHead;
-  console.warn("  scripts/stamp-version.ts not found — skipping Tauri stamp");
+  if (!checkoutAdded || checkoutRemoved) {
+    rmSync(temporaryWorktreeRoot, { recursive: true, force: true });
+  }
+}
+if (stampFailure) {
+  fail(
+    `could not prepare the isolated version stamp.\n  Git said: ${commandErrorOutput(stampFailure)}${cleanupHint}`,
+  );
 }
 
 const dirtyAfterStamp = run("git status --porcelain", { silent: true });
@@ -491,8 +540,8 @@ if (dirtyAfterStamp) {
   process.exit(1);
 }
 const headAfterStamp = run("git rev-parse HEAD", { silent: true });
-if (headAfterStamp !== releaseCommit) {
-  fail("HEAD changed after the version stamp was validated; restart the release.");
+if (headAfterStamp !== localCommit) {
+  fail("the main checkout HEAD changed while the isolated version stamp was prepared.");
 }
 
 // ── Tag and push ──────────────────────────────────────────────────────────────

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -17,8 +17,9 @@
 //   # docs/contributor/release.md#recovery
 
 import { execSync, execFileSync } from "child_process";
-import { existsSync } from "fs";
-import { resolve } from "path";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
 
 import {
   loadCuratedReleaseNotes,
@@ -376,15 +377,39 @@ if (existsSync(stampScript)) {
   // make the tag disagree with the store artifacts that CI builds from it.
   const stampDirty = run("git status --porcelain", { silent: true });
   if (stampDirty) {
-    execFileSync("git", ["add", "--", ...stampPaths], { cwd: root, stdio: "inherit" });
-    execFileSync(
-      "git",
-      ["commit", "--only", "-m", `chore(tauri): stamp version ${semver}`, "--", ...stampPaths],
-      {
+    // Capture the stamp in an isolated index. `git commit --only <paths>`
+    // re-reads those paths from the worktree, so a concurrent edit after
+    // staging could otherwise enter the release commit without review.
+    const temporaryIndexDirectory = mkdtempSync(join(tmpdir(), "hecate-release-index-"));
+    const temporaryIndex = join(temporaryIndexDirectory, "index");
+    const temporaryIndexEnvironment = { ...process.env, GIT_INDEX_FILE: temporaryIndex };
+    let capturedStampTree = "";
+    try {
+      execFileSync("git", ["read-tree", localCommit], {
         cwd: root,
+        env: temporaryIndexEnvironment,
         stdio: "inherit",
-      },
-    );
+      });
+      execFileSync("git", ["add", "--", ...stampPaths], {
+        cwd: root,
+        env: temporaryIndexEnvironment,
+        stdio: "inherit",
+      });
+      capturedStampTree = execFileSync("git", ["write-tree"], {
+        cwd: root,
+        env: temporaryIndexEnvironment,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
+
+      execFileSync("git", ["commit", "-m", `chore(tauri): stamp version ${semver}`], {
+        cwd: root,
+        env: temporaryIndexEnvironment,
+        stdio: "inherit",
+      });
+    } finally {
+      rmSync(temporaryIndexDirectory, { recursive: true, force: true });
+    }
 
     releaseCommit = run("git rev-parse HEAD", { silent: true });
     const stampParents = execFileSync("git", ["rev-list", "--parents", "-n", "1", releaseCommit], {
@@ -397,6 +422,16 @@ if (existsSync(stampScript)) {
     if (stampParents.length !== 2 || stampParents[1] !== localCommit) {
       fail(
         "the version stamp must create exactly one commit directly on the reviewed release commit; HEAD moved concurrently.",
+      );
+    }
+    const releaseTree = execFileSync("git", ["rev-parse", `${releaseCommit}^{tree}`], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    if (releaseTree !== capturedStampTree) {
+      fail(
+        "the version stamp commit differs from the exact tree captured before commit hooks ran.",
       );
     }
     const changedStampPaths = execFileSync(
@@ -417,6 +452,20 @@ if (existsSync(stampScript)) {
           `  ${unexpectedStampPaths.join("\n  ") || "(stamp commit had no changed files)"}`,
       );
     }
+    const reviewedTree = execFileSync("git", ["rev-parse", `${localCommit}^{tree}`], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    const realIndexTree = execFileSync("git", ["write-tree"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    if (realIndexTree !== reviewedTree) {
+      fail("the real Git index changed concurrently while the version stamp was committed.");
+    }
+    execFileSync("git", ["read-tree", releaseCommit], { cwd: root, stdio: "inherit" });
     console.log("  committed Tauri version stamp");
   } else {
     const unstampedHead = run("git rev-parse HEAD", { silent: true });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -13,9 +13,8 @@
 // confirmation. CI takes it from there (~5-10 min).
 //
 // Recovery if the CI run fails:
-//   git push --delete origin <version>
-//   git tag -d <version>
-//   # fix root cause, re-run this script
+//   # Stop/wait for the run, classify what published, and follow:
+//   # docs/contributor/release.md#recovery
 
 import { execSync, execFileSync } from "child_process";
 import { existsSync } from "fs";
@@ -77,11 +76,15 @@ type ReviewedReleaseNotes = {
   objectId: string;
 };
 
-function readReviewedReleaseNotes(relativePath: string, version: string): ReviewedReleaseNotes {
+function readReviewedReleaseNotes(
+  relativePath: string,
+  version: string,
+  revision = "HEAD",
+): ReviewedReleaseNotes {
   let bytes: Buffer;
   let objectId: string;
   try {
-    objectId = execFileSync("git", ["rev-parse", `HEAD:${relativePath}`], {
+    objectId = execFileSync("git", ["rev-parse", `${revision}:${relativePath}`], {
       cwd: root,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
@@ -336,6 +339,14 @@ if (dirtyBeforeStamp) {
   run("git status --short");
   process.exit(1);
 }
+const headBeforeStamp = run("git rev-parse HEAD", { silent: true });
+if (headBeforeStamp !== localCommit) {
+  fail(
+    "HEAD changed after release preflight; restart from the clean, reviewed default branch.\n" +
+      `  reviewed: ${localCommit}\n` +
+      `  current:  ${headBeforeStamp}`,
+  );
+}
 const stampScript = resolve(root, "scripts/stamp-version.ts");
 if (existsSync(stampScript)) {
   // execFileSync (no shell) so that paths/args with spaces or special
@@ -387,6 +398,7 @@ if (dirtyAfterStamp) {
   run("git status --short");
   process.exit(1);
 }
+const releaseCommit = run("git rev-parse HEAD", { silent: true });
 
 // ── Tag and push ──────────────────────────────────────────────────────────────
 
@@ -397,7 +409,11 @@ try {
 } catch (error) {
   fail((error as Error).message);
 }
-const notesInStampedCommit = readReviewedReleaseNotes(notesAtTag.relativePath, version);
+const notesInStampedCommit = readReviewedReleaseNotes(
+  notesAtTag.relativePath,
+  version,
+  releaseCommit,
+);
 if (
   worktreeReleaseNotesObjectId(notesAtTag) !== notesInStampedCommit.objectId ||
   !notesInStampedCommit.bytes.equals(reviewedReleaseNotes.bytes)
@@ -406,14 +422,24 @@ if (
     "release notes changed in the working tree or stamped commit after preflight; restart from a clean reviewed checkout.",
   );
 }
-execFileSync("git", ["tag", "-a", "--cleanup=verbatim", version, "-F", "-"], {
+execFileSync("git", ["tag", "-a", "--cleanup=verbatim", "-F", "-", version, releaseCommit], {
   cwd: root,
   input: notesInStampedCommit.bytes,
   stdio: ["pipe", "inherit", "inherit"],
 });
 console.log(`Tagged ${version}`);
 
-execFileSync("git", ["push", "origin", `HEAD:${branch}`, version], { cwd: root, stdio: "inherit" });
+execFileSync(
+  "git",
+  [
+    "push",
+    "--atomic",
+    "origin",
+    `${releaseCommit}:refs/heads/${branch}`,
+    `refs/tags/${version}:refs/tags/${version}`,
+  ],
+  { cwd: root, stdio: "inherit" },
+);
 console.log(`Pushed ${branch} and ${version}`);
 
 // ── Done ──────────────────────────────────────────────────────────────────────
@@ -426,5 +452,7 @@ console.log("  git pull --ff-only origin master");
 console.log(`\nWhen CI completes (~5-10 min), verify the published image:`);
 console.log(`  docker pull ghcr.io/hecatehq/hecate:${semver}`);
 console.log(`  docker run --rm -p 127.0.0.1:8765:8765 ghcr.io/hecatehq/hecate:${semver}`);
-console.log(`\nTo recover if CI fails:`);
-console.log(`  git push --delete origin ${version} && git tag -d ${version}`);
+console.log("\nIf CI fails, stop or wait for the run before changing published state.");
+console.log("Classify the failure, then follow docs/contributor/release.md#recovery.");
+console.log("Release/tag and GHCR cleanup are separate operations.");
+console.log("Do not delete a complete release for a delivery-only failure.");

--- a/ui/src/app/App.css
+++ b/ui/src/app/App.css
@@ -411,6 +411,41 @@ html[data-tauri-os="macos"] .hecate-shell {
   overflow-wrap: anywhere;
 }
 
+.desktop-update-details__notes-disclosure {
+  border-top: 1px solid var(--border);
+  min-width: 0;
+  padding-top: 8px;
+}
+
+.desktop-update-details__notes-disclosure > summary {
+  border-radius: var(--radius-sm);
+  color: var(--t1);
+  cursor: pointer;
+  font-weight: 600;
+  padding: 5px 3px;
+}
+
+.desktop-update-details__notes-disclosure > summary::marker {
+  color: var(--teal);
+}
+
+.desktop-update-details__notes-disclosure > summary:hover {
+  color: var(--t0);
+}
+
+.desktop-update-details__notes-disclosure > summary:focus-visible {
+  outline: 2px solid var(--teal);
+  outline-offset: 2px;
+}
+
+.desktop-update-details__notes-full {
+  border-left: 1px solid var(--border);
+  margin: 6px 0 2px 5px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding-left: 12px;
+}
+
 .desktop-update-details__verification {
   color: var(--t3);
   font-size: 11px;

--- a/ui/src/features/shared/DesktopUpdateControl.test.tsx
+++ b/ui/src/features/shared/DesktopUpdateControl.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DesktopUpdateController } from "../../lib/desktop-update";
@@ -59,7 +59,7 @@ describe("DesktopUpdateCenter", () => {
     expect(screen.queryByRole("button", { name: "Updates" })).toBeNull();
   });
 
-  it("opens a portal-mounted dialog with rendered release-note Markdown and returns focus", async () => {
+  it("opens a portal-mounted dialog with prioritized release notes and full safe Markdown", async () => {
     enterTauriRuntime();
     useDesktopUpdateMock.mockReturnValue(
       controllerFixture({
@@ -70,12 +70,26 @@ describe("DesktopUpdateCenter", () => {
           notes: [
             "# Hecate 0.3.0-alpha.2",
             "",
+            "A focused desktop update.",
+            "",
+            "## Verification",
+            "",
+            "- The release build passed its smoke suite.",
+            "",
+            '<img data-unsafe="release-note-image" src="https://invalid.example">',
+            "",
+            "## Breaking changes",
+            "",
+            "- Existing update preferences migrate automatically.",
+            "",
             "## Highlights",
             "",
             "- Added **rendered release notes** with `safe links`.",
             "- Read the [release guide](https://example.com/releases).",
             "",
-            '<img data-unsafe="release-note-image" src="https://invalid.example">',
+            "## Security",
+            "",
+            "- Download verification remains mandatory.",
           ].join("\n"),
         },
       }),
@@ -94,29 +108,64 @@ describe("DesktopUpdateCenter", () => {
     expect(dialog).toHaveTextContent("Available");
     expect(dialog).toHaveTextContent("0.3.0-alpha.2");
     expect(
-      screen.getByRole("heading", { level: 2, name: "Release notes from the published release" }),
+      screen.getByRole("heading", { level: 2, name: "What’s new in Hecate 0.3.0-alpha.2" }),
     ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("heading", { level: 3, name: "Hecate 0.3.0-alpha.2" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { level: 4, name: "Highlights" })).toBeInTheDocument();
-    expect(dialog).not.toHaveTextContent("# Hecate 0.3.0-alpha.2");
-    expect(dialog).not.toHaveTextContent("## Highlights");
-    expect(screen.getByText("rendered release notes").tagName).toBe("STRONG");
-    expect(screen.getByText("safe links").tagName).toBe("CODE");
-    expect(screen.getByText(/Added/).closest("li")).not.toBeNull();
-    expect(screen.getByRole("link", { name: "release guide" })).toHaveAttribute(
+    const highlights = screen.getByRole("heading", { level: 3, name: "Highlights" });
+    expect(highlights).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Security" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Breaking changes" })).toBeInTheDocument();
+    const featuredNotes = highlights.closest(".desktop-update-details__notes-content");
+    expect(featuredNotes).not.toBeNull();
+    const featured = within(featuredNotes as HTMLElement);
+    expect(featured.getByText("rendered release notes").tagName).toBe("STRONG");
+    expect(featured.getByText("safe links").tagName).toBe("CODE");
+    expect(featured.getByText(/Added/).closest("li")).not.toBeNull();
+    expect(featured.getByRole("link", { name: "release guide" })).toHaveAttribute(
       "href",
       "https://example.com/releases",
     );
-    expect(dialog).toHaveTextContent('<img data-unsafe="release-note-image"');
     expect(document.querySelector("[data-unsafe='release-note-image']")).toBeNull();
     expect(dialog.parentElement).toHaveStyle({ zIndex: "1100" });
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Install and restart" })).toHaveFocus(),
+      expect(screen.getByRole("button", { name: "Update and restart" })).toHaveFocus(),
     );
 
+    const fullNotes = screen.getByText("Full release notes", { selector: "summary" });
+    expect(fullNotes.parentElement).not.toHaveAttribute("open");
+    fireEvent.click(fullNotes);
+    expect(fullNotes.parentElement).toHaveAttribute("open");
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Hecate 0.3.0-alpha.2" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 4, name: "Verification" })).toBeInTheDocument();
+    expect(dialog).toHaveTextContent('<img data-unsafe="release-note-image"');
+    expect(document.querySelector("[data-unsafe='release-note-image']")).toBeNull();
+
     fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Hecate desktop update" })).toBeNull();
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it("defers an available update until later and returns focus to its trigger", async () => {
+    enterTauriRuntime();
+    const dismiss = vi.fn();
+    useDesktopUpdateMock.mockReturnValue(
+      controllerFixture({
+        dismiss,
+        update: {
+          currentVersion: "0.3.0-alpha.1",
+          version: "0.3.0-alpha.2",
+        },
+      }),
+    );
+
+    render(<DesktopUpdateCenter />);
+    const trigger = screen.getByRole("button", { name: "Update 0.3.0-alpha.2" });
+    trigger.focus();
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByRole("button", { name: "Later" }));
+
+    expect(dismiss).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("dialog", { name: "Hecate desktop update" })).toBeNull();
     await waitFor(() => expect(trigger).toHaveFocus());
   });
@@ -134,7 +183,7 @@ describe("DesktopUpdateCenter", () => {
     render(<DesktopUpdateCenter />);
     fireEvent.click(screen.getByRole("button", { name: "Updates" }));
 
-    expect(await screen.findByText(/dismissed for this app session/i)).toBeInTheDocument();
+    expect(await screen.findByText(/chose later for this app session/i)).toBeInTheDocument();
     expect(screen.queryByText(/hecate is up to date/i)).toBeNull();
   });
 
@@ -174,7 +223,7 @@ describe("DesktopUpdateCenter", () => {
 
     const { rerender } = render(<DesktopUpdateCenter />);
     fireEvent.click(screen.getByRole("button", { name: "Update 0.3.0-alpha.2" }));
-    const install = await screen.findByRole("button", { name: "Install and restart" });
+    const install = await screen.findByRole("button", { name: "Update and restart" });
     await waitFor(() => expect(install).toHaveFocus());
     fireEvent.click(install);
     expect(installAndRestart).toHaveBeenCalledTimes(1);
@@ -204,7 +253,7 @@ describe("DesktopUpdateCenter", () => {
 
     const { rerender } = render(<DesktopUpdateCenter />);
     fireEvent.click(screen.getByRole("button", { name: "Update 0.3.0-alpha.2" }));
-    const install = await screen.findByRole("button", { name: "Install and restart" });
+    const install = await screen.findByRole("button", { name: "Update and restart" });
     await waitFor(() => expect(install).toHaveFocus());
 
     useDesktopUpdateMock.mockReturnValue(controllerFixture({ checking: true, update }));

--- a/ui/src/features/shared/DesktopUpdateControl.tsx
+++ b/ui/src/features/shared/DesktopUpdateControl.tsx
@@ -2,7 +2,7 @@
 // The compact status-bar button is deliberately the only in-page affordance;
 // the macOS overlay titlebar stays a clean native drag surface.
 
-import { useCallback, useRef, useState, type RefObject } from "react";
+import { useCallback, useMemo, useRef, useState, type RefObject } from "react";
 import { createPortal } from "react-dom";
 
 import {
@@ -10,6 +10,7 @@ import {
   type DesktopUpdateController,
   useDesktopUpdate,
 } from "../../lib/desktop-update";
+import { buildReleaseNotesPresentation } from "../../lib/release-notes";
 import { isTauriRuntime } from "../../lib/tauri";
 import { Icon, Icons } from "./Icons";
 import { MarkdownContent } from "./MarkdownContent";
@@ -100,6 +101,10 @@ function DesktopUpdateDetails({
       : installButtonRef
     : checkButtonRef;
   const releaseNotes = boundedReleaseNotes(update);
+  const releaseNotesPresentation = useMemo(
+    () => (releaseNotes ? buildReleaseNotesPresentation(releaseNotes) : null),
+    [releaseNotes],
+  );
   const status = updateDetailsStatus({
     update,
     checking,
@@ -150,7 +155,7 @@ function DesktopUpdateDetails({
                           : "Installing…"
                       : installFailure === "install"
                         ? "Try install again"
-                        : "Install and restart"}
+                        : "Update and restart"}
                 </button>
               )}
               {!installing && installFailure !== "restart" && (
@@ -162,7 +167,7 @@ function DesktopUpdateDetails({
                   }}
                   type="button"
                 >
-                  Dismiss update
+                  Later
                 </button>
               )}
             </>
@@ -254,15 +259,29 @@ function DesktopUpdateDetails({
           </p>
         )}
 
-        {releaseNotes && (
+        {releaseNotesPresentation && update && (
           <section
             aria-labelledby="desktop-update-release-notes"
             className="desktop-update-details__notes"
           >
-            <h2 id="desktop-update-release-notes">Release notes from the published release</h2>
+            <h2 id="desktop-update-release-notes">What’s new in Hecate {update.version}</h2>
             <div className="desktop-update-details__notes-content">
-              <MarkdownContent content={releaseNotes} headingStartLevel={3} />
+              <MarkdownContent
+                content={releaseNotesPresentation.featuredMarkdown}
+                headingStartLevel={2}
+              />
             </div>
+            {releaseNotesPresentation.hasAdditionalDetails && (
+              <details className="desktop-update-details__notes-disclosure">
+                <summary>Full release notes</summary>
+                <div className="desktop-update-details__notes-full">
+                  <MarkdownContent
+                    content={releaseNotesPresentation.fullMarkdown}
+                    headingStartLevel={3}
+                  />
+                </div>
+              </details>
+            )}
           </section>
         )}
 
@@ -367,7 +386,7 @@ function updateDetailsStatus({
   if (manualCheck?.phase === "error")
     return "Hecate could not check for updates. Try again when ready.";
   if (dismissed) {
-    return "This update is dismissed for this app session. Check again to look for a newer release.";
+    return "You chose Later for this app session. Check again to look for a newer release.";
   }
   if (manualCheck?.phase === "up-to-date" || lastSuccessfulCheck === "up-to-date") {
     return `Hecate is up to date. Last checked ${formatCheckTime(lastCheckedAt)}.`;

--- a/ui/src/lib/markdown.test.ts
+++ b/ui/src/lib/markdown.test.ts
@@ -48,6 +48,14 @@ describe("parseMarkdownBlocks", () => {
     expect(blocks).toEqual([{ type: "ul", text: "", items: ["apple", "banana", "cherry"] }]);
   });
 
+  it.each(["\r\n", "\r"])("normalizes %s line endings before parsing", (separator) => {
+    const blocks = parseMarkdownBlocks(["## Highlights", "", "- Visible update."].join(separator));
+    expect(blocks).toEqual([
+      { type: "heading", text: "Highlights", level: 2 },
+      { type: "ul", text: "", items: ["Visible update."] },
+    ]);
+  });
+
   it("parses ordered list items", () => {
     const blocks = parseMarkdownBlocks("1. first\n2. second");
     expect(blocks).toEqual([{ type: "ol", text: "", items: ["first", "second"] }]);

--- a/ui/src/lib/markdown.ts
+++ b/ui/src/lib/markdown.ts
@@ -17,7 +17,7 @@ export type InlineNode =
 
 export function parseMarkdownBlocks(content: string): Block[] {
   const blocks: Block[] = [];
-  const lines = content.split("\n");
+  const lines = content.replace(/\r\n?/g, "\n").split("\n");
   let i = 0;
 
   while (i < lines.length) {

--- a/ui/src/lib/release-notes.test.ts
+++ b/ui/src/lib/release-notes.test.ts
@@ -45,6 +45,18 @@ describe("buildReleaseNotesPresentation", () => {
     });
   });
 
+  it.each([
+    ["LF", "\n"],
+    ["CRLF", "\r\n"],
+    ["CR", "\r"],
+  ])("keeps the Highlights preview with %s line endings", (_name, separator) => {
+    const notes = ["# Hecate v0.5.1", "", "## Highlights", "", "- Visible update."].join(separator);
+
+    expect(buildReleaseNotesPresentation(notes)?.featuredMarkdown).toBe(
+      "## Highlights\n\n- Visible update.",
+    );
+  });
+
   it("does not treat headings inside fenced code as release sections", () => {
     const notes = [
       "# Hecate v0.5.1",

--- a/ui/src/lib/release-notes.test.ts
+++ b/ui/src/lib/release-notes.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import { buildReleaseNotesPresentation } from "./release-notes";
+
+describe("buildReleaseNotesPresentation", () => {
+  it("prioritizes highlights, security, and breaking sections in that order", () => {
+    const notes = [
+      "# Hecate v0.5.1",
+      "",
+      "A concise release for desktop operators.",
+      "",
+      "## Breaking changes",
+      "",
+      "- Existing local state is migrated once.",
+      "",
+      "## Verification",
+      "",
+      "- Verified with the release smoke suite.",
+      "",
+      "## Highlights",
+      "",
+      "- Updates now show a useful summary.",
+      "",
+      "## Security",
+      "",
+      "- Download verification remains mandatory.",
+    ].join("\n");
+
+    expect(buildReleaseNotesPresentation(notes)).toEqual({
+      featuredMarkdown: [
+        "## Highlights",
+        "",
+        "- Updates now show a useful summary.",
+        "",
+        "## Security",
+        "",
+        "- Download verification remains mandatory.",
+        "",
+        "## Breaking changes",
+        "",
+        "- Existing local state is migrated once.",
+      ].join("\n"),
+      fullMarkdown: notes,
+      hasAdditionalDetails: true,
+    });
+  });
+
+  it("does not treat headings inside fenced code as release sections", () => {
+    const notes = [
+      "# Hecate v0.5.1",
+      "",
+      "```md",
+      "## Highlights",
+      "- This is an example, not a release highlight.",
+      "```",
+      "",
+      "## Security notes",
+      "",
+      "~~~md",
+      "- Ignore this fenced list too.",
+      "~~~",
+      "",
+      "- Fixed a credential disclosure edge case.",
+    ].join("\n");
+
+    expect(buildReleaseNotesPresentation(notes)?.featuredMarkdown).toBe(
+      "## Security notes\n\n- Fixed a credential disclosure edge case.",
+    );
+  });
+
+  it("ends a featured section when another document title starts", () => {
+    const notes = [
+      "## Highlights",
+      "",
+      "- Visible release change.",
+      "",
+      "# Embedded legacy changelog",
+      "",
+      "- Must stay out of the featured preview.",
+      "",
+      "## Security",
+      "",
+      "- Visible security change.",
+    ].join("\n");
+
+    const featured = buildReleaseNotesPresentation(notes)?.featuredMarkdown ?? "";
+
+    expect(featured).toContain("Visible release change.");
+    expect(featured).toContain("Visible security change.");
+    expect(featured).not.toContain("Embedded legacy changelog");
+    expect(featured).not.toContain("Must stay out of the featured preview.");
+  });
+
+  it("bounds malformed legacy highlight sections without losing the full notes", () => {
+    const longItem = `[Long linked change](https://example.com/details) ${"detail ".repeat(60)}`;
+    const notes = [
+      "## Highlights",
+      "",
+      `- ${longItem}`,
+      "- Change two.",
+      "- Change three.",
+      "- Change four.",
+      "- Change five.",
+      "- Change six.",
+      "- Change seven.",
+    ].join("\n");
+
+    const presentation = buildReleaseNotesPresentation(notes);
+
+    expect(presentation?.featuredMarkdown).toContain("Long linked change detail");
+    expect(presentation?.featuredMarkdown).not.toContain("https://example.com/details");
+    expect(presentation?.featuredMarkdown).toContain("Change six.");
+    expect(presentation?.featuredMarkdown).not.toContain("Change seven.");
+    expect(Array.from(presentation?.featuredMarkdown ?? "").length).toBeLessThan(500);
+    expect(presentation?.fullMarkdown).toContain(longItem);
+    expect(presentation?.fullMarkdown).toContain("Change seven.");
+    expect(presentation?.hasAdditionalDetails).toBe(true);
+  });
+
+  it("uses the first three list items as a concise legacy fallback", () => {
+    const notes = [
+      "# Changelog",
+      "",
+      "```md",
+      "- Ignore this example.",
+      "```",
+      "",
+      "## Changes",
+      "",
+      "- First shipped change.",
+      "- Second shipped change.",
+      "- Third shipped change.",
+      "- Fourth shipped change.",
+    ].join("\n");
+
+    const presentation = buildReleaseNotesPresentation(notes);
+
+    expect(presentation?.featuredMarkdown).toBe(
+      [
+        "## Changes at a glance",
+        "",
+        "- First shipped change.",
+        "- Second shipped change.",
+        "- Third shipped change.",
+      ].join("\n"),
+    );
+    expect(presentation?.featuredMarkdown).not.toContain("Ignore this example");
+    expect(presentation?.featuredMarkdown).not.toContain("Fourth shipped change");
+    expect(presentation?.fullMarkdown).toBe(notes);
+    expect(presentation?.hasAdditionalDetails).toBe(true);
+  });
+
+  it("falls back to a bounded plain-text paragraph when legacy notes have no list", () => {
+    const longParagraph = `Read the [release guide](https://example.com/releases) before ${"continuing ".repeat(50)}`;
+    const presentation = buildReleaseNotesPresentation(`# Changelog\n\n${longParagraph}`);
+
+    expect(
+      presentation?.featuredMarkdown.startsWith(
+        "## Changes at a glance\n\nRead the release guide before continuing",
+      ),
+    ).toBe(true);
+    expect(presentation?.featuredMarkdown).not.toContain("https://example.com");
+    expect(Array.from(presentation?.featuredMarkdown ?? "").length).toBeLessThan(360);
+    expect(presentation?.featuredMarkdown.endsWith("…")).toBe(true);
+  });
+
+  it("omits the disclosure when the concise notes are already the complete notes", () => {
+    const notes = "## Highlights\n\n- One focused improvement.";
+
+    expect(buildReleaseNotesPresentation(notes)).toEqual({
+      featuredMarkdown: notes,
+      fullMarkdown: notes,
+      hasAdditionalDetails: false,
+    });
+  });
+
+  it("returns null for empty notes", () => {
+    expect(buildReleaseNotesPresentation(" \n\t ")).toBeNull();
+  });
+});

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -52,7 +52,7 @@ export function buildReleaseNotesPresentation(content: string): ReleaseNotesPres
 }
 
 function levelTwoSections(content: string): MarkdownSection[] {
-  const lines = content.split(/\r?\n/);
+  const lines = content.replace(/\r\n?/g, "\n").split("\n");
   const sections: MarkdownSection[] = [];
   let activeHeading = "";
   let activeStart = -1;
@@ -212,7 +212,7 @@ function truncateAtWord(value: string, limit: number): string {
 }
 
 function markdownOutsideFences(content: string): string {
-  const lines = content.split(/\r?\n/);
+  const lines = content.replace(/\r\n?/g, "\n").split("\n");
   const visibleLines: string[] = [];
   let fence: { character: "`" | "~"; length: number } | null = null;
 

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -1,0 +1,249 @@
+import { markdownToPlainText, parseMarkdownBlocks } from "./markdown";
+
+const LEGACY_ITEM_LIMIT = 3;
+const LEGACY_PARAGRAPH_LIMIT = 320;
+const FEATURED_INLINE_LIMIT = 240;
+
+const FEATURED_SECTION_ORDER = ["highlights", "security", "breaking"] as const;
+const FEATURED_ITEM_LIMIT: Record<FeaturedSectionKind, number> = {
+  highlights: 6,
+  security: 3,
+  breaking: 3,
+};
+
+type FeaturedSectionKind = (typeof FEATURED_SECTION_ORDER)[number];
+
+type MarkdownSection = {
+  heading: string;
+  markdown: string;
+};
+
+export type ReleaseNotesPresentation = {
+  featuredMarkdown: string;
+  fullMarkdown: string;
+  hasAdditionalDetails: boolean;
+};
+
+/**
+ * Select the release information an operator needs before updating while
+ * preserving the complete publisher-authored Markdown for explicit review.
+ */
+export function buildReleaseNotesPresentation(content: string): ReleaseNotesPresentation | null {
+  const fullMarkdown = content.trim();
+  if (!fullMarkdown) return null;
+
+  const selectedSections = new Map<FeaturedSectionKind, MarkdownSection>();
+  for (const section of levelTwoSections(fullMarkdown)) {
+    const kind = featuredSectionKind(section.heading);
+    if (kind && !selectedSections.has(kind)) selectedSections.set(kind, section);
+  }
+
+  const featuredMarkdown = FEATURED_SECTION_ORDER.flatMap((kind) => {
+    const section = selectedSections.get(kind);
+    return section ? [conciseFeaturedSection(section, FEATURED_ITEM_LIMIT[kind])] : [];
+  }).join("\n\n");
+  const preview = featuredMarkdown || legacyReleaseNotesPreview(fullMarkdown);
+
+  return {
+    featuredMarkdown: preview,
+    fullMarkdown,
+    hasAdditionalDetails: comparableMarkdown(preview) !== comparableMarkdown(fullMarkdown),
+  };
+}
+
+function levelTwoSections(content: string): MarkdownSection[] {
+  const lines = content.split(/\r?\n/);
+  const sections: MarkdownSection[] = [];
+  let activeHeading = "";
+  let activeStart = -1;
+  let fence: { character: "`" | "~"; length: number } | null = null;
+
+  const finishSection = (end: number) => {
+    if (activeStart < 0) return;
+    const markdown = lines.slice(activeStart, end).join("\n").trim();
+    if (markdown) sections.push({ heading: activeHeading, markdown });
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const fenceMatch = /^\s*(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fence) {
+      if (
+        fenceMatch &&
+        fenceMatch[1][0] === fence.character &&
+        fenceMatch[1].length >= fence.length &&
+        fenceMatch[2].trim() === ""
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+    if (fenceMatch) {
+      fence = {
+        character: fenceMatch[1][0] as "`" | "~",
+        length: fenceMatch[1].length,
+      };
+      continue;
+    }
+
+    const headingMatch = /^ {0,3}(#{1,2})(?!#)[\t ]+(.+)$/.exec(line);
+    if (!headingMatch) continue;
+    finishSection(index);
+    activeStart = -1;
+    activeHeading = "";
+    if (headingMatch[1].length === 1) continue;
+    activeHeading = headingMatch[2].replace(/[\t ]+#+[\t ]*$/, "").trim();
+    activeStart = index;
+  }
+
+  finishSection(lines.length);
+  return sections;
+}
+
+function featuredSectionKind(heading: string): FeaturedSectionKind | null {
+  const normalized = heading
+    .toLocaleLowerCase("en-US")
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+  if (normalized === "highlights") return "highlights";
+  if (normalized === "security" || normalized === "security notes") return "security";
+  if (
+    normalized === "breaking" ||
+    normalized === "breaking changes" ||
+    normalized === "breaking and risky changes" ||
+    normalized === "breaking or risky changes"
+  ) {
+    return "breaking";
+  }
+  return null;
+}
+
+function conciseFeaturedSection(section: MarkdownSection, itemLimit: number): string {
+  const blocks = parseMarkdownBlocks(markdownOutsideFences(section.markdown));
+  const paragraph = blocks.find((block) => block.type === "p");
+  const items: string[] = [];
+
+  for (const block of blocks) {
+    if (block.type === "ul" || block.type === "ol") {
+      for (const item of block.items ?? []) {
+        if (item.trim()) items.push(boundedInlineMarkdown(item.trim()));
+        if (items.length === itemLimit) break;
+      }
+    } else if (block.type === "task") {
+      for (const task of block.tasks ?? []) {
+        if (task.text.trim()) {
+          items.push(`[${task.checked ? "x" : " "}] ${boundedInlineMarkdown(task.text.trim())}`);
+        }
+        if (items.length === itemLimit) break;
+      }
+    }
+    if (items.length === itemLimit) break;
+  }
+
+  const content: string[] = [`## ${section.heading}`];
+  if (paragraph) {
+    const paragraphMarkdown = paragraph.text.trim();
+    const paragraphCharacters = Array.from(paragraphMarkdown);
+    content.push(
+      "",
+      paragraphCharacters.length <= FEATURED_INLINE_LIMIT
+        ? paragraphMarkdown
+        : truncateAtWord(markdownToPlainText(paragraphMarkdown), FEATURED_INLINE_LIMIT),
+    );
+  }
+  if (items.length > 0) content.push("", ...items.map((item) => `- ${item}`));
+  if (!paragraph && items.length === 0) {
+    content.push("", "Review this section in the full release notes.");
+  }
+  return content.join("\n");
+}
+
+function boundedInlineMarkdown(value: string): string {
+  if (Array.from(value).length <= FEATURED_INLINE_LIMIT) return value;
+  return truncateAtWord(markdownToPlainText(value), FEATURED_INLINE_LIMIT);
+}
+
+function legacyReleaseNotesPreview(content: string): string {
+  const blocks = parseMarkdownBlocks(markdownOutsideFences(content));
+  const items: string[] = [];
+
+  for (const block of blocks) {
+    if (block.type === "ul" || block.type === "ol") {
+      for (const item of block.items ?? []) {
+        if (item.trim()) items.push(boundedInlineMarkdown(item.trim()));
+        if (items.length === LEGACY_ITEM_LIMIT) break;
+      }
+    } else if (block.type === "task") {
+      for (const task of block.tasks ?? []) {
+        if (task.text.trim()) {
+          items.push(`[${task.checked ? "x" : " "}] ${boundedInlineMarkdown(task.text.trim())}`);
+        }
+        if (items.length === LEGACY_ITEM_LIMIT) break;
+      }
+    }
+    if (items.length === LEGACY_ITEM_LIMIT) break;
+  }
+
+  if (items.length > 0) {
+    return ["## Changes at a glance", "", ...items.map((item) => `- ${item}`)].join("\n");
+  }
+
+  const paragraph = blocks.find((block) => block.type === "p");
+  if (paragraph) {
+    const plainText = markdownToPlainText(paragraph.text).replace(/\s+/g, " ").trim();
+    if (plainText) {
+      return `## Changes at a glance\n\n${truncateAtWord(plainText, LEGACY_PARAGRAPH_LIMIT)}`;
+    }
+  }
+
+  return "## Release details\n\nOpen the full release notes to review this update.";
+}
+
+function truncateAtWord(value: string, limit: number): string {
+  const characters = Array.from(value);
+  if (characters.length <= limit) return value;
+  const candidate = characters.slice(0, limit).join("");
+  const wordBoundary = candidate.lastIndexOf(" ");
+  const shortened =
+    wordBoundary >= Math.floor(limit * 0.6) ? candidate.slice(0, wordBoundary) : candidate;
+  return `${shortened.trimEnd()}…`;
+}
+
+function markdownOutsideFences(content: string): string {
+  const lines = content.split(/\r?\n/);
+  const visibleLines: string[] = [];
+  let fence: { character: "`" | "~"; length: number } | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = /^\s*(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fence) {
+      if (
+        fenceMatch &&
+        fenceMatch[1][0] === fence.character &&
+        fenceMatch[1].length >= fence.length &&
+        fenceMatch[2].trim() === ""
+      ) {
+        fence = null;
+      }
+      visibleLines.push("");
+      continue;
+    }
+    if (fenceMatch) {
+      fence = {
+        character: fenceMatch[1][0] as "`" | "~",
+        length: fenceMatch[1].length,
+      };
+      visibleLines.push("");
+      continue;
+    }
+    visibleLines.push(line);
+  }
+
+  return visibleLines.join("\n");
+}
+
+function comparableMarkdown(value: string): string {
+  return value.replace(/\r\n?/g, "\n").trim();
+}


### PR DESCRIPTION
## What changed

- replace the updater's raw release-note dump with a calm, bounded preview: Highlights first, then Security and Breaking changes when present
- keep the complete reviewed Markdown behind progressive disclosure in the native update dialog
- label the actions clearly as **Update and restart** and **Later**
- require every release to provide a tracked, curated notes file with `--notes`
- validate the release-note structure and reject lightweight tags, version-only notes, template placeholders, and unreviewed generated commit lists
- preserve the exact reviewed Markdown bytes from the final release commit through the annotated tag and GitHub release
- pin the tag and branch publication to the stamped commit and push them atomically
- reject release tags that are not contained in the current `origin/master` before any mobile or packaging job starts
- document failure cleanup as separate GitHub Release/tag and GHCR recovery operations
- add release tooling, parser, UI, accessibility, and workflow guard coverage

## Why

Update prompts should answer “what matters to me?” in a few seconds. Raw commit lists are noisy, inconsistent, and can hide security or breaking changes. The release pipeline now treats reviewed operator-facing notes as a required artifact rather than optional decoration.

## User impact

- update dialogs lead with concise product changes instead of implementation detail
- security and breaking changes cannot be buried below a long changelog
- full technical notes remain available without making the first screen overwhelming
- release authors get a checked template and actionable validation errors before a tag is created

## Validation

- UI unit suite (2,729 tests: 2,724 full-suite pass plus 5 focused line-ending regressions)
- focused Markdown/release-note UI suite (47 tests)
- UI typecheck, lint, format check, and production build
- release tooling suite (38 tests)
- release-workflow guard
- local end-to-end release simulation against a temporary Git remote, including isolated stamp publication, hidden version-file rejection, and hidden local stamp-script deletion
- agent-docs check
- Action workflow lint
- docs format and local-link checks
- `git diff --check`

## Review

Three independent exact-head subagent reviews found no remaining issues after the Markdown compatibility, release-publication race/cleanup, notes-provenance, and canonical-path fixes.
