### PR TITLE
chore(release): deliver v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ versioned GitHub Release assets below:
 
 | Platform              | Bundle                                                                                                                                                                                                                                 |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| macOS (Apple Silicon) | [Hecate_0.6.0_aarch64.dmg](https://github.com/hecatehq/hecate/releases/download/v0.6.0/Hecate_0.6.0_aarch64.dmg)                                                                                                                       |
-| Linux x86_64          | [Hecate_0.6.0_amd64.deb](https://github.com/hecatehq/hecate/releases/download/v0.6.0/Hecate_0.6.0_amd64.deb) or [Hecate_0.6.0_amd64.AppImage](https://github.com/hecatehq/hecate/releases/download/v0.6.0/Hecate_0.6.0_amd64.AppImage) |
-| Windows x86_64        | [Hecate_0.6.0_x64_en-US.msi](https://github.com/hecatehq/hecate/releases/download/v0.6.0/Hecate_0.6.0_x64_en-US.msi)                                                                                                                   |
+| macOS (Apple Silicon) | [Hecate_0.7.0_aarch64.dmg](https://github.com/hecatehq/hecate/releases/download/v0.7.0/Hecate_0.7.0_aarch64.dmg)                                                                                                                       |
+| Linux x86_64          | [Hecate_0.7.0_amd64.deb](https://github.com/hecatehq/hecate/releases/download/v0.7.0/Hecate_0.7.0_amd64.deb) or [Hecate_0.7.0_amd64.AppImage](https://github.com/hecatehq/hecate/releases/download/v0.7.0/Hecate_0.7.0_amd64.AppImage) |
+| Windows x86_64        | [Hecate_0.7.0_x64_en-US.msi](https://github.com/hecatehq/hecate/releases/download/v0.7.0/Hecate_0.7.0_x64_en-US.msi)                                                                                                                   |
 
 <!-- desktop-release-links:end -->
 
@@ -257,7 +257,7 @@ desktop status, updater behavior, signing notes, and footguns live in
 
 ```bash
 docker run --rm -p 127.0.0.1:8765:8765 -v hecate-data:/data \
-  ghcr.io/hecatehq/hecate:0.6.0
+  ghcr.io/hecatehq/hecate:0.7.0
 ```
 
 Open `http://127.0.0.1:8765`.

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -216,7 +216,7 @@ To pin to a specific release, replace `:latest` with the published tag (no `v` p
 
 ```yaml
 # docker-compose.yml
-image: ghcr.io/hecatehq/hecate:0.6.0
+image: ghcr.io/hecatehq/hecate:0.7.0
 ```
 
 Pinning is recommended for any deployment beyond local experimentation — `:latest` floats over alpha increments that may include schema or config changes.
@@ -275,8 +275,8 @@ The release workflow publishes static, single-file binaries for `linux+darwin ×
 
 ```bash
 # pick the right tarball for your OS / arch
-curl -LO https://github.com/hecatehq/hecate/releases/download/v0.6.0/hecate_0.6.0_linux_amd64.tar.gz
-tar -xzf hecate_0.6.0_linux_amd64.tar.gz
+curl -LO https://github.com/hecatehq/hecate/releases/download/v0.7.0/hecate_0.7.0_linux_amd64.tar.gz
+tar -xzf hecate_0.7.0_linux_amd64.tar.gz
 ./hecate serve
 ```
 
@@ -296,12 +296,12 @@ HECATE_DATA_DIR=/var/lib/hecate ./hecate serve
 
 For systemd, launchd, or supervisor wrappers, the only requirements are: the working directory is writable for `HECATE_DATA_DIR`, port 8765 is available, and `.env` (if used) sits in the working directory or is sourced into the unit file. The binary path itself can live anywhere on `$PATH`.
 
-Available tarballs for `v0.6.0`:
+Available tarballs for `v0.7.0`:
 
-- `hecate_0.6.0_linux_amd64.tar.gz`
-- `hecate_0.6.0_linux_arm64.tar.gz`
-- `hecate_0.6.0_darwin_amd64.tar.gz`
-- `hecate_0.6.0_darwin_arm64.tar.gz`
+- `hecate_0.7.0_linux_amd64.tar.gz`
+- `hecate_0.7.0_linux_arm64.tar.gz`
+- `hecate_0.7.0_darwin_amd64.tar.gz`
+- `hecate_0.7.0_darwin_arm64.tar.gz`
 
 Each tarball includes `hecate`, `LICENSE`, and `README.md`.
 Verify integrity against `checksums.txt` published alongside the release.

--- a/docs/operator/desktop-app.md
+++ b/docs/operator/desktop-app.md
@@ -43,7 +43,7 @@ For Linux or Windows operators who need the safest path today, use Docker or
 the standalone binary tarballs until the desktop bundles get real-machine
 smoke coverage.
 
-## Current state — `v0.6.0`
+## Current state — `v0.7.0`
 
 What works:
 


### PR DESCRIPTION
## Summary

- refresh the stable desktop download links from v0.6.0 to v0.7.0
- update the pinned container and standalone-binary examples to v0.7.0
- mark the desktop operator guide as current for v0.7.0

## Provenance

- generated by [release run 31383893920](https://github.com/hecatehq/hecate/actions/runs/31383893920)
- proposal base: `39e44cb5e18303938980569472c52a3506efd74d`
- proposal patch SHA-256: `117c77597f1ab6747bec19a08b8adbf9cf8524fa54927af65015ac1c6b30ca1d`
- resulting diff byte-matches the generated patch and changes only `README.md`, `docs/operator/deployment.md`, and `docs/operator/desktop-app.md`
- the v0.5.0 alpha updater bridge remains unchanged

## Verification

- `just docs-format-check`
- `just check-links`
- `git diff --cached --check`
- public release notes byte-match `docs/releases/v0.7.0.md`
- stable `latest.json` byte-matches the v0.7.0 updater manifest
- signed/notarized macOS app passed Gatekeeper and isolated launch/quit smoke
- multi-architecture container reports version 0.7.0 healthy
