### PR TITLE
fix(desktop): show only controllable Hecate instances

### DIFF
--- a/docs/operator/desktop-app.md
+++ b/docs/operator/desktop-app.md
@@ -116,17 +116,18 @@ What works:
   access. Turning Remote access off preserves the signed-in account; signing
   out revokes the app session and computer registration. New registrations use
   the operating system hostname unless `HECATE_DESKTOP_HOST_NAME` overrides it.
-- The same section lists **Other Hecate instances** available to the signed-in
-  account: hosted runtimes and the owner's other registered computers. The
-  current computer appears only in **Remote access for this computer** and
-  cannot be opened through Cloud back into itself. A computer with remote
-  access off remains visible but cannot be opened. A Cloud-managed stopped
-  runtime can be started from the list. Opening an available entry creates a
-  short-lived browser session and shows that runtime's normal Hecate UI in a
-  separate window of the same native app. It does not launch or install a
-  second Hecate app. Chats, Tasks, and Projects created there remain owned by
-  that selected runtime; opening it is remote supervision, not process,
-  workspace, or session migration.
+- The same section has an **Open another Hecate** picker. It contains only
+  controllable targets: reachable remote-access computers, hosted runtimes
+  that are online or starting, and stopped hosted runtimes that Cloud can
+  start. The current computer appears only in **Remote access for this
+  computer** and cannot be opened through Cloud back into itself. Offline or
+  disabled computer registrations stay out of the picker until they become
+  reachable, so an old host record never looks actionable. Opening an
+  available entry creates a short-lived browser session and shows that
+  runtime's normal Hecate UI in a separate window of the same native app. It
+  does not launch or install a second Hecate app. Chats, Tasks, and Projects
+  created there remain owned by that selected runtime; opening it is remote
+  supervision, not process, workspace, or session migration.
 - A remote runtime window is incognito and receives no Tauri command
   capability. The native layer keeps the Cloud account bearer, one-time
   bootstrap URL, desktop relay ticket, and server-authored navigation paths out
@@ -139,6 +140,10 @@ What works:
   browser-local state, including unsent drafts or queued prompts, but admitted
   work continues on the selected runtime. Signing out or native account expiry
   closes every remote runtime window and invalidates its parent Cloud session.
+- **Settings** in a remote runtime window starts with a **Controlled instance**
+  context rather than rendering the opening desktop's Cloud controls. Host-local
+  Cloud connection and plugin-registry controls are intentionally hidden there;
+  maintenance actions continue to operate on the controlled runtime itself.
 - Phone and remote-browser requests execute against this same running Hecate
   and its laptop-local projects, chats, Task Runs, providers, and External
   Agents. Hecate does not copy that state into Cloud or move a live process to

--- a/tauri/src-tauri/src/desktop/cloud_connection.rs
+++ b/tauri/src-tauri/src/desktop/cloud_connection.rs
@@ -721,7 +721,7 @@ impl CloudConnectionSupervisor {
             .await;
         self.ensure_authorized_generation(generation)?;
         let current_host_id = self.current_host_id()?;
-        let connections = without_current_desktop_host(connections, current_host_id.as_deref());
+        let connections = controllable_runtime_connections(connections, current_host_id.as_deref());
         Ok(connections)
     }
 
@@ -2467,13 +2467,28 @@ fn is_current_desktop_host(
         && current_host_id.is_some_and(|host_id| host_id == connection.id)
 }
 
-fn without_current_desktop_host(
+fn is_controllable_runtime_connection(connection: &CloudRuntimeConnection) -> bool {
+    match connection.kind.as_str() {
+        // A stopped hosted runtime remains useful when Cloud can start it. A
+        // registered desktop host does not: the desktop app cannot wake it.
+        "hosted_runtime" => {
+            connection.reachable || connection.status == "starting" || connection.can_start
+        }
+        "desktop_host" => connection.reachable && connection.remote_enabled,
+        _ => false,
+    }
+}
+
+fn controllable_runtime_connections(
     connections: Vec<CloudRuntimeConnection>,
     current_host_id: Option<&str>,
 ) -> Vec<CloudRuntimeConnection> {
     connections
         .into_iter()
-        .filter(|connection| !is_current_desktop_host(connection, current_host_id))
+        .filter(|connection| {
+            !is_current_desktop_host(connection, current_host_id)
+                && is_controllable_runtime_connection(connection)
+        })
         .collect()
 }
 
@@ -5413,17 +5428,49 @@ mod tests {
     }
 
     #[test]
-    fn current_desktop_host_is_omitted_without_guessing_from_its_name() {
+    fn runtime_picker_exposes_only_controllable_non_current_instances() {
         let runtime = hosted_runtime_connection();
+        let mut startable = runtime.clone();
+        startable.id = "runtime_startable".to_string();
+        startable.name = "Startable".to_string();
+        startable.status = "offline".to_string();
+        startable.reachable = false;
+        startable.can_start = true;
+
+        let mut stopped = startable.clone();
+        stopped.id = "runtime_stopped".to_string();
+        stopped.name = "Stopped".to_string();
+        stopped.can_start = false;
+
         let mut current = runtime.clone();
         current.id = "host_current".to_string();
         current.kind = "desktop_host".to_string();
         current.name = "Shared name".to_string();
+        current.remote_enabled = true;
         let mut other = current.clone();
         other.id = "host_other".to_string();
+        other.name = "Studio Mac".to_string();
 
-        let visible = without_current_desktop_host(
-            vec![runtime.clone(), current.clone(), other.clone()],
+        let mut stale = other.clone();
+        stale.id = "host_stale".to_string();
+        stale.name = "Mac.home".to_string();
+        stale.reachable = false;
+
+        let mut remote_off = other.clone();
+        remote_off.id = "host_remote_off".to_string();
+        remote_off.name = "Travel Mac".to_string();
+        remote_off.remote_enabled = false;
+
+        let visible = controllable_runtime_connections(
+            vec![
+                runtime.clone(),
+                startable.clone(),
+                stopped,
+                current.clone(),
+                other.clone(),
+                stale,
+                remote_off,
+            ],
             Some("host_current"),
         );
         assert_eq!(
@@ -5431,14 +5478,14 @@ mod tests {
                 .iter()
                 .map(|connection| connection.id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["runtime_1", "host_other"]
+            vec!["runtime_1", "runtime_startable", "host_other"]
         );
         assert!(is_current_desktop_host(&current, Some("host_current")));
         assert!(!is_current_desktop_host(&other, Some("host_current")));
         assert!(!is_current_desktop_host(&runtime, Some("runtime_1")));
-
-        let unfiltered = without_current_desktop_host(vec![runtime, current, other], None);
-        assert_eq!(unfiltered.len(), 3);
+        assert!(is_controllable_runtime_connection(&runtime));
+        assert!(is_controllable_runtime_connection(&startable));
+        assert!(is_controllable_runtime_connection(&current));
     }
 
     #[test]

--- a/ui/e2e/remote-settings.spec.ts
+++ b/ui/e2e/remote-settings.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "./fixtures";
+
+test("renders remote Settings as controlled-instance context without host-local panels", async ({
+  page,
+}) => {
+  await page.route("/hecate/v1/whoami", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        object: "session",
+        data: {
+          role: "operator",
+          runtime_host: {
+            id: "runtime_dogfood",
+            label: "Dogfood Runtime",
+            runtime_mode: "remote_runtime",
+            operator_access: "remote_supervision",
+            local_only_actions_available: false,
+          },
+          remote_identity: {
+            actor_id: "operator_1",
+            org_id: "org_1",
+            project_id: "project_1",
+            runtime_id: "runtime_dogfood",
+          },
+        },
+      }),
+    }),
+  );
+
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+  await page.locator(".hecate-activitybar [aria-label^='Settings']").click();
+
+  await expect(page.getByTestId("remote-runtime-settings")).toBeVisible();
+  await expect(page.getByText("Controlled instance")).toBeVisible();
+  await expect(page.getByText(/This window supervises Dogfood Runtime/i)).toBeVisible();
+  await expect(
+    page.getByText(/Host-local controls, including Hecate Cloud connection/i),
+  ).toBeVisible();
+  await expect(page.getByText(/Clean up old runtime data on Dogfood Runtime/i)).toBeVisible();
+  await expect(page.getByText("Plugins", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("Hecate Cloud", { exact: true })).toHaveCount(0);
+});

--- a/ui/src/features/settings/DesktopCloudSettings.tsx
+++ b/ui/src/features/settings/DesktopCloudSettings.tsx
@@ -13,12 +13,11 @@ import {
   type DesktopCloudConnectionStatus,
   type DesktopCloudRuntimeConnection,
 } from "../../lib/cloud-connection";
-import { formatRelativeTime } from "../../lib/runtime-utils";
-import { Badge, Icon, Icons, InlineError, Toggle } from "../shared/ui";
+import { DropdownPicker, Icon, Icons, InlineError, Toggle } from "../shared/ui";
 import { SettingsSectionHeader as SectionHeader } from "./SettingsSectionHeader";
 
-export function DesktopCloudSettings() {
-  if (!canUseDesktopCloudConnection()) return null;
+export function DesktopCloudSettings({ remoteRuntime = false }: { remoteRuntime?: boolean }) {
+  if (remoteRuntime || !canUseDesktopCloudConnection()) return null;
   return <DesktopCloudConnectionSettings />;
 }
 
@@ -316,6 +315,7 @@ function DesktopCloudRuntimeSettings({
   const [busy, setBusy] = useState<{ connectionID: string; action: "start" | "open" } | null>(null);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
+  const [selectedConnectionID, setSelectedConnectionID] = useState("");
   const requestGenerationRef = useRef(0);
   const requestInFlightRef = useRef<Promise<void> | null>(null);
   const mutationInFlightRef = useRef(false);
@@ -353,6 +353,11 @@ function DesktopCloudRuntimeSettings({
       requestGenerationRef.current += 1;
     };
   }, [loadConnections]);
+
+  useEffect(() => {
+    if (connections.some((connection) => connection.id === selectedConnectionID)) return;
+    setSelectedConnectionID(connections[0]?.id ?? "");
+  }, [connections, selectedConnectionID]);
 
   const hasStartingConnection = connections.some(
     (connection) => connection.kind === "hosted_runtime" && connection.status === "starting",
@@ -410,16 +415,51 @@ function DesktopCloudRuntimeSettings({
     }
   }
 
+  const selectedConnection = connections.find(
+    (connection) => connection.id === selectedConnectionID,
+  );
+  const selectedAction = selectedConnection
+    ? selectedConnection.kind === "hosted_runtime" &&
+      !selectedConnection.reachable &&
+      selectedConnection.can_start
+      ? "start"
+      : selectedConnection.reachable
+        ? "open"
+        : null
+    : null;
+  const selectedStatus = selectedConnection ? connectionPickerStatus(selectedConnection) : null;
+  let selectedBusyAction: "start" | "open" | null = null;
+  if (
+    busy !== null &&
+    selectedConnection !== undefined &&
+    busy.connectionID === selectedConnection.id
+  ) {
+    selectedBusyAction = busy.action;
+  }
+  const actionLabel =
+    selectedConnection?.status === "starting"
+      ? "Starting…"
+      : selectedAction === "start"
+        ? `Start ${selectedConnection?.name}`
+        : selectedAction === "open"
+          ? `Open ${selectedConnection?.name}`
+          : "Choose an instance";
+
+  async function actOnSelectedConnection() {
+    if (!selectedConnection || !selectedAction) return;
+    if (selectedAction === "start") {
+      await startConnection(selectedConnection);
+      return;
+    }
+    await openConnection(selectedConnection);
+  }
+
   return (
     <section style={{ marginBottom: 20 }} data-testid="desktop-cloud-runtimes">
       <SectionHeader
-        title="Other Hecate instances"
-        description="Hosted runtimes and your other computers. Each opens in its own Hecate window."
-        meta={
-          loading
-            ? undefined
-            : `${connections.length} instance${connections.length === 1 ? "" : "s"}`
-        }
+        title="Open another Hecate"
+        description="Choose a runtime Hecate can open now or start for you. Each opens in its own Hecate window."
+        meta={loading ? undefined : `${connections.length} available`}
         actions={
           <button
             className="btn btn-ghost btn-sm"
@@ -432,24 +472,61 @@ function DesktopCloudRuntimeSettings({
       />
       <div className="card" style={{ overflow: "hidden" }}>
         {loading ? (
-          <CloudMessage>Loading other Hecate instances…</CloudMessage>
+          <CloudMessage>Loading controllable Hecate instances…</CloudMessage>
         ) : connections.length === 0 && !error ? (
           <CloudMessage>
-            No other runtimes or computers are available for this account.
+            No reachable computers or startable hosted runtimes are available for this account.
           </CloudMessage>
         ) : (
-          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-            {connections.map((connection, index) => (
-              <CloudRuntimeConnectionRow
-                key={connection.id}
-                connection={connection}
-                busy={busy}
-                last={index === connections.length - 1}
-                onOpen={openConnection}
-                onStart={startConnection}
+          <div style={{ padding: "15px 20px", display: "grid", gap: 10 }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <span style={{ color: "var(--t0)", fontSize: 13, fontWeight: 650 }}>
+                Controlled instance
+              </span>
+              <span style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.45 }}>
+                Offline or disabled computers stay out of this picker until they can be opened.
+              </span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+              <DropdownPicker
+                ariaLabel="Controlled instance"
+                menuMinWidth={300}
+                onChange={setSelectedConnectionID}
+                options={connections.map((connection) => {
+                  const status = connectionPickerStatus(connection);
+                  return {
+                    value: connection.id,
+                    label: connection.name,
+                    detail: connectionPickerDetail(connection),
+                    statusLabel: status.label,
+                    statusColor: status.color,
+                  };
+                })}
+                placeholder="Choose instance"
+                searchable={connections.length > 6}
+                searchPlaceholder="Filter instances"
+                triggerMinWidth={220}
+                value={selectedConnectionID}
               />
-            ))}
-          </ul>
+              <button
+                className="btn btn-primary btn-sm"
+                disabled={busy !== null || selectedAction === null}
+                onClick={() => void actOnSelectedConnection()}
+                type="button"
+              >
+                {selectedBusyAction
+                  ? selectedBusyAction === "start"
+                    ? "Starting…"
+                    : "Opening…"
+                  : actionLabel}
+              </button>
+            </div>
+            {selectedConnection && selectedStatus && (
+              <div style={{ color: "var(--t3)", fontSize: 11, lineHeight: 1.45 }}>
+                {connectionPickerDetail(selectedConnection)} · {selectedStatus.description}
+              </div>
+            )}
+          </div>
         )}
         {(error || notice) && (
           <div style={{ padding: "0 20px 16px" }}>
@@ -467,104 +544,23 @@ function DesktopCloudRuntimeSettings({
   );
 }
 
-function CloudRuntimeConnectionRow({
-  busy,
-  connection,
-  last,
-  onOpen,
-  onStart,
-}: {
-  busy: { connectionID: string; action: "start" | "open" } | null;
-  connection: DesktopCloudRuntimeConnection;
-  last: boolean;
-  onOpen: (connection: DesktopCloudRuntimeConnection) => Promise<void>;
-  onStart: (connection: DesktopCloudRuntimeConnection) => Promise<void>;
-}) {
-  const lastSeen = connection.last_seen_at
-    ? formatRelativeTime(connection.last_seen_at)
-    : { label: "Not reported", iso: "" };
-  const connectionBusy = busy?.connectionID === connection.id;
-  const canStart =
-    connection.kind === "hosted_runtime" && !connection.reachable && connection.can_start;
-  const canOpen =
-    connection.reachable && (connection.kind === "hosted_runtime" || connection.remote_enabled);
-  const badge =
-    connection.status === "starting"
-      ? { status: "running", label: "starting" }
-      : connection.reachable
-        ? { status: "healthy", label: "online" }
-        : connection.kind === "desktop_host" && !connection.remote_enabled
-          ? { status: "disabled", label: "remote off" }
-          : connection.status === "failed"
-            ? { status: "failed", label: "failed" }
-            : { status: "disabled", label: connection.status };
+function connectionPickerDetail(connection: DesktopCloudRuntimeConnection): string {
+  const kind = connection.kind === "hosted_runtime" ? "Hosted runtime" : "Computer";
+  return connection.version ? `${kind} · ${connection.version}` : kind;
+}
 
-  return (
-    <li
-      style={{
-        padding: "15px 20px",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        gap: 20,
-        flexWrap: "wrap",
-        borderBottom: last ? undefined : "1px solid var(--border)",
-      }}
-    >
-      <div style={{ minWidth: 0 }}>
-        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-          <span style={{ color: "var(--t0)", fontSize: 13, fontWeight: 650 }}>
-            {connection.name}
-          </span>
-          <Badge status={badge.status} label={badge.label} />
-        </div>
-        <div
-          style={{
-            marginTop: 4,
-            color: "var(--t3)",
-            display: "flex",
-            gap: 8,
-            flexWrap: "wrap",
-            fontSize: 11,
-            lineHeight: 1.5,
-          }}
-        >
-          <span>{connection.kind === "hosted_runtime" ? "Hosted runtime" : "Computer"}</span>
-          {connection.version && <span>Version {connection.version}</span>}
-          <span>
-            Last seen{" "}
-            {lastSeen.iso ? (
-              <time dateTime={lastSeen.iso} title={lastSeen.iso}>
-                {lastSeen.label}
-              </time>
-            ) : (
-              lastSeen.label
-            )}
-          </span>
-        </div>
-      </div>
-      <div style={{ display: "flex", gap: 8, marginLeft: "auto" }}>
-        {canStart && (
-          <button
-            className="btn btn-ghost btn-sm"
-            disabled={busy !== null}
-            onClick={() => void onStart(connection)}
-          >
-            {connectionBusy && busy?.action === "start" ? "Starting…" : `Start ${connection.name}`}
-          </button>
-        )}
-        {canOpen && (
-          <button
-            className="btn btn-primary btn-sm"
-            disabled={busy !== null}
-            onClick={() => void onOpen(connection)}
-          >
-            {connectionBusy && busy?.action === "open" ? "Opening…" : `Open ${connection.name}`}
-          </button>
-        )}
-      </div>
-    </li>
-  );
+function connectionPickerStatus(connection: DesktopCloudRuntimeConnection): {
+  label: string;
+  color: string;
+  description: string;
+} {
+  if (connection.status === "starting") {
+    return { label: "starting", color: "var(--amber)", description: "Hecate Cloud is starting it" };
+  }
+  if (connection.reachable) {
+    return { label: "online", color: "var(--teal)", description: "Ready to open" };
+  }
+  return { label: "startable", color: "var(--amber)", description: "Hecate Cloud can start it" };
 }
 
 function CloudMessage({ children }: { children: string }) {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -154,10 +154,16 @@ describe("SettingsView", () => {
     expect(screen.getByText(/Unresolved auth: github_token/i)).toBeTruthy();
   });
 
-  it("does not probe local-only plugin registry in remote runtime mode", async () => {
+  it("shows controlled-instance context instead of host-local settings in remote runtime mode", async () => {
     const { state, actions } = setup({
       sessionInfo: {
         role: "operator",
+        runtime_host: createRuntimeHostFixture({
+          label: "Dogfood Runtime",
+          runtime_mode: "remote_runtime",
+          operator_access: "remote_supervision",
+          local_only_actions_available: false,
+        }),
         remote_identity: {
           actor_id: "actor_1",
           org_id: "org_1",
@@ -168,12 +174,15 @@ describe("SettingsView", () => {
     });
     render(withRuntimeConsole(<SettingsView />, { state, actions }));
 
-    expect(
-      screen.getByText(/Plugin registry inspection is available only from a local Hecate runtime/i),
-    ).toBeTruthy();
+    const context = screen.getByTestId("remote-runtime-settings");
+    expect(within(context).getByText("Controlled instance")).toBeTruthy();
+    expect(within(context).getByText(/This window supervises Dogfood Runtime/i)).toBeTruthy();
+    expect(within(context).getByText(/Host-local controls/i)).toBeTruthy();
     await waitFor(() => expect(getPlugins).not.toHaveBeenCalled());
-    expect(screen.queryByText(/The request was blocked/i)).toBeNull();
-    expect(screen.queryByRole("button", { name: /Refresh/i })).toBeNull();
+    expect(screen.queryByTestId("desktop-cloud-connection")).toBeNull();
+    expect(screen.queryByText("Plugins")).toBeNull();
+    expect(screen.getByText(/Clean up old runtime data on Dogfood Runtime/i)).toBeTruthy();
+    expect(screen.getByText("Reset remote runtime data unavailable")).toBeTruthy();
   });
 
   it("treats a forbidden plugin registry probe as local-only", async () => {
@@ -565,7 +574,7 @@ describe("SettingsView", () => {
     await waitFor(() => expect(screen.queryByTestId("desktop-cloud-runtimes")).toBeNull());
   });
 
-  it("lists other Hecate instances and starts or opens only eligible targets", async () => {
+  it("picks a controllable Hecate instance and omits stale computers", async () => {
     Reflect.set(window, "__TAURI_INTERNALS__", {});
     tauriInvokeMock.mockImplementation((command: string) => {
       if (command === "cloud_connection_status") {
@@ -667,26 +676,31 @@ describe("SettingsView", () => {
     render(withRuntimeConsole(<SettingsView />, { state, actions }));
 
     const section = await screen.findByTestId("desktop-cloud-runtimes");
-    expect(within(section).getByText("Other Hecate instances")).toBeTruthy();
+    expect(within(section).getByText("Open another Hecate")).toBeTruthy();
     expect(await within(section).findByText("Production")).toBeTruthy();
-    expect(within(section).getAllByText("Computer")).toHaveLength(2);
-    expect(within(section).getAllByText("Version 0.5.0-alpha.5")).toHaveLength(3);
+    const picker = within(section).getByRole("button", { name: "Controlled instance" });
+    await waitFor(() => expect(picker).toHaveTextContent("Production"));
     expect(within(section).getByRole("button", { name: "Open Production" })).toBeTruthy();
+
+    await user.click(picker);
+    expect(screen.getByRole("option", { name: /Production/i })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Staging/i })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Studio Mac/i })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: /Travel Mac/i })).toBeNull();
+    await user.click(screen.getByRole("option", { name: /Staging/i }));
     expect(within(section).getByRole("button", { name: "Start Staging" })).toBeTruthy();
-    expect(within(section).getByRole("button", { name: "Open Studio Mac" })).toBeTruthy();
-    expect(within(section).getByText("remote off")).toBeTruthy();
-    expect(within(section).queryByRole("button", { name: "Open Travel Mac" })).toBeNull();
-    expect(within(section).queryByRole("button", { name: "Start Travel Mac" })).toBeNull();
 
     await user.click(within(section).getByRole("button", { name: "Start Staging" }));
     expect(tauriInvokeMock).toHaveBeenCalledWith("cloud_runtime_start", {
       connectionId: "runtime_offline",
     });
-    expect(await within(section).findByText("starting")).toBeTruthy();
+    expect(await within(section).findByRole("button", { name: "Starting…" })).toBeTruthy();
     expect(within(section).getByRole("status")).toHaveTextContent(
       "Hecate Cloud is starting this runtime.",
     );
 
+    await user.click(picker);
+    await user.click(screen.getByRole("option", { name: /Production/i }));
     await user.click(within(section).getByRole("button", { name: "Open Production" }));
     expect(tauriInvokeMock).toHaveBeenCalledWith("cloud_runtime_open", {
       connectionId: "runtime_online",
@@ -759,13 +773,13 @@ describe("SettingsView", () => {
     await waitFor(() => expect(connectionReads).toBe(2));
 
     await user.click(start);
-    expect(await within(section).findByText("starting")).toBeTruthy();
+    expect(await within(section).findByRole("button", { name: "Starting…" })).toBeTruthy();
     await act(async () => {
       resolveStaleRefresh?.([offlineConnection]);
       await Promise.resolve();
     });
 
-    expect(within(section).getByText("starting")).toBeTruthy();
+    expect(within(section).getByRole("button", { name: "Starting…" })).toBeTruthy();
     expect(within(section).queryByRole("button", { name: "Start Staging" })).toBeNull();
   });
 

--- a/ui/src/features/settings/SettingsView.tsx
+++ b/ui/src/features/settings/SettingsView.tsx
@@ -20,6 +20,8 @@ export function SettingsView() {
   const loadRetentionRuns = retention.actions.loadRuns;
   const storageBackend = settings.state.config?.backend ?? "memory";
   const remoteRuntime = isRemoteRuntimeSession(runtime.state.sessionInfo);
+  const runtimeLabel =
+    runtime.state.sessionInfo?.runtime_host.label?.trim() || "this Hecate instance";
   const [plugins, setPlugins] = useState<PluginRecord[]>([]);
   const [pluginsLoading, setPluginsLoading] = useState(false);
   const [pluginsError, setPluginsError] = useState("");
@@ -71,15 +73,21 @@ export function SettingsView() {
   return (
     <div style={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
       <div className="settings-view__scroll" style={{ flex: 1, overflowY: "auto", padding: 16 }}>
-        <DesktopCloudSettings />
-        <PluginRegistrySettings
-          error={pluginsError}
-          loading={pluginsLoading}
-          plugins={plugins}
-          localOnly={remoteRuntime || pluginsLocalOnly}
-          onRefresh={() => void loadPlugins()}
-        />
+        <DesktopCloudSettings remoteRuntime={remoteRuntime} />
+        {remoteRuntime ? (
+          <RemoteRuntimeSettings runtimeLabel={runtimeLabel} />
+        ) : (
+          <PluginRegistrySettings
+            error={pluginsError}
+            loading={pluginsLoading}
+            plugins={plugins}
+            localOnly={pluginsLocalOnly}
+            onRefresh={() => void loadPlugins()}
+          />
+        )}
         <RetentionSettings
+          remoteRuntime={remoteRuntime}
+          runtimeLabel={runtimeLabel}
           storageBackend={storageBackend}
           state={retention.state}
           setRetentionSubsystems={retention.actions.setSubsystems}
@@ -87,6 +95,25 @@ export function SettingsView() {
         />
       </div>
     </div>
+  );
+}
+
+function RemoteRuntimeSettings({ runtimeLabel }: { runtimeLabel: string }) {
+  return (
+    <section style={{ marginBottom: 20 }} data-testid="remote-runtime-settings">
+      <SectionHeader
+        title="Controlled instance"
+        description={`This window supervises ${runtimeLabel}; work runs on that instance.`}
+        meta="remote"
+      />
+      <div
+        className="card"
+        style={{ padding: "14px 16px", color: "var(--t2)", fontSize: 12, lineHeight: 1.5 }}
+      >
+        Host-local controls, including Hecate Cloud connection and plugin registry inspection, are
+        managed from the desktop app that opened this window.
+      </div>
+    </section>
   );
 }
 
@@ -337,24 +364,30 @@ function relativeTime(iso: string): string {
 }
 
 function RetentionSettings({
+  remoteRuntime,
+  runtimeLabel,
   storageBackend,
   state,
   setRetentionSubsystems,
   runRetention,
 }: {
+  remoteRuntime: boolean;
+  runtimeLabel: string;
   storageBackend: string;
   state: RetentionState;
   setRetentionSubsystems: (value: string) => void;
   runRetention: () => Promise<void>;
 }) {
-  const resetTitle =
-    storageBackend === "memory"
+  const resetTitle = remoteRuntime
+    ? "Reset remote runtime data unavailable"
+    : storageBackend === "memory"
       ? "Reset runtime state unavailable"
       : storageBackend === "postgres"
         ? "Reset persisted data unavailable"
         : "Reset local data unavailable";
-  const resetDescription =
-    storageBackend === "memory"
+  const resetDescription = remoteRuntime
+    ? "In-process data reset is unavailable from a controlled runtime window."
+    : storageBackend === "memory"
       ? "Restart the runtime to clear Hecate-owned in-memory state. Stop the runtime and use the deployment procedure to clear persistent Cairnline project coordination."
       : storageBackend === "postgres"
         ? "Stop the runtime before clearing its configured Postgres state and any local Cairnline or bootstrap files with the deployment-specific procedure."
@@ -387,7 +420,11 @@ function RetentionSettings({
     <>
       <SectionHeader
         title="Maintenance"
-        description="Clean up old local runtime data. Hecate keeps durable configuration, provider credentials, and external-agent grants unless you remove them from Connections."
+        description={
+          remoteRuntime
+            ? `Clean up old runtime data on ${runtimeLabel}. Hecate keeps durable configuration, provider credentials, and external-agent grants unless you remove them from Connections.`
+            : "Clean up old local runtime data. Hecate keeps durable configuration, provider credentials, and external-agent grants unless you remove them from Connections."
+        }
         meta={`${runs.length} run${runs.length === 1 ? "" : "s"}`}
       />
 

--- a/ui/src/lib/cloud-connection.test.ts
+++ b/ui/src/lib/cloud-connection.test.ts
@@ -153,7 +153,7 @@ describe("desktop cloud connection bridge", () => {
 });
 
 describe("desktop cloud runtime bridge", () => {
-  it("normalizes the safe runtime connection projection", async () => {
+  it("normalizes only controllable runtime connections", async () => {
     Reflect.set(window, "__TAURI_INTERNALS__", {});
     invokeMock.mockResolvedValueOnce([
       {
@@ -172,14 +172,36 @@ describe("desktop cloud runtime bridge", () => {
         browser_open_path: "/must-not-cross-ipc",
       },
       {
-        id: "host_1",
+        id: "host_stale",
         kind: "desktop_host",
         org_id: "org_1",
-        name: "Studio Mac",
+        name: "Mac.home",
         status: "offline",
         reachable: false,
         can_start: false,
         remote_enabled: true,
+        capabilities: [],
+      },
+      {
+        id: "host_disabled",
+        kind: "desktop_host",
+        org_id: "org_1",
+        name: "Travel Mac",
+        status: "online",
+        reachable: true,
+        can_start: false,
+        remote_enabled: false,
+        capabilities: [],
+      },
+      {
+        id: "runtime_startable",
+        kind: "hosted_runtime",
+        org_id: "org_1",
+        name: "Dogfood Runtime",
+        status: "offline",
+        reachable: false,
+        can_start: true,
+        remote_enabled: false,
         capabilities: [],
       },
     ]);
@@ -200,15 +222,15 @@ describe("desktop cloud runtime bridge", () => {
         last_seen_at: "2026-07-31T12:00:00Z",
       },
       {
-        id: "host_1",
-        kind: "desktop_host",
+        id: "runtime_startable",
+        kind: "hosted_runtime",
         org_id: "org_1",
         project_id: null,
-        name: "Studio Mac",
+        name: "Dogfood Runtime",
         status: "offline",
         reachable: false,
-        can_start: false,
-        remote_enabled: true,
+        can_start: true,
+        remote_enabled: false,
         version: null,
         capabilities: [],
         last_seen_at: null,

--- a/ui/src/lib/cloud-connection.ts
+++ b/ui/src/lib/cloud-connection.ts
@@ -76,7 +76,21 @@ export async function getDesktopCloudRuntimeConnections(): Promise<
   if (!Array.isArray(value)) {
     throw new Error("Hecate Cloud returned an invalid connection list.");
   }
-  return value.map((connection) => normalizeRuntimeConnection(connection));
+  // New desktop shells filter this before crossing the native boundary. Keep
+  // the browser-side guard too so an older shell cannot offer stale registered
+  // computers that Hecate cannot open or start.
+  return value
+    .map((connection) => normalizeRuntimeConnection(connection))
+    .filter(isControllableDesktopCloudRuntimeConnection);
+}
+
+export function isControllableDesktopCloudRuntimeConnection(
+  connection: DesktopCloudRuntimeConnection,
+): boolean {
+  if (connection.kind === "hosted_runtime") {
+    return connection.reachable || connection.status === "starting" || connection.can_start;
+  }
+  return connection.reachable && connection.remote_enabled;
 }
 
 export async function startDesktopCloudRuntime(


### PR DESCRIPTION
## Summary
- replace the all-records Cloud instance list with a controlled-instance picker
- hide stale or disabled desktop-host registrations while retaining reachable, starting, and startable hosted runtimes
- make remote Settings describe the controlled runtime and omit host-local Cloud and plugin controls

## Verification
- `cd ui && bun run format:check`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run test`
- `cd ui && bun run test:e2e -- remote-settings.spec.ts`
- `just tauri-rust-test`
- `just docs-format-check`
- `just check-links`