### PR TITLE
feat(agent): expose effective code intelligence readiness

### DIFF
--- a/docs/design/implemented/native-code-intelligence.md
+++ b/docs/design/implemented/native-code-intelligence.md
@@ -2,8 +2,9 @@
 
 > **Status:** first read-only slice implemented.
 > **Current source of truth:** [Agent runtime](../../runtime/agent-runtime.md).
-> **Next action:** dogfood latency and result quality before adding per-run
-> language-server pooling or any write-capable refactoring operation.
+> **Next action:** dogfood the effective model guidance, provider-version
+> reporting, latency, and result quality before adding a friendly persisted
+> readiness view, per-run language-server pooling, or write-capable refactoring.
 
 Hecate's native agent loop already had bounded file reads, regular-expression
 search, and shell access. Those tools are enough to inspect a repository, but
@@ -16,6 +17,16 @@ This slice adds one read-only `code_intelligence` tool with three layers:
 1. LSP for type-aware navigation, hover, symbols, and diagnostics.
 2. Optional `ast-grep` for syntax-aware structural patterns.
 3. Existing bounded `grep` as the always-available fallback.
+
+The model-visible tool catalog now documents effective access for each Run
+before the model chooses an operation. Capability and structural access,
+semantic isolation policy, and `grep` approval posture are reported separately;
+the semantic statement is rendered from the same helper that enforces dispatch.
+Provider installation remains explicitly unchecked until the model makes the
+normal audited `capabilities` call. That call reports bounded normalized
+provider versions, Hecate's operation allowlist, and
+`installed_unverified` rather than claiming that an LSP handshake or
+structural invocation has succeeded.
 
 ## Decisions
 
@@ -104,6 +115,11 @@ the optional structural subprocess cannot meet.
   Capability discovery and structural search remain usable by read-only presets;
   semantic calls in those presets require Linux `bwrap`. Rename, code actions,
   and rewrites are not part of this contract.
+- Preparing a model request does not execute providers. Effective access
+  guidance exposes approval and isolation posture without turning an implicit
+  harness probe into an unaudited `read_file`-family action. Provider discovery
+  remains an explicit `capabilities` tool call and therefore pauses when
+  `read_file` or `all_tools` approval is configured.
 - The report-only `workflow_mode="qa"` v0 contract is narrower than an ordinary
   read-only preset: its catalog omits `code_intelligence`, and dispatch rejects
   every operation before approval or provider startup, including capability
@@ -121,8 +137,9 @@ Before adding write-side semantic operations:
 
 - measure cold-query latency and useful-result rate on Hecate's Go and
   TypeScript code;
-- add a visible readiness/probe surface with provider version, handshake stage,
-  negotiated encoding, supported operations, and a repair hint;
+- add a persisted operator-facing readiness view that extends the current
+  model guidance and capability versions with handshake stage, negotiated
+  encoding, supported operations, and repair hints;
 - prove a per-run pool has bounded size/idle lifetime, single-flight startup,
   document versioning, cancellation, crash eviction, and process-tree cleanup;
 - make rename/code actions produce proposed patches first, then route approved

--- a/docs/runtime/agent-runtime.md
+++ b/docs/runtime/agent-runtime.md
@@ -274,19 +274,41 @@ Tool argument schemas are JSON-Schema-shaped and surfaced to the LLM in the stan
 
 ### Code intelligence providers
 
+Before every model call, the `code_intelligence` tool description distinguishes
+three current-Run facts: whether capability/structural calls require approval,
+whether semantic LSP operations are permitted by the task and active host
+wrapper, and whether the bounded `grep` fallback requires approval. The same
+semantic-policy helper is used by dispatch, so a read-only or network-denied
+block is visible before the model spends a call on an operation that must be
+refused. The description deliberately reports provider installation as not
+checked. Hecate does not silently start provider processes while preparing a
+model request or bypass the `read_file` / `all_tools` approval family; the model
+uses the audited `capabilities` operation when provider discovery is useful.
+
 `code_intelligence` with `operation=capabilities` is permitted by the native
 sandbox gate, subject to normal preset tool enablement and approval policy. It
-resolves trusted executables and runs bounded `gopls version` / `tsc --version`
-probes, but does not initialize a language server; `ast-grep` discovery only
-inspects the executable. The other operations are available when the matching executable is installed
+resolves trusted executables and runs bounded `gopls version`, `tsc --version`,
+and `ast-grep --version` probes. Results include a normalized, bounded version
+token when the provider emits one Hecate recognizes, the operations Hecate may
+request, and the explicit
+`installed_unverified` stage. Capability discovery does not initialize a
+language server or execute a structural query; initialization or invocation is
+verified only by a real query. The other operations are available when the matching executable is installed
 on the gateway's trusted global `PATH` or bound to an exact operator-owned
 path:
+
+A trusted `ast-grep` executable remains `installed_unverified` when only its
+version probe fails because structural dispatch has no version compatibility
+contract; the first real structural query remains the invocation check.
 
 | Language / mode | Preferred provider                | Operations                                                                                                                      |
 | --------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | Go              | `gopls serve`                     | definition, references, hover, symbols, diagnostics                                                                             |
 | TypeScript / JS | TypeScript 7+ `tsc --lsp --stdio` | definition, references, hover, symbols, diagnostics                                                                             |
 | Structural      | `ast-grep run ... --json=stream`  | read-only structural search, including an optional contextual-pattern node-kind selector; rewrites are deliberately not exposed |
+
+The structural allowlist covers Go, JavaScript/TypeScript, Python, Rust, Java,
+C/C++/C#, HTML/CSS, JSON/YAML, and Bash.
 
 `just doctor` reports the local discovery state. Typical operator-managed
 installs are `go install golang.org/x/tools/gopls@latest`, a global TypeScript

--- a/internal/codeintel/dogfood_test.go
+++ b/internal/codeintel/dogfood_test.go
@@ -56,7 +56,7 @@ func TestService_RealProviderDogfood(t *testing.T) {
 	}
 	t.Logf("provider=%s operation=%s results=%d elapsed=%s", result.Provider, result.Operation, len(result.Items), time.Since(started))
 	for _, capability := range result.Capabilities {
-		t.Logf("capability language=%s provider=%s available=%t status=%s detail=%s", capability.Language, capability.Provider, capability.Available, capability.Status, capability.Detail)
+		t.Logf("capability language=%s provider=%s version=%s available=%t status=%s detail=%s", capability.Language, capability.Provider, capability.Version, capability.Available, capability.Status, capability.Detail)
 	}
 }
 

--- a/internal/codeintel/format.go
+++ b/internal/codeintel/format.go
@@ -16,7 +16,19 @@ func formatResult(result Result) string {
 			if capability.Available {
 				status = "available"
 			}
-			fmt.Fprintf(&builder, "%s: %s via %s [%s] (%s)\n", capability.Language, status, capability.Provider, capability.Status, capability.Detail)
+			fmt.Fprintf(&builder, "%s: %s via %s", capability.Language, status, capability.Provider)
+			if capability.Version != "" {
+				fmt.Fprintf(&builder, " version=%s", capability.Version)
+			}
+			fmt.Fprintf(&builder, " [%s]", capability.Status)
+			if len(capability.Operations) > 0 {
+				operations := make([]string, 0, len(capability.Operations))
+				for _, operation := range capability.Operations {
+					operations = append(operations, string(operation))
+				}
+				fmt.Fprintf(&builder, " operations=%s", strings.Join(operations, ","))
+			}
+			fmt.Fprintf(&builder, " (%s)\n", capability.Detail)
 		}
 		return truncateResultText(strings.TrimSpace(builder.String()))
 	}

--- a/internal/codeintel/format_test.go
+++ b/internal/codeintel/format_test.go
@@ -28,3 +28,28 @@ func TestFormatResultEnforcesCompleteUTF8OutputBudget(t *testing.T) {
 		t.Fatalf("formatted result must end with a valid UTF-8 truncation marker")
 	}
 }
+
+func TestFormatCapabilitiesIncludesVersionOperationsAndVerificationStage(t *testing.T) {
+	text := formatResult(Result{
+		Operation: OpCapabilities,
+		Capabilities: []Capability{{
+			Language:   "go",
+			Provider:   "gopls",
+			Version:    "0.20.0",
+			Available:  true,
+			Status:     "installed_unverified",
+			Operations: []Operation{OpDefinition, OpReferences},
+			Detail:     "trusted executable and version probe passed; LSP initialization is verified on query",
+		}},
+	})
+	for _, want := range []string{
+		"go: available via gopls version=0.20.0",
+		"[installed_unverified]",
+		"operations=definition,references",
+		"LSP initialization is verified on query",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("formatted capabilities = %q, want %q", text, want)
+		}
+	}
+}

--- a/internal/codeintel/servers.go
+++ b/internal/codeintel/servers.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -27,6 +28,10 @@ type serverSpec struct {
 	minMajor   int
 	probeArgs  []string
 }
+
+const maxProviderVersionBytes = 64
+
+var providerVersionPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
 
 func defaultServers() map[string][]serverSpec {
 	return map[string][]serverSpec{
@@ -104,7 +109,7 @@ func (s *Service) selectServer(ctx context.Context, fsys *workspacefs.FS, reques
 		}
 		spec.provider = provider
 		spec.command = path
-		if err := s.checkServerCompatibility(ctx, fsys, spec); err != nil {
+		if _, err := s.checkServerCompatibility(ctx, fsys, spec); err != nil {
 			skipped = append(skipped, err.Error())
 			continue
 		}
@@ -150,13 +155,15 @@ func (s *Service) capabilities(ctx context.Context, fsys *workspacefs.FS, _ Requ
 			}
 			spec.provider = provider
 			spec.command = path
-			if err := s.checkServerCompatibility(ctx, fsys, spec); err != nil {
+			version, err := s.checkServerCompatibility(ctx, fsys, spec)
+			if err != nil {
 				skipped = append(skipped, err.Error())
 				continue
 			}
 			capability.Available = true
 			capability.Status = "installed_unverified"
 			capability.Provider = filepath.Base(path)
+			capability.Version = version
 			capability.Detail = "trusted executable and version probe passed; LSP initialization is verified on query"
 			if len(skipped) > 0 {
 				capability.Detail += "; skipped " + strings.Join(skipped, ", ")
@@ -178,10 +185,22 @@ func (s *Service) capabilities(ctx context.Context, fsys *workspacefs.FS, _ Requ
 		Provider:   "ast-grep",
 		Operations: []Operation{OpStructuralSearch},
 	}
-	if _, err := s.resolveTrustedBinary(fsys, "ast-grep"); err == nil {
-		structural.Available = true
-		structural.Status = "installed_unverified"
-		structural.Detail = "trusted executable found; invocation is verified on query"
+	if path, err := s.resolveTrustedBinary(fsys, "ast-grep"); err == nil {
+		version, probeErr := s.checkServerCompatibility(ctx, fsys, serverSpec{
+			provider:  "ast-grep",
+			command:   path,
+			probeArgs: []string{"--version"},
+		})
+		if probeErr != nil {
+			structural.Available = true
+			structural.Status = "installed_unverified"
+			structural.Detail = "trusted executable found; version probe failed; invocation is verified on query"
+		} else {
+			structural.Available = true
+			structural.Status = "installed_unverified"
+			structural.Version = version
+			structural.Detail = "trusted executable and version probe passed; invocation is verified on query"
+		}
 	} else {
 		structural.Status = "unavailable"
 		structural.Detail = concise(err.Error(), 256)
@@ -190,13 +209,13 @@ func (s *Service) capabilities(ctx context.Context, fsys *workspacefs.FS, _ Requ
 	return result, nil
 }
 
-func (s *Service) checkServerCompatibility(ctx context.Context, fsys *workspacefs.FS, spec serverSpec) error {
+func (s *Service) checkServerCompatibility(ctx context.Context, fsys *workspacefs.FS, spec serverSpec) (string, error) {
 	if len(spec.probeArgs) == 0 {
-		return nil
+		return "", nil
 	}
 	argv := sandbox.WrapReadOnlyArgv(append([]string{spec.command}, spec.probeArgs...), fsys.Root(), false)
 	if len(argv) == 0 {
-		return fmt.Errorf("%s compatibility probe is empty", filepath.Base(spec.command))
+		return "", fmt.Errorf("%s compatibility probe is empty", filepath.Base(spec.command))
 	}
 	result, err := s.runner.Run(ctx, processrunner.Request{
 		Command:        argv[0],
@@ -208,35 +227,50 @@ func (s *Service) checkServerCompatibility(ctx context.Context, fsys *workspacef
 		MaxStderrBytes: 1024,
 	})
 	if err != nil {
-		return fmt.Errorf("%s version probe failed", filepath.Base(spec.command))
+		return "", fmt.Errorf("%s version probe failed", filepath.Base(spec.command))
 	}
 	version := strings.TrimSpace(result.Stdout)
 	if version == "" {
 		version = strings.TrimSpace(result.Stderr)
 	}
 	if version == "" {
-		return fmt.Errorf("%s version probe returned no version", filepath.Base(spec.command))
+		return "", fmt.Errorf("%s version probe returned no version", filepath.Base(spec.command))
 	}
-	if spec.minMajor <= 0 {
-		return nil
+	normalizedVersion, versionOK := normalizedProviderVersion(version)
+	if spec.minMajor > 0 {
+		if !versionOK {
+			return "", fmt.Errorf("%s version probe returned an unrecognized version", filepath.Base(spec.command))
+		}
+		major, ok := versionMajor(normalizedVersion)
+		if !ok || major < spec.minMajor {
+			return "", fmt.Errorf("%s version does not support the required native LSP mode (need major >= %d)", filepath.Base(spec.command), spec.minMajor)
+		}
 	}
-	major, ok := versionMajor(version)
-	if !ok || major < spec.minMajor {
-		return fmt.Errorf("%s version does not support the required native LSP mode (need major >= %d)", filepath.Base(spec.command), spec.minMajor)
-	}
-	return nil
+	return normalizedVersion, nil
 }
 
 func versionMajor(value string) (int, bool) {
+	version, ok := normalizedProviderVersion(value)
+	if !ok {
+		return 0, false
+	}
+	majorText, _, _ := strings.Cut(version, ".")
+	major, err := strconv.Atoi(majorText)
+	return major, err == nil
+}
+
+func normalizedProviderVersion(value string) (string, bool) {
 	for _, field := range strings.Fields(value) {
-		field = strings.TrimPrefix(strings.TrimSpace(field), "v")
-		majorText, _, _ := strings.Cut(field, ".")
-		major, err := strconv.Atoi(majorText)
-		if err == nil {
-			return major, true
+		candidate := strings.Trim(field, " ,;:()[]{}<>")
+		candidate = strings.TrimPrefix(candidate, "v")
+		if candidate == "" || len(candidate) > maxProviderVersionBytes {
+			continue
+		}
+		if providerVersionPattern.MatchString(candidate) {
+			return candidate, true
 		}
 	}
-	return 0, false
+	return "", false
 }
 
 func (s *Service) resolveTrustedBinary(fsys *workspacefs.FS, name string) (string, error) {

--- a/internal/codeintel/service_test.go
+++ b/internal/codeintel/service_test.go
@@ -417,8 +417,39 @@ func TestService_CapabilitiesDistinguishVerifiedExecutableFromLSPReadiness(t *te
 	if goCapability == nil || !goCapability.Available || goCapability.Status != "installed_unverified" {
 		t.Fatalf("Go capability = %+v, want installed_unverified", goCapability)
 	}
+	if goCapability.Version != "0.20.0" {
+		t.Fatalf("Go capability version = %q, want normalized 0.20.0", goCapability.Version)
+	}
 	if len(runner.requests) != 1 || len(runner.requests[0].Args) != 1 || runner.requests[0].Args[0] != "version" {
 		t.Fatalf("probe requests = %+v, want fixed gopls version probe", runner.requests)
+	}
+}
+
+func TestNormalizedProviderVersionIsBoundedAndModelSafe(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   string
+		want  string
+		valid bool
+	}{
+		{name: "gopls", raw: "golang.org/x/tools/gopls v0.20.0\n", want: "0.20.0", valid: true},
+		{name: "typescript prerelease", raw: "Version 7.0.0-dev.20260808", want: "7.0.0-dev.20260808", valid: true},
+		{name: "ast grep", raw: "ast-grep 0.40.4", want: "0.40.4", valid: true},
+		{name: "path only", raw: "/private/operator/provider", valid: false},
+		{name: "hostile token", raw: "1.2.3/private", valid: false},
+		{name: "missing minor", raw: "Version 7.", valid: false},
+		{name: "non-numeric minor", raw: "Version 7.not-a-version", valid: false},
+		{name: "four-part address", raw: "Version 10.0.0.1", valid: false},
+		{name: "empty prerelease", raw: "Version 7.0.0-", valid: false},
+		{name: "empty build", raw: "Version 7.0.0+", valid: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, valid := normalizedProviderVersion(test.raw)
+			if got != test.want || valid != test.valid {
+				t.Fatalf("normalizedProviderVersion(%q) = %q, %t; want %q, %t", test.raw, got, valid, test.want, test.valid)
+			}
+		})
 	}
 }
 
@@ -441,6 +472,92 @@ func TestService_CapabilitiesPreserveCancellationDuringProbe(t *testing.T) {
 	_, err := service.Query(ctx, workspace, Request{Operation: OpCapabilities})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want context cancellation", err)
+	}
+}
+
+func TestService_CapabilitiesVersionProbesStructuralProvider(t *testing.T) {
+	reset := sandbox.SetWrapperForTesting(sandbox.WrapperNone)
+	defer reset()
+	workspace := t.TempDir()
+	astGrep := executableFixture(t, t.TempDir(), "ast-grep")
+	runner := &recordingRunner{result: processrunner.Result{Stdout: "ast-grep 0.40.4\n"}}
+	service := NewService()
+	service.runner = runner
+	setProviderPath(service, "ast-grep", astGrep)
+	service.lookPath = func(name string) (string, error) {
+		return "", os.ErrNotExist
+	}
+	result, err := service.Query(context.Background(), workspace, Request{Operation: OpCapabilities})
+	if err != nil {
+		t.Fatalf("capabilities: %v", err)
+	}
+	var structural *Capability
+	for index := range result.Capabilities {
+		if result.Capabilities[index].Language == "structural" {
+			structural = &result.Capabilities[index]
+			break
+		}
+	}
+	if structural == nil || !structural.Available || structural.Status != "installed_unverified" || structural.Version != "0.40.4" {
+		t.Fatalf("structural capability = %+v, want versioned installed_unverified", structural)
+	}
+	if len(runner.requests) != 1 || len(runner.requests[0].Args) != 1 || runner.requests[0].Args[0] != "--version" {
+		t.Fatalf("probe requests = %+v, want fixed ast-grep --version probe", runner.requests)
+	}
+}
+
+func TestService_StructuralCapabilityVersionProbeFailureDoesNotContradictDispatch(t *testing.T) {
+	reset := sandbox.SetWrapperForTesting(sandbox.WrapperNone)
+	defer reset()
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	astGrep := executableFixture(t, t.TempDir(), "ast-grep")
+	runner := &recordingRunner{run: func(request processrunner.Request) (processrunner.Result, error) {
+		if len(request.Args) == 1 && request.Args[0] == "--version" {
+			return processrunner.Result{}, errors.New("version output unavailable")
+		}
+		return processrunner.Result{}, nil
+	}}
+	service := NewService()
+	service.runner = runner
+	setProviderPath(service, "ast-grep", astGrep)
+	service.lookPath = func(name string) (string, error) {
+		return "", os.ErrNotExist
+	}
+
+	capabilities, err := service.Query(context.Background(), workspace, Request{Operation: OpCapabilities})
+	if err != nil {
+		t.Fatalf("capabilities: %v", err)
+	}
+	var structural *Capability
+	for index := range capabilities.Capabilities {
+		if capabilities.Capabilities[index].Language == "structural" {
+			structural = &capabilities.Capabilities[index]
+			break
+		}
+	}
+	if structural == nil || !structural.Available || structural.Status != "installed_unverified" || structural.Version != "" {
+		t.Fatalf("structural capability = %+v, want available installed_unverified without a version", structural)
+	}
+	if !strings.Contains(structural.Detail, "version probe failed") || strings.Contains(structural.Detail, "version output unavailable") {
+		t.Fatalf("structural detail = %q, want bounded category without raw runner error", structural.Detail)
+	}
+
+	result, err := service.Query(context.Background(), workspace, Request{
+		Operation: OpStructuralSearch,
+		Path:      "main.go",
+		Query:     "package $NAME",
+	})
+	if err != nil {
+		t.Fatalf("structural search after failed version probe: %v", err)
+	}
+	if result.Provider != "ast-grep" || result.Text != "structural_search returned no results" {
+		t.Fatalf("structural result = %+v, want successful empty ast-grep query", result)
+	}
+	if len(runner.requests) != 2 || len(runner.requests[1].Args) == 0 || runner.requests[1].Args[0] != "run" {
+		t.Fatalf("provider requests = %+v, want version probe followed by structural run", runner.requests)
 	}
 }
 

--- a/internal/codeintel/types.go
+++ b/internal/codeintel/types.go
@@ -43,9 +43,11 @@ type Result struct {
 }
 
 // Capability reports whether a fixed, allowlisted local provider is present.
+// Version is a bounded normalized token and never contains raw provider output.
 type Capability struct {
 	Language   string
 	Provider   string
+	Version    string
 	Available  bool
 	Status     string
 	Operations []Operation

--- a/internal/orchestrator/executor_agent_loop.go
+++ b/internal/orchestrator/executor_agent_loop.go
@@ -264,6 +264,7 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (re
 		IncludeWebSearch:             e.toolDispatcher != nil && e.toolDispatcher.webSearch != nil,
 		IncludeBrowserInspection:     e.toolDispatcher != nil && e.toolDispatcher.browserInspector != nil,
 	})
+	codeIntelligenceDocumented := false
 	terminals := e.terminalSessionsForRun(spec.Run.ID)
 	defer func() {
 		if res == nil || res.Status != "awaiting_approval" {
@@ -475,6 +476,15 @@ func (e *AgentLoopExecutor) Execute(ctx context.Context, spec ExecutionSpec) (re
 			}
 			modelCall = runState.ModelCallCount() + 1
 			modelCallRef = currentAgentLoopModelCallRef(spec, modelCall)
+			if !codeIntelligenceDocumented {
+				applyCodeIntelligenceSelfDocumentation(
+					tools,
+					spec.Task,
+					e.approvalGate,
+					e.toolDispatcher != nil && e.toolDispatcher.codeIntelligence != nil,
+				)
+				codeIntelligenceDocumented = true
+			}
 			modelCallResult, failed, err := e.runModelCall(ctx, spec, &conversation, runState, tools, modelCall, modelCallStartedAt)
 			if failed != nil || err != nil {
 				return failed, err

--- a/internal/orchestrator/executor_agent_loop_approval_gate.go
+++ b/internal/orchestrator/executor_agent_loop_approval_gate.go
@@ -87,10 +87,15 @@ func (g agentLoopApprovalGate) isGated(call types.ToolCall, spec ExecutionSpec) 
 	if toolName == AgentToolBrowserInspect {
 		return g.browserInspectionAvailable && browserInspectionCallAllowed(task, call)
 	}
-	if _, ok := g.gatedTools[toolName]; ok {
+	if g.requiresExplicitApproval(toolName) {
 		return true
 	}
 	return mcpServerPolicy(toolName, task) == types.MCPApprovalRequireApproval
+}
+
+func (g agentLoopApprovalGate) requiresExplicitApproval(toolName string) bool {
+	_, ok := g.gatedTools[strings.TrimSpace(toolName)]
+	return ok
 }
 
 func browserInspectionCallAllowed(task types.Task, call types.ToolCall) bool {

--- a/internal/orchestrator/executor_agent_loop_code_intelligence.go
+++ b/internal/orchestrator/executor_agent_loop_code_intelligence.go
@@ -29,6 +29,7 @@ const (
 	codeIntelligenceStepStringBytes = 64
 	codeIntelligenceDefaultResults  = 50
 	codeIntelligenceMaximumResults  = 200
+	semanticCodeIntelligenceRepair  = "use grep or structural_search, or run semantic intelligence with a compatible OS sandbox/network-enabled preset"
 )
 
 func agentSandboxBlocksCodeIntelligence(task types.Task, call types.ToolCall) (bool, string) {
@@ -70,13 +71,13 @@ func codeIntelligenceToolDefinition() types.Tool {
 		Type: "function",
 		Function: types.ToolFunction{
 			Name:        AgentToolCodeIntelligence,
-			Description: "Use read-only semantic or structural code intelligence inside the task workspace. LSP operations provide definitions, references, hover, symbols, and diagnostics when an allowlisted language server is installed. structural_search uses optional ast-grep and accepts a safe tree-sitter node-kind selector for contextual patterns. Call capabilities to inspect availability; fall back to grep when a provider is missing. Returned paths are workspace-confined.",
+			Description: "Use read-only semantic or structural code intelligence inside the task workspace. Semantic LSP operations support Go through gopls and TypeScript/JavaScript through TypeScript 7+ native LSP. structural_search uses optional ast-grep for allowlisted Go, JavaScript/TypeScript, Python, Rust, Java, C/C++/C#, HTML/CSS, JSON/YAML, and Bash syntax, and accepts a safe tree-sitter node-kind selector for contextual patterns. Call capabilities to inspect trusted provider versions; installed_unverified means initialization or invocation is verified only by a real query. Fall back to grep when a provider is missing. Returned paths are workspace-confined.",
 			Parameters: json.RawMessage(`{
 				"type": "object",
 				"properties": {
 					"operation": {"type": "string", "enum": ["capabilities", "definition", "references", "hover", "document_symbols", "workspace_symbols", "diagnostics", "structural_search"]},
 					"path": {"type": "string", "maxLength": 4096, "description": "Workspace-relative source file, capped at 4096 UTF-8 bytes. Required for document-scoped LSP operations and TypeScript workspace_symbols; optional for Go workspace_symbols when language is supplied; optional structural_search scope defaults to '.'."},
-					"language": {"type": "string", "maxLength": 64, "description": "Optional language id capped at 64 UTF-8 bytes, usually inferred from path. Required for workspace_symbols without path and for directory-scoped structural_search."},
+					"language": {"type": "string", "maxLength": 64, "description": "Optional language id capped at 64 UTF-8 bytes, usually inferred from path. Semantic LSP accepts Go and TypeScript/JavaScript. structural_search additionally accepts Python, Rust, Java, C/C++/C#, HTML/CSS, JSON/YAML, and Bash. Required for workspace_symbols without path and for directory-scoped structural_search."},
 					"query": {"type": "string", "maxLength": 16384, "description": "Required workspace-symbol query or ast-grep pattern for structural_search, capped at 16384 UTF-8 bytes."},
 					"selector": {"type": "string", "maxLength": 128, "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "description": "Optional structural_search-only tree-sitter node kind used to select the match within a contextual pattern, for example call_expression. Must be one ASCII identifier token."},
 					"line": {"type": "integer", "minimum": 1, "description": "1-based source line. Required for definition, references, and hover."},
@@ -87,6 +88,39 @@ func codeIntelligenceToolDefinition() types.Tool {
 			}`),
 		},
 	}
+}
+
+func applyCodeIntelligenceSelfDocumentation(tools []types.Tool, task types.Task, gate agentLoopApprovalGate, serviceConfigured bool) {
+	for index := range tools {
+		if tools[index].Function.Name != AgentToolCodeIntelligence {
+			continue
+		}
+		tools[index].Function.Description += " " + effectiveCodeIntelligenceGuidance(task, gate, serviceConfigured)
+		return
+	}
+}
+
+func effectiveCodeIntelligenceGuidance(task types.Task, gate agentLoopApprovalGate, serviceConfigured bool) string {
+	grepAccess := "is permitted without an approval pause"
+	if gate.requiresExplicitApproval("grep") {
+		grepAccess = "requires operator approval"
+	}
+	if !serviceConfigured {
+		return "Effective access for this run: code_intelligence is unavailable because its runtime service is not configured. grep " + grepAccess + "."
+	}
+
+	toolAccess := "are permitted without an approval pause"
+	if gate.requiresExplicitApproval(AgentToolCodeIntelligence) {
+		toolAccess = "require operator approval"
+	}
+	blocked, reason := semanticCodeIntelligencePolicyBlock(task)
+	semanticAccess := "permitted by the current task and host isolation policy; provider installation is not checked yet and LSP initialization is verified on query"
+	if blocked {
+		semanticAccess = "blocked: " + reason + "; " + semanticCodeIntelligenceRepair
+	} else if gate.requiresExplicitApproval(AgentToolCodeIntelligence) {
+		semanticAccess = "approval-gated; provider installation is not checked yet and LSP initialization is verified on query"
+	}
+	return "Effective access for this run: capabilities and structural_search " + toolAccess + "; semantic LSP operations are " + semanticAccess + ". grep " + grepAccess + " as the text fallback. Dispatch-time policy remains authoritative."
 }
 
 func (d *agentLoopToolDispatcher) codeIntelligenceTool(ctx context.Context, spec ExecutionSpec, args codeIntelligenceArgs, stepIndex int, startedAt time.Time, toolName string) (string, *types.TaskStep, []types.TaskArtifact, error) {

--- a/internal/orchestrator/executor_agent_loop_code_intelligence_test.go
+++ b/internal/orchestrator/executor_agent_loop_code_intelligence_test.go
@@ -39,6 +39,11 @@ func TestAgentLoopCodeIntelligenceToolIsAdvertisedAndReadOnlySafe(t *testing.T) 
 	if !strings.Contains(string(tool.Function.Parameters), `"selector"`) || !strings.Contains(string(tool.Function.Parameters), `^[A-Za-z_][A-Za-z0-9_]*$`) {
 		t.Fatalf("tool schema omits the bounded structural selector: %s", tool.Function.Parameters)
 	}
+	for _, language := range []string{"Go", "TypeScript/JavaScript", "Python", "Rust", "C/C++/C#", "Bash"} {
+		if !strings.Contains(tool.Function.Description+string(tool.Function.Parameters), language) {
+			t.Errorf("tool self-documentation omits language family %q", language)
+		}
+	}
 	toolsEnabled := true
 	readOnlyTools := agentToolDefinitionsForExecution(types.Task{
 		AgentPresetID:           "review-read-only",
@@ -47,6 +52,113 @@ func TestAgentLoopCodeIntelligenceToolIsAdvertisedAndReadOnlySafe(t *testing.T) 
 	}, types.TaskRun{}, agentToolDefinitionOptions{})
 	if !hasToolDefinition(readOnlyTools, AgentToolCodeIntelligence) {
 		t.Fatalf("read-only catalog omits %s", AgentToolCodeIntelligence)
+	}
+}
+
+func TestAgentLoopCodeIntelligenceSelfDocumentationMatchesEffectivePolicy(t *testing.T) {
+	tests := []struct {
+		name              string
+		wrapper           sandbox.WrapperKind
+		task              types.Task
+		gatedTools        []string
+		serviceConfigured bool
+		want              []string
+	}{
+		{
+			name:              "read only host blocks semantics but preserves discovery and fallbacks",
+			wrapper:           sandbox.WrapperNone,
+			task:              types.Task{SandboxReadOnly: true, SandboxNetwork: true},
+			serviceConfigured: true,
+			want: []string{
+				"capabilities and structural_search are permitted without an approval pause",
+				"semantic LSP operations are blocked: semantic language servers are disabled for read-only tasks",
+				semanticCodeIntelligenceRepair,
+				"grep is permitted without an approval pause",
+			},
+		},
+		{
+			name:              "bwrap permits read only semantic queries",
+			wrapper:           sandbox.WrapperBwrap,
+			task:              types.Task{SandboxReadOnly: true},
+			serviceConfigured: true,
+			want: []string{
+				"semantic LSP operations are permitted by the current task and host isolation policy",
+				"provider installation is not checked yet",
+				"LSP initialization is verified on query",
+			},
+		},
+		{
+			name:              "read approval covers discovery semantics structure and grep",
+			wrapper:           sandbox.WrapperSandboxExec,
+			task:              types.Task{SandboxNetwork: true},
+			gatedTools:        []string{AgentToolCodeIntelligence, "grep"},
+			serviceConfigured: true,
+			want: []string{
+				"capabilities and structural_search require operator approval",
+				"semantic LSP operations are approval-gated",
+				"grep requires operator approval",
+			},
+		},
+		{
+			name:              "missing runtime service is explicit",
+			wrapper:           sandbox.WrapperBwrap,
+			serviceConfigured: false,
+			want:              []string{"code_intelligence is unavailable because its runtime service is not configured"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reset := sandbox.SetWrapperForTesting(test.wrapper)
+			defer reset()
+			tools := agentToolDefinitions()
+			applyCodeIntelligenceSelfDocumentation(tools, test.task, newAgentLoopApprovalGate(test.gatedTools), test.serviceConfigured)
+			tool := findToolDefinition(tools, AgentToolCodeIntelligence)
+			if tool == nil {
+				t.Fatal("code_intelligence tool definition missing")
+			}
+			for _, want := range test.want {
+				if !strings.Contains(tool.Function.Description, want) {
+					t.Errorf("description = %q, want %q", tool.Function.Description, want)
+				}
+			}
+		})
+	}
+}
+
+func TestAgentLoopCodeIntelligenceFirstModelRequestGetsEffectiveSelfDocumentationWithoutProviderProbe(t *testing.T) {
+	reset := sandbox.SetWrapperForTesting(sandbox.WrapperNone)
+	defer reset()
+	llm := &scriptedLLM{responses: []*types.ChatResponse{
+		makeChatResp(makeAssistantMsg("Inspection is unavailable under this posture.")),
+	}}
+	fake := &fakeCodeIntelligenceService{}
+	loop := NewAgentLoopExecutor(
+		llm,
+		&stubExecutor{},
+		&stubExecutor{},
+		&stubExecutor{},
+		1,
+		nil,
+		HTTPRequestPolicy{},
+		WithCodeIntelligenceService(fake),
+	)
+	spec := newAgentLoopSpec(t)
+	spec.Task.WorkingDirectory = t.TempDir()
+	spec.Task.SandboxReadOnly = true
+	spec.Task.SandboxNetwork = true
+	res, err := loop.Execute(context.Background(), spec)
+	if err != nil || res.Status != "completed" {
+		t.Fatalf("Execute() result = %+v, error %v", res, err)
+	}
+	if len(llm.lastReqs) != 1 {
+		t.Fatalf("model requests = %d, want 1", len(llm.lastReqs))
+	}
+	tool := findToolDefinition(llm.lastReqs[0].Tools, AgentToolCodeIntelligence)
+	if tool == nil || !strings.Contains(tool.Function.Description, "semantic LSP operations are blocked") {
+		t.Fatalf("first request tool = %+v, want effective semantic blocker", tool)
+	}
+	if fake.request.Operation != "" {
+		t.Fatalf("self-documentation unexpectedly probed provider with request %+v", fake.request)
 	}
 }
 

--- a/internal/orchestrator/executor_agent_loop_conversation.go
+++ b/internal/orchestrator/executor_agent_loop_conversation.go
@@ -185,7 +185,7 @@ func truncateConversationToRunModelCall(messages []types.Message, runModelCallCo
 
 // hydrateConversation returns the conversation history for this run.
 // On a fresh run, it prepends the composed system prompt (from the
-// runner's four-layer resolver) before the user prompt. On a resume,
+// runner's three-layer resolver) before the user prompt. On a resume,
 // it returns the JSON-decoded prior conversation from the source
 // run's persisted agent_conversation artifact — the loop continues
 // exactly where it left off, preserving tool results, prior reasoning,
@@ -220,8 +220,8 @@ func hydrateConversation(spec ExecutionSpec) ([]types.Message, *types.Message) {
 	//      and uses that path verbatim — which lands outside the
 	//      sandbox (an isolated clone) and the run fails with
 	//      "escapes allowed root".
-	//   2. composed operator system prompt (four layers) — global /
-	//      tenant / workspace CLAUDE.md|AGENTS.md / per-task. Empty
+	//   2. composed operator system prompt (three layers) — global /
+	//      workspace CLAUDE.md|AGENTS.md / per-task. Empty
 	//      when none of those layers contributed.
 	//   3. user prompt.
 	messages := make([]types.Message, 0, 3)
@@ -274,7 +274,7 @@ func environmentSystemMessage(spec ExecutionSpec) string {
 	b.WriteString("Use this path (or paths under it) when calling tools. ")
 	b.WriteString("`shell_exec` / `git_exec` default their working_directory to the workspace when omitted; ")
 	b.WriteString("`read_file` / `list_dir` / `grep` / `glob` / `code_intelligence` / `git_diff` resolve relative paths from the workspace. ")
-	b.WriteString("Prefer `code_intelligence` for definitions, references, symbols, hover, diagnostics, and structural patterns; call its capabilities operation when availability is unclear, then fall back to `grep`. ")
+	b.WriteString("Before choosing code intelligence, follow the `code_intelligence` tool description's effective access for this run; when available, use its capabilities operation to verify installed providers, then fall back to `grep` when needed. ")
 	b.WriteString("Tool calls that target paths outside this directory are rejected by the sandbox — ")
 	b.WriteString("don't reuse paths from the user prompt verbatim if they fall outside the workspace.")
 	return b.String()

--- a/internal/orchestrator/executor_agent_loop_conversation_test.go
+++ b/internal/orchestrator/executor_agent_loop_conversation_test.go
@@ -27,7 +27,7 @@ func TestAgentLoopConversation_FreshRunBuildsPreludeAndStableArtifactID(t *testi
 	if messages[0].Role != "system" || !strings.Contains(messages[0].Content, "/workspace/run") {
 		t.Fatalf("environment system message = %+v, want workspace grounding", messages[0])
 	}
-	if !strings.Contains(messages[0].Content, "`code_intelligence`") || !strings.Contains(messages[0].Content, "fall back to `grep`") {
+	if !strings.Contains(messages[0].Content, "`code_intelligence` tool description's effective access") || !strings.Contains(messages[0].Content, "fall back to `grep`") {
 		t.Fatalf("environment system message = %q, want code-intelligence guidance", messages[0].Content)
 	}
 	if messages[1].Role != "system" || messages[1].Content != "Use concise answers." {

--- a/internal/orchestrator/executor_agent_loop_tools.go
+++ b/internal/orchestrator/executor_agent_loop_tools.go
@@ -116,7 +116,7 @@ func (d *agentLoopToolDispatcher) Dispatch(ctx context.Context, spec ExecutionSp
 			startedAt,
 			"sandbox_code_intelligence",
 			reason,
-			"use grep or structural_search, or run semantic intelligence with a compatible OS sandbox/network-enabled preset",
+			semanticCodeIntelligenceRepair,
 		), nil
 	}
 	if agentReadOnlyBlocksTool(spec.Task, call.Function.Name) {


### PR DESCRIPTION
## Summary

- add current-run code-intelligence access guidance to the model tool catalog, including approval posture, semantic sandbox blockers, and the bounded grep fallback
- document supported semantic and structural languages directly in the tool schema
- report normalized provider versions, operation allowlists, and honest `installed_unverified` stages from the audited `capabilities` call
- keep provider discovery explicit and approval-aware instead of silently starting providers while preparing a model request
- update runtime/design documentation and add policy, version-sanitization, structural-consistency, and first-request coverage

## Why

Dogfooding showed that the model could be encouraged to call semantic code intelligence even when the current task/host posture would deterministically reject it. Provider capability output also lacked versions and operation details, making fallback choices less reliable.

This makes the model aware of effective access before it chooses a tool while keeping dispatch-time enforcement authoritative.

## Impact

Agents can avoid doomed semantic calls, distinguish semantic LSP support from ast-grep structural coverage, and choose capabilities or grep deliberately. Approval behavior is unchanged: `read_file` and `all_tools` still gate provider discovery and code-intelligence calls.

## Validation

- `GOCACHE="$PWD/.gocache" go build ./...`
- `GOCACHE="$PWD/.gocache" go vet ./internal/codeintel ./internal/orchestrator`
- `GOCACHE="$PWD/.gocache" go test -race -timeout 10m ./internal/codeintel ./internal/orchestrator`
- `just docs-check`
- `just go-format-check`
- independent subagent review of the final post-`master` diff: no findings

Repository-wide race retries reached all changed packages clean but exposed unrelated timing-sensitive failures in existing `internal/api` tests; targeted affected-package race coverage is green.
