### PR TITLE
Prepare v0.6.0 release notes

### DIFF
--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,39 @@
+# Hecate v0.6.0
+
+This release makes desktop updates and Hecate Cloud sign-in calmer and more
+trustworthy, with clearer operator-facing release information.
+
+## Highlights
+
+- Desktop updates now lead with curated highlights and keep full notes on demand.
+- Update actions are now **Update and restart** or **Later**.
+- macOS restores Cloud credentials without surprise Keychain password prompts.
+- Release and debug builds use separate credential identities.
+- The website now explains the operator workflow and fits compact screens.
+- Release publication now binds reviewed notes, versions, signatures, and artifacts.
+
+## Security
+
+- Linux desktop builds backport the upstream GLib `VariantStrIter` soundness fix while Tauri 2 remains on GTK3.
+- Background macOS credential restore and cleanup cannot request Keychain UI.
+- Release CI verifies app identity and updater signatures before publishing.
+
+## Breaking or risky changes
+
+- macOS Cloud credentials now use the `sh.hecate.app.cloud.v2` Keychain service.
+- After updating, sign in once in the browser; incompatible legacy items are not opened.
+- No runtime API, operator configuration, or storage migration is required.
+- Maintainers must use a stable tag and canonical `--notes` file; prerelease tags are rejected.
+
+## Verification
+
+- Release gate: `just verify`.
+- Merged changes passed the required Go, Rust, TypeScript, browser, Docker, unsigned mobile compile, and desktop bundle CI checks.
+
+## Known limitations
+
+- Hecate remains pre-1.0. Review the tracked [known limitations](https://github.com/hecatehq/hecate/blob/master/docs/operator/known-limitations.md) and back up persistent data before upgrading.
+- A desktop connection requires Hecate to remain open; the mobile app cannot wake a Mac or launch its desktop app.
+- Owners and admins can start a stopped Cloud-managed hosted runtime; manually registered runtimes still require their operator.
+- macOS Apple Silicon is launch-tested; Linux and Windows desktop bundles are CI-built but remain experimental.
+- Mobile jobs validate compilation; they do not produce App Store or Google Play packages.


### PR DESCRIPTION
Adds the canonical operator-facing v0.6.0 release notes required before the public tag can be cut. The notes cover the updater, macOS credential migration, release integrity checks, website refresh, verification, and current platform limitations.