### PR TITLE
fix(external-agents): auto-check readiness and clarify work policies

### DIFF
--- a/docs/design/accepted/external-agent-integrations.md
+++ b/docs/design/accepted/external-agent-integrations.md
@@ -184,23 +184,23 @@ DELETE /hecate/v1/chat/grants/{grant_id}
 ```
 
 The catalog and compatibility health `GET` endpoints are passive: they may
-resolve and inspect an executable path but must not execute it. The explicit
-`POST /agent-adapters/{id}/probe` endpoint is an optional, disposable
-diagnostic boundary that starts a temporary ACP runtime and performs a
-handshake without sending a prompt. Its provider-specific version or auth
-detection may execute the discovered app. Creating an External Agent chat is
-the independent real-session boundary: it resolves the current app and performs
-a fresh ACP handshake whether or not a diagnostic ran. Direct ACP peers launch
-during that setup. Embedded bridges may run bounded provider discovery during
-setup while deferring their prompt-serving vendor invocation and prompt-time
-auth result until the first message, which is authoritative for that deferred
-work. A cached diagnostic result can explain an earlier failure, but cannot
+resolve and inspect an executable path but must not execute it. Connections
+automatically calls `POST /agent-adapters/{id}/probe` once for each available
+agent; **Check again** repeats that disposable check. It starts a temporary ACP
+runtime and performs a handshake without sending a prompt. Its provider-specific
+version or auth detection may execute the discovered app. Creating an External
+Agent chat is the independent real-session boundary: it resolves the current app
+and performs a fresh ACP handshake whether or not a check ran. Direct ACP peers
+launch during that setup. Embedded bridges may run bounded provider discovery
+during setup while deferring their prompt-serving vendor invocation and
+prompt-time auth result until the first message, which is authoritative for that
+deferred work. A cached check result can explain an earlier failure, but cannot
 authorize or block the real session or first-message attempt. Clients refresh
-the passive catalog independently after install/path changes or a diagnostic;
-only that passive response may update pre-launch availability, status, error,
+the passive catalog independently after install/path changes or a check; only
+that passive response may update pre-launch availability, status, error,
 remote-credential gates, and last-discovered path. Clients may retain
 process-derived versions, auth/capability evidence, and launch controls with the
-cached diagnostic for troubleshooting.
+cached check for troubleshooting.
 
 Stored message diffs are read-only historical evidence. The current
 `workspace-diff` response carries an opaque revision for the complete scoped

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -367,14 +367,14 @@ environment.
 Codex and Claude Code use Hecate's built-in Go ACP adapter libraries, which
 launch their vendor CLIs as supervised child processes. Cursor Agent and Grok
 Build expose ACP modes directly in their vendor CLIs.
-Opening Connections performs passive path discovery only. The operator-owned
-**Run diagnostics** action calls `POST
-/hecate/v1/agent-adapters/{id}/probe`, which starts the discovered app and opens
-a disposable ACP session for troubleshooting. It is optional: **New chat**
-re-resolves the executable and prepares the real ACP session. Direct ACP peers
-start during setup. Embedded bridges may run bounded provider discovery during
-setup while deferring their prompt-serving vendor invocation and prompt-time
-auth result until the first message.
+Opening Connections performs passive path discovery, then automatically calls
+`POST /hecate/v1/agent-adapters/{id}/probe` once for each available adapter.
+That short-lived check starts the discovered app and opens a disposable ACP
+session without sending a prompt. **Check again** repeats it after a local
+repair or sign-in. **New chat** still re-resolves the executable and prepares
+the real ACP session. Direct ACP peers start during setup. Embedded bridges may
+run bounded provider discovery during setup while deferring their prompt-serving
+vendor invocation and prompt-time auth result until the first message.
 
 ## Resetting state
 

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -438,7 +438,8 @@ Hecate keeps one process-wide backend selector for Hecate-owned state.
 | `HECATE_BACKEND` | local default; resets on restart | Docker default; persists to `HECATE_SQLITE_PATH` | Remote runtime option; persists to `HECATE_POSTGRES_URL` |
 
 This backend covers settings, encrypted provider credentials, audit and usage
-history, Agent Presets, chat sessions, external-agent approvals and grants,
+history, Work policies (stored/API field: `agent_preset`), chat sessions,
+external-agent approvals and grants,
 chat attachment bodies, Tasks, the task queue, Task Schedules and their
 occurrence ledger, and Hecate's project-runtime overlays.
 

--- a/docs/operator/known-limitations.md
+++ b/docs/operator/known-limitations.md
@@ -108,8 +108,9 @@ storage, and operational behavior can still evolve across stable `v0.x.y` releas
   and configured `web_search`, and `all_tools`). Unknown policy names are
   rejected at startup. The per-MCP-server `approval_policy` axis
   (`auto` / `require_approval` / `block`) is separate.
-- Native project-assignment launches enforce Agent Preset surface, tools, write,
-  and network posture. The task snapshots the preset id, tools setting, and
+- Native project-assignment launches enforce Work policy surface, tools, write,
+  and network posture. The stable stored/API field remains `agent_preset`. The
+  task snapshots the policy id, tools setting, and
   effective sandbox flags. Tools-disabled tasks run as supervised model-only
   tasks: they expose no native or MCP tools, start no MCP host, and reject
   unexpected tool calls before dispatch. Legacy tasks without the tools snapshot
@@ -142,7 +143,7 @@ storage, and operational behavior can still evolve across stable `v0.x.y` releas
   browser, URL-check endpoint, or interactive browser controls.
 - Native browser evidence is a deliberately narrow alpha capability, not
   browser automation. It is available only to a local native project-assignment
-  task whose Agent Preset snapshots an exact-origin allowlist and only when the
+  task whose Work policy snapshots an exact-origin allowlist and only when the
   operator configured a local Chromium-compatible executable. Every call needs
   approval and creates a fresh script-disabled browser profile; Hecate does not import host
   cookies, reuse logins, keep profile state, allow downloads, or retain
@@ -232,7 +233,7 @@ storage, and operational behavior can still evolve across stable `v0.x.y` releas
   memory/source policy, skills, browser evidence, MCP selection, approval
   defaults, or External Agent options. Native project assignments can include
   bounded project memory and portable `AGENTS.md` workspace-instruction bodies
-  when the resolved Agent Preset explicitly asks for inclusion. Broader
+  when the resolved Work policy explicitly asks for inclusion. Broader
   prompt-content policy for chats, external-agent starts, host-specific guidance
   files, and arbitrary project source documents is still beta-hardening work.
   Tools-on chat still uses the selected workspace with the current chat runtime
@@ -291,10 +292,10 @@ storage, and operational behavior can still evolve across stable `v0.x.y` releas
   evasive agent can transform a path or split it into unrelated short message
   or activity records that are not individually recognizable as that alias.
 - Agent auth and billing state belongs to the underlying CLI account. Hecate
-  can classify common failures during a fresh chat launch or optional
-  diagnostics and surface friendly hints, but operators still need to use each
+  can classify common failures during a fresh chat launch or the automatic
+  Connections check and surface friendly hints, but operators still need to use each
   agent's own login/status flow when credentials expire.
-- Cached diagnostics and readiness fixtures are advisory only. They can force
+- Cached check results and readiness fixtures are advisory only. They can force
   Connections and Chats status states for UI testing, but they do not authorize
   or block a later launch. Real External Agent chats re-resolve the executable
   and require the underlying CLI and ACP adapter to start successfully. A

--- a/docs/operator/known-limitations.md
+++ b/docs/operator/known-limitations.md
@@ -257,8 +257,9 @@ storage, and operational behavior can still evolve across stable `v0.x.y` releas
   the stored native ACP session where supported.
 - Hecate does not yet authenticate a discovered provider CLI or persist an
   executable fingerprint approval. Catalog discovery is passive and shows the
-  last-discovered path; **Refresh** repeats discovery without execution. **New
-  chat**, **Run diagnostics**, auth/logout, setup discovery, and session launch
+  last-discovered path; **Refresh** repeats discovery without execution. Opening
+  **Connections** automatically runs one no-prompt check for each available
+  agent; **New chat**, **Check again**, auth/logout, setup discovery, and session launch
   resolve the executable again, so the executed path can differ from earlier
   discovery. A local SHA-256 digest alone would detect changed bytes;
   without a signed publisher manifest or attestation it would not prove origin

--- a/docs/operator/projects.md
+++ b/docs/operator/projects.md
@@ -17,13 +17,17 @@ register local skills, or launch work against files.
    workspace guidance and local skill metadata, then review the proposed memory
    candidates and role changes before applying them. A rootless project starts
    directly with **Create first work**.
-4. Set provider, model, Agent Preset, memory, and source defaults when the
+4. Set provider, model, Work policy, memory, and source defaults when the
    project should launch Hecate Chat, Hecate Tasks, or External Agents.
 5. Review and create the first work item.
 
 The guided start stays on Project Overview until the first work item exists.
 It presents one primary action at a time; supporting setup choices remain
 available without competing with that action.
+
+The UI calls reusable launch posture **Work policies**. The stable stored and
+API field remains `agent_preset` while that alpha-era identifier is retired from
+operator-facing language.
 
 | Guided state           | Primary action                       | Operator control                                                                        |
 | ---------------------- | ------------------------------------ | --------------------------------------------------------------------------------------- |
@@ -165,7 +169,7 @@ launch prerequisites.
 
 The project header's **Needs Attention** panel is server-derived from
 `GET /hecate/v1/projects/{id}/health`. It surfaces compact setup and operations
-signals such as missing defaults, missing roots, Agent Preset or skill
+signals such as missing defaults, missing roots, Work policy or skill
 reference issues, pending handoffs, review follow-up, stale assignment links,
 empty memory/context posture, and pending memory candidates. The menu also
 shows the server summary counts for setup, memory, context, and work follow-up
@@ -232,7 +236,7 @@ when lower-priority work is hidden by the cap.
 Memory/Context source edits use typed server mutations per source. Adding,
 editing, or deleting a source changes project source metadata only; it does not
 read local files, fetch remote content, write memory, or change launch context
-policy until the operator separately chooses a launch or Agent Preset posture
+policy until the operator separately chooses a launch or Work policy posture
 that includes enabled sources.
 
 Use the top Project Operations action for the single most useful operator step,
@@ -481,7 +485,7 @@ the workspace body with a full-width inspector. Focus moves to the Settings
 heading; **Back** or a successful save returns to the exact project control that
 opened it, including after the project refreshes. Settings and its navigation
 stay locked while a save is in progress so later edits are not lost. Timeline,
-Memory, Skills, sources, roots, roles, and Agent Presets remain supporting
+Memory, Skills, sources, roots, roles, and Work policies remain supporting
 surfaces. They do not create a second project state outside Cairnline or launch
 work without operator confirmation.
 
@@ -503,7 +507,7 @@ until those journeys break down in real Hecate development work.
 
 For Hecate-on-Hecate coding, register the checkout as a project root and keep
 **Isolated copy** as the default workspace mode. Use a `hecate_task`-compatible
-Agent Preset with tools and writes enabled; choose its network posture together
+Work policy with tools and writes enabled; choose its network posture together
 with the host sandbox. Semantic code intelligence can run network-denied under
 `bwrap` or `sandbox-exec`, while a wrapper-less host requires an explicitly
 network-enabled task. Normal write and shell approval policies still apply.
@@ -551,7 +555,7 @@ sibling workspaces outside the registered project root.
 
 Hecate's Projects API and cockpit use the embedded [Cairnline](https://github.com/hecatehq/cairnline) coordination store. Cairnline owns the portable project graph: project identity, roots, context-source and skill metadata, roles, work items, assignments, evidence, reviews, handoffs, accepted project memory, memory candidates, and Project Assistant proposal records.
 
-Hecate owns the host-specific layer around that graph: runtime host identity, Agent Presets, provider and model selection, task and External Agent launch, workspace and Git side effects, approvals, sandboxing, chats, execution references, context snapshots, traces, and the operator UI. Starting an assignment resolves Cairnline coordination intent into Hecate runtime behavior; Cairnline records never bypass Hecate policy. A remote operator can supervise this layer on its named runtime host, but the browser does not move running work or host-local state to another device.
+Hecate owns the host-specific layer around that graph: runtime host identity, Work policies, provider and model selection, task and External Agent launch, workspace and Git side effects, approvals, sandboxing, chats, execution references, context snapshots, traces, and the operator UI. Starting an assignment resolves Cairnline coordination intent into Hecate runtime behavior; Cairnline records never bypass Hecate policy. A remote operator can supervise this layer on its named runtime host, but the browser does not move running work or host-local state to another device.
 
 The Hecate facade remains at `/hecate/v1/projects*`, so the Projects UI does not depend on Cairnline's transport. Hecate stores embedded Cairnline state under its local data directory. There is no Hecate-native coordination backend, backend selector, mirror, or migration endpoint. A process-local project mutation fence only prevents Hecate cleanup rollback from interleaving with an acknowledged facade write to the same Cairnline graph; it does not store or duplicate coordination records. Multi-project Project Assistant operations, including chat moves, admit their complete project set together. Alpha dogfood records created by the removed native store are intentionally not migrated.
 
@@ -559,7 +563,7 @@ Cairnline itself remains agent-neutral and can also be used directly over MCP by
 
 Cross-host continuity therefore has two distinct checks: the project
 coordination graph must be reachable on the target host, and that host must have
-the required project root, Agent Preset, provider/model route, credentials, and
+the required project root, Work policy, provider/model route, credentials, and
 External Agent adapter. Hecate does not currently claim that a task, chat, or
 running process can migrate between runtime hosts.
 

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -92,14 +92,15 @@ discovery can establish an absolute invocation path and inspect its canonical
 regular target, but path shape, filename, `--version`, auth output, and an ACP
 handshake do not authenticate its publisher. The latter checks already execute
 the candidate, so they are diagnostics rather than security verification.
-Catalog and compatibility health GETs therefore stay passive. Hecate executes
-the candidate only after an explicit operator action such as **New chat**,
-**Run diagnostics**, authentication, or logout. **New chat** performs a fresh
-executable resolution and prepares the real ACP session. Direct ACP agents are
-started during that setup. Embedded bridges may run bounded provider discovery
-during setup while deferring their prompt-serving vendor invocation and
-prompt-time auth result until the first message. The optional diagnostic is not
-a security check or a prerequisite for use.
+Catalog and compatibility health GETs therefore stay passive. Opening
+**Connections** automatically starts each available External Agent once for a
+short-lived, no-prompt ACP check; **Check again**, **New chat**,
+authentication, and logout can also execute the candidate. **New chat**
+performs a fresh executable resolution and prepares the real ACP session.
+Direct ACP agents are started during that setup. Embedded bridges may run
+bounded provider discovery during setup while deferring their prompt-serving
+vendor invocation and prompt-time auth result until the first message. The
+Connections check is not a security check or a prerequisite for use.
 
 A locally computed SHA-256 digest proves byte identity and detects later
 replacement. It proves origin only when the expected digest came from an
@@ -237,7 +238,7 @@ Hecate stores local configuration and operational state on disk.
 - Do not commit `.env`, SQLite databases, Postgres dumps or DSNs, release keys,
   update signing keys, or platform credential files.
 - External agent credentials belong to the underlying CLI account. A fresh
-  chat launch and optional diagnostics can surface auth failures, but Hecate
+  chat launch and the automatic Connections check can surface auth failures, but Hecate
   does not own, proxy, or pool those accounts. See [External
   Agents](../runtime/external-agents.md#credential-and-account-boundaries) for
   credential and billing notes for Codex, Claude Code, Cursor Agent, and Grok

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -283,19 +283,18 @@ the real-session boundary: Hecate resolves the executable again, performs ACP
 embedded bridges may run bounded provider discovery without sending a prompt.
 In particular, the Claude bridge can start a short-lived `--bare` command-catalog
 process during session setup. The prompt-serving vendor invocation and
-prompt-time auth result can remain deferred until the first message. The
-optional **Run diagnostics** action and `POST
-/hecate/v1/agent-adapters/{id}/probe` open a disposable session and may execute
-the selected app for troubleshooting. Authentication and logout also execute
-it. Opening Chats or Connections never starts a newly discovered executable
-automatically.
+prompt-time auth result can remain deferred until the first message. Opening
+Connections automatically starts each available agent once through `POST
+/hecate/v1/agent-adapters/{id}/probe`, which opens a disposable session without
+sending a prompt. **Check again**, authentication, and logout also execute the
+selected app. Opening Chats alone does not start newly discovered executables.
 
 ## Hecate ACP Capability Contract
 
 `GET /hecate/v1/agent-adapters` includes a `capabilities` array for each
 adapter. This is Hecate's contract for the surfaces it knows how to supervise;
 each real chat session's fresh ACP `Initialize` decides which live features are
-available to that session. An optional diagnostic probe reports what its own
+available to that session. The automatic Connections check reports what its own
 disposable session advertised, but it is not launch authority for a later chat.
 
 | Capability          | Catalog status                                                       | What Hecate does                                                                                                                                                           |
@@ -461,13 +460,13 @@ guardrails, and Git diff review.
 External Agent controls have two sources:
 
 - **Launch controls** are owned by Hecate's adapter integration and can appear
-  in the separately resolved projection returned by optional diagnostics before
+  in the separately resolved projection returned by the automatic Connections check before
   a concrete chat session exists. Generating them may execute bounded
   help/model discovery, so the passive catalog omits them. Hecate passes
   selected values as process arguments when it starts or restarts the external
   agent. No current built-in requires one before session creation; a future
-  required control must first have a passive schema path so diagnostics remain
-  optional.
+  required control must first have a passive schema path so the catalog remains
+  useful before a check completes.
 - **ACP session controls** come from the agent during `session/new`,
   `session/load`, or `session/set_config_option`. Hecate surfaces model,
   reasoning, mode, and similar selectors in the composer after the External
@@ -530,9 +529,9 @@ chat** re-resolves that executable and prepares the real ACP session. Direct
 peers launch during setup. Embedded bridges may run bounded provider discovery
 during setup without sending a prompt; their prompt-serving vendor invocation
 and prompt-time auth result can remain deferred until the first message. The
-optional diagnostic response adds live ACP capabilities from its disposable
+automatic check response adds live ACP capabilities from its disposable
 session and separate auth/version classification when provider-specific checks
-can classify them. A ready ACP diagnostic alone does not mean vendor auth
+can classify them. A ready ACP check alone does not mean vendor auth
 succeeded. For built-in adapters, that response can report `adapter_version`
 for the compiled Go module and `agent_version` for the underlying vendor CLI.
 Direct ACP CLIs report their
@@ -547,19 +546,19 @@ Manual setup stays in the upstream CLIs:
 | Cursor Agent   | `cursor-agent login` |
 | Grok Build     | `grok login`         |
 
-If chat creation, the first message, or an optional diagnostic reports an auth
-failure, run the matching command in Terminal, then retry the message in a fresh
-session if needed. You can run diagnostics again when you need a narrower
-troubleshooting result. If diagnostics report a timeout or `context deadline
-exceeded`, the adapter did not finish its diagnostic checks or ACP session
-creation inside the diagnostic window. Hecate did not send a prompt; close any
-stuck browser or login prompt, fix the CLI if needed, then retry the chat.
+If chat creation, the first message, or the automatic Connections check reports
+an auth failure, run the matching command in Terminal, then use **Check again**
+or retry the message in a fresh session if needed. If a check reports a timeout
+or `context deadline exceeded`, the adapter did not finish ACP session creation
+inside the bounded check window. Hecate did not send a prompt; close any stuck
+browser or login prompt, fix the CLI if needed, then retry the chat.
 
-Connections labels newly discovered eligible apps **Available** without
-executing them. **Run diagnostics** is optional and opens a temporary ACP
-runtime plus a no-prompt session; provider-specific version or auth checks may
-also execute the installed app. The same diagnostic is available through the
-API:
+Connections first labels newly discovered eligible apps **Available** without
+executing them, then automatically opens a temporary ACP runtime plus a
+no-prompt session for each available app. Provider-specific version or auth
+checks may execute the installed app. **Check again** repeats that bounded
+session check after an operator repairs an install or signs in. The same check
+is available through the API:
 
 ![Connections — external agent diagnostics and durable approval grants](../screenshots/connections-external-agents.png)
 
@@ -567,18 +566,18 @@ API:
 curl -X POST http://127.0.0.1:8765/hecate/v1/agent-adapters/codex/probe | jq
 ```
 
-Diagnostic results make ACP `Initialize` capabilities authoritative for that
-diagnostic row. The catalog tells Hecate what the built-in adapter is expected
-to support; diagnostics tell the UI what the disposable inspected session
+Check results make ACP `Initialize` capabilities authoritative for that row.
+The catalog tells Hecate what the built-in adapter is expected to support; a
+check tells the UI what the disposable inspected session
 advertised (`supports_authenticate`, `supports_logout`,
 `supports_load_session`, and non-secret `auth_methods`). They do not authorize
 or block a later chat, whose fresh initialization remains authoritative. Before
-a diagnostic runs, Connections may offer **Sign in** or **Sign out** from the
-built-in catalog's expected capabilities. A diagnostic with known live
+the automatic check completes, Connections may offer **Sign in** or **Sign out**
+from the built-in catalog's expected capabilities. A check with known live
 capabilities overrides that fallback for its row. The action itself always
 opens a fresh ACP session and enforces the live capability before invoking ACP
-`agent-login` or `auth.logout`, so diagnostics are never a prerequisite.
-Diagnostics stay short so the UI can classify broken adapters quickly, while
+`agent-login` or `auth.logout`, so a completed check is never a prerequisite.
+Checks stay short so the UI can classify broken adapters quickly, while
 the managed local `authenticate` action allows a longer native sign-in flow
 because Codex and Claude Code may open a browser or terminal login.
 
@@ -633,15 +632,17 @@ Use this order when launching or troubleshooting:
    `Initialize`, and opens the real session. Direct ACP peers start during this
    setup. Embedded bridges may run bounded provider discovery while deferring
    their prompt-serving vendor invocation and prompt-time auth result until the
-   first message. No earlier diagnostic result is required, and a cached
+   first message. No earlier check result is required, and a cached
    diagnostic failure must not prevent this fresh session attempt after the
    operator fixes the underlying issue.
-3. **Optional diagnostics** — `POST /hecate/v1/agent-adapters/{id}/probe`
-   starts the adapter and opens a disposable ACP session to refresh version,
-   auth/capability, and launch-control troubleshooting details. It may consume
-   a no-op session and is advisory rather than a launch gate. Hecate re-reads
-   passive discovery after it completes so repaired installs become selectable
-   without treating the diagnostic result itself as authority. The UI may keep
+3. **Connections check / explicit retry** — Connections automatically calls
+   `POST /hecate/v1/agent-adapters/{id}/probe` once for each available adapter;
+   **Check again** repeats it. The endpoint starts the adapter and opens a
+   disposable ACP session to refresh version, auth/capability, and
+   launch-control troubleshooting details. It may consume a no-op session and
+   is advisory rather than a launch gate. Hecate re-reads passive discovery
+   after it completes so repaired installs become selectable without treating
+   the check result itself as authority. The UI may keep
    process-derived version, auth, capability, and launch-control details beside
    the cached diagnostic, but availability, status, error, path, and
    remote-credential gates always come from the latest passive catalog
@@ -975,7 +976,7 @@ checks so operators can confirm which ACP implementation answered the handshake.
 When a chat session is prepared or a turn runs, Hecate stores the same
 `agent_info` snapshot on the External Agent chat session and assistant message.
 This keeps transcript/project views explainable after restart even if no recent
-diagnostic result is available.
+check result is available.
 
 ![Chats workspace with an external-agent file-write approval waiting for operator review](../screenshots/chat-agent-approval.png)
 

--- a/docs/runtime/external-agents.md
+++ b/docs/runtime/external-agents.md
@@ -310,8 +310,8 @@ disposable session advertised, but it is not launch authority for a later chat.
 | `logout`            | `supported` for Codex and Claude Code, otherwise `adapter_dependent` | Calls ACP `auth.logout` only when the live adapter advertises logout.                                                                                                      |
 
 Connections renders this matrix as compact chips on each adapter row. If a
-diagnostic probe succeeds, its ACP `Initialize` capabilities override the
-static login and logout expectation for that diagnostic row so the UI does not
+Connections check succeeds, its ACP `Initialize` capabilities override the
+static login and logout expectation for that checked row so the UI does not
 show actions the inspected session did not advertise. A subsequent chat still
 uses the capabilities from its own fresh initialization.
 
@@ -441,11 +441,12 @@ agent runtime, while authentication and billing stay with the provider.
    after initial session and model/config setup succeeds, that buffer is zeroed
    and later stderr is discarded before a prompt can carry file data.
 7. If chat creation or the first message fails, or the agent row shows a
-   previous diagnostic issue, open **Connections** and optionally choose **Run
-   diagnostics**. It opens a temporary ACP session and may execute the selected
-   app to classify common auth, billing/subscription, version, and launch
-   failures. It is a troubleshooting tool, not a prerequisite for **New chat**
-   or the first message, and not a security verification of the executable.
+   previous check issue, open **Connections**. It runs one automatic bounded
+   check for each available agent; use **Check again** after fixing setup. A
+   check opens a temporary ACP session and may execute the selected app to
+   classify common auth, billing/subscription, version, and launch failures. It
+   is a troubleshooting tool, not a prerequisite for **New chat** or the first
+   message, and not a security verification of the executable.
 8. Send a small smoke prompt:
 
    ```text
@@ -560,7 +561,7 @@ checks may execute the installed app. **Check again** repeats that bounded
 session check after an operator repairs an install or signs in. The same check
 is available through the API:
 
-![Connections — external agent diagnostics and durable approval grants](../screenshots/connections-external-agents.png)
+![Connections — external agent checks and durable approval grants](../screenshots/connections-external-agents.png)
 
 ```sh
 curl -X POST http://127.0.0.1:8765/hecate/v1/agent-adapters/codex/probe | jq
@@ -633,7 +634,7 @@ Use this order when launching or troubleshooting:
    setup. Embedded bridges may run bounded provider discovery while deferring
    their prompt-serving vendor invocation and prompt-time auth result until the
    first message. No earlier check result is required, and a cached
-   diagnostic failure must not prevent this fresh session attempt after the
+   check failure must not prevent this fresh session attempt after the
    operator fixes the underlying issue.
 3. **Connections check / explicit retry** — Connections automatically calls
    `POST /hecate/v1/agent-adapters/{id}/probe` once for each available adapter;
@@ -644,7 +645,7 @@ Use this order when launching or troubleshooting:
    after it completes so repaired installs become selectable without treating
    the check result itself as authority. The UI may keep
    process-derived version, auth, capability, and launch-control details beside
-   the cached diagnostic, but availability, status, error, path, and
+   cached check details, but availability, status, error, path, and
    remote-credential gates always come from the latest passive catalog
    response.
 4. **Chat turn** — after the real session exists, send a prompt. The first

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -1648,9 +1648,11 @@ External Agent chats: it reports the agent runtimes Hecate knows how to
 supervise and whether their command can be found. This endpoint is deliberately
 cheap so the app can render startup state without spawning coding-agent CLIs.
 An eligible discovered command is available for an explicit chat launch; this
-does not claim that auth or ACP initialization will succeed. Use the optional
-`POST /hecate/v1/agent-adapters/{id}/probe` diagnostic for live version, auth,
-capability, and launch-control troubleshooting without creating a durable chat.
+does not claim that auth or ACP initialization will succeed. Connections then
+runs one bounded `POST /hecate/v1/agent-adapters/{id}/probe` check for each
+available adapter; **Check again** repeats it. That check may execute the
+selected app to refresh live version, auth, capability, and launch-control
+details, but it does not create a durable chat or authorize a later launch.
 
 Discovery checks the Hecate process's `PATH` followed by allowlisted standard
 vendor, Homebrew, Volta, npm, pnpm, and WinGet locations for the selected
@@ -1986,8 +1988,8 @@ Compatibility read for one adapter's passive discovery state. It performs the
 same non-executing path inspection as the catalog and never starts the selected
 app. **New chat** re-resolves it and prepares the real ACP session; the first
 message checks any deferred prompt-serving vendor invocation and auth. Use the
-explicit POST probe only for optional live version, auth classification, and
-ACP-capability diagnostics.
+Connections check or **Check again** for live version, auth classification, and
+ACP capabilities. It may execute the selected app, while this read never does.
 
 ```json
 GET /hecate/v1/agent-adapters/codex/health

--- a/docs/runtime/runtime-api.md
+++ b/docs/runtime/runtime-api.md
@@ -279,7 +279,7 @@ type while preserving the status and remediation fields.
 - [Usage endpoints](#usage-endpoints)
 - [Health and discovery endpoints](#health-and-discovery-endpoints)
 - [Plugin registry endpoints](#plugin-registry-endpoints)
-- [Agent Preset endpoints](#agent-preset-endpoints)
+- [Work policy endpoints](#work-policy-endpoints)
 - [Project endpoints](#project-endpoints)
 - [Project Assistant endpoints](#project-assistant-endpoints)
 - [Chat session endpoints](#chat-session-endpoints)
@@ -1795,9 +1795,9 @@ GET /hecate/v1/agent-adapters
 ```
 
 `adapter_version` and `agent_version` are omitted from the catalog response.
-They are populated by the optional diagnostic response after Hecate starts the
-ACP adapter. `version_outside_range` remains `false` until a diagnostic version
-is known to fall outside `supported_range`.
+They are populated by the Connections check after Hecate starts the ACP adapter.
+`version_outside_range` remains `false` until a checked version is known to fall
+outside `supported_range`.
 
 `embedded=true` means the ACP server implementation is compiled into Hecate;
 `command` and `path` then identify the vendor CLI that implementation launches.
@@ -1808,9 +1808,9 @@ process Hecate supervises.
 runtime override can classify it without spawning a CLI. **New chat** prepares
 the fresh ACP session. An embedded bridge may run bounded provider discovery
 during setup; the first message checks prompt-time auth when the bridge defers
-its prompt-serving vendor invocation. Use the optional `POST
-/hecate/v1/agent-adapters/{id}/probe` diagnostic when Connections needs a
-standalone login / billing classification, but do not infer verified vendor auth
+its prompt-serving vendor invocation. Connections automatically calls `POST
+/hecate/v1/agent-adapters/{id}/probe` for each available agent; **Check again**
+repeats that standalone login / billing check. Do not infer verified vendor auth
 from `health.status=ready` alone.
 
 `supports_authenticate` and `supports_logout` tell clients whether Hecate can
@@ -1831,8 +1831,8 @@ handoff, config options, terminal callbacks, authenticate, and logout. Capabilit
 | `operator_opt_in`   | Hecate supports the surface only behind an explicit operator setting.     |
 | `not_supported`     | Hecate should not show or invoke this surface.                            |
 
-Diagnostic results describe the live ACP `Initialize` features of the
-disposable session they created. For example, a diagnostic can turn
+Check results describe the live ACP `Initialize` features of the disposable
+session they created. For example, a check can turn
 `supports_authenticate` or `supports_logout` off for its result even when the
 catalog expected them. It does not authorize or block a later chat; the real
 session's fresh initialization is authoritative for that session.
@@ -1872,34 +1872,36 @@ before failing closed. This is not hard sandboxing of arbitrary wrappers,
 generated code, custom binaries, or external supervisors.
 
 `config_options` are omitted from the passive catalog response. Hecate returns
-Hecate-managed launch controls on optional diagnostic projections and returns
+Hecate-managed launch controls on automatic Connections check projections and returns
 agent-owned controls on prepared chat sessions, where it is acceptable to run
 the adapter's help/model discovery or consume the ACP session's own controls.
 Values prefixed with `__hecate_no_` are explicit "not selected" sentinels. No
 current built-in requires a pre-session launch control. The request validator
 can return `400 chat.model_required` for a registered required launch option,
 but a built-in must not introduce one until Hecate exposes its schema through a
-passive endpoint; optional diagnostics cannot be a prerequisite for use.
+passive endpoint; a completed Connections check cannot be a prerequisite for use.
 Agent-owned ACP model state appears on the prepared chat session and is updated
 with ACP `session/set_model`.
 
 ### `POST /hecate/v1/agent-adapters/{id}/probe`
 
-Runs an optional, disposable ACP session diagnostic. It re-runs discovery for
-one adapter, starts a direct peer or embedded bridge, performs ACP `Initialize`,
-and creates a temporary session without sending a prompt. Provider-specific
-version or auth-status classification may also execute the discovered app, but
-an embedded bridge may still defer its prompt-serving vendor invocation beyond
-this diagnostic. `data.health` is evidence from the disposable ACP attempt;
+Runs a disposable ACP session check. Connections calls it once for each
+available adapter and **Check again** calls it after a repair or sign-in. It
+re-runs discovery for one adapter, starts a direct peer or embedded bridge,
+performs ACP `Initialize`, and creates a temporary session without sending a
+prompt. Provider-specific version or auth-status classification may also
+execute the discovered app, but an embedded bridge may still defer its
+prompt-serving vendor invocation beyond this check. `data.health` is evidence
+from the disposable ACP attempt;
 `health.path` is the path that attempt used. `data.adapter` is a separately
 re-resolved diagnostic projection that combines full status, versions, launch
 controls, and the probe's auth/capability classification. Its `path`, `status`,
 or `error` can differ if discovery changes during the request and must not be
 treated as process-bound evidence. Hecate's UI then re-reads the passive catalog
 with `GET /hecate/v1/agent-adapters` before changing any launch gate or
-last-discovered path, so the diagnostic itself never becomes launch authority.
-It can retain diagnostic-only versions, auth/capability evidence, and
-`config_options` beside the cached diagnostic while replacing launch
+last-discovered path, so the check itself never becomes launch authority. It
+can retain check-only versions, auth/capability evidence, and `config_options`
+beside the cached check while replacing launch
 availability, status, error, path, and remote-credential fields from the passive
 response. Operators can also trigger that passive refresh without starting an
 agent.
@@ -1909,9 +1911,9 @@ authority. Starting an External Agent chat independently resolves the current
 executable, performs a fresh `Initialize`, and creates the real session. Direct
 ACP peers start during setup. An embedded bridge may run bounded provider
 discovery, while the first message remains authoritative for a prompt-serving
-vendor invocation or auth result deferred by that bridge. Clients should invoke
-the diagnostic only after an explicit operator action, label it as optional,
-and show the catalog `path` before that action.
+vendor invocation or auth result deferred by that bridge. Connections invokes
+the check automatically for available adapters; clients may expose **Check
+again** after a repair and should show the catalog `path` before execution.
 Treat that path as last-discovered evidence rather than a pinned launch target:
 chat creation resolves the executable again.
 
@@ -1997,7 +1999,7 @@ GET /hecate/v1/agent-adapters/codex/health
     "status": "unverified",
     "stage": "lookup",
     "path": "/Users/alice/.local/bin/codex",
-    "hint": "App found. New chat re-resolves it and prepares a fresh ACP session; the first message verifies any deferred prompt-serving vendor invocation and authentication. POST to the probe endpoint only for optional diagnostics.",
+    "hint": "App found. Connections checks available agents automatically. New chat re-resolves it and prepares a fresh ACP session; the first message verifies any deferred prompt-serving vendor invocation and authentication.",
     "supports_authenticate": false,
     "supports_logout": false,
     "supports_load_session": false,
@@ -2242,17 +2244,18 @@ Hecate-owned requirement for approval.
 unsupported permissions, unresolved secret-binding requests, disabled
 capabilities, and slash-command collisions. It does not call external services.
 
-## Agent preset endpoints
+## Work policy endpoints
 
-Agent presets are reusable Hecate runtime postures for project work, Hecate
-Chat, Chat-origin Task Runs, and External Agent launches. They describe defaults and
-constraints such as instructions, surface, provider/model hints, tool/write/
-network posture, optional native browser-evidence posture, approval policy,
-project-memory policy, context-source policy, skill ids, and external-agent
-options. `skill_ids` resolve against the selected project's skills registry
-when project work starts. Hecate snapshots resolved/skipped skill metadata and
-warnings into the context packet, but it does not install skills, execute
-scripts, grant tools, or inject `SKILL.md` bodies from an agent preset.
+Work policies are reusable Hecate launch postures for project work, Hecate
+Chat, Chat-origin Task Runs, and External Agent launches. The stable API uses
+the `agent_presets` resource name, but operators use a work policy to select
+instructions, intended surface, provider/model hints, and the allowed tool,
+workspace-write, network, browser-evidence, approval, memory, context, skill,
+and External Agent posture. `skill_ids` resolve against the selected project's
+skills registry when project work starts. Hecate snapshots resolved/skipped
+skill metadata and warnings into the context packet, but it does not install
+skills, execute scripts, grant tools, or inject `SKILL.md` bodies from a work
+policy.
 
 Hecate also exposes an immutable built-in preset catalog. Built-ins are
 returned by list/get requests with `built_in: true`, can be selected by project
@@ -4981,12 +4984,12 @@ fresh ACP `Initialize`, and starts or restores the native ACP session
 immediately. Direct ACP peers launch during this setup. Embedded command bridges
 may run bounded provider discovery while deferring their prompt-serving vendor
 invocation and prompt-time auth result until the first message. A prior
-diagnostic probe is neither required nor trusted as launch authority. Clients
-may include `config_options` selected from the latest explicit diagnostic
-projection when it exposes Hecate-managed launch controls; the passive catalog
-does not expose those controls. No current built-in requires one before session
-creation. A future required launch control must have a passive schema path
-before adoption so a diagnostic never becomes prerequisite.
+Connections check is neither required nor trusted as launch authority. Clients
+may include `config_options` selected from the latest check projection when it
+exposes Hecate-managed launch controls; the passive catalog does not expose
+those controls. No current built-in requires one before session creation. A
+future required launch control must have a passive schema path before adoption
+so a check never becomes prerequisite.
 Hecate validates that any required Hecate-managed launch selection is present,
 then uses matching launch-option values when starting the agent process. After
 the ACP session exists, agent-owned `config_options` are returned

--- a/internal/agentadapters/auth_status.go
+++ b/internal/agentadapters/auth_status.go
@@ -11,9 +11,9 @@ import (
 	"time"
 )
 
-// DetectAuthStatus is an explicit diagnostic. Most branches inspect local
-// credential hints, while Claude may run its bounded `auth status` command.
-// Callers must keep it behind an operator-owned execution boundary.
+// DetectAuthStatus supports the bounded Connections session check. Most
+// branches inspect local credential hints, while Claude may run its bounded
+// `auth status` command.
 func DetectAuthStatus(adapter Adapter) (string, string) {
 	switch adapter.ID {
 	case "codex":
@@ -31,7 +31,7 @@ func DetectAuthStatus(adapter Adapter) (string, string) {
 			return AuthStatusUnauthenticated, adapterSignInHint(adapter)
 		}
 		if fileAny("${HOME}/.claude.json", "${HOME}/.claude/settings.json", "${HOME}/.claude/.credentials.json") {
-			return AuthStatusUnknown, "Claude Code config is present on disk. Hecate verifies CLI auth when Claude Code handles the first message; Connections diagnostics are optional."
+			return AuthStatusUnknown, "Claude Code config is present on disk. Connections checks available agents automatically; Hecate also verifies CLI auth when Claude Code handles the first message."
 		}
 		return AuthStatusUnknown, "Send a message in a Claude Code chat to verify it. If it reports a sign-in error, run `claude /login` in Terminal or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment."
 	case "cursor_agent":

--- a/internal/agentadapters/auth_status_test.go
+++ b/internal/agentadapters/auth_status_test.go
@@ -109,9 +109,9 @@ func TestDetectAuthStatusClaudeConfigIsNotEnoughForACP(t *testing.T) {
 	if status != AuthStatusUnknown {
 		t.Fatalf("status = %q, want %q", status, AuthStatusUnknown)
 	}
-	if !strings.Contains(hint, "verifies CLI auth when Claude Code handles the first message") ||
-		!strings.Contains(hint, "diagnostics are optional") {
-		t.Fatalf("hint = %q, want first-message verification and optional-diagnostics guidance", hint)
+	if !strings.Contains(hint, "Connections checks available agents automatically") ||
+		!strings.Contains(hint, "verifies CLI auth when Claude Code handles the first message") {
+		t.Fatalf("hint = %q, want Connections-check and first-message verification guidance", hint)
 	}
 }
 

--- a/internal/agentadapters/version.go
+++ b/internal/agentadapters/version.go
@@ -19,9 +19,8 @@ var semverRe = regexp.MustCompile(`\d+\.\d+\.\d+(?:[-+][0-9A-Za-z._-]+)*`)
 // test binary mutates this var in `version_test.go`'s init() to
 // stay independent of CI subprocess-startup jitter.
 //
-// 5 s is generous on purpose. Probe runs are pre-flight — an
-// operator explicitly clicked the adapter's Run diagnostics action;
-// latency is surfaced in the UI as "diagnosing…" while the request
+// 5 s is generous on purpose. Probe runs are short-lived Connections
+// checks — the UI surfaces "checking…" while the request
 // is in flight, so a few seconds of overhead is acceptable.
 // Earlier values (2 s, then 5 s) flaked on CI under -race +
 // parallel-suite load: race-mode adds 2-20× CPU overhead, and

--- a/internal/api/handler_agent_adapter_health.go
+++ b/internal/api/handler_agent_adapter_health.go
@@ -51,7 +51,8 @@ func (h *Handler) SetAgentAdapterAuthenticate(fn AgentAdapterAuthenticate) {
 // it again and prepares the real ACP session; an embedded bridge may defer the
 // prompt-serving vendor invocation and auth result until the first message,
 // although session setup may run bounded provider discovery. POST
-// /agent-adapters/{id}/probe remains an optional disposable diagnostic.
+// /agent-adapters/{id}/probe runs the disposable session check used by
+// Connections and explicit operator retries.
 //
 // GET /hecate/v1/agent-adapters/{id}/health
 //
@@ -90,7 +91,7 @@ func passiveAgentAdapterHealth(status agentadapters.Status) agentadapters.ProbeR
 	if status.Available {
 		result.Status = agentadapters.ProbeStatusUnverified
 		result.Error = ""
-		result.Hint = "App found. New chat re-resolves it and prepares a fresh ACP session; the first message verifies any deferred prompt-serving vendor invocation and authentication. POST to the probe endpoint only for optional diagnostics."
+		result.Hint = "App found. Connections checks available agents automatically. New chat re-resolves it and prepares a fresh ACP session; the first message verifies any deferred prompt-serving vendor invocation and authentication."
 		return result
 	}
 	if status.AuthStatus == agentadapters.AuthStatusUnauthenticated {

--- a/internal/api/handler_agent_adapter_health_test.go
+++ b/internal/api/handler_agent_adapter_health_test.go
@@ -51,10 +51,10 @@ func TestAgentAdapterHealthIsPassiveAndUnverified(t *testing.T) {
 		t.Fatalf("health path = %q, want %q", resp.Data.Path, executable)
 	}
 	if resp.Data.Stage != agentadapters.ProbeStageLookup ||
+		!strings.Contains(resp.Data.Hint, "Connections checks available agents automatically") ||
 		!strings.Contains(resp.Data.Hint, "New chat") ||
-		!strings.Contains(resp.Data.Hint, "first message") ||
-		!strings.Contains(resp.Data.Hint, "optional diagnostics") {
-		t.Fatalf("health = %#v, want session and first-message guidance with optional diagnostics", resp.Data)
+		!strings.Contains(resp.Data.Hint, "first message") {
+		t.Fatalf("health = %#v, want automatic check plus session and first-message guidance", resp.Data)
 	}
 	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("passive GET executed candidate; marker stat = %v", err)

--- a/internal/api/handler_chat.go
+++ b/internal/api/handler_chat.go
@@ -977,7 +977,7 @@ func writeAgentChatPrepareError(w http.ResponseWriter, adapterName string, err e
 	if errors.Is(err, context.DeadlineExceeded) {
 		WriteErrorDetails(w, http.StatusGatewayTimeout, errCodeAgentAdapterUnavailable, err.Error(), ErrorDetails{
 			UserMessage:    "The external agent did not respond while starting the session.",
-			OperatorAction: "Retry New chat. If it keeps hanging, optionally run diagnostics in Connections; diagnostics start the app and open a temporary ACP session without sending a prompt.",
+			OperatorAction: "Retry New chat. Connections automatically checks available external agents with a temporary no-prompt ACP session; use Check again there if the issue persists.",
 		})
 		return
 	}

--- a/internal/api/handler_chat_preset_test.go
+++ b/internal/api/handler_chat_preset_test.go
@@ -101,7 +101,7 @@ func TestHecateChatSession_AgentPresetSnapshotsHintsAndToolsOff(t *testing.T) {
 		t.Fatalf("provider request messages = %#v, want system and user messages", request.Messages)
 	}
 	for _, want := range []string{
-		"Agent preset instructions:\nInspect before proposing changes.",
+		"Work policy instructions:\nInspect before proposing changes.",
 		"Operator system prompt:\nKeep it concise.",
 	} {
 		if !strings.Contains(request.Messages[0].Content, want) {

--- a/internal/api/handler_chat_project_prompt.go
+++ b/internal/api/handler_chat_project_prompt.go
@@ -76,7 +76,7 @@ func hecateChatPresetInstructions(session chat.Session) string {
 	if session.AgentPreset.Empty() || strings.TrimSpace(session.AgentPreset.Instructions) == "" {
 		return ""
 	}
-	return "Agent preset instructions:\n" + strings.TrimSpace(session.AgentPreset.Instructions)
+	return "Work policy instructions:\n" + strings.TrimSpace(session.AgentPreset.Instructions)
 }
 
 func (h *Handler) hecateChatTaskSystemPrompt(ctx context.Context, session chat.Session, operatorPrompt string, forceNewTask bool) string {

--- a/internal/api/handler_project_work_test.go
+++ b/internal/api/handler_project_work_test.go
@@ -3575,7 +3575,7 @@ func TestProjectWorkAPI_StartAssignmentCreatesNativeTaskRun(t *testing.T) {
 		"Work item:\n- Title: Native assignment start",
 		"Assignment:\n- ID: asgn_start",
 		"Role:\n- Name: Backend engineer",
-		"Execution hints:\n- Driver: hecate_task\n- Provider: anthropic\n- Model: claude-sonnet-4\n- Agent preset: implementation",
+		"Execution hints:\n- Driver: hecate_task\n- Provider: anthropic\n- Model: claude-sonnet-4\n- Work policy: implementation",
 		"Role defaults: provider=anthropic, model=claude-sonnet-4, preset=implementation",
 		"Project defaults: provider=ollama, model=qwen2.5-coder, workspace_mode=in_place",
 		"Request:\nExecute this assignment as a native agent_loop task.",
@@ -5268,7 +5268,7 @@ func TestProjectWorkAPI_StartAssignmentSnapshotsResolvedAgentProfile(t *testing.
 	if task.AgentPresetBrowserAllowed == nil || !*task.AgentPresetBrowserAllowed || !reflect.DeepEqual(task.AgentPresetBrowserAllowedOrigins, []string{"https://qa.example.test"}) {
 		t.Fatalf("task browser snapshot = allowed %v origins %v, want enabled role preset evidence", task.AgentPresetBrowserAllowed, task.AgentPresetBrowserAllowedOrigins)
 	}
-	if !strings.Contains(task.SystemPrompt, "Agent preset instructions:\nUse the profile-specific review checklist.") {
+	if !strings.Contains(task.SystemPrompt, "Work policy instructions:\nUse the profile-specific review checklist.") {
 		t.Fatalf("task system prompt = %q, want profile instructions", task.SystemPrompt)
 	}
 
@@ -6114,7 +6114,7 @@ func TestProjectWorkAPI_StartAssignmentFallsBackToProjectDefaults(t *testing.T) 
 	for _, want := range []string{
 		"- Provider: ollama",
 		"- Model: qwen2.5-coder",
-		"- Agent preset: project_review",
+		"- Work policy: project_review",
 		"Role defaults: none",
 		"Project defaults: provider=ollama, model=qwen2.5-coder, preset=project_review, workspace_mode=in_place",
 	} {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -3918,8 +3918,8 @@ func TestAgentChatExternalCreatePrepareTimeout(t *testing.T) {
 	if payload.Error.Type != errCodeAgentAdapterUnavailable {
 		t.Fatalf("error type = %q, want %q", payload.Error.Type, errCodeAgentAdapterUnavailable)
 	}
-	if payload.Error.OperatorAction != "Retry New chat. If it keeps hanging, optionally run diagnostics in Connections; diagnostics start the app and open a temporary ACP session without sending a prompt." {
-		t.Fatalf("operator action = %q, want optional Connections diagnostic guidance", payload.Error.OperatorAction)
+	if payload.Error.OperatorAction != "Retry New chat. Connections automatically checks available external agents with a temporary no-prompt ACP session; use Check again there if the issue persists." {
+		t.Fatalf("operator action = %q, want automatic Connections check guidance", payload.Error.OperatorAction)
 	}
 	if !runner.prepareHasDeadline {
 		t.Fatal("prepare context did not have a deadline")

--- a/internal/projectworkapp/launch_plan.go
+++ b/internal/projectworkapp/launch_plan.go
@@ -525,7 +525,7 @@ func AssignmentPrompt(project projects.Project, workItem projectwork.WorkItem, a
 			"- Driver: " + driver,
 			"- Provider: " + provider,
 			"- Model: " + model,
-			"- Agent preset: " + profile,
+			"- Work policy: " + profile,
 			"- Role defaults: " + formatAssignmentHints([]assignmentHint{
 				{"driver", role.DefaultDriverKind},
 				{"provider", role.DefaultProvider},
@@ -550,7 +550,7 @@ func AssignmentSystemPrompt(project projects.Project, role projectwork.AgentRole
 		parts = append(parts, "Project system prompt:\n"+prompt)
 	}
 	if instructions := strings.TrimSpace(profile.Instructions); instructions != "" && !profile.Missing {
-		parts = append(parts, "Agent preset instructions:\n"+instructions)
+		parts = append(parts, "Work policy instructions:\n"+instructions)
 	}
 	if instructions := strings.TrimSpace(role.Instructions); instructions != "" {
 		parts = append(parts, "Role instructions:\n"+instructions)

--- a/ui/e2e/projects.spec.ts
+++ b/ui/e2e/projects.spec.ts
@@ -2761,8 +2761,8 @@ test("Projects supporting surfaces stay read-first at desktop and narrow widths"
   await expect(settings).toBeHidden();
   await expect(projectSettingsButton).toBeFocused();
 
-  await page.getByRole("button", { name: "Agent presets" }).click();
-  const presets = page.getByRole("dialog", { name: "Agent presets" });
+  await page.getByRole("button", { name: "Work policies" }).click();
+  const presets = page.getByRole("dialog", { name: "Work policies" });
   await expect(presets).toBeVisible();
   expect(await presets.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(
     true,

--- a/ui/e2e/providers.spec.ts
+++ b/ui/e2e/providers.spec.ts
@@ -46,11 +46,19 @@ test("empty state shows the placeholder and an Add provider CTA", async ({ page 
   await expect(page.getByRole("button", { name: /add provider/i }).first()).toBeVisible();
 });
 
-test("passive external-agent refresh discovers a repaired install without probing", async ({
-  page,
-}) => {
+test("discovery refresh checks a newly available external agent once", async ({ page }) => {
   let catalogReads = 0;
-  let probeCalls = 0;
+  const checkedAdapterIDs: string[] = [];
+  const codex = MOCK_AGENT_ADAPTERS[0]!;
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (request.method() === "POST" && path.startsWith("/hecate/v1/agent-adapters/")) {
+      checkedAdapterIDs.push(path.split("/")[4] ?? "");
+    }
+  });
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+  await mockGatewayAPIs(page);
+  await page.unroute("/hecate/v1/agent-adapters*");
   await page.route("/hecate/v1/agent-adapters*", async (route) => {
     const request = route.request();
     const path = new URL(request.url()).pathname;
@@ -77,20 +85,49 @@ test("passive external-agent refresh discovers a repaired install without probin
       return;
     }
     if (request.method() === "POST" && path.endsWith("/probe")) {
-      probeCalls += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          object: "agent_adapter_probe",
+          data: {
+            adapter: {
+              ...codex,
+              available: true,
+              status: "available",
+              error: "",
+              path: "/Applications/Codex.app/Contents/Resources/codex",
+            },
+            health: {
+              adapter_id: "codex",
+              status: "ready",
+              stage: "ready",
+              path: "/Applications/Codex.app/Contents/Resources/codex",
+              duration_ms: 10,
+            },
+          },
+        }),
+      });
+      return;
     }
     await route.fallback();
   });
 
-  await page
-    .getByRole("button", { name: "Refresh external-agent discovery without starting agents" })
-    .click();
+  await page.goto("/");
+  await page.waitForSelector(".hecate-activitybar");
+  await page.locator(".hecate-activitybar [aria-label^='Connections']").click();
+  await expectConnectionsWorkspace(page);
 
   await expect(page.getByTestId("external-agents-adapter-codex")).toContainText(
     "last discovered path /Applications/Codex.app/Contents/Resources/codex",
   );
-  expect(catalogReads).toBe(1);
-  expect(probeCalls).toBe(0);
+  await expect.poll(() => checkedAdapterIDs).toEqual(["codex"]);
+  expect(catalogReads).toBeGreaterThanOrEqual(1);
+
+  // Passive rediscovery should not start another short-lived ACP session for
+  // this panel visit; the existing check remains sufficient until Check again.
+  await page.getByRole("button", { name: "Refresh external-agent discovery" }).click();
+  await expect.poll(() => checkedAdapterIDs).toEqual(["codex"]);
 });
 
 test("readiness repair card opens a blocked provider from Connections", async ({ page }) => {

--- a/ui/src/app/state/coordinators/agentAdapters.test.tsx
+++ b/ui/src/app/state/coordinators/agentAdapters.test.tsx
@@ -204,12 +204,35 @@ describe("useAgentAdapterActions", () => {
       diagnosticResult = await diagnostic;
     });
 
-    expect(diagnosticResult).toBeNull();
+    expect(diagnosticResult).toEqual({ ok: true, health: null });
     expect(result.current.providersAndModels.state.agentAdapters[0]).toMatchObject({
       auth_status: "ok",
     });
     expect(result.current.providersAndModels.state.agentAdapterHealthByID.has("codex")).toBe(false);
     expect(notices).toEqual([["success", "External agent sign-in completed."]]);
+  });
+
+  it("keeps an automatic check failure local to the adapter row", async () => {
+    probeAgentAdapterMock.mockRejectedValue(new Error("adapter launch failed"));
+    const notices: Array<[string, string]> = [];
+    const { result } = renderHook(
+      () =>
+        useAgentAdapterActions({
+          setNoticeMessage: (kind, message) => notices.push([kind, message]),
+        }),
+      { wrapper: ReadyWrapper },
+    );
+
+    let checkResult: unknown;
+    await act(async () => {
+      checkResult = await result.current.probeAgentAdapter("codex", {
+        notify: false,
+        refreshCatalog: false,
+      });
+    });
+
+    expect(checkResult).toEqual({ ok: false, error: "adapter launch failed" });
+    expect(notices).toEqual([]);
   });
 
   it("logs out an adapter and atomically replaces stale auth diagnostics", async () => {

--- a/ui/src/app/state/coordinators/agentAdapters.ts
+++ b/ui/src/app/state/coordinators/agentAdapters.ts
@@ -1,4 +1,4 @@
-// Agent-adapter coordinator: optional diagnostics for external agent adapters.
+// Agent-adapter coordinator: bounded session checks for external agent adapters.
 
 import { useContext } from "react";
 
@@ -15,30 +15,46 @@ export type UseAgentAdapterActionsParams = {
   setNoticeMessage: SettingsActions["setNoticeMessage"];
 };
 
+export type AgentAdapterCheckOptions = {
+  notify?: boolean;
+  refreshCatalog?: boolean;
+};
+
+export type AgentAdapterCheckResult =
+  | { ok: true; health: AgentAdapterHealthRecord | null }
+  | { ok: false; error: string };
+
+type AgentAdapterRefreshOptions = {
+  notify?: boolean;
+};
+
 export function useAgentAdapterActions(params: UseAgentAdapterActionsParams) {
   const providersAndModels = useProvidersAndModels();
 
-  async function refreshAgentAdapters(): Promise<boolean> {
+  async function refreshAgentAdapters(options: AgentAdapterRefreshOptions = {}): Promise<boolean> {
     const result = await providersAndModels.actions.refreshAgentAdapters();
     if (!result.ok) {
-      params.setNoticeMessage("error", result.error);
+      if (options.notify !== false) params.setNoticeMessage("error", result.error);
       return false;
     }
     return true;
   }
 
-  // probeAgentAdapter exercises the configured adapter and caches the typed
-  // diagnostic keyed by adapter id. Operators trigger it explicitly in
-  // Connections; it annotates status chips but never gates a later chat. The
-  // loading map is keyed by id so two adapters can run concurrently without
-  // confusing the UI.
-  async function probeAgentAdapter(adapterID: string): Promise<AgentAdapterHealthRecord | null> {
-    const result = await providersAndModels.actions.probeAgentAdapter(adapterID);
+  // probeAgentAdapter opens a short-lived ACP session and caches the typed
+  // result by adapter id. Connections runs it automatically without a global
+  // error notice; an operator retry keeps the same session check explicit.
+  // It annotates status but never gates a later chat.
+  async function probeAgentAdapter(
+    adapterID: string,
+    options: AgentAdapterCheckOptions = {},
+  ): Promise<AgentAdapterCheckResult> {
+    const result = await providersAndModels.actions.probeAgentAdapter(adapterID, {
+      refreshCatalog: options.refreshCatalog,
+    });
     if (!result.ok) {
-      params.setNoticeMessage("error", result.error);
-      return null;
+      if (options.notify !== false) params.setNoticeMessage("error", result.error);
     }
-    return result.health;
+    return result;
   }
 
   async function logoutAgentAdapter(adapterID: string): Promise<boolean> {

--- a/ui/src/app/state/providersAndModels.test.tsx
+++ b/ui/src/app/state/providersAndModels.test.tsx
@@ -387,6 +387,50 @@ describe("probeAgentAdapter", () => {
     });
   });
 
+  it("leaves catalog refresh to a grouped automatic check", async () => {
+    const adapter = {
+      id: "codex",
+      name: "Codex",
+      kind: "acp",
+      command: "codex",
+      available: true,
+      status: "available",
+      auth_status: "ok",
+      supports_authenticate: true,
+      supports_logout: true,
+    };
+    probeAgentAdapterMock.mockResolvedValueOnce({
+      object: "agent_adapter_probe",
+      data: {
+        adapter,
+        health: {
+          adapter_id: "codex",
+          status: "ready",
+          stage: "ready",
+          duration_ms: 12,
+        },
+      },
+    });
+    function SeededWrapper({ children }: { children: ReactNode }) {
+      return (
+        <ProvidersAndModelsProvider initialState={{ agentAdapters: [adapter] }}>
+          {children}
+        </ProvidersAndModelsProvider>
+      );
+    }
+    const { result } = renderHook(() => useProvidersAndModels(), { wrapper: SeededWrapper });
+
+    await act(async () => {
+      await result.current.actions.probeAgentAdapter("codex", { refreshCatalog: false });
+    });
+
+    expect(probeAgentAdapterMock).toHaveBeenCalledWith("codex");
+    expect(getAgentAdaptersMock).not.toHaveBeenCalled();
+    expect(result.current.state.agentAdapterHealthByID.get("codex")).toMatchObject({
+      status: "ready",
+    });
+  });
+
   it("discards a pre-sign-in diagnostic and lets a fresh diagnostic start", async () => {
     let resolveOldProbe: (value: unknown) => void = () => {};
     let resolveFreshProbe: (value: unknown) => void = () => {};

--- a/ui/src/app/state/providersAndModels.tsx
+++ b/ui/src/app/state/providersAndModels.tsx
@@ -77,6 +77,13 @@ export type ProbeAdapterResult =
   | { ok: true; health: AgentAdapterHealthRecord | null }
   | { ok: false; error: string };
 
+export type ProbeAgentAdapterOptions = {
+  // Connections checks several adapters together. Their individual probe
+  // results still update the local projection, while one follow-up catalog
+  // refresh updates passive discovery for the whole set.
+  refreshCatalog?: boolean;
+};
+
 export type RefreshAgentAdaptersResult =
   | { ok: true; adapters: AgentAdapterRecord[] }
   | { ok: false; error: string };
@@ -103,7 +110,10 @@ export type ProvidersAndModelsActions = {
   loadAgentAdapterCatalog: () => Promise<AgentAdapterResponse>;
   refreshProviders: () => Promise<void>;
   refreshAgentAdapters: () => Promise<RefreshAgentAdaptersResult>;
-  probeAgentAdapter: (adapterID: string) => Promise<ProbeAdapterResult>;
+  probeAgentAdapter: (
+    adapterID: string,
+    options?: ProbeAgentAdapterOptions,
+  ) => Promise<ProbeAdapterResult>;
   verifyModelToolSupport: (
     provider: string,
     model: string,
@@ -421,7 +431,10 @@ export function ProvidersAndModelsProvider({
   }, [loadAgentAdapterCatalog]);
 
   const probeAgentAdapter = useCallback(
-    async (adapterID: string): Promise<ProbeAdapterResult> => {
+    async (
+      adapterID: string,
+      options: ProbeAgentAdapterOptions = {},
+    ): Promise<ProbeAdapterResult> => {
       if (!adapterID) return { ok: false, error: "Adapter id required to probe." };
       const inFlight = probeAgentAdapterInFlightRef.current.get(adapterID);
       if (inFlight) return inFlight;
@@ -449,12 +462,14 @@ export function ProvidersAndModelsProvider({
                   : item,
               ),
           });
-          const catalogRefresh = await refreshAgentAdapters();
-          if (!catalogRefresh.ok) {
-            warn("agentAdapters.refreshAfterDiagnostic.failed", {
-              adapterID,
-              err: catalogRefresh.error,
-            });
+          if (options.refreshCatalog !== false) {
+            const catalogRefresh = await refreshAgentAdapters();
+            if (!catalogRefresh.ok) {
+              warn("agentAdapters.refreshAfterDiagnostic.failed", {
+                adapterID,
+                err: catalogRefresh.error,
+              });
+            }
           }
           return { ok: true, health: payload.data.health };
         } catch (error) {

--- a/ui/src/features/chats/ChatAgentControls.test.tsx
+++ b/ui/src/features/chats/ChatAgentControls.test.tsx
@@ -120,14 +120,14 @@ describe("NewChatAgentButton", () => {
       },
     );
     expect(probed.label).toBe("checked");
-    expect(probed.title).toContain("last Cursor Agent diagnostic completed ACP startup");
+    expect(probed.title).toContain("last Cursor Agent check completed ACP startup");
     expect(probed.title).toContain("without sending a prompt");
     expect(probed.title).toContain(
       "first message checks any deferred prompt-serving vendor invocation",
     );
   });
 
-  it("does not let a ready ACP diagnostic hide an explicit sign-in state", () => {
+  it("does not let a ready ACP check hide an explicit sign-in state", () => {
     const result = chatAgentOptionStatus(
       "claude_code",
       makeAdapter({
@@ -149,7 +149,7 @@ describe("NewChatAgentButton", () => {
       ready: true,
     });
     expect(result.title).toContain("Run claude /login");
-    expect(result.title).not.toContain("diagnostic completed ACP startup");
+    expect(result.title).not.toContain("check completed ACP startup");
   });
 
   it.each([
@@ -162,17 +162,17 @@ describe("NewChatAgentButton", () => {
     {
       status: "error",
       stage: "initialize",
-      hint: "The last diagnostic failed.",
+      hint: "The last check failed.",
       expectedLabel: "issue",
     },
     {
       status: "not_installed",
       stage: "resolve",
-      hint: "The executable was missing during the last diagnostic.",
-      expectedLabel: "diagnostic",
+      hint: "The executable was missing during the last check.",
+      expectedLabel: "check",
     },
   ])(
-    "keeps a discovered agent selectable after a cached $status diagnostic",
+    "keeps a discovered agent selectable after a cached $status check",
     ({ status, stage, hint, expectedLabel }) => {
       const result = chatAgentOptionStatus(
         "cursor_agent",
@@ -198,7 +198,7 @@ describe("NewChatAgentButton", () => {
     },
   );
 
-  it("keeps current passive discovery authoritative over a stale ready diagnostic", () => {
+  it("keeps current passive discovery authoritative over a stale ready check", () => {
     const result = chatAgentOptionStatus(
       "cursor_agent",
       makeAdapter({
@@ -311,7 +311,7 @@ describe("NewChatAgentButton", () => {
     expect(onCreate).toHaveBeenCalledWith("codex");
   });
 
-  it("discloses current discovery instead of a stale diagnostic executable", () => {
+  it("discloses current discovery instead of a stale checked executable", () => {
     render(
       <NewChatAgentButton
         value="codex"
@@ -362,7 +362,7 @@ describe("NewChatAgentButton", () => {
     });
   });
 
-  it("does not replace a remembered agent because its cached diagnostic failed", async () => {
+  it("does not replace a remembered agent because its cached check failed", async () => {
     const onChange = vi.fn();
     const onCreate = vi.fn();
     render(

--- a/ui/src/features/chats/ChatAgentControls.tsx
+++ b/ui/src/features/chats/ChatAgentControls.tsx
@@ -293,7 +293,7 @@ export function NewChatAgentButton({
 }
 
 function externalAgentExecutablePath(adapter: AgentAdapterRecord | undefined): string {
-  // Launch disclosure must describe current passive discovery. A diagnostic
+  // Launch disclosure must describe current passive discovery. A prior check
   // path is historical evidence and can differ from the executable that the
   // authoritative chat launch resolves now.
   const path = adapter?.path?.trim() || "";
@@ -447,7 +447,7 @@ export function chatAgentOptionStatus(
     return {
       label: "billing",
       color: "var(--amber)",
-      title: adapterDiagnosticTitle(optionID, adapter, adapter.auth_error),
+      title: adapterCheckTitle(optionID, adapter, adapter.auth_error),
       ready: launchReady,
     };
   }
@@ -467,7 +467,7 @@ export function chatAgentOptionStatus(
     return {
       label: "issue",
       color: "var(--amber)",
-      title: adapterDiagnosticTitle(
+      title: adapterCheckTitle(
         optionID,
         adapter,
         adapter.auth_error || `Auth status: ${adapter.auth_status}`,
@@ -485,17 +485,17 @@ export function chatAgentOptionStatus(
   }
   if (health?.status === "error") {
     return {
-      label: adapterProbeLooksLikeSetupState(health) ? "diagnostic" : "issue",
+      label: adapterProbeLooksLikeSetupState(health) ? "check" : "issue",
       color: "var(--amber)",
-      title: adapterDiagnosticTitle(optionID, adapter, health.hint || health.error),
+      title: adapterCheckTitle(optionID, adapter, health.hint || health.error),
       ready: launchReady,
     };
   }
   if (health?.status === "not_installed") {
     return {
-      label: "diagnostic",
+      label: "check",
       color: "var(--amber)",
-      title: adapterDiagnosticTitle(optionID, adapter, health.hint || health.error),
+      title: adapterCheckTitle(optionID, adapter, health.hint || health.error),
       ready: launchReady,
     };
   }
@@ -550,7 +550,7 @@ function adapterAuthSetupTitle(
   }
   const command = adapterLoginCommand(optionID);
   const action = command
-    ? `Run ${command} in Terminal, then retry the chat. Diagnostics in Connections are optional.`
+    ? `Run ${command} in Terminal, then use Check again in Connections or retry the chat.`
     : `Open Connections to sign in to ${name}.`;
   const cleanDetail = sanitizedAdapterDetail(detail);
   return cleanDetail ? `${action} ${cleanDetail}` : action;
@@ -567,14 +567,14 @@ function adapterRemoteCredentialTitle(
   return cleanDetail ? `${action} ${cleanDetail}` : action;
 }
 
-function adapterDiagnosticTitle(
+function adapterCheckTitle(
   optionID: ChatAgentOptionID,
   adapter: AgentAdapterRecord | undefined,
   detail: string | undefined,
 ): string {
   const name = adapterDisplayName(optionID, adapter);
   const cleanDetail = sanitizedAdapterDetail(detail);
-  const action = `The last ${name} diagnostic needs attention. Starting a chat retries the current ACP launch; use Connections for optional diagnostics.`;
+  const action = `The last ${name} check needs attention. Starting a chat retries the current ACP launch; Connections checks available agents automatically.`;
   return cleanDetail ? `${action} ${cleanDetail}` : action;
 }
 
@@ -625,7 +625,7 @@ function adapterCheckedTitle(
 ): string {
   const name = adapterDisplayName(optionID, adapter);
   const suffix = path ? ` Path: ${path}` : "";
-  return `The last ${name} diagnostic completed ACP startup and session checks without sending a prompt. New chat still prepares a fresh session; the first message checks any deferred prompt-serving vendor invocation and authentication.${suffix}`;
+  return `The last ${name} check completed ACP startup and session checks without sending a prompt. New chat still prepares a fresh session; the first message checks any deferred prompt-serving vendor invocation and authentication.${suffix}`;
 }
 
 function adapterAvailableTitle(

--- a/ui/src/features/chats/ChatSettingsPanel.test.tsx
+++ b/ui/src/features/chats/ChatSettingsPanel.test.tsx
@@ -152,11 +152,11 @@ describe("ChatSettingsPanel Hecate workspace execution", () => {
       />,
     );
 
-    expect(screen.getByText("Agent preset")).toBeTruthy();
+    expect(screen.getByText("Work policy")).toBeTruthy();
     expect(screen.getByText("Chat review")).toBeTruthy();
     expect(screen.getByText(/Frozen when this chat was created/i)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Tools off" })).toBeDisabled();
-    expect(screen.getByText(/frozen Agent Preset disables local tools/i)).toBeTruthy();
+    expect(screen.getByText(/frozen work policy disables local tools/i)).toBeTruthy();
   });
 
   it("explains isolated execution and changes the workspace mode", () => {

--- a/ui/src/features/chats/ChatSettingsPanel.tsx
+++ b/ui/src/features/chats/ChatSettingsPanel.tsx
@@ -148,7 +148,7 @@ export function ChatSettingsPanel({
               </div>
             </ChatSettingsSection>
             {agentPreset && (
-              <ChatSettingsSection title="Agent preset">
+              <ChatSettingsSection title="Work policy">
                 <ChatSettingsAgentPreset preset={agentPreset} />
               </ChatSettingsSection>
             )}
@@ -474,7 +474,7 @@ function ChatSettingsToolsRow({
         <div style={{ fontSize: 12, fontWeight: 650, color: "var(--t0)" }}>Tools</div>
         <div style={{ marginTop: 3, fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>
           {lockedByPreset
-            ? "This chat's frozen Agent Preset disables local tools. Messages go directly to the selected provider/model."
+            ? "This chat's frozen work policy disables local tools. Messages go directly to the selected provider/model."
             : effectiveEnabled
               ? "Create or continue a linked Task with tools, approvals, artifacts, and sandboxed tool calls."
               : "Send the next message directly to the selected provider/model. This does not create a Task or use local tools."}
@@ -530,14 +530,14 @@ function ChatSettingsAgentPreset({ preset }: { preset: ChatAgentPresetSnapshotRe
         gap: 6,
       }}
     >
-      <ChatSettingsField label="Preset" value={preset.name || preset.id} />
+      <ChatSettingsField label="Selected policy" value={preset.name || preset.id} />
       <ChatSettingsField label="ID" value={preset.id} mono />
       {preset.execution_profile && (
         <ChatSettingsField label="Profile" value={preset.execution_profile} mono />
       )}
       <ChatSettingsField label="Posture" value={posture} />
       <div style={{ fontSize: 11, color: "var(--t3)", lineHeight: 1.45 }}>
-        Frozen when this chat was created. Later Agent Preset edits or deletion do not change this
+        Frozen when this chat was created. Later work-policy edits or deletion do not change this
         chat or its backing Tasks.
       </div>
     </div>

--- a/ui/src/features/chats/ChatSidebar.test.tsx
+++ b/ui/src/features/chats/ChatSidebar.test.tsx
@@ -145,7 +145,7 @@ describe("ChatSidebar new-chat creation", () => {
     );
 
     const presetSelect = screen.getByRole("combobox", {
-      name: "Agent preset for new Hecate chat",
+      name: "Work policy for new Hecate chat",
     });
     expect(mockedGetAgentPresets).not.toHaveBeenCalled();
     fireEvent.focus(presetSelect);

--- a/ui/src/features/chats/ChatSidebar.tsx
+++ b/ui/src/features/chats/ChatSidebar.tsx
@@ -169,7 +169,7 @@ export function ChatSidebar({
       })
       .catch(() => {
         setHecatePresetsError(
-          "Could not load Agent Presets. You can still start a default Hecate Chat.",
+          "Could not load work policies. You can still start a default Hecate Chat.",
         );
       })
       .finally(() => {
@@ -381,10 +381,10 @@ export function ChatSidebar({
                   color: "var(--t3)",
                 }}
               >
-                Agent preset
+                Work policy
                 <select
                   className="input"
-                  aria-label="Agent preset for new Hecate chat"
+                  aria-label="Work policy for new Hecate chat"
                   value={newHecatePresetID}
                   disabled={chatCreating || chatSessionCreateInFlight}
                   onFocus={loadHecatePresets}

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -143,7 +143,8 @@ export function ConnectionsPanel({
   const [agentAdapterAutomaticCheckErrorByID, setAgentAdapterAutomaticCheckErrorByID] = useState<
     Map<string, string>
   >(() => new Map());
-  const checkedAgentAdapterIDsRef = useRef(new Set<string>());
+  const completedAgentAdapterCheckIDsRef = useRef(new Set<string>());
+  const agentAdapterCheckAttemptsRef = useRef(new Map<string, Promise<boolean>>());
   const chatGrants = approvals.state.grants;
   const chatGrantsLoading = approvals.state.grantsLoading;
   const chatGrantsError = approvals.state.grantsError;
@@ -172,24 +173,35 @@ export function ConnectionsPanel({
           adapter.available &&
           Boolean(adapter.id) &&
           !agentAdapterHealthByID.has(adapter.id) &&
-          !checkedAgentAdapterIDsRef.current.has(adapter.id),
+          !completedAgentAdapterCheckIDsRef.current.has(adapter.id),
       )
       .map((adapter) => adapter.id);
     if (adapterIDs.length === 0) return;
 
-    for (const adapterID of adapterIDs) checkedAgentAdapterIDsRef.current.add(adapterID);
+    const attempts = adapterIDs.map((adapterID) => {
+      const existingAttempt = agentAdapterCheckAttemptsRef.current.get(adapterID);
+      if (existingAttempt) return { adapterID, attempt: existingAttempt };
+
+      // StrictMode restarts effects during development. Keep the bounded
+      // session attempt in a ref so the restarted effect observes the same
+      // result rather than launching another adapter process or losing it.
+      const attempt = Promise.resolve()
+        .then(() => probeAgentAdapter(adapterID, { notify: false, refreshCatalog: false }))
+        .then((result) => result?.ok !== false)
+        .catch(() => false);
+      agentAdapterCheckAttemptsRef.current.set(adapterID, attempt);
+      return { adapterID, attempt };
+    });
     let active = true;
-    void Promise.allSettled(
-      adapterIDs.map((adapterID) =>
-        probeAgentAdapter(adapterID, { notify: false, refreshCatalog: false }),
-      ),
+    void Promise.all(
+      attempts.map(async ({ adapterID, attempt }) => ({ adapterID, succeeded: await attempt })),
     ).then((outcomes) => {
       if (!active) return;
+      outcomes.forEach(({ adapterID }) => completedAgentAdapterCheckIDsRef.current.add(adapterID));
       setAgentAdapterAutomaticCheckErrorByID((current) => {
         const next = new Map(current);
-        outcomes.forEach((outcome, index) => {
-          const adapterID = adapterIDs[index]!;
-          if (outcome.status === "fulfilled" && outcome.value?.ok !== false) {
+        outcomes.forEach(({ adapterID, succeeded }) => {
+          if (succeeded) {
             next.delete(adapterID);
             return;
           }

--- a/ui/src/features/connections/ConnectionsPanel.tsx
+++ b/ui/src/features/connections/ConnectionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useApprovals } from "../../app/state/approvals";
 import { useChatActions } from "../../app/state/coordinators/chat";
 import { useAgentAdapterActions } from "../../app/state/coordinators/agentAdapters";
@@ -107,8 +107,8 @@ function SectionHeader({
 // on retention and other non-connection configuration.
 //
 // Grants are lazy-loaded on panel mount — operators rarely visit this surface,
-// so we don't fetch them on every dashboard load. Adapter discovery stays
-// passive; optional diagnostics disclose that they execute the installed app.
+// so we don't fetch them on every dashboard load. Discovery stays passive;
+// available external agents then receive one bounded, no-prompt session check.
 export function ConnectionsPanel({
   onNavigate,
   onAddProvider,
@@ -140,6 +140,10 @@ export function ConnectionsPanel({
     Map<string, true>
   >(() => new Map());
   const [agentAdapterCatalogRefreshing, setAgentAdapterCatalogRefreshing] = useState(false);
+  const [agentAdapterAutomaticCheckErrorByID, setAgentAdapterAutomaticCheckErrorByID] = useState<
+    Map<string, string>
+  >(() => new Map());
+  const checkedAgentAdapterIDsRef = useRef(new Set<string>());
   const chatGrants = approvals.state.grants;
   const chatGrantsLoading = approvals.state.grantsLoading;
   const chatGrantsError = approvals.state.grantsError;
@@ -160,6 +164,50 @@ export function ConnectionsPanel({
   const refreshAgentAdapters = agentAdapterActions.refreshAgentAdapters;
   const authenticateAgentAdapter = agentAdapterActions.authenticateAgentAdapter;
   const logoutAgentAdapter = agentAdapterActions.logoutAgentAdapter;
+
+  useEffect(() => {
+    const adapterIDs = agentAdapters
+      .filter(
+        (adapter) =>
+          adapter.available &&
+          Boolean(adapter.id) &&
+          !agentAdapterHealthByID.has(adapter.id) &&
+          !checkedAgentAdapterIDsRef.current.has(adapter.id),
+      )
+      .map((adapter) => adapter.id);
+    if (adapterIDs.length === 0) return;
+
+    for (const adapterID of adapterIDs) checkedAgentAdapterIDsRef.current.add(adapterID);
+    let active = true;
+    void Promise.allSettled(
+      adapterIDs.map((adapterID) =>
+        probeAgentAdapter(adapterID, { notify: false, refreshCatalog: false }),
+      ),
+    ).then((outcomes) => {
+      if (!active) return;
+      setAgentAdapterAutomaticCheckErrorByID((current) => {
+        const next = new Map(current);
+        outcomes.forEach((outcome, index) => {
+          const adapterID = adapterIDs[index]!;
+          if (outcome.status === "fulfilled" && outcome.value?.ok !== false) {
+            next.delete(adapterID);
+            return;
+          }
+          // Automatic checks deliberately avoid global notices. Keep their
+          // generic failure local to the row, rather than exposing a transport
+          // or adapter error that may be unsuitable for an operator surface.
+          next.set(adapterID, "Automatic check could not complete. Use Check again.");
+        });
+        return next;
+      });
+      // Individual checks update their own health rows. One silent catalog
+      // refresh afterwards picks up repaired paths without multiplying GETs.
+      void refreshAgentAdapters({ notify: false });
+    });
+    return () => {
+      active = false;
+    };
+  }, [agentAdapters, agentAdapterHealthByID, probeAgentAdapter, refreshAgentAdapters]);
 
   useEffect(() => {
     if (liveAnthropicProvider) setRememberedAnthropicProvider(liveAnthropicProvider);
@@ -288,6 +336,18 @@ export function ConnectionsPanel({
     }
   }
 
+  async function handleProbeAdapter(adapterID: string) {
+    const result = await probeAgentAdapter(adapterID);
+    const succeeded = result?.ok !== false;
+    setAgentAdapterAutomaticCheckErrorByID((current) => {
+      if (!current.has(adapterID) && succeeded) return current;
+      const next = new Map(current);
+      if (succeeded) next.delete(adapterID);
+      else next.set(adapterID, "Check could not complete. Try again after fixing the setup.");
+      return next;
+    });
+  }
+
   return (
     <div className="connections-panel">
       {showProviderSummary && (
@@ -317,13 +377,14 @@ export function ConnectionsPanel({
         agentAdapters={agentAdapters}
         agentAdapterHealthByID={agentAdapterHealthByID}
         agentAdapterHealthLoadingByID={agentAdapterHealthLoadingByID}
+        agentAdapterAutomaticCheckErrorByID={agentAdapterAutomaticCheckErrorByID}
         agentAdapterAuthenticateLoadingByID={agentAdapterAuthenticateLoadingByID}
         agentAdapterLogoutLoadingByID={agentAdapterLogoutLoadingByID}
         remoteRuntime={remoteRuntime}
         catalogRefreshing={agentAdapterCatalogRefreshing}
         copyCommand={copyCommand}
         onRefreshCatalog={() => void handleRefreshAgentAdapters()}
-        onProbeAdapter={(adapterID) => void probeAgentAdapter(adapterID)}
+        onProbeAdapter={(adapterID) => void handleProbeAdapter(adapterID)}
         onAuthenticateAdapter={(adapterID) => void handleAuthenticateAdapter(adapterID)}
         onLogoutAdapter={(adapterID) => void handleLogoutAdapter(adapterID)}
       />
@@ -717,15 +778,15 @@ function AnthropicProviderKeyCard({
   );
 }
 
-// AdapterStatusSection lists the configured external agents. Optional
-// diagnostics start the runtime, complete an ACP handshake, and classify that
-// disposable session; they annotate this view but never gate a later chat.
-// Passive discovery and launch availability remain owned by the
-// /hecate/v1/agent-adapters catalog, which can be refreshed independently.
+// AdapterStatusSection lists configured external agents. Connections checks
+// each available agent once with a disposable ACP session, without sending a
+// prompt. The result annotates this view but never gates a later chat.
+// Passive discovery remains independently refreshable from the catalog.
 function AdapterStatusSection({
   agentAdapters,
   agentAdapterHealthByID,
   agentAdapterHealthLoadingByID,
+  agentAdapterAutomaticCheckErrorByID,
   agentAdapterAuthenticateLoadingByID,
   agentAdapterLogoutLoadingByID,
   remoteRuntime,
@@ -739,6 +800,7 @@ function AdapterStatusSection({
   agentAdapters: ProvidersAndModelsState["agentAdapters"];
   agentAdapterHealthByID: ProvidersAndModelsState["agentAdapterHealthByID"];
   agentAdapterHealthLoadingByID: ProvidersAndModelsState["agentAdapterHealthLoadingByID"];
+  agentAdapterAutomaticCheckErrorByID: Map<string, string>;
   agentAdapterAuthenticateLoadingByID: Map<string, true>;
   agentAdapterLogoutLoadingByID: Map<string, true>;
   remoteRuntime: boolean;
@@ -756,7 +818,7 @@ function AdapterStatusSection({
     <div style={{ marginBottom: 24 }} data-testid="external-agents-adapters">
       <SectionHeader
         title="External agents"
-        description="Hecate finds installed agents without launching them. Refresh only repeats that passive discovery. New chat re-resolves the app and prepares the real ACP session; the first message verifies any deferred prompt-serving vendor invocation and authentication. Optional diagnostics below start a temporary session for troubleshooting."
+        description="Hecate discovers installed agents, then checks each available agent here with a short-lived ACP session and no prompt. Refresh repeats passive discovery. New chat always prepares a fresh real session."
         meta={`${agentAdapters.length} agent${agentAdapters.length === 1 ? "" : "s"}`}
         actions={
           <button
@@ -767,10 +829,10 @@ function AdapterStatusSection({
             aria-label={
               catalogRefreshing
                 ? "Refreshing external-agent discovery"
-                : "Refresh external-agent discovery without starting agents"
+                : "Refresh external-agent discovery"
             }
             aria-live="polite"
-            title="Refresh installed-agent paths without starting an agent"
+            title="Refresh installed-agent paths; available agents are checked automatically"
           >
             <Icon d={Icons.refresh} size={13} />
             {catalogRefreshing ? "Refreshing…" : "Refresh"}
@@ -786,6 +848,7 @@ function AdapterStatusSection({
             divider={i < agentAdapters.length - 1}
             health={agentAdapterHealthByID.get(adapter.id) ?? null}
             loading={Boolean(agentAdapterHealthLoadingByID.get(adapter.id))}
+            automaticCheckError={agentAdapterAutomaticCheckErrorByID.get(adapter.id) ?? ""}
             authenticateLoading={Boolean(agentAdapterAuthenticateLoadingByID.get(adapter.id))}
             logoutLoading={Boolean(agentAdapterLogoutLoadingByID.get(adapter.id))}
             onCopyCommand={(command) => void copyCommand(command)}
@@ -805,6 +868,7 @@ function AdapterStatusRow({
   divider,
   health,
   loading,
+  automaticCheckError,
   authenticateLoading,
   logoutLoading,
   onCopyCommand,
@@ -817,6 +881,7 @@ function AdapterStatusRow({
   divider: boolean;
   health: AgentAdapterHealthRecord | null;
   loading: boolean;
+  automaticCheckError: string;
   authenticateLoading: boolean;
   logoutLoading: boolean;
   onCopyCommand: (command: string) => void;
@@ -825,6 +890,7 @@ function AdapterStatusRow({
   onLogoutAdapter: (adapter: AgentAdapterRecord) => void;
 }) {
   const readiness = resolveExternalAgentReadiness(adapter, health);
+  const visibleAutomaticCheckError = adapter.available ? automaticCheckError : "";
   const loginCommand = readiness.loginCommand;
   const showLocalAuthSetup =
     !remoteRuntime && Boolean(loginCommand) && readiness.kind === "sign_in";
@@ -839,7 +905,7 @@ function AdapterStatusRow({
   const visibleHealthError =
     health && shouldShowProbeError(health) ? humanizeProbeError(health.error ?? "") : "";
   const selectedPath = adapter.path || "";
-  const diagnosticPath =
+  const checkPath =
     health?.path && health.path !== selectedPath && !isDevOverridePath(health.path)
       ? health.path
       : "";
@@ -911,6 +977,9 @@ function AdapterStatusRow({
             {adapter.name}
           </span>
           <span className={`badge ${badgeClassForTone(readiness.tone)}`}>{readiness.label}</span>
+          {visibleAutomaticCheckError && (
+            <span className="badge badge-amber">check unavailable</span>
+          )}
           {adapter.embedded && (
             <span
               className="badge badge-neutral"
@@ -967,9 +1036,9 @@ function AdapterStatusRow({
               last discovered path <span style={{ color: "var(--t1)" }}>{selectedPath}</span>
             </span>
           )}
-          {diagnosticPath && (
+          {checkPath && (
             <span>
-              diagnostic path <span style={{ color: "var(--t1)" }}>{diagnosticPath}</span>
+              last check path <span style={{ color: "var(--t1)" }}>{checkPath}</span>
             </span>
           )}
           {showHealthDuration && health?.duration_ms !== undefined && (
@@ -1033,13 +1102,22 @@ function AdapterStatusRow({
             {detail.message}
           </div>
         )}
+        {visibleAutomaticCheckError && (
+          <div
+            data-testid={`external-agents-adapter-${adapter.id}-automatic-check-error`}
+            role="status"
+            style={{ marginTop: 6, fontSize: 11, color: "var(--amber)", lineHeight: 1.4 }}
+          >
+            {visibleAutomaticCheckError}
+          </div>
+        )}
         {showLocalAuthSetup && loginCommand && (
           <AdapterLocalAuthSetup
             adapterID={adapter.id}
             adapterName={adapter.name || adapter.id}
             loginCommand={loginCommand}
             onCopyCommand={onCopyCommand}
-            onRunDiagnostics={() => onProbeAdapter(adapter)}
+            onCheckAgain={() => onProbeAdapter(adapter)}
             testing={loading}
           />
         )}
@@ -1047,7 +1125,7 @@ function AdapterStatusRow({
           <AdapterRemoteCredentialSetup
             adapter={adapter}
             onCopyCommand={onCopyCommand}
-            onRunDiagnostics={() => onProbeAdapter(adapter)}
+            onCheckAgain={() => onProbeAdapter(adapter)}
             testing={loading}
           />
         )}
@@ -1088,7 +1166,7 @@ function AdapterStatusRow({
               whiteSpace: "nowrap",
             }}
           >
-            diagnosing…
+            checking…
           </span>
         )}
         {showProbeAction && (
@@ -1097,11 +1175,11 @@ function AdapterStatusRow({
             className="btn btn-ghost btn-sm"
             onClick={() => onProbeAdapter(adapter)}
             disabled={loading}
-            aria-label={`Run diagnostics for ${adapter.name || adapter.id}; opens a temporary ACP session and may execute the agent app`}
-            title={`Opens a temporary ${adapter.name || adapter.id} ACP session without sending a prompt and may execute the agent app`}
-            data-testid={`external-agents-test-${adapter.id}`}
+            aria-label={`Check ${adapter.name || adapter.id} again; opens a temporary ACP session and may execute the agent app`}
+            title={`Runs a short-lived ${adapter.name || adapter.id} session check without sending a prompt`}
+            data-testid={`external-agents-check-${adapter.id}`}
           >
-            <Icon d={Icons.refresh} size={12} /> {loading ? "Running..." : "Run diagnostics"}
+            <Icon d={Icons.refresh} size={12} /> {loading ? "Checking…" : "Check again"}
           </button>
         )}
         {showAuthenticateAction && (
@@ -1260,12 +1338,12 @@ function adapterAuthenticateSupportedByHecate(
 function AdapterRemoteCredentialSetup({
   adapter,
   onCopyCommand,
-  onRunDiagnostics,
+  onCheckAgain,
   testing,
 }: {
   adapter: AgentAdapterRecord;
   onCopyCommand: (command: string) => void;
-  onRunDiagnostics: () => void;
+  onCheckAgain: () => void;
   testing: boolean;
 }) {
   const keys = remoteCredentialKeys(adapter);
@@ -1333,12 +1411,12 @@ function AdapterRemoteCredentialSetup({
               <button
                 type="button"
                 className="btn btn-ghost btn-sm"
-                onClick={onRunDiagnostics}
+                onClick={onCheckAgain}
                 disabled={testing}
-                aria-label={`Run diagnostics for ${adapter.name || adapter.id}; opens a temporary ACP session and may execute the agent app`}
-                title={`Opens a temporary ${adapter.name || adapter.id} ACP session without sending a prompt and may execute the agent app`}
+                aria-label={`Check ${adapter.name || adapter.id} again; opens a temporary ACP session and may execute the agent app`}
+                title={`Runs a short-lived ${adapter.name || adapter.id} session check without sending a prompt`}
               >
-                {testing ? "Running..." : "Run diagnostics"}
+                {testing ? "Checking…" : "Check again"}
               </button>
             </div>
           )}
@@ -1353,14 +1431,14 @@ function AdapterLocalAuthSetup({
   adapterName,
   loginCommand,
   onCopyCommand,
-  onRunDiagnostics,
+  onCheckAgain,
   testing,
 }: {
   adapterID: string;
   adapterName: string;
   loginCommand: string;
   onCopyCommand: (command: string) => void;
-  onRunDiagnostics: () => void;
+  onCheckAgain: () => void;
   testing: boolean;
 }) {
   const accent = chipColor("amber");
@@ -1399,8 +1477,9 @@ function AdapterLocalAuthSetup({
             Local sign-in
           </div>
           <div style={{ fontSize: 11, color: "var(--t2)", lineHeight: 1.4 }}>
-            Run in Terminal, then retry the chat. Hecate uses local CLI auth as your OS user and
-            does not store credentials. Diagnostics are optional.
+            Hecate checks this agent automatically. Run this in Terminal if it needs sign-in, then
+            use Check again or start a new chat. Hecate uses local CLI auth as your OS user and does
+            not store credentials.
           </div>
           <div
             style={{
@@ -1435,12 +1514,12 @@ function AdapterLocalAuthSetup({
             <button
               type="button"
               className="btn btn-ghost btn-sm"
-              onClick={onRunDiagnostics}
+              onClick={onCheckAgain}
               disabled={testing}
-              aria-label={`Run diagnostics for ${adapterName}; opens a temporary ACP session and may execute the agent app`}
-              title={`Opens a temporary ${adapterName} ACP session without sending a prompt and may execute the agent app`}
+              aria-label={`Check ${adapterName} again; opens a temporary ACP session and may execute the agent app`}
+              title={`Runs a short-lived ${adapterName} session check without sending a prompt`}
             >
-              {testing ? "Running..." : "Run diagnostics"}
+              {testing ? "Checking…" : "Check again"}
             </button>
           </div>
         </div>
@@ -1489,7 +1568,7 @@ function adapterStatusDetail(
       tone: readiness.launchBlocked ? "muted" : "amber",
       message: readiness.launchBlocked
         ? `Set up to use: ${detail}`
-        : `Last diagnostic: ${detail} This result is advisory; New chat prepares a fresh ACP session and the first message retries any deferred prompt-serving vendor process.`,
+        : `Last check: ${detail} New chat still prepares a fresh ACP session and the first message retries any deferred prompt-serving vendor process.`,
     };
   }
 

--- a/ui/src/features/projects/AgentPresetsModal.test.tsx
+++ b/ui/src/features/projects/AgentPresetsModal.test.tsx
@@ -81,10 +81,10 @@ describe("AgentPresetsModal", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText("Preset id"), "implementation");
+    await userEvent.type(screen.getByLabelText("Policy ID"), "implementation");
     await userEvent.type(screen.getByLabelText("Name"), "Implementation");
     await userEvent.click(screen.getByLabelText("Use skill Backend"));
-    await userEvent.click(screen.getByRole("button", { name: "Create preset" }));
+    await userEvent.click(screen.getByRole("button", { name: "Create policy" }));
 
     expect(onCreate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -121,13 +121,16 @@ describe("AgentPresetsModal", () => {
     expect(selectedPreset).toHaveAttribute("aria-pressed", "true");
     expect(selectedPreset).not.toHaveClass("btn-primary");
     expect(
-      screen.getByRole("dialog", { name: "Agent presets" }).querySelectorAll(".btn-primary"),
+      screen.getByRole("dialog", { name: "Work policies" }).querySelectorAll(".btn-primary"),
     ).toHaveLength(1);
 
     await userEvent.clear(screen.getByLabelText("Name"));
     await userEvent.type(screen.getByLabelText("Name"), "Implementation lead");
-    await userEvent.type(screen.getByLabelText("Instructions"), "Ship the scoped change.");
-    await userEvent.click(screen.getByRole("button", { name: "Save preset" }));
+    await userEvent.type(
+      screen.getByLabelText("Instructions for new work"),
+      "Ship the scoped change.",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Save policy" }));
 
     expect(onUpdate).toHaveBeenCalledWith(
       "implementation",
@@ -156,27 +159,27 @@ describe("AgentPresetsModal", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText("Preset id"), "browser-review");
+    await userEvent.type(screen.getByLabelText("Policy ID"), "browser-review");
     await userEvent.type(screen.getByLabelText("Name"), "Browser review");
-    await userEvent.click(screen.getByLabelText("Browser evidence allowed"));
+    await userEvent.click(screen.getByLabelText("Allow browser evidence"));
 
     expect(screen.getByLabelText("Allowed browser origins")).toBeInTheDocument();
     expect(screen.getByText(/Add at least one exact origin/i)).toHaveAttribute("role", "alert");
-    expect(screen.getByRole("button", { name: "Create preset" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Create policy" })).toBeDisabled();
 
     await userEvent.type(
       screen.getByLabelText("Allowed browser origins"),
       "https://app.example.test",
     );
-    await userEvent.click(screen.getByLabelText("Browser evidence allowed"));
+    await userEvent.click(screen.getByLabelText("Allow browser evidence"));
     expect(screen.queryByLabelText("Allowed browser origins")).toBeNull();
-    await userEvent.click(screen.getByLabelText("Browser evidence allowed"));
+    await userEvent.click(screen.getByLabelText("Allow browser evidence"));
     expect(screen.getByLabelText("Allowed browser origins")).toHaveValue("");
     await userEvent.type(
       screen.getByLabelText("Allowed browser origins"),
       "https://app.example.test",
     );
-    await userEvent.click(screen.getByRole("button", { name: "Create preset" }));
+    await userEvent.click(screen.getByRole("button", { name: "Create policy" }));
 
     expect(onCreate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -208,9 +211,9 @@ describe("AgentPresetsModal", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText("Preset id"), "browser-review");
+    await userEvent.type(screen.getByLabelText("Policy ID"), "browser-review");
     await userEvent.type(screen.getByLabelText("Name"), "Browser review");
-    await userEvent.click(screen.getByLabelText("Browser evidence allowed"));
+    await userEvent.click(screen.getByLabelText("Allow browser evidence"));
     await userEvent.type(
       screen.getByLabelText("Allowed browser origins"),
       "https://app.example.test/",
@@ -219,7 +222,7 @@ describe("AgentPresetsModal", () => {
     expect(screen.getByText(/Browser runtime unavailable/i)).toHaveTextContent(
       "Set HECATE_TASK_BROWSER_EXECUTABLE",
     );
-    expect(screen.getByRole("button", { name: "Create preset" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Create policy" })).toBeEnabled();
   });
 
   it("rejects malformed browser origins in the form before save", async () => {
@@ -238,19 +241,19 @@ describe("AgentPresetsModal", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText("Preset id"), "browser-review");
+    await userEvent.type(screen.getByLabelText("Policy ID"), "browser-review");
     await userEvent.type(screen.getByLabelText("Name"), "Browser review");
-    await userEvent.click(screen.getByLabelText("Browser evidence allowed"));
+    await userEvent.click(screen.getByLabelText("Allow browser evidence"));
     const origins = screen.getByLabelText("Allowed browser origins");
     await userEvent.type(origins, "https://operator:secret@app.example.test/path?token=secret");
 
     expect(screen.getByRole("alert")).toHaveTextContent("Use exact http(s) origins only");
-    expect(screen.getByRole("button", { name: "Create preset" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Create policy" })).toBeDisabled();
     expect(origins).toHaveAttribute("aria-invalid", "true");
 
     await userEvent.clear(origins);
     await userEvent.type(origins, "https://app.example.test/");
-    expect(screen.getByRole("button", { name: "Create preset" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Create policy" })).toBeEnabled();
   });
 
   it("keeps browser evidence unavailable for an external-agent-only preset", async () => {
@@ -269,8 +272,8 @@ describe("AgentPresetsModal", () => {
       />,
     );
 
-    await userEvent.selectOptions(screen.getByLabelText("Surface"), "external_agent");
-    expect(screen.getByLabelText("Browser evidence allowed")).toBeDisabled();
+    await userEvent.selectOptions(screen.getByLabelText("Applies to"), "external_agent");
+    expect(screen.getByLabelText("Allow browser evidence")).toBeDisabled();
     expect(
       screen.getByText(/External Agents and Hecate Chat do not receive browser evidence/i),
     ).toBeInTheDocument();
@@ -292,14 +295,14 @@ describe("AgentPresetsModal", () => {
       />,
     );
 
-    await userEvent.click(screen.getByLabelText("Browser evidence allowed"));
+    await userEvent.click(screen.getByLabelText("Allow browser evidence"));
     await userEvent.type(
       screen.getByLabelText("Allowed browser origins"),
       "https://app.example.test",
     );
-    await userEvent.click(screen.getByLabelText("Tools enabled"));
+    await userEvent.click(screen.getByLabelText("Allow tools"));
 
-    expect(screen.getByLabelText("Browser evidence allowed")).toBeDisabled();
+    expect(screen.getByLabelText("Allow browser evidence")).toBeDisabled();
     expect(screen.queryByLabelText("Allowed browser origins")).toBeNull();
     expect(screen.getByText(/Enable Tools to configure browser evidence/i)).toBeInTheDocument();
   });
@@ -328,9 +331,9 @@ describe("AgentPresetsModal", () => {
     );
 
     expect(screen.getAllByText("built-in").length).toBeGreaterThan(0);
-    expect(screen.getByText("Built-in preset")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Save preset" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Delete preset" })).not.toBeInTheDocument();
+    expect(screen.getByText("Built-in policy")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save policy" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete policy" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Name")).toBeDisabled();
     expect(screen.getByLabelText("Use skill Backend")).toBeDisabled();
   });
@@ -381,15 +384,15 @@ describe("AgentPresetsModal", () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "Delete preset" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete policy" }));
 
     expect(
       screen.getByText(
-        /Referenced by this project's default preset; roles Developer\. Those references will fall back until changed\./,
+        /Referenced by this project's default work policy; roles Developer\. Those references will fall back until changed\./,
       ),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Delete agent preset" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete work policy" }));
 
     expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: "implementation" }));
   });

--- a/ui/src/features/projects/AgentPresetsModal.tsx
+++ b/ui/src/features/projects/AgentPresetsModal.tsx
@@ -19,10 +19,30 @@ import {
   presetRoleSubtleTextStyle,
 } from "./projectPresetRoleStyles";
 
-const AGENT_PRESET_SURFACES = ["any", "hecate_chat", "hecate_task", "external_agent"];
-const AGENT_PRESET_APPROVAL_POLICIES = ["inherit", "require", "block", "allow"];
-const AGENT_PRESET_MEMORY_POLICIES = ["inherit", "include", "visible_only", "exclude"];
-const AGENT_PRESET_CONTEXT_POLICIES = ["inherit", "include_enabled", "visible_only", "exclude"];
+const AGENT_PRESET_SURFACES = [
+  { value: "any", label: "All Hecate work" },
+  { value: "hecate_chat", label: "Hecate Chat" },
+  { value: "hecate_task", label: "Hecate Task" },
+  { value: "external_agent", label: "External Agent" },
+];
+const AGENT_PRESET_APPROVAL_POLICIES = [
+  { value: "inherit", label: "Use runtime default" },
+  { value: "require", label: "Always require approval" },
+  { value: "block", label: "Block approval-gated actions" },
+  { value: "allow", label: "Allow when otherwise permitted" },
+];
+const AGENT_PRESET_MEMORY_POLICIES = [
+  { value: "inherit", label: "Use project default" },
+  { value: "include", label: "Include project memory" },
+  { value: "visible_only", label: "Only visible memory" },
+  { value: "exclude", label: "Do not include memory" },
+];
+const AGENT_PRESET_CONTEXT_POLICIES = [
+  { value: "inherit", label: "Use project default" },
+  { value: "include_enabled", label: "Include enabled sources" },
+  { value: "visible_only", label: "Only visible sources" },
+  { value: "exclude", label: "Do not include sources" },
+];
 
 type AgentPresetsModalProps = {
   browserEvidenceReadiness?: BrowserEvidenceRuntimeReadiness;
@@ -108,7 +128,7 @@ export function AgentPresetsModal({
   return (
     <>
       <Modal
-        title="Agent presets"
+        title="Work policies"
         onClose={onClose}
         dismissible={!pending}
         width={840}
@@ -116,7 +136,7 @@ export function AgentPresetsModal({
           <div style={{ display: "flex", gap: 8, width: "100%" }}>
             {editingBuiltIn && (
               <span className="badge badge-muted" style={{ alignSelf: "center" }}>
-                Built-in preset
+                Built-in policy
               </span>
             )}
             {selectedPreset && !editingNew && !editingBuiltIn && (
@@ -127,7 +147,7 @@ export function AgentPresetsModal({
                 onClick={() => setDeletePreset(selectedPreset)}
                 style={{ color: "var(--red)" }}
               >
-                Delete preset
+                Delete policy
               </button>
             )}
             {!editingBuiltIn && (
@@ -138,7 +158,7 @@ export function AgentPresetsModal({
                 onClick={() => void submit()}
                 style={{ marginLeft: "auto" }}
               >
-                {pending ? "Saving…" : editingNew ? "Create preset" : "Save preset"}
+                {pending ? "Saving…" : editingNew ? "Create policy" : "Save policy"}
               </button>
             )}
           </div>
@@ -158,6 +178,7 @@ export function AgentPresetsModal({
               gap: 6,
             }}
           >
+            <div className="agent-presets-modal-list-heading">Saved policies</div>
             <button
               className="btn btn-ghost btn-sm agent-preset-choice"
               type="button"
@@ -167,7 +188,7 @@ export function AgentPresetsModal({
               style={{ justifyContent: "flex-start" }}
             >
               <Icon d={Icons.plus} size={12} />
-              New preset
+              New policy
             </button>
             {presets.map((preset) => (
               <button
@@ -194,351 +215,402 @@ export function AgentPresetsModal({
             }}
             style={{ display: "grid", gap: 12, alignContent: "start" }}
           >
+            <div className="work-policy-intro" role="note">
+              <strong>Reusable launch posture</strong>
+              <span>
+                Choose the instructions, intended runtime, and permission boundary for future
+                project work. Starting work copies this policy into the run, so later edits do not
+                change work already in progress.
+              </span>
+            </div>
             {error && <InlineError message={error} />}
-            <div
-              className="agent-presets-form-grid"
-              style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: 10 }}
-            >
+            <div className="work-policy-section">
+              <PolicySectionHeader
+                title="Identity"
+                description="A stable name for selecting this policy from project and role defaults."
+              />
+              <div
+                className="agent-presets-form-grid"
+                style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: 10 }}
+              >
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Policy ID</span>
+                  <input
+                    className="input"
+                    value={form.id}
+                    disabled={pending || !editingNew}
+                    placeholder="implementation"
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, id: event.target.value }))
+                    }
+                  />
+                </label>
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Name</span>
+                  <input
+                    className="input"
+                    value={form.name}
+                    autoFocus={editingNew}
+                    disabled={pending || editingBuiltIn}
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, name: event.target.value }))
+                    }
+                  />
+                </label>
+              </div>
               <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Preset id</span>
-                <input
+                <span style={presetRoleFieldLabelStyle}>Purpose</span>
+                <textarea
                   className="input"
-                  value={form.id}
-                  disabled={pending || !editingNew}
-                  placeholder="implementation"
+                  value={form.description}
+                  disabled={pending || editingBuiltIn}
+                  rows={2}
                   onChange={(event) =>
-                    setForm((current) => ({ ...current, id: event.target.value }))
+                    setForm((current) => ({ ...current, description: event.target.value }))
                   }
                 />
               </label>
               <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Name</span>
-                <input
+                <span style={presetRoleFieldLabelStyle}>Instructions for new work</span>
+                <textarea
                   className="input"
-                  value={form.name}
-                  autoFocus={editingNew}
+                  value={form.instructions}
                   disabled={pending || editingBuiltIn}
+                  rows={5}
                   onChange={(event) =>
-                    setForm((current) => ({ ...current, name: event.target.value }))
+                    setForm((current) => ({ ...current, instructions: event.target.value }))
                   }
                 />
               </label>
             </div>
-            <label style={presetRoleFieldStyle}>
-              <span style={presetRoleFieldLabelStyle}>Description</span>
-              <textarea
-                className="input"
-                value={form.description}
-                disabled={pending || editingBuiltIn}
-                rows={2}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, description: event.target.value }))
-                }
+            <div className="work-policy-section">
+              <PolicySectionHeader
+                title="Execution"
+                description="Choose where this policy applies and the provider or model preferences it carries."
               />
-            </label>
-            <label style={presetRoleFieldStyle}>
-              <span style={presetRoleFieldLabelStyle}>Instructions</span>
-              <textarea
-                className="input"
-                value={form.instructions}
-                disabled={pending || editingBuiltIn}
-                rows={5}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, instructions: event.target.value }))
-                }
+              <div
+                className="agent-presets-form-grid"
+                style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}
+              >
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Applies to</span>
+                  <select
+                    className="input"
+                    value={form.surface}
+                    disabled={pending || editingBuiltIn}
+                    onChange={(event) => {
+                      const surface = event.target.value;
+                      setForm((current) => ({
+                        ...current,
+                        surface,
+                        browserAllowed:
+                          surface === "any" || surface === "hecate_task"
+                            ? current.browserAllowed
+                            : false,
+                        browserAllowedOrigins:
+                          surface === "any" || surface === "hecate_task"
+                            ? current.browserAllowedOrigins
+                            : "",
+                      }));
+                    }}
+                  >
+                    {AGENT_PRESET_SURFACES.map((surface) => (
+                      <option key={surface.value} value={surface.value}>
+                        {surface.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Execution profile</span>
+                  <input
+                    className="input"
+                    value={form.executionProfile}
+                    disabled={pending || editingBuiltIn}
+                    placeholder="implementation"
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, executionProfile: event.target.value }))
+                    }
+                  />
+                </label>
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Preferred provider</span>
+                  <input
+                    className="input"
+                    value={form.providerHint}
+                    disabled={pending || editingBuiltIn}
+                    placeholder="ollama"
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, providerHint: event.target.value }))
+                    }
+                  />
+                </label>
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Preferred model</span>
+                  <input
+                    className="input"
+                    value={form.modelHint}
+                    disabled={pending || editingBuiltIn}
+                    placeholder="qwen2.5-coder"
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, modelHint: event.target.value }))
+                    }
+                  />
+                </label>
+              </div>
+            </div>
+            <div className="work-policy-section">
+              <PolicySectionHeader
+                title="Permissions"
+                description="These limits are enforced when compatible Hecate work starts."
               />
-            </label>
-            <div
-              className="agent-presets-form-grid"
-              style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}
-            >
-              <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Surface</span>
-                <select
-                  className="input"
-                  value={form.surface}
-                  disabled={pending || editingBuiltIn}
-                  onChange={(event) => {
-                    const surface = event.target.value;
-                    setForm((current) => ({
-                      ...current,
-                      surface,
-                      browserAllowed:
-                        surface === "any" || surface === "hecate_task"
-                          ? current.browserAllowed
-                          : false,
-                      browserAllowedOrigins:
-                        surface === "any" || surface === "hecate_task"
+              <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+                <label style={presetRoleCheckboxLabelStyle}>
+                  <input
+                    type="checkbox"
+                    checked={form.toolsEnabled}
+                    disabled={pending || editingBuiltIn}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        toolsEnabled: event.target.checked,
+                        browserAllowed: event.target.checked ? current.browserAllowed : false,
+                        browserAllowedOrigins: event.target.checked
                           ? current.browserAllowedOrigins
                           : "",
-                    }));
-                  }}
-                >
-                  {AGENT_PRESET_SURFACES.map((surface) => (
-                    <option key={surface} value={surface}>
-                      {surface}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Runtime profile</span>
-                <input
-                  className="input"
-                  value={form.executionProfile}
-                  disabled={pending || editingBuiltIn}
-                  placeholder="implementation"
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, executionProfile: event.target.value }))
-                  }
-                />
-              </label>
-              <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Provider hint</span>
-                <input
-                  className="input"
-                  value={form.providerHint}
-                  disabled={pending || editingBuiltIn}
-                  placeholder="ollama"
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, providerHint: event.target.value }))
-                  }
-                />
-              </label>
-              <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Model hint</span>
-                <input
-                  className="input"
-                  value={form.modelHint}
-                  disabled={pending || editingBuiltIn}
-                  placeholder="qwen2.5-coder"
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, modelHint: event.target.value }))
-                  }
-                />
-              </label>
-            </div>
-            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-              <label style={presetRoleCheckboxLabelStyle}>
-                <input
-                  type="checkbox"
-                  checked={form.toolsEnabled}
-                  disabled={pending || editingBuiltIn}
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      toolsEnabled: event.target.checked,
-                      browserAllowed: event.target.checked ? current.browserAllowed : false,
-                      browserAllowedOrigins: event.target.checked
-                        ? current.browserAllowedOrigins
-                        : "",
-                    }))
-                  }
-                />
-                Tools enabled
-              </label>
-              <label style={presetRoleCheckboxLabelStyle}>
-                <input
-                  type="checkbox"
-                  checked={form.writesAllowed}
-                  disabled={pending || editingBuiltIn}
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, writesAllowed: event.target.checked }))
-                  }
-                />
-                Writes allowed
-              </label>
-              <label style={presetRoleCheckboxLabelStyle}>
-                <input
-                  type="checkbox"
-                  checked={form.networkAllowed}
-                  disabled={pending || editingBuiltIn}
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, networkAllowed: event.target.checked }))
-                  }
-                />
-                Network allowed
-              </label>
-              <label style={presetRoleCheckboxLabelStyle}>
-                <input
-                  type="checkbox"
-                  checked={form.browserAllowed}
-                  disabled={
-                    pending || editingBuiltIn || !browserUsesNativeTaskSurface || !form.toolsEnabled
-                  }
-                  aria-describedby="browser-evidence-help"
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      browserAllowed: event.target.checked,
-                      browserAllowedOrigins: event.target.checked
-                        ? current.browserAllowedOrigins
-                        : "",
-                    }))
-                  }
-                />
-                Browser evidence allowed
-              </label>
-            </div>
-            <div id="browser-evidence-help" style={presetRoleSubtleTextStyle}>
-              Browser evidence is approval-gated static evidence: a fresh temporary browser profile
-              can inspect only the exact origins below. Page scripts and service workers are
-              disabled, so it cannot inspect script-rendered content or run workers, WebSockets, or
-              other dynamic browser activity. It cannot click, type, upload, download, use saved
-              browser state, or access clipboard/device permissions. A temporary profile does not
-              override OS or enterprise browser identity or network policy. It applies only to
-              Hecate-native task launches; External Agents and Hecate Chat do not receive browser
-              evidence. Each approved inspection is limited to its selected origin.
-              {!browserUsesNativeTaskSurface && " Select any or hecate_task to enable it."}
-              {!form.toolsEnabled && " Enable Tools to configure browser evidence."}
-            </div>
-            {browserUsesNativeTaskSurface && (
-              <div id="browser-evidence-runtime" style={presetRoleSubtleTextStyle} role="status">
-                {browserEvidenceReadiness?.available
-                  ? `Browser runtime ready: ${browserEvidenceReadiness.message}`
-                  : browserEvidenceReadiness
-                    ? `Browser runtime unavailable: ${browserEvidenceReadiness.message}${browserEvidenceReadiness.operator_action ? ` ${browserEvidenceReadiness.operator_action}` : ""}`
-                    : "Browser runtime status has not loaded. This preset records capability intent; task runs still require a configured local browser runtime."}
-              </div>
-            )}
-            {form.browserAllowed && (
-              <div style={presetRoleFieldStyle}>
-                <label htmlFor="browser-allowed-origins" style={presetRoleFieldLabelStyle}>
-                  Allowed browser origins
+                      }))
+                    }
+                  />
+                  Allow tools
                 </label>
-                <textarea
-                  id="browser-allowed-origins"
-                  className="input"
-                  value={form.browserAllowedOrigins}
-                  disabled={pending || editingBuiltIn}
-                  rows={3}
-                  placeholder={"https://app.example.com\nhttps://status.example.com"}
-                  aria-describedby={
-                    browserOriginsError
-                      ? "browser-origins-help browser-origins-error"
-                      : "browser-origins-help"
-                  }
-                  aria-invalid={Boolean(browserOriginsError) || undefined}
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      browserAllowedOrigins: event.target.value,
-                    }))
-                  }
-                />
-                <span id="browser-origins-help" style={presetRoleSubtleTextStyle}>
-                  One exact http(s) origin per line or comma-separated. Paths, query strings,
-                  fragments, credentials, and wildcard subdomains are not allowed.
-                </span>
-                {browserOriginsError && (
-                  <span
-                    id="browser-origins-error"
-                    role="alert"
-                    style={{ color: "var(--red)", fontSize: 12 }}
-                  >
-                    {browserOriginsError}
-                  </span>
-                )}
+                <label style={presetRoleCheckboxLabelStyle}>
+                  <input
+                    type="checkbox"
+                    checked={form.writesAllowed}
+                    disabled={pending || editingBuiltIn}
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, writesAllowed: event.target.checked }))
+                    }
+                  />
+                  Allow workspace changes
+                </label>
+                <label style={presetRoleCheckboxLabelStyle}>
+                  <input
+                    type="checkbox"
+                    checked={form.networkAllowed}
+                    disabled={pending || editingBuiltIn}
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, networkAllowed: event.target.checked }))
+                    }
+                  />
+                  Allow network
+                </label>
+                <label style={presetRoleCheckboxLabelStyle}>
+                  <input
+                    type="checkbox"
+                    checked={form.browserAllowed}
+                    disabled={
+                      pending ||
+                      editingBuiltIn ||
+                      !browserUsesNativeTaskSurface ||
+                      !form.toolsEnabled
+                    }
+                    aria-describedby="browser-evidence-help"
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        browserAllowed: event.target.checked,
+                        browserAllowedOrigins: event.target.checked
+                          ? current.browserAllowedOrigins
+                          : "",
+                      }))
+                    }
+                  />
+                  Allow browser evidence
+                </label>
               </div>
-            )}
-            <div
-              className="agent-presets-form-grid"
-              style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}
-            >
-              <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Approval policy</span>
-                <select
-                  className="input"
-                  value={form.approvalPolicy}
-                  disabled={pending || editingBuiltIn}
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, approvalPolicy: event.target.value }))
-                  }
-                >
-                  {AGENT_PRESET_APPROVAL_POLICIES.map((policy) => (
-                    <option key={policy} value={policy}>
-                      {policy}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Memory policy</span>
-                <select
-                  className="input"
-                  value={form.projectMemoryPolicy}
-                  disabled={pending || editingBuiltIn}
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, projectMemoryPolicy: event.target.value }))
-                  }
-                >
-                  {AGENT_PRESET_MEMORY_POLICIES.map((policy) => (
-                    <option key={policy} value={policy}>
-                      {policy}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>Context source policy</span>
-                <select
-                  className="input"
-                  value={form.contextSourcePolicy}
-                  disabled={pending || editingBuiltIn}
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, contextSourcePolicy: event.target.value }))
-                  }
-                >
-                  {AGENT_PRESET_CONTEXT_POLICIES.map((policy) => (
-                    <option key={policy} value={policy}>
-                      {policy}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label style={presetRoleFieldStyle}>
-                <span style={presetRoleFieldLabelStyle}>External agent kind</span>
-                <input
-                  className="input"
-                  value={form.externalAgentKind}
-                  disabled={pending || editingBuiltIn}
-                  placeholder="claude_code"
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, externalAgentKind: event.target.value }))
-                  }
-                />
-              </label>
+              <div id="browser-evidence-help" style={presetRoleSubtleTextStyle}>
+                Browser evidence is approval-gated static evidence: a fresh temporary browser
+                profile can inspect only the exact origins below. Page scripts and service workers
+                are disabled, so it cannot inspect script-rendered content or run workers,
+                WebSockets, or other dynamic browser activity. It cannot click, type, upload,
+                download, use saved browser state, or access clipboard/device permissions. A
+                temporary profile does not override OS or enterprise browser identity or network
+                policy. It applies only to Hecate-native task launches; External Agents and Hecate
+                Chat do not receive browser evidence. Each approved inspection is limited to its
+                selected origin.
+                {!browserUsesNativeTaskSurface && " Select any or hecate_task to enable it."}
+                {!form.toolsEnabled && " Enable Tools to configure browser evidence."}
+              </div>
+              {browserUsesNativeTaskSurface && (
+                <div id="browser-evidence-runtime" style={presetRoleSubtleTextStyle} role="status">
+                  {browserEvidenceReadiness?.available
+                    ? `Browser runtime ready: ${browserEvidenceReadiness.message}`
+                    : browserEvidenceReadiness
+                      ? `Browser runtime unavailable: ${browserEvidenceReadiness.message}${browserEvidenceReadiness.operator_action ? ` ${browserEvidenceReadiness.operator_action}` : ""}`
+                      : "Browser runtime status has not loaded. This work policy records capability intent; task runs still require a configured local browser runtime."}
+                </div>
+              )}
+              {form.browserAllowed && (
+                <div style={presetRoleFieldStyle}>
+                  <label htmlFor="browser-allowed-origins" style={presetRoleFieldLabelStyle}>
+                    Allowed browser origins
+                  </label>
+                  <textarea
+                    id="browser-allowed-origins"
+                    className="input"
+                    value={form.browserAllowedOrigins}
+                    disabled={pending || editingBuiltIn}
+                    rows={3}
+                    placeholder={"https://app.example.com\nhttps://status.example.com"}
+                    aria-describedby={
+                      browserOriginsError
+                        ? "browser-origins-help browser-origins-error"
+                        : "browser-origins-help"
+                    }
+                    aria-invalid={Boolean(browserOriginsError) || undefined}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        browserAllowedOrigins: event.target.value,
+                      }))
+                    }
+                  />
+                  <span id="browser-origins-help" style={presetRoleSubtleTextStyle}>
+                    One exact http(s) origin per line or comma-separated. Paths, query strings,
+                    fragments, credentials, and wildcard subdomains are not allowed.
+                  </span>
+                  {browserOriginsError && (
+                    <span
+                      id="browser-origins-error"
+                      role="alert"
+                      style={{ color: "var(--red)", fontSize: 12 }}
+                    >
+                      {browserOriginsError}
+                    </span>
+                  )}
+                </div>
+              )}
             </div>
-            <ProjectSkillPicker
-              disabled={pending || editingBuiltIn}
-              onChange={(skillIDs) => setForm((current) => ({ ...current, skillIDs }))}
-              skills={projectSkills}
-              value={form.skillIDs}
-            />
-            <div style={presetRoleSubtleTextStyle}>
-              Presets set runtime posture and skill references. Skills do not grant tools, writes,
-              network, or approvals.
+            <div className="work-policy-section">
+              <PolicySectionHeader
+                title="Context and controls"
+                description="Set the approval and context posture that accompanies this policy."
+              />
+              <div
+                className="agent-presets-form-grid"
+                style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}
+              >
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Approval policy</span>
+                  <select
+                    className="input"
+                    value={form.approvalPolicy}
+                    disabled={pending || editingBuiltIn}
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, approvalPolicy: event.target.value }))
+                    }
+                  >
+                    {AGENT_PRESET_APPROVAL_POLICIES.map((policy) => (
+                      <option key={policy.value} value={policy.value}>
+                        {policy.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Memory policy</span>
+                  <select
+                    className="input"
+                    value={form.projectMemoryPolicy}
+                    disabled={pending || editingBuiltIn}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        projectMemoryPolicy: event.target.value,
+                      }))
+                    }
+                  >
+                    {AGENT_PRESET_MEMORY_POLICIES.map((policy) => (
+                      <option key={policy.value} value={policy.value}>
+                        {policy.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>Context source policy</span>
+                  <select
+                    className="input"
+                    value={form.contextSourcePolicy}
+                    disabled={pending || editingBuiltIn}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        contextSourcePolicy: event.target.value,
+                      }))
+                    }
+                  >
+                    {AGENT_PRESET_CONTEXT_POLICIES.map((policy) => (
+                      <option key={policy.value} value={policy.value}>
+                        {policy.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label style={presetRoleFieldStyle}>
+                  <span style={presetRoleFieldLabelStyle}>External agent</span>
+                  <input
+                    className="input"
+                    value={form.externalAgentKind}
+                    disabled={pending || editingBuiltIn}
+                    placeholder="claude_code"
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, externalAgentKind: event.target.value }))
+                    }
+                  />
+                </label>
+              </div>
+              <ProjectSkillPicker
+                disabled={pending || editingBuiltIn}
+                onChange={(skillIDs) => setForm((current) => ({ ...current, skillIDs }))}
+                skills={projectSkills}
+                value={form.skillIDs}
+              />
+              <div style={presetRoleSubtleTextStyle}>
+                Skills add context references only. They never grant tools, workspace changes,
+                network, or approvals.
+              </div>
             </div>
           </form>
         </div>
       </Modal>
       {deletePreset && (
         <ConfirmModal
-          title="Delete agent preset"
+          title="Delete work policy"
           danger
           pending={pending}
-          confirmLabel="Delete agent preset"
+          confirmLabel="Delete work policy"
           onClose={() => setDeletePreset(null)}
           onConfirm={() => void deleteSelectedPreset(deletePreset)}
           message={
             <>
               Delete <strong>{deletePreset.name || deletePreset.id}</strong>.{" "}
               {presetReferenceSummary(deletePreset, project, roles)} Other projects may also
-              reference this global preset.
+              reference this global work policy.
             </>
           }
         />
       )}
     </>
+  );
+}
+
+function PolicySectionHeader({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="work-policy-section-heading">
+      <div>{title}</div>
+      <span>{description}</span>
+    </div>
   );
 }

--- a/ui/src/features/projects/ProjectSettingsPanel.tsx
+++ b/ui/src/features/projects/ProjectSettingsPanel.tsx
@@ -252,7 +252,7 @@ export function ProjectSettingsPanel({
                 <div style={fieldStyle}>
                   <span style={fieldLabelStyle}>Agent behavior</span>
                   <select
-                    aria-label="Default agent preset"
+                    aria-label="Default work policy"
                     className="input"
                     value={form.defaultAgentPreset}
                     onChange={(event) =>

--- a/ui/src/features/projects/ProjectWorkItemDetail.tsx
+++ b/ui/src/features/projects/ProjectWorkItemDetail.tsx
@@ -1818,7 +1818,7 @@ function AssignmentLaunchReadinessNotice({
     },
     {
       key: "profiles",
-      label: "Agent presets",
+      label: "Work policies",
       onClick: repairActions?.onManagePresets,
     },
     {
@@ -2290,7 +2290,7 @@ function projectAssignmentLaunchDraft({
     `- Driver: ${resolvedDriver}`,
     `- Provider: ${firstNonEmpty(provider, "auto")}`,
     `- Model: ${firstNonEmpty(model, "project/runtime default")}`,
-    `- Agent preset: ${firstNonEmpty(resolvedPreset, "none")}`,
+    `- Work policy: ${firstNonEmpty(resolvedPreset, "none")}`,
     `- Role defaults: ${formatHintList([
       ["driver", role?.default_driver_kind],
       ["provider", role?.default_provider],

--- a/ui/src/features/projects/ProjectsView.test.tsx
+++ b/ui/src/features/projects/ProjectsView.test.tsx
@@ -2240,7 +2240,7 @@ describe("ProjectsView index", () => {
     expect(actionLabels[0]).toMatch(/^Project attention/);
     expect(actionLabels.slice(1)).toEqual([
       "Roles",
-      "Agent presets",
+      "Work policies",
       "Project settings",
       "Refresh project work",
     ]);
@@ -6001,7 +6001,7 @@ describe("ProjectsView cockpit", () => {
       name: "Assignment asgn_1 context",
     });
     expect(dialog).toBeTruthy();
-    expect(within(dialog).getByText("Agent preset")).toBeTruthy();
+    expect(within(dialog).getByText("Work policy")).toBeTruthy();
     expect(within(dialog).getByText("Skills")).toBeTruthy();
     expect(within(dialog).getByText("Memory")).toBeTruthy();
     expect(within(dialog).getByText("Project sources")).toBeTruthy();
@@ -8153,7 +8153,7 @@ describe("ProjectsView cockpit", () => {
 
     await userEvent.click(presetAttentionItem);
 
-    expect(await screen.findByRole("dialog", { name: "Agent presets" })).toBeTruthy();
+    expect(await screen.findByRole("dialog", { name: "Work policies" })).toBeTruthy();
   });
 
   it("surfaces stale and missing linked execution in needs attention", async () => {
@@ -11813,7 +11813,7 @@ describe("ProjectsView cockpit", () => {
     fireEvent.change(within(dialog).getByLabelText("Default destination"), {
       target: { value: "hecate_task" },
     });
-    fireEvent.change(within(dialog).getByLabelText("Default preset"), {
+    fireEvent.change(within(dialog).getByLabelText("Default work policy"), {
       target: { value: "implementation" },
     });
     fireEvent.change(within(dialog).getByLabelText("Default provider"), {
@@ -11860,34 +11860,34 @@ describe("ProjectsView cockpit", () => {
       }),
     );
 
-    await userEvent.click(await screen.findByRole("button", { name: "Agent presets" }));
-    const dialog = screen.getByRole("dialog", { name: "Agent presets" });
-    await userEvent.click(within(dialog).getByRole("button", { name: "New preset" }));
-    fireEvent.change(within(dialog).getByLabelText("Preset id"), {
+    await userEvent.click(await screen.findByRole("button", { name: "Work policies" }));
+    const dialog = screen.getByRole("dialog", { name: "Work policies" });
+    await userEvent.click(within(dialog).getByRole("button", { name: "New policy" }));
+    fireEvent.change(within(dialog).getByLabelText("Policy ID"), {
       target: { value: "reviewer" },
     });
     fireEvent.change(within(dialog).getByLabelText("Name"), {
       target: { value: "Reviewer" },
     });
-    fireEvent.change(within(dialog).getByLabelText("Description"), {
+    fireEvent.change(within(dialog).getByLabelText("Purpose"), {
       target: { value: "Reviews implementation assignments." },
     });
-    fireEvent.change(within(dialog).getByLabelText("Instructions"), {
+    fireEvent.change(within(dialog).getByLabelText("Instructions for new work"), {
       target: { value: "Review the diff and surface risks." },
     });
-    fireEvent.change(within(dialog).getByLabelText("Surface"), {
+    fireEvent.change(within(dialog).getByLabelText("Applies to"), {
       target: { value: "hecate_task" },
     });
-    fireEvent.change(within(dialog).getByLabelText("Runtime profile"), {
+    fireEvent.change(within(dialog).getByLabelText("Execution profile"), {
       target: { value: "review" },
     });
-    fireEvent.change(within(dialog).getByLabelText("Provider hint"), {
+    fireEvent.change(within(dialog).getByLabelText("Preferred provider"), {
       target: { value: "ollama" },
     });
-    fireEvent.change(within(dialog).getByLabelText("Model hint"), {
+    fireEvent.change(within(dialog).getByLabelText("Preferred model"), {
       target: { value: "qwen2.5-coder" },
     });
-    await userEvent.click(within(dialog).getByLabelText("Writes allowed"));
+    await userEvent.click(within(dialog).getByLabelText("Allow workspace changes"));
     fireEvent.change(within(dialog).getByLabelText("Approval policy"), {
       target: { value: "require" },
     });
@@ -11898,7 +11898,7 @@ describe("ProjectsView cockpit", () => {
       target: { value: "visible_only" },
     });
     await userEvent.click(await within(dialog).findByLabelText("Use skill Backend"));
-    await userEvent.click(within(dialog).getByRole("button", { name: "Create preset" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Create policy" }));
 
     expect(createAgentPreset).toHaveBeenCalledWith({
       id: "reviewer",
@@ -11936,12 +11936,12 @@ describe("ProjectsView cockpit", () => {
       }),
     );
 
-    await userEvent.click(await screen.findByRole("button", { name: "Agent presets" }));
-    const dialog = screen.getByRole("dialog", { name: "Agent presets" });
+    await userEvent.click(await screen.findByRole("button", { name: "Work policies" }));
+    const dialog = screen.getByRole("dialog", { name: "Work policies" });
     fireEvent.change(within(dialog).getByLabelText("Name"), {
       target: { value: "Implementation reviewer" },
     });
-    await userEvent.click(within(dialog).getByRole("button", { name: "Save preset" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save policy" }));
 
     expect(updateAgentPreset).toHaveBeenCalledWith(
       "implementation",
@@ -11953,10 +11953,12 @@ describe("ProjectsView cockpit", () => {
       }),
     );
 
-    await userEvent.click(await within(dialog).findByRole("button", { name: "Delete preset" }));
+    await userEvent.click(await within(dialog).findByRole("button", { name: "Delete policy" }));
     expect(deleteAgentPreset).not.toHaveBeenCalled();
-    expect(screen.getByText(/Other projects may also reference this global preset/i)).toBeTruthy();
-    await userEvent.click(screen.getByRole("button", { name: "Delete agent preset" }));
+    expect(
+      screen.getByText(/Other projects may also reference this global work policy/i),
+    ).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Delete work policy" }));
     expect(deleteAgentPreset).toHaveBeenCalledWith("implementation");
   });
 
@@ -12717,7 +12719,7 @@ describe("ProjectsView cockpit", () => {
     expect(notice.textContent).toContain('No routable provider reports model "dogfood-model"');
     expect(within(preflight).getByRole("button", { name: "Open project settings" })).toBeTruthy();
     expect(within(preflight).getByRole("button", { name: "Manage roles" })).toBeTruthy();
-    expect(within(preflight).getByRole("button", { name: "Agent presets" })).toBeTruthy();
+    expect(within(preflight).getByRole("button", { name: "Work policies" })).toBeTruthy();
     expect(within(preflight).getByRole("button", { name: "Open Connections" })).toBeTruthy();
     const confirm = within(preflight).getByRole("button", {
       name: "Start assignment",

--- a/ui/src/features/projects/ProjectsView.tsx
+++ b/ui/src/features/projects/ProjectsView.tsx
@@ -1060,7 +1060,7 @@ export function ProjectsView({
       setAgentPresetsError("");
     } catch (error) {
       if (cancelled?.()) return;
-      setAgentPresetsError(errorMessage(error, "Failed to load agent presets."));
+      setAgentPresetsError(errorMessage(error, "Failed to load work policies."));
     }
   }, []);
 
@@ -2098,7 +2098,7 @@ export function ProjectsView({
       void refreshProjectOverview(selectedProjectID);
       return payload.data;
     } catch (error) {
-      setPresetsError(errorMessage(error, "Failed to create agent preset."));
+      setPresetsError(errorMessage(error, "Failed to create work policy."));
       return undefined;
     } finally {
       setPresetsPending(false);
@@ -2116,7 +2116,7 @@ export function ProjectsView({
       void refreshProjectOverview(selectedProjectID);
       return payload.data;
     } catch (error) {
-      setPresetsError(errorMessage(error, "Failed to update agent preset."));
+      setPresetsError(errorMessage(error, "Failed to update work policy."));
       return undefined;
     } finally {
       setPresetsPending(false);
@@ -2132,7 +2132,7 @@ export function ProjectsView({
       void refreshProjectOverview(selectedProjectID);
       return true;
     } catch (error) {
-      setPresetsError(errorMessage(error, "Failed to delete agent preset."));
+      setPresetsError(errorMessage(error, "Failed to delete work policy."));
       return false;
     } finally {
       setPresetsPending(false);
@@ -4683,8 +4683,8 @@ function ProjectHeader({
           <button
             className="btn btn-ghost btn-sm"
             type="button"
-            aria-label="Agent presets"
-            title="Agent presets"
+            aria-label="Work policies"
+            title="Work policies"
             onClick={onManagePresets}
             disabled={!project}
             style={projectHeaderActionButtonStyle}

--- a/ui/src/features/projects/RolesModal.test.tsx
+++ b/ui/src/features/projects/RolesModal.test.tsx
@@ -228,7 +228,7 @@ describe("RolesModal", () => {
     expect(destination).toHaveAccessibleDescription(
       "Track work completed by a person outside Hecate.",
     );
-    fireEvent.change(screen.getByLabelText("Default preset"), {
+    fireEvent.change(screen.getByLabelText("Default work policy"), {
       target: { value: "implementation" },
     });
     await userEvent.click(screen.getByLabelText("Use skill Backend"));

--- a/ui/src/features/projects/RolesModal.tsx
+++ b/ui/src/features/projects/RolesModal.tsx
@@ -157,7 +157,7 @@ export function RolesModal({
           )}
         </label>
         <label style={presetRoleFieldStyle}>
-          <span style={presetRoleFieldLabelStyle}>Default preset</span>
+          <span style={presetRoleFieldLabelStyle}>Default work policy</span>
           <select
             className="input"
             value={form.defaultAgentPreset}

--- a/ui/src/features/projects/projectPresetsRoles.ts
+++ b/ui/src/features/projects/projectPresetsRoles.ts
@@ -137,7 +137,7 @@ export function presetReferenceSummary(
 ) {
   const references: string[] = [];
   if (project.default_agent_profile === preset.id) {
-    references.push("this project's default preset");
+    references.push("this project's default work policy");
   }
   const roleNames = roles
     .filter((role) => role.default_agent_profile === preset.id)
@@ -146,7 +146,7 @@ export function presetReferenceSummary(
     references.push(`roles ${roleNames.join(", ")}`);
   }
   if (references.length === 0) {
-    return "No current project defaults or roles reference it.";
+    return "No current project defaults or roles reference this work policy.";
   }
   return `Referenced by ${references.join("; ")}. Those references will fall back until changed.`;
 }

--- a/ui/src/features/providers/ProvidersView.test.tsx
+++ b/ui/src/features/providers/ProvidersView.test.tsx
@@ -1327,15 +1327,15 @@ describe("ProvidersView table renders", () => {
     await user.click(screen.getByRole("button", { name: "OPENAI_API_KEY" }));
     expect(copyCommand).toHaveBeenCalledWith("OPENAI_API_KEY");
 
-    const runDiagnostics = screen.getByRole("button", {
-      name: "Run diagnostics for Codex; opens a temporary ACP session and may execute the agent app",
+    const checkAgain = screen.getByRole("button", {
+      name: "Check Codex again; opens a temporary ACP session and may execute the agent app",
     });
-    expect(runDiagnostics).toHaveAttribute(
+    expect(checkAgain).toHaveAttribute(
       "title",
-      "Opens a temporary Codex ACP session without sending a prompt and may execute the agent app",
+      "Runs a short-lived Codex session check without sending a prompt",
     );
-    await user.click(runDiagnostics);
-    expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
+    await user.click(checkAgain);
+    expect(probeAgentAdapter).toHaveBeenLastCalledWith("codex");
   });
 
   it("blocks submit when the typed Endpoint URL is already taken", async () => {

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -1127,6 +1127,36 @@ describe("Connections external-agent panel", () => {
     expect(await screen.findByTestId("external-agents-empty")).toBeTruthy();
   });
 
+  it("keeps an automatic external-agent check failure visible on its row", async () => {
+    const probeAgentAdapter = vi.fn(async () => ({ ok: false, error: "adapter launch failed" }));
+    const { state, actions } = setup(
+      {
+        agentAdapters: [
+          {
+            id: "codex",
+            name: "Codex",
+            kind: "acp",
+            command: "codex-acp-adapter",
+            available: true,
+            status: "available",
+            auth_status: "unknown",
+            supports_authenticate: true,
+            supports_logout: true,
+          },
+        ],
+      },
+      { probeAgentAdapter },
+    );
+    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
+
+    const row = await screen.findByTestId("external-agents-adapter-codex");
+    await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledWith("codex", expect.anything()));
+    expect(within(row).getByText("check unavailable")).toBeTruthy();
+    expect(
+      within(row).getByTestId("external-agents-adapter-codex-automatic-check-error"),
+    ).toHaveTextContent("Automatic check could not complete. Use Check again.");
+  });
+
   it("renders one row per grant with adapter / tool / decision metadata", async () => {
     const { state, actions } = setup({
       chatGrants: [
@@ -1668,11 +1698,11 @@ describe("Connections external-agent panel", () => {
     expect(setProviderAPIKey).toHaveBeenNthCalledWith(2, "anthropic", "");
   });
 
-  // External agent status panel — surfaces readiness diagnostics.
-  // Direct adapter binaries can be checked quietly.
+  // External agent status panel — surfaces readiness checks.
+  // Available adapters are checked quietly when Connections opens.
   // The section is hidden when no agents are registered (no point
   // showing an empty card); otherwise each row renders inline
-  // diagnostic copy when a result exists.
+  // session-check copy when a result exists.
   describe("adapter status panel", () => {
     function withAdapter(overrides: Record<string, unknown> = {}) {
       return {
@@ -1697,22 +1727,28 @@ describe("Connections external-agent panel", () => {
       expect(screen.queryByTestId("external-agents-adapters")).toBeNull();
     });
 
-    it("renders one row per adapter with an optional diagnostics action", async () => {
+    it("renders one row per adapter with a retryable session check", async () => {
       const { state, actions } = setup(withAdapter());
       render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       expect(await screen.findByTestId("external-agents-adapters")).toBeTruthy();
       expect(screen.getByTestId("external-agents-adapter-codex")).toBeTruthy();
-      expect(screen.getByTestId("external-agents-test-codex")).toHaveTextContent("Run diagnostics");
+      expect(screen.getByTestId("external-agents-check-codex")).toHaveTextContent("Check again");
     });
 
-    it("does not start available local adapters when Connections opens", async () => {
+    it("checks each available adapter once when Connections opens", async () => {
       const probeAgentAdapter = vi.fn(async () => null);
       const { state, actions } = setup(withAdapter(), { probeAgentAdapter });
 
       render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
       await screen.findByTestId("external-agents-adapter-codex");
-      expect(probeAgentAdapter).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(probeAgentAdapter).toHaveBeenCalledWith("codex", {
+          notify: false,
+          refreshCatalog: false,
+        }),
+      );
+      expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
     });
 
     it("shows bridge and underlying agent versions separately", async () => {
@@ -1767,15 +1803,12 @@ describe("Connections external-agent panel", () => {
       expect(row).toHaveTextContent("path /Users/alice/.local/bin/codex");
       expect(
         within(row).getByRole("button", {
-          name: "Run diagnostics for Codex; opens a temporary ACP session and may execute the agent app",
+          name: "Check Codex again; opens a temporary ACP session and may execute the agent app",
         }),
-      ).toHaveAttribute(
-        "title",
-        "Opens a temporary Codex ACP session without sending a prompt and may execute the agent app",
-      );
+      ).toHaveAttribute("title", "Runs a short-lived Codex session check without sending a prompt");
     });
 
-    it("refreshes passive agent discovery without running diagnostics", async () => {
+    it("refreshes passive discovery while the session check stays one-shot", async () => {
       const refreshAgentAdapters = vi.fn(async () => true);
       const probeAgentAdapter = vi.fn(async () => null);
       const { state, actions, user } = setup(withAdapter(), {
@@ -1785,16 +1818,18 @@ describe("Connections external-agent panel", () => {
       render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
       const refresh = await screen.findByRole("button", {
-        name: "Refresh external-agent discovery without starting agents",
+        name: "Refresh external-agent discovery",
       });
       expect(refresh).toHaveAttribute(
         "title",
-        "Refresh installed-agent paths without starting an agent",
+        "Refresh installed-agent paths; available agents are checked automatically",
       );
+      await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(refreshAgentAdapters).toHaveBeenCalledTimes(1));
       await user.click(refresh);
 
-      expect(refreshAgentAdapters).toHaveBeenCalledTimes(1);
-      expect(probeAgentAdapter).not.toHaveBeenCalled();
+      expect(refreshAgentAdapters).toHaveBeenCalledTimes(2);
+      expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
     });
 
     it("distinguishes current launch discovery from a stale diagnostic path", async () => {
@@ -1830,7 +1865,7 @@ describe("Connections external-agent panel", () => {
 
       const row = await screen.findByTestId("external-agents-adapter-codex");
       expect(row).toHaveTextContent("path /Applications/Codex.app/Contents/Resources/codex");
-      expect(row).toHaveTextContent("diagnostic path /usr/local/bin/codex-old");
+      expect(row).toHaveTextContent("last check path /usr/local/bin/codex-old");
     });
 
     it("discloses the remote credential retry process and keeps its selected path visible", async () => {
@@ -1878,16 +1913,17 @@ describe("Connections external-agent panel", () => {
 
       const row = await screen.findByTestId("external-agents-adapter-codex");
       expect(row).toHaveTextContent("path /opt/hecate/agents/codex");
-      const runDiagnostics = within(row).getByRole("button", {
-        name: "Run diagnostics for Codex; opens a temporary ACP session and may execute the agent app",
+      const checkAgain = within(row).getByRole("button", {
+        name: "Check Codex again; opens a temporary ACP session and may execute the agent app",
       });
-      expect(runDiagnostics).toHaveAttribute(
+      expect(checkAgain).toHaveAttribute(
         "title",
-        "Opens a temporary Codex ACP session without sending a prompt and may execute the agent app",
+        "Runs a short-lived Codex session check without sending a prompt",
       );
 
-      await user.click(runDiagnostics);
-      expect(probeAgentAdapter).toHaveBeenCalledWith("codex");
+      await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledTimes(1));
+      await user.click(checkAgain);
+      expect(probeAgentAdapter).toHaveBeenLastCalledWith("codex");
     });
 
     it("shows hosted credential repair for the backend missing-credential response", async () => {
@@ -1969,12 +2005,9 @@ describe("Connections external-agent panel", () => {
       expect(row).toHaveTextContent("path /usr/local/bin/codex-acp-adapter");
       expect(
         within(row).getByRole("button", {
-          name: "Run diagnostics for Codex; opens a temporary ACP session and may execute the agent app",
+          name: "Check Codex again; opens a temporary ACP session and may execute the agent app",
         }),
-      ).toHaveAttribute(
-        "title",
-        "Opens a temporary Codex ACP session without sending a prompt and may execute the agent app",
-      );
+      ).toHaveAttribute("title", "Runs a short-lived Codex session check without sending a prompt");
       expect(row).not.toHaveTextContent("412 ms");
       expect(row).not.toHaveTextContent("auth unknown");
     });
@@ -2106,17 +2139,16 @@ describe("Connections external-agent panel", () => {
       render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
 
       const codex = await screen.findByTestId("external-agents-adapter-codex");
-      expect(within(codex).getByText("diagnostic")).toBeTruthy();
-      expect(codex).toHaveTextContent("Last diagnostic: Install Codex");
-      expect(codex).toHaveTextContent("This result is advisory");
+      expect(within(codex).getByText("check failed")).toBeTruthy();
+      expect(codex).toHaveTextContent("Last check: Install Codex");
       expect(codex).not.toHaveTextContent("not installed");
       expect(codex).not.toHaveTextContent("auth unknown");
       expect(codex).not.toHaveTextContent("0 ms");
 
       const cursor = await screen.findByTestId("external-agents-adapter-cursor_agent");
-      expect(within(cursor).getByText("diagnostic")).toBeTruthy();
-      expect(cursor).toHaveTextContent("Last diagnostic: Install Cursor with Agent support");
-      expect(cursor).toHaveTextContent("New chat prepares a fresh ACP session");
+      expect(within(cursor).getByText("check failed")).toBeTruthy();
+      expect(cursor).toHaveTextContent("Last check: Install Cursor with Agent support");
+      expect(cursor).toHaveTextContent("New chat still prepares a fresh ACP session");
       expect(cursor).toHaveTextContent(
         "first message retries any deferred prompt-serving vendor process",
       );
@@ -2160,7 +2192,7 @@ describe("Connections external-agent panel", () => {
       );
       render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
       const status = await screen.findByTestId("external-agents-checking-codex");
-      expect(status).toHaveTextContent(/diagnosing/i);
+      expect(status).toHaveTextContent(/checking/i);
       expect(status).toHaveAttribute("role", "status");
       expect(status).toHaveAttribute("aria-live", "polite");
     });
@@ -2216,7 +2248,7 @@ describe("Connections external-agent panel", () => {
       expect(screen.queryByLabelText("Claude Code credential")).toBeNull();
     });
 
-    it("does not show Claude Code local auth guidance after diagnostics succeed", async () => {
+    it("does not show Claude Code local auth guidance after a session check succeeds", async () => {
       const { state, actions } = setup(
         withAdapter({
           agentAdapters: [
@@ -2272,7 +2304,7 @@ describe("Connections external-agent panel", () => {
       expect(copyCommand).toHaveBeenCalledWith("claude /login");
     });
 
-    it("can run optional diagnostics after local sign-in", async () => {
+    it("can check again after local sign-in", async () => {
       const probeAgentAdapter = vi.fn(async () => null);
       const { state, actions, user } = setup(
         withAdapter({
@@ -2296,15 +2328,16 @@ describe("Connections external-agent panel", () => {
 
       const row = await screen.findByTestId("external-agents-adapter-claude_code");
       expect(row).toHaveTextContent("path /Users/alice/.local/bin/claude");
-      const runDiagnostics = within(row).getByRole("button", {
-        name: "Run diagnostics for Claude Code; opens a temporary ACP session and may execute the agent app",
+      const checkAgain = within(row).getByRole("button", {
+        name: "Check Claude Code again; opens a temporary ACP session and may execute the agent app",
       });
-      expect(runDiagnostics).toHaveAttribute(
+      expect(checkAgain).toHaveAttribute(
         "title",
-        "Opens a temporary Claude Code ACP session without sending a prompt and may execute the agent app",
+        "Runs a short-lived Claude Code session check without sending a prompt",
       );
-      await user.click(runDiagnostics);
-      expect(probeAgentAdapter).toHaveBeenCalledWith("claude_code");
+      await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledTimes(1));
+      await user.click(checkAgain);
+      expect(probeAgentAdapter).toHaveBeenLastCalledWith("claude_code");
     });
   });
 });

--- a/ui/src/features/settings/SettingsView.test.tsx
+++ b/ui/src/features/settings/SettingsView.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -1147,10 +1148,11 @@ describe("Connections external-agent panel", () => {
       },
       { probeAgentAdapter },
     );
-    render(withRuntimeConsole(<ConnectionsPanel />, { state, actions }));
+    render(<StrictMode>{withRuntimeConsole(<ConnectionsPanel />, { state, actions })}</StrictMode>);
 
     const row = await screen.findByTestId("external-agents-adapter-codex");
     await waitFor(() => expect(probeAgentAdapter).toHaveBeenCalledWith("codex", expect.anything()));
+    expect(probeAgentAdapter).toHaveBeenCalledTimes(1);
     expect(within(row).getByText("check unavailable")).toBeTruthy();
     expect(
       within(row).getByTestId("external-agents-adapter-codex-automatic-check-error"),

--- a/ui/src/features/shared/AgentAdapterPicker.tsx
+++ b/ui/src/features/shared/AgentAdapterPicker.tsx
@@ -1,6 +1,6 @@
 // AgentAdapterPicker is the dropdown the chat view uses to switch between
 // registered external-agent adapters. Passive discovery controls whether an
-// adapter can be selected; an on-demand diagnostic is advisory because the
+// adapter can be selected; the latest Connections check is advisory because the
 // real chat setup always resolves the executable and performs a fresh ACP
 // handshake; an embedded vendor process may not start until the first prompt.
 
@@ -14,11 +14,11 @@ import { focusDropdownItem, focusInitialDropdownItem } from "./dropdownKeyboard"
 import { useFloatingDropdownStyle } from "./useFloatingDropdownStyle";
 import { useFloatingMenu } from "./useFloatingMenu";
 
-// adapterPickerDiagnostic combines current passive discovery with the latest
-// optional diagnostic for display. Current discovery and required remote
-// credentials win over stale diagnostics; failed diagnostics remain visible
-// but do not disable a locally available adapter.
-function adapterPickerDiagnostic(
+// adapterPickerCheck combines current passive discovery with the latest
+// Connections check for display. Current discovery and required remote
+// credentials win over stale checks; failed checks remain visible but do not
+// disable a locally available adapter.
+function adapterPickerCheck(
   adapter: AgentAdapterRecord,
   health: AgentAdapterHealthRecord | null | undefined,
 ): { title: string; iconColor: string; chipLabel: string; chipColor: string } {
@@ -84,27 +84,27 @@ function adapterPickerDiagnostic(
           chipColor: "var(--teal)",
         };
       case "auth_required":
-        // Handled above so an auth diagnostic stays ahead of ready-state
+        // Handled above so an auth check stays ahead of ready-state
         // presentation even when adapter metadata and health arrive separately.
         break;
       case "not_installed":
         return {
-          title: adapterDiagnosticTitle(
+          title: adapterCheckTitle(
             adapter,
             health.hint || health.error || `${adapter.name} command was not found`,
           ),
           iconColor: "var(--amber)",
-          chipLabel: "diagnostic",
+          chipLabel: "check",
           chipColor: "var(--amber)",
         };
       case "error":
         return {
-          title: adapterDiagnosticTitle(
+          title: adapterCheckTitle(
             adapter,
-            health.hint || health.error || `${adapter.name} diagnostic failed`,
+            health.hint || health.error || `${adapter.name} check failed`,
           ),
           iconColor: "var(--amber)",
-          chipLabel: adapterProbeLooksLikeSetupState(health) ? "diagnostic" : "issue",
+          chipLabel: adapterProbeLooksLikeSetupState(health) ? "check" : "issue",
           chipColor: "var(--amber)",
         };
     }
@@ -137,7 +137,7 @@ function adapterProbeLooksLikeSetupState(health: AgentAdapterHealthRecord): bool
 
 function adapterCheckedTitle(adapter: AgentAdapterRecord, path: string | undefined): string {
   const suffix = path ? ` Path: ${path}` : "";
-  return `The last ${adapter.name} diagnostic completed ACP startup and session checks without sending a prompt. New chat still prepares a fresh session; the first message checks any deferred prompt-serving vendor invocation and authentication.${suffix}`;
+  return `The last ${adapter.name} check completed ACP startup and session checks without sending a prompt. New chat still prepares a fresh session; the first message checks any deferred prompt-serving vendor invocation and authentication.${suffix}`;
 }
 
 function adapterAvailableTitle(adapter: AgentAdapterRecord, detail?: string): string {
@@ -150,12 +150,12 @@ function adapterAvailableTitle(adapter: AgentAdapterRecord, detail?: string): st
   return detail ? `${detail} ${action}` : action;
 }
 
-function adapterDiagnosticTitle(adapter: AgentAdapterRecord, detail: string): string {
-  return `The last ${adapter.name} diagnostic needs attention. New chat prepares a fresh ACP session, and the first message retries any deferred prompt-serving vendor invocation; diagnostics in Connections are optional. ${detail}`;
+function adapterCheckTitle(adapter: AgentAdapterRecord, detail: string): string {
+  return `The last ${adapter.name} check needs attention. New chat prepares a fresh ACP session, and the first message retries any deferred prompt-serving vendor invocation; Connections checks available agents automatically. ${detail}`;
 }
 
 function adapterAdvisoryTitle(adapter: AgentAdapterRecord, detail: string): string {
-  return `${detail} New chat prepares a fresh ${adapter.name} ACP session, and the first message retries any deferred prompt-serving vendor invocation; diagnostics in Connections are optional.`;
+  return `${detail} New chat prepares a fresh ${adapter.name} ACP session, and the first message retries any deferred prompt-serving vendor invocation; Connections checks available agents automatically.`;
 }
 
 export function AgentAdapterPicker({
@@ -171,7 +171,7 @@ export function AgentAdapterPicker({
   onChange: (v: string) => void;
   adapters: AgentAdapterRecord[];
   // healthByID is optional; when supplied, each row shows the most recent
-  // advisory diagnostic. It never overrides current passive availability.
+  // advisory check. It never overrides current passive availability.
   healthByID?: Map<string, AgentAdapterHealthRecord>;
   disabled?: boolean;
   disabledReason?: string;
@@ -268,7 +268,7 @@ export function AgentAdapterPicker({
           {adapters.map((adapter) => {
             const health = healthByID?.get(adapter.id);
             const disabled = resolveExternalAgentReadiness(adapter, health ?? null).launchBlocked;
-            const diag = adapterPickerDiagnostic(adapter, health);
+            const diag = adapterPickerCheck(adapter, health);
             return (
               <button
                 type="button"

--- a/ui/src/features/shared/ContextInspector.tsx
+++ b/ui/src/features/shared/ContextInspector.tsx
@@ -590,7 +590,7 @@ function humanExecutionMode(mode: string): string {
 function humanSectionLabel(section: string): string {
   switch (section) {
     case "profile":
-      return "Agent preset";
+      return "Work policy";
     case "instructions":
       return "Instructions";
     case "skills":

--- a/ui/src/features/shared/ui.test.tsx
+++ b/ui/src/features/shared/ui.test.tsx
@@ -1132,7 +1132,7 @@ describe("AgentAdapterPicker", () => {
     expect(onChange).toHaveBeenCalledWith("claude_code");
   });
 
-  it("shows a stale setup-shaped diagnostic without disabling a discovered adapter", async () => {
+  it("shows a stale setup-shaped check without disabling a discovered adapter", async () => {
     const user = userEvent.setup();
     render(
       <AgentAdapterPicker
@@ -1173,13 +1173,13 @@ describe("AgentAdapterPicker", () => {
     await user.click(screen.getByRole("button", { name: "External agent" }));
     const menu = document.querySelector(".dropdown-menu") as HTMLElement;
     const cursor = within(menu).getByText("Cursor Agent").closest("button") as HTMLElement;
-    expect(within(cursor).getByText("diagnostic")).toBeTruthy();
+    expect(within(cursor).getByText("check")).toBeTruthy();
     expect(within(cursor).queryByText("error")).toBeNull();
     expect(cursor.title).toContain("Install Cursor with Agent support");
     expect(cursor).not.toHaveAttribute("aria-disabled");
   });
 
-  it("does not let a stale ready diagnostic override a missing current executable", async () => {
+  it("does not let a stale ready check override a missing current executable", async () => {
     const user = userEvent.setup();
     render(
       <AgentAdapterPicker
@@ -1298,12 +1298,12 @@ describe("AgentAdapterPicker", () => {
     const menu = document.querySelector(".dropdown-menu") as HTMLElement;
     const cursor = within(menu).getByText("Cursor Agent").closest("button") as HTMLElement;
     expect(within(cursor).getByText("checked")).toBeTruthy();
-    expect(cursor.title).toContain("last Cursor Agent diagnostic completed ACP startup");
+    expect(cursor.title).toContain("last Cursor Agent check completed ACP startup");
     expect(cursor.title).toContain("without sending a prompt");
     expect(cursor.title).toContain("/Users/test/.local/bin/cursor-agent");
   });
 
-  it("keeps explicit sign-in guidance ahead of a ready ACP diagnostic", async () => {
+  it("keeps explicit sign-in guidance ahead of a ready ACP check", async () => {
     const user = userEvent.setup();
     render(
       <AgentAdapterPicker

--- a/ui/src/features/tasks/TaskDetail.test.tsx
+++ b/ui/src/features/tasks/TaskDetail.test.tsx
@@ -569,7 +569,7 @@ describe("TaskDetail effective sandbox posture", () => {
     render();
 
     const overview = screen.getByText("Run overview").parentElement!;
-    expect(within(overview).getByText("Agent preset")).toBeTruthy();
+    expect(within(overview).getByText("Work policy")).toBeTruthy();
     expect(within(overview).getByText("review_qa")).toBeTruthy();
     expect(within(overview).getByText("Disabled")).toBeTruthy();
     expect(
@@ -606,7 +606,7 @@ describe("TaskDetail effective sandbox posture", () => {
     render();
 
     const overview = screen.getByText("Run overview").parentElement!;
-    expect(within(overview).queryByText("Agent preset")).toBeNull();
+    expect(within(overview).queryByText("Work policy")).toBeNull();
     expect(within(overview).queryByText("File access")).toBeNull();
     expect(within(overview).queryByText("Network")).toBeNull();
   });

--- a/ui/src/features/tasks/TaskDetail.tsx
+++ b/ui/src/features/tasks/TaskDetail.tsx
@@ -1245,7 +1245,7 @@ export function TaskDetail({
                     ? [["Workflow", "QA · report only"]]
                     : task.agent_preset_id
                       ? [
-                          ["Agent preset", task.agent_preset_id],
+                          ["Work policy", task.agent_preset_id],
                           ...(task.agent_preset_tools_enabled !== undefined
                             ? [["Tools", task.agent_preset_tools_enabled ? "Enabled" : "Disabled"]]
                             : []),

--- a/ui/src/lib/chat-setup-readiness.test.ts
+++ b/ui/src/lib/chat-setup-readiness.test.ts
@@ -190,6 +190,47 @@ describe("resolveChatSetupRepairState", () => {
     });
   });
 
+  it("points billing and launch repairs at Connections checks", () => {
+    const billingRepair = resolveChatSetupRepairState({
+      ...base,
+      target: "external_agent",
+      selectedAgentName: "Codex",
+      externalAgentSetupRequired: true,
+      selectedAgentReadiness: {
+        kind: "billing",
+        tone: "amber",
+        label: "billing",
+        needsRepair: true,
+        launchBlocked: true,
+        setupHint: "",
+        loginCommand: "",
+        signInHint: "",
+        checkedByProbe: true,
+      },
+    });
+    const issueRepair = resolveChatSetupRepairState({
+      ...base,
+      target: "external_agent",
+      selectedAgentName: "Codex",
+      externalAgentSetupRequired: true,
+      selectedAgentReadiness: {
+        kind: "issue",
+        tone: "red",
+        label: "unavailable",
+        needsRepair: true,
+        launchBlocked: true,
+        setupHint: "",
+        loginCommand: "",
+        signInHint: "",
+        checkedByProbe: true,
+      },
+    });
+
+    expect(billingRepair?.message).toContain("Connections runs an automatic check");
+    expect(billingRepair?.message).toContain("Check again");
+    expect(issueRepair?.message).toContain("open Connections and use Check again");
+  });
+
   it("routes the hosted missing-credential wire shape before generic unavailability", () => {
     const repair = resolveChatSetupRepairState({
       ...base,

--- a/ui/src/lib/chat-setup-readiness.ts
+++ b/ui/src/lib/chat-setup-readiness.ts
@@ -171,10 +171,12 @@ function externalAgentSetupMessage(
       case "billing":
         return (
           readiness.detail ||
-          `Check ${agent}'s billing or subscription, then retry the chat. Diagnostics in Connections are optional.`
+          `Check ${agent}'s billing or subscription, then retry the chat. Connections runs an automatic check; use Check again after fixing setup.`
         );
       case "issue":
-        return readiness.detail || `Retry the chat, or use Connections diagnostics for details.`;
+        return (
+          readiness.detail || `Retry the chat, or open Connections and use Check again for details.`
+        );
       default:
         break;
     }

--- a/ui/src/lib/external-agent-readiness.test.ts
+++ b/ui/src/lib/external-agent-readiness.test.ts
@@ -92,7 +92,7 @@ describe("resolveExternalAgentReadiness", () => {
       stage: "resolve",
       hint: "The executable was missing during the last diagnostic.",
       expectedKind: "setup",
-      expectedLabel: "diagnostic",
+      expectedLabel: "check failed",
       expectedTone: "amber",
     },
   ])(
@@ -148,7 +148,7 @@ describe("resolveExternalAgentReadiness", () => {
     expect(readiness).toMatchObject({
       kind: "sign_in",
       detail:
-        "Run claude /login in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment, then retry the chat.",
+        "Run claude /login in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment, then use Check again or retry the chat.",
       needsRepair: true,
       launchBlocked: false,
     });
@@ -189,11 +189,8 @@ describe("resolveExternalAgentReadiness", () => {
       launchBlocked: false,
       checkedByProbe: false,
     });
-    expect(readiness.detail).toContain("New chat re-resolves the executable");
-    expect(readiness.detail).toContain(
-      "first message verifies any deferred prompt-serving vendor invocation",
-    );
-    expect(readiness.detail).toContain("Diagnostics are optional");
+    expect(readiness.detail).toContain("Hecate checks available agents automatically");
+    expect(readiness.detail).toContain("New chat still re-resolves the executable");
   });
 
   it("does not let a stale ready diagnostic override current passive discovery", () => {

--- a/ui/src/lib/external-agent-readiness.ts
+++ b/ui/src/lib/external-agent-readiness.ts
@@ -42,7 +42,7 @@ export function resolveExternalAgentReadiness(
     };
   }
 
-  // Diagnostics describe the last disposable ACP session; they never
+  // A Connections session check describes the last disposable ACP session; it never
   // authorize a later process launch or prove that a deferred prompt-serving
   // vendor process can authenticate and serve a message. Current passive
   // discovery and remote credential posture are the only client-side launch
@@ -154,7 +154,7 @@ export function resolveExternalAgentReadiness(
     return {
       kind: "setup",
       tone: "amber",
-      label: "diagnostic",
+      label: "check failed",
       needsRepair: true,
       launchBlocked,
       loginCommand,
@@ -197,7 +197,7 @@ export function resolveExternalAgentReadiness(
     setupHint,
     signInHint,
     detail:
-      "New chat re-resolves the executable and prepares a fresh ACP session. The first message verifies any deferred prompt-serving vendor invocation and authentication. Diagnostics are optional.",
+      "Hecate checks available agents automatically in Connections. New chat still re-resolves the executable and prepares a fresh ACP session.",
     authStatus,
     authError,
     checkedByProbe,
@@ -222,9 +222,9 @@ export function externalAgentLoginCommand(adapter: AgentAdapterRecord): string {
 export function externalAgentSignInHint(adapter: AgentAdapterRecord): string {
   switch (adapter.id) {
     case "codex":
-      return "Run codex login in Terminal, then retry the chat. Diagnostics in Connections are optional.";
+      return "Run codex login in Terminal, then use Check again or retry the chat.";
     case "claude_code":
-      return "Run claude /login in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment, then retry the chat.";
+      return "Run claude /login in Terminal, or set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN for the adapter environment, then use Check again or retry the chat.";
     case "cursor_agent":
       return "Run cursor-agent login, or set CURSOR_API_KEY for the adapter environment, then retry the chat.";
     case "grok_build":

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -396,6 +396,47 @@ textarea {
   color: var(--t0);
 }
 
+.agent-presets-modal-list-heading {
+  color: var(--t3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  margin: 2px 0 3px;
+  text-transform: uppercase;
+}
+
+.work-policy-intro {
+  color: var(--t2);
+  display: grid;
+  font-size: 12px;
+  gap: 3px;
+  line-height: 1.45;
+}
+
+.work-policy-intro strong,
+.work-policy-section-heading > div {
+  color: var(--t0);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.work-policy-section {
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 10px;
+  padding-top: 12px;
+}
+
+.work-policy-section-heading {
+  display: grid;
+  gap: 2px;
+}
+
+.work-policy-section-heading > span {
+  color: var(--t3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
 .entity-workspace {
   flex-direction: row;
 }

--- a/ui/src/test/fixtures/launch-context-v1-contract.json
+++ b/ui/src/test/fixtures/launch-context-v1-contract.json
@@ -17,7 +17,7 @@
       "Driver",
       "Provider",
       "Model",
-      "Agent preset",
+      "Work policy",
       "Role defaults",
       "Project defaults"
     ]

--- a/ui/src/test/runtime-console-fixture.ts
+++ b/ui/src/test/runtime-console-fixture.ts
@@ -332,8 +332,8 @@ export type RuntimeConsoleFixtureActions = {
     value: string | boolean,
   ) => Promise<boolean>;
   setHecateRTKEnabled: (enabled: boolean) => Promise<boolean>;
-  refreshAgentAdapters: () => Promise<boolean>;
-  probeAgentAdapter: (adapterID: string) => Promise<unknown>;
+  refreshAgentAdapters: (options?: unknown) => Promise<boolean>;
+  probeAgentAdapter: (adapterID: string, options?: unknown) => Promise<unknown>;
   verifyModelToolSupport: (provider: string, model: string) => Promise<unknown>;
   authenticateAgentAdapter: (adapterID: string) => Promise<boolean>;
   logoutAgentAdapter: (adapterID: string) => Promise<boolean>;
@@ -426,7 +426,7 @@ export function createRuntimeConsoleActions(): RuntimeConsoleFixtureActions {
     setChatConfigOption: async () => true,
     setHecateRTKEnabled: async () => true,
     refreshAgentAdapters: async () => true,
-    probeAgentAdapter: async () => null,
+    probeAgentAdapter: async () => ({ ok: true, health: null }),
     verifyModelToolSupport: async () => null,
     authenticateAgentAdapter: async () => true,
     logoutAgentAdapter: async () => true,

--- a/ui/src/types/task.ts
+++ b/ui/src/types/task.ts
@@ -14,7 +14,7 @@ export type TaskRecord = {
   execution_kind?: string;
   // Hecate-owned bounded task execution contract. "qa" is a
   // report-only, read-only QA runbook; it is not Cairnline project
-  // coordination or an Agent Preset capability grant.
+  // coordination or a work-policy capability grant.
   workflow_mode?: "qa";
   workflow_version?: string;
   execution_profile?: string;


### PR DESCRIPTION
## Summary
- Automatically run one bounded, no-prompt ACP session check for each available External Agent when Connections opens.
- Keep passive discovery non-executing; show a row-local check-unavailable state and **Check again** retry if an automatic check cannot complete.
- Replace operator-facing “Agent preset” language with **Work policy** and restructure the editor around launch posture, execution, permissions, and context.
- Keep the stable `agent_presets` resource and `agent_preset_id` fields unchanged.

## Verification
- `bun run typecheck`
- `bun run lint`
- Focused Settings/Connections, External Agent picker, coordinator, readiness, and Work Policy tests (the Settings/Connections suite passed in isolation)
- Connections Playwright smoke
- `go vet ./internal/api ./internal/agentadapters ./internal/projectworkapp`
- `go test ./internal/api ./internal/agentadapters ./internal/projectworkapp`
- `just docs-format-check && just check-links`

`just test-race` exercised the full repository but is currently blocked by two pre-existing timing-sensitive ACP/chat tests outside this diff: `TestSessionManagerConcurrentTurnsShareOneNativeSessionReplacement` and `TestAgentChatPersistsCoalescedActivityWhenRunCancelled`. The former passed three isolated race runs; the latter still fails in isolation and needs separate runtime follow-up.