### PR TITLE
Prepare v0.7.0 release notes

### DIFF
--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -40,6 +40,6 @@ changes and runtime readiness to narrowly approved browser interaction.
 - Hecate remains pre-1.0. Review the tracked [known limitations](https://github.com/hecatehq/hecate/blob/master/docs/operator/known-limitations.md) and back up persistent data before upgrading.
 - Browser interaction requires an operator-configured absolute Chromium executable and exact allowed origins, and is limited to 1–6 accessibility `click` / `wait_for` actions for local native project-assignment Tasks. It does not support typing, screenshots, uploads, downloads, retained sessions, Hecate Chat, External Agents, QA, or remote runtime.
 - Code-intelligence dogfood observed the expected policy blocks and unchanged isolated test workspaces, but has not established reliable model adoption of semantic or structural routes. Provider installation remains unchecked until the model makes the audited `capabilities` call.
-- Workspace review omits unsafe or unsupported file bodies and disables discard when its evidence or workspace authority is incomplete.
+- Workspace review omits unsafe or unsupported file bodies. Discard is a separate capability and closes when the exact unstaged tracked evidence or workspace authority is incomplete.
 - External Agents remain trusted local programs with their own accounts, billing, and runtime loops; Hecate supervises but does not sandbox them.
 - macOS Apple Silicon is launch-tested; Linux and Windows desktop bundles are CI-built but remain experimental. Mobile jobs validate compilation and do not publish store packages.

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,45 @@
+# Hecate v0.7.0
+
+This release makes agent work easier to inspect and control, from workspace
+changes and runtime readiness to narrowly approved browser interaction.
+
+## Highlights
+
+- Chat now presents staged, unstaged, and untracked workspace changes in one layered review with bounded rich diffs and text previews.
+- Operators can discard an exact, complete unstaged tracked snapshot after Hecate rechecks workspace identity, ownership, paths, and revision.
+- Native project-assignment Tasks can run one explicitly granted, approval-bound accessibility click/wait flow on an exact allowed browser origin.
+- Native code intelligence now tells the model each Run's effective approval and semantic-isolation posture before use, and reports bounded failure categories for attempted provider calls.
+- Opening Connections now runs and retains a disposable no-prompt ACP check for each available External Agent; **New chat** still resolves the executable and initializes a fresh ACP session.
+- Closing the desktop window keeps Hecate available in the background; explicit **Quit** still drains the runtime and its active work.
+
+## Security
+
+- Workspace discard authority is issued only from an exact, complete unstaged tracked snapshot and binds the canonical workspace to that patch. Hecate separately rechecks selected paths, active owners, staged or hidden index state, conflicts, and drift before mutation.
+- Browser interaction is off by default and independent from static browser inspection. Every flow requires approval of the query-free URL and complete ordered actions, uses a fresh owned Chromium process/profile, restricts traffic to the exact origin and `GET`/`HEAD`, and returns bounded plain-text evidence.
+- Browser controls are not an OS sandbox or identity boundary. Private destinations require an explicit operator opt-in, host browser policy may still supply identity, and an approved click or nominally read-like request can change the application.
+- Automatic External Agent checks execute the locally discovered agent binary but do not authenticate its publisher or prove it is malware-free. Use trusted vendor installation and signing channels.
+- No credential rotation is required for this release.
+
+## Breaking or risky changes
+
+- Closing the desktop main window no longer stops Hecate. Use the app's explicit **Quit** action when the runtime and active agents must stop.
+- Opening **Connections** runs one no-prompt diagnostic check for each available External Agent. The check is neither a security check nor a prerequisite for use; these agents remain trusted local subprocesses outside Hecate's sandbox.
+- An approved browser flow can complete earlier clicks before a later action fails. Hecate preserves partial evidence and warns that the application may already have changed; it does not roll the flow back.
+- Workspace discard is destructive and intentionally unavailable whenever Hecate cannot prove an exact, complete unstaged tracked snapshot. Staged and untracked changes remain review-only.
+- The workspace-review API is intentionally incompatible with clients that used the old top-level `data.revision` token: read the new `data.layers` evidence and submit only `data.discard.revision` as `expected_revision`. Staged or mixed reviews now return layered `200` evidence with discard unavailable instead of the old `422` response.
+- Persistent SQLite and Postgres stores automatically add and backfill the new browser-interaction and workspace-owner projection data at startup. No manual migration command is required; pre-1.0 backup guidance still applies.
+
+## Verification
+
+- Release gate: `just verify`.
+- Merged changes passed the required Go, race, Rust, TypeScript, browser, Docker, mobile compile, and desktop bundle CI checks.
+- The browser-flow change also passed its automated real-Chromium policy and cleanup matrix.
+
+## Known limitations
+
+- Hecate remains pre-1.0. Review the tracked [known limitations](https://github.com/hecatehq/hecate/blob/master/docs/operator/known-limitations.md) and back up persistent data before upgrading.
+- Browser interaction requires an operator-configured absolute Chromium executable and exact allowed origins, and is limited to 1–6 accessibility `click` / `wait_for` actions for local native project-assignment Tasks. It does not support typing, screenshots, uploads, downloads, retained sessions, Hecate Chat, External Agents, QA, or remote runtime.
+- Code-intelligence dogfood observed the expected policy blocks and unchanged isolated test workspaces, but has not established reliable model adoption of semantic or structural routes. Provider installation remains unchecked until the model makes the audited `capabilities` call.
+- Workspace review omits unsafe or unsupported file bodies and disables discard when its evidence or workspace authority is incomplete.
+- External Agents remain trusted local programs with their own accounts, billing, and runtime loops; Hecate supervises but does not sandbox them.
+- macOS Apple Silicon is launch-tested; Linux and Windows desktop bundles are CI-built but remain experimental. Mobile jobs validate compilation and do not publish store packages.


### PR DESCRIPTION
Adds the canonical operator-facing v0.7.0 release notes required before the public tag can be cut. The notes cover layered workspace review and guarded discard, approved browser flows, effective code-intelligence posture, automatic External Agent checks, desktop background behavior, compatibility changes, verification, and current platform limits.

Verification:
- Curated release-note validator
- Release-note workflow tests
- Markdown format check
- Link check
- Independent factual review against v0.6.0..master