### PR TITLE
fix(desktop): disable starts already in progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,11 @@ automatically. State lives in the platform data dir:
 - Windows: `%APPDATA%\sh.hecate.app\`
 - Linux: `~/.local/share/sh.hecate.app/`
 
-Open **Settings → Hecate Cloud** to sign in once, then use **Cloud instances**
-to start or open a hosted Hecate or a registered desktop Hecate in an isolated
-app window. Desktops with remote access off remain visible but cannot be
-opened. Account sign-in does not expose this computer: enable the separate
+Open **Settings → Hecate Cloud** to sign in once, then use **Open another
+Hecate** to start or open a controllable instance in an isolated app window.
+The picker shows reachable remote-access computers plus hosted runtimes that
+are online, starting, or startable; stale and disabled computer registrations
+stay hidden. Account sign-in does not expose this computer: enable the separate
 **Remote access** toggle only when you want phones, browsers, or other desktop
 apps to reach its local runtime. Installing the `hec` CLI is not required.
 Remote chats and tasks continue to execute on the selected runtime; Hecate does

--- a/ui/src/features/settings/DesktopCloudSettings.tsx
+++ b/ui/src/features/settings/DesktopCloudSettings.tsx
@@ -55,6 +55,17 @@ function DesktopCloudConnectionSettings() {
     return request;
   }, []);
 
+  const refreshStatusAfterCurrent = useCallback(async () => {
+    const observedGeneration = statusRequestGenerationRef.current;
+    const currentRequest = statusRequestInFlightRef.current;
+    if (currentRequest) await currentRequest;
+    // An instance request can discover an expired native session while the
+    // initial account snapshot is still settling. Re-read after that stale
+    // snapshot instead of letting request de-duplication hide the expiry.
+    if (observedGeneration !== statusRequestGenerationRef.current) return;
+    await loadStatus();
+  }, [loadStatus]);
+
   useEffect(() => {
     void loadStatus(true);
     return () => {
@@ -300,7 +311,9 @@ function DesktopCloudConnectionSettings() {
           )}
         </div>
       </section>
-      {signedIn && <DesktopCloudRuntimeSettings onAccountStatusRefresh={loadStatus} />}
+      {signedIn && (
+        <DesktopCloudRuntimeSettings onAccountStatusRefresh={refreshStatusAfterCurrent} />
+      )}
     </>
   );
 }
@@ -421,6 +434,7 @@ function DesktopCloudRuntimeSettings({
   const selectedAction = selectedConnection
     ? selectedConnection.kind === "hosted_runtime" &&
       !selectedConnection.reachable &&
+      selectedConnection.status !== "starting" &&
       selectedConnection.can_start
       ? "start"
       : selectedConnection.reachable

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -625,6 +625,20 @@ describe("SettingsView", () => {
             last_seen_at: null,
           },
           {
+            id: "runtime_starting",
+            kind: "hosted_runtime",
+            org_id: "org_1",
+            project_id: null,
+            name: "Canary",
+            status: "starting",
+            reachable: false,
+            can_start: true,
+            remote_enabled: false,
+            version: null,
+            capabilities: [],
+            last_seen_at: null,
+          },
+          {
             id: "host_online",
             kind: "desktop_host",
             org_id: "org_1",
@@ -685,8 +699,19 @@ describe("SettingsView", () => {
     await user.click(picker);
     expect(screen.getByRole("option", { name: /Production/i })).toBeTruthy();
     expect(screen.getByRole("option", { name: /Staging/i })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Canary/i })).toBeTruthy();
     expect(screen.getByRole("option", { name: /Studio Mac/i })).toBeTruthy();
     expect(screen.queryByRole("option", { name: /Travel Mac/i })).toBeNull();
+
+    await user.click(screen.getByRole("option", { name: /Canary/i }));
+    const starting = within(section).getByRole("button", { name: "Starting…" });
+    expect(starting).toBeDisabled();
+    await user.click(starting);
+    expect(tauriInvokeMock).not.toHaveBeenCalledWith("cloud_runtime_start", {
+      connectionId: "runtime_starting",
+    });
+
+    await user.click(picker);
     await user.click(screen.getByRole("option", { name: /Staging/i }));
     expect(within(section).getByRole("button", { name: "Start Staging" })).toBeTruthy();
 

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -839,8 +839,8 @@ describe("SettingsView", () => {
     const { state, actions } = setup();
     render(withRuntimeConsole(<SettingsView />, { state, actions }));
 
+    await waitFor(() => expect(statusReads).toBe(2));
     expect(await screen.findByRole("button", { name: "Sign in to Hecate Cloud" })).toBeTruthy();
-    expect(statusReads).toBe(2);
     expect(screen.queryByTestId("desktop-cloud-runtimes")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- disable the controlled-instance Start action while a hosted runtime is already starting
- refresh account state after an instance request races the initial Cloud status load
- document the controllable-instance picker in the README

## Verification
- `cd ui && bun run test -- features/settings/SettingsView.test.tsx`
- `cd ui && bun run typecheck`
- `cd ui && bun run lint`
- `cd ui && bun run format:check`
- `just docs-format-check`
- `just check-links`

`cd ui && bun run test` also reproduces two pre-existing failures outside this diff on current master: ChatView workspace-diff timeout and ProjectsView Add-assignment lookup. The focused Settings suite passes.